### PR TITLE
Show old duplicate matches carried over from an earlier cycle the support interface dashboard

### DIFF
--- a/app/controllers/support_interface/duplicate_matches_controller.rb
+++ b/app/controllers/support_interface/duplicate_matches_controller.rb
@@ -36,7 +36,6 @@ module SupportInterface
 
     def duplicate_matches(resolved: false)
       DuplicateMatch.where(
-        recruitment_cycle_year: RecruitmentCycle.current_year,
         resolved: resolved,
       ).order(created_at: :desc)
     end

--- a/spec/system/support_interface/duplicate_matches_spec.rb
+++ b/spec/system/support_interface/duplicate_matches_spec.rb
@@ -45,12 +45,17 @@ RSpec.feature 'See Duplicate candidate matches' do
     then_the_duplicate_match_is_resolved
   end
 
-  def given_i_am_a_support_user
-    sign_in_as_support_user
+  scenario 'Old duplicates are shown in the dashboard', sidekiq: true do
+    given_i_am_a_support_user
+    when_there_are_candidates_with_duplicate_applications_in_the_system
+    and_the_duplicate_match_was_created_last_recruitment_cycle
+    and_i_go_to_duplicate_matches_page
+    and_i_click_the_duplicate_matches_tab
+    then_i_should_see_list_of_duplicates_from_last_recruitment_cycle
   end
 
-  def then_i_should_see_a_message_that_there_are_no_matches
-    expect(page).to have_content 'There are currently no duplicate applications'
+  def given_i_am_a_support_user
+    sign_in_as_support_user
   end
 
   def when_there_are_candidates_with_duplicate_applications_in_the_system
@@ -63,6 +68,21 @@ RSpec.feature 'See Duplicate candidate matches' do
     @roberts_application_form = create(:application_form, candidate: @robert, first_name: 'Robert', last_name: 'Roberts', date_of_birth: '1998-08-08', postcode: 'W6 9BH')
     @alices_application_form = create(:application_form, candidate: @alice, first_name: 'Alice', last_name: 'Roberts', date_of_birth: '1999-10-12', postcode: 'W3 6ET', submitted_at: 10.days.ago)
     @alis_application_form = create(:application_form, candidate: @ali, first_name: 'Ali', last_name: 'Roberts', date_of_birth: '1999-10-12', postcode: 'W3 6ET')
+  end
+
+  def and_the_duplicate_match_was_created_last_recruitment_cycle
+    create(
+      :duplicate_match,
+      candidates: [@bob, @robert],
+      recruitment_cycle_year: 2021,
+      postcode: 'W6 9BH',
+      last_name: 'Roberts',
+      date_of_birth: '1998-08-08',
+    )
+  end
+
+  def then_i_should_see_list_of_duplicates_from_last_recruitment_cycle
+    expect(page).to have_content('2 candidates with postcode W6 9BH and DOB 8 Aug 1998')
   end
 
   def and_the_update_duplicate_matches_worker_has_run
@@ -95,6 +115,32 @@ RSpec.feature 'See Duplicate candidate matches' do
     click_link 'Back'
   end
 
+  def when_i_click_on_a_the_resolved_link
+    click_link 'Resolved'
+  end
+
+  def when_i_search_for_a_duplicate_match_by_email
+    fill_in :query, with: @bob.email_address
+    click_on 'Apply filters'
+  end
+
+  def when_i_search_for_a_resolved_duplicate_match_by_email
+    fill_in :query, with: @alice.email_address
+    click_on 'Apply filters'
+  end
+
+  def when_i_click_on_resolve
+    click_button 'Mark as resolved'
+  end
+
+  def when_i_click_on_a_the_under_review_link
+    click_link 'Under review'
+  end
+
+  def and_i_click_on_a_duplicate
+    click_link '2 candidates with postcode W6 9BH and DOB 8 Aug 1998'
+  end
+
   def i_should_be_taken_to_the_under_review_view
     expect(page).to have_current_path(support_interface_duplicate_matches_path(resolved: @bob.reload.duplicate_match.resolved))
   end
@@ -111,30 +157,9 @@ RSpec.feature 'See Duplicate candidate matches' do
     expect(page.find('span.app-count').text).to eq('1')
   end
 
-  def when_i_click_on_a_the_resolved_link
-    click_link 'Resolved'
-  end
-
-  def then_i_should_see_list_of_resolved_duplicates
-    expect(page).to have_content('2 candidates with postcode W3 6ET and DOB 12 Oct 1999')
-    expect(page).not_to have_link('2 candidates with postcode W6 9BH')
-  end
-
-  def when_i_click_on_a_the_under_review_link
-    click_link 'Under review'
-  end
-
-  def and_i_click_on_a_duplicate
-    click_link '2 candidates with postcode W6 9BH and DOB 8 Aug 1998'
-  end
-
   def then_i_see_the_details_for_each_duplicate_candidate
     expect(page).to have_content('2 candidates with postcode W6 9BH and DOB 8 Aug 1998')
     expect(page).to have_button('Mark as resolved')
-  end
-
-  def when_i_click_on_resolve
-    click_button 'Mark as resolved'
   end
 
   def then_the_duplicate_match_is_resolved
@@ -142,17 +167,16 @@ RSpec.feature 'See Duplicate candidate matches' do
     expect(page).to have_button('Mark as unresolved')
   end
 
-  def when_i_search_for_a_duplicate_match_by_email
-    fill_in :query, with: @bob.email_address
-    click_on 'Apply filters'
-  end
-
-  def when_i_search_for_a_resolved_duplicate_match_by_email
-    fill_in :query, with: @alice.email_address
-    click_on 'Apply filters'
-  end
-
   def then_i_see_that_candidates_email_address
     expect(page).to have_content(@bob.email_address)
+  end
+
+  def then_i_should_see_a_message_that_there_are_no_matches
+    expect(page).to have_content 'There are currently no duplicate applications'
+  end
+
+  def then_i_should_see_list_of_resolved_duplicates
+    expect(page).to have_content('2 candidates with postcode W3 6ET and DOB 12 Oct 1999')
+    expect(page).not_to have_link('2 candidates with postcode W6 9BH')
   end
 end


### PR DESCRIPTION
## Context

If 2 (or more) candidates were flagged as duplicates in 2021 and they both carry over their applications they have duplicate applications in the 2022 cycle. We do not display these on the dashboard because we don't show matches from earlier recruitment cycles and we don't 're-detect' matches that have already been detected regardless of cycle, so if two candidates were matched in 2021 they are now invisible to the support team.

## Changes proposed in this pull request

- [x] Show all duplicate matches on the support interface dashboard including those from previous recruitment cycles.
- [x] Add new scenario to existing system spec.

## Guidance to review

You will have to manually change `fraud_matches.recruitment_cycle_year` to test this change.

## Link to Trello card

https://trello.com/c/VRCGHtDd/4495-show-old-duplicate-matches-into-the-dashboard

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
