### PR TITLE
Add truncation for uk_residency_status api field

### DIFF
--- a/app/presenters/concerns/candidate_api_data.rb
+++ b/app/presenters/concerns/candidate_api_data.rb
@@ -1,4 +1,8 @@
 module CandidateAPIData
+  include FieldTruncation
+
+  UK_RESIDENCY_STATUS_FIELD = 'Candidate.properties.uk_residency_status'.freeze
+
   UCAS_FEE_PAYER_CODES = {
     'SLC,SAAS,NIBd,EU,Chl,IoM' => '02',
     'Not Known' => '99',
@@ -19,7 +23,7 @@ module CandidateAPIData
       date_of_birth: application_form.date_of_birth,
       nationality: application_choice.nationalities,
       domicile: application_form.domicile,
-      uk_residency_status: uk_residency_status,
+      uk_residency_status: truncate_if_over_advertised_limit(UK_RESIDENCY_STATUS_FIELD, uk_residency_status),
       uk_residency_status_code: uk_residency_status_code,
       fee_payer: provisional_fee_payer_status,
       english_main_language: application_form.english_main_language,

--- a/app/presenters/concerns/field_truncation.rb
+++ b/app/presenters/concerns/field_truncation.rb
@@ -5,6 +5,7 @@ private
 
   def truncate_if_over_advertised_limit(field_name, field_value)
     limit = field_length(field_name)
+    return field_value if field_value.nil?
     return field_value if field_value.length <= limit
 
     Sentry.capture_message("#{field_name} truncated for application with id #{application_choice.id} as length exceeded #{limit} chars")


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
https://trello.com/c/i6l1z7Jr/1327-dfe-applications-failing-to-refresh-into-our-student-record-system-mmu

## Changes proposed in this pull request
Added truncation to the API field for uk_residency_status, which is now able to draw from a freetext field that doesn't have the same character limit
<!-- If there are UI changes, please include Before and After screenshots. -->
