### PR TITLE
Add application number to candidate interface

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -30,6 +30,7 @@ module CandidateInterface
     def course_choice_rows(application_choice)
       [
         course_row(application_choice),
+        application_number_row(application_choice),
         study_mode_row(application_choice),
         location_row(application_choice),
         type_row(application_choice),
@@ -123,6 +124,15 @@ module CandidateInterface
       }
     end
 
+    def application_number_row(application_choice)
+      return if application_choice.unsubmitted?
+
+      {
+        key: 'Application number',
+        value: application_choice.id,
+      }
+    end
+
     def course_row_value(application_choice)
       if CycleTimetable.find_down?
         "#{application_choice.current_course.name} (#{application_choice.current_course.code})"
@@ -195,7 +205,7 @@ module CandidateInterface
     end
 
     def degree_required_row(application_choice)
-      return nil unless application_choice.current_course.degree_grade?
+      return unless application_choice.current_course.degree_grade?
 
       {
         key: 'Degree requirements',
@@ -204,9 +214,9 @@ module CandidateInterface
     end
 
     def gcse_required_row(application_choice)
-      return nil unless candidate_has_pending_or_missing_gcses?(application_choice) &&
-                        !application_choice.current_course.accept_pending_gcse.nil? &&
-                        !application_choice.current_course.accept_gcse_equivalency.nil?
+      return unless candidate_has_pending_or_missing_gcses?(application_choice) &&
+                    !application_choice.current_course.accept_pending_gcse.nil? &&
+                    !application_choice.current_course.accept_gcse_equivalency.nil?
 
       {
         key: 'GCSE requirements',
@@ -224,9 +234,9 @@ module CandidateInterface
     end
 
     def visa_details_row(application_choice)
-      return nil if immigration_right_to_work?(application_choice) ||
-                    application_predates_visa_sponsorship_information?(application_choice) ||
-                    !FeatureFlag.active?(:restructured_immigration_status)
+      return if immigration_right_to_work?(application_choice) ||
+                application_predates_visa_sponsorship_information?(application_choice) ||
+                !FeatureFlag.active?(:restructured_immigration_status)
 
       {
         key: 'Visa sponsorship',
@@ -253,7 +263,7 @@ module CandidateInterface
     end
 
     def offer_withdrawal_reason_row(application_choice)
-      return nil unless application_choice.offer_withdrawn?
+      return unless application_choice.offer_withdrawn?
 
       if application_choice.offer_withdrawal_reason.present?
         {
@@ -264,7 +274,7 @@ module CandidateInterface
     end
 
     def rejection_reasons_row(application_choice)
-      return nil unless application_choice.rejected?
+      return unless application_choice.rejected?
 
       if application_choice.structured_rejection_reasons.present?
         {

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true do
+RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true, type: :component do
   context 'when course choices are editable' do
     let(:application_form) do
       create_application_form_with_course_choices(statuses: %w[unsubmitted])
@@ -17,6 +17,12 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true
       expect(result.css('.govuk-summary-list__value').to_html).to include('1 year')
       expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.course.start_date.to_s(:month_and_year))
       expect(result.css('a').to_html).to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course.code}")
+    end
+
+    it 'does not show the application number' do
+      render_inline(described_class.new(application_form: application_form))
+
+      expect(rendered_component).not_to include 'Application number'
     end
 
     context 'when Find is down' do
@@ -220,6 +226,14 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true
       result = render_inline(described_class.new(application_form: application_form, editable: false))
 
       expect(result.css('.app-summary-card__actions').text).not_to include(t('application_form.courses.delete'))
+    end
+
+    it 'shows the application number' do
+      application_form = create_application_form_with_course_choices(statuses: %w[awaiting_provider_decision])
+      render_inline(described_class.new(application_form: application_form, editable: false))
+
+      expect(rendered_component).to include 'Application number'
+      expect(rendered_component).to include application_form.application_choices.first.id.to_s
     end
 
     context 'When multiple courses available at a provider' do


### PR DESCRIPTION
This only shows up in the detailed application review, not the dashboard, and only once the application has been submitted.

We have learnt that some downstream services may ask candidates for a reference, eg when filling in forms for providers. Ideally we’d ask those services to remove this requirement (especially if it's still asking for a 10 digit UCAS reference), but in the meantime this provides candidates with a way to see their reference.

We’re showing a reference per application choice, not per candidate or per application, for alignment with the provider-facing interface, and to avoid confusing candidates with other forms of personal identifier they will get later – eg a Teacher Reference Number (TRN).

See:

* ➡️ [Preview application](https://apply-review-6619.london.cloudapps.digital)
* 🗂️ [Trello card](https://trello.com/c/RBZiKi3O/4464-surface-application-choice-id-next-to-application-choices-on-apply)
* 🏫   [Replacing reference number and candidate ID with application number](https://bat-design-history.netlify.app/manage-teacher-training-applications/replacing-reference-number-and-candidate-id-with-application-number/)

## Screenshot

<img width="983" alt="Screenshot 2022-03-03 at 10 40 31" src="https://user-images.githubusercontent.com/30665/156549412-118ac1d8-0675-41e8-b951-ab4b8b5e8e98.png">

