### PR TITLE
Remove inset from explained breaks in work history

### DIFF
--- a/app/components/shared/work_history_and_unpaid_experience_item_component.html.erb
+++ b/app/components/shared/work_history_and_unpaid_experience_item_component.html.erb
@@ -1,6 +1,6 @@
 <section>
-  <% if break? %>
-    <div class="govuk-inset-text">
+  <% if unexplained_break? %>
+    <div class="govuk-inset-text govuk-!-padding-bottom-0 govuk-!-padding-top-0">
   <% end %>
 
   <h3 class="govuk-heading-s govuk-!-margin-bottom-0">
@@ -30,7 +30,7 @@
       </p>
     <% end %>
   </p>
-  <% if break? %>
+  <% if unexplained_break? %>
     </div>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
   <% else %>

--- a/app/components/shared/work_history_and_unpaid_experience_item_component.rb
+++ b/app/components/shared/work_history_and_unpaid_experience_item_component.rb
@@ -9,8 +9,8 @@ class WorkHistoryAndUnpaidExperienceItemComponent < WorkHistoryItemComponent
     end
   end
 
-  def break?
-    item.is_a?(ApplicationWorkHistoryBreak) || item.is_a?(WorkHistoryWithBreaks::BreakPlaceholder)
+  def unexplained_break?
+    item.is_a?(WorkHistoryWithBreaks::BreakPlaceholder)
   end
 
   def role_type

--- a/spec/components/shared/work_history_and_unpaid_experience_item_component_spec.rb
+++ b/spec/components/shared/work_history_and_unpaid_experience_item_component_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe WorkHistoryAndUnpaidExperienceItemComponent do
   subject(:experience_item) { described_class.new(item: item) }
 
   describe '#title' do
-    context 'when the item is a voluntery role' do
+    context 'when the item is a voluntary role' do
       let(:item) { build(:application_volunteering_experience, role: 'Teacher', working_pattern: 'Full time') }
 
       it 'includes (unpaid) for any volunteer roles' do
@@ -21,20 +21,22 @@ RSpec.describe WorkHistoryAndUnpaidExperienceItemComponent do
     end
   end
 
-  describe '#break' do
-    context 'when ApplicationWorkHistoryBreak or BreakPlaceHolder' do
+  describe '#unexplained_break?' do
+    context 'when BreakPlaceholder' do
       let(:item) { build(:application_work_history_break) }
 
+      before { allow(item).to receive(:is_a?).with(WorkHistoryWithBreaks::BreakPlaceholder).and_return(true) }
+
       it 'returns true' do
-        expect(experience_item.break?).to be(true)
+        expect(experience_item.unexplained_break?).to be(true)
       end
     end
 
-    context 'when not ApplicationWorkHistoryBreak or BreakPlaceHolder' do
-      let(:item) { build(:application_volunteering_experience) }
+    context 'when ApplicationWorkHistoryBreak' do
+      let(:item) { build(:application_work_history_break) }
 
       it 'returns false' do
-        expect(experience_item.break?).to be(false)
+        expect(experience_item.unexplained_break?).to be(false)
       end
     end
   end


### PR DESCRIPTION
## Context
https://trello.com/c/QouYaHqU/4848-highlighting-unexplained-breaks-in-work-history
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Made the explained breaks follow the default format, without the insetting. Also matched the prototype padding/margins for the inset unexplained items.

|OLD|NEW|
|-|-|
| ![image](https://user-images.githubusercontent.com/25597009/157892208-8b9eeaef-b7ad-4a85-a9f7-62e6c723a6f2.png)|![image](https://user-images.githubusercontent.com/25597009/157892159-18fe6915-6c61-4fa0-9ed9-a1837aa5bedd.png)|
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
