### PR TITLE
Remove `support_user_change_offered_course` feature flag

### DIFF
--- a/app/components/support_interface/application_choice_component.html.erb
+++ b/app/components/support_interface/application_choice_component.html.erb
@@ -1,6 +1,6 @@
 <%= render SummaryCardComponent.new(rows: rows) do %>
   <%= render SummaryCardHeaderComponent.new(title: title, heading_level: 3, anchor: anchor) do %>
-    <% if FeatureFlag.active?(:support_user_change_offered_course) && (application_choice.pending_conditions? || application_choice.unconditional_offer_pending_recruitment?) %>
+    <% if application_choice.pending_conditions? || application_choice.unconditional_offer_pending_recruitment? %>
       <div class="app-summary-card__actions">
         <ul class="app-summary-card__actions-list">
           <div class="app-summary-card__actions">

--- a/app/controllers/support_interface/application_forms/application_choices/change_offered_course_controller.rb
+++ b/app/controllers/support_interface/application_forms/application_choices/change_offered_course_controller.rb
@@ -2,7 +2,7 @@ module SupportInterface
   module ApplicationForms
     module ApplicationChoices
       class ChangeOfferedCourseController < BaseController
-        before_action :build_application_form, :build_application_choice, :redirect_to_application_form_unless_accepted_and_change_offered_course_course_flag_active
+        before_action :build_application_form, :build_application_choice, :redirect_to_application_form_unless_accepted
 
         def change_offered_course_search
           @course_search = CourseSearchForm.new
@@ -80,8 +80,8 @@ module SupportInterface
           params.require(:support_interface_application_forms_update_offered_course_option_form).permit(:course_option_id, :audit_comment, :accept_guidance)
         end
 
-        def redirect_to_application_form_unless_accepted_and_change_offered_course_course_flag_active
-          return if FeatureFlag.active?(:support_user_change_offered_course) && application_choice_pending_recruitment?
+        def redirect_to_application_form_unless_accepted
+          return if application_choice_pending_recruitment?
 
           redirect_to support_interface_application_form_path(@application_form.id)
         end

--- a/app/services/data_migrations/drop_support_user_change_offered_course_feature_flag.rb
+++ b/app/services/data_migrations/drop_support_user_change_offered_course_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class DropSupportUserChangeOfferedCourseFeatureFlag
+    TIMESTAMP = 20220301180044
+    MANUAL_RUN = false
+
+    def change
+      Feature.where(name: :support_user_change_offered_course).first&.destroy
+    end
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -29,7 +29,6 @@ class FeatureFlag
     [:unconditional_offers_via_api, 'Activates the ability to accept unconditional offers via the API', 'Steve Laing'],
     [:support_user_reinstate_offer, 'Allows a support users to reinstate a declined course choice offer', 'James Glenn'],
     [:expanded_quals_export, 'Rework the Qualifications export to contain all candidate qualifications', 'Malcolm Baig'],
-    [:support_user_change_offered_course, 'Allows support users to offer a different course option for an application choice', 'David Gisbey'],
     [:withdraw_at_candidates_request, "Allows providers to withdraw an application at the candidate's request", 'Steve Laing'],
     [:summer_recruitment_banner, 'Show a banner to indicate a shorter recruitment timeframe during summer', 'Richard Pattinson'],
     [:restructured_immigration_status, 'New model for right to work and study in the UK to be released from 2022 cycle', 'Steve Hook'],

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,6 +1,7 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
   'DataMigrations::DropContentSecurityPolicyFeatureFlag',
+  'DataMigrations::DropSupportUserChangeOfferedCourseFeatureFlag',
   'DataMigrations::DropApplyAgainWithThreeChoicesFeatureFlag',
   'DataMigrations::DropPilotOpenFeatureFlag',
   'DataMigrations::BackfillChaseProviderDecisionSetting',

--- a/spec/components/support_interface/application_choice_component_spec.rb
+++ b/spec/components/support_interface/application_choice_component_spec.rb
@@ -44,9 +44,7 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
   context 'Conditions pending' do
     let(:accepted_choice) { create(:application_choice, :with_completed_application_form, :with_accepted_offer) }
 
