### PR TITLE
Course Change - Add the study mode wizard

### DIFF
--- a/app/components/provider_interface/change_course_details_component.html.erb
+++ b/app/components/provider_interface/change_course_details_component.html.erb
@@ -1,5 +1,5 @@
 <section class="app-section govuk-!-width-two-thirds">
-  <h2 class="govuk-heading-m govuk-!-font-size-27" id="course-details">Course applied for</h2>
+  <h2 class="govuk-heading-m govuk-!-font-size-27" id="course-details">Course details</h2>
 
   <%= render SummaryListComponent.new(rows: rows) %>
 </section>

--- a/app/components/provider_interface/change_course_details_component.rb
+++ b/app/components/provider_interface/change_course_details_component.rb
@@ -7,9 +7,9 @@ module ProviderInterface
 
     attr_reader :application_choice, :provider_name_and_code, :course_name_and_code,
                 :cycle, :preferred_location, :study_mode, :qualification, :available_providers,
-                :available_courses
+                :available_courses, :course
 
-    def initialize(application_choice:, available_providers: [], available_courses: [])
+    def initialize(application_choice:, course: nil, available_providers: [], available_courses: [])
       @application_choice = application_choice
       @provider_name_and_code = application_choice.provider.name_and_code
       @course_name_and_code = application_choice.course.name_and_code
@@ -19,6 +19,7 @@ module ProviderInterface
       @qualification = qualification_text(application_choice.course_option)
       @available_providers = available_providers
       @available_courses = available_courses
+      @course = course
     end
 
     def rows
@@ -26,7 +27,7 @@ module ProviderInterface
         { key: 'Training provider', value: provider_name_and_code, action: { href: change_provider_path } },
         { key: 'Course', value: course_name_and_code, action: { href: change_course_path } },
         { key: 'Cycle', value: cycle },
-        { key: 'Full or part time', value: study_mode },
+        { key: 'Full or part time', value: study_mode, action: { href: change_study_mode_path } },
         { key: 'Location', value: preferred_location },
         { key: 'Accredited body', value: accredited_body },
         { key: 'Qualification', value: qualification },
@@ -65,6 +66,10 @@ module ProviderInterface
 
     def change_course_path
       available_courses.length > 1 ? edit_provider_interface_application_choice_course_courses_path(application_choice) : nil
+    end
+
+    def change_study_mode_path
+      course.full_time_or_part_time? ? edit_provider_interface_application_choice_course_study_modes_path(application_choice) : nil
     end
   end
 end

--- a/app/components/provider_interface/course_details_component.html.erb
+++ b/app/components/provider_interface/course_details_component.html.erb
@@ -1,5 +1,5 @@
 <section class="app-section govuk-!-width-two-thirds">
-  <h2 class="govuk-heading-m govuk-!-font-size-27" id="course-details">Course applied for</h2>
+  <h2 class="govuk-heading-m govuk-!-font-size-27" id="course-details">Course details</h2>
 
   <%= render SummaryListComponent.new(rows: rows) %>
 </section>

--- a/app/controllers/provider_interface/courses/courses_controller.rb
+++ b/app/controllers/provider_interface/courses/courses_controller.rb
@@ -14,7 +14,11 @@ module ProviderInterface
         if @wizard.valid_for_current_step?
           @wizard.save_state!
 
-          redirect_to [:edit, :provider_interface, @application_choice, :offer, @wizard.next_step]
+          if @wizard.next_step.nil?
+            redirect_to provider_interface_application_choice_path(@application_choice)
+          else
+            redirect_to [:edit, :provider_interface, @application_choice, :course, @wizard.next_step]
+          end
         else
           @courses = available_courses(@wizard.provider_id)
           track_validation_error(@wizard)

