### PR TITLE
Add chase_provider_decision switches to user notifications

### DIFF
--- a/app/components/shared/provider_user_notification_preferences_component.html.erb
+++ b/app/components/shared/provider_user_notification_preferences_component.html.erb
@@ -1,6 +1,6 @@
 <%= form_with model: notification_preferences, url: form_path, method: :put do |f| %>
   <div class='govuk-form-group'>
-    <% ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |notification_preference| %>
+    <% ProviderUserNotificationPreferences.notification_preferences.each do |notification_preference| %>
       <%= f.govuk_collection_radio_buttons notification_preference,
         on_off_options,
         :value,

--- a/app/components/support_interface/provider_user_summary_component.rb
+++ b/app/components/support_interface/provider_user_summary_component.rb
@@ -38,7 +38,7 @@ module SupportInterface
     end
 
     def notification_preferences_rows
-      ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.map do |type|
+      ProviderUserNotificationPreferences.notification_preferences.map do |type|
         { preference: t("provider_user_notification_preferences.#{type}.legend"), active: provider_user.notification_preferences.send(type) ? 'Yes' : 'No' }
       end
     end

--- a/app/controllers/provider_interface/notifications_controller.rb
+++ b/app/controllers/provider_interface/notifications_controller.rb
@@ -17,7 +17,7 @@ module ProviderInterface
       return ActionController::Parameters.new unless params.key?(:provider_user_notification_preferences)
 
       params.require(:provider_user_notification_preferences)
-        .permit(ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES)
+        .permit(ProviderUserNotificationPreferences.notification_preferences)
     end
   end
 end

--- a/app/controllers/support_interface/provider_user_notification_preferences_controller.rb
+++ b/app/controllers/support_interface/provider_user_notification_preferences_controller.rb
@@ -21,7 +21,7 @@ module SupportInterface
       return ActionController::Parameters.new unless params.key?(:provider_user_notification_preferences)
 
       params.require(:provider_user_notification_preferences)
-        .permit(ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES)
+        .permit(ProviderUserNotificationPreferences.notification_preferences)
     end
   end
 end

--- a/app/controllers/support_interface/single_provider_user_notifications_controller.rb
+++ b/app/controllers/support_interface/single_provider_user_notifications_controller.rb
@@ -22,7 +22,7 @@ module SupportInterface
       return ActionController::Parameters.new unless params.key?(:provider_user_notification_preferences)
 
       params.require(:provider_user_notification_preferences)
-        .permit(ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES)
+        .permit(ProviderUserNotificationPreferences.notification_preferences)
     end
   end
 end

--- a/app/models/provider_user_notification_preferences.rb
+++ b/app/models/provider_user_notification_preferences.rb
@@ -8,18 +8,35 @@ class ProviderUserNotificationPreferences < ApplicationRecord
   NOTIFICATION_PREFERENCES = %i[
     application_received
     application_withdrawn
+    chase_provider_decision
+    application_rejected_by_default
+    offer_accepted
+    offer_declined
+  ].freeze
+
+  OLD_NOTIFICATION_PREFERENCES = %i[
+    application_received
+    application_withdrawn
     application_rejected_by_default
     offer_accepted
     offer_declined
   ].freeze
 
   def update_all_preferences(value)
-    NOTIFICATION_PREFERENCES.each { |notification| assign_attributes(notification => value) }
+    self.class.notification_preferences.each { |notification| assign_attributes(notification => value) }
 
     save!
   end
 
+  def self.notification_preferences
+    if FeatureFlag.active?(:make_decision_reminder_notification_setting)
+      NOTIFICATION_PREFERENCES
+    else
+      OLD_NOTIFICATION_PREFERENCES
+    end
+  end
+
   def self.notification_preference_exists?(notification_name)
-    NOTIFICATION_PREFERENCES.include? notification_name
+    notification_preferences.include? notification_name
   end
 end

