### PR TITLE
Course Change - Add the checks page

### DIFF
--- a/app/components/provider_interface/change_course_details_component.html.erb
+++ b/app/components/provider_interface/change_course_details_component.html.erb
@@ -1,5 +1,5 @@
 <section class="app-section govuk-!-width-two-thirds">
-  <h2 class="govuk-heading-m govuk-!-font-size-27" id="course-details">Course details</h2>
+  <h2 class="govuk-heading-m govuk-!-font-size-27" id="course-details">Course</h2>
 
   <%= render SummaryListComponent.new(rows: rows) %>
 </section>

--- a/app/components/provider_interface/change_course_details_component.rb
+++ b/app/components/provider_interface/change_course_details_component.rb
@@ -28,8 +28,7 @@ module ProviderInterface
       [
         { key: 'Training provider', value: provider_name_and_code, action: { href: change_provider_path } },
         { key: 'Course', value: course_name_and_code, action: { href: change_course_path } },
-        { key: 'Cycle', value: cycle },
-        { key: 'Full or part time', value: study_mode, action: { href: change_study_mode_path } },
+        { key: 'Full time or part time', value: study_mode, action: { href: change_study_mode_path } },
         { key: 'Location', value: preferred_location, action: { href: change_location_path } },
         { key: 'Accredited body', value: accredited_body },
         { key: 'Qualification', value: qualification },

--- a/app/components/provider_interface/change_course_details_component.rb
+++ b/app/components/provider_interface/change_course_details_component.rb
@@ -7,10 +7,11 @@ module ProviderInterface
 
     attr_reader :application_choice, :provider_name_and_code, :course_name_and_code,
                 :cycle, :preferred_location, :study_mode, :qualification, :available_providers,
-                :available_courses, :course, :available_course_options
+                :available_courses, :course, :available_course_options, :course_option
 
-    def initialize(application_choice:, course: nil, available_providers: [], available_courses: [], available_course_options: [])
+    def initialize(application_choice:, course_option: nil, course: nil, available_providers: [], available_courses: [], available_course_options: [])
       @application_choice = application_choice
+      @course_option = course_option
       @provider_name_and_code = application_choice.provider.name_and_code
       @course_name_and_code = application_choice.course.name_and_code
       @cycle = application_choice.course.recruitment_cycle_year

--- a/app/components/provider_interface/check_course_details_component.html.erb
+++ b/app/components/provider_interface/check_course_details_component.html.erb
@@ -1,0 +1,3 @@
+<section class="app-section govuk-!-width-one-thirds">
+  <%= render SummaryListComponent.new(rows: rows) %>
+</section>

--- a/app/components/provider_interface/check_course_details_component.rb
+++ b/app/components/provider_interface/check_course_details_component.rb
@@ -1,0 +1,20 @@
+module ProviderInterface
+  class CheckCourseDetailsComponent < ChangeCourseDetailsComponent
+    def rows
+      [
+        { key: 'Training provider', value: course_option.provider.name_and_code, action: { href: change_provider_path } },
+        { key: 'Course', value: course_option.course.name_and_code, action: { href: change_course_path } },
+        { key: 'Full time or part time', value: course_option.study_mode.humanize, action: { href: change_study_mode_path } },
+        { key: 'Location', value: course_option.site.name_and_address, action: { href: change_location_path } },
+        { key: 'Accredited body', value: accredited_body },
+        { key: 'Qualification', value: qualification_text(course_option) },
+        { key: 'Funding type', value: course.funding_type.humanize },
+      ]
+    end
+
+    def accredited_body
+      accredited_body = course_option.course.accredited_provider
+      accredited_body.present? ? accredited_body.name_and_code : provider_name_and_code
+    end
+  end
+end

--- a/app/components/provider_interface/course_details_component.html.erb
+++ b/app/components/provider_interface/course_details_component.html.erb
@@ -1,5 +1,5 @@
 <section class="app-section govuk-!-width-two-thirds">
-  <h2 class="govuk-heading-m govuk-!-font-size-27" id="course-details">Course details</h2>
+  <h2 class="govuk-heading-m govuk-!-font-size-27" id="course-details">Course</h2>
 
   <%= render SummaryListComponent.new(rows: rows) %>
 </section>

--- a/app/controllers/provider_interface/courses/checks_controller.rb
+++ b/app/controllers/provider_interface/courses/checks_controller.rb
@@ -1,0 +1,14 @@
+module ProviderInterface
+  module Courses
+    class ChecksController < CoursesController
+      def edit
+        @wizard = CourseWizard.new(change_course_store, { current_step: 'check', action: action })
+        @wizard.save_state!
+
+        @providers = available_providers
+        @courses = available_courses(@wizard.provider_id)
+        @course_options = available_course_options(@wizard.course_id, @wizard.study_mode)
+      end
+    end
+  end
+end

--- a/app/controllers/provider_interface/courses/courses_controller.rb
+++ b/app/controllers/provider_interface/courses/courses_controller.rb
@@ -14,11 +14,7 @@ module ProviderInterface
         if @wizard.valid_for_current_step?
           @wizard.save_state!
 
-          if @wizard.next_step.nil?
-            redirect_to provider_interface_application_choice_path(@application_choice)
-          else
-            redirect_to [:edit, :provider_interface, @application_choice, :course, @wizard.next_step]
-          end
+          redirect_to [:edit, :provider_interface, @application_choice, :course, @wizard.next_step]
         else
           @courses = available_courses(@wizard.provider_id)
           track_validation_error(@wizard)

--- a/app/controllers/provider_interface/courses/locations_controller.rb
+++ b/app/controllers/provider_interface/courses/locations_controller.rb
@@ -14,7 +14,7 @@ module ProviderInterface
         if @wizard.valid_for_current_step?
           @wizard.save_state!
 
-          redirect_to provider_interface_application_choice_path(@application_choice)
+          redirect_to [:edit, :provider_interface, @application_choice, :course, @wizard.next_step]
         else
           @course_options = available_course_options(@wizard.course_id, @wizard.study_mode)
           track_validation_error(@wizard)

--- a/app/controllers/provider_interface/courses/study_modes_controller.rb
+++ b/app/controllers/provider_interface/courses/study_modes_controller.rb
@@ -16,11 +16,7 @@ module ProviderInterface
         if @wizard.valid_for_current_step?
           @wizard.save_state!
 
-          if @wizard.next_step.nil?
-            redirect_to provider_interface_application_choice_path(@application_choice)
-          else
-            redirect_to [:edit, :provider_interface, @application_choice, :course, @wizard.next_step]
-          end
+          redirect_to [:edit, :provider_interface, @application_choice, :course, @wizard.next_step]
         else
           @course = Course.find(@wizard.course_id)
           @study_modes = available_study_modes(@course)

--- a/app/controllers/provider_interface/courses_controller.rb
+++ b/app/controllers/provider_interface/courses_controller.rb
@@ -7,6 +7,25 @@ module ProviderInterface
       redirect_to provider_interface_application_choice_course_path(@application_choice)
     end
 
+    def update
+      @wizard = CourseWizard.new(change_course_store)
+      if @wizard.valid?(:save)
+        begin
+          @wizard.clear_state!
+          flash[:success] = t('.success')
+        rescue IdenticalOfferError
+          @wizard.clear_state!
+          flash[:success] = t('.success')
+        end
+      else
+        @wizard.clear_state!
+        track_validation_error(@wizard)
+
+        flash[:warning] = t('.failure')
+      end
+      redirect_to provider_interface_application_choice_offer_path(@application_choice)
+    end
+
   private
 
     def change_course_store

--- a/app/forms/provider_interface/course_wizard.rb
+++ b/app/forms/provider_interface/course_wizard.rb
@@ -3,7 +3,7 @@ module ProviderInterface
     include Wizard
     include Wizard::PathHistory
 
-    STEPS = %i[select_option providers courses study_modes locations].freeze
+    STEPS = %i[select_option providers courses study_modes locations check].freeze
 
     attr_accessor :path_history, :provider_id, :decision, :application_choice_id,
                   :course_option_id, :course_id, :provider_user_id, :study_mode

--- a/app/views/provider_interface/courses/checks/edit.html.erb
+++ b/app/views/provider_interface/courses/checks/edit.html.erb
@@ -1,0 +1,26 @@
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+
+<%= form_with model: @wizard, url: provider_interface_application_choice_course_path(@application_choice), method: :put do |f| %>
+  <h1 class="govuk-heading-l">
+    <span class="govuk-caption-l"><%= t('.caption', name: @application_choice.application_form.full_name) %></span>
+    <%= t('.title') %>
+  </h1>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= f.govuk_error_summary %>
+      <%= render ProviderInterface::CheckCourseDetailsComponent.new(application_choice: @application_choice,
+                                                                    course_option: @wizard.course_option,
+                                                                    course: @wizard.course_option.course,
+                                                                    available_providers: @providers,
+                                                                    available_courses: @courses,
+                                                                    available_course_options: @course_options) %>
+
+      <%= f.govuk_submit t('.submit') %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to t('cancel'), provider_interface_application_choice_path(@application_choice), no_visited_state: true %>
+      </p>
+    </div>
+  </div>
+<% end %>

--- a/config/locales/provider_interface/change_course.yml
+++ b/config/locales/provider_interface/change_course.yml
@@ -17,3 +17,11 @@ en:
         edit:
           title: Location
           caption: Update course - %{name}
+      checks:
+        edit:
+          title: Check details and update course
+          caption: Update course - %{name}
+          submit: Update course
+      update:
+        success: Course updated
+        failure: Unable to update course

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -729,6 +729,8 @@ Rails.application.routes.draw do
       resource :offers, only: %i[new edit create show update], as: :application_choice_offer
       resource :offers, only: %i[new edit], as: :application_choice_offer_referer
 
+      resource :courses, only: %i[update], as: :application_choice_course
+
       namespace :offer, as: :application_choice_offer do
         resource :providers, only: %i[new create edit update]
         resource :courses, only: %i[new create edit update]
@@ -743,6 +745,7 @@ Rails.application.routes.draw do
         resource :courses, only: %i[edit update]
         resource :study_modes, only: %i[edit update], path: 'study-modes'
         resource :locations, only: %i[edit update]
+        resource :check, only: %i[edit update]
       end
 
       get '/rejection-reasons' => 'reasons_for_rejection#edit_initial_questions', as: :reasons_for_rejection_initial_questions

--- a/spec/components/provider_interface/change_course_details_component_spec.rb
+++ b/spec/components/provider_interface/change_course_details_component_spec.rb
@@ -67,12 +67,11 @@ RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
   def row_text_selector(row_name, render)
     rows = { provider: 0,
              course: 1,
-             cycle: 2,
-             full_or_part_time: 3,
-             location: 4,
-             accredited_body: 5,
-             qualification: 6,
-             funding_type: 7 }
+             full_or_part_time: 2,
+             location: 3,
+             accredited_body: 4,
+             qualification: 5,
+             funding_type: 6 }
 
     render.css('.govuk-summary-list__row')[rows[row_name]].text
   end
