### PR TITLE
Ignore immigration_right_to_work column from cache

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -1,7 +1,7 @@
 # The Application Form is filled in and submitted by the Candidate. Candidates
 # can initially apply to 3 different courses, represented by an Application Choice.
 class ApplicationForm < ApplicationRecord
-  self.ignored_columns = %w[immigration_status_details immigration_entry_date immigration_route immigration_route_details]
+  self.ignored_columns = %w[immigration_status_details immigration_entry_date immigration_route immigration_route_details immigration_right_to_work]
   audited
   has_associated_audits
   geocoded_by :address_formatted_for_geocoding, params: { region: 'uk' }


### PR DESCRIPTION
## Context

Ignore `immigration_right_to_work` column from cache in preperation for the removal of the column.

Adding this to the other four which will be removed in the same PR.

## Link to Trello card

https://trello.com/c/8zpS5N1w/4539-remove-5-columns-from-the-applicationform-table

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
