### PR TITLE
Log Vendor API requests for v1.1

### DIFF
--- a/app/middlewares/vendor_api_request_middleware.rb
+++ b/app/middlewares/vendor_api_request_middleware.rb
@@ -68,6 +68,6 @@ private
   end
 
   def vendor_api_path?
-    @request.path =~ /^\/api\/v1\/.*$/
+    @request.path =~ /^\/api\/v1(\.\d+)?\/.*$/
   end
 end

--- a/spec/middlewares/vendor_api_request_middleware_spec.rb
+++ b/spec/middlewares/vendor_api_request_middleware_spec.rb
@@ -40,6 +40,16 @@ RSpec.describe VendorAPIRequestMiddleware, type: :request do
     end
   end
 
+  describe '#call on an API path with a minor version' do
+    it 'enqueues a worker job' do
+      get '/api/v1.1/applications/1', params: { foo: 'bar' }
+
+      expect(VendorAPIRequestWorker).to have_received(:perform_async).with(
+        hash_including('path' => '/api/v1.1/applications/1', 'params' => { 'foo' => 'bar' }, 'method' => 'GET'), anything, 401, anything
+      )
+    end
+  end
+
   describe '#call on an API path with POST data' do
     it 'enqueues a worker job including post data' do
       post '/api/v1/applications/1/offer', as: :json, params: { foo: 'bar' }

--- a/spec/requests/vendor_api/throttling_spec.rb
+++ b/spec/requests/vendor_api/throttling_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe 'Vendor API throttling', rack_attack: true do
     expect(Rack::Attack.cache.count('vendor_api/ip:127.0.0.1', 1.minute)).to eq 2
   end
 
+  it 'counts requests to Vendor API with minor versions' do
+    get_api_request '/api/v1.1/applications?since=2021-01-01T12:00:00Z'
+
+    expect(Rack::Attack.cache.count('vendor_api/ip:127.0.0.1', 1.minute)).to eq 2
+  end
+
   it 'does not count requests to other paths' do
     get_api_request '/provider'
 


### PR DESCRIPTION
## Context

We aren't creating `VendorAPI` records currently for anything other than `v1`

## Changes proposed in this pull request

Amend regex to optionally include a minor version only for now.
Also added a test for rack attack to ensure we capture minor versions there as well

## Guidance to review

Did I miss anything?

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
