### PR TITLE
Reduce spacing between work history items

### DIFF
--- a/app/components/shared/work_history_and_unpaid_experience_component.rb
+++ b/app/components/shared/work_history_and_unpaid_experience_component.rb
@@ -5,9 +5,11 @@ class WorkHistoryAndUnpaidExperienceComponent < WorkHistoryComponent
   end
 
   def subtitle
-    if work_history? && !unpaid_experience?
+    if work_history? && unpaid_experience?
+      'Details of work history and unpaid experience'
+    elsif work_history?
       'Details of work history'
-    elsif !work_history? && unpaid_experience?
+    elsif unpaid_experience?
       'Details of unpaid experience'
     end
   end

--- a/app/components/shared/work_history_and_unpaid_experience_item_component.html.erb
+++ b/app/components/shared/work_history_and_unpaid_experience_item_component.html.erb
@@ -1,6 +1,6 @@
 <section>
   <% if unexplained_break? %>
-    <div class="govuk-inset-text govuk-!-padding-bottom-0 govuk-!-padding-top-0">
+    <div class="govuk-inset-text govuk-!-padding-bottom-0 govuk-!-padding-top-0 govuk-!-margin-bottom-0 govuk-!-margin-top-0">
   <% end %>
 
   <h3 class="govuk-heading-s govuk-!-margin-bottom-0">
@@ -12,17 +12,17 @@
   <p class="govuk-caption-m govuk-!-font-size-16 govuk-!-margin-top-0">
     <%= dates %>
   </p>
-  <p class="govuk-body">
+  <p class="govuk-body govuk-!-margin-bottom-3">
     <%= details %>
     <% if relevant_skills? %>
-      <p class="govuk-body govuk-!-font-size-16">
+      <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-3">
         <svg class="app-icon govuk-!-margin-right-1" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 200 200" focusable="false" fill="currentColor" aria-hidden="true">
           <path d="M100 200a100 100 0 1 1 0-200 100 100 0 0 1 0 200zm-60-85l40 40 80-80-20-20-60 60-20-20-20 20z"></path>
         </svg>
         This role used skills relevant to teaching
       </p>
     <% elsif working_with_children? %>
-      <p class="govuk-body govuk-!-font-size-16">
+      <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-3">
         <svg class="app-icon govuk-!-margin-right-1" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 200 200" focusable="false" fill="currentColor" aria-hidden="true">
           <path d="M100 200a100 100 0 1 1 0-200 100 100 0 0 1 0 200zm-60-85l40 40 80-80-20-20-60 60-20-20-20 20z"></path>
         </svg>
@@ -32,8 +32,8 @@
   </p>
   <% if unexplained_break? %>
     </div>
-    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-bottom-3 govuk-!-margin-top-3">
   <% else %>
-    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-bottom-3 govuk-!-margin-top-3">
   <% end %>
 </section>

--- a/spec/components/shared/work_history_and_unpaid_experience_component_spec.rb
+++ b/spec/components/shared/work_history_and_unpaid_experience_component_spec.rb
@@ -97,7 +97,9 @@ RSpec.describe WorkHistoryAndUnpaidExperienceComponent, type: :component do
         expect(summary).not_to have_css('dd', class: 'govuk-summary-list__value', text: 'No')
       end
 
-      expect(page).not_to have_css('h3#work-history-subheader', class: 'govuk-heading-m')
+      expect(page).to have_css('h3#work-history-subheader', class: 'govuk-heading-m') do |subheader|
+        expect(subheader).to have_text('Details of work history and unpaid experience')
+      end
 
       expect(page).to have_css('section', class: 'app-section') do |section|
         expect(section).to have_text 'Livestock management'


### PR DESCRIPTION
## Context
https://trello.com/c/44mo1mLu/4936-tidying-up-work-history-list-in-line-with-prototype
As a follow up to the prototype audit dev-design, we spotted a discrepancy with the work history on an application page.

In particular, items were being spaced too far apart, but also that a conditional header that was supposed to appear did not. It's not clear if this was an oversight or deliberate
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
The spacing has been tweaked on a number of the elements in the `work_history_and_unpaid_experience_item_component` to bring it in line with the prototype. It doesn't quite match up in terms of what's `padding` and what's `margin`, but this is more a feature of how we've built our component, and the spacing between things should still appear to be identical across both.

|OLD|NEW|
|-|-|
| ![image](https://user-images.githubusercontent.com/25597009/158594868-be098b5d-baa8-4cca-8892-fe09ec04e7aa.png)| ![image](https://user-images.githubusercontent.com/25597009/158594787-b2f4aa89-3047-428f-a068-c92434481b96.png)|
<!-- If there are UI changes, please include Before and After screenshots. -->

Additionally, if a candidate has said that they both have paid and unpaid experience, we should be showing a subheading that reflects this. There's an additional `if` check to cover this now.

|OLD|NEW|
|-|-|
| ![image](https://user-images.githubusercontent.com/25597009/158595245-b932122e-217a-4e94-ae53-4d772149d988.png)| ![image](https://user-images.githubusercontent.com/25597009/158595182-ee0a7974-583a-4d61-a66f-297a19562879.png)|
## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
