### PR TITLE
Rename unit4 to thesis cloud

### DIFF
--- a/app/workers/vendor_integration_stats_worker.rb
+++ b/app/workers/vendor_integration_stats_worker.rb
@@ -8,7 +8,7 @@ class VendorIntegrationStatsWorker
   SLACK_CHANNELS = {
     'tribal' => 'tribal_dfe_collaboration_',
     'ellucian' => 'ellucian_dfe_collaboration',
-    'unit4' => 'unit4_dfe_collaboration',
+    'unit4' => 'thesiscloud_dfe_collaboration',
     'oracle' => 'oracle_dfe_collaboration',
   }.freeze
 


### PR DESCRIPTION
## Context

Unit4 is now ThesisCloud. We send slack notifications about errors etc and those are tied to slack channel names

## Changes proposed in this pull request

Rename unit4 channel to the correct updated name

## Guidance to review

We currently map vendors to providers. To change unit4 past that we'll need to add a data migration, so for now keeping as is until we refresh the names next cycle

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