--- a/app/services/notifications_list.rb
+++ b/app/services/notifications_list.rb
@@ -1,5 +1,14 @@
 class NotificationsList
   NOTIFICATION_PREFERENCE_NAMES_FOR_EVENTS = {
+    application_received: %i[application_submitted],
+    application_withdrawn: %i[application_withdrawn],
+    application_rejected_by_default: %i[application_rejected_by_default],
+    offer_accepted: %i[offer_accepted unconditional_offer_accepted],
+    offer_declined: %i[declined declined_by_default],
+    chase_provider_decision: %i[chase_provider_decision],
+  }.freeze
+
+  OLD_NOTIFICATION_PREFERENCE_NAMES_FOR_EVENTS = {
     application_received: %i[application_submitted chase_provider_decision],
     application_withdrawn: %i[application_withdrawn],
     application_rejected_by_default: %i[application_rejected_by_default],
@@ -8,12 +17,20 @@ class NotificationsList
   }.freeze
 
   def self.for(application_choice, include_ratifying_provider: false, event: nil)
-    notification_name = NOTIFICATION_PREFERENCE_NAMES_FOR_EVENTS.select { |k, v| k if event.in? v }.keys.first
+    notification_name = feature_flag_preference_names.select { |k, v| k if event.in? v }.keys.first
     raise 'Undefined type of notification event' unless ProviderUserNotificationPreferences.notification_preference_exists?(notification_name)
 
     return application_choice.provider.provider_users.joins(:notification_preferences).where("#{notification_name} IS true") if application_choice.accredited_provider.nil? || !include_ratifying_provider
 
     application_choice.provider.provider_users.or(application_choice.accredited_provider.provider_users)
       .joins(:notification_preferences).where("#{notification_name} IS true").distinct
+  end
+
+  def self.feature_flag_preference_names
+    if FeatureFlag.active?(:make_decision_reminder_notification_setting)
+      NOTIFICATION_PREFERENCE_NAMES_FOR_EVENTS
+    else
+      OLD_NOTIFICATION_PREFERENCE_NAMES_FOR_EVENTS
+    end
   end
 end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -7,7 +7,7 @@
       "check_name": "Redirect",
       "message": "Possible unprotected redirect",
       "file": "app/controllers/candidate_interface/after_sign_in_controller.rb",
-      "line": 28,
+      "line": 27,
       "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
       "code": "redirect_to(params[:path])",
       "render_path": null,
@@ -63,26 +63,6 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "38104ade37d5c61659409d037de157949b23a917a7f5b504534ac0a46fa5cf8f",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/services/notifications_list.rb",
-      "line": 17,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "application_choice.provider.provider_users.or(application_choice.accredited_provider.provider_users).joins(:notification_preferences).where(\"#{{ :application_received => ([:application_submitted, :chase_provider_decision]), :application_withdrawn => ([:application_withdrawn]), :application_rejected_by_default => ([:application_rejected_by_default]), :offer_accepted => ([:offer_accepted, :unconditional_offer_accepted]), :offer_declined => ([:declined, :declined_by_default]) }.select do\n k if event.in?(v)\n end.keys.first} IS true\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "NotificationsList",
-        "method": "s(:self).for"
-      },
-      "user_input": "{ :application_received => ([:application_submitted, :chase_provider_decision]), :application_withdrawn => ([:application_withdrawn]), :application_rejected_by_default => ([:application_rejected_by_default]), :offer_accepted => ([:offer_accepted, :unconditional_offer_accepted]), :offer_declined => ([:declined, :declined_by_default]) }.select do\n k if event.in?(v)\n end.keys.first",
-      "confidence": "Weak",
-      "note": "not a user input"
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
       "fingerprint": "471859383ef3e9fba03933907e1bb043a8a57520241d275846126e6a2425f2e1",
       "check_name": "SQL",
       "message": "Possible SQL injection",
@@ -98,6 +78,26 @@
       },
       "user_input": "start_time",
       "confidence": "Medium",
