### PR TITLE
Use standard Rails logger in development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,7 @@ gem 'yabeda-prometheus'
 # Logging
 gem 'request_store_rails'
 gem 'request_store-sidekiq'
-gem 'rails_semantic_logger', group: %w[development production]
+gem 'rails_semantic_logger', group: %w[production]
 
 # Background processing
 gem 'sidekiq'

--- a/Gemfile
+++ b/Gemfile
@@ -166,5 +166,4 @@ group :development, :test do
   gem 'pry-rails'
   gem 'bullet'
   gem 'parallel_tests'
-  gem 'amazing_print'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,6 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     aes_key_wrap (1.1.0)
-    amazing_print (1.4.0)
     anyway_config (2.2.2)
       ruby-next-core (>= 0.11.0)
     ar-sequence (0.2.1)
@@ -710,7 +709,6 @@ PLATFORMS
 DEPENDENCIES
   active_hash
   activerecord-cte
-  amazing_print
   ar-sequence
   archive-zip
   audited!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -70,13 +70,7 @@ Rails.application.configure do
 
   # Logging configuration
   config.log_level = :debug
-  config.rails_semantic_logger.started = true
-  config.rails_semantic_logger.processing = true
-  config.rails_semantic_logger.rendered = true
-
-  config.rails_semantic_logger.format = :color
-
-  config.semantic_logger.backtrace_level = :info
+  config.logger = ActiveSupport::Logger.new(STDOUT)
 
   config.x.read_only_database_url = "postgres://localhost/bat_apply_development"
 end


### PR DESCRIPTION
Standard Rails logger (`ActiveSupport::Logger`) is easier to read, and debug, I think?

Open to discussion!

## Before

<img width="1123" alt="Screenshot 2022-03-03 at 11 20 42" src="https://user-images.githubusercontent.com/30665/156555017-646631ad-a971-4cbd-8d5b-0eec879e9667.png">

## After

<img width="1123" alt="Screenshot 2022-03-03 at 11 20 07" src="https://user-images.githubusercontent.com/30665/156554970-47a276d4-1500-450e-862c-acdb2cbd9a81.png">

(Not sure why there’s such a gap between `web.1` and the `|` character. Any ideas?)