### PR TITLE
Fix `VendorAPIRequestWorker` deprecation warning

### DIFF
--- a/app/middlewares/vendor_api_request_middleware.rb
+++ b/app/middlewares/vendor_api_request_middleware.rb
@@ -28,7 +28,7 @@ class VendorAPIRequestMiddleware
 
     begin
       if trace_request?
-        VendorAPIRequestWorker.perform_async(request_data, response_data, status, Time.zone.now)
+        VendorAPIRequestWorker.perform_async(request_data, response_data, status, Time.zone.now.to_s)
       end
     rescue Redis::BaseError => e
       Rails.logger.warn e.message

--- a/app/middlewares/vendor_api_request_middleware.rb
+++ b/app/middlewares/vendor_api_request_middleware.rb
@@ -46,7 +46,7 @@ private
     {
       headers: @headers,
       body: body,
-    }
+    }.deep_stringify_keys
   end
 
   def request_data
@@ -56,7 +56,7 @@ private
       body: @request.body.read.dup.force_encoding('utf-8'),
       headers: request_headers,
       method: @request.request_method,
-    }
+    }.deep_stringify_keys
   end
 
   def request_headers

--- a/spec/middlewares/vendor_api_request_middleware_spec.rb
+++ b/spec/middlewares/vendor_api_request_middleware_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe VendorAPIRequestMiddleware, type: :request do
       get '/api/v1/applications/1', params: { foo: 'bar' }
 
       expect(VendorAPIRequestWorker).to have_received(:perform_async).with(
-        hash_including(path: '/api/v1/applications/1', params: { 'foo' => 'bar' }, method: 'GET'), anything, 401, anything
+        hash_including('path' => '/api/v1/applications/1', 'params' => { 'foo' => 'bar' }, 'method' => 'GET'), anything, 401, anything
       )
     end
   end
@@ -45,7 +45,7 @@ RSpec.describe VendorAPIRequestMiddleware, type: :request do
       post '/api/v1/applications/1/offer', as: :json, params: { foo: 'bar' }
 
       expect(VendorAPIRequestWorker).to have_received(:perform_async).with(
-        hash_including(path: '/api/v1/applications/1/offer', body: '{"foo":"bar"}', method: 'POST'), anything, 401, anything
+        hash_including('path' => '/api/v1/applications/1/offer', 'body' => '{"foo":"bar"}', 'method' => 'POST'), anything, 401, anything
       )
     end
   end

--- a/spec/workers/vendor_api_request_worker_spec.rb
+++ b/spec/workers/vendor_api_request_worker_spec.rb
@@ -42,6 +42,11 @@ RSpec.describe VendorAPIRequestWorker do
     expect(VendorAPIRequest.find_by(request_path: '/api/v1/bar').request_method).to eq('GET')
   end
 
