### PR TITLE
Change conditions not met to standard button class

### DIFF
--- a/app/components/provider_interface/individual_condition_status_review_component.html.erb
+++ b/app/components/provider_interface/individual_condition_status_review_component.html.erb
@@ -14,7 +14,7 @@
   </p>
 <% end %>
 
-<%= govuk_button_to confirm_button_text, provider_interface_condition_statuses_path(application_choice), method: :patch, class: confirm_button_class %>
+<%= govuk_button_to confirm_button_text, provider_interface_condition_statuses_path(application_choice), method: :patch %>
 
 <p class="govuk-body">
   <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(application_choice), no_visited_state: true %>

--- a/app/components/provider_interface/individual_condition_status_review_component.rb
+++ b/app/components/provider_interface/individual_condition_status_review_component.rb
@@ -26,9 +26,5 @@ module ProviderInterface
         'Update status'
       end
     end
-
-    def confirm_button_class
-      'govuk-button--warning' if form_object.any_condition_not_met?
-    end
   end
 end

--- a/spec/components/provider_interface/individual_condition_status_review_component_spec.rb
+++ b/spec/components/provider_interface/individual_condition_status_review_component_spec.rb
@@ -18,8 +18,7 @@ RSpec.describe ProviderInterface::IndividualConditionStatusReviewComponent do
       expect(render.css('h1').text).to eq('Check and update status of conditions')
     end
 
-    it 'shows the correct button text without the warning class' do
-      expect(render.css('input .govuk-button--warning')).to be_empty
+    it 'shows the correct button text' do
       expect(render.css('input[type="submit"]').first['value']).to eq('Update status')
     end
   end
@@ -31,8 +30,7 @@ RSpec.describe ProviderInterface::IndividualConditionStatusReviewComponent do
       expect(render.css('h1').text).to eq('Check your changes and mark conditions as met')
     end
 
-    it 'shows the correct button text without the warning class' do
-      expect(render.css('input .govuk-button--warning')).to be_empty
+    it 'shows the correct button text' do
       expect(render.css('input[type="submit"]').first['value']).to eq('Mark conditions as met and tell candidate')
     end
   end
@@ -44,8 +42,8 @@ RSpec.describe ProviderInterface::IndividualConditionStatusReviewComponent do
       expect(render.css('h1').text).to eq('Check your changes and mark conditions as not met')
     end
 
-    it 'shows the correct button text with the warning class' do
-      expect(render.css('.govuk-button--warning').css('input[type="submit"]').first['value']).to eq('Mark conditions as not met')
+    it 'shows the correct button text' do
+      expect(render.css('.govuk-button').css('input[type="submit"]').first['value']).to eq('Mark conditions as not met')
     end
 
     it 'shows the information text about the status of the application' do


### PR DESCRIPTION
## Context

https://trello.com/c/9OSOEFWO/4802-changing-the-way-we-use-red-warning-buttons

## Changes proposed in this pull request

| OLD | NEW |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/25597009/156407680-7d85177d-9657-4f5a-b66f-dfc2876f6687.png)| ![image](https://user-images.githubusercontent.com/25597009/156407890-ace3c80e-ac89-427d-b54a-8d50f46cf0c8.png) |

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
