### PR TITLE
Make Provider/Support users confirm sign-in before expiring their DSI fallback link

### DIFF
--- a/app/controllers/provider_interface/sessions_controller.rb
+++ b/app/controllers/provider_interface/sessions_controller.rb
@@ -37,6 +37,19 @@ module ProviderInterface
 
     def check_your_email; end
 
+    def confirm_authentication_with_token
+      if FeatureFlag.active?('dfe_sign_in_fallback')
+        authentication_token = AuthenticationToken.find_by_hashed_token(
+          user_type: 'ProviderUser',
+          raw_token: params.fetch(:token),
+        )
+
+        render_404 unless authentication_token&.still_valid?
+      else
+        redirect_to provider_interface_sign_in_path
+      end
+    end
+
     def authenticate_with_token
       redirect_to action: :new and return unless FeatureFlag.active?('dfe_sign_in_fallback')
 

--- a/app/controllers/provider_interface/sessions_controller.rb
+++ b/app/controllers/provider_interface/sessions_controller.rb
@@ -27,27 +27,29 @@ module ProviderInterface
 
       provider_user = ProviderUser.find_by(email_address: params.dig(:provider_user, :email_address).downcase.strip)
 
-      if provider_user && provider_user.dfe_sign_in_uid.present?
-        magic_link_token = provider_user.create_magic_link_token!
-        ProviderMailer.fallback_sign_in_email(provider_user, magic_link_token).deliver_later
-      end
-
-      redirect_to provider_interface_check_your_email_path
+      send_new_authentication_token! provider_user
     end
 
     def check_your_email; end
 
     def confirm_authentication_with_token
       if FeatureFlag.active?('dfe_sign_in_fallback')
-        authentication_token = AuthenticationToken.find_by_hashed_token(
-          user_type: 'ProviderUser',
-          raw_token: params.fetch(:token),
-        )
+        authentication_token = look_up_token params.fetch(:token)
 
-        render_404 unless authentication_token&.still_valid?
+        if authentication_token
+          render :expired_token unless authentication_token.still_valid?
+        else
+          render_404
+        end
       else
         redirect_to provider_interface_sign_in_path
       end
+    end
+
+    def request_new_token
+      authentication_token = look_up_token params.fetch(:token)
+
+      send_new_authentication_token! authentication_token.user
     end
 
     def authenticate_with_token
@@ -72,6 +74,22 @@ module ProviderInterface
     end
 
   private
+
+    def look_up_token(token)
+      AuthenticationToken.find_by_hashed_token(
+        user_type: 'ProviderUser',
+        raw_token: token,
+      )
+    end
+
+    def send_new_authentication_token!(user)
+      if user && user.dfe_sign_in_uid.present?
+        magic_link_token = user.create_magic_link_token!
+        ProviderMailer.fallback_sign_in_email(user, magic_link_token).deliver_later
+      end
+
+      redirect_to provider_interface_check_your_email_path
+    end
 
     def impersonation?
       ProviderImpersonation.load_from_session(session)

--- a/app/controllers/support_interface/sessions_controller.rb
+++ b/app/controllers/support_interface/sessions_controller.rb
@@ -27,25 +27,27 @@ module SupportInterface
 
       support_user = SupportUser.find_by(email_address: params.dig(:support_user, :email_address).downcase.strip)
 
-      if support_user
-        magic_link_token = support_user.create_magic_link_token!
-        SupportMailer.fallback_sign_in_email(support_user, magic_link_token).deliver_later
-      end
-
-      redirect_to support_interface_check_your_email_path
+      send_new_authentication_token! support_user
     end
 
     def confirm_authentication_with_token
       if FeatureFlag.active?('dfe_sign_in_fallback')
-        authentication_token = AuthenticationToken.find_by_hashed_token(
-          user_type: 'SupportUser',
-          raw_token: params.fetch(:token),
-        )
+        authentication_token = look_up_token params.fetch(:token)
 
