### PR TITLE
Relabel "Interview" as "Interview needs" to match candidate interface

### DIFF
--- a/app/components/shared/interview_preferences_component.html.erb
+++ b/app/components/shared/interview_preferences_component.html.erb
@@ -1,5 +1,5 @@
 <section class="app-section govuk-!-width-two-thirds">
-  <h2 class="govuk-heading-m govuk-!-font-size-27" id="interview">Interview</h2>
+  <h2 class="govuk-heading-m govuk-!-font-size-27" id="interview">Interview needs</h2>
 
   <%= simple_format interview_preferences, class: 'govuk-body' %>
 </section>

--- a/app/components/shared/interview_preferences_component.rb
+++ b/app/components/shared/interview_preferences_component.rb
@@ -9,6 +9,6 @@ class InterviewPreferencesComponent < ViewComponent::Base
   def interview_preferences
     return application_form.interview_preferences if application_form.interview_preferences.present?
 
-    'No preferences.'
+    'None given.'
   end
 end

--- a/spec/components/utility/interview_preferences_component_spec.rb
+++ b/spec/components/utility/interview_preferences_component_spec.rb
@@ -1,22 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe InterviewPreferencesComponent do
-  it 'renders `No preferences` if `#interview_preferences` is nil' do
+  it 'renders `None given` if `#interview_preferences` is nil' do
     application_form = instance_double(
       ApplicationForm,
       interview_preferences: nil,
     )
     result = render_inline(described_class.new(application_form: application_form))
-    expect(result.text).to include('No preferences.')
+    expect(result.text).to include('None given.')
   end
 
-  it 'renders `No preferences` if `#interview_preferences` is blank' do
+  it 'renders `None given` if `#interview_preferences` is blank' do
     application_form = instance_double(
       ApplicationForm,
       interview_preferences: '',
     )
     result = render_inline(described_class.new(application_form: application_form))
-    expect(result.text).to include('No preferences.')
+    expect(result.text).to include('None given.')
   end
 
   it 'renders interview preferences if there are any' do


### PR DESCRIPTION
Spotted when reviewing the Support interface that heading "Interview" is used for what in the candidate interface is called "Interview needs".

This updates both the Support and Manage interfaces.

🗂️ [Trello card](https://trello.com/c/6Ul1visV/4515-audit-what-questions-are-missing-from-application-details-in-support-console)

## Before and after

| Before  | After |
| ------------- | ------------- |
| <img width="793" alt="Before - with needs" src="https://user-images.githubusercontent.com/30665/158602260-8e83b826-84cd-430b-90fc-c7c8ab4dbc72.png">  | <img width="763" alt="After - with needs" src="https://user-images.githubusercontent.com/30665/158602810-763f66c6-b1fd-47cf-a9f1-2477a6d432c0.png">  |
| <img width="398" alt="Before - no needs" src="https://user-images.githubusercontent.com/30665/158602357-1415d20a-c58f-4b29-a7bd-ea71eec98a38.png">  | <img width="368" alt="After - no needs" src="https://user-images.githubusercontent.com/30665/158602409-8c67c249-e858-463a-887f-11bcc3da89dd.png">l  |


## Candidate interface (for reference)

![interview-needs](https://user-images.githubusercontent.com/30665/158603406-213256e6-820a-4115-a7b3-3e28d36ebfe6.png)

