### PR TITLE
Inform candidates that they do not have to respond yet when they're waiting on another decision

### DIFF
--- a/app/views/candidate_mailer/application_rejected_one_offer_one_awaiting_decision.text.erb
+++ b/app/views/candidate_mailer/application_rejected_one_offer_one_awaiting_decision.text.erb
@@ -22,7 +22,7 @@ Their deadline is <%= @awaiting_decision_by %>.
 
 You can wait until you’ve received their decision, plus 10 working days, before you accept or decline any offers.
 
-You should not feel pressured to repond sooner than this.
+You should not feel pressured to respond sooner than this.
 
 However, if you are ready to respond to your existing offer you can do so through your account:
 

--- a/app/views/candidate_mailer/application_rejected_one_offer_one_awaiting_decision.text.erb
+++ b/app/views/candidate_mailer/application_rejected_one_offer_one_awaiting_decision.text.erb
@@ -16,7 +16,7 @@ Dear <%= @application_form.first_name %>
 
 You have an offer from <%= @offer.course_option.course.provider.name %> to study <%= @offer.course_option.course.name %>.
 
-You're waiting for <%= @awaiting_decision.course_option.course.provider.name %> to make a decision about your application to study <%= @awaiting_decision.course_option.course.name %>.
+You’re waiting for <%= @awaiting_decision.course_option.course.provider.name %> to make a decision about your application to study <%= @awaiting_decision.course_option.course.name %>.
 
 Their deadline is <%= @awaiting_decision_by %>.
 

--- a/app/views/candidate_mailer/application_rejected_one_offer_one_awaiting_decision.text.erb
+++ b/app/views/candidate_mailer/application_rejected_one_offer_one_awaiting_decision.text.erb
@@ -12,12 +12,14 @@ Dear <%= @application_form.first_name %>
 
 <% end %>
 
-# You have an offer and are waiting for a decision about another course
+# Your application status
 
 You have an offer from <%= @offer.course_option.course.provider.name %> to study <%= @offer.course_option.course.name %>.
 
-<%= @awaiting_decision.course_option.course.provider.name %> has until <%= @awaiting_decision_by %> to make a decision about your application to study <%= @awaiting_decision.course_option.course.name %>.
+You're waiting for <%= @awaiting_decision.course_option.course.provider.name %> to make a decision about your application to study <%= @awaiting_decision.course_option.course.name %>. Their deadline is <%= @awaiting_decision_by %>.
 
-You can wait until you’ve received both decisions before you respond. Alternatively, you can sign in to your account and accept your existing offer:
+You can wait until you’ve received all decisions, plus 10 working days, before you accept or decline any offers. You should not feel pressured to repond sooner than this.
+
+However, if you are ready to respond to your existing offer you can do so through your account:
 
 <%= @candidate_magic_link %>

--- a/app/views/candidate_mailer/application_rejected_one_offer_one_awaiting_decision.text.erb
+++ b/app/views/candidate_mailer/application_rejected_one_offer_one_awaiting_decision.text.erb
@@ -12,13 +12,17 @@ Dear <%= @application_form.first_name %>
 
 <% end %>
 
-# Your application status
+# Application status
 
 You have an offer from <%= @offer.course_option.course.provider.name %> to study <%= @offer.course_option.course.name %>.
 
-You're waiting for <%= @awaiting_decision.course_option.course.provider.name %> to make a decision about your application to study <%= @awaiting_decision.course_option.course.name %>. Their deadline is <%= @awaiting_decision_by %>.
+You're waiting for <%= @awaiting_decision.course_option.course.provider.name %> to make a decision about your application to study <%= @awaiting_decision.course_option.course.name %>.
 
-You can wait until you’ve received all decisions, plus 10 working days, before you accept or decline any offers. You should not feel pressured to repond sooner than this.
+Their deadline is <%= @awaiting_decision_by %>.
+
+You can wait until you’ve received their decision, plus 10 working days, before you accept or decline any offers.
+
+You should not feel pressured to repond sooner than this.
 
 However, if you are ready to respond to your existing offer you can do so through your account:
 

--- a/app/views/candidate_mailer/application_withdrawn_on_request_one_offer_one_awaiting_decision.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_one_offer_one_awaiting_decision.text.erb
@@ -16,7 +16,7 @@ Their deadline is <%= @awaiting_decision_by %>.
 
 You can wait until you’ve received their decision, plus 10 working days, before you accept or decline any offers.
 
-You should not feel pressured to repond sooner than this.
+You should not feel pressured to respond sooner than this.
 
 However, if you are ready to respond to your existing offer you can do so through your account:
 

--- a/app/views/candidate_mailer/application_withdrawn_on_request_one_offer_one_awaiting_decision.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_one_offer_one_awaiting_decision.text.erb
@@ -6,12 +6,18 @@ Get in touch if you did not ask them to do this:
 
 <%= I18n.t('get_into_teaching.url_online_chat') %>
 
-# You have an offer and are waiting for a decision about another course
+# Application status
 
 You have an offer from <%= @offer.course_option.course.provider.name %> to study <%= @offer.course_option.course.name %>.
 
-<%= @awaiting_decision.course_option.course.provider.name %> has until <%= @awaiting_decision_by %> to make a decision about your application to study <%= @awaiting_decision.course_option.course.name %>.
+You're waiting for <%= @awaiting_decision.course_option.course.provider.name %> to make a decision about your application to study <%= @awaiting_decision.course_option.course.name %>.
 