+  it 'saves the created at timestamp on the vendor api request' do
+    described_class.new.perform({ 'headers' => {}, 'path' => '/api/v1/bar', 'method' => 'GET' }, {}.to_json, 500, stringified_time)
+    expect(VendorAPIRequest.find_by(request_path: '/api/v1/bar').created_at.to_s).to eq(stringified_time)
+  end
+
   it 'saves params from GET requests' do
     described_class.new.perform({
       'params' => { 'foo' => 'meh' },

--- a/spec/workers/vendor_api_request_worker_spec.rb
+++ b/spec/workers/vendor_api_request_worker_spec.rb
@@ -1,10 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe VendorAPIRequestWorker do
+  let(:stringified_time) { Time.zone.now.to_s }
+
   describe '#perform' do
     it 'creates a VendorAPIRequest record' do
       expect {
-        described_class.new.perform({}, {}.to_json, 401, Time.zone.now)
+        described_class.new.perform({}, {}.to_json, 401, stringified_time)
       }.to change(VendorAPIRequest, :count).by(1)
     end
 
@@ -14,7 +16,7 @@ RSpec.describe VendorAPIRequestWorker do
       create(:vendor_api_token, hashed_token: hashed_token, provider_id: provider.id)
 
       headers = { 'HTTP_AUTHORIZATION' => "Bearer #{unhashed_token}" }
-      described_class.new.perform({ 'headers' => headers }, {}.to_json, 500, Time.zone.now)
+      described_class.new.perform({ 'headers' => headers }, {}.to_json, 500, stringified_time)
 
       expect(VendorAPIRequest.find_by(provider_id: provider.id)).not_to be_nil
     end
@@ -25,7 +27,7 @@ RSpec.describe VendorAPIRequestWorker do
       { 'path' => '/api/v1/foo' },
       { 'headers' => { 'this' => 'that' }, 'body' => { 'that' => 'this' }.to_json },
       500,
-      Time.zone.now,
+      stringified_time,
     )
 
     vendor_api_request = VendorAPIRequest.find_by(request_path: '/api/v1/foo')
@@ -35,7 +37,7 @@ RSpec.describe VendorAPIRequestWorker do
   end
 
   it 'saves the request method on the vendor api request' do
-    described_class.new.perform({ 'headers' => {}, 'path' => '/api/v1/bar', 'method' => 'GET' }, {}.to_json, 500, Time.zone.now)
+    described_class.new.perform({ 'headers' => {}, 'path' => '/api/v1/bar', 'method' => 'GET' }, {}.to_json, 500, stringified_time)
 
     expect(VendorAPIRequest.find_by(request_path: '/api/v1/bar').request_method).to eq('GET')
   end
@@ -45,7 +47,7 @@ RSpec.describe VendorAPIRequestWorker do
       'params' => { 'foo' => 'meh' },
       'path' => '/api/v1/bar',
       'method' => 'GET',
-    }, {}.to_json, 500, Time.zone.now)
+    }, {}.to_json, 500, stringified_time)
 
     expect(VendorAPIRequest.find_by(request_path: '/api/v1/bar').request_body).to eq('foo' => 'meh')
   end
@@ -55,7 +57,7 @@ RSpec.describe VendorAPIRequestWorker do
       'body' => { 'foo' => 'meh' }.to_json,
       'path' => '/api/v1/bar',
       'method' => 'POST',
-    }, {}.to_json, 500, Time.zone.now)
+    }, {}.to_json, 500, stringified_time)
 
     expect(VendorAPIRequest.find_by(request_path: '/api/v1/bar').request_body).to eq('foo' => 'meh')
   end
@@ -65,7 +67,7 @@ RSpec.describe VendorAPIRequestWorker do
       'body' => 'This is not JSON',
       'path' => '/api/v1/bar',
       'method' => 'POST',
-    }, {}.to_json, 500, Time.zone.now)
+    }, {}.to_json, 500, stringified_time)
 
     expect(VendorAPIRequest.find_by(request_path: '/api/v1/bar').request_body).to eq('error' => 'request data did not contain valid JSON')
   end
@@ -75,7 +77,7 @@ RSpec.describe VendorAPIRequestWorker do
       'body' => '',
       'path' => '/api/v1/bar',
       'method' => 'POST',
-    }, {}.to_json, 500, Time.zone.now)
+    }, {}.to_json, 500, stringified_time)
 
     expect(VendorAPIRequest.find_by(request_path: '/api/v1/bar').request_body).to be_nil
   end


### PR DESCRIPTION
## Context
We are receiving deprecation warnings when passing arguments to perform_async that are not composed of simple JSON datatypes. This will become an error when moving to Sidekiq 7.0:
```
WARN: Job arguments to VendorAPIRequestWorker do not serialize to JSON safely. This will raise an error in
Sidekiq 7.0. See https://github.com/mperham/sidekiq/wiki/Best-Practices or raise an error today
by calling `Sidekiq.strict_args!` during Sidekiq initialization.
```

## Changes proposed in this pull request
- Change timestamp to a string when being passed into `VendorAPIRequestWorker`
- Ensure all hash keys are stringified before passing them to `perform_async`

## Guidance to review

[<!-- How could someone else check this work? Which parts do you want more feedback on? -->
](https://github.com/mperham/sidekiq/wiki/Best-Practices#1-make-your-job-parameters-small-and-simple)

## Link to Trello card

[<!-- http://trello.com/123-example-card -->
](https://trello.com/c/VDFAN4u0/2274-change-vendorapirequestworker-to-use-native-json-types)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