-        render_404 unless authentication_token&.still_valid?
+        if authentication_token
+          render :expired_token unless authentication_token.still_valid?
+        else
+          render_404
+        end
       else
         redirect_to support_interface_sign_in_path
       end
+    end
+
+    def request_new_token
+      authentication_token = look_up_token params.fetch(:token)
+
+      send_new_authentication_token! authentication_token.user
     end
 
     def authenticate_with_token
@@ -82,6 +84,24 @@ module SupportInterface
       else
         render :confirm_environment
       end
+    end
+
+  private
+
+    def look_up_token(token)
+      AuthenticationToken.find_by_hashed_token(
+        user_type: 'SupportUser',
+        raw_token: token,
+      )
+    end
+
+    def send_new_authentication_token!(user)
+      if user && user.dfe_sign_in_uid.present?
+        magic_link_token = user.create_magic_link_token!
+        SupportMailer.fallback_sign_in_email(user, magic_link_token).deliver_later
+      end
+
+      redirect_to support_interface_check_your_email_path
     end
   end
 end

--- a/app/controllers/support_interface/sessions_controller.rb
+++ b/app/controllers/support_interface/sessions_controller.rb
@@ -35,6 +35,19 @@ module SupportInterface
       redirect_to support_interface_check_your_email_path
     end
 
+    def confirm_authentication_with_token
+      if FeatureFlag.active?('dfe_sign_in_fallback')
+        authentication_token = AuthenticationToken.find_by_hashed_token(
+          user_type: 'SupportUser',
+          raw_token: params.fetch(:token),
+        )
+
+        render_404 unless authentication_token&.still_valid?
+      else
+        redirect_to support_interface_sign_in_path
+      end
+    end
+
     def authenticate_with_token
       redirect_to action: :new and return unless FeatureFlag.active?('dfe_sign_in_fallback')
 

--- a/app/views/provider_interface/sessions/confirm_authentication_with_token.html.erb
+++ b/app/views/provider_interface/sessions/confirm_authentication_with_token.html.erb
@@ -1,0 +1,16 @@
+<% content_for :title, t('authentication.confirm_authentication.heading') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: provider_interface_authenticate_with_token_path, method: :post do |f| %>
+      <h1 class="govuk-heading-xl">
+        Confirm sign in
+      </h1>
+      <p class="govuk-body">
+        Click below to sign in
+      </p>
+      <%= hidden_field_tag :token, params[:token] %>
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/provider_interface/sessions/expired_token.html.erb
+++ b/app/views/provider_interface/sessions/expired_token.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title, t('authentication.expired_token.heading') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: provider_interface_request_new_token_path, method: :post do |f| %>
+      <h1 class="govuk-heading-xl">
+        <%= t('authentication.expired_token.heading') %>
+      </h1>
+      <p class="govuk-body">
+        Sign in links only work once and expire after one hour, so you need to request a new one. We’ll send this by email.
+      </p>
+
+      <%= hidden_field_tag :token, params[:token] %>
+      <%= f.govuk_submit t('authentication.expired_token.button') %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/sessions/confirm_authentication_with_token.html.erb
+++ b/app/views/support_interface/sessions/confirm_authentication_with_token.html.erb
@@ -1,0 +1,16 @@
+<% content_for :title, t('authentication.confirm_authentication.heading') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: support_interface_authenticate_with_token_path, method: :post do |f| %>
+      <h1 class="govuk-heading-xl">
+        Confirm sign in
+      </h1>
+      <p class="govuk-body">
+        Click below to sign in
+      </p>
+      <%= hidden_field_tag :token, params[:token] %>
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/sessions/expired_token.html.erb
+++ b/app/views/support_interface/sessions/expired_token.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title, t('authentication.expired_token.heading') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: support_interface_request_new_token_path, method: :post do |f| %>
+      <h1 class="govuk-heading-xl">
+        <%= t('authentication.expired_token.heading') %>
+      </h1>
+      <p class="govuk-body">
+        Sign in links only work once and expire after one hour, so you need to request a new one. We’ll send this by email.
+      </p>
+
+      <%= hidden_field_tag :token, params[:token] %>
+      <%= f.govuk_submit t('authentication.expired_token.button') %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -780,6 +780,7 @@ Rails.application.routes.draw do
     get '/sign-in/check-email', to: 'sessions#check_your_email', as: :check_your_email
     get '/sign-in-by-email' => 'sessions#confirm_authentication_with_token', as: :confirm_authentication_with_token
     post '/sign-in-by-email' => 'sessions#authenticate_with_token', as: :authenticate_with_token
