### PR TITLE
Remove extra fields from blocklist as they've been removed

### DIFF
--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -42,12 +42,8 @@
   - address_type
   - latitude
   - longitude
-  - immigration_right_to_work
   - immigration_status
-  - immigration_status_details
-  - immigration_entry_date
   - immigration_route
-  - immigration_route_details
   - region_code
   :authentication_tokens:
   - id


### PR DESCRIPTION
## Context

We've recently added a workflow to fail if the database fields were out of sync with what we send/don't send to big query

## Changes proposed in this pull request

Remove all fields that have been removed from the database from the blocklist as we don't need them anymore 
## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
