### PR TITLE
Course Change - Update Interviews

### DIFF
--- a/app/components/provider_interface/course_change_warning_text_component.html.erb
+++ b/app/components/provider_interface/course_change_warning_text_component.html.erb
@@ -1,0 +1,8 @@
+<% if only_location_or_study_mode_change? || !application_choice.interviewing? %>
+  <%= govuk_warning_text(text: 'The candidate will be sent an email to tell them that the course has been updated.') %>
+<% elsif application_choice.interviewing? %>
+  <%= govuk_warning_text(
+    text: "The upcoming interview will be updated with the new course details.\n
+    The candidate will be sent emails to tell them that the course and the upcoming interview have been updated.",
+  ) %>
+<% end %>

--- a/app/components/provider_interface/course_change_warning_text_component.rb
+++ b/app/components/provider_interface/course_change_warning_text_component.rb
@@ -1,0 +1,16 @@
+module ProviderInterface
+  class CourseChangeWarningTextComponent < ViewComponent::Base
+    attr_reader :application_choice, :wizard
+
+    def initialize(application_choice:, wizard:)
+      @application_choice = application_choice
+      @wizard = wizard
+    end
+
+    def only_location_or_study_mode_change?
+      application_choice.course.id == wizard.course_id &&
+        application_choice.provider.id == wizard.provider_id &&
+        (application_choice.site.id != wizard.location_id || application_choice.course_option.study_mode != wizard.study_mode)
+    end
+  end
+end

--- a/app/controllers/provider_interface/courses_controller.rb
+++ b/app/controllers/provider_interface/courses_controller.rb
@@ -13,7 +13,8 @@ module ProviderInterface
         begin
           ChangeCourse.new(actor: current_provider_user,
                            application_choice: @application_choice,
-                           course_option: @wizard.course_option).save!
+                           course_option: @wizard.course_option,
+                           update_interviews_provider_service: update_interviews_provider_service).save!
           @wizard.clear_state!
           flash[:success] = t('.success')
         rescue IdenticalCourseError
@@ -63,6 +64,12 @@ module ProviderInterface
 
     def redirect_to_application_page_unless_feature_flag_is_active
       redirect_to provider_interface_application_choice_path(@application_choice) unless FeatureFlag.active?(:change_course_details_before_offer)
+    end
+
+    def update_interviews_provider_service
+      UpdateInterviewsProvider.new(actor: current_provider_user,
+                                   application_choice: @application_choice,
+                                   provider: @wizard.course_option.provider)
     end
   end
 end

--- a/app/forms/provider_interface/course_wizard.rb
+++ b/app/forms/provider_interface/course_wizard.rb
@@ -6,7 +6,8 @@ module ProviderInterface
     STEPS = %i[select_option providers courses study_modes locations check].freeze
 
     attr_accessor :path_history, :provider_id, :decision, :application_choice_id,
-                  :course_option_id, :course_id, :provider_user_id, :study_mode
+                  :course_option_id, :course_id, :provider_user_id, :study_mode,
+                  :location_id
 
     validates :course_id, presence: true, on: %i[courses save]
     validates :study_mode, presence: true, on: %i[study_mode save]
@@ -21,6 +22,7 @@ module ProviderInterface
         course_option_id: course_option.id,
         provider_id: course_option.provider.id,
         study_mode: course_option.study_mode,
+        location_id: course_option.site.id,
       }.merge(options)
 
       new(state_store, attrs)

--- a/app/services/change_course.rb
+++ b/app/services/change_course.rb
@@ -1,14 +1,16 @@
 class ChangeCourse
   include ImpersonationAuditHelper
 
-  attr_reader :actor, :application_choice, :course_option
+  attr_reader :actor, :application_choice, :course_option, :update_interviews_provider_service
 
   def initialize(actor:,
                  application_choice:,
-                 course_option:)
+                 course_option:,
+                 update_interviews_provider_service:)
     @actor = actor
     @application_choice = application_choice
     @course_option = course_option
+    @update_interviews_provider_service = update_interviews_provider_service
   end
 
   def save!
@@ -21,6 +23,7 @@ class ChangeCourse
             course_option,
             other_fields: { course_option: course_option },
           )
+          update_interviews_provider_service.save!
         end
 
         CandidateMailer.change_course(application_choice).deliver_later

