### PR TITLE
SR4R Re-design: Add configuration-driven RejectionReasons wizard

### DIFF
--- a/app/forms/provider_interface/rejection_reasons_wizard.rb
+++ b/app/forms/provider_interface/rejection_reasons_wizard.rb
@@ -7,11 +7,7 @@ module ProviderInterface
         @rejection_reasons ||= RejectionReasons.from_config
       end
 
-      delegate :collection_attribute_names, :single_attribute_names, :reasons, to: :rejection_reasons
-
-      def attribute_names
-        (single_attribute_names + collection_attribute_names).sort
-      end
+      delegate :attribute_names, :collection_attribute_names, :single_attribute_names, :reasons, to: :rejection_reasons
     end
 
     attr_accessor(*attribute_names)

--- a/app/forms/provider_interface/rejection_reasons_wizard.rb
+++ b/app/forms/provider_interface/rejection_reasons_wizard.rb
@@ -1,0 +1,27 @@
+module ProviderInterface
+  class RejectionReasonsWizard
+    include Wizard
+
+    class << self
+      def rejection_reasons
+        @rejection_reasons ||= RejectionReasons.from_config
+      end
+
+      delegate :collection_attribute_names, :single_attribute_names, :reasons, to: :rejection_reasons
+
+      def attribute_names
+        (single_attribute_names + collection_attribute_names).sort
+      end
+    end
+
+    attr_accessor(*attribute_names)
+
+    def initialize_extra(_attrs)
+      @checking_answers = true if current_step == 'check'
+    end
+
+    def next_step
+      'check'
+    end
+  end
+end

--- a/app/models/rejection_reasons.rb
+++ b/app/models/rejection_reasons.rb
@@ -11,14 +11,22 @@ class RejectionReasons
   end
 
   def single_attribute_names
-    reasons.map(&:single_attribute_names).flatten.sort
+    (nested_reasons + details).map(&:id).map(&:to_sym)
   end
 
   def collection_attribute_names
-    reasons.map(&:collection_attribute_names).flatten.sort
+    reasons.map { |r| [r.id, r.reasons_id].compact }.flatten.map(&:to_sym)
   end
 
   def attribute_names
-    (single_attribute_names + collection_attribute_names).sort
+    single_attribute_names + collection_attribute_names
+  end
+
+  def nested_reasons
+    reasons.map(&:reasons).flatten.compact
+  end
+
+  def details
+    (reasons + nested_reasons).map(&:details).compact
   end
 end

--- a/app/models/rejection_reasons.rb
+++ b/app/models/rejection_reasons.rb
@@ -17,4 +17,8 @@ class RejectionReasons
   def collection_attribute_names
     reasons.map(&:collection_attribute_names).flatten.sort
   end
+
+  def attribute_names
+    (single_attribute_names + collection_attribute_names).sort
+  end
 end

--- a/app/models/rejection_reasons.rb
+++ b/app/models/rejection_reasons.rb
@@ -1,15 +1,20 @@
 class RejectionReasons
+  include ActiveModel::Model
   CONFIG_PATH = 'config/rejection_reasons.yml'.freeze
 
-  attr_reader :reasons
+  attr_accessor :reasons, :selected_reasons
 
-  def initialize(config: configuration)
-    @reasons = config[:reasons].map { |hash| Reason.new(hash) }
+  def self.from_config(config: YAML.load_file(CONFIG_PATH))
+    instance = new
+    instance.reasons = config[:reasons].map { |rattrs| Reason.new(rattrs) }
+    instance
   end
 
-private
+  def single_attribute_names
+    reasons.map(&:single_attribute_names).flatten.sort
+  end
 
-  def configuration
-    @configuration ||= YAML.load_file(CONFIG_PATH)
+  def collection_attribute_names
+    reasons.map(&:collection_attribute_names).flatten.sort
   end
 end

--- a/app/models/rejection_reasons/reason.rb
+++ b/app/models/rejection_reasons/reason.rb
@@ -9,18 +9,5 @@ class RejectionReasons
       @details = Details.new(attrs[:details]) if attrs.key?(:details)
       @reasons = attrs[:reasons].map { |rattrs| self.class.new(rattrs) } if attrs.key?(:reasons)
     end
