### PR TITLE
Set application choice status explicitly on flakey test

### DIFF
--- a/spec/components/provider_interface/course_change_warning_text_component_spec.rb
+++ b/spec/components/provider_interface/course_change_warning_text_component_spec.rb
@@ -2,18 +2,17 @@ require 'rails_helper'
 
 RSpec.describe ProviderInterface::CourseChangeWarningTextComponent do
   let(:application_choice) { create(:application_choice, :awaiting_provider_decision) }
-  let(:new_application_choice) { create(:application_choice, :awaiting_provider_decision, course_option: course_option) }
   let(:course_option) { create(:course_option, course: create(:course)) }
 
   let(:course_wizard) do
     instance_double(
       ProviderInterface::CourseWizard,
-      application_choice_id: new_application_choice.id,
-      course_id: new_application_choice.course_option.course.id,
-      course_option_id: new_application_choice.course_option.id,
-      provider_id: new_application_choice.course_option.provider.id,
-      study_mode: new_application_choice.course_option.study_mode,
-      location_id: new_application_choice.course_option.site.id,
+      application_choice_id: application_choice.id,
+      course_id: course_option.course.id,
+      course_option_id: course_option.id,
+      provider_id: course_option.provider.id,
+      study_mode: course_option.study_mode,
+      location_id: course_option.site.id,
     )
   end
 
@@ -41,7 +40,7 @@ RSpec.describe ProviderInterface::CourseChangeWarningTextComponent do
         course_id: application_choice.course_option.course.id,
         course_option_id: application_choice.course_option.id,
         provider_id: application_choice.course_option.provider.id,
-        study_mode: new_application_choice.course_option.study_mode,
+        study_mode: course_option.study_mode,
         location_id: application_choice.course_option.site.id,
       )
     end
@@ -60,7 +59,7 @@ RSpec.describe ProviderInterface::CourseChangeWarningTextComponent do
         course_option_id: application_choice.course_option.id,
         provider_id: application_choice.course_option.provider.id,
         study_mode: application_choice.course_option.study_mode,
-        location_id: new_application_choice.course_option.site.id,
+        location_id: course_option.site.id,
       )
     end
 

--- a/spec/components/provider_interface/course_change_warning_text_component_spec.rb
+++ b/spec/components/provider_interface/course_change_warning_text_component_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe ProviderInterface::CourseChangeWarningTextComponent do
-  let(:application_choice) { create(:application_choice) }
-  let(:new_application_choice) { create(:application_choice, course_option: course_option) }
+  let(:application_choice) { create(:application_choice, :awaiting_provider_decision) }
+  let(:new_application_choice) { create(:application_choice, :awaiting_provider_decision, course_option: course_option) }
   let(:course_option) { create(:course_option, course: create(:course)) }
 
   let(:course_wizard) do


### PR DESCRIPTION
## Context

If an application choice is in interviewing state we have different text to show. Since the factory chooses statuses randomly we sometimes will choose an interviewing application choice showing the wrong text. Instead set the choice explicitly

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
