### PR TITLE
Write to `ApplicationChoice#rejection_reasons type` field

### DIFF
--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -47,6 +47,12 @@ class ApplicationChoice < ApplicationRecord
     offer_deferred: 'offer_deferred',
   }
 
+  enum rejection_reasons_type: {
+    rejection_reason: 'rejection_reason',           # API only single text field reason
+    reasons_for_rejection: 'reasons_for_rejection', # Current structured ReasonsForRejection model
+    rejection_reasons: 'rejection_reasons',         # Redesigned RejectionReasons model
+  }
+
   scope :decision_pending, -> { where(status: ApplicationStateChange::DECISION_PENDING_STATUSES) }
 
   def decision_pending?

--- a/app/services/reject_application.rb
+++ b/app/services/reject_application.rb
@@ -26,6 +26,7 @@ class RejectApplication
         @application_choice.update!(
           rejection_reason: @rejection_reason,
           structured_rejection_reasons: @structured_rejection_reasons,
+          rejection_reasons_type: structured_rejection_reasons.blank? ? :rejection_reason : :reasons_for_rejection,
           rejected_at: Time.zone.now,
         )
         SetDeclineByDefault.new(application_form: @application_choice.application_form).call

--- a/app/services/reject_by_default_feedback.rb
+++ b/app/services/reject_by_default_feedback.rb
@@ -15,6 +15,7 @@ class RejectByDefaultFeedback
       ActiveRecord::Base.transaction do
         application_choice.rejection_reason = rejection_reason
         application_choice.structured_rejection_reasons = structured_rejection_reasons
+        application_choice.rejection_reasons_type = structured_rejection_reasons.blank? ? :rejection_reason : :reasons_for_rejection
         application_choice.reject_by_default_feedback_sent_at = Time.zone.now
         application_choice.save!
       end

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -98,6 +98,7 @@ FactoryBot.define do
     trait :with_rejection do
       status { 'rejected' }
       rejection_reason { Faker::Lorem.paragraph_by_chars(number: 300) }
+      rejection_reasons_type { 'rejection_reason' }
       rejected_at { Time.zone.now }
     end
 
@@ -112,6 +113,7 @@ FactoryBot.define do
     trait :with_rejection_by_default_and_feedback do
       with_rejection_by_default
       rejection_reason { Faker::Lorem.paragraph_by_chars(number: 200) }
+      rejection_reasons_type { 'rejection_reason' }
       reject_by_default_feedback_sent_at { Time.zone.now }
 
       after(:create) do |_choice, evaluator|
@@ -164,6 +166,7 @@ FactoryBot.define do
           other_advice_or_feedback_details: nil,
         }
       end
+      rejection_reasons_type { 'reasons_for_rejection' }
       reject_by_default_feedback_sent_at { Time.zone.now }
 
       after(:create) do |_choice, evaluator|

--- a/spec/presenters/concerns/decisions_api_data_spec.rb
+++ b/spec/presenters/concerns/decisions_api_data_spec.rb
@@ -31,7 +31,16 @@ RSpec.describe DecisionsAPIData do
 
   describe '#rejection' do
     let(:rejected_at) { Time.zone.local(2019, 1, 1, 0, 0, 0) }
-    let!(:application_choice) { create(:application_choice, :rejected, application_form: application_form, rejected_at: rejected_at, rejection_reason: 'Course full') }
+    let!(:application_choice) do
+      create(
+        :application_choice,
+        :with_rejection,
+        application_form: application_form,
+        rejected_at: rejected_at,
+        rejection_reason: 'Course full',
+        rejection_reasons_type: 'rejection_reason',
+      )
+    end
 
     it 'returns a rejection object' do
       expect(presenter.rejection).to eq({ reason: 'Course full', date: rejected_at.iso8601 })

--- a/spec/presenters/rejected_application_choice_presenter_spec.rb
+++ b/spec/presenters/rejected_application_choice_presenter_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe RejectedApplicationChoicePresenter do
     describe 'when there is a rejection_reason set' do
       it 'returns that reason only' do
         application_choice.rejection_reason = 'There was something wrong with your application'
+        application_choice.rejection_reasons_type = 'rejection_reason'
 
         expect(rejected_application_choice.rejection_reasons).to eq(
           { 'Why your application was unsuccessful' => ['There was something wrong with your application'] },

--- a/spec/services/reject_application_spec.rb
+++ b/spec/services/reject_application_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe RejectApplication do
       service.save
 
       expect(application_choice.rejection_reason).to eq('wrong')
+      expect(application_choice.rejection_reasons_type).to eq('rejection_reason')
     end
 
     it 'updates the structured rejection reasons on the application' do
@@ -56,6 +57,7 @@ RSpec.describe RejectApplication do
       service.save
 
       expect(application_choice.structured_rejection_reasons.symbolize_keys).to eq(reasons_for_rejection_attrs)
+      expect(application_choice.rejection_reasons_type).to eq('reasons_for_rejection')
     end
 
     it 'emails the candidate' do

--- a/spec/services/reject_by_default_feedback_spec.rb
+++ b/spec/services/reject_by_default_feedback_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe RejectByDefaultFeedback, sidekiq: true do
   it 'changes rejection_reason for the application choice' do
     expect { service.save }.to change(application_choice, :rejection_reason).to(rejection_reason)
     expect(application_choice.structured_rejection_reasons).to be_nil
+    expect(application_choice.rejection_reasons_type).to eq('rejection_reason')
   end
 
   it 'changes structured_rejection_reasons for the application choice when provided' do
@@ -38,6 +39,7 @@ RSpec.describe RejectByDefaultFeedback, sidekiq: true do
 
     expect(application_choice.structured_rejection_reasons.symbolize_keys).to eq(reasons_for_rejection_attrs)
     expect(application_choice.rejection_reason).to be_nil
+    expect(application_choice.rejection_reasons_type).to eq('reasons_for_rejection')
   end
 
   it 'sets reject_by_default_feedback_sent_at' do


### PR DESCRIPTION
## Context

We're changing the reasons on the R4R form, this will result in a different serialized JSON structure.
We're adding a `rejection_reasons_type` field to `ApplicationChoice` so that we can easily query the format of the rejection data.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Adds an enum to `ApplicationChoice` which contains the various rejection reasons types.
- Writes to `ApplicationChoice#rejection_reasons_type` from the 2 rejection services.
- Backfills existing rejected applications with the relevant type value.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/IP91rE34/4830-sr4r-redesign-add-sr4r-type-field-to-applicationchoices
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