-
-    def collection_attribute_names
-      return [] unless reasons
-
-      [reasons_id].concat(reasons.map(&:id)).map(&:to_sym)
-    end
-
-    def single_attribute_names
-      [].tap do |ary|
-        ary << details.id.to_sym if details
-        ary << id.to_sym unless reasons
-      end
-    end
   end
 end

--- a/app/models/rejection_reasons/reason.rb
+++ b/app/models/rejection_reasons/reason.rb
@@ -2,12 +2,25 @@ class RejectionReasons
   class Reason
     include ActiveModel::Model
 
-    attr_accessor :id, :details, :label, :reasons
+    attr_accessor :id, :details, :label, :reasons_id, :reasons, :selected_reasons
 
     def initialize(attrs)
       super(attrs)
       @details = Details.new(attrs[:details]) if attrs.key?(:details)
-      @reasons = attrs[:reasons].map { |hash| self.class.new(hash) } if attrs.key?(:reasons)
+      @reasons = attrs[:reasons].map { |rattrs| self.class.new(rattrs) } if attrs.key?(:reasons)
+    end
+
+    def collection_attribute_names
+      return [] unless reasons
+
+      [reasons_id].concat(reasons.map(&:id)).map(&:to_sym)
+    end
+
+    def single_attribute_names
+      [].tap do |ary|
+        ary << details.id.to_sym if details
+        ary << id.to_sym unless reasons
+      end
     end
   end
 end

--- a/config/rejection_reasons.yml
+++ b/config/rejection_reasons.yml
@@ -2,6 +2,7 @@
 :reasons:
 - :id: qualifications
   :label: Qualifications
+  :reasons_id: qualifications_reasons
   :reasons:
   - :id: no_maths_gcse
     :label: No maths GCSE at minimum grade 4 or C, or equivalent
@@ -27,6 +28,7 @@
       :id: qualifications_other_details
       :label: Details
 - :id: personal_statement
+  :reasons_id: personal_statement_reasons
   :label: Personal statement
   :reasons:
   - :id: quality_of_writing
@@ -40,6 +42,7 @@
       :id: personal_statement_other_details
       :label: Details
 - :id: teaching_knowledge
+  :reasons_id: teaching_knowledge_reasons
   :label: Teaching knowledge and ability
   :reasons:
   - :id: subject_knowledge
@@ -73,6 +76,7 @@
       :id: teaching_knowledge_other_details
       :label: Details
 - :id: communication_and_scheduling
+  :reasons_id: communication_and_scheduling_reasons
   :label: Communication, attendance and scheduling
   :reasons:
   - :id: did_not_reply

--- a/spec/forms/provider_interface/rejection_reasons_wizard_spec.rb
+++ b/spec/forms/provider_interface/rejection_reasons_wizard_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::RejectionReasonsWizard do
+  let(:attrs) { { current_step: 'edit' } }
+  let(:store) { instance_double(WizardStateStores::RedisStore) }
+
+  before { allow(store).to receive(:read) }
+
+  subject(:instance) { described_class.new(store, attrs) }
+
+  describe '.rejection_reasons' do
+    it 'builds rejection reasons from configuration' do
+      rejection_reasons = described_class.rejection_reasons
+      expect(rejection_reasons).to be_a(RejectionReasons)
+      expect(rejection_reasons.reasons.first).to be_a(RejectionReasons::Reason)
+      expect(rejection_reasons.reasons.first.reasons.first).to be_a(RejectionReasons::Reason)
+      expect(rejection_reasons.reasons.last.details).to be_a(RejectionReasons::Details)
+    end
+  end
+
+  describe '.attribute_names' do
+    it 'returns an array of all attribute names' do
+      expect(described_class.attribute_names).to eq(%i[
+        communication_and_scheduling_other
+        communication_and_scheduling_reasons
+        could_not_arrange_interview
+        course_full
+        did_not_attend_interview
+        did_not_reply
+        no_degree
+        no_english_gcse
+        no_maths_gcse
+        no_science_gcse
+        other
+        other_details
+        personal_statement_other
+        personal_statement_reasons
+        qualifications_other
+        qualifications_reasons
+        quality_of_writing
+        references
+        references_details
+        safeguarding
+        safeguarding_details
+        safeguarding_knowledge
+        subject_knowledge
+        teaching_demonstration_knowledge
+        teaching_knowledge_other
+        teaching_knowledge_reasons
+        teaching_method_knowledge
+        teaching_role_knowledge
+        unsuitable_degree
+        unverified_qualifications
+        visa_sponsorship
+        visa_sponsorship_details
+      ])
+    end
+  end
+
+  describe 'dynamic attributes' do
+    it 'defines accessors for all attributes' do
+      described_class.attribute_names.each do |attr_name|
+        expect(instance.respond_to?(attr_name)).to be(true)
+        expect(instance.respond_to?("#{attr_name}=")).to be(true)
+      end
+    end
+  end
+end

