### PR TITLE
4530 saving degree uuids from the interface

### DIFF
--- a/app/forms/candidate_interface/degree_grade_form.rb
+++ b/app/forms/candidate_interface/degree_grade_form.rb
@@ -16,12 +16,14 @@ module CandidateInterface
       submitted_grade = determine_submitted_grade
       degree_grade = Hesa::Grade.find_by_description(submitted_grade)
       hesa_code = degree_grade&.hesa_code
-      degree_grade_uuid = degree_grade&.id
+      new_data_degree_grade = DfE::ReferenceData::Degrees::GRADES.all.find do |grade|
+        grade.name == submitted_grade || submitted_grade.in?(grade.synonyms)
+      end
 
       degree.update!(
         grade: determine_submitted_grade,
         grade_hesa_code: hesa_code,
-        degree_grade_uuid: degree_grade_uuid
+        degree_grade_uuid: new_data_degree_grade&.id
       )
     end
 

--- a/app/forms/candidate_interface/degree_grade_form.rb
+++ b/app/forms/candidate_interface/degree_grade_form.rb
@@ -23,7 +23,7 @@ module CandidateInterface
       degree.update!(
         grade: determine_submitted_grade,
         grade_hesa_code: hesa_code,
-        degree_grade_uuid: new_data_degree_grade&.id
+        degree_grade_uuid: new_data_degree_grade&.id,
       )
     end
 

--- a/app/forms/candidate_interface/degree_grade_form.rb
+++ b/app/forms/candidate_interface/degree_grade_form.rb
@@ -14,11 +14,14 @@ module CandidateInterface
       return false unless valid?
 
       submitted_grade = determine_submitted_grade
-      hesa_code = Hesa::Grade.find_by_description(submitted_grade)&.hesa_code
+      degree_grade = Hesa::Grade.find_by_description(submitted_grade)
+      hesa_code = degree_grade&.hesa_code
+      degree_grade_uuid = degree_grade&.id
 
       degree.update!(
         grade: determine_submitted_grade,
         grade_hesa_code: hesa_code,
+        degree_grade_uuid: degree_grade_uuid
       )
     end
 

--- a/app/forms/candidate_interface/degree_institution_form.rb
+++ b/app/forms/candidate_interface/degree_institution_form.rb
@@ -18,6 +18,7 @@ module CandidateInterface
         institution_name: institution_name,
         institution_country: institution_country,
         institution_hesa_code: hesa_code,
+        degree_institution_uuid: degree_institution_uuid,
       )
     end
 
@@ -30,7 +31,15 @@ module CandidateInterface
   private
 
     def hesa_code
-      Hesa::Institution.find_by_name(institution_name)&.hesa_code
+      institution&.hesa_code
+    end
+
+    def degree_institution_uuid
+      institution&.id
+    end
+
+    def institution
+      Hesa::Institution.find_by_name(institution_name)
     end
   end
 end

--- a/app/forms/candidate_interface/degree_institution_form.rb
+++ b/app/forms/candidate_interface/degree_institution_form.rb
@@ -35,7 +35,11 @@ module CandidateInterface
     end
 
     def degree_institution_uuid
-      institution&.id
+      degree_institution = DfE::ReferenceData::Degrees::INSTITUTIONS.all.find do |institution|
+        institution.name == institution_name || institution_name.in?(institution.match_synonyms)
+      end
+
+      degree_institution&.id
     end
 
     def institution

--- a/app/forms/candidate_interface/degree_subject_form.rb
+++ b/app/forms/candidate_interface/degree_subject_form.rb
@@ -12,7 +12,7 @@ module CandidateInterface
     def save
       return false unless valid?
 
-      degree.update!(subject: subject, subject_hesa_code: hesa_code)
+      degree.update!(subject: subject, subject_hesa_code: hesa_code, degree_subject_uuid: degree_subject_uuid)
     end
 
     def assign_form_values
@@ -23,7 +23,15 @@ module CandidateInterface
   private
 
     def hesa_code
