### PR TITLE
Fix erd rake task

### DIFF
--- a/lib/tasks/erd.rake
+++ b/lib/tasks/erd.rake
@@ -8,11 +8,7 @@ namespace :erd do
     say 'Loading code in search of Active Record models...'
     begin
       Rails.application.eager_load!
-      if Rails.application.respond_to?(:config) && Rails.application.config.autoloader == :zeitwerk
-        Zeitwerk::Loader.eager_load_all
-      else
-        Rails.application.eager_load!
-      end
+      Zeitwerk::Loader.eager_load_all
 
       if Rails.application.respond_to?(:config) &&
          !Rails.application.config.nil? &&


### PR DESCRIPTION
When upgrading to Rails 7, we no longer can set the autoloading mode. Remove this from the rake task to generate
the domain model