--- a/spec/forms/provider_interface/rejection_reasons_wizard_spec.rb
+++ b/spec/forms/provider_interface/rejection_reasons_wizard_spec.rb
@@ -18,45 +18,6 @@ RSpec.describe ProviderInterface::RejectionReasonsWizard do
     end
   end
 
-  describe '.attribute_names' do
-    it 'returns an array of all attribute names' do
-      expect(described_class.attribute_names).to eq(%i[
-        communication_and_scheduling_other
-        communication_and_scheduling_reasons
-        could_not_arrange_interview
-        course_full
-        did_not_attend_interview
-        did_not_reply
-        no_degree
-        no_english_gcse
-        no_maths_gcse
-        no_science_gcse
-        other
-        other_details
-        personal_statement_other
-        personal_statement_reasons
-        qualifications_other
-        qualifications_reasons
-        quality_of_writing
-        references
-        references_details
-        safeguarding
-        safeguarding_details
-        safeguarding_knowledge
-        subject_knowledge
-        teaching_demonstration_knowledge
-        teaching_knowledge_other
-        teaching_knowledge_reasons
-        teaching_method_knowledge
-        teaching_role_knowledge
-        unsuitable_degree
-        unverified_qualifications
-        visa_sponsorship
-        visa_sponsorship_details
-      ])
-    end
-  end
-
   describe 'dynamic attributes' do
     it 'defines accessors for all attributes' do
       described_class.attribute_names.each do |attr_name|

--- a/spec/models/rejection_reasons_spec.rb
+++ b/spec/models/rejection_reasons_spec.rb
@@ -1,9 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe RejectionReasons do
-  subject(:instance) { described_class.new }
+  subject(:instance) { described_class.from_config }
 
-  describe 'initialize' do
+  describe '#reasons' do
+    it 'memoizes reasons' do
+      allow(YAML).to receive(:load_file).with(described_class::CONFIG_PATH).and_call_original
+
+      instance.reasons
+      instance.reasons
+
+      expect(YAML).to have_received(:load_file).with(described_class::CONFIG_PATH).once
+    end
+
     it 'builds top level rejection reasons' do
       expect(instance.reasons).to be_a(Array)
       expect(instance.reasons.first).to be_a(RejectionReasons::Reason)
@@ -35,6 +44,52 @@ RSpec.describe RejectionReasons do
 
       expect(other).to be_a(RejectionReasons::Reason)
       expect(other.details).to be_a(RejectionReasons::Details)
