### PR TITLE
Remove applyagainwiththreechoices feature flag

### DIFF
--- a/app/services/data_migrations/drop_apply_again_with_three_choices_feature_flag.rb
+++ b/app/services/data_migrations/drop_apply_again_with_three_choices_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class DropApplyAgainWithThreeChoicesFeatureFlag
+    TIMESTAMP = 20220228145523
+    MANUAL_RUN = false
+
+    def change
+      Feature.where(name: :apply_again_with_three_choices).first&.destroy
+    end
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -40,7 +40,6 @@ class FeatureFlag
     [:publish_monthly_statistics, 'Publish monthly statistics at publications/monthly-statistics', 'Duncan Brown'],
     [:draft_vendor_api_specification, 'The specification for Draft Vendor API v1.1', 'Abeer Salameh'],
     [:immigration_entry_date, 'Extends the restructured_immigration_status feature to include the "Date of entry into the UK" question', 'Steve Hook'],
-    [:apply_again_with_three_choices, 'Replaces the current apply again logic which only allows one choice', 'Avin & Tomas'],
     [:change_course_details_before_offer, 'Allows providers to change course choice details before the point of offer', 'James Glenn'],
     [:structured_reasons_for_rejection_redesign, 'Latest iteration of structured reasons for rejection', 'Steve Laing'],
     [:make_decision_reminder_notification_setting, 'Adds a notification setting to turn off make decision email reminders', 'Sam Culley'],

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::DropApplyAgainWithThreeChoicesFeatureFlag',
   'DataMigrations::BackfillChaseProviderDecisionSetting',
   'DataMigrations::BackfillWithdrawnOrDeclinedForCandidateByProvider',
   'DataMigrations::BackfillUserColumnsOnNotes',

--- a/spec/services/data_migrations/drop_apply_again_with_three_choices_feature_flag_spec.rb
+++ b/spec/services/data_migrations/drop_apply_again_with_three_choices_feature_flag_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::DropApplyAgainWithThreeChoicesFeatureFlag do
+  context 'when the feature flag exists' do
+    it 'removes the feature flag' do
+      create(:feature, name: 'apply_again_with_three_choices')
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: 'apply_again_with_three_choices')).to be_blank
+    end
+  end
+
+  context 'when the feature flag has already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end


### PR DESCRIPTION
## Context

Apply again with three choices is here to stay!  

The feature flag logic was removed in #6566. This is a follow up PR to remove the actual feature flag, which has been active on production since 21/02/22.

## Changes proposed in this pull request

- Remove the `apply_again_with_three_choices` feature flag.
- Data migration to drop the `apply_again_with_three_choices` feature flag record.

## Link to Trello card

https://trello.com/c/qSaSJr20/4481-remove-applyagainwiththreechoices-feature-flag

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
