### PR TITLE
Add rejections 'check' step

### DIFF
--- a/app/components/shared/rejection_reasons_component.html.erb
+++ b/app/components/shared/rejection_reasons_component.html.erb
@@ -1,0 +1,36 @@
+<dl class="govuk-summary-list">
+  <% rejection_reasons.selected_reasons.each do |reason| %>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key"><%= reason.label %></dt>
+      <dd class="govuk-summary-list__value">
+        <% if reason.details %>
+          <% paragraphs(reason.details.text).each do |paragraph| %>
+            <p><%= paragraph %></p>
+          <% end %>
+        <% elsif reason.selected_reasons.present? %>
+          <ul class="govuk-list app-list--spaced">
+            <% reason.selected_reasons.each do |nested_reason| %>
+              <% if nested_reason.details %>
+                <li>
+                  <% paragraphs(nested_reason.details.text).each do |paragraph| %>
+                    <p><%= paragraph %></p>
+                  <% end %>
+                </li>
+              <% else %>
+                <li><%= nested_reason.label %></li>
+              <% end %>
+            <% end %>
+          </ul>
+        <% else %>
+          <%# TODO: I18n translation %>
+          <p>The course is full.</p>
+        <% end %>
+      </dd>
+      <% if editable? %>
+        <dd class="govuk-summary-list__actions">
+          <%= govuk_link_to 'Change', new_provider_interface_rejection_path(application_choice) %>
+        </dd>
+      <% end %>
+    </div>
+  <% end %>
+</dl>

--- a/app/components/shared/rejection_reasons_component.html.erb
+++ b/app/components/shared/rejection_reasons_component.html.erb
@@ -23,8 +23,7 @@
             <% end %>
           </ul>
         <% else %>
-          <%# TODO: I18n translation %>
-          <p>The course is full.</p>
+          <p><%= I18n.t("rejection_reasons.#{reason.id}.description") %></p>
         <% end %>
       </dd>
       <% if editable? %>

--- a/app/components/shared/rejection_reasons_component.html.erb
+++ b/app/components/shared/rejection_reasons_component.html.erb
@@ -12,6 +12,7 @@
             <% reason.selected_reasons.each do |nested_reason| %>
               <% if nested_reason.details %>
                 <li>
+                  <p><%= nested_reason.label %>:</p>
                   <% paragraphs(nested_reason.details.text).each do |paragraph| %>
                     <p><%= paragraph %></p>
                   <% end %>

--- a/app/components/shared/rejection_reasons_component.rb
+++ b/app/components/shared/rejection_reasons_component.rb
@@ -1,0 +1,19 @@
+class RejectionReasonsComponent < ViewComponent::Base
+  include ViewHelper
+
+  attr_reader :application_choice, :editable, :rejection_reasons
+
+  def initialize(application_choice:, rejection_reasons:, editable: false)
+    @application_choice = application_choice
+    @rejection_reasons = rejection_reasons
+    @editable = editable
+  end
+
+  def editable?
+    editable
+  end
+
+  def paragraphs(input)
+    input.split("\r\n")
+  end
+end

--- a/app/frontend/styles/provider/_rejection.scss
+++ b/app/frontend/styles/provider/_rejection.scss
@@ -26,3 +26,7 @@
     top: 0;
   }
 }
+
+.govuk-summary-list__value p {
+  margin-top: 0;
+}

--- a/config/locales/provider_interface/rejections.yml
+++ b/config/locales/provider_interface/rejections.yml
@@ -1,4 +1,7 @@
 en:
+  rejection_reasons:
+    course_full:
+      description: The course is full.
   activemodel:
     errors:
       models:

--- a/spec/components/shared/rejection_reasons_component_spec.rb
+++ b/spec/components/shared/rejection_reasons_component_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe RejectionReasonsComponent do
+  describe 'rendered component' do
+    let(:provider) { build_stubbed(:provider, name: 'The University of Metal') }
+    let(:application_choice) { build_stubbed(:application_choice) }
+    let(:rejection_reasons) do
+      RejectionReasons.new(
+        selected_reasons: [
+          RejectionReasons::Reason.new(id: 'qualifications', label: 'Qualifications', selected_reasons: [
+            RejectionReasons::Reason.new(id: 'no_maths_gcse', label: 'No maths GCSE at minimum grade 4 or C, or equivalent.'),
+            RejectionReasons::Reason.new(id: 'no_english_gcse', label: 'No English GCSE at minimum grade 4 or C, or equivalent.'),
+            RejectionReasons::Reason.new(id: 'no_science_gcse', label: 'No science GCSE at minimum grade 4 or C, or equivalent.'),
+            RejectionReasons::Reason.new(id: 'unsuitable_degree', label: 'Degree does not meet course requirements',
+                                         details: {
+                                           id: 'unsuitable_degree_details',
+                                           label: 'Details',
+                                           text: 'A degree in falconry is no use.',
+                                         }),
+          ]),
+          RejectionReasons::Reason.new(id: 'references', label: 'References',
+                                       details: {
+                                         id: 'references_details',
+                                         label: 'Details',
+                                         text: 'A close family member, suchas your mother, cannot give a reference.',
+                                       }),
+          RejectionReasons::Reason.new(id: 'course_full', label: 'Course full'),
+          RejectionReasons::Reason.new(id: 'other', label: 'Other',
+                                       details: {
+                                         id: 'other_details',
+                                         label: 'Details',
+                                         text: 'Here are some additional details',
+                                       }),
+        ],
+      )
+    end
+
+    before { allow(application_choice).to receive(:provider).and_return(provider) }
+
+    it 'renders rejection reasons as a summary list' do
+      result = render_inline(described_class.new(application_choice: application_choice, rejection_reasons: rejection_reasons))
+
+      expect(result.css('.govuk-summary-list__key').map(&:text)).to eq([
+        'Qualifications',
+        'References',
+        'Course full',
+        'Other',
+      ])
+      expect(result.css('.govuk-summary-list__value ul li').map(&:text).map(&:strip)).to eq([
+        'No maths GCSE at minimum grade 4 or C, or equivalent.',
+        'No English GCSE at minimum grade 4 or C, or equivalent.',
+        'No science GCSE at minimum grade 4 or C, or equivalent.',
+        'A degree in falconry is no use.',
+      ])
+      expect(result.css('.govuk-summary-list__value p').map(&:text).map(&:strip)).to eq([
+        'A degree in falconry is no use.',
+        'A close family member, suchas your mother, cannot give a reference.',
+        'The course is full.',
+        'Here are some additional details',
+      ])
+    end
+
+    it 'renders change links' do
+      result = render_inline(described_class.new(application_choice: application_choice, rejection_reasons: rejection_reasons, editable: true))
+
+      expect(result.css('.govuk-summary-list__actions a').first.text).to eq('Change')
+      expect(result.css('.govuk-summary-list__actions a').first['href']).to eq("/provider/applications/#{application_choice.id}/rejections/new")
+    end
+  end
+end

--- a/spec/components/shared/rejection_reasons_component_spec.rb
+++ b/spec/components/shared/rejection_reasons_component_spec.rb
@@ -46,13 +46,14 @@ RSpec.describe RejectionReasonsComponent do
         'Course full',
         'Other',
       ])
-      expect(result.css('.govuk-summary-list__value ul li').map(&:text).map(&:strip)).to eq([
+      expect(result.css('.govuk-summary-list__value ul li').map { |li| li.text.gsub(/\s+/, ' ').strip }).to eq([
         'No maths GCSE at minimum grade 4 or C, or equivalent.',
         'No English GCSE at minimum grade 4 or C, or equivalent.',
         'No science GCSE at minimum grade 4 or C, or equivalent.',
-        'A degree in falconry is no use.',
+        'Degree does not meet course requirements: A degree in falconry is no use.',
       ])
       expect(result.css('.govuk-summary-list__value p').map(&:text).map(&:strip)).to eq([
+        'Degree does not meet course requirements:',
         'A degree in falconry is no use.',
         'A close family member, suchas your mother, cannot give a reference.',
         'The course is full.',


### PR DESCRIPTION
## Context

The last step of the wizard flow presents the reasons and details given in the previous step.
This is currently handled via a shared component which can't easily be extended to accommodate the new design. 

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Adds a new component to summarise the new rejection reasons format.
- Renders component on `check` step of rejections wizard flow

![image](https://user-images.githubusercontent.com/93511/158805520-49474a6a-a9c5-4bcf-bf58-65d38384db4d.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/ONxWd8Ce/4836-sr4r-redesign-add-reasons-presentation

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
