### PR TITLE
Course Change - Add the course change service

### DIFF
--- a/app/components/provider_interface/change_course_details_component.rb
+++ b/app/components/provider_interface/change_course_details_component.rb
@@ -9,19 +9,21 @@ module ProviderInterface
                 :cycle, :preferred_location, :study_mode, :qualification, :available_providers,
                 :available_courses, :course, :available_course_options, :course_option
 
-    def initialize(application_choice:, course_option: nil, course: nil, available_providers: [], available_courses: [], available_course_options: [])
+    def initialize(application_choice:, course_option:, available_providers: [], available_courses: [], available_course_options: [])
       @application_choice = application_choice
       @course_option = course_option
-      @provider_name_and_code = application_choice.provider.name_and_code
-      @course_name_and_code = application_choice.course.name_and_code
-      @cycle = application_choice.course.recruitment_cycle_year
-      @preferred_location = preferred_location_text
-      @study_mode = application_choice.course_option.study_mode.humanize
-      @qualification = qualification_text(application_choice.course_option)
       @available_providers = available_providers
       @available_courses = available_courses
-      @course = course
       @available_course_options = available_course_options
+
+      @course = course_option.course
+
+      @provider_name_and_code = course.provider.name_and_code
+      @course_name_and_code = course.name_and_code
+      @cycle = course.recruitment_cycle_year
+      @preferred_location = preferred_location_text
+      @study_mode = course_option.study_mode.humanize
+      @qualification = qualification_text(course_option)
     end
 
     def rows
@@ -37,24 +39,24 @@ module ProviderInterface
     end
 
     def preferred_location_text
-      "#{application_choice.site.name_and_code}\n" \
+      "#{course_option.site.name_and_code}\n" \
         "#{formatted_address}"
     end
 
     def accredited_body
-      accredited_body = @application_choice.course.accredited_provider
+      accredited_body = course.accredited_provider
       accredited_body.present? ? accredited_body.name_and_code : provider_name_and_code
     end
 
     def funding_type
-      key = @application_choice.course.funding_type.to_sym
+      key = course.funding_type.to_sym
       FUNDING_TYPES[key].to_s.humanize
     end
 
   private
 
     def formatted_address
-      site = application_choice.site
+      site = course_option.site
       "#{site.address_line1}, " \
         "#{site.address_line2}, " \
         "#{site.address_line3}\n" \

--- a/app/controllers/provider_interface/courses_controller.rb
+++ b/app/controllers/provider_interface/courses_controller.rb
@@ -11,11 +11,16 @@ module ProviderInterface
       @wizard = CourseWizard.new(change_course_store)
       if @wizard.valid?(:save)
         begin
+          ChangeCourse.new(actor: current_provider_user,
+                           application_choice: @application_choice,
+                           course_option: @wizard.course_option).save!
           @wizard.clear_state!
           flash[:success] = t('.success')
-        rescue IdenticalOfferError
+        rescue IdenticalCourseError
           @wizard.clear_state!
-          flash[:success] = t('.success')
+          flash[:warning] = t('.failure')
+        rescue ExistingCourseError
+          flash[:warning] = t('.failure')
         end
       else
         @wizard.clear_state!

--- a/app/errors/existing_course_error.rb
+++ b/app/errors/existing_course_error.rb
@@ -1,0 +1,1 @@
+class ExistingCourseError < StandardError; end

--- a/app/errors/identical_course_error.rb
+++ b/app/errors/identical_course_error.rb
@@ -1,0 +1,1 @@
+class IdenticalCourseError < StandardError; end

--- a/app/services/change_course.rb
+++ b/app/services/change_course.rb
@@ -1,0 +1,41 @@
+class ChangeCourse
+  include ImpersonationAuditHelper
+
+  attr_reader :actor, :application_choice, :course_option
+
+  def initialize(actor:,
+                 application_choice:,
+                 course_option:)
+    @actor = actor
+    @application_choice = application_choice
+    @course_option = course_option
+  end
+
+  def save!
+    auth.assert_can_make_decisions!(application_choice: application_choice, course_option: course_option)
+
+    if course.valid?
+      audit(actor) do
+        ActiveRecord::Base.transaction do
+          application_choice.update_course_option_and_associated_fields!(
+            course_option,
+            other_fields: { course_option: course_option },
+          )
+        end
+      end
+    else
+      raise ValidationException, course.errors.map(&:message)
+    end
+  end
+
+private
+
+  def auth
+    @auth ||= ProviderAuthorisation.new(actor: actor)
+  end
+
+  def course
+    @course ||= CourseValidations.new(application_choice: application_choice,
+                                      course_option: course_option)
+  end
+end

