### PR TITLE
4901 remove make decision reminder flag

### DIFF
--- a/app/components/shared/provider_user_notification_preferences_component.html.erb
+++ b/app/components/shared/provider_user_notification_preferences_component.html.erb
@@ -1,6 +1,6 @@
 <%= form_with model: notification_preferences, url: form_path, method: :put do |f| %>
   <div class='govuk-form-group'>
-    <% ProviderUserNotificationPreferences.notification_preferences.each do |notification_preference| %>
+    <% ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |notification_preference| %>
       <%= f.govuk_collection_radio_buttons notification_preference,
         on_off_options,
         :value,

--- a/app/components/support_interface/provider_user_summary_component.rb
+++ b/app/components/support_interface/provider_user_summary_component.rb
@@ -38,7 +38,7 @@ module SupportInterface
     end
 
     def notification_preferences_rows
-      ProviderUserNotificationPreferences.notification_preferences.map do |type|
+      ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.map do |type|
         { preference: t("provider_user_notification_preferences.#{type}.legend"), active: provider_user.notification_preferences.send(type) ? 'Yes' : 'No' }
       end
     end

--- a/app/controllers/provider_interface/notifications_controller.rb
+++ b/app/controllers/provider_interface/notifications_controller.rb
@@ -17,7 +17,7 @@ module ProviderInterface
       return ActionController::Parameters.new unless params.key?(:provider_user_notification_preferences)
 
       params.require(:provider_user_notification_preferences)
-        .permit(ProviderUserNotificationPreferences.notification_preferences)
+        .permit(ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES)
     end
   end
 end

--- a/app/controllers/support_interface/provider_user_notification_preferences_controller.rb
+++ b/app/controllers/support_interface/provider_user_notification_preferences_controller.rb
@@ -21,7 +21,7 @@ module SupportInterface
       return ActionController::Parameters.new unless params.key?(:provider_user_notification_preferences)
 
       params.require(:provider_user_notification_preferences)
-        .permit(ProviderUserNotificationPreferences.notification_preferences)
+        .permit(ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES)
     end
   end
 end

--- a/app/controllers/support_interface/single_provider_user_notifications_controller.rb
+++ b/app/controllers/support_interface/single_provider_user_notifications_controller.rb
@@ -22,7 +22,7 @@ module SupportInterface
       return ActionController::Parameters.new unless params.key?(:provider_user_notification_preferences)
 
       params.require(:provider_user_notification_preferences)
-        .permit(ProviderUserNotificationPreferences.notification_preferences)
+        .permit(ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES)
     end
   end
 end

--- a/app/models/provider_user_notification_preferences.rb
+++ b/app/models/provider_user_notification_preferences.rb
@@ -14,29 +14,13 @@ class ProviderUserNotificationPreferences < ApplicationRecord
     offer_declined
   ].freeze
 
-  OLD_NOTIFICATION_PREFERENCES = %i[
-    application_received
-    application_withdrawn
-    application_rejected_by_default
-    offer_accepted
-    offer_declined
-  ].freeze
-
   def update_all_preferences(value)
-    self.class.notification_preferences.each { |notification| assign_attributes(notification => value) }
+    NOTIFICATION_PREFERENCES.each { |notification| assign_attributes(notification => value) }
 
     save!
   end
 
-  def self.notification_preferences
-    if FeatureFlag.active?(:make_decision_reminder_notification_setting)
-      NOTIFICATION_PREFERENCES
-    else
-      OLD_NOTIFICATION_PREFERENCES
-    end
-  end
-
   def self.notification_preference_exists?(notification_name)
-    notification_preferences.include? notification_name
+    NOTIFICATION_PREFERENCES.include? notification_name
   end
 end

--- a/app/services/data_migrations/make_decision_reminder_notification_setting_feature_flag.rb
+++ b/app/services/data_migrations/make_decision_reminder_notification_setting_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class MakeDecisionReminderNotificationSettingFeatureFlag
+    TIMESTAMP = 20220308094833
+    MANUAL_RUN = false
+
+    def change
+      Feature.where(name: :make_decision_reminder_notification_setting).first&.destroy
+    end
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -37,7 +37,6 @@ class FeatureFlag
     [:immigration_entry_date, 'Extends the restructured_immigration_status feature to include the "Date of entry into the UK" question', 'Steve Hook'],
     [:change_course_details_before_offer, 'Allows providers to change course choice details before the point of offer', 'James Glenn'],
     [:structured_reasons_for_rejection_redesign, 'Latest iteration of structured reasons for rejection', 'Steve Laing'],
