### PR TITLE
Call to action links replace empty values on contact details review page

### DIFF
--- a/app/components/candidate_interface/contact_details_review_component.rb
+++ b/app/components/candidate_interface/contact_details_review_component.rb
@@ -70,6 +70,24 @@ module CandidateInterface
             },
           },
         }
+      elsif address_only_missing_postcode?
+        {
+          key: t('application_form.contact_details.full_address.label'),
+          value: full_address +
+            [govuk_link_to(
+              'Enter postcode',
+              candidate_interface_edit_address_path(return_to_params)
+            )],
+          action: {
+            href: candidate_interface_edit_address_type_path(return_to_params),
+            visually_hidden_text: t('application_form.contact_details.full_address.change_action'),
+          },
+          html_attributes: {
+            data: {
+              qa: 'contact-details-address',
+            },
+          },
+        }
       else
         {
           key: t('application_form.contact_details.full_address.label'),
@@ -100,8 +118,12 @@ module CandidateInterface
     end
 
     def address_complete?
-      @contact_details_form.valid?(:address_type) &&
-        @contact_details_form.valid?(:address)
+      @contact_details_form.valid?(:address_type) && @contact_details_form.valid?(:address)
+    end
+
+    def address_only_missing_postcode?
+      @contact_details_form.validate(:address)
+      @contact_details_form.errors.attribute_names == %i[postcode]
     end
 
     def return_to_params

--- a/app/components/candidate_interface/contact_details_review_component.rb
+++ b/app/components/candidate_interface/contact_details_review_component.rb
@@ -30,7 +30,7 @@ module CandidateInterface
     attr_reader :application_form
 
     def phone_number_row
-      if (@contact_details_form.phone_number.present?)
+      if @contact_details_form.phone_number.present?
         {
           key: t('application_form.contact_details.phone_number.label'),
           value: @contact_details_form.phone_number,
@@ -51,6 +51,11 @@ module CandidateInterface
             'Enter phone number',
             candidate_interface_edit_phone_number_path(return_to_params),
           ),
+          html_attributes: {
+            data: {
+              qa: 'contact-details-phone-number',
+            },
+          },
         }
       end
     end
@@ -76,7 +81,7 @@ module CandidateInterface
           value: full_address +
             [govuk_link_to(
               'Enter postcode',
-              candidate_interface_edit_address_path(return_to_params)
+              candidate_interface_edit_address_path(return_to_params),
             )],
           action: {
             href: candidate_interface_edit_address_type_path(return_to_params),
@@ -95,6 +100,11 @@ module CandidateInterface
             'Enter address',
             candidate_interface_edit_address_type_path(return_to_params),
           ),
+          html_attributes: {
+            data: {
+              qa: 'contact-details-address',
+            },
+          },
         }
       end
     end

--- a/app/components/candidate_interface/contact_details_review_component.rb
+++ b/app/components/candidate_interface/contact_details_review_component.rb
@@ -30,35 +30,55 @@ module CandidateInterface
     attr_reader :application_form
 
     def phone_number_row