--- a/app/services/course_validations.rb
+++ b/app/services/course_validations.rb
@@ -1,0 +1,26 @@
+class CourseValidations
+  include ActiveModel::Model
+
+  attr_accessor :application_choice, :course_option
+
+  validates :course_option, presence: true
+  validate :ratifying_provider_changed?, if: %i[application_choice course_option]
+  validate :identical_to_existing_course?, if: %i[application_choice course_option]
+  validate :course_already_exists_on_application?, if: %i[application_choice course_option]
+
+  def ratifying_provider_changed?
+    if application_choice.current_course.ratifying_provider != course_option.course.ratifying_provider
+      errors.add(:base, :different_ratifying_provider)
+    end
+  end
+
+  def identical_to_existing_course?
+    raise IdenticalCourseError if application_choice.current_course_option == course_option
+  end
+
+  def course_already_exists_on_application?
+    application_choices = application_choice.self_and_siblings - [application_choice].reject { |choice| ApplicationStateChange::UNSUCCESSFUL_END_STATES.include?(choice) }
+
+    raise ExistingCourseError if application_choices.any? { |choice| choice.current_course_option == course_option }
+  end
+end

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -48,13 +48,13 @@
 <% if @provider_can_respond && FeatureFlag.active?(:change_course_details_before_offer) %>
   <%= render ProviderInterface::ChangeCourseDetailsComponent.new(
     application_choice: @application_choice,
+    course_option: @application_choice.course_option,
     available_providers: @available_training_providers,
     available_courses: @available_courses,
-    course: @application_choice.current_course_option.course,
     available_course_options: @available_course_options,
   ) %>
 <% else %>
-  <%= render ProviderInterface::CourseDetailsComponent.new(application_choice: @application_choice) %>
+  <%= render ProviderInterface::CourseDetailsComponent.new(application_choice: @application_choice, course_option: @application_choice.course_option) %>
 <% end %>
 
 <%= render ProviderInterface::SafeguardingDeclarationComponent.new(application_choice: @application_choice, current_provider_user: current_provider_user) %>

--- a/app/views/provider_interface/courses/checks/edit.html.erb
+++ b/app/views/provider_interface/courses/checks/edit.html.erb
@@ -11,7 +11,6 @@
       <%= f.govuk_error_summary %>
       <%= render ProviderInterface::CheckCourseDetailsComponent.new(application_choice: @application_choice,
                                                                     course_option: @wizard.course_option,
-                                                                    course: @wizard.course_option.course,
                                                                     available_providers: @providers,
                                                                     available_courses: @courses,
                                                                     available_course_options: @course_options) %>

--- a/config/locales/provider_interface/change_course.yml
+++ b/config/locales/provider_interface/change_course.yml
@@ -25,3 +25,8 @@ en:
       update:
         success: Course updated
         failure: Unable to update course
+  activemodel:
+    errors:
+      models:
+        course_validations:
+          different_ratifying_provider: The course's ratifying provider must be the same as the one originally requested

--- a/spec/components/provider_interface/change_course_details_component_spec.rb
+++ b/spec/components/provider_interface/change_course_details_component_spec.rb
@@ -2,29 +2,34 @@ require 'rails_helper'
 
 RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
   let(:course_option) do
-    instance_double(CourseOption,
-                    study_mode: 'Full time',
-                    course: course)
+    build_stubbed(:course_option,
+                  :full_time,
+                  course: course,
+                  site: site)
   end
 
   let(:course_option2) do
-    instance_double(CourseOption,
-                    study_mode: 'Full time',
-                    course: course)
+    build_stubbed(:course_option,
+                  :full_time,
+                  course: course2,
+                  site: site)
   end
 
   let(:site) do