+    post '/request-new-token' => 'sessions#request_new_token', as: :request_new_token
 
     get '/account' => 'account#show'
 
@@ -1132,6 +1133,7 @@ Rails.application.routes.draw do
     get '/sign-in/check-email', to: 'sessions#check_your_email', as: :check_your_email
     get '/sign-in-by-email' => 'sessions#confirm_authentication_with_token', as: :confirm_authentication_with_token
     post '/sign-in-by-email' => 'sessions#authenticate_with_token', as: :authenticate_with_token
+    post '/request-new-token' => 'sessions#request_new_token', as: :request_new_token
 
     # https://github.com/mperham/sidekiq/wiki/Monitoring#rails-http-basic-auth-from-routes
     require 'sidekiq/web'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -778,7 +778,8 @@ Rails.application.routes.draw do
 
     post '/request-sign-in-by-email' => 'sessions#sign_in_by_email', as: :sign_in_by_email
     get '/sign-in/check-email', to: 'sessions#check_your_email', as: :check_your_email
-    get '/sign-in-by-email' => 'sessions#authenticate_with_token', as: :authenticate_with_token
+    get '/sign-in-by-email' => 'sessions#confirm_authentication_with_token', as: :confirm_authentication_with_token
+    post '/sign-in-by-email' => 'sessions#authenticate_with_token', as: :authenticate_with_token
 
     get '/account' => 'account#show'
 
@@ -1127,8 +1128,10 @@ Rails.application.routes.draw do
     post '/confirm-environment' => 'sessions#confirmed_environment'
 
     post '/request-sign-in-by-email' => 'sessions#sign_in_by_email', as: :sign_in_by_email
+
     get '/sign-in/check-email', to: 'sessions#check_your_email', as: :check_your_email
-    get '/sign-in-by-email' => 'sessions#authenticate_with_token', as: :authenticate_with_token
+    get '/sign-in-by-email' => 'sessions#confirm_authentication_with_token', as: :confirm_authentication_with_token
+    post '/sign-in-by-email' => 'sessions#authenticate_with_token', as: :authenticate_with_token
 
     # https://github.com/mperham/sidekiq/wiki/Monitoring#rails-http-basic-auth-from-routes
     require 'sidekiq/web'

