### PR TITLE
Reset contact details completed when invalid

### DIFF
--- a/app/controllers/candidate_interface/contact_details/address_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_controller.rb
@@ -7,7 +7,10 @@ module CandidateInterface
     end
 
     def create
-      @contact_details_form = form_from_params
+      @contact_details_form = ContactDetailsForm.build_from_application(
+        current_application,
+      )
+      @contact_details_form.assign_attributes(contact_details_params)
 
       if @contact_details_form.save_address(current_application)
         redirect_to candidate_interface_contact_information_review_path
@@ -23,8 +26,10 @@ module CandidateInterface
     end
 
     def update
-      @contact_details_form = form_from_params
-      @return_to = return_to_after_edit(default: candidate_interface_contact_information_review_path)
+      @contact_details_form = ContactDetailsForm.build_from_application(
+        current_application,
+      )
+      @contact_details_form.assign_attributes(contact_details_params)
 
       if @contact_details_form.save_address(current_application)
         redirect_to @return_to[:back_path]
@@ -38,14 +43,6 @@ module CandidateInterface
 
     def load_contact_form
       ContactDetailsForm.build_from_application(current_application)
-    end
-
-    def form_from_params
-      ContactDetailsForm.new(
-        contact_details_params.merge(
-          address_type: current_application.address_type,
-        ),
-      )
     end
 
     def contact_details_params

--- a/app/controllers/candidate_interface/contact_details/address_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_controller.rb
@@ -26,9 +26,8 @@ module CandidateInterface
     end
 
     def update
-      @contact_details_form = ContactDetailsForm.build_from_application(
-        current_application,
-      )
+      @contact_details_form = ContactDetailsForm.build_from_application(current_application)
+      @return_to = return_to_after_edit(default: candidate_interface_contact_information_review_path)
       @contact_details_form.assign_attributes(contact_details_params)
 
       if @contact_details_form.save_address(current_application)

--- a/app/controllers/candidate_interface/contact_details/address_type_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_type_controller.rb
@@ -7,9 +7,7 @@ module CandidateInterface
     end
 
     def create
-      @contact_details_form = ContactDetailsForm.build_from_application(
-        current_application,
-      )
+      @contact_details_form = ContactDetailsForm.build_from_application(current_application)
       @contact_details_form.assign_attributes(address_type_params)
 
       if @contact_details_form.save_address_type(current_application)

--- a/app/controllers/candidate_interface/contact_details/address_type_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_type_controller.rb
@@ -7,7 +7,10 @@ module CandidateInterface
     end
 
     def create
-      @contact_details_form = ContactDetailsForm.new(address_type_params)
+      @contact_details_form = ContactDetailsForm.build_from_application(
+        current_application,
+      )
+      @contact_details_form.assign_attributes(address_type_params)
 
       if @contact_details_form.save_address_type(current_application)
         redirect_to candidate_interface_new_address_path
@@ -23,7 +26,10 @@ module CandidateInterface
     end
 
     def update
-      @contact_details_form = form_from_params
+      @contact_details_form = ContactDetailsForm.build_from_application(
+        current_application,
+      )
+      @contact_details_form.assign_attributes(address_type_params)
       @return_to = return_to_after_edit(default: candidate_interface_personal_details_complete_path)
 
       if @contact_details_form.save_address_type(current_application)
@@ -40,10 +46,6 @@ module CandidateInterface
 
     def load_contact_form
       ContactDetailsForm.build_from_application(current_application)
-    end
-
-    def form_from_params
-      ContactDetailsForm.new(address_type_params)
     end
 
     def address_type_params

--- a/app/controllers/candidate_interface/contact_details/phone_number_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/phone_number_controller.rb
@@ -7,7 +7,8 @@ module CandidateInterface
     end
 
     def create
-      @contact_details_form = form_from_params
+      @contact_details_form = ContactDetailsForm.build_from_application(current_application)
+      @contact_details_form.assign_attributes(contact_details_params)
 
       if @contact_details_form.save_base(current_application)
         redirect_to candidate_interface_new_address_type_path
