### PR TITLE
Fix subject route degree class TAD export

### DIFF
--- a/app/services/support_interface/applications_by_subject_route_and_degree_grade_export.rb
+++ b/app/services/support_interface/applications_by_subject_route_and_degree_grade_export.rb
@@ -30,7 +30,7 @@ module SupportInterface
         {
           subject: subject,
           route: choice.route,
-          grade_hesa_code: choice.grade_hesa_code,
+          grade_hesa_code: choice.grade_hesa_codes.min,
           applications: 0,
           offers_received: 0,
           number_of_acceptances: 0,
@@ -85,7 +85,19 @@ module SupportInterface
 
     def choices_with_courses_and_subjects
       ApplicationChoice
-        .select('application_choices.id as id, application_choices.status as status, providers.provider_type as route, application_qualifications.grade_hesa_code as grade_hesa_code, application_form.id as application_form_id, application_form.phase as phase, courses.name as course_name, courses.level as course_level, ARRAY_AGG(subjects.name ORDER BY subjects.id) as subject_names, ARRAY_AGG(subjects.code ORDER BY subjects.id) as subject_codes, (CASE WHEN a2_latest_application_forms.candidate_id IS NOT NULL THEN true ELSE false END) AS is_latest_a2_app')
+        .select(
+          'application_choices.id as id,
+          application_choices.status as status,
+          providers.provider_type as route,
+          ARRAY_AGG(application_qualifications.grade_hesa_code) as grade_hesa_codes,
+          application_form.id as application_form_id,
+          application_form.phase as phase,
+          courses.name as course_name,
+          courses.level as course_level,
+          ARRAY_AGG(subjects.name ORDER BY subjects.id) as subject_names,
+          ARRAY_AGG(subjects.code ORDER BY subjects.id) as subject_codes,
+          (CASE WHEN a2_latest_application_forms.candidate_id IS NOT NULL THEN true ELSE false END) AS is_latest_a2_app',
+        )
         .joins(application_form: :application_qualifications)
         .joins(course_option: { course: :provider })
         .joins(course_option: { course: :subjects })
@@ -93,7 +105,17 @@ module SupportInterface
         .where(application_form: { recruitment_cycle_year: RecruitmentCycle.current_year })
         .where(application_form: { application_qualifications: { level: 'degree' } })
         .where.not(application_form: { submitted_at: nil })
-        .group('application_choices.id', 'application_form.id', 'a2_latest_application_forms.candidate_id', 'courses.name', 'courses.level', 'status', 'providers.provider_type', 'subjects.name', 'subjects.code', 'application_qualifications.grade_hesa_code')
+        .group(
+          'application_choices.id',
+          'application_form.id',
+          'a2_latest_application_forms.candidate_id',
+          'courses.name',
+          'courses.level',
+          'status',
+          'providers.provider_type',
+          'subjects.name',
+          'subjects.code',
+        )
     end
   end
 end

--- a/app/services/support_interface/applications_by_subject_route_and_degree_grade_export.rb
+++ b/app/services/support_interface/applications_by_subject_route_and_degree_grade_export.rb
@@ -30,7 +30,7 @@ module SupportInterface
         {
           subject: subject,
           route: choice.route,
-          grade_hesa_code: choice.grade_hesa_codes.min,
+          grade_hesa_code: choice.grade_hesa_codes.compact.min,
           applications: 0,
           offers_received: 0,
           number_of_acceptances: 0,

--- a/spec/services/support_interface/applications_by_subject_route_and_degree_grade_export_spec.rb
+++ b/spec/services/support_interface/applications_by_subject_route_and_degree_grade_export_spec.rb
@@ -48,6 +48,24 @@ RSpec.describe SupportInterface::ApplicationsBySubjectRouteAndDegreeGradeExport 
       )
     end
 
+    context 'when the candidate has two degrees' do
+      it 'returns just a single match' do
+        drama = create(:subject, code: '13')
+        first_application_form = create(:completed_application_form)
+        create(:application_qualification, level: 'degree', grade_hesa_code: '2', application_form: first_application_form)
+        create(:application_qualification, level: 'degree', grade_hesa_code: '3', application_form: first_application_form)
+        scitt_provider = create(:provider, provider_type: 'scitt')
+        first_course = create(:course, provider: scitt_provider, subjects: [drama])
+        first_course_option = create(:course_option, course: first_course)
+
+        create(:application_choice, :with_declined_offer, course_option: first_course_option, application_form: first_application_form)
+
+        data = described_class.new.call
+
+        expect(data.size).to be(1)
+      end
+    end
+
     context 'when the candidate has an apply again application' do
       it 'only includes the latest apply again application' do
         candidate = create(:candidate)

--- a/spec/services/support_interface/applications_by_subject_route_and_degree_grade_export_spec.rb
+++ b/spec/services/support_interface/applications_by_subject_route_and_degree_grade_export_spec.rb
@@ -66,6 +66,24 @@ RSpec.describe SupportInterface::ApplicationsBySubjectRouteAndDegreeGradeExport 
       end
     end
 
+    context 'when HESA degree grade is missing' do
+      it 'returns just a single match' do
+        drama = create(:subject, code: '13')
+        first_application_form = create(:completed_application_form)
+        create(:application_qualification, level: 'degree', grade_hesa_code: '2', application_form: first_application_form)
+        create(:application_qualification, level: 'degree', grade_hesa_code: nil, application_form: first_application_form)
+        scitt_provider = create(:provider, provider_type: 'scitt')
+        first_course = create(:course, provider: scitt_provider, subjects: [drama])
+        first_course_option = create(:course_option, course: first_course)
+
+        create(:application_choice, :with_declined_offer, course_option: first_course_option, application_form: first_application_form)
+
+        data = described_class.new.call
+
+        expect(data.size).to be(1)
+      end
+    end
+
     context 'when the candidate has an apply again application' do
       it 'only includes the latest apply again application' do
         candidate = create(:candidate)


### PR DESCRIPTION
## Context

This export was reported to be returning more records than it should. 

## Changes proposed in this pull request

The export was returning multiple records for candidates that have more than one degree. I've changed the query to return only the degree with the highest (HESA) grade.

## Guidance to review

- Does this make sense is?
- Is there anything else about this query that could return multiple records for the same application?

## Link to Trello card

https://trello.com/c/eabMmT8l/4564-fix-data-api-issues-raised-by-tad

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
