### PR TITLE
Course Change - Add the new email

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -298,7 +298,7 @@ class CandidateMailer < ApplicationMailer
 
     email_for_candidate(
       @application_choice.application_form,
-      subject: I18n.t!('candidate_mailer.changed_offer.subject', provider_name: @course_option.course.provider.name),
+      subject: I18n.t!('candidate_mailer.changed_offer.subject', course_details: @course_option.course.name_and_code),
     )
   end
 

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -1,5 +1,6 @@
 class CandidateMailer < ApplicationMailer
   layout 'candidate_email_with_support_footer'
+  include QualificationValueHelper
 
   def application_submitted(application_form)
     @candidate_magic_link = candidate_magic_link(application_form.candidate)
@@ -293,10 +294,26 @@ class CandidateMailer < ApplicationMailer
     @offers = @application_choice.self_and_siblings.select(&:offer?).map do |choice|
       "#{choice.current_course_option.course.name_and_code} at #{choice.current_course_option.course.provider.name}"
     end
+    @qualification = qualification_text(@current_course_option)
 
     email_for_candidate(
       @application_choice.application_form,
       subject: I18n.t!('candidate_mailer.changed_offer.subject', provider_name: @course_option.course.provider.name),
+    )
+  end
+
+  def change_course(application_choice)
+    @application_choice = application_choice
+    @course_option = @application_choice.course_option
+    @current_course_option = @application_choice.current_course_option
+    @qualification = qualification_text(@current_course_option)
+
+    email_for_candidate(
+      @application_choice.application_form,
+      subject: I18n.t!(
+        'candidate_mailer.course_change.subject',
+        course_details: @course_option.course.name_and_code,
+      ),
     )
   end
 

--- a/app/services/change_course.rb
+++ b/app/services/change_course.rb
@@ -22,6 +22,8 @@ class ChangeCourse
             other_fields: { course_option: course_option },
           )
         end
+
+        CandidateMailer.change_course(application_choice).deliver_later
       end
     else
       raise ValidationException, course.errors.map(&:message)

--- a/app/views/candidate_mailer/change_course.text.erb
+++ b/app/views/candidate_mailer/change_course.text.erb
@@ -1,0 +1,13 @@
+Dear <%= @application_form.first_name %>
+
+The details of your application to study <%= @course_option.course.name_and_code %> have been changed.
+
+The new details are:
+
+^ Training provider: <%= @current_course_option.course.provider.name %>
+^ Course: <%= @current_course_option.course.name %>
+^ Full time or part time: <%= @current_course_option.course.study_mode.humanize %>
+^ Location: <%= @current_course_option.site.name %>
+^ Qualification: <%= @qualification %>
+
+If you were not expecting this change, contact <%= @current_course_option.course.provider.name %> to find out more.

--- a/app/views/candidate_mailer/changed_offer.text.erb
+++ b/app/views/candidate_mailer/changed_offer.text.erb
@@ -1,13 +1,14 @@
 Dear <%= @application_form.first_name %>
 
-Your offer from <%= @course_option.course.provider.name %> to study <%= @course_option.course.name %> has been changed.
+The offer from <%= @course_option.course.provider.name %> to study <%= @course_option.course.name_and_code %> has been changed.
 
-Your new offer is:
+The new offer is:
 
 ^ Training provider: <%= @current_course_option.course.provider.name %>
 ^ Course: <%= @current_course_option.course.name %>
-^ Location: <%= @current_course_option.site.name %>
 ^ Full time or part time: <%= @current_course_option.course.study_mode.humanize %>
+^ Location: <%= @current_course_option.site.name %>
+^ Qualification: <%= @qualification %>
 
 <% if @conditions.blank? %>
 ^ Your offer does not have any conditions.
@@ -25,7 +26,7 @@ If you were not expecting this change, contact <%= @course_option.course.provide
 
 <% else %>
 
-# Respond by <%= @application_choice.decline_by_default_at.to_fs(:govuk_date) %>
+# Make a decision by <%= @application_choice.decline_by_default_at.to_fs(:govuk_date) %>
 
 If you do not respond by <%= @application_choice.decline_by_default_at.to_fs(:govuk_date) %>, your <%= 'offer'.pluralize(@offers.length) %> will be declined automatically.
 