@@ -23,7 +24,9 @@ module CandidateInterface
     end
 
     def update
-      @contact_details_form = form_from_params
+      @contact_details_form = ContactDetailsForm.build_from_application(current_application)
+      @contact_details_form.assign_attributes(contact_details_params)
+
       @return_to = return_to_after_edit(default: candidate_interface_contact_information_review_path)
 
       if @contact_details_form.save_base(current_application)
@@ -38,10 +41,6 @@ module CandidateInterface
 
     def load_contact_form
       ContactDetailsForm.build_from_application(current_application)
-    end
-
-    def form_from_params
-      ContactDetailsForm.new(contact_details_params)
     end
 
     def contact_details_params

--- a/app/controllers/candidate_interface/contact_details/review_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/review_controller.rb
@@ -4,6 +4,7 @@ module CandidateInterface
 
     def show
       @application_form = current_application
+      @can_complete = ContactDetailsForm.build_from_application(current_application).valid_for_submission?
       @section_complete_form = SectionCompleteForm.new(
         completed: current_application.contact_details_completed,
       )

--- a/app/controllers/candidate_interface/contact_details/review_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/review_controller.rb
@@ -31,7 +31,7 @@ module CandidateInterface
     end
 
     def details_complete?
-      contact_details_form.valid?(:address) && contact_details_form.valid?(:base)
+      contact_details_form.valid_for_submission?
     end
 
     def contact_details_form

--- a/app/forms/candidate_interface/contact_details_form.rb
+++ b/app/forms/candidate_interface/contact_details_form.rb
@@ -107,6 +107,8 @@ module CandidateInterface
   private
 
     def save(application_form, attributes)
+      attributes[:postcode] = nil if international?
+
       unless valid_for_submission?
         attributes = attributes.merge(contact_details_completed: false)
       end

--- a/app/forms/candidate_interface/contact_details_form.rb
+++ b/app/forms/candidate_interface/contact_details_form.rb
@@ -59,7 +59,7 @@ module CandidateInterface
       return false unless valid?(:address_type)
 
       save(
-        application_form, 
+        application_form,
         address_type: address_type,
         country: country,
       )

--- a/app/forms/candidate_interface/contact_details_form.rb
+++ b/app/forms/candidate_interface/contact_details_form.rb
@@ -38,7 +38,7 @@ module CandidateInterface
     def save_base(application_form)
       return false unless valid?(:base)
 
-      application_form.update(phone_number: phone_number)
+      save(application_form, phone_number: phone_number)
     end
 
     def save_address(application_form)
@@ -52,13 +52,14 @@ module CandidateInterface
         postcode: postcode&.upcase,
       }
       attrs[:country] = 'GB' if uk?
-      application_form.update(attrs)
+      save(application_form, attrs)
     end
 
     def save_address_type(application_form)
       return false unless valid?(:address_type)
 