-You can wait until you’ve received both decisions before you respond. Alternatively, you can sign in to your account and accept your existing offer:
+Their deadline is <%= @awaiting_decision_by %>.
+
+You can wait until you’ve received their decision, plus 10 working days, before you accept or decline any offers.
+
+You should not feel pressured to repond sooner than this.
+
+However, if you are ready to respond to your existing offer you can do so through your account:
 
 <%= @candidate_magic_link %>

--- a/app/views/candidate_mailer/application_withdrawn_on_request_one_offer_one_awaiting_decision.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_one_offer_one_awaiting_decision.text.erb
@@ -10,7 +10,7 @@ Get in touch if you did not ask them to do this:
 
 You have an offer from <%= @offer.course_option.course.provider.name %> to study <%= @offer.course_option.course.name %>.
 
-You're waiting for <%= @awaiting_decision.course_option.course.provider.name %> to make a decision about your application to study <%= @awaiting_decision.course_option.course.name %>.
+You’re waiting for <%= @awaiting_decision.course_option.course.provider.name %> to make a decision about your application to study <%= @awaiting_decision.course_option.course.name %>.
 
 Their deadline is <%= @awaiting_decision_by %>.
 

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe CandidateMailer, type: :mailer do
           'course name and code' => 'Applied Science (Psychology)',
           'qualifications rejection heading' => 'Qualifications',
           'qualifications rejection content' => 'Bad qualifications',
-          'other application details' => 'You have an offer and are waiting for a decision about another course',
+          'other application details' => 'Application status',
           'application with offer' => 'You have an offer from Brighthurst Technical College to study Applied Science (Psychology)',
           'application awaiting decision' => 'to make a decision about your application to study Forensic Science',
           'decision day' => "has until #{40.business_days.from_now.to_s(:govuk_date)} to make a decision",

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe CandidateMailer, type: :mailer do
           'course name and code' => 'Applied Science (Psychology)',
           'qualifications rejection heading' => 'Qualifications',
           'qualifications rejection content' => 'Bad qualifications',
-          'other application details' => 'You have an offer and are waiting for a decision about another course',
+          'other application details' => 'Application status',
           'application with offer' => 'You have an offer from Brighthurst Technical College to study Applied Science (Psychology)',
           'application awaiting decision' => 'to make a decision about your application to study Forensic Science',
           'decision day' => "Their deadline is #{40.business_days.from_now.to_s(:govuk_date)}",

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe CandidateMailer, type: :mailer do
           'other application details' => 'You have an offer and are waiting for a decision about another course',
           'application with offer' => 'You have an offer from Brighthurst Technical College to study Applied Science (Psychology)',
           'application awaiting decision' => 'to make a decision about your application to study Forensic Science',
-          'decision day' => "has until #{40.business_days.from_now.to_s(:govuk_date)} to make a decision",
+          'decision day' => "Their deadline is #{40.business_days.from_now.to_s(:govuk_date)}",
         )
       end
 
@@ -227,7 +227,7 @@ RSpec.describe CandidateMailer, type: :mailer do
           'other application details' => 'Application status',
           'application with offer' => 'You have an offer from Brighthurst Technical College to study Applied Science (Psychology)',
           'application awaiting decision' => 'to make a decision about your application to study Forensic Science',
-          'decision day' => "has until #{40.business_days.from_now.to_s(:govuk_date)} to make a decision",
+          'decision day' => "Their deadline is #{40.business_days.from_now.to_s(:govuk_date)}",
         )
       end
     end

--- a/spec/mailers/candidate_mailer_withdrawn_on_request_spec.rb
+++ b/spec/mailers/candidate_mailer_withdrawn_on_request_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       'withdrawn sentence' => 'At your request, Arithmetic College has withdrawn your application to study Mathematics (M101)',
       'link to support' => I18n.t('get_into_teaching.url_online_chat'),
       'offer content' => 'You have an offer from Arithmetic College to study Mathematics.',
-      'awaiting decision content' => 'Falconholt Technical College has until 1 July 2021 to make a decision about your application to study Forensic Science.',
+      'awaiting decision content' => 'You're waiting for Falconholt Technical College to make a decision about your application to study Forensic Science.',
     )
   end
 end

--- a/spec/mailers/candidate_mailer_withdrawn_on_request_spec.rb
+++ b/spec/mailers/candidate_mailer_withdrawn_on_request_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       'withdrawn sentence' => 'At your request, Arithmetic College has withdrawn your application to study Mathematics (M101)',
       'link to support' => I18n.t('get_into_teaching.url_online_chat'),
       'offer content' => 'You have an offer from Arithmetic College to study Mathematics.',
-      'awaiting decision content' => 'You're waiting for Falconholt Technical College to make a decision about your application to study Forensic Science.',
+      'awaiting decision content' => 'You’re waiting for Falconholt Technical College to make a decision about your application to study Forensic Science.',
     )
   end
 end


### PR DESCRIPTION
There's a section of content in our emails that gets shown when:

* someone has just had a rejection or RBD
* but they have an offer from another provider 
* and they're waiting for a decision from another provider

In the copy, we say that candidates do not have the respond to their offer yet. 

We want to make this extra clear. Some providers pressure candidates into accepting an offer sooner than they have to. 

# Before

<img width="615" alt="Screenshot 2022-03-03 at 20 59 50" src="https://user-images.githubusercontent.com/56349171/156652097-5e78500a-516a-4034-ab95-a026205c487f.png">

# After

<img width="666" alt="Screenshot 2022-03-03 at 20 56 00" src="https://user-images.githubusercontent.com/56349171/156651809-466c737e-cf9e-472d-9815-192847f76d74.png">