-      Hesa::Subject.find_by_name(subject)&.hesa_code
+      degree_subject&.hesa_code
+    end
+
+    def degree_subject_uuid
+      degree_subject&.id
+    end
+
+    def degree_subject
+      Hesa::Subject.find_by_name(subject)
     end
   end
 end

--- a/app/forms/candidate_interface/degree_subject_form.rb
+++ b/app/forms/candidate_interface/degree_subject_form.rb
@@ -27,7 +27,10 @@ module CandidateInterface
     end
 
     def degree_subject_uuid
-      degree_subject&.id
+      new_data_degree_subject = DfE::ReferenceData::Degrees::SUBJECTS.all.find do |new_data_subject|
+        new_data_subject.name == subject
+      end
+      new_data_degree_subject&.id
     end
 
     def degree_subject

--- a/app/forms/candidate_interface/degree_type_form.rb
+++ b/app/forms/candidate_interface/degree_type_form.rb
@@ -18,6 +18,7 @@ module CandidateInterface
         international: international?,
         qualification_type: international? ? international_type_description : type_description,
         qualification_type_hesa_code: international? ? nil : hesa_code,
+        degree_type_uuid: degree_type_uuid,
       )
     end
 
@@ -37,6 +38,7 @@ module CandidateInterface
           international: international?,
           qualification_type: international? ? international_type_description : type_description,
           qualification_type_hesa_code: international? ? nil : hesa_code,
+          degree_type_uuid: degree_type_uuid,
         )
       end
     end
@@ -53,7 +55,7 @@ module CandidateInterface
     def type_description_is_for_bachelor_degree?
       return false if international?
 
-      HESA_DEGREE_TYPES.select { |dt| dt[3] == :bachelor }.collect(&:third).include?(type_description)
+      Hesa::DegreeType.all.select(&:bachelor?).map(&:name).include?(type_description)
     end
 
     def current_grade_is_invalid_for_bachelor_degree?
@@ -88,6 +90,10 @@ module CandidateInterface
 
     def uk?
       uk_degree == 'yes'
+    end
+
+    def degree_type_uuid
+      Hesa::DegreeType.find_by_name(type_description)&.id
     end
   end
 end

--- a/app/forms/candidate_interface/degree_type_form.rb
+++ b/app/forms/candidate_interface/degree_type_form.rb
@@ -93,7 +93,11 @@ module CandidateInterface
     end
 
     def degree_type_uuid
-      Hesa::DegreeType.find_by_name(type_description)&.id
+      new_data_degree_type = DfE::ReferenceData::Degrees::TYPES_INCLUDING_GENERICS.all.find do |degree_type|
+        degree_type.name == type_description
+      end
+
+      new_data_degree_type&.id
     end
   end
 end

--- a/app/lib/dfe/reference_data/degrees.rb
+++ b/app/lib/dfe/reference_data/degrees.rb
@@ -553,7 +553,47 @@ module DfE
             synonyms: [],
             qualification: '181eb0ae-eeb8-487b-9c6a-a4ee3e1907b6',
             dqt_id: nil,