--- a/spec/system/provider_interface/authentication_fallback_expired_link_spec.rb
+++ b/spec/system/provider_interface/authentication_fallback_expired_link_spec.rb
@@ -1,0 +1,104 @@
+require 'rails_helper'
+
+RSpec.describe 'A provider with an expired DSI fallback link' do
+  include DfESignInHelpers
+
+  scenario 'signs in by requesting a new token' do
+    FeatureFlag.activate('dfe_sign_in_fallback')
+
+    given_i_am_registered_as_a_provider_user
+    when_i_visit_the_interviews_schedule_path
+    then_i_am_redirected_to_the_provider_sign_in_path
+
+    when_i_provide_my_email_address
+    then_i_receive_an_email_with_a_signin_link
+    when_i_visit_the_link_in_my_email
+    then_i_see_a_confirm_sign_in_page
+    when_i_click_on_continue
+    then_i_am_signed_in
+
+    when_i_sign_out
+    then_i_am_not_signed_in
+
+    when_i_visit_the_link_in_my_email
+    then_i_see_the_expired_token_page
+
+    when_i_request_a_new_token
+    then_i_receive_an_email_with_a_signin_link
+
+    when_i_visit_the_link_in_my_email
+    then_i_see_a_confirm_sign_in_page
+
+    when_i_click_on_continue
+    then_i_am_signed_in
+  end
+
+  def given_i_am_registered_as_a_provider_user
+    @email = 'provider@example.com'
+    @provider_user = create(:provider_user, email_address: @email, dfe_sign_in_uid: 'DFE_SIGN_IN_UID', first_name: 'Michael')
+  end
+
+  def when_i_visit_the_provider_interface_applications_path
+    visit provider_interface_applications_path(some_key: 'some_value')
+  end
+
+  def when_i_visit_the_interviews_schedule_path
+    visit provider_interface_interview_schedule_path
+  end
+
+  def then_i_am_redirected_to_the_provider_sign_in_path
+    expect(page).to have_current_path(provider_interface_sign_in_path)
+  end
+
+  def when_i_provide_my_email_address
+    fill_in 'Email address', with: 'pRoViDeR@example.com '
+    click_on t('continue')
+  end
+
+  def then_i_do_not_receive_an_email_with_a_signin_link
+    open_email(@email)
+    expect(current_email).not_to be_present
+  end
+
+  def then_i_receive_an_email_with_a_signin_link
+    open_email(@email)
+    expect(current_email.subject).to have_content 'Sign in - manage teacher training applications'
+  end
+
+  def when_i_visit_the_link_in_my_email
+    uri = URI(current_email.find_css('a').first.text)
+    visit "#{uri.path}?#{uri.query}"
+  end
+
+  def then_i_see_the_expired_token_page
+    expect(page).to have_content 'The link you clicked has expired'
+  end
+
+  def when_i_request_a_new_token
+    click_on 'Email me a new link'
+  end
+
+  def then_i_see_a_confirm_sign_in_page
+    expect(page).to have_content 'Confirm sign in'
+  end
+
+  def when_i_click_on_continue
+    click_on 'Continue'
+  end
+
+  def then_i_am_signed_in
+    within 'header' do
+      expect(page).to have_content 'Sign out'
+    end
+  end
+
+  def when_i_sign_out
+    click_on 'Sign out'
+  end
+
+  def then_i_am_not_signed_in
+    within 'header' do
+      expect(page).not_to have_content @email
+    end
+  end
+end

--- a/spec/system/provider_interface/authentication_fallback_spec.rb
+++ b/spec/system/provider_interface/authentication_fallback_spec.rb
@@ -19,7 +19,14 @@ RSpec.describe 'A provider authenticates via the fallback mechanism' do
 
     when_i_provide_my_email_address
     then_i_receive_an_email_with_a_signin_link
+
+    when_i_click_an_incorrect_sign_in_link
+    then_i_see_a_404
+
     when_i_visit_the_link_in_my_email
+    then_i_see_a_confirm_sign_in_page
+
+    when_i_click_on_continue
     then_i_am_signed_in
     and_i_am_on_the_interviews_schedule_page
 
@@ -28,7 +35,8 @@ RSpec.describe 'A provider authenticates via the fallback mechanism' do
 
     given_the_feature_flag_is_switched_off
     when_i_visit_the_link_in_my_email
-    then_i_am_not_signed_in
+    then_i_do_not_see_a_confirm_sign_in_page
+    and_i_am_asked_to_sign_in_the_normal_way
   end
 
   def given_i_am_registered_as_a_provider_user_without_a_dsi_uid
@@ -71,9 +79,25 @@ RSpec.describe 'A provider authenticates via the fallback mechanism' do
     expect(current_email.subject).to have_content 'Sign in - manage teacher training applications'
   end
 
+  def when_i_click_an_incorrect_sign_in_link
+    visit provider_interface_authenticate_with_token_path(token: 'NOT_A_REAL_TOKEN')
+  end
+
+  def then_i_see_a_404
+    expect(page).to have_content 'Page not found'
+  end
+
   def when_i_visit_the_link_in_my_email
     uri = URI(current_email.find_css('a').first.text)
     visit "#{uri.path}?#{uri.query}"
