### PR TITLE
Remove the phrase 'through GOV.UK'

### DIFF
--- a/config/locales/provider_interface/provider_relationship_permissions.yml
+++ b/config/locales/provider_interface/provider_relationship_permissions.yml
@@ -29,10 +29,10 @@ en:
         next_steps: Next steps
     organisation_permissions_setup_list_component:
       single:
-        introduction: 'Candidates can now apply through GOV.UK for courses %{provider_name} works on with:'
+        introduction: 'Candidates can now apply for courses %{provider_name} works on with:'
         cannot_manage_rules: You cannot manage applications to these courses until you set up organisation permissions.
       multiple:
-        introduction: Candidates can now apply through GOV.UK for courses you work on with partner organisations.
+        introduction: Candidates can now apply for courses you work on with partner organisations.
         cannot_manage_rules: You cannot manage applications to these courses until either you or your partner organisations have set up organisation permissions.
         provider_list_heading: 'For %{provider_name}, you need to set up permissions for courses you work on with:'
       continue_button: Set up organisation permissions

--- a/spec/components/provider_interface/organisation_permissions_setup_list_component_spec.rb
+++ b/spec/components/provider_interface/organisation_permissions_setup_list_component_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe ProviderInterface::OrganisationPermissionsSetupListComponent do
 
   context 'when there is a single main provider' do
     it 'renders the correct intro text' do
-      expect(render.css('p').first.text.squish).to eq('Candidates can now apply through GOV.UK for courses Main provider works on with:')
+      expect(render.css('p').first.text.squish).to eq('Candidates can now apply for courses Main provider works on with:')
     end
 
     it 'renders the providers in order' do
@@ -49,7 +49,7 @@ RSpec.describe ProviderInterface::OrganisationPermissionsSetupListComponent do
     end
 
     it 'renders the correct intro text' do
-      expect(render.css('p')[0].text.squish).to eq('Candidates can now apply through GOV.UK for courses you work on with partner organisations.')
+      expect(render.css('p')[0].text.squish).to eq('Candidates can now apply for courses you work on with partner organisations.')
     end
 
     it 'renders the text about managing applications' do

--- a/spec/system/provider_interface/provider_user_sets_up_organisation_permissions_spec.rb
+++ b/spec/system/provider_interface/provider_user_sets_up_organisation_permissions_spec.rb
@@ -81,7 +81,7 @@ RSpec.feature 'Setting up organisation permissions' do
 
   def then_i_can_see_the_organisations_needing_permissions_setup
     expect(page).to have_content('Set up organisation permissions')
-    expect(page).to have_content('Candidates can now apply through GOV.UK for courses you work on with partner organisations')
+    expect(page).to have_content('Candidates can now apply for courses you work on with partner organisations')
     expect(page).to have_content("For #{@training_provider.name}, you need to set up permissions for courses you work on with:")
     expect(page).to have_content(@another_ratifying_provider.name)
     expect(page).to have_content("For #{@ratifying_provider.name}, you need to set up permissions for courses you work on with:")


### PR DESCRIPTION
## Context
https://trello.com/c/jb1ykZnY/4803-removing-the-phrase-through-govuk
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Removing the 'through GOV.UK' caveat now that we're off UCAS
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