-    it 'renders a link to the change the offered course choice when the `change_offered_course` flag is active' do
-      FeatureFlag.activate(:support_user_change_offered_course)
-
+    it 'renders a link to the change the offered course choice' do
       result = render_inline(described_class.new(accepted_choice))
 
       expect(result.css('.app-summary-card__actions a')[0].attr('href')).to include(
@@ -56,15 +54,6 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
         ),
       )
       expect(result.css('.app-summary-card__actions').text.strip).to include('Change offered course')
-    end
-
-    it 'does not render a link to the change the offered course choice when the`change_offered_course` flag is not active' do
-      FeatureFlag.deactivate(:support_user_change_offered_course)
-
-      render_inline(described_class.new(accepted_choice))
-
-      expect(page).not_to have_selector '.app-summary-card__actions a'
-      expect(page).not_to have_text 'Change offered course'
     end
 
     it 'renders a link to change conditions' do
@@ -101,9 +90,7 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
              offer: build(:unconditional_offer))
     end
 
-    it 'renders a link to the change the offered course choice when the `change_offered_course` flag is active' do
-      FeatureFlag.activate(:support_user_change_offered_course)
-
+    it 'renders a link to the change the offered course choice' do
       result = render_inline(described_class.new(unconditional_offer))
 
       expect(result.css('.app-summary-card__actions a')[0].attr('href')).to include(
@@ -113,15 +100,6 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
         ),
       )
       expect(result.css('.app-summary-card__actions').text.strip).to include('Change offered course')
-    end
-
-    it 'does not render a link to the change the offered course choice when the`change_offered_course` flag is not active' do
-      FeatureFlag.deactivate(:support_user_change_offered_course)
-
-      render_inline(described_class.new(unconditional_offer))
-
-      expect(page).not_to have_selector '.app-summary-card__actions a'
-      expect(page).not_to have_text 'Change offered course'
     end
   end
 

--- a/spec/services/data_migrations/drop_support_user_change_offered_course_feature_flag_spec.rb
+++ b/spec/services/data_migrations/drop_support_user_change_offered_course_feature_flag_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::DropSupportUserChangeOfferedCourseFeatureFlag do
+  context 'when the feature flag exists' do
+    it 'removes the feature flag' do
+      create(:feature, name: 'support_user_change_offered_course')
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: 'support_user_change_offered_course')).to be_blank
+    end
+  end
+
+  context 'when the feature flag has already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end

--- a/spec/system/support_interface/change_offered_course_for_a_submitted_application_spec.rb
+++ b/spec/system/support_interface/change_offered_course_for_a_submitted_application_spec.rb
@@ -5,7 +5,6 @@ RSpec.feature 'Add course to submitted application' do
 
   scenario 'Support user adds course to submitted application' do
     given_i_am_a_support_user
-    and_the_change_offered_course_flag_is_active
     and_there_is_a_submitted_application_in_the_system_with_an_accepted_offer
     and_i_visit_the_support_page
 
@@ -42,10 +41,6 @@ RSpec.feature 'Add course to submitted application' do
 
   def given_i_am_a_support_user
     sign_in_as_support_user
-  end
-
-  def and_the_change_offered_course_flag_is_active
-    FeatureFlag.activate(:support_user_change_offered_course)
   end
 
   def and_there_is_a_submitted_application_in_the_system_with_an_accepted_offer


### PR DESCRIPTION
## Context

As part of the feature flag tidy up, we are removing the `support_user_changed_offered_course` feature flag as its been active in production for a while now.

## Changes proposed in this pull request

- Remove activation and deactivation of the feature flag in tests
- Remove tests for when feature flag is disabled
- Remove feature flag check in view 
- Remove feature flag check in controller
- Rename method
- Remove feature flag
-  Data migration to drop the `support_user_change_offered_course` feature flag

## Guidance to review

- Anything missing?

## Link to Trello card
https://trello.com/c/fECew8Ac/4489-remove-supportuserchangeofferedcourse-feature-flag

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