-    instance_double(Site,
-                    name_and_code: 'First Road (F34)',
-                    address_line1: 'Fountain Street',
-                    address_line2: 'Morley',
-                    address_line3: 'Leeds',
-                    postcode: 'LS27 OPD')
+    build_stubbed(:site,
+                  name: 'First Road',
+                  code: 'F34',
+                  address_line1: 'Fountain Street',
+                  address_line2: 'Morley',
+                  address_line3: 'Leeds',
+                  postcode: 'LS27 OPD',
+                  provider: provider)
   end
 
   let(:provider) do
-    instance_double(Provider,
-                    name_and_code: 'Best Training (B54)')
+    create(:provider,
+           name: 'Best Training',
+           code: 'B54')
   end
 
   let(:accredited_provider) do
@@ -40,7 +45,8 @@ RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
                   recruitment_cycle_year: 2020,
                   accredited_provider: nil,
                   qualifications: %w[qts pgce],
-                  funding_type: 'fee')
+                  funding_type: 'fee',
+                  provider: provider)
   end
 
   let(:course2) do
@@ -56,13 +62,23 @@ RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
 
   let(:application_choice) do
     instance_double(ApplicationChoice,
+                    current_course_option: course_option,
                     course_option: course_option,
                     provider: provider,
                     course: course,
                     site: site)
   end
 