+    end
+  end
+
+  describe '#single_attribute_names' do
+    it 'returns an array of all single attribute names' do
+      expect(instance.single_attribute_names).to eq(%i[
+        course_full
+        other
+        other_details
+        references
+        references_details
+        safeguarding
+        safeguarding_details
+        visa_sponsorship
+        visa_sponsorship_details
+      ])
+    end
+  end
+
+  describe '#collection_attribute_names' do
+    it 'returns an array of all collection attribute names' do
+      expect(instance.collection_attribute_names).to eq(%i[
+        communication_and_scheduling_other
+        communication_and_scheduling_reasons
+        could_not_arrange_interview
+        did_not_attend_interview
+        did_not_reply
+        no_degree
+        no_english_gcse
+        no_maths_gcse
+        no_science_gcse
+        personal_statement_other
+        personal_statement_reasons
+        qualifications_other
+        qualifications_reasons
+        quality_of_writing
+        safeguarding_knowledge
+        subject_knowledge
+        teaching_demonstration_knowledge
+        teaching_knowledge_other
+        teaching_knowledge_reasons
+        teaching_method_knowledge
+        teaching_role_knowledge
+        unsuitable_degree
+        unverified_qualifications
+      ])
     end
   end
 end

--- a/spec/models/rejection_reasons_spec.rb
+++ b/spec/models/rejection_reasons_spec.rb
@@ -92,4 +92,43 @@ RSpec.describe RejectionReasons do
       ])
     end
   end
+
+  describe '#attribute_names' do
+    it 'returns an array of all attribute names' do
+      expect(instance.attribute_names).to eq(%i[
+        communication_and_scheduling_other
+        communication_and_scheduling_reasons
+        could_not_arrange_interview
+        course_full
+        did_not_attend_interview
+        did_not_reply
+        no_degree
+        no_english_gcse
+        no_maths_gcse
+        no_science_gcse
+        other
+        other_details
+        personal_statement_other
+        personal_statement_reasons
+        qualifications_other
+        qualifications_reasons
+        quality_of_writing
+        references
+        references_details
+        safeguarding
+        safeguarding_details
+        safeguarding_knowledge
+        subject_knowledge
+        teaching_demonstration_knowledge
+        teaching_knowledge_other
+        teaching_knowledge_reasons
+        teaching_method_knowledge
+        teaching_role_knowledge
+        unsuitable_degree
+        unverified_qualifications
+        visa_sponsorship
+        visa_sponsorship_details
+      ])
+    end
+  end
 end

--- a/spec/models/rejection_reasons_spec.rb
+++ b/spec/models/rejection_reasons_spec.rb
@@ -1,12 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe RejectionReasons do
+  let(:test_config) do
+    {
+      reasons: [
+        { id: 'a', label: 'A', reasons_id: 'a_reasons',
+          reasons: [
+            { id: 'aa', label: 'AA', details: { id: 'ad', label: 'AD' } },
+            { id: 'ab', label: 'AB' },
+          ] },
+        { id: 'b', label: 'B', details: { id: 'bd', label: 'BD' } },
+        { id: 'c', label: 'C' },
+      ],
+    }
+  end
+
   subject(:instance) { described_class.from_config }
+
+  before do
+    allow(YAML).to receive(:load_file).with(described_class::CONFIG_PATH).and_return(test_config)
+  end
 
   describe '#reasons' do
     it 'memoizes reasons' do
-      allow(YAML).to receive(:load_file).with(described_class::CONFIG_PATH).and_call_original
-
       instance.reasons
       instance.reasons
 
@@ -16,10 +32,7 @@ RSpec.describe RejectionReasons do
     it 'builds top level rejection reasons' do
       expect(instance.reasons).to be_a(Array)
       expect(instance.reasons.first).to be_a(RejectionReasons::Reason)
-      expect(instance.reasons.map(&:id)).to eq(%w[
-        qualifications personal_statement teaching_knowledge communication_and_scheduling
-        references safeguarding visa_sponsorship course_full other
-      ])
+      expect(instance.reasons.map(&:id)).to eq(%w[a b c])
     end
 
     it 'builds nested reasons' do
@@ -27,108 +40,38 @@ RSpec.describe RejectionReasons do
 
       expect(qualifications.reasons).to be_a(Array)
       expect(qualifications.reasons.first).to be_a(RejectionReasons::Reason)
-      expect(qualifications.reasons.map(&:id)).to eq(%w[
-        no_maths_gcse no_english_gcse no_science_gcse no_degree unsuitable_degree
-        unverified_qualifications qualifications_other
-      ])
+      expect(qualifications.reasons.map(&:id)).to eq(%w[aa ab])
     end
 
     it 'builds details for reasons' do
