### PR TITLE
use the apply again component (still_interested_content) as the conte…

### DIFF
--- a/app/views/candidate_mailer/_still_interested_in_teaching.text.erb
+++ b/app/views/candidate_mailer/_still_interested_in_teaching.text.erb
@@ -1,3 +1,0 @@
-# Are you still interested in teaching?
-
-<%= render 'still_interested_content' %>

--- a/app/views/candidate_mailer/decline_last_application_choice.text.erb
+++ b/app/views/candidate_mailer/decline_last_application_choice.text.erb
@@ -2,4 +2,4 @@ Dear <%= @application_form.first_name %>
 
 You’ve declined your offer to study <%= @declined_course_name %>.
 
-<%= render 'still_interested_in_teaching' %>
+<%= render 'still_interested_content' %>

--- a/app/views/candidate_mailer/declined_by_default_with_rejections.text.erb
+++ b/app/views/candidate_mailer/declined_by_default_with_rejections.text.erb
@@ -2,4 +2,4 @@ Dear <%= @application_form.first_name %>
 
 You did not respond within <%= @declined_courses.first.decline_by_default_days %> working days so we declined your <%= 'offer'.pluralize(@declined_course_names.size) %> for <%= @declined_course_names.to_sentence %>.
 
-<%= render 'still_interested_in_teaching' %>
+<%= render 'still_interested_content' %>

--- a/app/views/candidate_mailer/declined_by_default_without_rejections.text.erb
+++ b/app/views/candidate_mailer/declined_by_default_without_rejections.text.erb
@@ -2,4 +2,4 @@ Dear <%= @application_form.first_name %>
 
 You did not respond within <%= @declined_courses.first.decline_by_default_days %> working days so we declined your <%= 'offer'.pluralize(@declined_course_names.size) %> for <%= @declined_course_names.to_sentence %>.
 
-<%= render 'still_interested_in_teaching' %>
+<%= render 'still_interested_content' %>

--- a/app/views/candidate_mailer/withdraw_last_application_choice.text.erb
+++ b/app/views/candidate_mailer/withdraw_last_application_choice.text.erb
@@ -2,4 +2,4 @@ Dear <%= @application_form.first_name %>
 
 You’ve withdrawn your <%= 'application'.pluralize(@withdrawn_course_names.size) %> for <%= @withdrawn_course_names.to_sentence %>.
 
-<%= render 'still_interested_in_teaching' %>
+<%= render 'still_interested_content' %>


### PR DESCRIPTION
I don't think there's any scenario where we need to use the 'still_interested_in_teaching' file rather than the 'still_interested_content' file. The content is the same in both except that one has a H1 (which we don't really need). 

My goal with this PR was to remove this H1 (see screenshot) because it seems unnecessary to have a h1 so far up the page. 

It looks like we only use the 'still_interested_in_teaching' file rather than the 'still_interested_content' file in a few emails,  where we don't really need the heading anyway. So proposing we just delete the 'still_interested_in_teaching' file. 

![Screenshot 2022-03-10 at 18 21 34](https://user-images.githubusercontent.com/56349171/157729408-90750a09-b0f4-42a0-825c-5b688debd642.png)