--- a/app/services/update_interviews_provider.rb
+++ b/app/services/update_interviews_provider.rb
@@ -1,0 +1,50 @@
+class UpdateInterviewsProvider
+  include ImpersonationAuditHelper
+
+  attr_reader :auth, :interviews, :provider, :application_choice
+
+  def initialize(
+    actor:,
+    application_choice:,
+    provider:
+  )
+    @auth = ProviderAuthorisation.new(actor: actor)
+    @application_choice = application_choice
+    @provider = provider
+    @interviews = application_choice.interviews
+  end
+
+  def save!
+    auth.assert_can_set_up_interviews!(application_choice: application_choice,
+                                       course_option: application_choice.current_course_option)
+
+    interviews.upcoming.each do |interview|
+      next if interview.cancelled?
+      next if provider_already_associated_with_interview?(interview)
+
+      update_provider!(interview)
+    end
+  end
+
+private
+
+  def provider_already_associated_with_interview?(interview)
+    interview.provider == provider || interview.provider == application_choice.current_accredited_provider
+  end
+
+  def update_provider!(interview)
+    interview.provider = provider
+
+    InterviewWorkflowConstraints.new(interview: interview).update!
+
+    interview_validations = InterviewValidations.new(interview: interview)
+
+    if interview_validations.valid?(:update)
+      audit(auth.actor) do
+        interview.save!
+      end
+    else
+      raise ValidationException, interview_validations.errors.map(&:message)
+    end
+  end
+end

--- a/app/views/provider_interface/courses/checks/edit.html.erb
+++ b/app/views/provider_interface/courses/checks/edit.html.erb
@@ -15,6 +15,8 @@
                                                                     available_courses: @courses,
                                                                     available_course_options: @course_options) %>
 
+      <%= render ProviderInterface::CourseChangeWarningTextComponent.new(application_choice: @application_choice, wizard: @wizard) %>
+
       <%= f.govuk_submit t('.submit') %>
 
       <p class="govuk-body">

--- a/spec/components/provider_interface/course_change_warning_text_component_spec.rb
+++ b/spec/components/provider_interface/course_change_warning_text_component_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::CourseChangeWarningTextComponent do
+  let(:application_choice) { create(:application_choice) }
+  let(:new_application_choice) { create(:application_choice, course_option: course_option) }
+  let(:course_option) { create(:course_option, course: create(:course)) }
+
+  let(:course_wizard) do
+    instance_double(
+      ProviderInterface::CourseWizard,
+      application_choice_id: new_application_choice.id,
+      course_id: new_application_choice.course_option.course.id,
+      course_option_id: new_application_choice.course_option.id,
+      provider_id: new_application_choice.course_option.provider.id,
+      study_mode: new_application_choice.course_option.study_mode,
+      location_id: new_application_choice.course_option.site.id,
+    )
+  end
+
+  let(:render) do
+    render_inline(described_class.new(
+                    application_choice: application_choice,
+                    wizard: course_wizard,
+                  ))
+  end
+
+  context 'when there are interviews' do
+    let(:application_choice) { create(:application_choice, :with_scheduled_interview) }
+
+    it 'renders the warning text' do
+      expect(render.css('.govuk-warning-text').text).to eq "!WarningThe upcoming interview will be updated with the new course details.\n
+    The candidate will be sent emails to tell them that the course and the upcoming interview have been updated."
+    end
+  end
+
+  context 'when only the study mode is changed' do
+    let(:course_wizard) do
+      instance_double(
+        ProviderInterface::CourseWizard,
+        application_choice_id: application_choice.id,
+        course_id: application_choice.course_option.course.id,
+        course_option_id: application_choice.course_option.id,
+        provider_id: application_choice.course_option.provider.id,
+        study_mode: new_application_choice.course_option.study_mode,
+        location_id: application_choice.course_option.site.id,
+      )
+    end
+
+    it 'renders the warning text' do
+      expect(render.css('.govuk-warning-text').text).to eq '!WarningThe candidate will be sent an email to tell them that the course has been updated.'
+    end
+  end
+
+  context 'when only the location is changed' do
+    let(:course_wizard) do
+      instance_double(
+        ProviderInterface::CourseWizard,
+        application_choice_id: application_choice.id,
+        course_id: application_choice.course_option.course.id,
+        course_option_id: application_choice.course_option.id,
+        provider_id: application_choice.course_option.provider.id,
+        study_mode: application_choice.course_option.study_mode,
+        location_id: new_application_choice.course_option.site.id,
+      )
+    end
+
+    it 'renders the warning text' do
+      expect(render.css('.govuk-warning-text').text).to eq '!WarningThe candidate will be sent an email to tell them that the course has been updated.'
+    end
+  end
+
+  it 'renders the warning text' do
+    expect(render.css('.govuk-warning-text').text).to eq '!WarningThe candidate will be sent an email to tell them that the course has been updated.'
+  end
+end