--- a/app/controllers/provider_interface/courses/study_modes_controller.rb
+++ b/app/controllers/provider_interface/courses/study_modes_controller.rb
@@ -1,0 +1,47 @@
+module ProviderInterface
+  module Courses
+    class StudyModesController < CoursesController
+      def edit
+        @wizard = CourseWizard.new(change_course_store, { current_step: 'study_modes', action: action })
+        @wizard.save_state!
+
+        @course = Course.find(@wizard.course_id)
+        @study_modes = available_study_modes(@course)
+      end
+
+      def update
+        @wizard = CourseWizard.new(change_course_store, attributes_for_wizard)
+        @wizard.course_option_id = nil if @wizard.course_option_id && @wizard.course_option.study_mode != @wizard.study_mode
+
+        if @wizard.valid_for_current_step?
+          @wizard.save_state!
+
+          redirect_to provider_interface_application_choice_path(@application_choice)
+        else
+          @course = Course.find(@wizard.course_id)
+          @study_modes = available_study_modes(@course)
+          track_validation_error(@wizard)
+
+          render :edit
+        end
+      end
+
+    private
+
+      def study_mode_params
+        params.require(:provider_interface_course_wizard).permit(:study_mode)
+      end
+
+      def available_study_modes(course)
+        GetChangeOfferOptions.new(
+          user: current_provider_user,
+          current_course: @application_choice.current_course,
+        ).available_study_modes(course: course)
+      end
+
+      def attributes_for_wizard
+        study_mode_params.to_h.merge!(current_step: 'study_modes')
+      end
+    end
+  end
+end

--- a/app/forms/provider_interface/course_wizard.rb
+++ b/app/forms/provider_interface/course_wizard.rb
@@ -9,6 +9,7 @@ module ProviderInterface
                   :course_option_id, :course_id, :provider_user_id, :study_mode
 
     validates :course_id, presence: true, on: %i[courses save]
+    validates :study_mode, presence: true, on: %i[study_mode save]
 
     def self.build_from_application_choice(state_store, application_choice, options = {})
       course_option = application_choice.current_course_option

--- a/app/forms/provider_interface/course_wizard.rb
+++ b/app/forms/provider_interface/course_wizard.rb
@@ -3,7 +3,7 @@ module ProviderInterface
     include Wizard
     include Wizard::PathHistory
 
-    STEPS = %i[select_option providers courses study_modes locations check].freeze
+    STEPS = %i[select_option providers courses study_modes].freeze
 
     attr_accessor :path_history, :provider_id, :decision, :application_choice_id,
                   :course_option_id, :course_id, :provider_user_id, :study_mode
@@ -18,9 +18,14 @@ module ProviderInterface
         course_id: course_option.course.id,
         course_option_id: course_option.id,
         provider_id: course_option.provider.id,
+        study_mode: course_option.study_mode,
       }.merge(options)
 
       new(state_store, attrs)
+    end
+
+    def course_option
+      CourseOption.find(course_option_id)
     end
 
     def next_step(step = current_step)
@@ -32,6 +37,7 @@ module ProviderInterface
       return save_and_go_to_next_step(next_step) if next_step.eql?(:providers) && available_providers.length == 1
       return save_and_go_to_next_step(next_step) if next_step.eql?(:courses) && available_courses.length == 1
       return save_and_go_to_next_step(next_step) if next_step.eql?(:study_modes) && available_study_modes.length == 1
+      return save_and_go_to_next_step(next_step) if next_step.eql?(:locations) && available_course_options.length == 1
 
       next_step
     end
@@ -73,6 +79,10 @@ module ProviderInterface
       query_service.available_study_modes(course: course)
     end
 
+    def available_course_options
+      query_service.available_course_options(course: course, study_mode: study_mode)
+    end
+
     def save_and_go_to_next_step(step)
       attrs = { provider_id: available_providers.first.id } if step.eql?(:providers)
       attrs = { course_id: available_courses.first.id } if step.eql?(:courses)
@@ -83,6 +93,17 @@ module ProviderInterface
       save_state!
 
       next_step(step)
+    end
+
+    def state_excluded_attributes
+      %w[state_store errors validation_context query_service wizard_path_history _further_condition_models]
+    end
+
+    def sanitize_attrs(attrs)
+      if !last_saved_state.empty? && attrs[:course_id].present? && last_saved_state['course_id'] != attrs[:course_id].to_i
+        attrs.merge!(study_mode: nil, course_option_id: nil)
+      end
+      attrs
     end
   end
 end

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -50,6 +50,7 @@
     application_choice: @application_choice,
     available_providers: @available_training_providers,
     available_courses: @available_courses,
