### PR TITLE
Update Vendor API docs to include two new residency statuses

### DIFF
--- a/app/views/api_docs/vendor_api_docs/pages/release_notes.md
+++ b/app/views/api_docs/vendor_api_docs/pages/release_notes.md
@@ -1,3 +1,9 @@
+## 28th March 2022
+
+Documentation:
+
+Add two new possible values a candidate can submit as a residency status: "EU settled status" and "EU pre-settled status" to the field `uk_residency_status`.
+
 ## 21st February 2022
 
 Business rule change: Candidates can now apply to up to three courses when applying again in "Apply 2", similar to "Apply 1". Previously, candidates could only apply to 1 course in "Apply 2".

--- a/config/vendor_api/v1.0.yml
+++ b/config/vendor_api/v1.0.yml
@@ -593,7 +593,7 @@ components:
         uk_residency_status:
           type: string
           maxLength: 256
-          description: The candidate’s UK residency status indicating their right to work and study in the UK. Possible values include "UK Citizen", "Irish Citizen" and "Candidate needs to apply for permission to work and study in the UK". The candidate can also provide details as free text for example "Settled status".
+          description: The candidate’s UK residency status indicating their right to work and study in the UK. Possible values include "UK Citizen", "Irish Citizen", "Candidate needs to apply for permission to work and study in the UK", "EU settled status" and "EU pre-settled status". The candidate can also provide details as free text for example "Settled status".
           example: UK Citizen
         uk_residency_status_code:
           type: string


### PR DESCRIPTION
## Context

 A recent change on the candidate side allows two new values for UK residency to be submitted:
https://github.com/DFE-Digital/apply-for-teacher-training/pull/6657/commits/a983dd10c90657cdb9dfb88ec753fa7449bbc0cd and https://github.com/DFE-Digital/apply-for-teacher-training/pull/6657/commits/e8857cabbd7372617b2879dd81778bb3028a4fc2

## Changes proposed in this pull request

Update API docs to reflect this new addition to the `uk_residency_status` field

## Guidance to review

This isn't a breaking change as we also expect free text in this field

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
