### PR TITLE
Ensure that contact details forms are pre-loaded with existing data

### DIFF
--- a/app/controllers/candidate_interface/contact_details/address_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_controller.rb
@@ -3,13 +3,11 @@ module CandidateInterface
     before_action :redirect_to_dashboard_if_submitted
 
     def new
-      @contact_details_form = ContactDetailsForm.new(address_type: current_application.address_type)
+      @contact_details_form = load_contact_form
     end
 
     def create
-      @contact_details_form = ContactDetailsForm.new(
-        contact_details_params.merge(address_type: current_application.address_type),
-      )
+      @contact_details_form = form_from_params
 
       if @contact_details_form.save_address(current_application)
         redirect_to candidate_interface_contact_information_review_path
@@ -20,16 +18,12 @@ module CandidateInterface
     end
 
     def edit
-      @contact_details_form = ContactDetailsForm.build_from_application(
-        current_application,
-      )
+      @contact_details_form = load_contact_form
       @return_to = return_to_after_edit(default: candidate_interface_contact_information_review_path)
     end
 
     def update
-      @contact_details_form = ContactDetailsForm.new(
-        contact_details_params.merge(address_type: current_application.address_type),
-      )
+      @contact_details_form = form_from_params
       @return_to = return_to_after_edit(default: candidate_interface_contact_information_review_path)
 
       if @contact_details_form.save_address(current_application)
@@ -41,6 +35,18 @@ module CandidateInterface
     end
 
   private
+
+    def load_contact_form
+      ContactDetailsForm.build_from_application(current_application)
+    end
+
+    def form_from_params
+      ContactDetailsForm.new(
+        contact_details_params.merge(
+          address_type: current_application.address_type,
+        ),
+      )
+    end
 
     def contact_details_params
       strip_whitespace params.require(:candidate_interface_contact_details_form).permit(

--- a/app/controllers/candidate_interface/contact_details/address_type_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_type_controller.rb
@@ -3,7 +3,7 @@ module CandidateInterface
     before_action :redirect_to_dashboard_if_submitted
 
     def new
-      @contact_details_form = ContactDetailsForm.new
+      @contact_details_form = load_contact_form
     end
 
     def create
@@ -18,14 +18,12 @@ module CandidateInterface
     end
 
     def edit
-      @contact_details_form = ContactDetailsForm.build_from_application(
-        current_application,
-      )
+      @contact_details_form = load_contact_form
       @return_to = return_to_after_edit(default: candidate_interface_personal_details_complete_path)
     end
 
     def update
-      @contact_details_form = ContactDetailsForm.new(address_type_params)
+      @contact_details_form = form_from_params
       @return_to = return_to_after_edit(default: candidate_interface_personal_details_complete_path)
 
       if @contact_details_form.save_address_type(current_application)
@@ -39,6 +37,14 @@ module CandidateInterface
     end
 
   private
+
+    def load_contact_form
+      ContactDetailsForm.build_from_application(current_application)
+    end
+
+    def form_from_params
+      ContactDetailsForm.new(address_type_params)
+    end
 
     def address_type_params
       strip_whitespace params.require(:candidate_interface_contact_details_form).permit(

--- a/app/controllers/candidate_interface/contact_details/phone_number_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/phone_number_controller.rb
@@ -3,11 +3,12 @@ module CandidateInterface
     before_action :redirect_to_dashboard_if_submitted
 
     def new
-      @contact_details_form = ContactDetailsForm.new
+      @contact_details_form = load_contact_form
     end
 
     def create
-      @contact_details_form = ContactDetailsForm.new(contact_details_params)
+      @contact_details_form = form_from_params
+
       if @contact_details_form.save_base(current_application)
         redirect_to candidate_interface_new_address_type_path
       else
@@ -17,14 +18,12 @@ module CandidateInterface
     end
 
     def edit
-      @contact_details_form = ContactDetailsForm.build_from_application(
-        current_application,
-      )
+      @contact_details_form = load_contact_form
       @return_to = return_to_after_edit(default: candidate_interface_contact_information_review_path)
     end
 
     def update
-      @contact_details_form = ContactDetailsForm.new(contact_details_params)
+      @contact_details_form = form_from_params
       @return_to = return_to_after_edit(default: candidate_interface_contact_information_review_path)
 
       if @contact_details_form.save_base(current_application)
@@ -36,6 +35,14 @@ module CandidateInterface
     end
 
   private
+
+    def load_contact_form
+      ContactDetailsForm.build_from_application(current_application)
+    end
+
+    def form_from_params
+      ContactDetailsForm.new(contact_details_params)
+    end
 
     def contact_details_params
       strip_whitespace params.require(:candidate_interface_contact_details_form).permit(:phone_number)

--- a/app/forms/candidate_interface/contact_details_form.rb
+++ b/app/forms/candidate_interface/contact_details_form.rb
@@ -30,7 +30,7 @@ module CandidateInterface
         address_line3: application_form.address_line3,
         address_line4: application_form.address_line4,
         postcode: application_form.postcode,
-        address_type: application_form.address_type || 'GB',
+        address_type: application_form.address_type,
         country: application_form.country,
       )
     end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -69,7 +69,7 @@ class ApplicationForm < ApplicationRecord
     uk: 'uk',
     international: 'international',
   }, _suffix: :address