+  end
+
+  def then_i_see_a_confirm_sign_in_page
+    expect(page).to have_content 'Confirm sign in'
+  end
+
+  def when_i_click_on_continue
+    click_on 'Continue'
   end
 
   def then_i_am_signed_in
@@ -94,5 +118,13 @@ RSpec.describe 'A provider authenticates via the fallback mechanism' do
     within 'header' do
       expect(page).not_to have_content @email
     end
+  end
+
+  def then_i_do_not_see_a_confirm_sign_in_page
+    expect(page).not_to have_content 'Confirm sign in'
+  end
+
+  def and_i_am_asked_to_sign_in_the_normal_way
+    expect(page).to have_current_path(provider_interface_sign_in_path)
   end
 end

--- a/spec/system/support_interface/authentication_fallback_expired_link_spec.rb
+++ b/spec/system/support_interface/authentication_fallback_expired_link_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+RSpec.describe 'A support with an expired DSI fallback link' do
+  include DfESignInHelpers
+
+  scenario 'signs in by requesting a new token' do
+    FeatureFlag.activate('dfe_sign_in_fallback')
+
+    given_i_am_registered_as_a_support_user
+    when_i_visit_the_support_interface_applications_path
+    then_i_am_redirected_to_the_support_sign_in_path
+
+    when_i_provide_my_email_address
+    then_i_receive_an_email_with_a_signin_link
+    when_i_click_on_the_link_in_my_email
+    then_i_see_a_confirm_sign_in_page
+
+    when_i_click_on_continue
+    then_i_am_signed_in
+
+    when_i_sign_out
+    then_i_am_not_signed_in
+
+    when_i_click_on_the_link_in_my_email
+    then_i_see_the_expired_token_page
+
+    when_i_request_a_new_token
+    then_i_receive_an_email_with_a_signin_link
+
+    when_i_click_on_the_link_in_my_email
+    then_i_see_a_confirm_sign_in_page
+
+    when_i_click_on_continue
+    then_i_am_signed_in
+  end
+
+  def given_i_am_registered_as_a_support_user
+    @email = 'support@example.com'
+    @support_user = create(:support_user, email_address: @email, dfe_sign_in_uid: 'DFE_SIGN_IN_UID', first_name: 'Michael')
+  end
+
+  def when_i_visit_the_support_interface_applications_path
+    visit support_interface_applications_path(some_key: 'some_value')
+  end
+
+  def then_i_am_redirected_to_the_support_sign_in_path
+    expect(page).to have_current_path(support_interface_sign_in_path)
+  end
+
+  def when_i_provide_my_email_address
+    fill_in 'Email address', with: 'sUpPoRt@example.com '
+    click_on t('continue')
+  end
+
+  def then_i_receive_an_email_with_a_signin_link
+    open_email(@email)
+    expect(current_email.subject).to have_content t('authentication.sign_in.email.subject')
+  end
+
+  def when_i_click_on_the_link_in_my_email
+    current_email.find_css('a').first.click
+  end
+
+  def then_i_see_a_confirm_sign_in_page
+    expect(page).to have_content 'Confirm sign in'
+  end
+
+  def when_i_click_on_continue
+    click_on 'Continue'
+  end
+
+  def then_i_am_signed_in
+    within 'header' do
+      expect(page).to have_content 'Sign out'
+    end
+  end
+
+  def when_i_sign_out
+    click_on 'Sign out'
+  end
+
+  def then_i_am_not_signed_in
+    within 'header' do
+      expect(page).not_to have_content @email
+    end
+  end
+
+  def then_i_see_the_expired_token_page
+    expect(page).to have_content 'The link you clicked has expired'
+  end
+
+  def when_i_request_a_new_token
+    click_on 'Email me a new link'
+  end
+end

