### PR TITLE
Update referee email duplicate error message

### DIFF
--- a/config/locales/candidate_interface/references.yml
+++ b/config/locales/candidate_interface/references.yml
@@ -110,7 +110,7 @@ en:
           attributes:
             email_address:
               blank: Enter your referee’s email address
-              duplicate: Please give a different email address for each referee
+              duplicate: You have already entered that email address for a referee. You can send them a reminder if they have not yet given you a reference.
               own: Enter an email address that’s not your own
         candidate_interface/reference/referee_relationship_form:
           attributes:


### PR DESCRIPTION
We think that some people seeing this error message are likely trying to nudge a referee into giving a reference by adding them again, rather than using the "send a reminder" link.

#6713 tried to make the link more visible, but this PR also aims to help people who still don't see it.

Suggestions on improvements to the wording welcome!

## Screenshots

| Before  | After |
| ------------- | ------------- |
|  <img width="721" alt="Screenshot 2022-03-23 at 11 35 03" src="https://user-images.githubusercontent.com/30665/159690649-722273c4-b3c8-4515-bbe7-e19d234df69e.png">  | <img width="749" alt="Screenshot 2022-03-23 at 11 36 19" src="https://user-images.githubusercontent.com/30665/159690724-85e0dab5-6f91-4a0c-a1d7-fc5db4ac28a6.png">  |