+      "note": ""
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "51aae2b6b9548a033b8832f0f9481aa76d039c54266505d4e24aa78111519467",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/services/notifications_list.rb",
+      "line": 23,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "application_choice.provider.provider_users.joins(:notification_preferences).where(\"#{feature_flag_preference_names.select do\n k if event.in?(v)\n end.keys.first} IS true\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "NotificationsList",
+        "method": "s(:self).for"
+      },
+      "user_input": "feature_flag_preference_names.select do\n k if event.in?(v)\n end.keys.first",
+      "confidence": "Weak",
       "note": ""
     },
     {
@@ -119,26 +119,6 @@
       "user_input": "deferred_offers_pending_reconfirmation",
       "confidence": "Weak",
       "note": ""
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "8b9afd450cdaed47a32fe72f50753a5a92d16a04993c636d8eac438f9f4079a1",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/services/notifications_list.rb",
-      "line": 14,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "application_choice.provider.provider_users.joins(:notification_preferences).where(\"#{{ :application_received => ([:application_submitted, :chase_provider_decision]), :application_withdrawn => ([:application_withdrawn]), :application_rejected_by_default => ([:application_rejected_by_default]), :offer_accepted => ([:offer_accepted, :unconditional_offer_accepted]), :offer_declined => ([:declined, :declined_by_default]) }.select do\n k if event.in?(v)\n end.keys.first} IS true\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "NotificationsList",
-        "method": "s(:self).for"
-      },
-      "user_input": "{ :application_received => ([:application_submitted, :chase_provider_decision]), :application_withdrawn => ([:application_withdrawn]), :application_rejected_by_default => ([:application_rejected_by_default]), :offer_accepted => ([:offer_accepted, :unconditional_offer_accepted]), :offer_declined => ([:declined, :declined_by_default]) }.select do\n k if event.in?(v)\n end.keys.first",
-      "confidence": "Weak",
-      "note": "not a user input"
     },
     {
       "warning_type": "SQL Injection",
@@ -223,6 +203,26 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
+      "fingerprint": "c7a49e24443f2f349019426ecc069e1d6db928bccefdecfdfcdfbb8319a924ec",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/services/notifications_list.rb",
+      "line": 26,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "application_choice.provider.provider_users.or(application_choice.accredited_provider.provider_users).joins(:notification_preferences).where(\"#{feature_flag_preference_names.select do\n k if event.in?(v)\n end.keys.first} IS true\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "NotificationsList",
+        "method": "s(:self).for"
+      },
+      "user_input": "feature_flag_preference_names.select do\n k if event.in?(v)\n end.keys.first",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
       "fingerprint": "dee8e3d32c167d6090d7a67d1bc9add167f8ef7b154fcc1d1311fc7aad779a84",
       "check_name": "SQL",
       "message": "Possible SQL injection",
@@ -261,6 +261,6 @@
       "note": ""
     }
   ],
-  "updated": "2022-02-09 13:54:32 +0000",
+  "updated": "2022-03-02 16:53:07 +0000",
   "brakeman_version": "5.2.1"
 }

--- a/config/locales/provider_user_notification_preferences.yml
+++ b/config/locales/provider_user_notification_preferences.yml
@@ -10,3 +10,5 @@ en:
       legend: Offer accepted
     offer_declined:
       legend: Offer declined
+    chase_provider_decision:
+      legend: Reminder to make a decision 20 working days before automatic rejection

--- a/spec/components/support_interface/provider_user_summary_component_spec.rb
+++ b/spec/components/support_interface/provider_user_summary_component_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe SupportInterface::ProviderUserSummaryComponent do
   end
 
   it "renders the provider user's notifications" do
-    ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |notification_preference|
+    ProviderUserNotificationPreferences.notification_preferences.each do |notification_preference|
       expect(rendered_component.squish).to include(t("provider_user_notification_preferences.#{notification_preference}.legend"))
     end
   end

--- a/spec/components/utility/provider_user_notification_preferences_component_spec.rb
+++ b/spec/components/utility/provider_user_notification_preferences_component_spec.rb
@@ -4,14 +4,33 @@ RSpec.describe ProviderUserNotificationPreferencesComponent do
   let(:provider_user) { create(:provider_user) }
   let(:notification_preferences) { provider_user.notification_preferences }
 
