### PR TITLE
Reorder references on review screen

### DIFF
--- a/app/controllers/candidate_interface/references/review_controller.rb
+++ b/app/controllers/candidate_interface/references/review_controller.rb
@@ -102,7 +102,9 @@ module CandidateInterface
         @references_selected = current_application.application_references.includes(:application_form).selected
         @references_given = current_application.application_references.includes(:application_form).feedback_provided
         @references_waiting_to_be_sent = current_application.application_references.includes(:application_form).not_requested_yet
-        @references_sent = current_application.application_references.includes(:application_form).pending_feedback_or_failed
+        @references_waiting_feedback = current_application.application_references.includes(:application_form).feedback_requested
+        @references_bounced = current_application.application_references.includes(:application_form).email_bounced
+        @references_failed = current_application.application_references.includes(:application_form).failed
       end
     end
   end

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -37,8 +37,8 @@ class ApplicationReference < ApplicationRecord
     never_asked: 'never_asked',
   }
 
-  def self.pending_feedback_or_failed
-    where.not(feedback_status: %i[not_requested_yet feedback_provided])
+  def self.failed
+    where(feedback_status: %i[feedback_refused cancelled cancelled_at_end_of_cycle])
   end
 
   def self_and_siblings

--- a/app/views/candidate_interface/references/review/show.html.erb
+++ b/app/views/candidate_interface/references/review/show.html.erb
@@ -11,24 +11,38 @@
   </div>
 </div>
 
-<% if @references_given.present? %>
-  <div id="references_given">
-    <h2 class="govuk-heading-m">References you have received</h2>
-    <%= render(CandidateInterface::ReferencesReviewComponent.new(references: @references_given, show_history: true, heading_level: 3)) %>
-  </div>
-<% end %>
-
 <% if @references_waiting_to_be_sent.present? %>
   <div id="references_waiting_to_be_sent">
-    <h2 class="govuk-heading-m">Requests you have not sent yet</h2>
+    <h2 class="govuk-heading-m">Unsent requests</h2>
     <%= render(CandidateInterface::ReferencesReviewComponent.new(references: @references_waiting_to_be_sent, show_history: true, heading_level: 3)) %>
   </div>
 <% end %>
 
-<% if @references_sent.present? %>
+<% if @references_waiting_feedback.present? %>
   <div id="references_sent">
-    <h2 class="govuk-heading-m">Reference requests</h2>
-    <%= render(CandidateInterface::ReferencesReviewComponent.new(references: @references_sent, editable: false, show_history: true, heading_level: 3)) %>
+    <h2 class="govuk-heading-m">References you have not received yet</h2>
+    <%= render(CandidateInterface::ReferencesReviewComponent.new(references: @references_waiting_feedback, editable: false, show_history: true, heading_level: 3)) %>
+  </div>
+<% end %>
+
+<% if @references_given.present? %>
+  <div id="references_given">
+    <h2 class="govuk-heading-m">Received references</h2>
+    <%= render(CandidateInterface::ReferencesReviewComponent.new(references: @references_given, show_history: true, heading_level: 3)) %>
+  </div>
+<% end %>
+
+<% if @references_bounced.present? %>
+  <div id="references_failed">
+    <h2 class="govuk-heading-m">Email bounced</h2>
+    <%= render(CandidateInterface::ReferencesReviewComponent.new(references: @references_bounced, editable: false, show_history: true, heading_level: 3)) %>
+  </div>
+<% end %>
+
+<% if @references_failed.present? %>
+  <div id="references_failed">
+    <h2 class="govuk-heading-m">Declined or cancelled requests</h2>
+    <%= render(CandidateInterface::ReferencesReviewComponent.new(references: @references_failed, editable: false, show_history: true, heading_level: 3)) %>
   </div>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -168,7 +168,7 @@ en:
     add_volunteering_role: Add role
     edit_volunteering_role: Edit role
     destroy_volunteering_role: Are you sure you want to delete this role?
-    references: References
+    references: Reference requests
     references_start: Requesting a reference
     references_name: What is the referee’s name?
     references_email_address: What is the referee’s email address?


### PR DESCRIPTION
Re-order references to move references not yet received higher up the page.

This is to try and avoid users from re-entering the same referee email again rather than using the "Send reminder" feature.

See #6719.