### PR TITLE
Course Change - Add the location wizard

### DIFF
--- a/app/components/provider_interface/change_course_details_component.rb
+++ b/app/components/provider_interface/change_course_details_component.rb
@@ -7,9 +7,9 @@ module ProviderInterface
 
     attr_reader :application_choice, :provider_name_and_code, :course_name_and_code,
                 :cycle, :preferred_location, :study_mode, :qualification, :available_providers,
-                :available_courses, :course
+                :available_courses, :course, :available_course_options
 
-    def initialize(application_choice:, course: nil, available_providers: [], available_courses: [])
+    def initialize(application_choice:, course: nil, available_providers: [], available_courses: [], available_course_options: [])
       @application_choice = application_choice
       @provider_name_and_code = application_choice.provider.name_and_code
       @course_name_and_code = application_choice.course.name_and_code
@@ -20,6 +20,7 @@ module ProviderInterface
       @available_providers = available_providers
       @available_courses = available_courses
       @course = course
+      @available_course_options = available_course_options
     end
 
     def rows
@@ -28,7 +29,7 @@ module ProviderInterface
         { key: 'Course', value: course_name_and_code, action: { href: change_course_path } },
         { key: 'Cycle', value: cycle },
         { key: 'Full or part time', value: study_mode, action: { href: change_study_mode_path } },
-        { key: 'Location', value: preferred_location },
+        { key: 'Location', value: preferred_location, action: { href: change_location_path } },
         { key: 'Accredited body', value: accredited_body },
         { key: 'Qualification', value: qualification },
         { key: 'Funding type', value: funding_type },
@@ -70,6 +71,10 @@ module ProviderInterface
 
     def change_study_mode_path
       course.full_time_or_part_time? ? edit_provider_interface_application_choice_course_study_modes_path(application_choice) : nil
+    end
+
+    def change_location_path
+      available_course_options.length > 1 ? edit_provider_interface_application_choice_course_locations_path(application_choice) : nil
     end
   end
 end

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -52,6 +52,7 @@ module ProviderInterface
 
       @available_training_providers = available_training_providers
       @available_courses = available_courses
+      @available_course_options = available_course_options
     end
 
     def timeline; end
@@ -86,6 +87,10 @@ module ProviderInterface
 
     def available_courses
       query_service.available_courses(provider: @application_choice.current_provider)
+    end
+
+    def available_course_options
+      query_service.available_course_options(course: @application_choice.course, study_mode: @application_choice.course.study_mode)
     end
 
     def query_service

--- a/app/controllers/provider_interface/courses/locations_controller.rb
+++ b/app/controllers/provider_interface/courses/locations_controller.rb
@@ -1,0 +1,37 @@
+module ProviderInterface
+  module Courses
+    class LocationsController < CoursesController
+      def edit
+        @wizard = CourseWizard.new(change_course_store, { current_step: 'locations', action: action })
+        @wizard.save_state!
+
+        @course_options = available_course_options(@wizard.course_id, @wizard.study_mode).includes([:site])
+      end
+
+      def update
+        @wizard = CourseWizard.new(change_course_store, attributes_for_wizard)
+
+        if @wizard.valid_for_current_step?
+          @wizard.save_state!
+
+          redirect_to provider_interface_application_choice_path(@application_choice)
+        else
+          @course_options = available_course_options(@wizard.course_id, @wizard.study_mode)
+          track_validation_error(@wizard)
+
+          render :edit
+        end
+      end
+
+    private
+
+      def course_option_params
+        params.require(:provider_interface_course_wizard).permit(:course_option_id)
+      end
+
+      def attributes_for_wizard
+        course_option_params.to_h.merge!(current_step: 'locations')
+      end
+    end
+  end
+end

--- a/app/controllers/provider_interface/courses/study_modes_controller.rb
+++ b/app/controllers/provider_interface/courses/study_modes_controller.rb
@@ -16,7 +16,11 @@ module ProviderInterface
         if @wizard.valid_for_current_step?
           @wizard.save_state!
 
-          redirect_to provider_interface_application_choice_path(@application_choice)
+          if @wizard.next_step.nil?
+            redirect_to provider_interface_application_choice_path(@application_choice)
+          else
+            redirect_to [:edit, :provider_interface, @application_choice, :course, @wizard.next_step]
+          end
         else
           @course = Course.find(@wizard.course_id)
           @study_modes = available_study_modes(@course)

