### PR TITLE
[540] Fix Github rate limiting

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -174,7 +174,7 @@ runs:
 
     - name: Update ${{ env.DEPLOY_ENV }} status
       if: always()
-      uses: bobheadxi/deployments@v1 
+      uses: bobheadxi/deployments@v1
       with:
         env:  ${{ env.DEPLOY_ENV }}
         step: finish
@@ -183,6 +183,7 @@ runs:
         status: ${{ env.JOB_STATUS }}
         deployment_id: ${{ steps.deployment.outputs.deployment_id }}
         env_url: ${{ env.DEPLOY_URL }}
+        override: false
 
     - name: Notify Slack channel on job failure
       if: failure() && inputs.pr-number == ''


### PR DESCRIPTION
## Context
bobheadxi/deployments@v1 by default updates 100 environments and we suspect it breaches Github rate limiting

## Changes proposed in this pull request
Set override: false to stop doing this

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