-            hesa_itt_code: nil } },
+            hesa_itt_code: nil },
+          # These next four are HESA codes found in production data that weren't
+          # in the current HESA list, so presumably had been removed; so are
+          # included here to not break existing data, but probably shouldn't be
+          # offered as options for new entries
+          '7ba49954-7595-437c-8df0-6a777c97307b' =>
+          { priority: 1,
+            name: 'Bachelor of Science in Education',
+            abbreviation: 'BSc/Education',
+            synonyms: [],
+            qualification: 'b580a760-da23-4d38-b803-62ae11de6a65',
+            dqt_id: nil,
+            hesa_itt_code: '3',
+            deprecated: true },
+          'c6aeedca-9147-4e88-886a-a90302f3d097' =>
+          { priority: 1,
+            name: 'Bachelor of Technology in Education',
+            abbreviation: 'BTech/Education',
+            synonyms: [],
+            qualification: 'b580a760-da23-4d38-b803-62ae11de6a65',
+            dqt_id: nil,
+            hesa_itt_code: '5',
+            deprecated: true },
+          '007a0999-87f7-4afc-8ccd-ce1e1d92c9ac' =>
+          { priority: 1,
+            name: 'Bachelor of Arts in Education',
+            abbreviation: 'BA/Education',
+            synonyms: [],
+            qualification: 'b580a760-da23-4d38-b803-62ae11de6a65',
+            dqt_id: nil,
+            hesa_itt_code: '7',
+            deprecated: true },
+          'da47d378-f4bb-45ec-bda0-14af40ad974e' =>
+          { priority: 1,
+            name: 'Bachelor of Arts in Combined Studies / Education of the Deaf',
+            abbreviation: nil,
+            synonyms: [],
+            qualification: 'b580a760-da23-4d38-b803-62ae11de6a65',
+            dqt_id: nil,
+            hesa_itt_code: '9',
+            deprecated: true } },
       )
       GENERIC_TYPES = DfE::ReferenceData::HardcodedReferenceList.new(
         {

--- a/app/lib/dfe/reference_data/degrees.rb
+++ b/app/lib/dfe/reference_data/degrees.rb
@@ -4006,7 +4006,7 @@ module DfE
             dttp_id: 'bf8170f0-5dce-e911-a985-000d3ab79618',
             hesa_itt_code: '100456' },
           '9f8070f0-5dce-e911-a985-000d3ab79618' =>
-          { name: "children's nursing",
+          { name: "Children's nursing",
             synonyms: [],
             dttp_id: '9f8070f0-5dce-e911-a985-000d3ab79618',
             hesa_itt_code: '100280' },
@@ -6436,7 +6436,7 @@ module DfE
             dttp_id: '058770f0-5dce-e911-a985-000d3ab79618',
             hesa_itt_code: '101421' },
           '8f8270f0-5dce-e911-a985-000d3ab79618' =>
-          { name: "men's studies",
+          { name: "Men's studies",
             synonyms: [],
             dttp_id: '8f8270f0-5dce-e911-a985-000d3ab79618',
             hesa_itt_code: '100623' },
@@ -8206,7 +8206,7 @@ module DfE
             dttp_id: '1d8670f0-5dce-e911-a985-000d3ab79618',
             hesa_itt_code: '101258' },
           '358770f0-5dce-e911-a985-000d3ab79618' =>
-          { name: "the Qur'an and Islamic texts",
+          { name: "The Qur'an and Islamic texts",
             synonyms: [],
             dttp_id: '358770f0-5dce-e911-a985-000d3ab79618',
             hesa_itt_code: '101445' },
@@ -8561,7 +8561,7 @@ module DfE
             dttp_id: '7b8770f0-5dce-e911-a985-000d3ab79618',
             hesa_itt_code: '101482' },
           '8d8270f0-5dce-e911-a985-000d3ab79618' =>
-          { name: "women's studies",
+          { name: "Women's studies",
             synonyms: [],
             dttp_id: '8d8270f0-5dce-e911-a985-000d3ab79618',
             hesa_itt_code: '100622' },

--- a/spec/forms/candidate_interface/degree_grade_form_spec.rb
+++ b/spec/forms/candidate_interface/degree_grade_form_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe CandidateInterface::DegreeGradeForm, type: :model do
       degree_form = described_class.new(degree: degree, grade: 'Upper second-class honours (2:1)')
 
       degree_form.save
-      expect(degree_form.degree.degree_grade_uuid).to eq(Hesa::Grade.all.second.id)
+      expect(degree_form.degree.degree_grade_uuid).to eq('e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f')
     end
   end
 

--- a/spec/forms/candidate_interface/degree_grade_form_spec.rb
+++ b/spec/forms/candidate_interface/degree_grade_form_spec.rb
@@ -20,11 +20,22 @@ RSpec.describe CandidateInterface::DegreeGradeForm, type: :model do
       )
     end
 
-    it 'sets the grade uuid using the HESA grade description' do
-      degree_form = described_class.new(degree: degree, grade: 'Upper second-class honours (2:1)')
+    context 'when search by name' do
+      it 'sets the grade uuid using the HESA grade description' do
+        degree_form = described_class.new(degree: degree, grade: 'Upper second-class honours (2:1)')
 
-      degree_form.save
-      expect(degree_form.degree.degree_grade_uuid).to eq('e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f')
+        degree_form.save
+        expect(degree_form.degree.degree_grade_uuid).to eq('e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f')
+      end
+    end
+
+    context 'when search by synonym' do
+      it 'sets the grade uuid using the HESA grade description' do
+        degree_form = described_class.new(degree: degree, grade: 'First class honours')
+
+        degree_form.save
+        expect(degree_form.degree.degree_grade_uuid).to eq('8741765a-13d8-4550-a413-c5a860a59d25')
+      end
     end
   end
 

--- a/spec/forms/candidate_interface/degree_grade_form_spec.rb
+++ b/spec/forms/candidate_interface/degree_grade_form_spec.rb
@@ -12,6 +12,22 @@ RSpec.describe CandidateInterface::DegreeGradeForm, type: :model do
     )
   end
 
