### PR TITLE
R4R redesign: Email presentation of  redesigned reasons

### DIFF
--- a/app/presenters/rejection_reasons/rejection_reasons_presenter.rb
+++ b/app/presenters/rejection_reasons/rejection_reasons_presenter.rb
@@ -21,15 +21,17 @@ class RejectionReasons
 
     def nested_reasons(reason)
       reason.selected_reasons.each_with_object([]) do |nested_reason, ary|
-        ary << formatted_label(nested_reason)
-        ary << nested_reason.details.text if nested_reason.details
+        if nested_reason.details
+          ary << "#{nested_reason.label}:" if render_label?(nested_reason.label, reason.selected_reasons)
+          ary << nested_reason.details.text
+        else
+          ary << "#{nested_reason.label}."
+        end
       end
     end
 
-    def formatted_label(reason)
-      return "#{reason.label}:" if reason.details
-
-      "#{reason.label}."
+    def render_label?(label, nested_reasons)
+      label != 'Other' || nested_reasons.size > 1
     end
   end
 end

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -260,7 +260,11 @@ class CandidateMailerPreview < ActionMailer::Preview
   end
 
   def application_rejected_one_offer_one_awaiting_decision_redesigned_reasons
-    application_rejected_one_offer_one_awaiting_decision(rejection_reasons)
+    # Creates an example where 'other' details are the only selected reason as there are rendering rules for this.
+    reasons = rejection_reasons
+    reasons[:selected_reasons].first[:selected_reasons] = [qualifications_other]
+
+    application_rejected_one_offer_one_awaiting_decision(reasons)
   end
 
   def application_rejected_by_default_one_offer_one_awaiting_decision
@@ -929,9 +933,7 @@ private
           { id: 'unverified_qualifications',
             label: 'Could not verify qualifications',
             details: { id: 'unverified_qualifications_details', text: 'We could find no record of your GCSEs.' } },
-          { id: 'qualifications_other',
-            label: 'Other',
-            details: { id: 'qualifications_other_details', text: 'Some other things were sub-optimal...' } },
+          qualifications_other,
         ] },
         { id: 'personal_statement',
           label: 'Personal statement',
@@ -950,6 +952,14 @@ private
         { id: 'course_full',  label: 'Course full' },
         { id: 'other', label: 'Other', details: { id: 'other_details', text: 'So many other things were wrong...' } },
       ],
+    }
+  end
+
+  def qualifications_other
+    {
+      id: 'qualifications_other',
+      label: 'Other',
+      details: { id: 'qualifications_other_details', text: 'Some other things were sub-optimal...' },
     }
   end
 

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -177,34 +177,42 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.new_offer_decisions_pending(application_choice)
   end
 
-  def application_rejected_all_applications_rejected_mid_cycle
+  def application_rejected_all_applications_rejected_mid_cycle(reasons = reasons_for_rejection_with_qualifications)
     SiteSetting.set(name: 'cycle_schedule', value: 'today_is_mid_cycle')
     application_choice = FactoryBot.build_stubbed(
       :application_choice,
       application_form: application_form,
       course_option: course_option,
       status: :rejected,
-      structured_rejection_reasons: reasons_for_rejection_with_qualifications,
-      rejection_reasons_type: 'reasons_for_rejection',
+      structured_rejection_reasons: reasons,
+      rejection_reasons_type: reasons_type(reasons),
     )
     CandidateMailer.application_rejected_all_applications_rejected(application_choice)
   ensure
     SiteSetting.set(name: 'real', value: 'real')
   end
 
-  def application_rejected_all_applications_rejected_after_apply2_deadline
+  def application_rejected_all_applications_rejected_mid_cycle_redesigned_reasons
+    application_rejected_all_applications_rejected_mid_cycle(rejection_reasons)
+  end
+
+  def application_rejected_all_applications_rejected_after_apply2_deadline(reasons = reasons_for_rejection_with_qualifications)
     SiteSetting.set(name: 'cycle_schedule', value: 'today_is_after_apply_2_deadline_passed')
     application_choice = FactoryBot.build_stubbed(
       :application_choice,
       application_form: application_form,
       course_option: course_option,
       status: :rejected,
-      structured_rejection_reasons: reasons_for_rejection_with_qualifications,
-      rejection_reasons_type: 'reasons_for_rejection',
+      structured_rejection_reasons: reasons,
+      rejection_reasons_type: reasons_type(reasons),
     )
     CandidateMailer.application_rejected_all_applications_rejected(application_choice)
   ensure
     SiteSetting.set(name: 'real', value: 'real')
+  end
+
+  def application_rejected_all_applications_rejected_after_apply2_deadline_redesigned_reasons
+    application_rejected_all_applications_rejected_after_apply2_deadline(rejection_reasons)
   end
 
   def application_rejected_by_default_all_applications_rejected
