### PR TITLE
Attempt to fix flakey app choice filtering spec

### DIFF
--- a/spec/services/filter_application_choices_for_providers_spec.rb
+++ b/spec/services/filter_application_choices_for_providers_spec.rb
@@ -3,7 +3,24 @@ require 'rails_helper'
 RSpec.describe FilterApplicationChoicesForProviders do
   describe '.call' do
     let(:application_choices) do
-      create_list(:application_choice, 2, :with_completed_application_form)
+      create(
+        :application_choice,
+        application_form: create(
+          :completed_application_form,
+          first_name: 'Bob',
+          last_name: 'Roberts',
+          support_reference: 'AB1234',
+        ),
+      )
+      create(
+        :application_choice,
+        application_form: create(
+          :completed_application_form,
+          first_name: 'Alice',
+          last_name: 'Alison',
+          support_reference: 'XY6789',
+        ),
+      )
       ApplicationChoice.all
     end
 


### PR DESCRIPTION
## Context

I've seen spec failures a couple of times and they seem to be due to
the randomness of values assigned in the application form factories.

## Changes proposed in this pull request

If we create two application forms via factories there is a slim chance
that both will be assigned the same last name. This breaks at least one
of the examples in this test file.

Faker has a `unique` option but I don't think we can use that in
factories because it would limit the number of objects we can create
without errors (Faker throws an error if it runs out of unique values).

So I have simple hard-coded unique values for the searchable fields that
seem to cause problems.

## Guidance to review

Is there a tidier way to do this that avoids the extra setup code?

## Link to Trello card

n/a

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