+  describe '#save' do
+    let(:degree) do
+      build(
+        :degree_qualification,
+        grade_hesa_code: 2,
+      )
+    end
+
+    it 'sets the grade uuid using the HESA grade description' do
+      degree_form = described_class.new(degree: degree, grade: 'Upper second-class honours (2:1)')
+
+      degree_form.save
+      expect(degree_form.degree.degree_grade_uuid).to eq(Hesa::Grade.all.second.id)
+    end
+  end
+
   describe '#assign_form_values' do
     context 'when the database degree has a grade_hesa_code, for a HESA grade with visual_grouping "main"' do
       let(:degree) do

--- a/spec/forms/candidate_interface/degree_institution_form_spec.rb
+++ b/spec/forms/candidate_interface/degree_institution_form_spec.rb
@@ -31,6 +31,21 @@ RSpec.describe CandidateInterface::DegreeInstitutionForm do
       end
     end
 
+    context 'when institutions match a synonym' do
+      let(:form) do
+        described_class.new(
+          degree: create(:degree_qualification), institution_name: 'The Royal Central School of Speech and Drama'
+        )
+      end
+      before do
+        form.save
+      end
+
+      it 'saves the degree institution uuid' do
+        expect(form.degree.degree_institution_uuid).to eq 'd90a4e73-a141-e811-80ff-3863bb351d40'
+      end
+    end
+
     context 'when institution does not match a HESA entry' do
       let(:form) do
         described_class.new(

--- a/spec/forms/candidate_interface/degree_institution_form_spec.rb
+++ b/spec/forms/candidate_interface/degree_institution_form_spec.rb
@@ -12,28 +12,42 @@ RSpec.describe CandidateInterface::DegreeInstitutionForm do
     end
 
     context 'when institution matches a HESA entry' do
-      it 'updates the degree institution and HESA code' do
-        form = described_class.new(
+      let(:form) do
+        described_class.new(
           degree: create(:degree_qualification), institution_name: 'Harper Adams University',
         )
-
+      end
+      before do
         form.save
+      end
 
+      it 'updates the degree institution and HESA code' do
         expect(form.degree.institution_name).to eq 'Harper Adams University'
         expect(form.degree.institution_hesa_code).to eq '18'
+      end
+
+      it 'updates the degree institution uuid' do
+        expect(form.degree.degree_institution_uuid).to eq('1b369414-75d9-e911-a863-000d3ab0da57')
       end
     end
 
     context 'when institution does not match a HESA entry' do
-      it 'updates the degree institution' do
-        form = described_class.new(
+      let(:form) do
+        described_class.new(
           degree: create(:degree_qualification), institution_name: 'Non-HESA institution',
         )
-
+      end
+      before do
         form.save
+      end
 
+      it 'updates the degree institution' do
         expect(form.degree.institution_name).to eq 'Non-HESA institution'
         expect(form.degree.institution_hesa_code).to be_nil
+      end
+
+      it 'saves the degree institution uuid as nil' do
+        expect(form.degree.degree_institution_uuid).to eq nil
       end
     end
 

--- a/spec/forms/candidate_interface/degree_institution_form_spec.rb
+++ b/spec/forms/candidate_interface/degree_institution_form_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe CandidateInterface::DegreeInstitutionForm do
           degree: create(:degree_qualification), institution_name: 'Harper Adams University',
         )
       end
+
       before do
         form.save
       end
@@ -34,9 +35,10 @@ RSpec.describe CandidateInterface::DegreeInstitutionForm do
     context 'when institutions match a synonym' do
       let(:form) do
         described_class.new(
-          degree: create(:degree_qualification), institution_name: 'The Royal Central School of Speech and Drama'
+          degree: create(:degree_qualification), institution_name: 'The Royal Central School of Speech and Drama',
         )
       end
+
       before do
         form.save
       end
@@ -52,6 +54,7 @@ RSpec.describe CandidateInterface::DegreeInstitutionForm do
           degree: create(:degree_qualification), institution_name: 'Non-HESA institution',
         )
       end
+
       before do
         form.save
       end
@@ -62,7 +65,7 @@ RSpec.describe CandidateInterface::DegreeInstitutionForm do
       end
 
       it 'saves the degree institution uuid as nil' do
-        expect(form.degree.degree_institution_uuid).to eq nil
+        expect(form.degree.degree_institution_uuid).to be_nil
       end
     end
 

--- a/spec/forms/candidate_interface/degree_subject_form_spec.rb
+++ b/spec/forms/candidate_interface/degree_subject_form_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe CandidateInterface::DegreeSubjectForm do
           degree: build(:degree_qualification), subject: 'Metallurgy',
         )
       end
