### PR TITLE
Change Make Decision button to green once interviewing

### DIFF
--- a/app/components/provider_interface/application_choice_header_component.html.erb
+++ b/app/components/provider_interface/application_choice_header_component.html.erb
@@ -24,7 +24,7 @@
               <%= govuk_button_link_to 'Set up interview', new_provider_interface_application_choice_interview_path(application_choice), class: 'govuk-!-margin-bottom-0' %>
             <% end %>
             <% if respond_to_application? %>
-              <%= govuk_button_link_to 'Make decision', new_provider_interface_application_choice_decision_path(application_choice), secondary: set_up_interview?, class: 'govuk-!-margin-bottom-0' %>
+              <%= govuk_button_link_to 'Make decision', new_provider_interface_application_choice_decision_path(application_choice), class: make_decision_button_class %>
             <% end %>
           </div>
         <% elsif awaiting_decision_but_cannot_respond? -%>

--- a/app/components/provider_interface/application_choice_header_component.rb
+++ b/app/components/provider_interface/application_choice_header_component.rb
@@ -96,6 +96,10 @@ module ProviderInterface
       end
     end
 
+    def make_decision_button_class
+      "govuk-!-margin-bottom-0#{' govuk-button--secondary' if set_up_interview?}"
+    end
+
   private
 
     def application_navigation_item

--- a/spec/components/provider_interface/application_choice_header_component_spec.rb
+++ b/spec/components/provider_interface/application_choice_header_component_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ProviderInterface::ApplicationChoiceHeaderComponent do
       it 'the Make decision and Set up interview buttons are available and RDB info is presented' do
         expect(result.css('h2.govuk-heading-m').first.text.strip).to eq('Set up an interview or make a decision')
         expect(result.css('.govuk-button').first.text).to eq('Set up interview')
-        expect(result.css('.govuk-button').last.text).to eq('Make decision')
+        expect(result.css('.govuk-button--secondary').last.text).to eq('Make decision')
         expect(result.css('.govuk-inset-text').text).to include(
           "This application will be automatically rejected if a decision has not been made by the end of tomorrow (#{reject_by_default_at.to_s(:govuk_date_and_time)}).",
         )


### PR DESCRIPTION
## Context
https://trello.com/c/n54pktAd/4920-make-the-make-decision-button-green-when-interviewing
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
The Make Decision button was appearing as `govuk-button--secondary` even when in the interviewing state. I've rejigged the logic so that it only appears grey when there's a `Set up interview` button before it. I think the original implementation assumed that the `secondary: set_up_interview?` arg being passed would be toggled on or off, but that's apparently not how the `govuk_button_link_to` works
<!-- If there are UI changes, please include Before and After screenshots. -->
| OLD | NEW | 
| - | - |
| ![image](https://user-images.githubusercontent.com/25597009/157275927-c3f94a71-9de4-41b5-9c34-1f233e3d1c5d.png)| ![image](https://user-images.githubusercontent.com/25597009/157275885-602d057f-d806-4bf8-b94e-0e17b14218e1.png)|
## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
