### PR TITLE
headers can be shorter and more consistent

### DIFF
--- a/app/views/candidate_mailer/application_rejected_awaiting_decision_only.text.erb
+++ b/app/views/candidate_mailer/application_rejected_awaiting_decision_only.text.erb
@@ -14,13 +14,13 @@ Dear <%= @application_form.first_name %>
 
 <% if @awaiting_decision.length == 1 %>
 
-# You’re waiting for a decision
+# Application status
 
 You’re waiting for <%= @awaiting_decision.first.course_option.course.provider.name %> to make a decision about your application to study <%= @awaiting_decision.first.course_option.course.name %>. They should do this by <%= @awaiting_decision.first.reject_by_default_at.to_s(:govuk_date) %>.
 
 <% else %>
 
-# You’re waiting for decisions
+# Application status
 
 You're waiting for decisions about your applications to:
 

--- a/app/views/candidate_mailer/application_withdrawn_on_request_awaiting_decision_only.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_awaiting_decision_only.text.erb
@@ -8,13 +8,13 @@ Get in touch if you did not ask them to do this:
 
 <% if @awaiting_decision.length == 1 %>
 
-# You’re waiting for a decision
+# Application status
 
 You’re waiting for <%= @awaiting_decision.first.course_option.course.provider.name %> to make a decision about your application to study <%= @awaiting_decision.first.course_option.course.name %>. They should do this by <%= @awaiting_decision.first.reject_by_default_at.to_s(:govuk_date) %>.
 
 <% else %>
 
-# You’re waiting for decisions
+# Application status
 
 You're waiting for decisions about your applications to:
 

--- a/app/views/candidate_mailer/feedback_received_for_application_rejected_by_default.text.erb
+++ b/app/views/candidate_mailer/feedback_received_for_application_rejected_by_default.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>,
+Dear <%= @application_form.first_name %>
 
 As you know, your application for <%= @course.name_and_code %> could not progress because <%= @course.provider.name %>
 did not respond by their deadline of <%= @application_choice.rejected_at.to_s(:govuk_date) %>.


### PR DESCRIPTION
Our email headers are sometimes a bit wordy and repeat other content in the email. Aiming to make them more consistent. 