### PR TITLE
Remove TODO

### DIFF
--- a/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
@@ -26,8 +26,6 @@
         <% @reference_section_errors.each do |error| %>
           <li><%= link_to error.message, error.anchor %></li>
         <% end %>
-
-        TODO: add additional validations here...
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Bugfix: remove TODO note accidentally left in on Application review page (after trying to continue when there are blue warnings):

<img width="1021" alt="Screenshot 2022-03-14 at 16 15 13" src="https://user-images.githubusercontent.com/30665/158219542-a9ef2b5a-434b-4339-bceb-423fa9a1190f.png">
