### PR TITLE
Access the rails console in all environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ edit-cypress-secrets: read-keyvault-config install-fetch-config azure-login ## E
 .PHONY: shell
 shell: ## Open a shell on the app instance on PaaS, eg: make qa shell
 	cf target -s ${SPACE}
-	cf ssh apply-clock-${APP_NAME_SUFFIX} -t -c 'cd /app && /usr/local/bin/bundle exec rails c'
+	cf ssh apply-${APP_NAME_SUFFIX} -t -c 'cd /app && /usr/local/bin/bundle exec rails c'
 
 deploy-init:
 	$(if $(IMAGE_TAG), , $(eval export IMAGE_TAG=main))


### PR DESCRIPTION
## Context

Before this PR, the make command was accessing the clock app which has less memory than the others so the following error was raised:

```
$ make qa console
wait: remote command exited without exit status or exit signal
FAILED
```

This PR adds the possibility to access the other server which has more memory therefore we can access the rails console without errors.