-    [:make_decision_reminder_notification_setting, 'Adds a notification setting to turn off make decision email reminders', 'Sam Culley'],
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day

--- a/app/services/notifications_list.rb
+++ b/app/services/notifications_list.rb
@@ -8,29 +8,13 @@ class NotificationsList
     chase_provider_decision: %i[chase_provider_decision],
   }.freeze
 
-  OLD_NOTIFICATION_PREFERENCE_NAMES_FOR_EVENTS = {
-    application_received: %i[application_submitted chase_provider_decision],
-    application_withdrawn: %i[application_withdrawn],
-    application_rejected_by_default: %i[application_rejected_by_default],
-    offer_accepted: %i[offer_accepted unconditional_offer_accepted],
-    offer_declined: %i[declined declined_by_default],
-  }.freeze
-
   def self.for(application_choice, include_ratifying_provider: false, event: nil)
-    notification_name = feature_flag_preference_names.select { |k, v| k if event.in? v }.keys.first
+    notification_name = NOTIFICATION_PREFERENCE_NAMES_FOR_EVENTS.select { |k, v| k if event.in? v }.keys.first
     raise 'Undefined type of notification event' unless ProviderUserNotificationPreferences.notification_preference_exists?(notification_name)
 
     return application_choice.provider.provider_users.joins(:notification_preferences).where("#{notification_name} IS true") if application_choice.accredited_provider.nil? || !include_ratifying_provider
 
     application_choice.provider.provider_users.or(application_choice.accredited_provider.provider_users)
       .joins(:notification_preferences).where("#{notification_name} IS true").distinct
-  end
-
-  def self.feature_flag_preference_names
-    if FeatureFlag.active?(:make_decision_reminder_notification_setting)
-      NOTIFICATION_PREFERENCE_NAMES_FOR_EVENTS
-    else
-      OLD_NOTIFICATION_PREFERENCE_NAMES_FOR_EVENTS
-    end
   end
 end

--- a/app/services/save_provider_user_notification_preferences.rb
+++ b/app/services/save_provider_user_notification_preferences.rb
@@ -8,10 +8,6 @@ class SaveProviderUserNotificationPreferences
   def update_all_notification_preferences!(notification_preferences_params: {})
     return false if notification_preferences_params.empty?
 
-    unless FeatureFlag.active?(:make_decision_reminder_notification_setting)
-      notification_preferences_params.merge!(chase_provider_decision: notification_preferences_params[:application_received])
-    end
-
     provider_user_notification_preferences.update!(notification_preferences_params)
   end
 

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -83,26 +83,6 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "51aae2b6b9548a033b8832f0f9481aa76d039c54266505d4e24aa78111519467",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/services/notifications_list.rb",
-      "line": 23,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "application_choice.provider.provider_users.joins(:notification_preferences).where(\"#{feature_flag_preference_names.select do\n k if event.in?(v)\n end.keys.first} IS true\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "NotificationsList",
-        "method": "s(:self).for"
-      },
-      "user_input": "feature_flag_preference_names.select do\n k if event.in?(v)\n end.keys.first",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
       "fingerprint": "6d81f7b094e032bfa59965942a4bef495d671628fb22d9175bd5b270fb3e29e4",
       "check_name": "SQL",
       "message": "Possible SQL injection",
@@ -117,6 +97,26 @@
         "method": "s(:self).for_task_view"
       },
       "user_input": "deferred_offers_pending_reconfirmation",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "8630e06624baa5823e65b3d8c8cf85f0aa3f8a77b7c45633b27921323b5c25c7",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/services/notifications_list.rb",
