### PR TITLE
Improve seed data

### DIFF
--- a/spec/components/provider_interface/personal_details_component_spec.rb
+++ b/spec/components/provider_interface/personal_details_component_spec.rb
@@ -74,15 +74,29 @@ RSpec.describe ProviderInterface::PersonalDetailsComponent do
       end
     end
 
-    context 'the right to work or study status is "yes"' do
+    context 'the right to work or study status is "yes" and a radio answer was selected' do
       before do
         application_form.right_to_work_or_study = 'yes'
-        application_form.right_to_work_or_study_details = 'I have settled status'
+        application_form.immigration_status = 'eu_settled'
+        application_form.right_to_work_or_study_details = nil
       end
 
       it 'renders the residency_details_row' do
         expect(result.css('.govuk-summary-list__key').text).to include('Residency details')
-        expect(result.css('.govuk-summary-list__value').text).to include('I have settled status')
+        expect(result.css('.govuk-summary-list__value').text).to include('EU settled status')
+      end
+    end
+
+    context 'the right to work or study status is "yes" and another immigration status was given' do
+      before do
+        application_form.right_to_work_or_study = 'yes'
+        application_form.immigration_status = 'other'
+        application_form.right_to_work_or_study_details = 'Indefinite leave to remain'
+      end
+
+      it 'renders the residency_details_row' do
+        expect(result.css('.govuk-summary-list__key').text).to include('Residency details')
+        expect(result.css('.govuk-summary-list__value').text).to include('Indefinite leave to remain')
       end
     end
 

--- a/spec/components/support_interface/personal_details_component_spec.rb
+++ b/spec/components/support_interface/personal_details_component_spec.rb
@@ -96,15 +96,29 @@ RSpec.describe SupportInterface::PersonalDetailsComponent do
       end
     end
 
-    context 'the right to work or study status is "yes"' do
+    context 'the right to work or study status is "yes" and a radio answer was selected' do
       before do
         application_form.right_to_work_or_study = 'yes'
-        application_form.right_to_work_or_study_details = 'I have settled status'
+        application_form.immigration_status = 'eu_settled'
+        application_form.right_to_work_or_study_details = nil
       end
 
       it 'renders the residency_details_row' do
         expect(result.css('.govuk-summary-list__key').text).to include('Immigration status')
-        expect(result.css('.govuk-summary-list__value').text).to include('I have settled status')
+        expect(result.css('.govuk-summary-list__value').text).to include('EU settled status')
+      end
+    end
+
+    context 'the right to work or study status is "yes" and another immigration status was given' do
+      before do
+        application_form.right_to_work_or_study = 'yes'
+        application_form.immigration_status = 'other'
+        application_form.right_to_work_or_study_details = 'Indefinite leave to remain'
+      end
+
+      it 'renders the residency_details_row' do
+        expect(result.css('.govuk-summary-list__key').text).to include('Immigration status')
+        expect(result.css('.govuk-summary-list__value').text).to include('Indefinite leave to remain')
       end
     end
 

--- a/spec/decorators/application_choice_export_decorator_spec.rb
+++ b/spec/decorators/application_choice_export_decorator_spec.rb
@@ -3,12 +3,15 @@ require 'rails_helper'
 RSpec.describe ApplicationChoiceExportDecorator do
   describe 'gcse_qualifications_summary' do
     it 'returns a summary of maths, science and english GCSEs for an application form' do
-      application_form = create(:application_form, :with_gcses)
+      application_form = create(:application_form)
       application_choice = create(:application_choice, application_form: application_form)
+      create(:gcse_qualification, application_form: application_form, subject: 'maths', grade: 'A', award_year: '2000')
+      create(:gcse_qualification, :multiple_english_gcses, application_form: application_form, award_year: '2000', constituent_grades: { english_language: { grade: 'B', public_id: 120282 }, english_literature: { grade: 'C', public_id: 120283 } })
+      create(:gcse_qualification, :science_gcse, application_form: application_form, subject: 'science double award', grade: 'AB', award_year: '2000')
 
       summary = described_class.new(application_choice).gcse_qualifications_summary
 