-      {
-        key: t('application_form.contact_details.phone_number.label'),
-        value: @contact_details_form.phone_number,
-        action: {
-          href: candidate_interface_edit_phone_number_path(return_to_params),
-          visually_hidden_text: t('application_form.contact_details.phone_number.change_action'),
-        },
-        html_attributes: {
-          data: {
-            qa: 'contact-details-phone-number',
+      if (@contact_details_form.phone_number.present?)
+        {
+          key: t('application_form.contact_details.phone_number.label'),
+          value: @contact_details_form.phone_number,
+          action: {
+            href: candidate_interface_edit_phone_number_path(return_to_params),
+            visually_hidden_text: t('application_form.contact_details.phone_number.change_action'),
           },
-        },
-      }
+          html_attributes: {
+            data: {
+              qa: 'contact-details-phone-number',
+            },
+          },
+        }
+      else
+        {
+          key: t('application_form.contact_details.phone_number.label'),
+          value: govuk_link_to(
+            'Enter phone number',
+            candidate_interface_edit_phone_number_path(return_to_params),
+          ),
+        }
+      end
     end
 
     def address_row
-      {
-        key: t('application_form.contact_details.full_address.label'),
-        value: full_address,
-        action: {
-          href: candidate_interface_edit_address_type_path(return_to_params),
-          visually_hidden_text: t('application_form.contact_details.full_address.change_action'),
-        },
-        html_attributes: {
-          data: {
-            qa: 'contact-details-address',
+      if address_complete?
+        {
+          key: t('application_form.contact_details.full_address.label'),
+          value: full_address,
+          action: {
+            href: candidate_interface_edit_address_type_path(return_to_params),
+            visually_hidden_text: t('application_form.contact_details.full_address.change_action'),
           },
-        },
-      }
+          html_attributes: {
+            data: {
+              qa: 'contact-details-address',
+            },
+          },
+        }
+      else
+        {
+          key: t('application_form.contact_details.full_address.label'),
+          value: govuk_link_to(
+            'Enter address',
+            candidate_interface_edit_address_type_path(return_to_params),
+          ),
+        }
+      end
     end
 
     def full_address
@@ -77,6 +97,11 @@ module CandidateInterface
         @contact_details_form.address_line4,
         @contact_details_form.postcode,
       ]
+    end
+
+    def address_complete?
+      @contact_details_form.valid?(:address_type) &&
+        @contact_details_form.valid?(:address)
     end
 
     def return_to_params

--- a/spec/components/candidate_interface/contact_details_review_component_spec.rb
+++ b/spec/components/candidate_interface/contact_details_review_component_spec.rb
@@ -65,6 +65,23 @@ RSpec.describe CandidateInterface::ContactDetailsReviewComponent do
         expect(result.css('.govuk-summary-list__value .govuk-link').to_html).to include('Enter phone number')
         expect(result.css('.govuk-summary-list__value .govuk-link').to_html).to include('Enter address')
       end
+
+      it 'renders an Enter postcode link if only the postcode is missing' do
+        application_form = build_stubbed(
+          :application_form,
+          phone_number: '0123456789',
+          address_type: 'uk',
+          address_line1: '1 Nothrew Road',
+          address_line3: 'Knowtown',
+          postcode: nil,
+          country: 'GB',
+        )
+        result = render_inline(described_class.new(application_form: application_form))
+
+        expect(result.css('.govuk-summary-list__value .govuk-link').to_html).not_to include('Enter phone number')
+        expect(result.css('.govuk-summary-list__value .govuk-link').to_html).not_to include('Enter address')
+        expect(result.css('.govuk-summary-list__value .govuk-link').to_html).to include('Enter postcode')
+      end
     end
 
     it 'renders the address fields that are not empty strings' do

--- a/spec/components/candidate_interface/contact_details_review_component_spec.rb
+++ b/spec/components/candidate_interface/contact_details_review_component_spec.rb
@@ -51,6 +51,22 @@ RSpec.describe CandidateInterface::ContactDetailsReviewComponent do
       end
     end
 
+    context 'when contact details are incomplete' do
+      it 'renders an Enter phone number and Enter address link' do
+        application_form = build_stubbed(
+          :application_form,
+          phone_number: nil,
+          address_type: 'international',
+          address_line1: '',
+          country: 'IN',
+        )
+        result = render_inline(described_class.new(application_form: application_form))
+
+        expect(result.css('.govuk-summary-list__value .govuk-link').to_html).to include('Enter phone number')
+        expect(result.css('.govuk-summary-list__value .govuk-link').to_html).to include('Enter address')
+      end
+    end
+
     it 'renders the address fields that are not empty strings' do
       application_form = build(
         :application_form,

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_contact_details_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_contact_details_section_spec.rb
@@ -108,7 +108,7 @@ RSpec.feature 'Candidate is redirected correctly' do
 
   def when_i_click_change_address
     within('[data-qa="contact-details-address"]') do
-      click_link 'Change'
+      click_link 'Enter address'
     end
   end
 

--- a/spec/system/candidate_interface/submitting/candidate_submits_application_with_a_missing_address_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submits_application_with_a_missing_address_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature 'Candidate attempts to submit their application without a valid ad
 
   def when_i_complete_my_contact_details
     click_link 'Complete your contact details'
-    click_link 'Change address'
+    click_link 'Enter address'
 
     choose 'In the UK'
     click_button t('save_and_continue')


### PR DESCRIPTION
## Context

This PR brings the design of the contact details review page in line with others such as the references review page, making it more obvious what needs to be done to complete contact details if more information is needed from the candidate. It addresses one of the concerns we had with the contact details flow and is a follow up to https://github.com/DFE-Digital/apply-for-teacher-training/pull/6597 .

<img width="933" alt="image" src="https://user-images.githubusercontent.com/450843/155981301-c87e1c16-83d3-45cb-9652-79c8a13694a9.png">

<img width="1015" alt="image" src="https://user-images.githubusercontent.com/450843/156210947-aa3c9149-ea1c-4043-ac80-5c8153a4df03.png">


## Changes proposed in this pull request

- [x] When data is missing or invalid add a call to action instead of a blank value. 

## Guidance to review

- Are the tests adequate?

## Link to Trello card

https://trello.com/c/xTS5cO2C/4482-fix-issues-with-contact-details-flow

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
