### PR TITLE
rspec matcher helper for summary lists

### DIFF
--- a/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
+++ b/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe CandidateInterface::ApplicationDashboardCourseChoicesComponent do
+RSpec.describe CandidateInterface::ApplicationDashboardCourseChoicesComponent, type: :component do
   it 'renders component without a delete link and with a withdraw link' do
     application_form = create_application_form_with_course_choices(statuses: %w[unsubmitted])
 
@@ -91,12 +91,10 @@ RSpec.describe CandidateInterface::ApplicationDashboardCourseChoicesComponent do
         rejection_reason: 'Course full',
       )
 
-      result = render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
+      render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
 
-      expect(result.css('.govuk-summary-list__key').text).to include('Status')
-      expect(result.css('.govuk-summary-list__value').to_html).to include('Unsuccessful')
-      expect(result.css('.govuk-summary-list__key').text).to include('Feedback')
-      expect(result.css('.govuk-summary-list__value').to_html).to include('Course full')
+      expect(rendered_component).to summarise(key: 'Status', value: 'Unsuccessful')
+      expect(rendered_component).to summarise(key: 'Feedback', value: 'Course full')
     end
   end
 
@@ -112,21 +110,18 @@ RSpec.describe CandidateInterface::ApplicationDashboardCourseChoicesComponent do
     end
 
     it 'renders component with the status as Offer withdrawn and displays the reason' do
-      result = render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
+      render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
 
-      expect(result.css('.govuk-summary-list__key').text).to include('Status')
-      expect(result.css('.govuk-summary-list__value').to_html).to include('Offer withdrawn')
-      expect(result.css('.govuk-summary-list__key').text).to include('Reason for offer withdrawal')
-      expect(result.css('.govuk-summary-list__value').to_html).to include('Course full')
+      expect(rendered_component).to summarise(key: 'Status', value: 'Offer withdrawn')
+      expect(rendered_component).to summarise(key: 'Reason for offer withdrawal', value: 'Course full')
     end
 
     it 'does not render the reason if an offer is subsequently made' do
       application_choice.offer!
 
-      result = render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
+      render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
 
-      expect(result.css('.govuk-summary-list__key').text).not_to include('Reason for offer withdrawal')
-      expect(result.css('.govuk-summary-list__value').to_html).not_to include('Course full')
+      expect(rendered_component).not_to summarise(key: 'Reason for offer withdrawal', value: 'Course full')
     end
   end
 
@@ -134,10 +129,9 @@ RSpec.describe CandidateInterface::ApplicationDashboardCourseChoicesComponent do
     let(:application_form) { create_application_form_with_course_choices(statuses: %w[awaiting_provider_decision]) }
 
     it 'renders component with the status as awaiting decision' do
-      result = render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
+      render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
 
-      expect(result.css('.govuk-summary-list__key').text).to include('Status')
-      expect(result.css('.govuk-summary-list__value').to_html).to include('Awaiting decision')
+      expect(rendered_component).to summarise(key: 'Status', value: 'Awaiting decision')
     end
 
     it 'renders component with a withdraw link' do
@@ -154,13 +148,10 @@ RSpec.describe CandidateInterface::ApplicationDashboardCourseChoicesComponent do
       application_choice = application_form.application_choices.first
       create(:offer, application_choice: application_choice, conditions: conditions)
 
-      result = render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
+      render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
 
-      expect(result.css('.govuk-summary-list__key').text).to include('Status')
-      expect(result.css('.govuk-summary-list__value').to_html).to include('Offer received')
-      expect(result.css('.govuk-summary-list__key').text).to include('Condition')
-      expect(result.css('.govuk-summary-list__value').to_html).to include('DBS check')
-      expect(result.css('.govuk-summary-list__value').to_html).to include('Get a haircut')
+      expect(rendered_component).to summarise(key: 'Status', value: "Offer received What to do if you’re unable to start training in #{application_choice.course_option.course.start_date.to_s(:month_and_year)} Some providers allow you to defer your offer. This means that you could start your course a year later. Every provider is different, so it may or may not be possible to do this. Find out by contacting #{application_choice.course_option.course.provider.name}. Asking if it’s possible to defer will not affect your existing offer. If your provider agrees to defer your offer, you’ll need to accept the offer on your account first.")
+      expect(rendered_component).to summarise(key: 'Conditions', value: 'DBS check Get a haircut Contact the provider to find out more about these conditions. You should also have received full terms and conditions from the provider.')
     end
 
     it 'renders component with the respond to offer link and message about waiting for providers to respond' do