--- a/spec/services/change_course_spec.rb
+++ b/spec/services/change_course_spec.rb
@@ -12,12 +12,14 @@ RSpec.describe ChangeCourse do
     )
   end
   let(:course_option) { course_option_for_provider(provider: application_choice.current_course_option.provider, course: application_choice.current_course_option.course) }
+  let(:update_interviews_provider_service) { instance_double(UpdateInterviewsProvider, save!: true) }
 
   let(:change_course) do
     described_class.new(
       actor: provider_user,
       application_choice: application_choice,
       course_option: course_option,
+      update_interviews_provider_service: update_interviews_provider_service,
     )
   end
 
@@ -52,6 +54,7 @@ RSpec.describe ChangeCourse do
         change_course.save!
 
         expect(application_choice).to have_received(:update_course_option_and_associated_fields!)
+        expect(update_interviews_provider_service).to have_received(:save!)
       end
     end
 

--- a/spec/services/update_interviews_provider_spec.rb
+++ b/spec/services/update_interviews_provider_spec.rb
@@ -1,0 +1,175 @@
+require 'rails_helper'
+
+RSpec.describe UpdateInterviewsProvider do
+  include CourseOptionHelpers
+
+  let(:application_choice) { create(:application_choice, status: :interviewing, interviews: [interview], course_option: course_option, current_course_option: course_option) }
+  let(:interview) { create(:interview, provider: old_training_provider) }
+  let(:another_interview) { create(:interview, provider: old_training_provider) }
+  let(:cancelled_interview) { create(:interview, :future_date_and_time, :cancelled, provider: old_training_provider) }
+  let(:application_choice_with_multiple_interviews) { create(:application_choice, status: :interviewing, interviews: [interview, another_interview, cancelled_interview], course_option: course_option) }
+  let(:course_option) { course_option_for_accredited_provider(provider: new_training_provider, accredited_provider: accredited_provider) }
+  let(:old_training_provider) { create(:provider) }
+  let(:new_training_provider) { create(:provider) }
+  let(:accredited_provider) { create(:provider) }
+
+  let(:provider_user) { create(:provider_user, :with_set_up_interviews, providers: [old_training_provider, new_training_provider, accredited_provider]) }
+
+  let(:old_provider_params) do
+    {
+      actor: provider_user,
+      provider: old_training_provider,
+      application_choice: application_choice,
+    }
+  end
+
+  let(:new_provider_params) do
+    {
+      actor: provider_user,
+      provider: new_training_provider,
+      application_choice: application_choice,
+    }
+  end
+
+  describe '#save!' do
+    context 'when it is a valid provider' do
+      it 'updates the existing interview with provided params' do
+        described_class.new(new_provider_params).save!
+
+        expect(interview.reload.provider).to eq(new_training_provider)
+      end
+
+      it 'touches the application choice' do
+        expect {
+          described_class.new(new_provider_params).save!
+        }.to change(application_choice, :updated_at)
+      end
+    end
+
+    context 'when the provider is the same' do
+      it 'does not update the existing interview with provided params' do
+        expect {
+          described_class.new(old_provider_params).save!
+        }.not_to change(interview, :provider_id)
+      end
+
+      it 'does not touch the application choice' do
+        expect {
+          described_class.new(old_provider_params).save!
+        }.not_to change(application_choice, :updated_at)
+      end
+    end
+
+    context 'when the interview is set to the accredited provider' do
+      let(:interview) { create(:interview, provider: accredited_provider) }
+
+      it 'does not update the existing interview with provided params' do
+        expect {
+          described_class.new(new_provider_params).save!
+        }.not_to change(interview, :provider_id)
+      end
+
+      it 'does not touch the application choice' do
+        expect {
+          described_class.new(new_provider_params).save!
+        }.not_to change(application_choice, :updated_at)
+      end
+    end
+
+    context 'when the provider is the same as the accredited provider' do
+      let(:course_option) { course_option_for_accredited_provider(provider: accredited_provider, accredited_provider: accredited_provider) }
+      let(:service_params) do
+        {
+          actor: provider_user,
+          provider: accredited_provider,
+          application_choice: application_choice,
+        }
+      end
+
+      it 'updates the existing interview with provided params' do
+        described_class.new(service_params).save!
+
+        expect(interview.reload.provider).to eq(accredited_provider)
+      end
+
+      it 'touches the application choice' do
+        expect {
+          described_class.new(service_params).save!
+        }.to change(application_choice, :updated_at)
+      end
+    end
+
+    context 'when there are multiple interviews' do
+      let(:service_params) do
+        {
+          actor: provider_user,
+          provider: new_training_provider,
+          application_choice: application_choice_with_multiple_interviews,
+        }
+      end
+
+      it 'updates all the existing interviews with provided params' do
+        described_class.new(service_params).save!
+
+        expect(interview.reload.provider_id).to eq(new_training_provider.id)
+        expect(another_interview.reload.provider_id).to eq(new_training_provider.id)
+        expect(cancelled_interview.reload.provider_id).to eq(old_training_provider.id)
+      end
+    end
+
+    context 'when an interview is in the past' do
+      let(:interview) { create(:interview, :past_date_and_time, provider: old_training_provider) }
+
+      it 'does not update the existing interview with provided params' do
+        expect {
+          described_class.new(old_provider_params).save!
+        }.not_to change(interview, :provider_id)
+      end
+
+      it 'does not touch the application choice' do
+        expect {
+          described_class.new(old_provider_params).save!
+        }.not_to change(application_choice, :updated_at)
+      end
+    end
+
+    context 'when an interview has been cancelled' do
+      let(:interview) { create(:interview, :cancelled, provider: old_training_provider) }
+
+      it 'does not update the existing interview with provided params' do
+        expect {
+          described_class.new(old_provider_params).save!
+        }.not_to change(interview, :provider_id)
+      end
+
+      it 'does not touch the application choice' do
+        expect {
+          described_class.new(old_provider_params).save!
+        }.not_to change(application_choice, :updated_at)
+      end
+    end
+
+    context 'when an application has been rejected' do
+      let(:application_choice) { create(:application_choice, status: :rejected, interviews: [interview], current_course_option: course_option) }
+
+      it 'raises a validation error' do
+        expect { described_class.new(new_provider_params).save! }.to raise_error(InterviewWorkflowConstraints::WorkflowError)
+      end
+    end
+
+    context 'when the provider is not valid' do
+      let(:different_provider) { create(:provider) }
+      let(:service_params) do
+        {
+          actor: provider_user,
+          provider: different_provider,
+          application_choice: application_choice,
+        }
+      end
+
+      it 'raises a validation error' do
+        expect { described_class.new(service_params).save! }.to raise_error(ValidationException)
+      end
+    end
+  end
+end