+      "line": 15,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "application_choice.provider.provider_users.joins(:notification_preferences).where(\"#{{ :application_received => ([:application_submitted]), :application_withdrawn => ([:application_withdrawn]), :application_rejected_by_default => ([:application_rejected_by_default]), :offer_accepted => ([:offer_accepted, :unconditional_offer_accepted]), :offer_declined => ([:declined, :declined_by_default]), :chase_provider_decision => ([:chase_provider_decision]) }.select do\n k if event.in?(v)\n end.keys.first} IS true\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "NotificationsList",
+        "method": "s(:self).for"
+      },
+      "user_input": "{ :application_received => ([:application_submitted]), :application_withdrawn => ([:application_withdrawn]), :application_rejected_by_default => ([:application_rejected_by_default]), :offer_accepted => ([:offer_accepted, :unconditional_offer_accepted]), :offer_declined => ([:declined, :declined_by_default]), :chase_provider_decision => ([:chase_provider_decision]) }.select do\n k if event.in?(v)\n end.keys.first",
       "confidence": "Weak",
       "note": ""
     },
@@ -203,20 +203,20 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "c7a49e24443f2f349019426ecc069e1d6db928bccefdecfdfcdfbb8319a924ec",
+      "fingerprint": "c57c66f76d2283c814433c43983363caa8a0320362115c3321a1d47116b856ab",
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/services/notifications_list.rb",
-      "line": 26,
+      "line": 18,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "application_choice.provider.provider_users.or(application_choice.accredited_provider.provider_users).joins(:notification_preferences).where(\"#{feature_flag_preference_names.select do\n k if event.in?(v)\n end.keys.first} IS true\")",
+      "code": "application_choice.provider.provider_users.or(application_choice.accredited_provider.provider_users).joins(:notification_preferences).where(\"#{{ :application_received => ([:application_submitted]), :application_withdrawn => ([:application_withdrawn]), :application_rejected_by_default => ([:application_rejected_by_default]), :offer_accepted => ([:offer_accepted, :unconditional_offer_accepted]), :offer_declined => ([:declined, :declined_by_default]), :chase_provider_decision => ([:chase_provider_decision]) }.select do\n k if event.in?(v)\n end.keys.first} IS true\")",
       "render_path": null,
       "location": {
         "type": "method",
         "class": "NotificationsList",
         "method": "s(:self).for"
       },
-      "user_input": "feature_flag_preference_names.select do\n k if event.in?(v)\n end.keys.first",
+      "user_input": "{ :application_received => ([:application_submitted]), :application_withdrawn => ([:application_withdrawn]), :application_rejected_by_default => ([:application_rejected_by_default]), :offer_accepted => ([:offer_accepted, :unconditional_offer_accepted]), :offer_declined => ([:declined, :declined_by_default]), :chase_provider_decision => ([:chase_provider_decision]) }.select do\n k if event.in?(v)\n end.keys.first",
       "confidence": "Weak",
       "note": ""
     },
@@ -261,6 +261,6 @@
       "note": ""
     }
   ],
-  "updated": "2022-03-02 16:53:07 +0000",
+  "updated": "2022-03-08 10:05:48 +0000",
   "brakeman_version": "5.2.1"
 }

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::MakeDecisionReminderNotificationSettingFeatureFlag',
   'DataMigrations::DropContentSecurityPolicyFeatureFlag',
   'DataMigrations::DropSupportUserChangeOfferedCourseFeatureFlag',
   'DataMigrations::DropRegionFromPostcodeFeatureFlag',

--- a/spec/components/support_interface/provider_user_summary_component_spec.rb
+++ b/spec/components/support_interface/provider_user_summary_component_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe SupportInterface::ProviderUserSummaryComponent do
   end
 
   it "renders the provider user's notifications" do
-    ProviderUserNotificationPreferences.notification_preferences.each do |notification_preference|
+    ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |notification_preference|
       expect(rendered_component.squish).to include(t("provider_user_notification_preferences.#{notification_preference}.legend"))
     end
   end

--- a/spec/components/utility/provider_user_notification_preferences_component_spec.rb
+++ b/spec/components/utility/provider_user_notification_preferences_component_spec.rb
@@ -4,33 +4,15 @@ RSpec.describe ProviderUserNotificationPreferencesComponent do
   let(:provider_user) { create(:provider_user) }
   let(:notification_preferences) { provider_user.notification_preferences }
 
-  context 'when the :make_decision_reminder_notification_setting feature flag is on' do
-    before { FeatureFlag.activate(:make_decision_reminder_notification_setting) }
+  it 'renders correct labels for notification preferences' do
+    result = render_inline(described_class.new(notification_preferences, form_path: '/provider/account/notification-settings'))
 
