### PR TITLE
Fix 'change' links for personal statement in support interface

### DIFF
--- a/app/components/shared/personal_statement_component.html.erb
+++ b/app/components/shared/personal_statement_component.html.erb
@@ -1,18 +1,25 @@
 <section id="personal-statement-section" class="app-section govuk-!-width-two-thirds">
   <h2 class="govuk-heading-m govuk-!-font-size-27" id="personal-statement"><%= t('personal_statement.title') %></h2>
-  <% if @editable %>
-    <h3 class="govuk-heading-s"><%= t('personal_statement.vocation') %><%= govuk_link_to 'Change', support_interface_application_form_edit_becoming_a_teacher_path, class: 'govuk-body' %></h3>
-    <%= simple_format becoming_a_teacher, class: 'govuk-body' %>
 
-    <h3 class="govuk-heading-s"><%= t('personal_statement.subject_knowledge') %><%= govuk_link_to 'Change', support_interface_application_form_edit_subject_knowledge_path, class: 'govuk-body' %></h3>
-    <%= simple_format subject_knowledge, class: 'govuk-body' %>
-  <% else %>
-    <h3 class="govuk-heading-s"><%= t('personal_statement.vocation') %></h3>
-    <%= simple_format becoming_a_teacher, class: 'govuk-body' %>
+  <h3 class="govuk-heading-s"><%= t('personal_statement.vocation') %>
+    <% if @editable %>
+      <%= govuk_link_to support_interface_application_form_edit_becoming_a_teacher_path, class: 'govuk-body' do %>
+        Change <span class="govuk-visually-hidden">answer to ‘<%= t('personal_statement.vocation') %>’</span>
+      <% end %>
+    <% end %>
+  </h3>
 
-    <h3 class="govuk-heading-s"><%= t('personal_statement.subject_knowledge') %></h3>
-    <%= simple_format subject_knowledge, class: 'govuk-body' %>
-  <% end %>
+  <%= simple_format becoming_a_teacher, class: 'govuk-body' %>
+
+  <h3 class="govuk-heading-s"><%= t('personal_statement.subject_knowledge') %>
+    <% if @editable %>
+      <%= govuk_link_to support_interface_application_form_edit_subject_knowledge_path, class: 'govuk-body' do %>
+        Change <span class="govuk-visually-hidden">answer to ‘<%= t('personal_statement.subject_knowledge') %>’</span>
+      <% end %>
+    <% end %>
+  </h3>
+
+  <%= simple_format subject_knowledge, class: 'govuk-body' %>
 
   <h3 class="govuk-heading-s"><%= t('personal_statement.further_information') %>
   <%= simple_format further_information, class: 'govuk-body' %>

--- a/app/components/shared/personal_statement_component.html.erb
+++ b/app/components/shared/personal_statement_component.html.erb
@@ -21,6 +21,6 @@
 
   <%= simple_format subject_knowledge, class: 'govuk-body' %>
 
-  <h3 class="govuk-heading-s"><%= t('personal_statement.further_information') %>
+  <h3 class="govuk-heading-s"><%= t('personal_statement.further_information') %></h3>
   <%= simple_format further_information, class: 'govuk-body' %>
 </section>


### PR DESCRIPTION
Noticed a few minor bugs whilst auditing the Support interface:

* the 'Change' links didn't have a space before them
* the spacing between the headings and the following text was inconsistent, due to a missing `</h3>`
* the 2 change links both had the same link text, which makes them less accessible to screen reader users who may be hearing them out of context (fixed by adding visually hidden text).

Also did a minor bit of refactoring to remove some duplication, at the expense of repeating the `if @editable` condition.

## Before

<img width="840" alt="Screenshot 2022-03-14 at 16 08 54" src="https://user-images.githubusercontent.com/30665/158213640-0b171a61-e65b-4720-9416-3519be4c9a0a.png">

## After

<img width="846" alt="Screenshot 2022-03-14 at 16 08 39" src="https://user-images.githubusercontent.com/30665/158213662-e0bd3d83-885a-4864-8928-c9f3c488c51d.png">

