### PR TITLE
make rejection text more sympathetic

### DIFF
--- a/app/views/candidate_mailer/_reasons_for_rejection_intro.text.erb
+++ b/app/views/candidate_mailer/_reasons_for_rejection_intro.text.erb
@@ -1,5 +1,9 @@
 <% unless @application_choice.rejected_by_default? %>
 
-  <%= @course.provider.name %> has decided not to make you an offer to study <%= @course.name_and_code %>. They've given feedback to explain this decision.
+  <%= @course.provider.name %> has reviewed your application for <%= @course.name_and_code %>.
+
+  On this occasion, they've decided not to make an offer.
+
+  They've given the following feedback:
 
 <% end %>

--- a/app/views/candidate_mailer/_reasons_for_rejection_intro.text.erb
+++ b/app/views/candidate_mailer/_reasons_for_rejection_intro.text.erb
@@ -2,7 +2,7 @@
 
   <%= @course.provider.name %> has reviewed your application for <%= @course.name_and_code %>.
 
-  On this occasion, they’ve decided not to make an offer.
+  On this occasion, they’re not offering you a place on this course.
 
   They’ve given the following feedback:
 

--- a/app/views/candidate_mailer/_reasons_for_rejection_intro.text.erb
+++ b/app/views/candidate_mailer/_reasons_for_rejection_intro.text.erb
@@ -2,7 +2,7 @@
 
   Thank you for your application to study <%= @course.name_and_code %> at <%= @course.provider.name %>.
 
-  On this occasion, the provider has not offered you a place on this course.
+  On this occasion, the provider is not offering you a place on this course.
 
   They’ve given the following feedback to explain their decision:
 

--- a/app/views/candidate_mailer/_reasons_for_rejection_intro.text.erb
+++ b/app/views/candidate_mailer/_reasons_for_rejection_intro.text.erb
@@ -1,9 +1,9 @@
 <% unless @application_choice.rejected_by_default? %>
 
-  <%= @course.provider.name %> has reviewed your application for <%= @course.name_and_code %>.
+  Thank you for your application to study <%= @course.name_and_code %> at <%= @course.provider.name %>.
 
-  On this occasion, they’re not offering you a place on this course.
+  On this occasion, the provider has not offered you a place on this course.
 
-  They’ve given the following feedback:
+  They’ve given the following feedback to explain their decision:
 
 <% end %>

--- a/app/views/candidate_mailer/_reasons_for_rejection_intro.text.erb
+++ b/app/views/candidate_mailer/_reasons_for_rejection_intro.text.erb
@@ -2,8 +2,8 @@
 
   <%= @course.provider.name %> has reviewed your application for <%= @course.name_and_code %>.
 
-  On this occasion, they've decided not to make an offer.
+  On this occasion, they’ve decided not to make an offer.
 
-  They've given the following feedback:
+  They’ve given the following feedback:
 
 <% end %>

--- a/app/views/candidate_mailer/application_rejected_all_applications_rejected.text.erb
+++ b/app/views/candidate_mailer/application_rejected_all_applications_rejected.text.erb
@@ -8,7 +8,7 @@ Dear <%= @application_form.first_name %>
   <%= render 'reasons_for_rejection_intro' %>
   <%= render 'reasons_for_rejection' %>
 
-  Contact <%= @course.provider.name %> directly if you have any questions about their feedback.
+  Contact <%= @course.provider.name %> if you would like to talk about their feedback.
 
 <% end %>
 

--- a/app/views/candidate_mailer/application_rejected_awaiting_decision_only.text.erb
+++ b/app/views/candidate_mailer/application_rejected_awaiting_decision_only.text.erb
@@ -8,7 +8,7 @@ Dear <%= @application_form.first_name %>
   <%= render 'reasons_for_rejection_intro' %>
   <%= render 'reasons_for_rejection' %>
 
-  Contact <%= @course.provider.name %> directly if you have any questions about their feedback.
+  Contact <%= @course.provider.name %> if you would like to talk about their feedback.
 
 <% end %>
 

--- a/app/views/candidate_mailer/application_rejected_offers_only.text.erb
+++ b/app/views/candidate_mailer/application_rejected_offers_only.text.erb
@@ -8,7 +8,7 @@ Dear <%= @application_form.first_name %>
   <%= render 'reasons_for_rejection_intro' %>
   <%= render 'reasons_for_rejection' %>
 
-  Contact <%= @course.provider.name %> directly if you have any questions about their feedback.
+  Contact <%= @course.provider.name %> if you would like to talk about their feedback.
 
 <% end %>
 

--- a/app/views/candidate_mailer/application_rejected_one_offer_one_awaiting_decision.text.erb
+++ b/app/views/candidate_mailer/application_rejected_one_offer_one_awaiting_decision.text.erb
@@ -8,7 +8,7 @@ Dear <%= @application_form.first_name %>
   <%= render 'reasons_for_rejection_intro' %>
   <%= render 'reasons_for_rejection' %>
 
-  Contact <%= @course.provider.name %> directly if you have any questions about their feedback.
+  Contact <%= @course.provider.name %> if you would like to talk about their feedback.
 
 <% end %>
 


### PR DESCRIPTION
We know that candidates are often disheartened when they get a rejection. 

This PR aims to soften the language slightly in the rejection email, while still being to the point.

# Before

![Screenshot 2022-03-10 at 15 49 28](https://user-images.githubusercontent.com/56349171/157699481-53a61128-724e-4d8c-a1ea-b2e2e3952ee5.png)

# After

<img width="522" alt="Screenshot 2022-03-10 at 23 09 14" src="https://user-images.githubusercontent.com/56349171/157770432-a866c278-4e10-4450-b772-d1d9f2d4fc79.png">