@@ -217,7 +225,7 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.application_rejected_all_applications_rejected(application_choice)
   end
 
-  def application_rejected_one_offer_one_awaiting_decision
+  def application_rejected_one_offer_one_awaiting_decision(reasons = reasons_for_rejection)
     application_form = FactoryBot.build(
       :application_form,
       first_name: 'Tyrell',
@@ -229,8 +237,8 @@ class CandidateMailerPreview < ActionMailer::Preview
           application_form: application_form,
           course_option: course_option,
           status: :rejected,
-          structured_rejection_reasons: reasons_for_rejection,
-          rejection_reasons_type: 'reasons_for_rejection',
+          structured_rejection_reasons: reasons,
+          rejection_reasons_type: reasons_type(reasons),
         ),
         FactoryBot.build(
           :application_choice,
@@ -249,6 +257,10 @@ class CandidateMailerPreview < ActionMailer::Preview
       ],
     )
     CandidateMailer.application_rejected_one_offer_one_awaiting_decision(application_form.application_choices.first)
+  end
+
+  def application_rejected_one_offer_one_awaiting_decision_redesigned_reasons
+    application_rejected_one_offer_one_awaiting_decision(rejection_reasons)
   end
 
   def application_rejected_by_default_one_offer_one_awaiting_decision
@@ -283,7 +295,7 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.application_rejected_one_offer_one_awaiting_decision(application_form.application_choices.first)
   end
 
-  def application_rejected_awaiting_decision_only
+  def application_rejected_awaiting_decision_only(reasons = reasons_for_rejection)
     application_form = FactoryBot.build_stubbed(
       :application_form,
       first_name: 'Tyrell',
@@ -295,8 +307,8 @@ class CandidateMailerPreview < ActionMailer::Preview
           application_form: application_form,
           course_option: course_option,
           status: :rejected,
-          structured_rejection_reasons: reasons_for_rejection,
-          rejection_reasons_type: 'reasons_for_rejection',
+          structured_rejection_reasons: reasons,
+          rejection_reasons_type: reasons_type(reasons),
         ),
         FactoryBot.build_stubbed(
           :application_choice,
@@ -315,6 +327,10 @@ class CandidateMailerPreview < ActionMailer::Preview
       ],
     )
     CandidateMailer.application_rejected_awaiting_decision_only(application_form.application_choices.first)
+  end
+
+  def application_rejected_awaiting_decision_only_redesigned_reasons
+    application_rejected_awaiting_decision_only(rejection_reasons)
   end
 
   def application_rejected_by_default_awaiting_decision_only
@@ -342,7 +358,7 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.application_rejected_awaiting_decision_only(application_form.application_choices.first)
   end
 
-  def application_rejected_offers_only
+  def application_rejected_offers_only(reasons = reasons_for_rejection)
     application_form = FactoryBot.build(
       :application_form,
       first_name: 'Tyrell',
@@ -354,8 +370,8 @@ class CandidateMailerPreview < ActionMailer::Preview
           application_form: application_form,
           course_option: course_option,
           status: :rejected,
-          structured_rejection_reasons: reasons_for_rejection,
-          rejection_reasons_type: 'reasons_for_rejection',
+          structured_rejection_reasons: reasons,
+          rejection_reasons_type: reasons_type(reasons),
         ),
         FactoryBot.build(
           :application_choice,
@@ -374,6 +390,10 @@ class CandidateMailerPreview < ActionMailer::Preview
       ],
     )
     CandidateMailer.application_rejected_offers_only(application_form.application_choices.first)
+  end
+
+  def application_rejected_offers_only_redesigned_reasons
+    application_rejected_offers_only(rejection_reasons)
   end
 
   def application_rejected_by_default_offers_only
@@ -511,11 +531,11 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.application_withdrawn_on_request_offers_only(application_form.application_choices.first)
   end
 
-  def feedback_received_for_application_rejected_by_default
+  def feedback_received_for_application_rejected_by_default(reasons_trait = :with_structured_rejection_reasons)
     application_choice =
       FactoryBot.build(
         :application_choice,
-        :with_structured_rejection_reasons,
+        reasons_trait,
         application_form: application_form,
         course_option: course_option,
       )
@@ -524,17 +544,25 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.feedback_received_for_application_rejected_by_default(application_choice, show_apply_again_guidance)
   end
 
-  def feedback_received_for_application_rejected_by_default_apply_again
+  def feedback_received_for_application_rejected_by_default_redesigned_reasons
+    feedback_received_for_application_rejected_by_default(:with_redesigned_rejection_reasons)
+  end
+
+  def feedback_received_for_application_rejected_by_default_apply_again(reasons_trait = :with_structured_rejection_reasons)
     application_choice =
       FactoryBot.build(
         :application_choice,
-        :with_structured_rejection_reasons,
+        reasons_trait,
         application_form: application_form,
         course_option: course_option,
       )
     show_apply_again_guidance = true
 
     CandidateMailer.feedback_received_for_application_rejected_by_default(application_choice, show_apply_again_guidance)