@@ -36,5 +37,7 @@ If you do not respond by <%= @application_choice.decline_by_default_at.to_fs(:go
 Sign in to your account to respond:
 
 <%= candidate_magic_link(@application_choice.application_form.candidate) %>
+
+Contact <%= @current_course_option.course.provider.name %> directly if you have any questions about this
 
 <% end %>

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -78,7 +78,9 @@ en:
     conditions_not_met:
       subject: "You have not met your conditions for %{course_name}: next steps"
     changed_offer:
-      subject: "Offer changed by %{provider_name}"
+      subject: "Offer changed for %{course_name_and_code}"
+    course_change:
+      subject: "Course details changed for %{course_details}"
     deferred_offer:
       subject: "Your offer has been deferred"
     deferred_offer_reminder:

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -78,7 +78,7 @@ en:
     conditions_not_met:
       subject: "You have not met your conditions for %{course_name}: next steps"
     changed_offer:
-      subject: "Offer changed for %{course_name_and_code}"
+      subject: "Offer changed for %{course_details}"
     course_change:
       subject: "Course details changed for %{course_details}"
     deferred_offer:

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -398,7 +398,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       it_behaves_like(
         'a mail with subject and content',
-        'Offer changed by Brighthurst Technical College',
+        'Offer changed for Applied Science (Psychology) (3TT5)',
         'heading' => 'Dear Bob',
         'name for original course' => 'Applied Science (Psychology)',
         'name for new course' => 'Course: Forensic Science',
@@ -414,7 +414,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       it_behaves_like(
         'a mail with subject and content',
-        'Offer changed by Brighthurst Technical College',
+        'Offer changed for Applied Science (Psychology) (3TT5)',
         'heading' => 'Dear Bob',
         'name for original course' => 'Applied Science (Psychology)',
         'name for new course' => 'Course: Forensic Science',

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -410,6 +410,71 @@ RSpec.describe CandidateMailer, type: :mailer do
     end
   end
 
+  describe '.change_course' do
+    # TODO: swap out course_option with original_course_option once implemented.
+    let(:application_choice) do
+      create(
+        :application_choice,
+        course_option: course_option,
+        current_course_option: current_course_option,
+        site: site,
+        application_form: create(:application_form, first_name: 'Fred'),
+      )
+    end
+    let(:email) { mailer.change_course(application_choice) }
+    let(:course_option) do
+      create(
+        :course_option,
+        course: create(
+          :course,
+          name: 'Mathematics',
+          code: 'M101',
+        ),
+      )
+    end
+    let(:current_course_option) do
+      create(
+        :course_option,
+        course: create(
+          :course,
+          :part_time,
+          name: 'Geography',
+          code: 'H234',
+          provider: provider,
+        ),
+        site: site,
+      )
+    end
+    let(:site) do
+      create(:site,
+             name: 'First Road',
+             code: 'F34',
+             address_line1: 'Fountain Street',
+             address_line2: 'Morley',
+             address_line3: 'Leeds',
+             postcode: 'LS27 OPD',
+             provider: provider)
+    end
+
+    let(:provider) do
+      create(:provider,
+             name: 'Best Training',
+             code: 'B54')
+    end
+
+    it_behaves_like(
+      'a mail with subject and content',
+      'Course details changed for Mathematics (M101)',
+      'greeting' => 'Dear Fred',
+      'old course' => 'The details of your application to study Mathematics (M101) have been changed',
+      'new details' => 'The new details are:',
+      'provider' => 'Training provider: Best Training',
+      'course' => 'Course: Geography',
+      'location' => 'Location: First Road',
+      'study mode' => 'Full time or part time: Part time',
+    )
+  end
+
   describe '.deadline_reminder' do
     context 'when a candidate is in Apply 1' do
       let(:email) { mailer.eoc_deadline_reminder(application_form) }

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -22,6 +22,18 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.changed_offer(application_choice)
   end
 
+  def change_course
+    application_form = application_form_with_course_choices([application_choice_with_offer, application_choice_with_offer])
+    application_choice = FactoryBot.build_stubbed(:submitted_application_choice,
+                                                  :with_offer,
+                                                  course_option: course_option,
+                                                  application_form: application_form,
+                                                  current_course_option: course_option,
+                                                  decline_by_default_at: 10.business_days.from_now)
+
+    CandidateMailer.change_course(application_choice)
+  end
+
   def changed_unconditional_offer
     application_form = application_form_with_course_choices([application_choice_with_offer, application_choice_with_offer])
     application_choice = FactoryBot.build(:submitted_application_choice,

--- a/spec/services/change_course_spec.rb
+++ b/spec/services/change_course_spec.rb
@@ -81,5 +81,13 @@ RSpec.describe ChangeCourse do
         expect(audit_with_status_change.audited_changes).to have_key('current_course_option_id')
       end
     end
+
+    describe 'emails', sidekiq: true do
+      it 'sends an email' do
+        change_course.save!
+
+        expect(ActionMailer::Base.deliveries.first['rails-mail-template'].value).to eq('change_course')
+      end
+    end
   end
 end

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -43,6 +43,7 @@ RSpec.feature 'Docs' do
       candidate_mailer-find_has_opened
       candidate_mailer-unconditional_offer_accepted
       candidate_mailer-conditions_statuses_changed
+      candidate_mailer-change_course
       provider_mailer-unconditional_offer_accepted
       provider_mailer-confirm_sign_in
       provider_mailer-organisation_permissions_set_up


### PR DESCRIPTION
## Context

Currently providers can change the details of a course at the point of offer. We'd like to let providers do this before the point of offer.

Following from [#6683](https://github.com/DFE-Digital/apply-for-teacher-training/pull/6683) this is the seventh PR in the series. This is the the email that will be sent once a provider updates a candidates course. This also includes a minor change to the content of the changed offer email.

## Changes proposed in this pull request

- Introduce a new email that the `ChangeCourse` service will send
- Update the copy of the `changed_offer` email

## Guidance to review

[New email copy](https://bat-design-history.netlify.app/manage-teacher-training-applications/emailing-a-candidate-when-their-course-details-are-changed/#changing-the-course-details-before-making-an-offer)

## Link to Trello card

https://trello.com/c/ws79kLkM

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
