### PR TITLE
can't remove hint text

### DIFF
--- a/app/views/candidate_interface/restructured_work_history/review/show.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/review/show.html.erb
@@ -26,7 +26,6 @@
 
     <%= render(CandidateInterface::CompleteSectionComponent.new(
       form: f,
-      hint_text: t('application_form.work_history.complete.hint_text'),
     )) %>
 
     <%= f.govuk_submit t('continue') %>

--- a/app/views/candidate_interface/work_history/review/show.html.erb
+++ b/app/views/candidate_interface/work_history/review/show.html.erb
@@ -17,7 +17,7 @@
   </div>
 
   <%= render CandidateInterface::WorkHistoryReviewComponent.new(application_form: @application_form) %>
-  <%= render CandidateInterface::CompleteSectionComponent.new(form: f, hint_text: t('application_form.work_history.complete.hint_text')) %>
+  <%= render CandidateInterface::CompleteSectionComponent.new(form: f) %>
 
   <%= f.govuk_submit t('continue') %>
 <% end %>

--- a/config/locales/candidate_interface/work_history.yml
+++ b/config/locales/candidate_interface/work_history.yml
@@ -3,7 +3,7 @@ en:
     work_history:
       complete:
         label: Yes, I have a complete work history
-        hint_text: You’ll be able to give details once you’ve entered your employment history. Please explain any break longer than a month.
+        hint_text: I'm trying to remove this hint text!
       full_time_education:
         label: No, I have always been in full time education
       missing:

--- a/config/locales/candidate_interface/work_history.yml
+++ b/config/locales/candidate_interface/work_history.yml
@@ -3,7 +3,6 @@ en:
     work_history:
       complete:
         label: Yes, I have a complete work history
-        hint_text: I'm trying to remove this hint text!
       full_time_education:
         label: No, I have always been in full time education
       missing:

--- a/config/locales/candidate_interface/work_history.yml
+++ b/config/locales/candidate_interface/work_history.yml
@@ -3,6 +3,7 @@ en:
     work_history:
       complete:
         label: Yes, I have a complete work history
+        hint_text: You’ll be able to give details once you’ve entered your employment history. Please explain any break longer than a month.
       full_time_education:
         label: No, I have always been in full time education
       missing:


### PR DESCRIPTION
I tried to delete the hint text here (because the current hint text doesn't make sense) but doing so broke Apply locally. 

Does that mean it's not as simple as deleting the line?

Can a dev help? 


<img width="863" alt="Screenshot 2022-03-23 at 15 03 04" src="https://user-images.githubusercontent.com/56349171/159730298-4bbece5c-da83-4dbc-93ef-36f30ad55711.png">

