### PR TITLE
Revert the renaming of `AddIndexToProviderUserDfESignInUid`

### DIFF
--- a/config/rubocop/config/rails.yml
+++ b/config/rubocop/config/rails.yml
@@ -106,4 +106,5 @@ Rails/I18nLocaleTexts:
 
 Rails/MigrationClassName:
   Exclude:
+    - 'db/migrate/20200330084106_add_index_to_provider_user_dfe_sign_in_uid.rb'
     - 'db/migrate/20211011142611_create_fraud_matches_table.rb'

--- a/db/migrate/20200330084106_add_index_to_provider_user_dfe_sign_in_uid.rb
+++ b/db/migrate/20200330084106_add_index_to_provider_user_dfe_sign_in_uid.rb
@@ -1,4 +1,4 @@
-class AddIndexToProviderUserDfeSignInUid < ActiveRecord::Migration[6.0]
+class AddIndexToProviderUserDfESignInUid < ActiveRecord::Migration[6.0]
   def change
     remove_index :provider_users, :dfe_sign_in_uid
     add_index :provider_users, :dfe_sign_in_uid, unique: true


### PR DESCRIPTION
## Context

This migration class name was changed to `AddIndexToProviderUserDfeSignInUid` to appease Rubocop in https://github.com/DFE-Digital/apply-for-teacher-training/pull/6686. This seems to cause errors when deploying review apps, e.g.:

https://sentry.io/organizations/dfe-teacher-services/issues/3110289345/?project=1765973&referrer=slack

I think the ActiveSupport Inflector is expecting the file name to map to
the old class name because `DfE` is declared as an acronym in
`config/inflector.rb`.

## Changes proposed in this pull request

- [x] Rename `AddIndexToProviderUserDfeSignInUid` back to `AddIndexToProviderUserDfESignInUid`.
- [x] Add a rule to Rubocop config to skip name checks on this class.

## Guidance to review

Does this make sense?
Is there a better way?

## Link to Trello card

n/a

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