+    course: @application_choice.current_course_option.course,
   ) %>
 <% else %>
   <%= render ProviderInterface::CourseDetailsComponent.new(application_choice: @application_choice) %>

--- a/app/views/provider_interface/courses/study_modes/edit.html.erb
+++ b/app/views/provider_interface/courses/study_modes/edit.html.erb
@@ -1,13 +1,12 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
 
-<%= render CollectionSelectComponent.new(attribute: :course_id,
-                                         collection: @courses,
-                                         value_method: :id,
-                                         text_method: :name_and_code,
-                                         hint_method: :description,
-                                         bold_labels: false,
+<%= render CollectionSelectComponent.new(attribute: :study_mode,
+                                         collection: @study_modes,
+                                         value_method: :to_s,
+                                         text_method: :humanize,
+                                         hint_method: nil,
                                          form_object: @wizard,
-                                         form_path: provider_interface_application_choice_course_courses_path,
+                                         form_path: provider_interface_application_choice_course_study_modes_path,
                                          form_method: :put,
                                          page_title: t('.title'),
                                          caption: t('.caption', name: @application_choice.application_form.full_name)) do %>

--- a/config/locales/provider_interface/change_course.yml
+++ b/config/locales/provider_interface/change_course.yml
@@ -9,3 +9,7 @@ en:
         edit:
           title: Course
           caption: Update course - %{name}
+      study_modes:
+        edit:
+          title: Full time or part time
+          caption: Update course - %{name}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -741,6 +741,7 @@ Rails.application.routes.draw do
       namespace :courses, as: :application_choice_course do
         resource :providers, only: %i[edit update]
         resource :courses, only: %i[edit update]
+        resource :study_modes, only: %i[edit update], path: 'study-modes'
       end
 
       get '/rejection-reasons' => 'reasons_for_rejection#edit_initial_questions', as: :reasons_for_rejection_initial_questions

--- a/spec/components/provider_interface/change_course_details_component_spec.rb
+++ b/spec/components/provider_interface/change_course_details_component_spec.rb
@@ -27,21 +27,25 @@ RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
   end
 
   let(:course) do
-    instance_double(Course,
-                    name_and_code: 'Geography (H234)',
-                    recruitment_cycle_year: 2020,
-                    accredited_provider: nil,
-                    qualifications: %w[qts pgce],
-                    funding_type: 'fee')
+    build_stubbed(:course,
+                  :with_both_study_modes,
+                  name: 'Geography',
+                  code: 'H234',
+                  recruitment_cycle_year: 2020,
+                  accredited_provider: nil,
+                  qualifications: %w[qts pgce],
+                  funding_type: 'fee')
   end
 
   let(:course2) do
-    instance_double(Course,
-                    name_and_code: 'Geography (H234)',
-                    recruitment_cycle_year: 2020,
-                    accredited_provider: nil,
-                    qualifications: %w[qts pgce],
-                    funding_type: 'fee')
+    build_stubbed(:course,
+                  :part_time,
+                  name: 'Geography',
+                  code: 'H234',
+                  recruitment_cycle_year: 2020,
+                  accredited_provider: nil,
+                  qualifications: %w[qts pgce],
+                  funding_type: 'fee')
   end
 
   let(:application_choice) do
@@ -52,7 +56,7 @@ RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
                     site: site)
   end
 