+  end
+
+  def feedback_received_for_application_rejected_by_default_apply_again_redesigned_reasons
+    feedback_received_for_application_rejected_by_default_apply_again(:with_redesigned_rejection_reasons)
   end
 
   def reference_received
@@ -888,5 +916,46 @@ private
       qualifications_other_details: 'Bad qualifications',
       qualifications_which_qualifications: %w[no_english_gcse other],
     }
+  end
+
+  def rejection_reasons
+    {
+      selected_reasons: [
+        { id: 'qualifications', label: 'Qualifications', selected_reasons: [
+          { id: 'no_maths_gcse', label: 'No maths GCSE at minimum grade 4 or C, or equivalent' },
+          { id: 'no_english_gcse', label: 'No English GCSE at minimum grade 4 or C, or equivalent' },
+          { id: 'no_science_gcse', label: 'No science GCSE at minimum grade 4 or C, or equivalent' },
+          { id: 'no_degree', label: 'No bachelor’s degree or equivalent' },
+          { id: 'unverified_qualifications',
+            label: 'Could not verify qualifications',
+            details: { id: 'unverified_qualifications_details', text: 'We could find no record of your GCSEs.' } },
+          { id: 'qualifications_other',
+            label: 'Other',
+            details: { id: 'qualifications_other_details', text: 'Some other things were sub-optimal...' } },
+        ] },
+        { id: 'personal_statement',
+          label: 'Personal statement',
+          selected_reasons: [
+            { id: 'quality_of_writing',
+              label: 'Quality of writing',
+              details: { id: 'quality_of_writing_details', text: 'We do not accept applications written in Old Norse.' } },
+          ] },
+        {
+          id: 'references', label: 'References',
+          details: {
+            id: 'references_details',
+            text: 'We do not accept references from close family members, such as your mum.',
+          }
+        },
+        { id: 'course_full',  label: 'Course full' },
+        { id: 'other', label: 'Other', details: { id: 'other_details', text: 'So many other things were wrong...' } },
+      ],
+    }
+  end
+
+  def reasons_type(reasons)
+    return 'rejection_reasons' if reasons.key?(:selected_reasons)
+
+    'reasons_for_rejection'
   end
 end

--- a/spec/presenters/rejection_reasons/rejection_reasons_presenter_spec.rb
+++ b/spec/presenters/rejection_reasons/rejection_reasons_presenter_spec.rb
@@ -25,10 +25,14 @@ RSpec.describe RejectionReasons::RejectionReasonsPresenter do
           selected_reasons: [
             { id: 'qualifications', label: 'Qualifications', selected_reasons: [
               { id: 'no_maths_gcse', label: 'No maths GCSE at minimum grade 4 or C, or equivalent' },
-              { id: 'qualifications_other', label: 'Other', details: { id: 'qualifications_other_details', text: 'Some text' } },
+              other_reason,
             ] },
           ],
         }
+      end
+
+      let(:other_reason) do
+        { id: 'qualifications_other', label: 'Other', details: { id: 'qualifications_other_details', text: 'Some other text' } }
       end
 
       it 'adds nested reasons as values keyed by top level reason label' do
@@ -36,8 +40,16 @@ RSpec.describe RejectionReasons::RejectionReasonsPresenter do
           'Qualifications' => [
             'No maths GCSE at minimum grade 4 or C, or equivalent.',
             'Other:',
-            'Some text',
+            'Some other text',
           ],
+        })
+      end
+
+      it "conditionally omits the 'Other:' label when only this reason is selected." do
+        reasons[:selected_reasons].first[:selected_reasons] = [other_reason]
+
+        expect(rejected_application_choice.rejection_reasons).to eq({
+          'Qualifications' => ['Some other text'],
         })
       end
     end


### PR DESCRIPTION
## Context

We've redesigned structured reasons for rejection. Data will be stored as JSON in `ApplicationChoice#structured_rejection_reasons` in two different formats.

Emails sent to the candidate will need to be able to handle the two formats at least temporarily.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Uses the presenter work from https://github.com/DFE-Digital/apply-for-teacher-training/pull/6723 we render reasons in emails according to the [Design History Entry rules](https://bat-design-history.netlify.app/manage-teacher-training-applications/reasons-for-rejection-iteration-6/#emails).

![image](https://user-images.githubusercontent.com/93511/160848425-bd1864be-6ea9-4967-86cf-1211c371c4fc.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

This PR includes several commits from https://github.com/DFE-Digital/apply-for-teacher-training/pull/6723. Only the last 3 are unique to this PR.

I've added specific mailer preview methods for rejection emails suffixed with `_redesigned_reasons`.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/2peGz5aA/4890-sr4r-redesign-email-presentation-of-reasons
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
