### PR TITLE
edit referee mailers

### DIFF
--- a/app/views/referee_mailer/reference_cancelled_email.text.erb
+++ b/app/views/referee_mailer/reference_cancelled_email.text.erb
@@ -1,3 +1,7 @@
 Dear <%= @name %>
 
-<%= @candidate_name %> said they do not need you to give a reference anymore.
+<%= @candidate_name %> had asked for a reference from you for their teacher training application.
+
+It looks like they do not need a reference anymore.
+
+You do not need to do anything.

--- a/app/views/referee_mailer/reference_cancelled_email.text.erb
+++ b/app/views/referee_mailer/reference_cancelled_email.text.erb
@@ -4,8 +4,6 @@ Dear <%= @name %>
 
 It looks like they do not need a reference anymore.
 
-This might be because they got a reference from someone else, for example, or decided not to apply.
-
 You do not need to do anything.
 
 If you’re in touch with the candidate they may be able to explain why they no longer need a reference.

--- a/app/views/referee_mailer/reference_cancelled_email.text.erb
+++ b/app/views/referee_mailer/reference_cancelled_email.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @name %>
 
-<%= @candidate_name %> had asked for a reference for their teacher training application.
+<%= @candidate_name %> had previously asked for a reference from you for their teacher training application.
 
 It looks like they do not need a reference anymore.
 

--- a/app/views/referee_mailer/reference_cancelled_email.text.erb
+++ b/app/views/referee_mailer/reference_cancelled_email.text.erb
@@ -4,6 +4,8 @@ Dear <%= @name %>
 
 It looks like they do not need a reference anymore.
 
-This might be because they got a reference from someone else or decided not to apply.
+This might be because they got a reference from someone else, for example, or decided not to apply.
 
-You do not need to do anything, but you can contact the candidate if you want to find out more.
+You do not need to do anything.
+
+If you’re in touch with the candidate they may be able to explain why they no longer need a reference.

--- a/app/views/referee_mailer/reference_cancelled_email.text.erb
+++ b/app/views/referee_mailer/reference_cancelled_email.text.erb
@@ -1,7 +1,9 @@
 Dear <%= @name %>
 
-<%= @candidate_name %> had asked for a reference from you for their teacher training application.
+<%= @candidate_name %> had asked for a reference for their teacher training application.
 
 It looks like they do not need a reference anymore.
 
-You do not need to do anything.
+This might be because they got a reference from someone else or decided not to apply.
+
+You do not need to do anything, but you can contact the candidate if you want to find out more.

--- a/app/views/referee_mailer/reference_confirmation_email.text.erb
+++ b/app/views/referee_mailer/reference_confirmation_email.text.erb
@@ -2,4 +2,6 @@ Dear <%= @name %>
 
 Thank you for your reference for <%= @candidate_name %>.
 
-Find out how the Department for Education looks after your data:
+Find out how the Department for Education processes your reference:
+
+<%= candidate_interface_privacy_policy_url %>

--- a/app/views/referee_mailer/reference_confirmation_email.text.erb
+++ b/app/views/referee_mailer/reference_confirmation_email.text.erb
@@ -1,3 +1,5 @@
 Dear <%= @name %>
 
 Thank you for your reference for <%= @candidate_name %>.
+
+Find out how the Department for Education looks after your data:

--- a/app/views/referee_mailer/reference_confirmation_email.text.erb
+++ b/app/views/referee_mailer/reference_confirmation_email.text.erb
@@ -1,9 +1,3 @@
 Dear <%= @name %>
 
 Thank you for your reference for <%= @candidate_name %>.
-
-# Your data
-
-Find out how we use and look after your data:
-
-<%= candidate_interface_privacy_policy_url %>

--- a/config/locales/referee_interface/referee_interface.yml
+++ b/config/locales/referee_interface/referee_interface.yml
@@ -50,7 +50,7 @@ en:
   reference_confirmation_email:
     subject: Reference submitted for %{candidate_name}
   reference_cancelled_email:
-    subject: %{candidate_name} no longer needs a reference
+    subject: "%{candidate_name} no longer needs a reference"
 
   activemodel:
     errors:

--- a/config/locales/referee_interface/referee_interface.yml
+++ b/config/locales/referee_interface/referee_interface.yml
@@ -50,7 +50,7 @@ en:
   reference_confirmation_email:
     subject: Reference submitted for %{candidate_name}
   reference_cancelled_email:
-    subject: Reference request cancelled by %{candidate_name}
+    subject: %{candidate_name} no longer needs a reference
 
   activemodel:
     errors:

--- a/config/locales/referee_interface/referee_interface.yml
+++ b/config/locales/referee_interface/referee_interface.yml
@@ -50,7 +50,7 @@ en:
   reference_confirmation_email:
     subject: Reference submitted for %{candidate_name}
   reference_cancelled_email:
-    subject: no longer needs a reference
+    subject: %{candidate_name} no longer needs a reference
 
   activemodel:
     errors:

--- a/config/locales/referee_interface/referee_interface.yml
+++ b/config/locales/referee_interface/referee_interface.yml
@@ -50,7 +50,7 @@ en:
   reference_confirmation_email:
     subject: Reference submitted for %{candidate_name}
   reference_cancelled_email:
-    subject: %{candidate_name} no longer needs a reference
+    subject: no longer needs a reference
 
   activemodel:
     errors:

--- a/spec/system/candidate_interface/references/candidate_reviews_references_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_reviews_references_spec.rb
@@ -152,7 +152,7 @@ RSpec.feature 'Review references' do
     open_email(@requested_reference.email_address)
 
     expect(current_email.subject).to include 'Reference request cancelled by'
-    expect(current_email.text).to include 'said they do not need you to give a reference anymore.'
+    expect(current_email.text).to include 'It looks like they do not need a reference anymore.'
   end
 
   def and_i_can_return_to_the_application_page

--- a/spec/system/candidate_interface/references/candidate_reviews_references_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_reviews_references_spec.rb
@@ -151,7 +151,7 @@ RSpec.feature 'Review references' do
   def and_referee_receives_email_about_reference_cancellation
     open_email(@requested_reference.email_address)
 
-    expect(current_email.subject).to include 'Reference request cancelled by'
+    expect(current_email.subject).to include 'no longer needs a reference'
     expect(current_email.text).to include 'It looks like they do not need a reference anymore.'
   end
 


### PR DESCRIPTION
# Change # 1

This email sounds a bit abrupt and is insensitive to the relationship between candidates and their referee.

Edit it so it sounds less harsh.  

## Before:

![Screenshot 2022-03-23 at 18 53 30](https://user-images.githubusercontent.com/56349171/159774677-b6a1fbb4-ef80-4786-8c54-78aa646cc177.png)

## After:

![Screenshot 2022-03-23 at 19 34 21](https://user-images.githubusercontent.com/56349171/159781367-49d8db04-4186-4f56-a808-85209b7749d0.png)

# Change # 2

Remove big heading which is just auxiliary to the main message of the email but draws your attention disproportionately. 

## Before:

![Screenshot 2022-03-23 at 19 28 53](https://user-images.githubusercontent.com/56349171/159780556-505a87cb-734e-4c99-a9b9-621bad65c3d4.png)

## After:

![Screenshot 2022-03-23 at 19 40 18](https://user-images.githubusercontent.com/56349171/159782312-69a10bad-0d7b-46a7-9773-826eed1c481b.png)