--- a/spec/system/provider_interface/provider_changes_a_course_before_point_of_offer_spec.rb
+++ b/spec/system/provider_interface/provider_changes_a_course_before_point_of_offer_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'Provider changes a course' do
   include DfESignInHelpers
   include ProviderUserPermissionsHelper
 
-  let(:provider_user) { create(:provider_user, :with_dfe_sign_in) }
+  let(:provider_user) { create(:provider_user, :with_dfe_sign_in, :with_set_up_interviews) }
   let(:provider) { provider_user.providers.first }
   let(:ratifying_provider) { create(:provider) }
   let(:application_form) { build(:application_form, :minimum_info) }
@@ -93,7 +93,7 @@ RSpec.feature 'Provider changes a course' do
 
   def and_the_provider_user_can_offer_multiple_provider_courses
     @selected_provider = create(:provider, :with_signed_agreement)
-    create(:provider_permissions, provider: @selected_provider, provider_user: provider_user, make_decisions: true)
+    create(:provider_permissions, provider: @selected_provider, provider_user: provider_user, make_decisions: true, set_up_interviews: true)
     courses = [create(:course, study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: ratifying_provider),
                create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: ratifying_provider)]
     @selected_course = courses.sample


### PR DESCRIPTION
## Context

Currently providers can change the details of a course at the point of offer. We'd like to let providers do this before the point of offer.

Following from [#6683](https://github.com/DFE-Digital/apply-for-teacher-training/pull/6683) this is the eighth PR in the series. This adds a new service that will update the provider associated with an interview.

## Changes proposed in this pull request

- Adds `UpdateInterviewsProvider` service
- Injects this service into the `CourseChange` service
- Displays warning text on the final page informing the user of the actions that will happen once they confirm the change

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/heIRGgGL

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