-  attribute :address_type, :string, default: 'uk'
+  attribute :address_type, :string
 
   enum feedback_satisfaction_level: {
     very_satisfied: 'very_satisfied',

--- a/spec/system/candidate_interface/entering_details/candidate_completes_contact_details_with_a_missing_address_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_completes_contact_details_with_a_missing_address_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'Candidate attempts to submit their application without a valid ad
 
   scenario 'The candidate has completed their contact details without entering an address' do
     given_i_complete_my_application
-    and_my_address_details_are_blank
+    and_my_address_details_are_incomplete
 
     when_i_click_contact_details_link_from_dashboard
     then_i_see_populated_telephone_number_form
@@ -27,13 +27,9 @@ RSpec.feature 'Candidate attempts to submit their application without a valid ad
     candidate_completes_application_form
   end
 
-  def and_my_address_details_are_blank
+  def and_my_address_details_are_incomplete
     current_candidate.current_application.update(
       address_line1: nil,
-      address_line2: nil,
-      address_line3: nil,
-      address_line4: nil,
-      postcode: nil,
     )
   end
 
@@ -63,5 +59,9 @@ RSpec.feature 'Candidate attempts to submit their application without a valid ad
 
   def then_i_see_address_details_form
     expect(page).to have_content('What is your address?')
+    expect(page).to have_field(
+      'Postcode',
+      with: current_candidate.current_application.postcode,
+    )
   end
 end

--- a/spec/system/candidate_interface/entering_details/candidate_completes_contact_details_with_a_missing_address_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_completes_contact_details_with_a_missing_address_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate attempts to submit their application without a valid address' do
+  include CandidateHelper
+
+  scenario 'The candidate has completed their contact details without entering an address' do
+    given_i_complete_my_application
+    and_my_address_details_are_blank
+
+    when_i_click_contact_details_link_from_dashboard
+    then_i_see_populated_telephone_number_form
+
+    when_i_click_continue
+    then_i_see_populated_address_type_form
+
+    when_i_click_continue
+    then_i_see_address_details_form
+
+    when_i_click_back
+    then_i_see_populated_address_type_form
+
+    when_i_click_back
+    then_i_see_populated_telephone_number_form
+  end
+
+  def given_i_complete_my_application
+    candidate_completes_application_form
+  end
+
+  def and_my_address_details_are_blank
+    current_candidate.current_application.update(
+      address_line1: nil,
+      address_line2: nil,
+      address_line3: nil,
+      address_line4: nil,
+      postcode: nil,
+    )
+  end
+
+  def when_i_click_contact_details_link_from_dashboard
+    visit candidate_interface_application_form_path
+    click_link 'Contact information'
+  end
+
+  def then_i_see_populated_telephone_number_form
+    expect(page).to have_field(
+      'Phone number',
+      with: current_candidate.current_application.phone_number,
+    )
+  end
+
+  def when_i_click_continue
+    click_button 'Save and continue'
+  end
+
+  def when_i_click_back
+    click_link 'Back'
+  end
+
+  def then_i_see_populated_address_type_form
+    expect(find_field('In the UK').checked?).to be(true)
+  end
+
+  def then_i_see_address_details_form
+    expect(page).to have_content('What is your address?')
+  end
+end


### PR DESCRIPTION
## Context

In some circumstances the forms that make up the contact details flow are rendered without loading existing data giving the impression that state has been reset.

## Changes proposed in this pull request

- [x] Ensure that data is loaded on `new` actions as well as `edit` actions in the various contact details controllers. (The normal distinction between `new` and `edit` actions doesn't really apply here because the data manipulations here are always updates to `ApplicationForm` records).
- [x] System spec to assert that forms always display latest data.

## Guidance to review

- Are there any good reasons for presenting an empty form that I'm missing?

## Link to Trello card

https://trello.com/c/xTS5cO2C/4482-fix-issues-with-contact-details-flow

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