-      qualifications = instance.reasons.first
-      qualifications_other = qualifications.reasons.last
+      reason = instance.reasons.first
+      nested_reason = reason.reasons.first
 
-      expect(qualifications_other).to be_a(RejectionReasons::Reason)
-      expect(qualifications_other.details).to be_a(RejectionReasons::Details)
+      expect(nested_reason).to be_a(RejectionReasons::Reason)
+      expect(nested_reason.details).to be_a(RejectionReasons::Details)
 
-      other = instance.reasons.last
+      reason_with_details = instance.reasons.second
 
-      expect(other).to be_a(RejectionReasons::Reason)
-      expect(other.details).to be_a(RejectionReasons::Details)
+      expect(reason_with_details).to be_a(RejectionReasons::Reason)
+      expect(reason_with_details.details).to be_a(RejectionReasons::Details)
     end
   end
 
   describe '#single_attribute_names' do
     it 'returns an array of all single attribute names' do
-      expect(instance.single_attribute_names).to eq(%i[
-        course_full
-        other
-        other_details
-        references
-        references_details
-        safeguarding
-        safeguarding_details
-        visa_sponsorship
-        visa_sponsorship_details
-      ])
+      expect(instance.single_attribute_names.sort).to eq(%i[aa ab ad bd])
     end
   end
 
   describe '#collection_attribute_names' do
     it 'returns an array of all collection attribute names' do
-      expect(instance.collection_attribute_names).to eq(%i[
-        communication_and_scheduling_other
-        communication_and_scheduling_reasons
-        could_not_arrange_interview
-        did_not_attend_interview
-        did_not_reply
-        no_degree
-        no_english_gcse
-        no_maths_gcse
-        no_science_gcse
-        personal_statement_other
-        personal_statement_reasons
-        qualifications_other
-        qualifications_reasons
-        quality_of_writing
-        safeguarding_knowledge
-        subject_knowledge
-        teaching_demonstration_knowledge
-        teaching_knowledge_other
-        teaching_knowledge_reasons
-        teaching_method_knowledge
-        teaching_role_knowledge
-        unsuitable_degree
-        unverified_qualifications
-      ])
+      expect(instance.collection_attribute_names.sort).to eq(%i[a a_reasons b c])
     end
   end
 
   describe '#attribute_names' do
     it 'returns an array of all attribute names' do
-      expect(instance.attribute_names).to eq(%i[
-        communication_and_scheduling_other
-        communication_and_scheduling_reasons
-        could_not_arrange_interview
-        course_full
-        did_not_attend_interview
-        did_not_reply
-        no_degree
-        no_english_gcse
-        no_maths_gcse
-        no_science_gcse
-        other
-        other_details
-        personal_statement_other
-        personal_statement_reasons
-        qualifications_other
-        qualifications_reasons
-        quality_of_writing
-        references
-        references_details
-        safeguarding
-        safeguarding_details
-        safeguarding_knowledge
-        subject_knowledge
-        teaching_demonstration_knowledge
-        teaching_knowledge_other
-        teaching_knowledge_reasons
-        teaching_method_knowledge
-        teaching_role_knowledge
-        unsuitable_degree
-        unverified_qualifications
-        visa_sponsorship
-        visa_sponsorship_details
-      ])
+      expect(instance.attribute_names.sort).to eq(%i[a a_reasons aa ab ad b bd c])
     end
   end
 end


### PR DESCRIPTION
## Context

As part of the redesign of SR4R we'd like to make the wizard, form and presenters dynamically driven by a central configuration.
This will reduce the amount of repetitive code necessary when dealing with form field attributes and validations.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Add methods to `RejectionReasons::Reason` to retrieve attribute names.
- Adds `RejectionReasonsWizard`
- Defines attributes from config on the wizard

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

This code isn't currently called anywhere, this PR serves to break down some of the form work into smaller reviewable chunks.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

Part of
https://trello.com/c/OwBEV4gv/4831-sr4r-redesign-add-configuration-driven-reasons-for-rejection-form

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
