### PR TITLE
Do not let enum override ApplicationChoice#rejection_reason?

### DIFF
--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -51,7 +51,7 @@ class ApplicationChoice < ApplicationRecord
     rejection_reason: 'rejection_reason',           # API only single text field reason
     reasons_for_rejection: 'reasons_for_rejection', # Current structured ReasonsForRejection model
     rejection_reasons: 'rejection_reasons',         # Redesigned RejectionReasons model
-  }
+  }, _prefix: :rejection_reasons_type
 
   scope :decision_pending, -> { where(status: ApplicationStateChange::DECISION_PENDING_STATUSES) }
 

--- a/app/services/support_interface/revert_rejection.rb
+++ b/app/services/support_interface/revert_rejection.rb
@@ -11,6 +11,7 @@ module SupportInterface
         rejected_at: nil,
         structured_rejection_reasons: nil,
         rejection_reason: nil,
+        rejection_reasons_type: nil,
         audit_comment: "Support request to revert rejection: #{@zendesk_ticket}",
       )
     end

--- a/spec/services/support_interface/revert_rejection_spec.rb
+++ b/spec/services/support_interface/revert_rejection_spec.rb
@@ -3,22 +3,24 @@ require 'rails_helper'
 RSpec.describe SupportInterface::RevertRejection, with_audited: true do
   describe '#save!' do
     it 'reverts the application choice status back to `awaiting_provider_decision` and sets an audit comment' do
-      application_choice = create(:application_choice, :awaiting_provider_decision)
-      original_application_choice = application_choice.clone
-
+      application_choice = create(:application_choice, :with_rejection)
       zendesk_ticket = 'becomingateacher.zendesk.com/agent/tickets/example'
 
-      RejectApplication.new(
-        actor: create(:support_user),
-        application_choice: application_choice,
-      ).save
       described_class.new(
         application_choice: application_choice,
         zendesk_ticket: zendesk_ticket,
       ).save!
 
-      expect(application_choice).to eq(original_application_choice)
       expect(application_choice.audits.last.comment).to include(zendesk_ticket)
+      expect(application_choice.attributes.symbolize_keys).to match(
+        a_hash_including({
+          rejected_at: nil,
+          structured_rejection_reasons: nil,
+          rejection_reason: nil,
+          rejection_reasons_type: nil,
+          status: 'awaiting_provider_decision',
+        }),
+      )
     end
   end
 end


### PR DESCRIPTION
This caused a bug where calling code expected this to be false, because
there was no value in that field. In fact Rails enum magic created a
method from the value of the rejection_reasons_type enum with the same
name - and this returned true because there was in fact a value in the
rejection_reasons_type field that we had forgotten to revert.

Fix the spec and cause the revert to actually nil out this field.

https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1647965380198209

and 

https://sentry.io/organizations/dfe-teacher-services/issues/3122579485/?project=1765973&referrer=slack

