### PR TITLE
Fix error rendering on address type form

### DIFF
--- a/app/views/candidate_interface/contact_details/address_type/_form.html.erb
+++ b/app/views/candidate_interface/contact_details/address_type/_form.html.erb
@@ -1,6 +1,6 @@
-<%= f.govuk_radio_buttons_fieldset :address_types, legend: { text: t('page_titles.where_do_you_live'), size: 'xl', tag: 'h1' } do %>
-  <%= f.govuk_radio_button :address_type, 'uk', label: { text: t('application_form.contact_details.address_type.values.uk') } %>
-  <%= f.govuk_radio_button :address_type, 'international', label: { text: t('application_form.contact_details.address_type.values.international') }, link_errors: true do %>
+<%= f.govuk_radio_buttons_fieldset :address_type, legend: { text: t('page_titles.where_do_you_live'), size: 'xl', tag: 'h1' } do %>
+  <%= f.govuk_radio_button :address_type, 'uk', label: { text: t('application_form.contact_details.address_type.values.uk') }, link_errors: true %>
+  <%= f.govuk_radio_button :address_type, 'international', label: { text: t('application_form.contact_details.address_type.values.international') } do %>
     <%= f.govuk_collection_select :country, select_country_options, :id, :name, label: { text: t('application_form.contact_details.country.label') } %>
   <% end %>
 <% end %>


### PR DESCRIPTION
## Context

The contact details address type form had a rendering error, it was not
highlighting a missing value for the address type radio button fieldset.

## Changes proposed in this pull request

This problem seems to be due to a simple name mismatch between the
radio button fieldset and the attribute. I've just renamed the fieldset to `address_type`.

## Guidance to review

Does it all still work?

## Link to Trello card

https://trello.com/c/27PybOhn/4528-validations-errors-not-rendered-correctly-on-address-type-form

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