-    it 'renders correct labels for notification preferences' do
-      result = render_inline(described_class.new(notification_preferences, form_path: '/provider/account/notification-settings'))
-
-      expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[0].text).to include('Application received')
-      expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[1].text).to include('Application withdrawn by candidate')
-      expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[2].text).to include('Reminder to make a decision 20 working days before automatic rejection')
-      expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[3].text).to include('Application automatically rejected')
-      expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[4].text).to include('Offer accepted')
-      expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[5].text).to include('Offer declined')
-    end
-  end
-
-  context 'when the :make_decision_reminder_notification_setting feature flag is off' do
-    before { FeatureFlag.deactivate(:make_decision_reminder_notification_setting) }
-
-    it 'renders correct labels for notification preferences' do
-      result = render_inline(described_class.new(notification_preferences, form_path: '/provider/account/notification-settings'))
-
-      expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[0].text).to include('Application received')
-      expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[1].text).to include('Application withdrawn by candidate')
-      expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[2].text).to include('Application automatically rejected')
-      expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[3].text).to include('Offer accepted')
-      expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[4].text).to include('Offer declined')
-    end
+    expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[0].text).to include('Application received')
+    expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[1].text).to include('Application withdrawn by candidate')
+    expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[2].text).to include('Reminder to make a decision 20 working days before automatic rejection')
+    expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[3].text).to include('Application automatically rejected')
+    expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[4].text).to include('Offer accepted')
+    expect(result.css(:legend, '#govuk-fieldset__legend govuk-fieldset__legend--m')[5].text).to include('Offer declined')
   end
 
   it 'renders on and off radio buttons' do

--- a/spec/models/provider_user_notification_preferences_spec.rb
+++ b/spec/models/provider_user_notification_preferences_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ProviderUserNotificationPreferences do
       notification_preferences = create(:provider_user_notification_preferences)
       notification_preferences.update_all_preferences(false)
 
-      described_class.notification_preferences.each do |type|
+      described_class::NOTIFICATION_PREFERENCES.each do |type|
         expect(notification_preferences.send(type)).to be(false)
       end
     end
@@ -18,7 +18,7 @@ RSpec.describe ProviderUserNotificationPreferences do
     let(:notification_preferences) { build(:provider_user_notification_preferences) }
 
     it 'returns true for defined notification preferences types' do
-      described_class.notification_preferences.each do |type|
+      described_class::NOTIFICATION_PREFERENCES.each do |type|
         expect(described_class.notification_preference_exists?(type)).to be(true)
       end
     end

--- a/spec/services/data_migrations/make_decision_reminder_notification_setting_feature_flag_spec.rb
+++ b/spec/services/data_migrations/make_decision_reminder_notification_setting_feature_flag_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::MakeDecisionReminderNotificationSettingFeatureFlag do
+  context 'when the feature flag exists' do
+    it 'removes the feature flag' do
+      create(:feature, name: 'make_decision_reminder_notification_setting')
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: 'make_decision_reminder_notification_setting')).to be_blank
+    end
+  end
+
+  context 'when the feature flag has already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end

--- a/spec/services/notifications_list_spec.rb
+++ b/spec/services/notifications_list_spec.rb
@@ -17,17 +17,13 @@ RSpec.describe NotificationsList do
       expect(described_class.for(application_choice, event: :offer_accepted).to_a).to eql([provider_user])
     end
 
-    context 'when the make_decision_reminder_notification_setting feature flag is on' do
-      before { FeatureFlag.activate(:make_decision_reminder_notification_setting) }
+    it 'does not return training provider users for a disabled chase_provider_decision preference' do
+      application_choice = create(:application_choice)
+      provider_user = create(:provider_user, :with_notifications_enabled, providers: [application_choice.course.provider])
 
-      it 'does not return training provider users for a disabled chase_provider_decision preference' do
-        application_choice = create(:application_choice)
-        provider_user = create(:provider_user, :with_notifications_enabled, providers: [application_choice.course.provider])
+      create(:provider_user_notification_preferences, chase_provider_decision: false, provider_user: create(:provider_user, providers: [application_choice.course.provider]))
 