--- a/spec/system/support_interface/authentication_fallback_spec.rb
+++ b/spec/system/support_interface/authentication_fallback_spec.rb
@@ -13,6 +13,9 @@ RSpec.describe 'A support authenticates via the fallback mechanism' do
     when_i_provide_my_email_address
     then_i_receive_an_email_with_a_signin_link
     when_i_click_on_the_link_in_my_email
+    then_i_see_a_confirm_sign_in_page
+
+    when_i_click_on_continue
     then_i_am_signed_in
 
     when_i_sign_out
@@ -23,7 +26,8 @@ RSpec.describe 'A support authenticates via the fallback mechanism' do
 
     given_the_feature_flag_is_switched_off
     when_i_click_on_the_link_in_my_email
-    then_i_am_not_signed_in
+    then_i_do_not_see_a_confirm_sign_in_page
+    and_i_am_asked_to_sign_in_the_normal_way
   end
 
   def given_i_am_registered_as_a_support_user
@@ -53,6 +57,14 @@ RSpec.describe 'A support authenticates via the fallback mechanism' do
     current_email.find_css('a').first.click
   end
 
+  def then_i_see_a_confirm_sign_in_page
+    expect(page).to have_content 'Confirm sign in'
+  end
+
+  def when_i_click_on_continue
+    click_on 'Continue'
+  end
+
   def then_i_am_signed_in
     within 'header' do
       expect(page).to have_content 'Sign out'
@@ -79,5 +91,13 @@ RSpec.describe 'A support authenticates via the fallback mechanism' do
 
   def then_i_see_a_404
     expect(page).to have_content 'Page not found'
+  end
+
+  def then_i_do_not_see_a_confirm_sign_in_page
+    expect(page).not_to have_content 'Confirm sign in'
+  end
+
+  def and_i_am_asked_to_sign_in_the_normal_way
+    expect(page).to have_current_path(support_interface_sign_in_path)
   end
 end


### PR DESCRIPTION
## Context

The current DSI fallback sign-in flow is not ideal because clicking on the link in the email signs you in automatically. Eager email clients or browsers attempting to pre-load pages may inadvertently use and invalidate these links.

Furthermore, allowing the establishment of authenticated sessions through simple GET requests is bad from a security point of view; adding a confirmation step at least prevents CSRF attacks, as authentication requires a POST form submission including a valid authenticity token. This increases the likelihood the sign-in is intentional and triggered by the user.

Finally, we have tried to improve the experience of people using expired links, by saving them the trouble of re-typing their email. Instead, we infer the email address from the expired link/token.

## Changes proposed in this pull request

With the existing flow, clicking on the link in the email (if it is still valid) immediately signs you in.

### New sign-in flow:

![image](https://user-images.githubusercontent.com/107591/157558141-178eb93d-31c3-42ec-9418-d2dd930adada.png)
---
![image](https://user-images.githubusercontent.com/107591/157557912-2150fcc5-ed8e-40c1-ba6e-38c3da142c45.png)
---
![image](https://user-images.githubusercontent.com/107591/157558291-78784e5a-a2d3-45b7-b870-4bb23f43d28b.png)
---
![image](https://user-images.githubusercontent.com/107591/157558379-d584df4b-3165-4226-808c-e8c96405d91c.png)

### After signing out, if you try to re-use the same link from before:

![image](https://user-images.githubusercontent.com/107591/157557856-5bb4f103-0341-4cf0-b6df-33b25180902e.png)
---
![image](https://user-images.githubusercontent.com/107591/157557912-2150fcc5-ed8e-40c1-ba6e-38c3da142c45.png)

### If you try to use an incorrect link (attempting to guess the token):

![image](https://user-images.githubusercontent.com/107591/157558575-152ff813-458f-463f-b006-f507bd097cf0.png)

## Guidance to review

Try the flow locally. Run the tests.

## Link to Trello card

https://trello.com/c/uQnd7Q17

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