--- a/app/controllers/provider_interface/courses_controller.rb
+++ b/app/controllers/provider_interface/courses_controller.rb
@@ -26,6 +26,10 @@ module ProviderInterface
       query_service.available_courses(provider: Provider.find(provider_id))
     end
 
+    def available_course_options(course_id, study_mode)
+      query_service.available_course_options(course: Course.find(course_id), study_mode: study_mode)
+    end
+
     def query_service
       @query_service ||= GetChangeOfferOptions.new(
         user: current_provider_user,

--- a/app/forms/provider_interface/course_wizard.rb
+++ b/app/forms/provider_interface/course_wizard.rb
@@ -3,13 +3,14 @@ module ProviderInterface
     include Wizard
     include Wizard::PathHistory
 
-    STEPS = %i[select_option providers courses study_modes].freeze
+    STEPS = %i[select_option providers courses study_modes locations].freeze
 
     attr_accessor :path_history, :provider_id, :decision, :application_choice_id,
                   :course_option_id, :course_id, :provider_user_id, :study_mode
 
     validates :course_id, presence: true, on: %i[courses save]
     validates :study_mode, presence: true, on: %i[study_mode save]
+    validates :course_option_id, presence: true, on: %i[locations save]
 
     def self.build_from_application_choice(state_store, application_choice, options = {})
       course_option = application_choice.current_course_option

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -51,6 +51,7 @@
     available_providers: @available_training_providers,
     available_courses: @available_courses,
     course: @application_choice.current_course_option.course,
+    available_course_options: @available_course_options,
   ) %>
 <% else %>
   <%= render ProviderInterface::CourseDetailsComponent.new(application_choice: @application_choice) %>

--- a/app/views/provider_interface/courses/locations/edit.html.erb
+++ b/app/views/provider_interface/courses/locations/edit.html.erb
@@ -1,0 +1,16 @@
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+
+<%= render CollectionSelectComponent.new(attribute: :course_option_id,
+                                         collection: @course_options,
+                                         value_method: :id,
+                                         text_method: :site_name,
+                                         hint_method: :site_full_address,
+                                         form_object: @wizard,
+                                         form_path: provider_interface_application_choice_course_locations_path,
+                                         form_method: :put,
+                                         page_title: t('.title'),
+                                         caption: t('.caption', name: @application_choice.application_form.full_name)) do %>
+  <p class="govuk-body">
+    <%= govuk_link_to t('cancel'), provider_interface_application_choice_path(@application_choice) %>
+  </p>
+<% end %>

--- a/config/locales/provider_interface/change_course.yml
+++ b/config/locales/provider_interface/change_course.yml
@@ -13,3 +13,7 @@ en:
         edit:
           title: Full time or part time
           caption: Update course - %{name}
+      locations:
+        edit:
+          title: Location
+          caption: Update course - %{name}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -742,6 +742,7 @@ Rails.application.routes.draw do
         resource :providers, only: %i[edit update]
         resource :courses, only: %i[edit update]
         resource :study_modes, only: %i[edit update], path: 'study-modes'
+        resource :locations, only: %i[edit update]
       end
 
       get '/rejection-reasons' => 'reasons_for_rejection#edit_initial_questions', as: :reasons_for_rejection_initial_questions

--- a/spec/components/provider_interface/change_course_details_component_spec.rb
+++ b/spec/components/provider_interface/change_course_details_component_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
                     course: course)
   end
 
+  let(:course_option2) do
+    instance_double(CourseOption,
+                    study_mode: 'Full time',
+                    course: course)
+  end
+
   let(:site) do
     instance_double(Site,
                     name_and_code: 'First Road (F34)',
@@ -138,6 +144,32 @@ RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
       expect(render_text).to include('Full or part time')
       expect(render_text).to include('Full time')
       expect(render_text).not_to include('Change')
+    end
+  end
+
+  context 'when there is only one location' do
+    it 'does not render the change link' do
+      render_text = row_text_selector(:location, render)
+
+      expect(render_text).to include('Location')
+      expect(render_text).to include('First Road (F34)')
+      expect(render_text).to include('Fountain Street, Morley, Leeds')
+      expect(render_text).to include('LS27 OPD')
+      expect(render_text).not_to include('Change')
+    end
+  end
+
+  context 'when there are multiple locations' do
+    let(:render) { render_inline(described_class.new(application_choice: application_choice, course: course, available_course_options: [course_option, course_option2])) }
+
+    it 'renders the change link' do
+      render_text = row_text_selector(:location, render)
+
+      expect(render_text).to include('Location')
+      expect(render_text).to include('First Road (F34)')
+      expect(render_text).to include('Fountain Street, Morley, Leeds')
+      expect(render_text).to include('LS27 OPD')
+      expect(render_text).to include('Change')
     end
   end
 end

--- a/spec/forms/provider_interface/course_wizard_spec.rb
+++ b/spec/forms/provider_interface/course_wizard_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe ProviderInterface::CourseWizard do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:course_id).on(:courses).on(:save) }
     it { is_expected.to validate_presence_of(:study_mode).on(:study_modes).on(:save) }