-        create(:provider_user_notification_preferences, chase_provider_decision: false, provider_user: create(:provider_user, providers: [application_choice.course.provider]))
-
-        expect(described_class.for(application_choice, event: :chase_provider_decision).to_a).to eql([provider_user])
-      end
+      expect(described_class.for(application_choice, event: :chase_provider_decision).to_a).to eql([provider_user])
     end
 
     it 'returns training and ratifying provider users for the application choice for a given type of event' do

--- a/spec/services/save_provider_user_notification_preferences_spec.rb
+++ b/spec/services/save_provider_user_notification_preferences_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe SaveProviderUserNotificationPreferences do
       it 'sets the correct value for the #notification_preferences for a provider user' do
         service.update_all_notification_preferences!(notification_preferences_params: notification_preferences_params)
 
-        ProviderUserNotificationPreferences.notification_preferences.each do |preference|
+        ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |preference|
           expect(provider_user.reload.notification_preferences.send(preference)).to be(false)
         end
       end
@@ -52,29 +52,6 @@ RSpec.describe SaveProviderUserNotificationPreferences do
           'application_rejected_by_default' => false,
           'offer_accepted' => true,
           'offer_declined' => false,
-        )
-      end
-    end
-
-    context 'when the :make_decision_reminder_notification_setting feature flag is off' do
-      before { FeatureFlag.deactivate(:make_decision_reminder_notification_setting) }
-
-      let(:notification_preferences_params) do
-        {
-          application_received: false,
-          application_withdrawn: false,
-          application_rejected_by_default: false,
-          offer_accepted: false,
-          offer_declined: false,
-        }
-      end
-
-      it 'updates the chase_provider_decision alongside the application_received' do
-        service.update_all_notification_preferences!(notification_preferences_params: notification_preferences_params)
-
-        expect(provider_user.reload.notification_preferences.attributes).to include(
-          'application_received' => false,
-          'chase_provider_decision' => false,
         )
       end
     end

--- a/spec/system/provider_interface/manage_provider_user_notifications_spec.rb
+++ b/spec/system/provider_interface/manage_provider_user_notifications_spec.rb
@@ -29,13 +29,13 @@ RSpec.feature 'Managing notifications' do
   end
 
   def then_i_can_see_all_notifications_are_on_by_default
-    ProviderUserNotificationPreferences.notification_preferences.each do |type|
+    ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |type|
       expect(find(:css, "#provider-user-notification-preferences-#{type.to_s.dasherize}-true-field")).to be_checked
     end
   end
 
   def when_i_choose_not_to_receive_notifications
-    ProviderUserNotificationPreferences.notification_preferences.each do |type|
+    ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |type|
       choose "provider-user-notification-preferences-#{type.to_s.dasherize}-false-field"
     end
     click_on 'Save settings'
@@ -44,7 +44,7 @@ RSpec.feature 'Managing notifications' do
   def then_my_notification_preferences_are_updated
     expect(page).to have_content 'Email notification settings saved'
 
-    ProviderUserNotificationPreferences.notification_preferences.each do |type|
+    ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |type|
       expect(find(:css, "#provider-user-notification-preferences-#{type.to_s.dasherize}-false-field")).to be_checked
     end
   end

--- a/spec/system/support_interface/managing_provider_user_notification_preferences_spec.rb
+++ b/spec/system/support_interface/managing_provider_user_notification_preferences_spec.rb
@@ -50,13 +50,13 @@ RSpec.feature 'Managing provider user notification preferences' do
   end
 
   def then_i_can_see_all_notifications_are_on_by_default
-    ProviderUserNotificationPreferences.notification_preferences.each do |type|
+    ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |type|
       expect(find(:css, "#provider-user-notification-preferences-#{type.to_s.dasherize}-true-field")).to be_checked
     end
   end
 
   def when_i_update_all_notifications_to_be_off
-    ProviderUserNotificationPreferences.notification_preferences.each do |type|
+    ProviderUserNotificationPreferences::NOTIFICATION_PREFERENCES.each do |type|
       choose "provider-user-notification-preferences-#{type.to_s.dasherize}-false-field"
     end
     click_on 'Save settings'


### PR DESCRIPTION
## Context
https://trello.com/c/Mha9zku0/4901-extract-makedecisionremindernotificationsetting
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Taking out the `:make_decision_reminder_notification_setting` feature flag. I think I've gotten it everywhere, the setting seems to work locally
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