-  let(:render) { render_inline(described_class.new(application_choice: application_choice)) }
+  let(:render) { render_inline(described_class.new(application_choice: application_choice, course: course)) }
 
   def row_text_selector(row_name, render)
     rows = { provider: 0,
@@ -72,7 +76,7 @@ RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
   end
 
   context 'when there are multiple available providers' do
-    let(:render) { render_inline(described_class.new(application_choice: application_choice, available_providers: [provider, accredited_provider])) }
+    let(:render) { render_inline(described_class.new(application_choice: application_choice, course: course, available_providers: [provider, accredited_provider])) }
 
     it 'renders a link to change' do
       render_text = row_text_selector(:provider, render)
@@ -94,7 +98,7 @@ RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
   end
 
   context 'when multiple courses' do
-    let(:render) { render_inline(described_class.new(application_choice: application_choice, available_courses: [course, course2])) }
+    let(:render) { render_inline(described_class.new(application_choice: application_choice, course: course, available_courses: [course, course2])) }
 
     it 'renders a change link' do
       render_text = row_text_selector(:course, render)
@@ -111,6 +115,28 @@ RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
 
       expect(render_text).to include('Course')
       expect(render_text).to include('Geography (H234)')
+      expect(render_text).not_to include('Change')
+    end
+  end
+
+  context 'when there are multiple study modes' do
+    it 'renders the study mode' do
+      render_text = row_text_selector(:full_or_part_time, render)
+
+      expect(render_text).to include('Full or part time')
+      expect(render_text).to include('Full time')
+      expect(render_text).to include('Change')
+    end
+  end
+
+  context 'when there is only one study mode' do
+    let(:render) { render_inline(described_class.new(application_choice: application_choice, course: course2, available_providers: [provider, accredited_provider])) }
+
+    it 'renders the study mode' do
+      render_text = row_text_selector(:full_or_part_time, render)
+
+      expect(render_text).to include('Full or part time')
+      expect(render_text).to include('Full time')
       expect(render_text).not_to include('Change')
     end
   end

--- a/spec/forms/provider_interface/course_wizard_spec.rb
+++ b/spec/forms/provider_interface/course_wizard_spec.rb
@@ -22,6 +22,48 @@ RSpec.describe ProviderInterface::CourseWizard do
     it { is_expected.to validate_presence_of(:course_id).on(:courses).on(:save) }
   end
 
+  describe '#initialize' do
+    context 'is responsible for sanitising the attributes' do
+      context 'when the provided course_id does not match the stored value' do
+        let(:wizard) do
+          described_class.new(store, course_id: course_id)
+        end
+        let(:stored_data) { { course_id: 5, course_option_id: 3, study_mode: :full_time, provider_id: 10 }.to_json }
+        let(:course_id) { 4 }
+
+        before do
+          allow(store).to receive(:read).and_return(stored_data)
+        end
+
+        it 'resets the study mode and course_option_id' do
+          expect(wizard.study_mode).to be_nil
+          expect(wizard.course_option_id).to be_nil
+          expect(wizard.course_id).to eq(course_id)
+          expect(wizard.provider_id).to eq(10)
+        end
+      end
+
+      context 'when the provided course_id does match the stored value' do
+        let(:wizard) do
+          described_class.new(store, course_id: course_id)
+        end
+        let(:stored_data) { { course_id: 5, course_option_id: 3, study_mode: :full_time, provider_id: 10 }.to_json }
+        let(:course_id) { 5 }
+
+        before do
+          allow(store).to receive(:read).and_return(stored_data)
+        end
+
+        it 'does not reset the study mode and course_option_id' do
+          expect(wizard.study_mode).to eq('full_time')
+          expect(wizard.course_option_id).to eq(3)
+          expect(wizard.course_id).to eq(course_id)
+          expect(wizard.provider_id).to eq(10)
+        end
+      end
+    end
+  end
+
   context 'when changing an offer' do
     let(:decision) { :change_offer }
     let(:query_service) { instance_double(GetChangeOfferOptions) }
@@ -105,7 +147,23 @@ RSpec.describe ProviderInterface::CourseWizard do
           allow(query_service).to receive(:available_course_options).and_return(create_list(:course_option, 2))
         end
 
-        it 'returns :study_modes' do
+        # TODO: Remove pending on next PR
+        xit 'returns :locations' do
+          expect(wizard.next_step).to eq(:locations)
+        end
+      end
+    end
+
+    context 'when current_step is :study_modes' do
+      let(:current_step) { :study_modes }
+
+      context 'when there are multiple locations available' do
+        before do
+          allow(query_service).to receive(:available_course_options).and_return(create_list(:course_option, 2))
+        end
+
+        # TODO: Remove pending on next PR
+        xit 'returns :locations' do
           expect(wizard.next_step).to eq(:locations)
         end
       end

--- a/spec/forms/provider_interface/course_wizard_spec.rb
+++ b/spec/forms/provider_interface/course_wizard_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe ProviderInterface::CourseWizard do
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:course_id).on(:courses).on(:save) }
+    it { is_expected.to validate_presence_of(:study_mode).on(:study_modes).on(:save) }
   end
 
   describe '#initialize' do