+
       before do
         form.save
       end
@@ -37,6 +38,7 @@ RSpec.describe CandidateInterface::DegreeSubjectForm do
           degree: build(:degree_qualification), subject: 'Non-HESA subject',
         )
       end
+
       before do
         form.save
       end

--- a/spec/forms/candidate_interface/degree_subject_form_spec.rb
+++ b/spec/forms/candidate_interface/degree_subject_form_spec.rb
@@ -12,28 +12,42 @@ RSpec.describe CandidateInterface::DegreeSubjectForm do
     end
 
     context 'when subject matches a HESA entry' do
-      it 'updates the degree subject and HESA code' do
-        form = described_class.new(
+      let(:form) do
+        described_class.new(
           degree: build(:degree_qualification), subject: 'Metallurgy',
         )
-
+      end
+      before do
         form.save
+      end
 
+      it 'updates the degree subject and HESA code' do
         expect(form.degree.subject).to eq 'Metallurgy'
         expect(form.degree.subject_hesa_code).to eq '100033'
+      end
+
+      it 'updates the degree subject uuid' do
+        expect(form.degree.degree_subject_uuid).to eq '317f70f0-5dce-e911-a985-000d3ab79618'
       end
     end
 
     context 'when subject does not match a HESA entry' do
-      it 'updates the degree subject' do
-        form = described_class.new(
+      let(:form) do
+        described_class.new(
           degree: build(:degree_qualification), subject: 'Non-HESA subject',
         )
-
+      end
+      before do
         form.save
+      end
 
+      it 'updates the degree subject' do
         expect(form.degree.subject).to eq 'Non-HESA subject'
         expect(form.degree.subject_hesa_code).to be_nil
+      end
+
+      it 'saves the subject uuid as nil' do
+        expect(form.degree.degree_subject_uuid).to be_nil
       end
     end
   end

--- a/spec/forms/candidate_interface/degree_type_form_spec.rb
+++ b/spec/forms/candidate_interface/degree_type_form_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::DegreeTypeForm do
+  let(:degree) do
+    form.application_form.application_qualifications.degree.first
+  end
+
   describe '#save' do
     context 'when the description matches an entry in the HESA data' do
       let(:form) do
@@ -11,13 +15,18 @@ RSpec.describe CandidateInterface::DegreeTypeForm do
         )
       end
 
-      it 'persists both type description and HESA code' do
+      before do
         form.save
+      end
 
+      it 'persists both type description and HESA code' do
         expect(form.application_form.application_qualifications.degree.size).to eq 1
-        degree = form.application_form.application_qualifications.degree.first
         expect(degree.qualification_type).to eq 'Doctor of Divinity'
         expect(degree.qualification_type_hesa_code).to eq '300'
+      end
+
+      it 'persists the degree type uuid' do
+        expect(degree.degree_type_uuid).to eq '5b6a5652-c197-e711-80d8-005056ac45bb'
       end
     end
 
@@ -29,13 +38,17 @@ RSpec.describe CandidateInterface::DegreeTypeForm do
           uk_degree: 'yes',
         )
       end
