### PR TITLE
Remove `region_from_postcode` feature flag

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -433,9 +433,7 @@ private
       )
     else
       GeocodeApplicationAddressWorker.perform_in(5.seconds, id)
-      if FeatureFlag.active?(:region_from_postcode)
-        LookupAreaByPostcodeWorker.perform_in(10.seconds, id)
-      end
+      LookupAreaByPostcodeWorker.perform_in(10.seconds, id)
     end
   end
 

--- a/app/services/data_migrations/drop_region_from_postcode_feature_flag.rb
+++ b/app/services/data_migrations/drop_region_from_postcode_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class DropRegionFromPostcodeFeatureFlag
+    TIMESTAMP = 20220302105929
+    MANUAL_RUN = false
+
+    def change
+      Feature.where(name: :region_from_postcode).first&.destroy
+    end
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -33,7 +33,6 @@ class FeatureFlag
     [:summer_recruitment_banner, 'Show a banner to indicate a shorter recruitment timeframe during summer', 'Richard Pattinson'],
     [:restructured_immigration_status, 'New model for right to work and study in the UK to be released from 2022 cycle', 'Steve Hook'],
     [:support_user_revert_withdrawn_offer, 'Allows a support user to revert an application withdrawn by the candidate', 'James Glenn'],
-    [:region_from_postcode, 'Uses an external service to find the region code for each candidate using their postcode', 'Steve Hook'],
     [:publish_monthly_statistics, 'Publish monthly statistics at publications/monthly-statistics', 'Duncan Brown'],
     [:draft_vendor_api_specification, 'The specification for Draft Vendor API v1.1', 'Abeer Salameh'],
     [:immigration_entry_date, 'Extends the restructured_immigration_status feature to include the "Date of entry into the UK" question', 'Steve Hook'],

--- a/app/workers/lookup_area_by_postcode_worker.rb
+++ b/app/workers/lookup_area_by_postcode_worker.rb
@@ -21,8 +21,6 @@ class LookupAreaByPostcodeWorker
   sidekiq_options queue: :low_priority, retry: 5
 
   def perform(application_form_id)
-    return unless FeatureFlag.active?(:region_from_postcode)
-
     application_form = ApplicationForm.find(application_form_id)
     return if application_form&.postcode.blank?
 

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -2,6 +2,7 @@ DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
   'DataMigrations::DropContentSecurityPolicyFeatureFlag',
   'DataMigrations::DropSupportUserChangeOfferedCourseFeatureFlag',
+  'DataMigrations::DropRegionFromPostcodeFeatureFlag',
   'DataMigrations::DropApplyAgainWithThreeChoicesFeatureFlag',
   'DataMigrations::DropPilotOpenFeatureFlag',
   'DataMigrations::BackfillChaseProviderDecisionSetting',

--- a/lib/tasks/region_code_backfill.rake
+++ b/lib/tasks/region_code_backfill.rake
@@ -5,8 +5,6 @@ end
 
 desc 'Generate mappings'
 task region_code_backfill: :environment do
-  raise '`region_from_postcode` feature flag must be enabled to run this task' unless FeatureFlag.active?(:region_from_postcode)
-
   next_batch_time = 1.minute.from_now
   ApplicationForm
     .where(region_code: nil)

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -161,7 +161,6 @@ RSpec.describe ApplicationForm do
       end
 
       context 'region from postcode' do
-
         it 'queues an LookupAreaByPostcodeWorker job for Westminster postcode' do
           application_form = create(:application_form)
 

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -160,10 +160,7 @@ RSpec.describe ApplicationForm do
         expect(application_form.reload.european_economic_area?).to be(true)
       end
 
-      context 'with `region_from_postcode` feature flag active' do
-        before do
-          FeatureFlag.activate(:region_from_postcode)
-        end
+      context 'region from postcode' do
 
         it 'queues an LookupAreaByPostcodeWorker job for Westminster postcode' do
           application_form = create(:application_form)
@@ -185,23 +182,6 @@ RSpec.describe ApplicationForm do
           )
 
           expect(LookupAreaByPostcodeWorker).to have_received(:perform_in).with(anything, application_form.id)
