### PR TITLE
Remove `publish_monthly_statistics` feature flag

### DIFF
--- a/app/controllers/publications/monthly_statistics_controller.rb
+++ b/app/controllers/publications/monthly_statistics_controller.rb
@@ -1,6 +1,5 @@
 module Publications
   class MonthlyStatisticsController < ApplicationController
-    before_action :redirect_unless_published
     rescue_from ActiveRecord::RecordNotFound, with: :render_404
 
     def show
@@ -18,10 +17,6 @@ module Publications
       header_row = raw_data['rows'].first.keys
       data = SafeCSV.generate(raw_data['rows'].map(&:values), header_row)
       send_data data, filename: export_filename, disposition: :attachment
-    end
-
-    def redirect_unless_published
-      redirect_to root_path unless FeatureFlag.active?(:publish_monthly_statistics)
     end
 
     def calculate_download_sizes(report)

--- a/app/services/data_migrations/drop_publish_monthly_statistics_feature_flag.rb
+++ b/app/services/data_migrations/drop_publish_monthly_statistics_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class DropPublishMonthlyStatisticsFeatureFlag
+    TIMESTAMP = 20220302134920
+    MANUAL_RUN = false
+
+    def change
+      Feature.where(name: :publish_monthly_statistics).first&.destroy
+    end
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -33,7 +33,6 @@ class FeatureFlag
     [:summer_recruitment_banner, 'Show a banner to indicate a shorter recruitment timeframe during summer', 'Richard Pattinson'],
     [:restructured_immigration_status, 'New model for right to work and study in the UK to be released from 2022 cycle', 'Steve Hook'],
     [:support_user_revert_withdrawn_offer, 'Allows a support user to revert an application withdrawn by the candidate', 'James Glenn'],
-    [:publish_monthly_statistics, 'Publish monthly statistics at publications/monthly-statistics', 'Duncan Brown'],
     [:draft_vendor_api_specification, 'The specification for Draft Vendor API v1.1', 'Abeer Salameh'],
     [:immigration_entry_date, 'Extends the restructured_immigration_status feature to include the "Date of entry into the UK" question', 'Steve Hook'],
     [:change_course_details_before_offer, 'Allows providers to change course choice details before the point of offer', 'James Glenn'],

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -3,6 +3,7 @@ DATA_MIGRATION_SERVICES = [
   'DataMigrations::DropContentSecurityPolicyFeatureFlag',
   'DataMigrations::DropSupportUserChangeOfferedCourseFeatureFlag',
   'DataMigrations::DropRegionFromPostcodeFeatureFlag',
+  'DataMigrations::DropPublishMonthlyStatisticsFeatureFlag',
   'DataMigrations::DropApplyAgainWithThreeChoicesFeatureFlag',
   'DataMigrations::DropPilotOpenFeatureFlag',
   'DataMigrations::BackfillChaseProviderDecisionSetting',

--- a/spec/requests/publications/monthly_statistics_spec.rb
+++ b/spec/requests/publications/monthly_statistics_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe 'Monthly Statistics', type: :request do
   end
 
   before do
-    FeatureFlag.activate(:publish_monthly_statistics)
     generate_statistics_test_data
 
     report = Publications::MonthlyStatistics::MonthlyStatisticsReport.new(month: '2021-11')

--- a/spec/services/data_migrations/drop_publish_monthly_statistics_feature_flag_spec.rb
+++ b/spec/services/data_migrations/drop_publish_monthly_statistics_feature_flag_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::DropPublishMonthlyStatisticsFeatureFlag do
+  context 'when the feature flag exists' do
+    it 'removes the feature flag' do
+      create(:feature, name: 'publish_monthly_statistics')
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: 'publish_monthly_statistics')).to be_blank
+    end
+  end
+
+  context 'when the feature flag has already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end

--- a/spec/system/monthly_statistics/monthly_statistics_page_spec.rb
+++ b/spec/system/monthly_statistics/monthly_statistics_page_spec.rb
@@ -11,7 +11,6 @@ RSpec.feature 'Monthly statistics page', mid_cycle: false do
 
   before do
     allow(MonthlyStatisticsTimetable).to receive(:generate_monthly_statistics?).and_return true
-    FeatureFlag.activate('publish_monthly_statistics')
     generate_statistics_test_data
     create_monthly_stats_report
   end


### PR DESCRIPTION
## Context

As part of the feature flag tidy up, we are removing the `publish_monthly_statistics` feature flag as its been active in production for a while now.

## Changes proposed in this pull request

- Remove all logic associated with the feature flag 
- Remove the `publish_monthly_statistics`  feature flag
- Data migration to drop the `publish_monthly_statistics` feature flag

## Guidance to review

Anything missing?

## Link to Trello card

https://trello.com/c/EGHDW8Ql/4496-remove-publishmonthlystatistics-feature-flag

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
