### PR TITLE
Fix cancellation reason limit in API draft

### DIFF
--- a/config/vendor_api/draft.yml
+++ b/config/vendor_api/draft.yml
@@ -533,7 +533,7 @@ components:
           type: string
           description: The reason for the cancellation. If none are yet provided for an application rejected by default, the value `Not entered` is returned
           example: 'Candidate has accepted an alternative offer'
-          maxLength: 10240
+          maxLength: 2000
         created_at:
           type: string
           format: date-time


### PR DESCRIPTION
## Context

Flagged by a vendor, cancellation reason limit in manage is 2000, should be same in API

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
