### PR TITLE
Fix time zone dependant test when clocks go forward

### DIFF
--- a/spec/forms/provider_interface/interview_wizard_spec.rb
+++ b/spec/forms/provider_interface/interview_wizard_spec.rb
@@ -206,13 +206,15 @@ RSpec.describe ProviderInterface::InterviewWizard do
 
     context 'when the time format is valid' do
       it 'converts the :date and :time to valid datetime' do
-        valid_times.each do |time|
-          wizard.time = time[:input]
-          expect(wizard.date_and_time.hour).to equal(time[:expected_hour])
-          expect(wizard.date_and_time.min).to equal(time[:expected_minute])
-          expect(wizard.date_and_time.day).to equal(20)
-          expect(wizard.date_and_time.month).to equal(2)
-          expect(wizard.date_and_time.year).to equal(2022)
+        Timecop.freeze(Date.new(2022, 2, 13)) do
+          valid_times.each do |time|
+            wizard.time = time[:input]
+            expect(wizard.date_and_time.hour).to equal(time[:expected_hour])
+            expect(wizard.date_and_time.min).to equal(time[:expected_minute])
+            expect(wizard.date_and_time.day).to equal(20)
+            expect(wizard.date_and_time.month).to equal(2)
+            expect(wizard.date_and_time.year).to equal(2022)
+          end
         end
       end
     end

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe ViewHelper, type: :helper do
     end
 
     it 'returns the bare time for a time today' do
-      Timecop.freeze(Time.zone.now.midnight) do
+      Timecop.freeze(Date.parse('22-02-2022').midnight) do
         time = 6.hours.from_now
         expect(helper.time_today_or_tomorrow(time)).to eq '6am'
       end


### PR DESCRIPTION
## Context

The clocks went forward today causing test failures

## Changes proposed in this pull request

Freeze time in tests to avoid failures due to clocks going forward

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