--- a/spec/system/provider_interface/provider_changes_a_course_before_point_of_offer_spec.rb
+++ b/spec/system/provider_interface/provider_changes_a_course_before_point_of_offer_spec.rb
@@ -18,6 +18,28 @@ RSpec.feature 'Provider changes a course' do
   end
   let(:course_option) { build(:course_option, course: course) }
 
+  scenario 'Changing a course choice before point of offer (only one study mode)' do
+    given_i_am_a_provider_user
+    and_the_feature_flag_is_enabled
+    and_i_am_permitted_to_make_decisions_for_my_provider
+    and_i_sign_in_to_the_provider_interface
+    and_the_provider_has_multiple_courses
+    and_the_provider_user_can_offer_multiple_provider_courses
+
+    when_i_visit_the_provider_interface
+    and_i_click_an_application_choice_that_is_interviewing
+    and_i_click_on_change_the_training_provider
+    then_i_see_a_list_of_training_providers_to_select_from
+
+    when_i_select_a_different_provider
+    and_i_click_continue
+    then_i_see_a_list_of_courses_to_select_from
+
+    when_i_select_a_course_with_one_study_mode
+    and_i_click_continue
+    then_i_dont_see_the_study_mode_page
+  end
+
   scenario 'Changing a course choice before point of offer' do
     given_i_am_a_provider_user
     and_the_feature_flag_is_enabled
@@ -34,6 +56,10 @@ RSpec.feature 'Provider changes a course' do
     when_i_select_a_different_provider
     and_i_click_continue
     then_i_see_a_list_of_courses_to_select_from
+
+    when_i_select_a_different_course
+    and_i_click_continue
+    then_no_study_mode_is_pre_selected
   end
 
   def given_i_am_a_provider_user
@@ -68,6 +94,9 @@ RSpec.feature 'Provider changes a course' do
     courses = [create(:course, study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: ratifying_provider),
                create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: ratifying_provider)]
     @selected_course = courses.sample
+
+    @one_mode_course = create(:course, :open_on_apply, study_mode: :full_time, provider: @selected_provider, accredited_provider: ratifying_provider)
+    create(:course_option, :full_time, course: @one_mode_course)
 
     course_options = [create(:course_option, :part_time, course: @selected_course),
                       create(:course_option, :full_time, course: @selected_course),
@@ -121,5 +150,24 @@ RSpec.feature 'Provider changes a course' do
   def then_i_see_a_list_of_courses_to_select_from
     expect(page).to have_content "Update course - #{application_form.full_name}"
     expect(page).to have_content 'Course'
+  end
+
+  def when_i_select_a_different_course
+    choose @selected_course.name_and_code
+  end
+
+  def when_i_select_a_course_with_one_study_mode
+    choose @one_mode_course.name_and_code
+  end
+
+  def then_i_dont_see_the_study_mode_page
+    expect(page.current_url).not_to include 'study-modes'
+  end
+
+  def then_no_study_mode_is_pre_selected
+    expect(page).to have_content "Update course - #{application_form.full_name}"
+    expect(page).to have_content 'Full time or part time'
+    expect(find_field('Full time')).not_to be_checked
+    expect(find_field('Part time')).not_to be_checked
   end
 end


### PR DESCRIPTION
## Context

Currently providers can change the details of a course at the point of offer. We'd like to let providers do this before the point of offer.

Following from [#6585](https://github.com/DFE-Digital/apply-for-teacher-training/pull/6585) this is the third PR in the series which will allow the user to change the study mode.

This stage of the flow will be skipped if the user picks an option which doesn't have both modes available to select

## Changes proposed in this pull request

<img width="678" alt="image" src="https://user-images.githubusercontent.com/47917431/155980677-99d349cb-824e-47a4-afb5-6022ebfdd463.png">

## Guidance to review

- Should not be preselected if they've changed course

## Link to Trello card

https://trello.com/c/E97RWJnY

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