-  it 'renders correct labels for notification preferences' do
-    result = render_inline(described_class.new(notification_preferences, form_path: '/provider/account/notification-settings'))
+  context 'when the :make_decision_reminder_notification_setting feature flag is on' do
+    before { FeatureFlag.activate(:make_decision_reminder_notification_setting) }
 
-    expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[0].text).to include('Application received')
-    expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[1].text).to include('Application withdrawn by candidate')
-    expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[2].text).to include('Application automatically rejected')
-    expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[3].text).to include('Offer accepted')
-    expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[4].text).to include('Offer declined')
+    it 'renders correct labels for notification preferences' do
+      result = render_inline(described_class.new(notification_preferences, form_path: '/provider/account/notification-settings'))
+
+      expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[0].text).to include('Application received')
+      expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[1].text).to include('Application withdrawn by candidate')
+      expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[2].text).to include('Reminder to make a decision 20 working days before automatic rejection')
+      expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[3].text).to include('Application automatically rejected')
+      expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[4].text).to include('Offer accepted')
+      expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[5].text).to include('Offer declined')
+    end
+  end
+
+  context 'when the :make_decision_reminder_notification_setting feature flag is off' do
+    before { FeatureFlag.deactivate(:make_decision_reminder_notification_setting) }
+
+    it 'renders correct labels for notification preferences' do
+      result = render_inline(described_class.new(notification_preferences, form_path: '/provider/account/notification-settings'))
+
+      expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[0].text).to include('Application received')
+      expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[1].text).to include('Application withdrawn by candidate')
+      expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[2].text).to include('Application automatically rejected')
+      expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[3].text).to include('Offer accepted')
+      expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[4].text).to include('Offer declined')
+    end
   end
 
   it 'renders on and off radio buttons' do

--- a/spec/models/provider_user_notification_preferences_spec.rb
+++ b/spec/models/provider_user_notification_preferences_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ProviderUserNotificationPreferences do
       notification_preferences = create(:provider_user_notification_preferences)
       notification_preferences.update_all_preferences(false)
 
-      described_class::NOTIFICATION_PREFERENCES.each do |type|
+      described_class.notification_preferences.each do |type|
         expect(notification_preferences.send(type)).to be(false)
       end
     end
@@ -18,7 +18,7 @@ RSpec.describe ProviderUserNotificationPreferences do
     let(:notification_preferences) { build(:provider_user_notification_preferences) }
 
     it 'returns true for defined notification preferences types' do
-      described_class::NOTIFICATION_PREFERENCES.each do |type|
+      described_class.notification_preferences.each do |type|
         expect(described_class.notification_preference_exists?(type)).to be(true)
       end
     end

--- a/spec/services/notifications_list_spec.rb
+++ b/spec/services/notifications_list_spec.rb
@@ -17,6 +17,19 @@ RSpec.describe NotificationsList do
       expect(described_class.for(application_choice, event: :offer_accepted).to_a).to eql([provider_user])
     end
 
+    context 'when the make_decision_reminder_notification_setting feature flag is on' do
+      before { FeatureFlag.activate(:make_decision_reminder_notification_setting) }
+
+      it 'does not return training provider users for a disabled chase_provider_decision preference' do
+        application_choice = create(:application_choice)
+        provider_user = create(:provider_user, :with_notifications_enabled, providers: [application_choice.course.provider])
+
+        create(:provider_user_notification_preferences, chase_provider_decision: false, provider_user: create(:provider_user, providers: [application_choice.course.provider]))
+
+        expect(described_class.for(application_choice, event: :chase_provider_decision).to_a).to eql([provider_user])
+      end
+    end
+
     it 'returns training and ratifying provider users for the application choice for a given type of event' do
       ratifying_provider = create(:provider)
       ratifying_provider_user = create(:provider_user, :with_notifications_enabled, providers: [ratifying_provider])

--- a/spec/services/save_provider_user_notification_preferences_spec.rb
+++ b/spec/services/save_provider_user_notification_preferences_spec.rb
@@ -19,13 +19,14 @@ RSpec.describe SaveProviderUserNotificationPreferences do
           application_rejected_by_default: false,
           offer_accepted: false,
           offer_declined: false,
