### PR TITLE
remove random sentence from email code

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -80,7 +80,6 @@ class CandidateMailer < ApplicationMailer
     @course = application_choice.current_course_option.course
     @application_choice = RejectedApplicationChoicePresenter.new(application_choice)
     @candidate_magic_link = candidate_magic_link(@application_choice.application_form.candidate)
-    @multiple_applications = application_choice.self_and_siblings.count > 1
 
     email_for_candidate(application_choice.application_form)
   end
@@ -130,7 +129,6 @@ class CandidateMailer < ApplicationMailer
     @course = application_choice.current_course_option.course
     @application_choice = RejectedApplicationChoicePresenter.new(application_choice)
     @candidate_magic_link = candidate_magic_link(@application_choice.application_form.candidate)
-    @multiple_applications = application_choice.self_and_siblings.count > 1
 
     email_for_candidate(application_choice.application_form)
   end

--- a/app/views/candidate_mailer/application_rejected_all_applications_rejected.text.erb
+++ b/app/views/candidate_mailer/application_rejected_all_applications_rejected.text.erb
@@ -14,8 +14,4 @@ Dear <%= @application_form.first_name %>
 
 # You can apply again
 
-<% if @multiple_applications %>
-  You’ve now had decisions about all the courses you applied for. You did not get any offers, so you can apply again.
-<% end %>
-
 <%= render 'still_interested_content' %>

--- a/app/views/candidate_mailer/application_withdrawn_on_request_all_applications_withdrawn.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_all_applications_withdrawn.text.erb
@@ -8,8 +8,4 @@ Get in touch if you did not ask them to do this:
 
 # You can apply again
 
-<% if @multiple_applications %>
-  You’ve now had decisions about all the courses you applied for. You did not get any offers, so you can apply again.
-<% end %>
-
 <%= render 'still_interested_content' %>


### PR DESCRIPTION
I spotted a sentence in the code of one of our emails, which doesn't show when you look at the email content in QA. So I didn't know it existed. 

I don't think the sentence is necessary and it sounds a bit harsh. 

I think the paragraph we already have about applying again suffices to communicate the point that the application didn't work out. 