### PR TITLE
Ensure inset help text still appears

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -235,8 +235,7 @@ module CandidateInterface
 
     def visa_details_row(application_choice)
       return if immigration_right_to_work?(application_choice) ||
-                application_predates_visa_sponsorship_information?(application_choice) ||
-                !FeatureFlag.active?(:restructured_immigration_status)
+                application_predates_visa_sponsorship_information?(application_choice)
 
       {
         key: 'Visa sponsorship',
@@ -246,7 +245,7 @@ module CandidateInterface
 
     def immigration_right_to_work?(application_choice)
       application_choice.application_form.british_or_irish? ||
-        application_choice.application_form.immigration_right_to_work?
+        application_form.right_to_work_or_study == 'yes'
     end
 
     def application_predates_visa_sponsorship_information?(application_choice)

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -234,8 +234,9 @@ module CandidateInterface
     end
 
     def visa_details_row(application_choice)
-      return if immigration_right_to_work?(application_choice) ||
-                application_predates_visa_sponsorship_information?(application_choice)
+      return if (immigration_right_to_work?(application_choice) ||
+                application_predates_visa_sponsorship_information?(application_choice)) ||
+                provider_can_sponsor_visa?(application_choice)
 
       {
         key: 'Visa sponsorship',
@@ -250,6 +251,16 @@ module CandidateInterface
 
     def application_predates_visa_sponsorship_information?(application_choice)
       application_choice.application_form.recruitment_cycle_year < 2022
+    end
+
+    def provider_can_sponsor_visa?(application_choice)
+      (
+        application_choice.course.salary? &&
+          application_choice.provider.can_sponsor_skilled_worker_visa?
+      ) || (
+        !application_choice.course.salary? &&
+          application_choice.provider.can_sponsor_student_visa?
+      )
     end
 
     def status_row(application_choice)

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -246,7 +246,7 @@ module CandidateInterface
 
     def immigration_right_to_work?(application_choice)
       application_choice.application_form.british_or_irish? ||
-        application_form.right_to_work_or_study == 'yes'
+        application_form.right_to_work_or_study_yes?
     end
 
     def application_predates_visa_sponsorship_information?(application_choice)

--- a/app/components/candidate_interface/course_choices_review_visa_status_component.html.erb
+++ b/app/components/candidate_interface/course_choices_review_visa_status_component.html.erb
@@ -2,11 +2,11 @@
   <p class="govuk-heading-s app-inset-text__title">Visa sponsorship is not available for this course</p>
 
   <p class="govuk-body">
-    Check your eligibility for different <%= govuk_link_to('visa types and immigration statuses', t('train_to_teach_in_england.url')) %>.
+    If you need a Student or Skilled Worker visa to get the right to work or study in the UK, you should
+    <%= govuk_link_to('find a course', t('find_postgraduate_teacher_training.production_url')) %> where sponsorship is available.
   </p>
 
   <p class="govuk-body">
-    If you need a Student or Skilled Worker visa to get the right to work or study in the UK, you should
-    <%= govuk_link_to('find a course', t('find_postgraduate_teacher_training.production_url')) %> where sponsorship is available.
+    Check your eligibility for different <%= govuk_link_to('visa types and immigration statuses', t('train_to_teach_in_england.url')) %>.
   </p>
 <% end %>

--- a/app/components/candidate_interface/course_choices_review_visa_status_component.html.erb
+++ b/app/components/candidate_interface/course_choices_review_visa_status_component.html.erb
@@ -1,18 +1,12 @@
-<% if can_sponsor_visa? %>
-  <%= title %>
-<% else %>
-  <%= govuk_inset_text(classes: 'app-inset-text--narrow-border app-inset-text--important') do %>
-    <p class="govuk-heading-s app-inset-text__title"><%= title %></p>
+<%= govuk_inset_text(classes: 'app-inset-text--narrow-border app-inset-text--important') do %>
+  <p class="govuk-heading-s app-inset-text__title">Visa sponsorship is not available for this course</p>
 
-    <p class="govuk-body">
-      You said that you do not yet have the right to work or study in the UK.
-    </p>
+  <p class="govuk-body">
+    Check your eligibility for different <%= govuk_link_to('visa types and immigration statuses', t('train_to_teach_in_england.url')) %>.
+  </p>
 
-    <p class="govuk-body">You can:</p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>find a course that can sponsor student visas</li>
-      <li>find out about <%= govuk_link_to('other visas that allow you to study in the UK', t('train_to_teach_in_england.url')) %></li>
-    </ul>
-  <% end %>
+  <p class="govuk-body">
+    If you need a Student or Skilled Worker visa to get the right to work or study in the UK, you should
+    <%= govuk_link_to('find a course', t('find_postgraduate_teacher_training.production_url')) %> where sponsorship is available.
+  </p>
 <% end %>

--- a/app/components/candidate_interface/course_choices_review_visa_status_component.rb
+++ b/app/components/candidate_interface/course_choices_review_visa_status_component.rb
@@ -5,27 +5,5 @@ module CandidateInterface
     def initialize(application_choice:)
       @application_choice = application_choice
     end
-
-  private
-
-    def can_sponsor_visa?
-      (
-        @application_choice.course.salary? &&
-        @application_choice.provider.can_sponsor_skilled_worker_visa?
-      ) || (
-        !@application_choice.course.salary? &&
-        @application_choice.provider.can_sponsor_student_visa?
-      )
-    end
-
-    def title
-      if can_sponsor_visa?
-        'Visas can be sponsored'
-      elsif @application_choice.course.salary?
-        'This provider cannot sponsor Skilled Worker visas'
-      else
-        'This provider cannot sponsor Student visas'
-      end
-    end
   end
 end

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -462,10 +462,13 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true
   end
 
   describe 'Visa sponsorship details' do
-    context 'in 2022 cycle when the candidate does not need a visa' do
+    context 'when a candidate has an application from 2022 and has the right to work' do
       it 'does NOT render a Visa sponsorship row' do
         application_form = create(
           :completed_application_form,
+          first_nationality: 'Indian',
+          second_nationality: nil,
+          right_to_work_or_study: 'yes',
           recruitment_cycle_year: 2022,
         )
         create(:application_choice, application_form: application_form)
@@ -475,46 +478,13 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true
       end
     end
 
-    context 'in 2022 cycle when the candidate needs a visa' do
-      it 'does render a Visa sponsorship row' do
+    context 'when a candidate has an application from 2022 and does not have the right to work' do
+      it 'does renders a Visa sponsorship row' do
         application_form = create(
           :completed_application_form,
           first_nationality: 'Indian',
           second_nationality: nil,
-          immigration_right_to_work: true,
-          recruitment_cycle_year: 2022,
-        )
-        create(:application_choice, application_form: application_form)
-
-        result = render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
-        expect(result.css('.govuk-summary-list__key').text).not_to include('Visa sponsorship')
-      end
-    end
-
-    context 'in 2021 cycle when the candidate needs a visa' do
-      it 'does NOT render a Visa sponsorship row' do
-        application_form = create(
-          :completed_application_form,
-          first_nationality: 'Indian',
-          second_nationality: nil,
-          immigration_right_to_work: true,
-          recruitment_cycle_year: 2021,
-        )
-        create(:application_choice, application_form: application_form)
-
-        result = render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
-        expect(result.css('.govuk-summary-list__key').text).not_to include('Visa sponsorship')
-      end
-    end
-
-    context 'when candidate does not have right to work Feature flag on' do
-      it 'does render a Visa sponsorship row' do
-        FeatureFlag.activate(:restructured_immigration_status)
-        application_form = create(
-          :completed_application_form,
-          first_nationality: 'Indian',
-          second_nationality: nil,
-          immigration_right_to_work: false,
+          right_to_work_or_study: 'no',
           recruitment_cycle_year: 2022,
         )
         create(:application_choice, application_form: application_form)
@@ -524,15 +494,14 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true
       end
     end
 
-    context 'when candidate does not have right to work Feature flag off' do
-      it 'does render a Visa sponsorship row' do
-        FeatureFlag.deactivate(:restructured_immigration_status)
+    context 'when a candidate has an application from 2021 and does not have the right to work' do
+      it 'does NOT render a Visa sponsorship row' do
         application_form = create(
           :completed_application_form,
           first_nationality: 'Indian',
           second_nationality: nil,
-          immigration_right_to_work: false,
-          recruitment_cycle_year: 2022,
+          right_to_work_or_study: 'no',
+          recruitment_cycle_year: 2021,
         )
         create(:application_choice, application_form: application_form)
 
@@ -541,13 +510,29 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true
       end
     end
 
-    context 'when candidate does have right to work' do
+    context 'when a candidate has an application from 2021 and has the right to work' do
       it 'does NOT render a Visa sponsorship row' do
         application_form = create(
           :completed_application_form,
           first_nationality: 'Indian',
           second_nationality: nil,
-          immigration_right_to_work: true,
+          right_to_work_or_study: 'yes',
+          recruitment_cycle_year: 2021,
+        )
+        create(:application_choice, application_form: application_form)
+
+        result = render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
+        expect(result.css('.govuk-summary-list__key').text).not_to include('Visa sponsorship')
+      end
+    end
+
+    context 'when british candidate has an application from 2022 and does not have the right to work' do
+      it 'does NOT render a Visa sponsorship row' do
+        application_form = create(
+          :completed_application_form,
+          first_nationality: 'British',
+          second_nationality: nil,
+          right_to_work_or_study: 'no',
           recruitment_cycle_year: 2022,
         )
         create(:application_choice, application_form: application_form)

--- a/spec/components/candidate_interface/course_choices_review_visa_status_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_visa_status_component_spec.rb
@@ -1,82 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::CourseChoicesReviewVisaStatusComponent do
-  context 'when course is salaried' do
-    context 'and provider does NOT sponsor Skilled Worker visas' do
-      it 'renders component with warning' do
-        application_choice = setup_application(
-          funding_type: :salary,
-          can_sponsor_skilled_worker_visa: false,
-          can_sponsor_student_visa: false,
-        )
-        result = render_inline(described_class.new(application_choice: application_choice))
+  it 'renders component with warning' do
+    application_choice = setup_application
+    result = render_inline(described_class.new(application_choice: application_choice))
 
-        expect(result.css('.app-inset-text__title').text).to include('This provider cannot sponsor Skilled Worker visas')
-      end
-    end
-
-    context 'and provider does sponsor Skilled Worker visas' do
-      it 'renders component with message that visas are sponsored' do
-        application_choice = setup_application(
-          funding_type: :salary,
-          can_sponsor_skilled_worker_visa: true,
-          can_sponsor_student_visa: false,
-        )
-        result = render_inline(described_class.new(application_choice: application_choice))
-
-        expect(result.text).to include('Visas can be sponsored')
-      end
-    end
+    expect(result.css('.app-inset-text__title').text).to include('Visa sponsorship is not available for this course')
   end
 
-  context 'when course has a fee' do
-    context 'and provider does NOT sponsor Student visas' do
-      it 'renders component with warning' do
-        application_choice = setup_application(
-          funding_type: :fee,
-          can_sponsor_skilled_worker_visa: false,
-          can_sponsor_student_visa: false,
-        )
-        result = render_inline(described_class.new(application_choice: application_choice))
-
-        expect(result.css('.app-inset-text__title').text).to include('This provider cannot sponsor Student visas')
-      end
-    end
-
-    context 'and provider does sponsor Student visas' do
-      it 'renders component with message that visas are sponsored' do
-        application_choice = setup_application(
-          funding_type: :fee,
-          can_sponsor_skilled_worker_visa: false,
-          can_sponsor_student_visa: true,
-        )
-        result = render_inline(described_class.new(application_choice: application_choice))
-
-        expect(result.text).to include('Visas can be sponsored')
-      end
-    end
-  end
-
-  def setup_application(
-    funding_type:,
-    can_sponsor_skilled_worker_visa:,
-    can_sponsor_student_visa:
-  )
+  def setup_application
     course_option = create(
       :course_option,
       course: create(
         :course,
         provider: create(
           :provider,
-          can_sponsor_skilled_worker_visa: can_sponsor_skilled_worker_visa,
-          can_sponsor_student_visa: can_sponsor_student_visa,
         ),
-        funding_type: funding_type,
       ),
     )
     create(
       :application_choice,
-      :with_completed_application_form,
       course_option: course_option,
     )
   end


### PR DESCRIPTION
## Context

There is a different right to work question, which is currently still behind a feature flag. We have decided not to use this question. 

The trigger for the inset text once a course was chosen was this question. 

This PR changes that trigger, it will now be the original right to work question. This PR also adds an extra conditional (detailed below).

## Changes proposed in this pull request

**This is being removed from the feature flag in this PR and will be in production once merged.**

When selecting a course, the help text should now appear if the all the following criteria are satisfied:

- The RC is greater than or equal to`2022`
- The candidate is a `Citizen of a different country`
- The candidate has chosen `no` to the right to work question
- The provider can not sponsor the visa (sponsored skilled worker visa for salaried courses, and student visa for non salaried courses)


The tests have also been reworked, as this is now being removed from the feature flag.


## Screenshot

<img width="375" alt="image" src="https://user-images.githubusercontent.com/50492247/157322566-8dc722d1-ddbb-4d21-afd7-874c22d05bcb.png">


## Guidance to review

- Change the nationality to `Citizen of a different country`
- Choose `Not yet` to `Right to work or study in the UK`
- Choose a course and ensure the inset text appears 
- Repeat for different scenarios and ensure the inset text either does appear or does not depending on the situation



<img width="460" alt="image" src="https://user-images.githubusercontent.com/50492247/157242959-1b0baaf6-79c0-4e06-b718-4ec9b1997611.png">

## Link to Trello card

https://trello.com/c/VGbMj72b/4500-ensure-help-inset-text-still-appears