--- a/spec/components/candidate_interface/contact_details_review_component_spec.rb
+++ b/spec/components/candidate_interface/contact_details_review_component_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe CandidateInterface::ContactDetailsReviewComponent do
+RSpec.describe CandidateInterface::ContactDetailsReviewComponent, type: :component do
   let(:application_form) do
     build_stubbed(
       :application_form,
@@ -15,12 +15,16 @@ RSpec.describe CandidateInterface::ContactDetailsReviewComponent do
 
   context 'when contact details are editable' do
     it 'renders component with correct values for a phone number' do
-      result = render_inline(described_class.new(application_form: application_form))
+      render_inline(described_class.new(application_form: application_form))
 
-      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.contact_details.phone_number.label'))
-      expect(result.css('.govuk-summary-list__value').text).to include('07700 900 982')
-      expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_edit_phone_number_path)
-      expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.contact_details.phone_number.change_action')}")
+      expect(rendered_component).to summarise(
+        key: 'Phone number',
+        value: '07700 900 982',
+        action: {
+          text: 'Change phone number',
+          href: Rails.application.routes.url_helpers.candidate_interface_edit_phone_number_path,
+        },
+      )
     end
 
     context 'when contact details are completed' do

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -8,15 +8,31 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true
 
     it 'renders component with correct values for a course' do
       application_choice = application_form.application_choices.first
-      result = render_inline(described_class.new(application_form: application_form))
+      render_inline(described_class.new(application_form: application_form))
 
-      expect(result.css('.app-summary-card__title').text).to include(application_choice.provider.name)
-      expect(result.css('.govuk-summary-list__key').text).to include('Course')
-      expect(result.css('.govuk-summary-list__value').to_html).to include("#{application_choice.course.name} (#{application_choice.course.code})")
-      expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.course.description)
-      expect(result.css('.govuk-summary-list__value').to_html).to include('1 year')
-      expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.course.start_date.to_fs(:month_and_year))
-      expect(result.css('a').to_html).to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course.code}")
+      expect(rendered_component).to summarise(
+        key: 'Course',
+        value: "#{application_choice.course.name} (#{application_choice.course.code})",
+      )
+
+      expect(rendered_component).to summarise(
+        key: 'Course length',
+        value: '1 year',
+      )
+
+      expect(rendered_component).to summarise(
+        key: 'Type',
+        value: application_choice.course.description,
+      )
+
+      expect(rendered_component).to summarise(
+        key: 'Date course starts',
+        value: application_choice.course.start_date.to_s(:month_and_year),
+      )
+
+      expect(rendered_component).to have_css('.app-summary-card__title', text: application_choice.provider.name)
+
+      expect(rendered_component).to have_link("#{application_choice.course.name} (#{application_choice.course.code})", href: "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course.code}")
     end
 
     it 'does not show the application number' do
@@ -101,10 +117,12 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true
 
     it 'renders component with correct values for a location' do
       application_choice = application_form.application_choices.first
-      result = render_inline(described_class.new(application_form: application_form))
+      render_inline(described_class.new(application_form: application_form))
 
-      expect(result.css('.govuk-summary-list__key').text).to include('Location')
-      expect(result.css('.govuk-summary-list__value').text).to include("#{application_choice.site.name}\n#{application_choice.site.full_address}")
+      expect(rendered_component).to summarise(
+        key: 'Location',
+        value: "#{application_choice.site.name} #{application_choice.site.full_address}",
+      )
     end
 
     it 'renders component along with a delete link for each course' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -44,6 +44,9 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
+  config.include ViewComponent::TestHelpers, type: :component
+  config.include Capybara::RSpecMatchers, type: :component
+
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.

--- a/spec/support/summarise_matcher.rb
+++ b/spec/support/summarise_matcher.rb
@@ -1,0 +1,47 @@
+RSpec::Matchers.define :summarise do |expected|
+  match do |_actual|
+    if expected[:action]
+      key_html && value_html && value_text == expected[:value] && action_link && action_link[:href] == expected[:action][:href]
+    else
+      key_html && value_html && value_text == expected[:value]
+    end
+  end
+
+  failure_message do |actual|
+    if !key_html
+      "Could not find the key ‘#{expected[:key]}’ within\n\n #{actual}"
+    elsif !value_html
+      "Could not find a <dd class=\"govuk-summary-list__value\"> element within HTML: \n#{row_html.native.to_html}"
+    elsif value_text != expected[:text]
+      "Expected ‘#{expected[:key]}’ value to be ‘#{expected[:value]}’ but was ‘#{value_text}’"
+    elsif !action_link
+      "Could not find the link ‘#{expected[:action][:text]}’ within HTML: \n#{row_html.native.to_html}"
+    else
+      "Expected link href to be #{expected[:action][:href]}, was #{action_link[:href]}"
+    end
+  end
+
+  def html
+    @html ||= Capybara::Node::Simple.new(actual)
+  end
+
+  def key_html
+    @key_html ||= html.all('dt.govuk-summary-list__key', exact_text: expected[:key]).first
+  end
+
+  def row_html
+    @row_html ||= key_html.ancestor('.govuk-summary-list__row')
+  end
+
+  def value_html
+    @value_html ||= row_html.all('dd.govuk-summary-list__value').first
+  end
+
+  def value_text
+    @value_text ||= value_html.text(normalize_ws: true)
+  end
+
+  def action_link
+    @action_link ||= row_html.all(:link, exact_text: expected[:action][:text]).first
+  end
+end


### PR DESCRIPTION
Following #6713, this introduces a custom matcher for Summary Lists which does not depend upon the order of the rows.

Also aims to have better error messages to make debugging faster.

Feedback welcome, this is just a quick initial proof-of-concept...