@@ -129,7 +128,7 @@ RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
     it 'renders the study mode' do
       render_text = row_text_selector(:full_or_part_time, render)
 
-      expect(render_text).to include('Full or part time')
+      expect(render_text).to include('Full time or part time')
       expect(render_text).to include('Full time')
       expect(render_text).to include('Change')
     end
@@ -141,7 +140,7 @@ RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
     it 'renders the study mode' do
       render_text = row_text_selector(:full_or_part_time, render)
 
-      expect(render_text).to include('Full or part time')
+      expect(render_text).to include('Full time or part time')
       expect(render_text).to include('Full time')
       expect(render_text).not_to include('Change')
     end

--- a/spec/forms/provider_interface/course_wizard_spec.rb
+++ b/spec/forms/provider_interface/course_wizard_spec.rb
@@ -153,6 +153,17 @@ RSpec.describe ProviderInterface::CourseWizard do
           expect(wizard.next_step).to eq(:locations)
         end
       end
+
+      context 'when there is only one study mode and location' do
+        before do
+          allow(query_service).to receive(:available_study_modes).and_return(%w[part_time])
+          allow(query_service).to receive(:available_course_options).and_return([create(:course_option)])
+        end
+
+        it 'returns :check' do
+          expect(wizard.next_step).to eq(:check)
+        end
+      end
     end
 
     context 'when current_step is :study_modes' do
