### PR TITLE
Add missing grade

### DIFF
--- a/config/initializers/qualifications/other_uk_qualifications.rb
+++ b/config/initializers/qualifications/other_uk_qualifications.rb
@@ -10,6 +10,7 @@ OTHER_UK_QUALIFICATIONS = [
 ].freeze
 
 OTHER_UK_QUALIFICATION_GRADES = [
+  'Distinction *',
   'Distinction',
   'Merit',
   'Pass',


### PR DESCRIPTION
## Context
Distinction * was missing for the BTEC qualification on other qualification type details page

## Changes proposed in this pull request

Before
<img width="1002" alt="Screenshot 2022-04-05 at 12 00 48" src="https://user-images.githubusercontent.com/58793682/161739964-e53165d5-a426-42d1-a40c-aaa058cfde05.png">


After 
<img width="1122" alt="Screenshot 2022-04-05 at 11 59 37" src="https://user-images.githubusercontent.com/58793682/161739777-4784d652-0ed9-4bcc-a3d2-31bc8bba1225.png">


## Guidance to review

Don't think theres any data issues, it would just be a different string value in the grade field on application qualification

## Link to Trello card
https://trello.com/c/6aZ8w6zu/4589-add-distinction-star-distinction-to-the-btec-grades-in-other-uk-qualifications

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
