### PR TITLE
Update email content

### DIFF
--- a/app/views/candidate_mailer/_wait_or_respond.text.erb
+++ b/app/views/candidate_mailer/_wait_or_respond.text.erb
@@ -1,6 +1,4 @@
-You do not need to accept or decline this offer yet.
-
-You can wait until you’ve received decisions about your other application(s). 
+You can wait to hear back about your other application(s) before accepting or declining any offers.
 
 When the last decision is in, you’ll have 10 working days to respond.
 

--- a/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
+++ b/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
@@ -2,13 +2,9 @@ Dear <%= @application_form.first_name %>
 
 You have an offer from <%= @provider_name %> to study <%= @course_name %>.
 
-<% if @conditions.blank? %>
-  The provider has not set any conditions.
-<% else %>
-  <%= render "candidate_mailer/offer_conditions" %>
-<% end %>
+They’ll let you know if they need further information before you can start training
 
-Contact <%= @provider_name %> if you have any questions about the offer.
+Contact <%= @provider_name %> if you have any questions about this.
 
 <%= render "candidate_mailer/wait_or_respond" %>
 

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -94,8 +94,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       'a mail with subject and content',
       'Successful application for Brighthurst Technical College',
       'heading' => 'Dear Bob',
-      'first_condition' => 'Be cool',
-      'instructions' => 'You can wait until you’ve received decisions about your other application(s)',
+      'instructions' => 'You can wait to hear back about your other application(s) before accepting or declining any offers.',
       'deferral_guidance' => 'Some teacher training providers allow you to defer your offer.',
     )
   end


### PR DESCRIPTION
## Context

Update content on email to make sure we're firm in saying that a candidate can wait for their other choices to get back to them before making a decision (and that they shouldn't feel pressured to do anything else).

## Changes proposed in this pull request

### Before

<img width="489" alt="image" src="https://user-images.githubusercontent.com/50492247/158429173-b5216134-bfcb-429a-9813-f2d140fc225f.png">

### After

<img width="468" alt="image" src="https://user-images.githubusercontent.com/50492247/158429471-53c02eb4-14c4-4f40-aef7-29b097153446.png">


## Link to Trello card

https://trello.com/c/hPtemsg2/4521-provide-input-on-amending-of-email-templates