@@ -166,6 +177,24 @@ RSpec.describe ProviderInterface::CourseWizard do
         it 'returns :locations' do
           expect(wizard.next_step).to eq(:locations)
         end
+      end
+
+      context 'when there is only one location available' do
+        before do
+          allow(query_service).to receive(:available_course_options).and_return([build_stubbed(:course_option)])
+        end
+
+        it 'returns :check' do
+          expect(wizard.next_step).to eq(:check)
+        end
+      end
+    end
+
+    context 'when the current_step is :locations' do
+      let(:current_step) { :locations }
+
+      it 'returns :check' do
+        expect(wizard.next_step).to eq(:check)
       end
     end
   end


### PR DESCRIPTION
## Context

Currently providers can change the details of a course at the point of offer. We'd like to let providers do this before the point of offer.

Following from [#6622](https://github.com/DFE-Digital/apply-for-teacher-training/pull/6622) this is the fifth PR in the series. This is the checks page which will allow the users to review - and still change - their answers before confirming the update.

## Changes proposed in this pull request

<img width="698" alt="image" src="https://user-images.githubusercontent.com/47917431/157273649-b6bc4b7a-770f-450a-806e-2b86e0b88c86.png">


## Guidance to review

Currently nothing happens when you click 'Update course' – this is intentional. The actual service to perform the update will follow in another PR.

## Link to Trello card

https://trello.com/c/9c0r9yR8

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