+    it { is_expected.to validate_presence_of(:course_option_id).on(:locations).on(:save) }
   end
 
   describe '#initialize' do
@@ -148,8 +149,7 @@ RSpec.describe ProviderInterface::CourseWizard do
           allow(query_service).to receive(:available_course_options).and_return(create_list(:course_option, 2))
         end
 
-        # TODO: Remove pending on next PR
-        xit 'returns :locations' do
+        it 'returns :locations' do
           expect(wizard.next_step).to eq(:locations)
         end
       end
@@ -163,8 +163,7 @@ RSpec.describe ProviderInterface::CourseWizard do
           allow(query_service).to receive(:available_course_options).and_return(create_list(:course_option, 2))
         end
 
-        # TODO: Remove pending on next PR
-        xit 'returns :locations' do
+        it 'returns :locations' do
           expect(wizard.next_step).to eq(:locations)
         end
       end

--- a/spec/system/provider_interface/provider_changes_a_course_before_point_of_offer_spec.rb
+++ b/spec/system/provider_interface/provider_changes_a_course_before_point_of_offer_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature 'Provider changes a course' do
 
     when_i_select_a_course_with_one_study_mode
     and_i_click_continue
-    then_i_dont_see_the_study_mode_page
+    then_i_am_taken_to_the_change_location_page
   end
 
   scenario 'Changing a course choice before point of offer' do
@@ -60,6 +60,10 @@ RSpec.feature 'Provider changes a course' do
     when_i_select_a_different_course
     and_i_click_continue
     then_no_study_mode_is_pre_selected
+
+    when_i_select_a_study_mode
+    and_i_click_continue
+    then_i_am_taken_to_the_change_location_page
   end
 
   def given_i_am_a_provider_user
@@ -96,7 +100,8 @@ RSpec.feature 'Provider changes a course' do
     @selected_course = courses.sample
 
     @one_mode_course = create(:course, :open_on_apply, study_mode: :full_time, provider: @selected_provider, accredited_provider: ratifying_provider)
-    create(:course_option, :full_time, course: @one_mode_course)
+    create(:course_option, :full_time, site: create(:site, provider: @one_mode_course.provider), course: @one_mode_course)
+    create(:course_option, :full_time, site: create(:site, provider: @one_mode_course.provider), course: @one_mode_course)
 
     course_options = [create(:course_option, :part_time, course: @selected_course),
                       create(:course_option, :full_time, course: @selected_course),
@@ -169,5 +174,14 @@ RSpec.feature 'Provider changes a course' do
     expect(page).to have_content 'Full time or part time'
     expect(find_field('Full time')).not_to be_checked
     expect(find_field('Part time')).not_to be_checked
+  end
+
+  def when_i_select_a_study_mode
+    choose @selected_course_option.study_mode.humanize
+  end
+
+  def then_i_am_taken_to_the_change_location_page
+    expect(page).to have_content "Update course - #{application_form.full_name}"
+    expect(page).to have_content 'Location'
   end
 end


### PR DESCRIPTION
## Context

Currently providers can change the details of a course at the point of offer. We'd like to let providers do this before the point of offer.

Following from [#6599](https://github.com/DFE-Digital/apply-for-teacher-training/pull/6599) this is the fourth PR in the series which will allow the user to change the study mode.

This stage of the flow will be skipped if the user picks an option which doesn't have multiple locations to select from.

## Changes proposed in this pull request

<img width="673" alt="image" src="https://user-images.githubusercontent.com/47917431/156621023-a0eb6104-7841-4b28-a61b-1f0c829fc5d9.png">

## Guidance to review

If there is only one location then this stage is skipped

## Link to Trello card

https://trello.com/c/HWF5g8dm

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
