### PR TITLE
Update monthly statistics page to factor in 3 choices at Apply Again

### DIFF
--- a/app/views/publications/monthly_statistics/show.html.erb
+++ b/app/views/publications/monthly_statistics/show.html.erb
@@ -127,7 +127,7 @@
     </ul>
 
     <p class="govuk-body">If a candidate’s first set of applications do not lead to a place, the candidate can “apply again”,
-    to other courses, one application at a time, as many times as they like.</p>
+    to other courses, three applications at a time, as many times as they like.</p>
     <p class="govuk-body">The “apply again” column of the first table below counts only the status of a candidate’s most
        recent “apply again” application. Their previous “apply again” applications are not counted anywhere in the table.</p>
     <p class="govuk-body">The status of any one application changes throughout its lifecycle. Statuses are captured at

--- a/app/views/publications/monthly_statistics/show.html.erb
+++ b/app/views/publications/monthly_statistics/show.html.erb
@@ -127,7 +127,7 @@
     </ul>
 
     <p class="govuk-body">If a candidate’s first set of applications do not lead to a place, they can apply again
-    to other courses, submitting up to 3 applications at a time. They can keep applying again as many times as they like if their application does not work out.</p>
+    to up to 3 courses at a time. There’s no limit to the number of times someone can apply again. As soon as their application ends (for example, all 3 applications were unsuccessful) they’re invited to apply again.</p>
     <p class="govuk-body">The “apply again” column of the first table below counts only the status of a candidate’s most
        recent “apply again” application. Their previous “apply again” applications are not counted anywhere in the table.</p>
     <p class="govuk-body">The status of any one application changes throughout its lifecycle. Statuses are captured at

--- a/app/views/publications/monthly_statistics/show.html.erb
+++ b/app/views/publications/monthly_statistics/show.html.erb
@@ -126,7 +126,7 @@
       <li>application rejected by provider (least “advanced”)</li>
     </ul>
 
-    <p class="govuk-body">If a candidate’s first set of applications do not lead to a place, the candidate can “apply again”,
+    <p class="govuk-body">If a candidate’s first set of applications do not lead to a place, the candidate can “apply again”
     to other courses, submitting up to 3 applications at a time. They can keep applying again as many times as they like if their application does not work out.</p>
     <p class="govuk-body">The “apply again” column of the first table below counts only the status of a candidate’s most
        recent “apply again” application. Their previous “apply again” applications are not counted anywhere in the table.</p>

--- a/app/views/publications/monthly_statistics/show.html.erb
+++ b/app/views/publications/monthly_statistics/show.html.erb
@@ -127,7 +127,7 @@
     </ul>
 
     <p class="govuk-body">If a candidate’s first set of applications do not lead to a place, the candidate can “apply again”,
-    to other courses, three applications at a time, as many times as they like.</p>
+    to other courses, submitting up to 3 applications at a time. They can keep applying again as many times as they like if their application does not work out.</p>
     <p class="govuk-body">The “apply again” column of the first table below counts only the status of a candidate’s most
        recent “apply again” application. Their previous “apply again” applications are not counted anywhere in the table.</p>
     <p class="govuk-body">The status of any one application changes throughout its lifecycle. Statuses are captured at

--- a/app/views/publications/monthly_statistics/show.html.erb
+++ b/app/views/publications/monthly_statistics/show.html.erb
@@ -126,7 +126,7 @@
       <li>application rejected by provider (least “advanced”)</li>
     </ul>
 
-    <p class="govuk-body">If a candidate’s first set of applications do not lead to a place, the candidate can “apply again”
+    <p class="govuk-body">If a candidate’s first set of applications do not lead to a place, they can apply again
     to other courses, submitting up to 3 applications at a time. They can keep applying again as many times as they like if their application does not work out.</p>
     <p class="govuk-body">The “apply again” column of the first table below counts only the status of a candidate’s most
        recent “apply again” application. Their previous “apply again” applications are not counted anywhere in the table.</p>


### PR DESCRIPTION
## Context

I've noticed we talk about Apply Again in old terms on the monthly statistics page.

## Changes proposed in this pull request

Amend 'One application at a time' -> 'Three applications at a time'.

## Guidance to review

Is this the best way to redraft from a content design perspective?

Does this need a more wholesale review given how we are counting AA applications for reporting?

## Link to Trello card

N/A - quick fix.