-      expect(summary).to match(/^Gcse Maths, [ABCD], \d{4},Gcse English, [ABCD], \d{4},Gcse Science, [ABCD], \d{4}$/)
+      expect(summary).to match('Gcse Maths, A, 2000,Gcse English, B (English Language) C (English Literature), 2000,Gcse Science double award, AB (Double award), 2000')
     end
 
     it 'returns the gcse start year if present' do

--- a/spec/decorators/application_choice_export_decorator_spec.rb
+++ b/spec/decorators/application_choice_export_decorator_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ApplicationChoiceExportDecorator do
       expect(summary).to match('Gcse Maths, A, 2000,Gcse English, B (English Language) C (English Literature), 2000,Gcse Science double award, AB (Double award), 2000')
     end
 
-    it 'returns the gcse start year if present' do
+    it 'returns the GCSE start year if present' do
       application_form = create(:application_form)
       application_choice = create(:application_choice, application_form: application_form)
       create(:application_qualification, qualification_type: :gcse, level: :gcse, start_year: '2005', award_year: '2006', subject: :maths, application_form: application_form)
@@ -24,7 +24,7 @@ RSpec.describe ApplicationChoiceExportDecorator do
       expect(summary).to match(/^Gcse Maths, [ABCD], \d{4}-\d{4}$/)
     end
 
-    it 'does not include gcses in other subjects' do
+    it 'does not include GCSEs in other subjects' do
       application_form = create(:application_form, :with_gcses)
       application_choice = create(:application_choice, application_form: application_form)
       create(:application_qualification, level: :gcse, subject: :french, application_form: application_form)
@@ -35,7 +35,7 @@ RSpec.describe ApplicationChoiceExportDecorator do
       expect(summary).not_to include('French')
     end
 
-    it 'includes qualifications that are equivalent to gcses' do
+    it 'includes qualifications that are equivalent to GCSEs' do
       application_form = create(:application_form)
       application_choice = create(:application_choice, application_form: application_form)
       o_level = create(:application_qualification, level: :gcse, qualification_type: 'gce_o_level', subject: :maths, application_form: application_form)
@@ -45,7 +45,7 @@ RSpec.describe ApplicationChoiceExportDecorator do
       expect(summary).to include('Gce o level Maths', o_level.grade)
     end
 
-    it 'returns nil if a form has no relevant gcses' do
+    it 'returns nil if a form has no relevant GCSEs' do
       application_form = create(:completed_application_form)
       application_choice = create(:application_choice, application_form: application_form)
 
@@ -66,7 +66,7 @@ RSpec.describe ApplicationChoiceExportDecorator do
       expect(explanation).to include('Maths GCSE or equivalent', missing_gcse.not_completed_explanation)
     end
 
-    it 'returns nil if a form has no missing gcses' do
+    it 'returns nil if a form has no missing GCSEs' do
       application_form = create(:application_form, :with_gcses)
       application_choice = create(:application_choice, application_form: application_form)
 

--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -150,6 +150,22 @@ FactoryBot.define do
       phase { :apply_1 }
       recruitment_cycle_year { RecruitmentCycle.current_year }
 
+      right_to_work_or_study { %w[yes no].sample }
+      immigration_status {
+        if right_to_work_or_study == 'yes'
+          %w[eu_settled eu_pre_settled other].sample
+        else
+          nil
+        end
+      }
+      right_to_work_or_study_details {
+        if immigration_status == 'other'
+          "Indefinite leave to remain"
+        else
+          nil
+        end
+      }
+
       # Checkboxes to mark a section as complete
       course_choices_completed { true }
       degrees_completed { true }

--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -128,9 +128,12 @@ FactoryBot.define do
       minimum_info
 
       support_reference { GenerateSupportReference.call }