+          chase_provider_decision: false,
         }
       end
 
       it 'sets the correct value for the #notification_preferences for a provider user' do
         service.update_all_notification_preferences!(notification_preferences_params: notification_preferences_params)
 
-        ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |preference|
+        ProviderUserNotificationPreferences.notification_preferences.each do |preference|
           expect(provider_user.reload.notification_preferences.send(preference)).to be(false)
         end
       end
@@ -56,9 +57,7 @@ RSpec.describe SaveProviderUserNotificationPreferences do
     end
 
     context 'when the :make_decision_reminder_notification_setting feature flag is off' do
-      before do
-        FeatureFlag.deactivate(:make_decision_reminder_notification_setting)
-      end
+      before { FeatureFlag.deactivate(:make_decision_reminder_notification_setting) }
 
       let(:notification_preferences_params) do
         {

--- a/spec/system/provider_interface/manage_provider_user_notifications_spec.rb
+++ b/spec/system/provider_interface/manage_provider_user_notifications_spec.rb
@@ -29,13 +29,13 @@ RSpec.feature 'Managing notifications' do
   end
 
   def then_i_can_see_all_notifications_are_on_by_default
-    ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |type|
+    ProviderUserNotificationPreferences.notification_preferences.each do |type|
       expect(find(:css, "#provider-user-notification-preferences-#{type.to_s.dasherize}-true-field")).to be_checked
     end
   end
 
   def when_i_choose_not_to_receive_notifications
-    ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |type|
+    ProviderUserNotificationPreferences.notification_preferences.each do |type|
       choose "provider-user-notification-preferences-#{type.to_s.dasherize}-false-field"
     end
     click_on 'Save settings'
@@ -44,7 +44,7 @@ RSpec.feature 'Managing notifications' do
   def then_my_notification_preferences_are_updated
     expect(page).to have_content 'Email notification settings saved'
 
-    ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |type|
+    ProviderUserNotificationPreferences.notification_preferences.each do |type|
       expect(find(:css, "#provider-user-notification-preferences-#{type.to_s.dasherize}-false-field")).to be_checked
     end
   end

--- a/spec/system/support_interface/managing_provider_user_notification_preferences_spec.rb
+++ b/spec/system/support_interface/managing_provider_user_notification_preferences_spec.rb
@@ -50,13 +50,13 @@ RSpec.feature 'Managing provider user notification preferences' do
   end
 
   def then_i_can_see_all_notifications_are_on_by_default
-    ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |type|
+    ProviderUserNotificationPreferences.notification_preferences.each do |type|
       expect(find(:css, "#provider-user-notification-preferences-#{type.to_s.dasherize}-true-field")).to be_checked
     end
   end
 
   def when_i_update_all_notifications_to_be_off
-    ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |type|
+    ProviderUserNotificationPreferences.notification_preferences.each do |type|
       choose "provider-user-notification-preferences-#{type.to_s.dasherize}-false-field"
     end
     click_on 'Save settings'


### PR DESCRIPTION
## Context

https://trello.com/c/uX0FkHsy/4895-email-reminders-add-switch-in-notification-settings-for-provider-chaser

## Changes proposed in this pull request
Adding the `chase_provider_decision` email notification preference to the appropriate spots. 

Where there were constants in `NotificationsList` and `ProviderUserNotificationPreferences` there are now two alternative constants in each, which are decided between based on the feature flag. This has been expanded out to the entire app, so that everywhere will pick from the constants based on the current flag state. This is to avoid trying to mutate the constant itself depending on the feature flag, which caused issues when testing, and would probably cause issues when the flag is switched on/off.

Components that use this notification preference list all get the updated `legend` included in the PR

![image](https://user-images.githubusercontent.com/25597009/155974593-72335c1a-ca37-48c7-8c12-86eb607e5ce8.png)

![image](https://user-images.githubusercontent.com/25597009/155974623-5dc9d204-0501-4dc5-8c74-37f30b7ce6b9.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
