### PR TITLE
make wait or respond section more consistent with other emails

### DIFF
--- a/app/views/candidate_mailer/_wait_or_respond.text.erb
+++ b/app/views/candidate_mailer/_wait_or_respond.text.erb
@@ -1,7 +1,11 @@
-^You can wait to hear back about your other application(s) before making a decision. When the last decision is in, you’ll have 10 working days to respond.
+You do not need to accept or decline this offer yet.
 
-^Or
+You can wait until you’ve recieved decisions about your other application(s). 
 
-^You can respond to the offer now. If you accept the offer, your other teacher training application(s) will be withdrawn. Sign in to your account if you want to respond:
+When the last decision is in, you’ll have 10 working days to respond.
+
+You should not feel pressured to respond sooner than this.
+
+However, if you are ready to respond to your existing offer you can do so through your account:
 
 <%= candidate_magic_link(@application_form.candidate) %>

--- a/app/views/candidate_mailer/_wait_or_respond.text.erb
+++ b/app/views/candidate_mailer/_wait_or_respond.text.erb
@@ -1,6 +1,6 @@
 You do not need to accept or decline this offer yet.
 
-You can wait until you’ve recieved decisions about your other application(s). 
+You can wait until you’ve received decisions about your other application(s). 
 
 When the last decision is in, you’ll have 10 working days to respond.
 

--- a/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
+++ b/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
@@ -3,14 +3,12 @@ Dear <%= @application_form.first_name %>
 You have an offer from <%= @provider_name %> to study <%= @course_name %>.
 
 <% if @conditions.blank? %>
-  They’ll let you know if they need further information before you can start training.
+  The provider has not set any conditions.
 <% else %>
   <%= render "candidate_mailer/offer_conditions" %>
 <% end %>
 
-Contact <%= @provider_name %> if you have any questions about this.
-
-# Next steps
+Contact <%= @provider_name %> if you have any questions about the offer.
 
 <%= render "candidate_mailer/wait_or_respond" %>
 

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       'Successful application for Brighthurst Technical College',
       'heading' => 'Dear Bob',
       'first_condition' => 'Be cool',
-      'instructions' => 'You can wait to hear back about your other application(s) before making a decision',
+      'instructions' => 'You can wait until you’ve received decisions about your other application(s)',
       'deferral_guidance' => 'Some teacher training providers allow you to defer your offer.',
     )
   end


### PR DESCRIPTION
Make the 'wait or respond' component more consistent with emails edited here: https://github.com/DFE-Digital/apply-for-teacher-training/pull/6626

This is an interim solution. In the future, we should make this even more consistent with https://github.com/DFE-Digital/apply-for-teacher-training/pull/6626, by pulling in the details of the applications they're waiting on. 

Before:

![Screenshot 2022-03-06 at 22 07 41](https://user-images.githubusercontent.com/56349171/156944129-61750f93-c972-4201-ad98-c44f1b5df836.png)


After:

![Screenshot 2022-03-06 at 22 06 03](https://user-images.githubusercontent.com/56349171/156944084-1b19f1e1-7c3f-40db-aa15-c31d02b13ae4.png)

