### PR TITLE
Add coverage for API presentation of redesigned RejectionReasons

### DIFF
--- a/spec/presenters/vendor_api/v1.0/rejection_reason_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.0/rejection_reason_presenter_spec.rb
@@ -107,5 +107,21 @@ RSpec.describe VendorAPI::RejectionReasonPresenter do
         ])
       end
     end
+
+    context 'simple text rejection reason' do
+      let(:application_choice) do
+        build_stubbed(
+          :application_choice,
+          structured_rejection_reasons: nil,
+          rejection_reason: 'We are sorry, thanks but no thanks.',
+          rejection_reasons_type: 'rejection_reason',
+          course_option: course_option,
+        )
+      end
+
+      it 'returns the simple text rejection reason' do
+        expect(presenter.present).to eq('We are sorry, thanks but no thanks.')
+      end
+    end
   end
 end

--- a/spec/presenters/vendor_api/v1.0/rejection_reason_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.0/rejection_reason_presenter_spec.rb
@@ -38,11 +38,13 @@ RSpec.describe VendorAPI::RejectionReasonPresenter do
       }
     end
 
+    let(:rejection_reasons_type) { 'reasons_for_rejection' }
+
     let(:application_choice) do
       build_stubbed(
         :application_choice,
         structured_rejection_reasons: structured_rejection_reasons,
-        rejection_reasons_type: 'reasons_for_rejection',
+        rejection_reasons_type: rejection_reasons_type,
         course_option: course_option,
       )
     end
@@ -72,6 +74,37 @@ RSpec.describe VendorAPI::RejectionReasonPresenter do
 
       it 'returns the rejection_reason attribute' do
         expect(presenter.present).to eq('Course was full')
+      end
+    end
+
+    context 'redesigned rejection reasons' do
+      let(:structured_rejection_reasons) do
+        {
+          selected_reasons: [
+            { id: 'qualifications', label: 'Qualifications', selected_reasons: [
+              { id: 'no_maths_gcse', label: 'No maths GCSE at minimum grade 4 or C, or equivalent' },
+              { id: 'qualifications_other', label: 'Other', details: { id: 'qualifications_other_details', text: 'Some text about qualifications.' } },
+            ] },
+            { id: 'personal_statement', label: 'Personal statement', selected_reasons: [
+              { id: 'quality_of_writing', label: 'Quality of writing', details: { id: 'quality_of_writing_details', text: 'We could not read your handwriting.' } },
+            ] },
+            { id: 'references', label: 'References', details: { id: 'references_details', text: 'We cannot accept references from your mother.' } },
+            { id: 'course_full', label: 'Course full' },
+            { id: 'other', label: 'Other', details: { id: 'other_details', text: 'Some additional details.' } },
+          ],
+        }
+      end
+
+      let(:rejection_reasons_type) { 'rejection_reasons' }
+
+      it 'returns a formatted string from structured rejection reasons field' do
+        expect(presenter.present.split("\n\n")).to eq([
+          "Qualifications:\nNo maths GCSE at minimum grade 4 or C, or equivalent.\nOther:\nSome text about qualifications.",
+          "Personal statement:\nQuality of writing:\nWe could not read your handwriting.",
+          "References:\nWe cannot accept references from your mother.",
+          "Course full:\nThe course is full.",
+          "Other:\nSome additional details.",
+        ])
       end
     end
   end


### PR DESCRIPTION
## Context

We've redesigned rejection reasons. New and existing rejections data will continue to be presented via the API.
The presentation work was completed in https://github.com/DFE-Digital/apply-for-teacher-training/pull/6723 when we split the rejection reasons presenters up on a per-format basis.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Add test coverage for API specific presentations.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/TjTBCG5o/4938-present-all-the-r4r-via-the-api
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