-      application_form.update(
+      save(
+        application_form, 
         address_type: address_type,
         country: country,
       )
@@ -101,6 +102,15 @@ module CandidateInterface
 
     def valid_for_submission?
       all_errors.blank?
+    end
+
+  private
+
+    def save(application_form, attributes)
+      unless valid_for_submission?
+        attributes = attributes.merge(contact_details_completed: false)
+      end
+      application_form.update(attributes)
     end
   end
 end

--- a/app/views/candidate_interface/contact_details/review/show.html.erb
+++ b/app/views/candidate_interface/contact_details/review/show.html.erb
@@ -12,6 +12,9 @@
   </h1>
 
   <%= render CandidateInterface::ContactDetailsReviewComponent.new(application_form: @application_form) %>
-  <%= render CandidateInterface::CompleteSectionComponent.new(form: f) %>
-  <%= f.govuk_submit t('continue') %>
+
+  <% if @can_complete %>
+    <%= render CandidateInterface::CompleteSectionComponent.new(form: f) %>
+    <%= f.govuk_submit t('continue') %>
+  <% end %>
 <% end %>

--- a/spec/forms/candidate_interface/contact_details_form_spec.rb
+++ b/spec/forms/candidate_interface/contact_details_form_spec.rb
@@ -110,6 +110,48 @@ RSpec.describe CandidateInterface::ContactDetailsForm, type: :model do
 
       expect(contact_details.save_address_type(application_form)).to be(false)
     end
+
+    it 'resets the `contact_details_completed` flag if data is incomplete' do
+      form_data = {
+        address_type: 'uk',
+        phone_number: '0123456789',
+        address_line1: '123 Long Road',
+      }
+      application_form = create(
+        :application_form,
+        phone_number: '0123456789',
+        address_type: 'international',
+        address_line1: '123 Long Road',
+        contact_details_completed: true,
+      )
+      contact_details = described_class.new(form_data)
+
+      expect(contact_details.save_address_type(application_form)).to be(true)
+      expect(application_form.reload.contact_details_completed).to be(false)
+    end
+
+    it 'preserves the `contact_details_completed` flag if data is complete' do
+      form_data = {
+        address_type: 'uk',
+        phone_number: '0123456789',
+        address_line1: '123 Long Road',
+        address_line3: 'Bigtown',
+        postcode: 'BN1 1BN',
+      }
+      application_form = create(
+        :application_form,
+        phone_number: '0123456789',
+        address_type: 'international',
+        address_line1: '123 Long Road',
+        address_line3: 'Bigtown',
+        postcode: 'BN1 1BN',
+        contact_details_completed: true,
+      )
+      contact_details = described_class.new(form_data)
+
+      expect(contact_details.save_address_type(application_form)).to be(true)
+      expect(application_form.reload.contact_details_completed).to be(true)
+    end
   end
 
   describe 'validations' do

--- a/spec/forms/candidate_interface/contact_details_form_spec.rb
+++ b/spec/forms/candidate_interface/contact_details_form_spec.rb
@@ -152,6 +152,28 @@ RSpec.describe CandidateInterface::ContactDetailsForm, type: :model do
       expect(contact_details.save_address_type(application_form)).to be(true)
       expect(application_form.reload.contact_details_completed).to be(true)
     end
+
+    it 'resets the postcode to nil if changing a UK address to international' do
+      form_data = {
+        address_type: 'international',
+        country: 'FR',
+      }
+      application_form = create(
+        :application_form,
+        phone_number: '0123456789',
+        address_type: 'international',
+        address_line1: '123 Long Road',
+        address_line3: 'Bigtown',
+        postcode: 'BN1 1BN',
+      )
+      contact_details = described_class.new(form_data)
+
+      expect(contact_details.save_address_type(application_form)).to be(true)
+      expect(application_form.reload.address_type).to eq('international')
+      expect(application_form.country).to eq('FR')
+      expect(application_form.address_line1).to eq('123 Long Road')
+      expect(application_form.postcode).to be_nil
+    end
   end
 
   describe 'validations' do

--- a/spec/system/candidate_interface/entering_details/candidate_changes_contact_details_address_from_international_to_uk_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_changes_contact_details_address_from_international_to_uk_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'Candidate updates their contact information from an international
 
     when_i_change_to_an_international_address
     and_i_click_the_back_button
-    then_i_see_my_contact_details_are_incomplete
+    then_i_do_not_have_the_option_to_complete
   end
 
   def given_i_am_signed_in
@@ -54,7 +54,8 @@ RSpec.feature 'Candidate updates their contact information from an international
     click_link 'Back'
   end
 
-  def then_i_see_my_contact_details_are_incomplete
-    expect(find_field('Yes, I have completed this section')).not_to be_checked
+  def then_i_do_not_have_the_option_to_complete
+    expect(page).not_to have_field('Yes, I have completed this section')
+    expect(page).not_to have_button('Continue')
   end
 end

--- a/spec/system/candidate_interface/entering_details/candidate_changes_contact_details_address_from_international_to_uk_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_changes_contact_details_address_from_international_to_uk_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate updates their contact information from an international address to a UK' do
+  include CandidateHelper
+
+  scenario 'Candidate submits their contact information' do
+    given_i_am_signed_in
+    and_i_have_already_filled_in_an_international_address
+    and_i_visit_the_site
+
+    when_i_click_on_contact_information
+    then_i_see_my_contact_details_are_complete
+
+    when_i_change_to_an_international_address
+    and_i_click_the_back_button
+    then_i_see_my_contact_details_are_incomplete
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_have_already_filled_in_an_international_address
+    current_candidate.current_application.update(
+      phone_number: '+123 456 7890',
+      address_type: 'international',
+      address_line1: '1 Big Road',
+      address_line3: 'Small Town',
+      country: 'FR',
+      postcode: nil,
+      contact_details_completed: true,
+    )
+  end
+
+  def and_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def when_i_click_on_contact_information
+    click_link t('page_titles.contact_information')
+  end
+
+  def then_i_see_my_contact_details_are_complete
+    expect(find_field('Yes, I have completed this section')).to be_checked
+  end
+
+  def when_i_change_to_an_international_address
+    click_link('Change address')
+    choose('In the UK')
+    click_button('Save and continue')
+  end
+
+  def and_i_click_the_back_button
+    click_link 'Back'
+  end
+
+  def then_i_see_my_contact_details_are_incomplete
+    expect(find_field('Yes, I have completed this section')).not_to be_checked
+  end
+end

--- a/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
@@ -46,9 +46,6 @@ RSpec.feature 'Entering their contact information' do
     and_i_submit_my_address
     then_i_can_check_my_revised_address
 
-    when_i_submit_my_details
-    then_i_see_a_section_complete_error
-
     when_i_mark_the_section_as_completed
     and_i_submit_my_details
     then_i_should_see_the_form
@@ -203,10 +200,6 @@ RSpec.feature 'Entering their contact information' do
 
   def when_i_submit_my_details
     and_i_submit_my_details
-  end
-
-  def then_i_see_a_section_complete_error
-    expect(page).to have_content t('activemodel.errors.models.candidate_interface/section_complete_form.attributes.completed.blank')
   end
 
   def then_i_should_see_the_form

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_contact_details_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_contact_details_section_spec.rb
@@ -16,8 +16,7 @@ RSpec.feature 'Candidate is redirected correctly' do
     when_i_enter_a_phone_number_and_submit
     then_i_should_see_the_contact_information_review_page
 
-    when_i_select_section_complete_and_submit
-    then_i_should_see_a_message_saying_that_details_are_incomplete
+    then_i_should_not_see_the_complete_form
 
     when_i_set_my_address
     and_i_select_section_complete_and_submit
@@ -84,15 +83,14 @@ RSpec.feature 'Candidate is redirected correctly' do
     expect(page).to have_current_path(candidate_interface_contact_information_review_path)
   end
 
-  def when_i_select_section_complete_and_submit
+  def and_i_select_section_complete_and_submit
     choose t('application_form.completed_radio')
     click_button t('continue')
   end
-  alias_method :and_i_select_section_complete_and_submit, :when_i_select_section_complete_and_submit
 
-  def then_i_should_see_a_message_saying_that_details_are_incomplete
-    expect(page).to have_current_path(candidate_interface_contact_information_review_path)
-    expect(page).to have_content('You cannot mark this section complete with incomplete contact details.')
+  def then_i_should_not_see_the_complete_form
+    expect(page).not_to have_field(t('application_form.completed_radio'))
+    expect(page).not_to have_button(t('save_and_continue'))
   end
 
   def when_i_set_my_address


### PR DESCRIPTION
## Context

If the candidate invalidates their contact details, e.g. by switching
from international to uk without entering a `postcode` then we should
reset the `contact_details_completed` attribute to false.

## Changes proposed in this pull request

- [x] Reset contact details at the point of saving in `ContactDetailsForm`.
- [x] Refactor `ContactDetailsForm` to permit us to validate the whole of contact details.
- [x] Reset postcode when switching address type from UK to International.

<img width="1106" alt="image" src="https://user-images.githubusercontent.com/450843/157244359-4ea9d01d-ff65-4e47-b465-08a664353622.png">

## Guidance to review



## Link to Trello card

https://trello.com/c/xTS5cO2C/4482-fix-issues-with-contact-details-flow

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
