### PR TITLE
Make reference status and reminder link more prominent

### DIFF
--- a/app/components/candidate_interface/references_review_component.rb
+++ b/app/components/candidate_interface/references_review_component.rb
@@ -17,11 +17,11 @@ module CandidateInterface
 
     def reference_rows(reference)
       [
+        feedback_status_row(reference),
         reference_type_row(reference),
         name_row(reference),
         email_row(reference),
         relationship_row(reference),
-        feedback_status_row(reference),
         history_row(reference),
       ].compact
     end
@@ -51,7 +51,7 @@ module CandidateInterface
     end
 
     def ignore_editable_for
-      %w[History]
+      %w[Status]
     end
 
     def too_many_references_error
@@ -138,10 +138,21 @@ module CandidateInterface
     def feedback_status_row(reference)
       value = feedback_status_label(reference) + feedback_status_content(reference)
 
-      {
+      row_attributes = {
         key: 'Status',
         value: value,
       }
+
+      if can_send_reminder?(reference)
+        row_attributes.merge!(
+          action: {
+            href: candidate_interface_references_new_reminder_path(reference),
+            text: t('application_form.references.send_reminder.action'),
+          },
+        )
+      end
+
+      row_attributes
     end
 
     def history_row(reference)

--- a/spec/components/candidate_interface/references_review_component_spec.rb
+++ b/spec/components/candidate_interface/references_review_component_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe CandidateInterface::ReferencesReviewComponent, type: :component d
     reference = create(:reference, :not_requested_yet)
     result = render_inline(described_class.new(references: [reference]))
 
-    name_row = result.css('.govuk-summary-list__row')[1].text
-    email_row = result.css('.govuk-summary-list__row')[2].text
+    name_row = result.css('.govuk-summary-list__row')[2].text
+    email_row = result.css('.govuk-summary-list__row')[3].text
     expect(name_row).to include 'Name'
     expect(name_row).to include reference.name
     expect(email_row).to include 'Email address'
@@ -17,7 +17,7 @@ RSpec.describe CandidateInterface::ReferencesReviewComponent, type: :component d
     reference = create(:reference, :not_requested_yet, referee_type: :school_based)
     result = render_inline(described_class.new(references: [reference]))
 
-    type_row = result.css('.govuk-summary-list__row')[0].text
+    type_row = result.css('.govuk-summary-list__row')[1].text
     expect(type_row).to include 'Reference type'
     expect(type_row).to include 'School-based'
   end
@@ -26,7 +26,7 @@ RSpec.describe CandidateInterface::ReferencesReviewComponent, type: :component d
     reference = create(:reference, :not_requested_yet)
     result = render_inline(described_class.new(references: [reference]))
 
-    relationship_row = result.css('.govuk-summary-list__row')[3].text
+    relationship_row = result.css('.govuk-summary-list__row')[4].text
     expect(relationship_row).to include 'Relationship to referee'
     expect(relationship_row).to include reference.relationship
   end
@@ -42,9 +42,9 @@ RSpec.describe CandidateInterface::ReferencesReviewComponent, type: :component d
 
       info = t("application_form.references.info.#{row.info_identifier}", row.info_args || {})
       if info.is_a?(Array)
-        info.each { |line| expect(result.css('.govuk-summary-list__value')[4].text).to(include(line)) }
+        info.each { |line| expect(result.css('.govuk-summary-list__value')[0].text).to(include(line)) }
       else
-        expect(result.css('.govuk-summary-list__value')[4].text).to(include(info))
+        expect(result.css('.govuk-summary-list__value')[0].text).to(include(info))
       end
     end
   end

--- a/spec/system/candidate_interface/references/backlinks_spec.rb
+++ b/spec/system/candidate_interface/references/backlinks_spec.rb
@@ -151,19 +151,19 @@ RSpec.feature 'References' do
   end
 
   def when_i_click_change_on_the_references_name
-    page.all('.govuk-summary-list__actions')[0].click_link
+    click_link 'Change name for Jesse Pinkman'
   end
 
   def when_i_click_change_on_email_address
-    page.all('.govuk-summary-list__actions')[1].click_link
+    click_link 'Change email address for Jesse Pinkman'
   end
 
   def when_i_click_change_on_the_reference_type
-    page.all('.govuk-summary-list__actions')[2].click_link
+    click_link 'Change reference type for Jesse Pinkman'
   end
 
   def when_i_click_change_on_relationship
-    page.all('.govuk-summary-list__actions')[3].click_link
+    click_link 'Change relationship for Jesse Pinkman'
   end
 
   def when_i_choose_that_im_not_ready_to_submit_my_reference

--- a/spec/system/candidate_interface/references/candidate_adding_referees_in_sandbox_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_adding_referees_in_sandbox_spec.rb
@@ -50,11 +50,11 @@ RSpec.feature 'Candidate adding referees in Sandbox', sandbox: true do
 
   def then_i_see_that_references_are_given
     within all('.app-summary-card')[0] do
-      expect(all('.govuk-summary-list__value')[4].text).to have_content('Reference received')
+      expect(all('.govuk-summary-list__value')[0].text).to have_content('Reference received')
     end
 
     within all('.app-summary-card')[1] do
-      expect(all('.govuk-summary-list__value')[4].text).to have_content('Reference received')
+      expect(all('.govuk-summary-list__value')[0].text).to have_content('Reference received')
     end
   end
 end


### PR DESCRIPTION
We have some evidence that candidates are adding multiple referees with the same email address, often a few days apart.

We think this may be because they are doing this in order to re-request a reference from a referee who has not yet responded, and that they have not realised that there is a feature to send a reminder.

This aims to reduce the number of error messages about adding a referee with the same email as an existing one by moving the status row to the top of the summary, and moving the "Send a reminder to this referee" link to the top, next to the status.

If this doesn't work, we could explore a bigger change.

🗂️ [Trello card](https://trello.com/c/0xuvREUQ/4516-design-review-our-reference-summary-page-to-address-some-of-the-issues-users-had-with-validation)

## Screenshots

### Before

![references-before](https://user-images.githubusercontent.com/30665/159305024-5a771790-02ec-4964-9896-4202e53718a0.png)

### After

![references-after](https://user-images.githubusercontent.com/30665/159305059-8a1cbe3f-a20f-4a1d-b6f3-d27b71aaf31a.png)