+      before do
+        form.save
+      end
 
       it 'persists type description but no HESA code' do
-        form.save
-
-        degree = form.application_form.application_qualifications.degree.first
         expect(degree.qualification_type).to eq 'Doctor of Rap Battles'
         expect(degree.qualification_type_hesa_code).to be_nil
+      end
+
+      it 'persists type description but no degree type uuid' do
+        expect(degree.degree_type_uuid).to be_nil
       end
     end
 
@@ -70,12 +83,17 @@ RSpec.describe CandidateInterface::DegreeTypeForm do
       let(:form) do
         described_class.new(degree: degree, type_description: 'Doctor of Divinity', uk_degree: 'yes')
       end
+      before do
+        form.update
+      end
 
       it 'updates the qualification_type and HESA code' do
-        form.update
-
         expect(degree.qualification_type).to eq 'Doctor of Divinity'
         expect(degree.qualification_type_hesa_code).to eq '300'
+      end
+
+      it 'updates the degree type uuid' do
+        expect(degree.degree_type_uuid).to eq '5b6a5652-c197-e711-80d8-005056ac45bb'
       end
     end
 
@@ -132,7 +150,6 @@ RSpec.describe CandidateInterface::DegreeTypeForm do
 
       it 'updates the qualification_type and sets international to false' do
         form.update
-
         expect(degree.qualification_type).to eq 'Doctor of Rap Battles'
         expect(degree.qualification_type_hesa_code).to be_nil
         expect(degree.international).to be false

--- a/spec/forms/candidate_interface/degree_type_form_spec.rb
+++ b/spec/forms/candidate_interface/degree_type_form_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe CandidateInterface::DegreeTypeForm do
           uk_degree: 'yes',
         )
       end
+
       before do
         form.save
       end
@@ -83,6 +84,7 @@ RSpec.describe CandidateInterface::DegreeTypeForm do
       let(:form) do
         described_class.new(degree: degree, type_description: 'Doctor of Divinity', uk_degree: 'yes')
       end
+
       before do
         form.update
       end


### PR DESCRIPTION
## Context

This PR adds the behaviour of saving the new degree data UUIDs to the database when the user selects the old data in the interface.

## Changes proposed in this pull request

When the user selects the degrees from the old data (types, institutions, subjects, and grades) we should save the UUIDs from the new data to the database.

This will help when we replace the old data with the new because we have the UUIDs saved and we can use the UUIDs internally for finding degree grades in other parts of the application.

## Deployment plan

This are the steps for deploying the work

1. New columns are added in the database (PR https://github.com/DFE-Digital/apply-for-teacher-training/pull/6638) √
2. Add all new UUIDs to all existing degrees (PR https://github.com/DFE-Digital/apply-for-teacher-training/pull/6646) √
3. Save the UUIDS from the degrees interface (this PR)

For last: 
Replace the old data with the new data (breaking changes https://github.com/DFE-Digital/apply-for-teacher-training/pull/6582) PR almost done -> √

## Link to Trello card

https://trello.com/c/NTwJIzKS/4530-degree-new-source-of-data-saving-new-data-degree-uuids