-        end
-      end
-
-      context 'with `region_from_postcode` feature flag inactive' do
-        before do
-          FeatureFlag.deactivate(:region_from_postcode)
-        end
-
-        it 'does not queue an LookupAreaByPostcodeWorker job for Westminster postcode' do
-          application_form = create(:application_form)
-
-          application_form.update!(
-            address_type: :uk,
-            postcode: 'SW1P 3BT',
-          )
-
-          expect(LookupAreaByPostcodeWorker).not_to have_received(:perform_in).with(application_form.id)
         end
       end
     end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe ApplicationForm do
         expect(application_form.reload.european_economic_area?).to be(true)
       end
 
-      context 'region from postcode' do
+      describe 'region from postcode' do
         it 'queues an LookupAreaByPostcodeWorker job for Westminster postcode' do
           application_form = create(:application_form)
 

--- a/spec/requests/vendor_api/v1.0/post_test_data_generate_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_test_data_generate_spec.rb
@@ -3,8 +3,6 @@ require 'rails_helper'
 RSpec.describe 'Vendor API - POST /api/v1/test-data/generate', type: :request, sidekiq: true do
   include VendorAPISpecHelpers
 
-  before { FeatureFlag.activate(:region_from_postcode) }
-
   it 'generates test data' do
     create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
 

--- a/spec/requests/vendor_api/v1.0/post_test_data_regenerate_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_test_data_regenerate_spec.rb
@@ -3,8 +3,6 @@ require 'rails_helper'
 RSpec.describe 'Vendor API - POST /api/v1/test-data/regenerate', type: :request, sidekiq: true do
   include VendorAPISpecHelpers
 
-  before { FeatureFlag.activate(:region_from_postcode) }
-
   it 'returns an error' do
     post_api_request '/api/v1/test-data/regenerate'
 

--- a/spec/services/data_migrations/drop_region_from_postcode_feature_flag_spec.rb
+++ b/spec/services/data_migrations/drop_region_from_postcode_feature_flag_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::DropRegionFromPostcodeFeatureFlag do
+  context 'when the feature flag exists' do
+    it 'removes the feature flag' do
+      create(:feature, name: 'region_from_postcode')
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: 'region_from_postcode')).to be_blank
+    end
+  end
+
+  context 'when the feature flag has already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end

--- a/spec/workers/lookup_area_by_postcode_worker_spec.rb
+++ b/spec/workers/lookup_area_by_postcode_worker_spec.rb
@@ -10,25 +10,7 @@ RSpec.describe LookupAreaByPostcodeWorker do
     allow(api).to receive(:lookup).and_return(result)
   end
 
-  context 'with `region_from_postcode` feature flag inactive' do
-    before do
-      FeatureFlag.deactivate(:region_from_postcode)
-    end
-
-    context 'when the API returns an English region' do
-      it 'updates the region code' do
-        described_class.new.perform(application_form.id)
-        expect(application_form.reload.region_code).to be_nil
-        expect(api).not_to have_received(:lookup)
-      end
-    end
-  end
-
-  context 'with `region_from_postcode` feature flag active' do
-    before do
-      FeatureFlag.activate(:region_from_postcode)
-    end
-
+  context 'region from postcode' do
     context 'when the API returns an English region' do
       before do
         allow(result).to receive(:region).and_return('South West')

--- a/spec/workers/lookup_area_by_postcode_worker_spec.rb
+++ b/spec/workers/lookup_area_by_postcode_worker_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe LookupAreaByPostcodeWorker do
     allow(api).to receive(:lookup).and_return(result)
   end
 
-  context 'region from postcode' do
+  describe 'region from postcode' do
     context 'when the API returns an English region' do
       before do
         allow(result).to receive(:region).and_return('South West')


### PR DESCRIPTION
## Context

As part of the feature flag tidy up, we are removing the `region_from_postcode` feature flag as its been active in production for a while now.

## Changes proposed in this pull request

- Remove all logic associated with the feature flag 
- Remove the `region_from_postcode`  feature flag
- Data migration to drop the `region_from_postcode` feature flag

## Guidance to review

Anything missing?

## Link to Trello card

https://trello.com/c/jm5XAfKE/4493-remove-regionfrompostcode-feature-flag

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