-      english_main_language { %w[true false].sample }
-      english_language_details { Faker::Lorem.paragraph_by_chars(number: 200) }
-      other_language_details { Faker::Lorem.paragraph_by_chars(number: 200) }
+
+      # These 3 questions are no longer asked.
+      english_main_language { nil }
+      english_language_details { nil }
+      other_language_details { nil }
+
       further_information { Faker::Lorem.paragraph_by_chars(number: 300) }
       disclose_disability { %w[true false].sample }
       disability_disclosure { Faker::Lorem.paragraph_by_chars(number: 300) }

--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -150,7 +150,11 @@ FactoryBot.define do
       phase { :apply_1 }
       recruitment_cycle_year { RecruitmentCycle.current_year }
 
-      right_to_work_or_study { %w[yes no].sample }
+      right_to_work_or_study {
+        if first_nationality != 'British'
+          %w[yes no].sample
+        end
+      }
       immigration_status {
         if right_to_work_or_study == 'yes'
           %w[eu_settled eu_pre_settled other].sample

--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -154,15 +154,11 @@ FactoryBot.define do
       immigration_status {
         if right_to_work_or_study == 'yes'
           %w[eu_settled eu_pre_settled other].sample
-        else
-          nil
         end
       }
       right_to_work_or_study_details {
         if immigration_status == 'other'
-          "Indefinite leave to remain"
-        else
-          nil
+          'Indefinite leave to remain'
         end
       }
 

--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -95,9 +95,9 @@ FactoryBot.define do
 
     trait :with_gcses do
       after(:create) do |application_form, _|
-        %i[maths english science].each do |subject|
-          create(:gcse_qualification, application_form: application_form, subject: subject)
-        end
+        create(:gcse_qualification, application_form: application_form, subject: 'maths')
+        create(:gcse_qualification, :multiple_english_gcses, application_form: application_form)
+        create(:gcse_qualification, :science_gcse, application_form: application_form)
       end
     end
 

--- a/spec/factories/application_qualification.rb
+++ b/spec/factories/application_qualification.rb
@@ -46,6 +46,28 @@ FactoryBot.define do
         missing_explanation { 'I have 10 years experience teaching English Language' }
       end
 
+      trait :science_gcse do
+        subject { ['science single award', 'science double award',  'science triple award'].sample }
+
+        grade {
+          if subject == 'science single award'
+            %w[A B C].sample
+          elsif subject == 'science double award'
+            %w[AA BB CC].sample
+          else
+            nil
+          end
+        }
+
+        constituent_grades {
+          if subject == 'science triple award'
+            { biology: { grade: 'A' }, physics: { grade: 'D' }, chemistry: { grade: 'B' } }
+          else
+            nil
+          end
+        }
+      end
+
       trait :multiple_english_gcses do
         grade { nil }
         subject { 'english' }

--- a/spec/factories/application_qualification.rb
+++ b/spec/factories/application_qualification.rb
@@ -47,23 +47,19 @@ FactoryBot.define do
       end
 
       trait :science_gcse do
-        subject { ['science single award', 'science double award',  'science triple award'].sample }
+        subject { ['science single award', 'science double award', 'science triple award'].sample }
 
         grade {
           if subject == 'science single award'
             %w[A B C].sample
           elsif subject == 'science double award'
             %w[AA BB CC].sample
-          else
-            nil
           end
         }
 
         constituent_grades {
           if subject == 'science triple award'
             { biology: { grade: 'A' }, physics: { grade: 'D' }, chemistry: { grade: 'B' } }
-          else
-            nil
           end
         }
       end


### PR DESCRIPTION
Our 'seed' data - used to generate random applications for both automated testing purposes and to test the interface in Review applications and in QA - is a bit out of date, following some changes to the application interface and structure.

This aims to bring it more up-to-date by:

* Not setting any answers to the "Is English your main language?" question, as we dropped that ages ago
* Updating the GCSE answers so that grades are correctly entered for single, double and triple science, and for English Literature and Language
* Setting answers to the Right to work in the UK and Immigration status questions

Is there anything else that needs updating?