### PR TITLE
make message stronger about not needing to respond yet

### DIFF
--- a/app/components/candidate_interface/course_choices_summary_card_action_component.rb
+++ b/app/components/candidate_interface/course_choices_summary_card_action_component.rb
@@ -13,7 +13,7 @@ module CandidateInterface
       if application_choice.application_form.all_provider_decisions_made?
         "You have #{pluralize(days_left_to_respond, 'day')} (until #{application_choice.decline_by_default_at.to_s(:govuk_date)}) to respond."
       else
-        'You can wait to hear back from everyone before you respond.'
+        'You do not need to respond to this offer yet. Once you’ve recieved decisions from all of your training providers, you’ll have 10 working days to accept or decline any offers.'
       end
     end
 

--- a/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
+++ b/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe CandidateInterface::ApplicationDashboardCourseChoicesComponent do
         ),
       )
       expect(result.css('.govuk-summary-list__value').text).to include(
-        'You can wait to hear back from everyone before you respond.',
+        'You do not need to respond to this offer yet. Once you’ve recieved decisions from all of your training providers, you’ll have 10 working days to accept or decline any offers.',
       )
     end
 


### PR DESCRIPTION
This PR aims to makes it clearer that candidates don't need to respond to an offer yet if they're still waiting for decisions. 

See Trello card for more context:

https://trello.com/c/olgf5xJY/4328-make-it-clearer-to-candidates-that-they-can-wait-for-other-choices-to-be-decided-before-accepting-an-offer

There's a lot more we could do to resolve this issue, but just trying to cover the basics in this PR - e.g. making it clear that the candidate will have 10 working days when they receive their final decision. 

p.s. @frankieroberto can u help me put a paragraph break in the text? 

Before

![Screenshot 2022-03-08 at 18 33 38](https://user-images.githubusercontent.com/56349171/157304001-db0b3297-2fb7-471d-b46a-499a8adce290.png)

After

![Screenshot 2022-03-08 at 18 35 07](https://user-images.githubusercontent.com/56349171/157303996-455cfd2a-46de-4356-8db5-fff730472b32.png)