-  let(:render) { render_inline(described_class.new(application_choice: application_choice, course: course)) }
+  let(:single_study_mode_application_choice) do
+    instance_double(ApplicationChoice,
+                    current_course_option: course_option2,
+                    course_option: course_option2,
+                    provider: provider,
+                    course: course2,
+                    site: site)
+  end
+
+  let(:render) { render_inline(described_class.new(application_choice: application_choice, course_option: course_option)) }
 
   def row_text_selector(row_name, render)
     rows = { provider: 0,
@@ -81,7 +97,7 @@ RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
   end
 
   context 'when there are multiple available providers' do
-    let(:render) { render_inline(described_class.new(application_choice: application_choice, course: course, available_providers: [provider, accredited_provider])) }
+    let(:render) { render_inline(described_class.new(application_choice: application_choice, course_option: course_option, available_providers: [provider, accredited_provider])) }
 
     it 'renders a link to change' do
       render_text = row_text_selector(:provider, render)
@@ -103,7 +119,7 @@ RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
   end
 
   context 'when multiple courses' do
-    let(:render) { render_inline(described_class.new(application_choice: application_choice, course: course, available_courses: [course, course2])) }
+    let(:render) { render_inline(described_class.new(application_choice: application_choice, course_option: course_option, available_courses: [course, course2])) }
 
     it 'renders a change link' do
       render_text = row_text_selector(:course, render)
@@ -135,7 +151,7 @@ RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
   end
 
   context 'when there is only one study mode' do
-    let(:render) { render_inline(described_class.new(application_choice: application_choice, course: course2, available_providers: [provider, accredited_provider])) }
+    let(:render) { render_inline(described_class.new(application_choice: single_study_mode_application_choice, course_option: course_option2, available_providers: [provider, accredited_provider])) }
 
     it 'renders the study mode' do
       render_text = row_text_selector(:full_or_part_time, render)
@@ -159,7 +175,7 @@ RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
   end
 
   context 'when there are multiple locations' do
-    let(:render) { render_inline(described_class.new(application_choice: application_choice, course: course, available_course_options: [course_option, course_option2])) }
+    let(:render) { render_inline(described_class.new(application_choice: application_choice, course_option: course_option, available_course_options: [course_option, course_option2])) }
 
     it 'renders the change link' do
       render_text = row_text_selector(:location, render)

--- a/spec/components/provider_interface/course_details_component_spec.rb
+++ b/spec/components/provider_interface/course_details_component_spec.rb
@@ -2,50 +2,79 @@ require 'rails_helper'
 
 RSpec.describe ProviderInterface::CourseDetailsComponent do
   let(:course_option) do
-    instance_double(CourseOption,
-                    study_mode: 'Full time',
-                    course: course)
+    create(:course_option,
+           :full_time,
+           course: course,
+           site: site)
+  end
+
+  let(:course_option2) do
+    create(:course_option,
+           :full_time,
+           course: course_with_accredited_body,
+           site: site_with_accredited_provider)
   end
 
   let(:site) do
-    instance_double(Site,
-                    name_and_code: 'First Road (F34)',
-                    address_line1: 'Fountain Street',
-                    address_line2: 'Morley',
-                    address_line3: 'Leeds',
-                    postcode: 'LS27 OPD')
+    create(:site,
+           name: 'First Road',
+           code: 'F34',
+           address_line1: 'Fountain Street',
+           address_line2: 'Morley',
+           address_line3: 'Leeds',
+           postcode: 'LS27 OPD',
+           provider: provider)
+  end
+
+  let(:site_with_accredited_provider) do
+    create(:site,
+           name: 'First Road',
+           code: 'F34',
+           address_line1: 'Fountain Street',
+           address_line2: 'Morley',
+           address_line3: 'Leeds',
+           postcode: 'LS27 OPD',
+           provider: accredited_provider)
   end
 
   let(:provider) do
-    instance_double(Provider,
-                    name_and_code: 'Best Training (B54)')
+    create(:provider,
+           name: 'Best Training',
+           code: 'B54')
   end
 
   let(:accredited_provider) do
-    instance_double(Provider,
-                    name_and_code: 'Accredit Now (A78)')
+    create(:provider,
+           name: 'Accredit Now',
+           code: 'A78')
   end
 
   let(:course) do
-    instance_double(Course,
-                    name_and_code: 'Geograpghy (H234)',
-                    recruitment_cycle_year: 2020,
-                    accredited_provider: nil,
-                    qualifications: %w[qts pgce],
-                    funding_type: 'fee')
+    create(:course,
+           :with_both_study_modes,
+           name: 'Geography',
+           code: 'H234',
+           recruitment_cycle_year: 2020,
+           accredited_provider: nil,
+           qualifications: %w[qts pgce],
+           funding_type: 'fee',
+           provider: provider)
   end
 
   let(:course_with_accredited_body) do
-    instance_double(Course,
-                    name_and_code: 'Geograpghy (H234)',
-                    recruitment_cycle_year: 2020,
-                    accredited_provider: accredited_provider,
-                    qualifications: ['qts'],
-                    funding_type: 'fee')
+    create(:course,
+           name: 'Geography',
+           code: 'H234',
+           recruitment_cycle_year: 2020,
+           provider: accredited_provider,
+           accredited_provider: accredited_provider,
+           qualifications: ['qts'],
+           funding_type: 'fee')
   end
 
   let(:application_choice) do
     instance_double(ApplicationChoice,
+                    current_course_option: course_option,
                     course_option: course_option,
                     provider: provider,
                     course: course,
@@ -54,13 +83,14 @@ RSpec.describe ProviderInterface::CourseDetailsComponent do
 
   let(:application_choice_with_accredited_body) do
     instance_double(ApplicationChoice,
-                    course_option: course_option,
-                    provider: provider,
+                    current_course_option: course_option2,
+                    course_option: course_option2,
+                    provider: accredited_provider,
                     course: course_with_accredited_body,
-                    site: site)
+                    site: site_with_accredited_provider)
   end
 
-  let(:render) { render_inline(described_class.new(application_choice: application_choice)) }
+  let(:render) { render_inline(described_class.new(application_choice: application_choice, course_option: course_option)) }
 
   def row_text_selector(row_name, render)
     rows = { provider: 0,
@@ -84,7 +114,7 @@ RSpec.describe ProviderInterface::CourseDetailsComponent do
 
   context 'when an accredited body is present' do
     it 'renders the accredited body name and code when it is present' do
-      render = render_inline(described_class.new(application_choice: application_choice_with_accredited_body))
+      render = render_inline(described_class.new(application_choice: application_choice_with_accredited_body, course_option: course_option2))
 
       render_text = row_text_selector(:accredited_body, render)
 
@@ -106,7 +136,7 @@ RSpec.describe ProviderInterface::CourseDetailsComponent do
     render_text = row_text_selector(:course, render)
 
     expect(render_text).to include('Course')
-    expect(render_text).to include('Geograpghy (H234)')
+    expect(render_text).to include('Geography (H234)')
   end
 
   it 'renders the recruitment cycle year' do

--- a/spec/services/change_course_spec.rb
+++ b/spec/services/change_course_spec.rb
@@ -46,12 +46,30 @@ RSpec.describe ChangeCourse do
                providers: [application_choice.course_option.provider])
       end
 
-      it 'then it calls various services' do
+      it 'then it calls the services' do
         allow(application_choice).to receive(:update_course_option_and_associated_fields!)
 
         change_course.save!
 
         expect(application_choice).to have_received(:update_course_option_and_associated_fields!)
+      end
+    end
+
+    describe 'if the change is invalid' do
+      let(:application_choice) { create(:application_choice, status: :awaiting_provider_decision, current_course_option: course_option, course_option: course_option) }
+      let(:course_option) { create(:course_option, :open_on_apply) }
+
+      let(:provider_user) do
+        create(:provider_user,
+               :with_make_decisions,
+               providers: [application_choice.course_option.provider])
+      end
+
+      it 'does not call the service' do
+        expect {
+          change_course.save!
+        }.to raise_error(IdenticalCourseError)
+        .and change { application_choice.updated_at }.by(0)
       end
     end
 

--- a/spec/services/change_course_spec.rb
+++ b/spec/services/change_course_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe ChangeCourse do
+  include CourseOptionHelpers
+
+  let(:application_choice) { create(:application_choice, status: :awaiting_provider_decision) }
+  let(:provider_user) do
+    create(
+      :provider_user,
+      :with_make_decisions,
+      providers: [application_choice.current_course_option.provider],
+    )
+  end
+  let(:course_option) { course_option_for_provider(provider: application_choice.current_course_option.provider, course: application_choice.current_course_option.course) }
+
+  let(:change_course) do
+    described_class.new(
+      actor: provider_user,
+      application_choice: application_choice,
+      course_option: course_option,
+    )
+  end
+
+  describe '#save!' do
+    describe 'if the actor is not authorised to perform this action' do
+      let(:provider_user) do
+        create(:provider_user,
+               providers: [application_choice.current_course_option.provider])
+      end
+
+      it 'throws an exception' do
+        expect {
+          change_course.save!
+        }.to raise_error(
+          ProviderAuthorisation::NotAuthorisedError,
+          'You do not have the required user level permissions to make decisions on applications for this provider.',
+        )
+      end
+    end
+
+    describe 'if the provided details are correct' do
+      let(:application_choice) { create(:application_choice, status: :awaiting_provider_decision) }
+      let(:provider_user) do
+        create(:provider_user,
+               :with_make_decisions,
+               providers: [application_choice.course_option.provider])
+      end
+
+      it 'then it calls various services' do
+        allow(application_choice).to receive(:update_course_option_and_associated_fields!)
+
+        change_course.save!
+
+        expect(application_choice).to have_received(:update_course_option_and_associated_fields!)
+      end
+    end
+
+    describe 'audits', with_audited: true do
+      it 'generates an audit event combining status change with current_course_option_id' do
+        change_course.save!
+
+        audit_with_status_change = application_choice.reload.audits.find_by('jsonb_exists(audited_changes, ?)', 'status')
+        expect(audit_with_status_change.audited_changes).to have_key('current_course_option_id')
+      end
+    end
+  end
+end

--- a/spec/services/course_validations_spec.rb
+++ b/spec/services/course_validations_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+RSpec.describe CourseValidations, type: :model do
+  subject(:course_choice) { described_class.new(application_choice: application_choice, course_option: course_option) }
+
+  let(:application_choice) { nil }
+  let(:course_option) { create(:course_option, course: course) }
+  let(:course) { create(:course, :open_on_apply) }
+
+  context 'validations' do
+    it { is_expected.to validate_presence_of(:course_option) }
+
+    describe '#identical_to_existing_course?' do
+      context 'when the course details are identical to the existing course' do
+        let(:application_choice) { create(:application_choice, current_course_option: course_option, course_option: course_option) }
+        let(:course_option) { build(:course_option, :open_on_apply) }
+
+        it 'raises an IdenticalCourseError' do
+          expect { course_choice.valid? }.to raise_error(IdenticalCourseError)
+        end
+      end
+    end
+
+    describe '#course_already_exists_on_application?' do
+      context 'when the course to be updated already exists on the application form' do
+        let!(:application_form) { create(:application_form, application_choices: [first_application_choice, application_choice]) }
+        let(:first_application_choice) { build(:application_choice, current_course_option: course_option, course_option: course_option) }
+        let(:application_choice) { build(:application_choice, current_course_option: course_option2, course_option: course_option2) }
+        let(:course) { create(:course, :with_accredited_provider) }
+        let(:course_option) { create(:course_option, :open_on_apply, course: course) }
+        let(:course_option2) { create(:course_option, :open_on_apply, course: course) }
+
+        it 'raises an ExistingCourseError' do
+          expect { course_choice.valid? }.to raise_error(ExistingCourseError)
+        end
+      end
+    end
+
+    describe '#ratifying_provider_changed?' do
+      context 'when the ratifying provider is different than the one of the requested course' do
+        let(:candidate) { create(:candidate) }
+        let(:application_choice) { create(:application_choice, current_course_option: current_course_option) }
+        let!(:application_form) { create(:application_form, phase: 'apply_1', candidate: candidate, application_choices: [application_choice]) }
+        let(:current_course_option) { create(:course_option, :open_on_apply) }
+        let(:course_option) { build(:course_option, :open_on_apply) }
+
+        it 'adds a :different_ratifying_provider error' do
+          expect(course_choice).to be_invalid
+
+          expect(course_choice.errors[:base]).to contain_exactly('The course\'s ratifying provider must be the same as the one originally requested')
+        end
+      end
+    end
+  end
+end

--- a/spec/system/provider_interface/provider_changes_a_course_before_point_of_offer_spec.rb
+++ b/spec/system/provider_interface/provider_changes_a_course_before_point_of_offer_spec.rb
@@ -60,6 +60,9 @@ RSpec.feature 'Provider changes a course' do
     and_i_select_a_course_with_one_study_mode_and_one_location
     and_i_click_continue
     then_the_review_page_is_loaded
+
+    when_i_click_update_course
+    then_i_see_the_changed_offer_details
   end
 
   def given_i_am_a_provider_user
@@ -100,7 +103,7 @@ RSpec.feature 'Provider changes a course' do
     create(:course_option, :full_time, site: create(:site, provider: @one_mode_course.provider), course: @one_mode_course)
 
     @one_mode_and_location_course = create(:course, :open_on_apply, study_mode: :full_time, provider: @selected_provider, accredited_provider: ratifying_provider)
-    create(:course_option, :full_time, site: create(:site, provider: @one_mode_and_location_course.provider), course: @one_mode_and_location_course)
+    @one_mode_and_location_course_option = create(:course_option, :full_time, site: create(:site, provider: @one_mode_and_location_course.provider), course: @one_mode_and_location_course)
 
     course_options = [create(:course_option, :part_time, course: @selected_course),
                       create(:course_option, :full_time, course: @selected_course),
@@ -210,5 +213,21 @@ RSpec.feature 'Provider changes a course' do
 
   def and_i_select_a_course_with_one_study_mode_and_one_location
     choose @one_mode_and_location_course.name_and_code
+  end
+
+  def when_i_click_update_course
+    click_on 'Update course'
+  end
+
+  def then_i_see_the_changed_offer_details
+    within(all('.govuk-summary-list')[2]) do
+      expect(page).to have_content(@one_mode_and_location_course.provider.name_and_code)
+      expect(page).to have_content(@one_mode_and_location_course.name_and_code)
+      expect(page).to have_content(@one_mode_and_location_course.study_mode.humanize)
+      expect(page).to have_content(@one_mode_and_location_course_option.site.name_and_code)
+      expect(page).to have_content(@one_mode_and_location_course_option.site.address_line1)
+      expect(page).to have_content(@one_mode_and_location_course_option.site.address_line2)
+      expect(page).to have_content(@one_mode_and_location_course_option.site.address_line3)
+    end
   end
 end


### PR DESCRIPTION
## Context

Currently providers can change the details of a course at the point of offer. We'd like to let providers do this before the point of offer.

Following from [#6647](https://github.com/DFE-Digital/apply-for-teacher-training/pull/6647) this is the sixth PR in the series. This is the actual service that will be called to update the course choice.

## Changes proposed in this pull request

Implement the new `ChangeCourse` service into `ProviderInterface::CoursesController` update `method`.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/EtYamWqC

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
