### PR TITLE
SR4R Redesign: Make `RejectionReasonsHistory` work new R4R data

### DIFF
--- a/app/components/candidate_interface/review_rejection_reasons_component.html.erb
+++ b/app/components/candidate_interface/review_rejection_reasons_component.html.erb
@@ -1,0 +1,9 @@
+<% if hide_other_label? %>
+  <p class="govuk-body"><%= rejection_reasons.first.details.text %></p>
+<% else %>
+  <br>
+  <% rejection_reasons.each do |rejection_reason| %>
+    <p class="govuk-body"><%= rejection_reason.label %>:</p>
+    <p class="govuk-body"><%= rejection_reason.details.text %></p>
+  <% end %>
+<% end %>

--- a/app/components/candidate_interface/review_rejection_reasons_component.html.erb
+++ b/app/components/candidate_interface/review_rejection_reasons_component.html.erb
@@ -1,7 +1,6 @@
 <% if hide_other_label? %>
   <p class="govuk-body"><%= rejection_reasons.first.details.text %></p>
 <% else %>
-  <br>
   <% rejection_reasons.each do |rejection_reason| %>
     <p class="govuk-body"><%= rejection_reason.label %>:</p>
     <p class="govuk-body"><%= rejection_reason.details.text %></p>

--- a/app/components/candidate_interface/review_rejection_reasons_component.rb
+++ b/app/components/candidate_interface/review_rejection_reasons_component.rb
@@ -9,7 +9,7 @@ module CandidateInterface
     end
 
     def hide_other_label?
-      rejection_reasons.count == 1 && rejection_reasons.first.label == 'Other'
+      rejection_reasons.one? && rejection_reasons.first.label == 'Other'
     end
   end
 end

--- a/app/components/candidate_interface/review_rejection_reasons_component.rb
+++ b/app/components/candidate_interface/review_rejection_reasons_component.rb
@@ -1,0 +1,15 @@
+module CandidateInterface
+  class ReviewRejectionReasonsComponent < ViewComponent::Base
+    include ViewHelper
+
+    attr_reader :rejection_reasons
+
+    def initialize(rejection_reasons)
+      @rejection_reasons = rejection_reasons
+    end
+
+    def hide_other_label?
+      rejection_reasons.count == 1 && rejection_reasons.first.label == 'Other'
+    end
+  end
+end

--- a/app/models/candidate_interface/rejection_reasons_history.rb
+++ b/app/models/candidate_interface/rejection_reasons_history.rb
@@ -81,28 +81,20 @@ module CandidateInterface
     end
 
     def feedback_for_becoming_a_teacher(rejection_reasons)
-      personal_statement = find_reason(rejection_reasons, 'personal_statement')
-      details = %w[quality_of_writing personal_statement_other]
-        .map { |rid| find_reason(personal_statement, rid)&.details&.text }
+      details = %w[quality_of_writing_details personal_statement_other_details]
+        .map { |rid| rejection_reasons.find(rid)&.text }
         .compact
 
       return if details.empty?
       return details.first if details.size == 1
 
+      details[0] = "Quality of writing:#{tag.br}#{details.last}".html_safe
       details[1] = "Other:#{tag.br}#{details.last}".html_safe
       details.map { |d| tag.p(d) }.join.html_safe
     end
 
     def feedback_for_subject_knowledge(rejection_reasons)
-      teaching_knowledge = find_reason(rejection_reasons, 'teaching_knowledge')
-
-      find_reason(teaching_knowledge, 'subject_knowledge')&.details&.text
-    end
-
-    def find_reason(reason, rid)
-      return if reason.blank?
-
-      reason.selected_reasons.find { |r| r.id == rid }
+      rejection_reasons.find('subject_knowledge_details')&.text
     end
 
     def map_section_to_method

--- a/app/models/candidate_interface/rejection_reasons_history.rb
+++ b/app/models/candidate_interface/rejection_reasons_history.rb
@@ -1,7 +1,5 @@
 module CandidateInterface
   class RejectionReasonsHistory
-    include ActionView::Helpers::TagHelper
-
     class UnsupportedSectionError < StandardError; end
     HistoryItem = Struct.new(:provider_name, :section, :feedback, :feedback_type)
 

--- a/app/models/candidate_interface/rejection_reasons_history.rb
+++ b/app/models/candidate_interface/rejection_reasons_history.rb
@@ -82,20 +82,13 @@ module CandidateInterface
     end
 
     def feedback_for_becoming_a_teacher(rejection_reasons)
-      details = %w[quality_of_writing_details personal_statement_other_details]
-        .map { |rid| rejection_reasons.find(rid)&.text }
+      %w[quality_of_writing personal_statement_other]
+        .map { |id| rejection_reasons.find(id) }
         .compact
-
-      return if details.empty?
-      return details.first if details.size == 1
-
-      details[0] = "Quality of writing:#{tag.br}#{details.last}".html_safe
-      details[1] = "Other:#{tag.br}#{details.last}".html_safe
-      details.map { |d| tag.p(d) }.join.html_safe
     end
 
     def feedback_for_subject_knowledge(rejection_reasons)
-      rejection_reasons.find('subject_knowledge_details')&.text
+      [rejection_reasons.find('subject_knowledge')].compact
     end
 
     def map_section_to_method

--- a/app/models/candidate_interface/rejection_reasons_history.rb
+++ b/app/models/candidate_interface/rejection_reasons_history.rb
@@ -3,7 +3,7 @@ module CandidateInterface
     include ActionView::Helpers::TagHelper
 
     class UnsupportedSectionError < StandardError; end
-    HistoryItem = Struct.new(:provider_name, :section, :feedback)
+    HistoryItem = Struct.new(:provider_name, :section, :feedback, :feedback_type)
 
     def self.all_previous_applications(application_form, section)
       new(application_form, section).all_previous_applications
@@ -60,6 +60,7 @@ module CandidateInterface
             choice.provider.name,
             section,
             feedback,
+            choice.rejection_reasons_type,
           )
         end
       end

--- a/app/models/rejection_reasons.rb
+++ b/app/models/rejection_reasons.rb
@@ -39,6 +39,12 @@ class RejectionReasons
     @selected_reasons = attrs[:selected_reasons].map { |rattrs| Reason.new(rattrs) } if attrs.key?(:selected_reasons)
   end
 
+  def find(identifier)
+    selected_reasons.find { |reason| reason.id == identifier } ||
+      nested_reasons(collection: :selected_reasons).find { |nested_reason| nested_reason.id == identifier } ||
+      details(collection: :selected_reasons).find { |details| details.id == identifier }
+  end
+
   def single_attribute_names
     details.map(&:id).map(&:to_sym)
   end
@@ -75,11 +81,11 @@ class RejectionReasons
     super
   end
 
-  def nested_reasons
-    reasons.map(&:reasons).flatten.compact
+  def nested_reasons(collection: :reasons)
+    send(collection).map(&collection).flatten.compact
   end
 
-  def details
-    (reasons + nested_reasons).map(&:details).compact
+  def details(collection: :reasons)
+    (send(collection) + nested_reasons(collection: collection)).map(&:details).compact
   end
 end

--- a/app/views/candidate_interface/personal_statement/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/show.html.erb
@@ -16,7 +16,11 @@
       <% @application_form.rejection_reasons(:becoming_a_teacher).each do |rejection_reason| %>
         <h3 class="govuk-heading-s govuk-!-margin-bottom-2"><%= rejection_reason.provider_name %></h3>
         <blockquote class="govuk-!-margin-left-0 govuk-!-margin-top-0">
-          <p class="govuk-body">“<%= rejection_reason.feedback %>”</p>
+          <% if rejection_reason.feedback_type == 'reasons_for_rejection' %>
+            <p class="govuk-body">“<%= rejection_reason.feedback %>”</p>
+          <% elsif rejection_reason.feedback_type == 'rejection_reasons' %>
+             <%= render(CandidateInterface::ReviewRejectionReasonsComponent.new(rejection_reason.feedback)) %>
+          <% end %>
         </blockquote>
       <% end %>
     <% end %>

--- a/app/views/candidate_interface/subject_knowledge/show.html.erb
+++ b/app/views/candidate_interface/subject_knowledge/show.html.erb
@@ -16,7 +16,11 @@
       <% rejection_reasons.each do |rejection_reason| %>
         <h3 class="govuk-heading-s govuk-!-margin-bottom-2"><%= rejection_reason.provider_name %></h3>
         <blockquote class="govuk-!-margin-left-0 govuk-!-margin-top-0">
-          <p class="govuk-body">“<%= rejection_reason.feedback %>”</p>
+          <% if rejection_reason.feedback_type == 'reasons_for_rejection' %>
+            <p class="govuk-body">“<%= rejection_reason.feedback %>”</p>
+          <% elsif rejection_reason.feedback_type == 'rejection_reasons' %>
+             <%= render(CandidateInterface::ReviewRejectionReasonsComponent.new(rejection_reason.feedback)) %>
+          <% end %>
         </blockquote>
       <% end %>
     <% end %>

--- a/spec/components/candidate_interface/review_rejection_reasons_component_spec.rb
+++ b/spec/components/candidate_interface/review_rejection_reasons_component_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::ReviewRejectionReasonsComponent do
+  it 'renders a single rejection reason with a label' do
+    rejection_details = { id: 'quality_of_writing_details', text: 'Quality Bad' }
+    rejection_reasons = [RejectionReasons::Reason.new(id: 'quality_of_writing', label: 'Quality of writing', details: rejection_details)]
+
+    result = render_inline(described_class.new(rejection_reasons))
+
+    expect(result.css('p').text).to include('Quality of writing:Quality Bad')
+  end
+
+  it 'renders multiple rejections reason with a label' do
+    qualitfy_rejection_details = { id: 'quality_of_writing_details', text: 'Quality Bad' }
+    personal_statement_rejection_details = { id: 'personal_statement_other_details', text: 'Personal statement Bad' }
+    rejection_reasons = [
+      RejectionReasons::Reason.new(id: 'quality_of_writing', label: 'Quality of writing', details: qualitfy_rejection_details),
+      RejectionReasons::Reason.new(id: 'personal_statement_other', label: 'Other', details: personal_statement_rejection_details),
+    ]
+
+    result = render_inline(described_class.new(rejection_reasons))
+
+    expect(result.css('p').text).to include('Quality of writing:Quality Bad')
+    expect(result.css('p').text).to include('Other:Personal statement Bad')
+  end
+
+  it 'does not render the other label for a single rejection reason' do
+    personal_statement_rejection_details = { id: 'personal_statement_other_details', text: 'Personal statement Bad' }
+    rejection_reasons = [
+      RejectionReasons::Reason.new(id: 'personal_statement_other', label: 'Other', details: personal_statement_rejection_details),
+    ]
+
+    result = render_inline(described_class.new(rejection_reasons))
+
+    expect(result.css('p').text).not_to include('Other:')
+    expect(result.css('p').text).to include('Personal statement Bad')
+  end
+
+  describe '#hide_other_label?' do
+    it 'returns true if there is a single other rejection reasons' do
+      personal_statement_rejection_details = { id: 'personal_statement_other_details', text: 'Personal statement Bad' }
+      rejection_reasons = [
+        RejectionReasons::Reason.new(id: 'personal_statement_other', label: 'Other', details: personal_statement_rejection_details),
+      ]
+
+      result = described_class.new(rejection_reasons)
+
+      expect(result.hide_other_label?).to be(true)
+    end
+
+    it 'returns false if there is a single non other details rejection reasons' do
+      rejection_details = { id: 'quality_of_writing_details', text: 'Quality Bad' }
+      rejection_reasons = [RejectionReasons::Reason.new(id: 'quality_of_writing', label: 'Quality of writing', details: rejection_details)]
+
+      result = described_class.new(rejection_reasons)
+
+      expect(result.hide_other_label?).to be(false)
+    end
+
+    it 'returns false if there are multiple rejection reasons' do
+      qualitfy_rejection_details = { id: 'quality_of_writing_details', text: 'Quality Bad' }
+      personal_statement_rejection_details = { id: 'personal_statement_other_details', text: 'Personal statement Bad' }
+      rejection_reasons = [
+        RejectionReasons::Reason.new(id: 'quality_of_writing', label: 'Quality of writing', details: qualitfy_rejection_details),
+        RejectionReasons::Reason.new(id: 'personal_statement_other', label: 'Other', details: personal_statement_rejection_details),
+      ]
+
+      result = described_class.new(rejection_reasons)
+
+      expect(result.hide_other_label?).to be(false)
+    end
+  end
+end

--- a/spec/models/candidate_interface/rejection_reasons_history_spec.rb
+++ b/spec/models/candidate_interface/rejection_reasons_history_spec.rb
@@ -35,9 +35,9 @@ RSpec.describe CandidateInterface::RejectionReasonsHistory do
       feedback = described_class.all_previous_applications(current_application_form, :becoming_a_teacher)
 
       expect(feedback).to match_array [
-        described_class::HistoryItem.new(choice3.provider.name, :becoming_a_teacher, 'Amazing'),
-        described_class::HistoryItem.new(choice2.provider.name, :becoming_a_teacher, 'Good'),
-        described_class::HistoryItem.new(choice1.provider.name, :becoming_a_teacher, 'Bad'),
+        described_class::HistoryItem.new(choice3.provider.name, :becoming_a_teacher, 'Amazing', 'reasons_for_rejection'),
+        described_class::HistoryItem.new(choice2.provider.name, :becoming_a_teacher, 'Good', 'reasons_for_rejection'),
+        described_class::HistoryItem.new(choice1.provider.name, :becoming_a_teacher, 'Bad', 'reasons_for_rejection'),
       ]
     end
 
@@ -62,9 +62,9 @@ RSpec.describe CandidateInterface::RejectionReasonsHistory do
       feedback = described_class.all_previous_applications(current_application_form, :becoming_a_teacher)
 
       expect(feedback).to match_array [
-        described_class::HistoryItem.new(choice1.provider.name, :becoming_a_teacher, %(<p>We do not accept applications written in Old Norse.</p><p>Other:<br>Some other things weren't right...</p>)),
-        described_class::HistoryItem.new(choice2.provider.name, :becoming_a_teacher, 'Good'),
-        described_class::HistoryItem.new(choice3.provider.name, :becoming_a_teacher, 'Bad'),
+        described_class::HistoryItem.new(choice1.provider.name, :becoming_a_teacher, %(<p>We do not accept applications written in Old Norse.</p><p>Other:<br>Some other things weren't right...</p>), 'rejection_reasons'),
+        described_class::HistoryItem.new(choice2.provider.name, :becoming_a_teacher, 'Good', 'rejection_reasons'),
+        described_class::HistoryItem.new(choice3.provider.name, :becoming_a_teacher, 'Bad', 'rejection_reasons'),
       ]
     end
 

--- a/spec/models/candidate_interface/rejection_reasons_history_spec.rb
+++ b/spec/models/candidate_interface/rejection_reasons_history_spec.rb
@@ -41,31 +41,97 @@ RSpec.describe CandidateInterface::RejectionReasonsHistory do
       ]
     end
 
-    it 'returns a history of redesigned rejection reasons from previous applications' do
-      previous_application_form1 = create(:application_form)
-      choice1 = create(:application_choice, :with_redesigned_rejection_reasons, application_form: previous_application_form1)
-      choice2 = create(:application_choice, :with_redesigned_rejection_reasons, application_form: previous_application_form1)
-      previous_application_form2 = apply_again!(previous_application_form1)
-      choice3 = create(:application_choice, :with_redesigned_rejection_reasons, application_form: previous_application_form2)
-      choice1.structured_rejection_reasons['selected_reasons'][1]['selected_reasons'] = [
-        { 'id' => 'quality_of_writing', 'details' => { 'text' => 'We do not accept applications written in Old Norse.' } },
-        { 'id' => 'personal_statement_other', 'details' => { 'text' => "Some other things weren't right..." } },
-      ]
-      choice2.structured_rejection_reasons['selected_reasons'][1]['selected_reasons'][0]['details']['text'] = 'Good'
-      choice3.structured_rejection_reasons['selected_reasons'][1]['selected_reasons'] = [
-        { 'id' => 'personal_statement_other', 'details' => { 'text' => 'Bad' } },
-      ]
-      [choice1, choice2, choice3].map(&:save!)
+    context 'when redesigned rejection reasons' do
+      let(:previous_application_form) { create(:application_form) }
+      let!(:application_choice1) { create(:application_choice, :with_redesigned_rejection_reasons, application_form: previous_application_form, structured_rejection_reasons: rejection_reasons) }
+      let(:current_application_form) { apply_again!(previous_application_form) }
+      let!(:application_choice2) { create(:application_choice, :with_redesigned_rejection_reasons, application_form: current_application_form) }
 
-      current_application_form = apply_again!(previous_application_form2)
+      context 'when no reasons for section selected' do
+        let(:rejection_reasons) { { selected_reasons: [{ id: 'course_full', label: 'Course full' }] } }
 
-      feedback = described_class.all_previous_applications(current_application_form, :becoming_a_teacher)
+        it 'returns nothing' do
+          feedback = described_class.all_previous_applications(current_application_form, :becoming_a_teacher)
 
-      expect(feedback).to match_array [
-        described_class::HistoryItem.new(choice1.provider.name, :becoming_a_teacher, %(<p>We do not accept applications written in Old Norse.</p><p>Other:<br>Some other things weren't right...</p>), 'rejection_reasons'),
-        described_class::HistoryItem.new(choice2.provider.name, :becoming_a_teacher, 'Good', 'rejection_reasons'),
-        described_class::HistoryItem.new(choice3.provider.name, :becoming_a_teacher, 'Bad', 'rejection_reasons'),
-      ]
+          expect(feedback).to be_empty
+        end
+      end
+
+      context 'when reasons selected for the `becoming_a_teacher` section' do
+        let(:rejection_reasons) do
+          {
+            selected_reasons: [
+              {
+                id: 'personal_statement',
+                label: 'Personal statement',
+                selected_reasons: [
+                  {
+                    id: 'quality_of_writing',
+                    label: 'Quality of writing',
+                    details: {
+                      id: 'quality_of_writing_details',
+                      text: 'Quality Bad',
+                    },
+                  },
+                  {
+                    id: 'personal_statement_other',
+                    label: 'Other',
+                    details: {
+                      id: 'personal_statement_other_details',
+                      text: 'Personal statement Bad',
+                    },
+                  },
+                ],
+              },
+            ],
+          }
+        end
+
+        it 'returns the related rejections in history items' do
+          feedback = described_class.all_previous_applications(current_application_form, :becoming_a_teacher)
+
+          history_item = feedback.first
+          expect(feedback.count).to eq(1)
+          expect(history_item.provider_name).to eq(application_choice1.provider.name)
+          expect(history_item.section).to eq(:becoming_a_teacher)
+          expect(history_item.feedback.flat_map(&:details).map(&:text)).to contain_exactly('Quality Bad', 'Personal statement Bad')
+          expect(history_item.feedback_type).to eq('rejection_reasons')
+        end
+      end
+
+      context 'when reasons selected for the `subject_knowledge` section' do
+        let(:rejection_reasons) do
+          {
+            selected_reasons: [
+              {
+                id: 'teaching_knowledge',
+                label: 'Teaching knowledge and ability',
+                selected_reasons: [
+                  {
+                    id: 'subject_knowledge',
+                    label: 'Subject knowledge',
+                    details: {
+                      id: 'subject_knowledge_details',
+                      text: 'Subject knowledge bad',
+                    },
+                  },
+                ],
+              },
+            ],
+          }
+        end
+
+        it 'returns the related rejections in history items' do
+          feedback = described_class.all_previous_applications(current_application_form, :subject_knowledge)
+
+          history_item = feedback.first
+          expect(feedback.count).to eq(1)
+          expect(history_item.provider_name).to eq(application_choice1.provider.name)
+          expect(history_item.section).to eq(:subject_knowledge)
+          expect(history_item.feedback.flat_map(&:details).map(&:text)).to contain_exactly('Subject knowledge bad')
+          expect(history_item.feedback_type).to eq('rejection_reasons')
+        end
+      end
     end
 
     it 'ignores application choices with no relevant feedback' do

--- a/spec/models/candidate_interface/rejection_reasons_history_spec.rb
+++ b/spec/models/candidate_interface/rejection_reasons_history_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe CandidateInterface::RejectionReasonsHistory do
       feedback = described_class.all_previous_applications(current_application_form, :becoming_a_teacher)
 
       expect(feedback).to match_array [
-        described_class::HistoryItem.new(choice.provider.name, :becoming_a_teacher, 'Use a spellchecker'),
+        described_class::HistoryItem.new(choice.provider.name, :becoming_a_teacher, 'Use a spellchecker', 'reasons_for_rejection'),
       ]
     end
 

--- a/spec/models/candidate_interface/rejection_reasons_history_spec.rb
+++ b/spec/models/candidate_interface/rejection_reasons_history_spec.rb
@@ -32,9 +32,9 @@ RSpec.describe CandidateInterface::RejectionReasonsHistory do
       end
       current_application_form = apply_again!(previous_application_form2)
 
-      feedback = described_class.all_previous_applications(current_application_form, :becoming_a_teacher)
+      history_items = described_class.all_previous_applications(current_application_form, :becoming_a_teacher)
 
-      expect(feedback).to match_array [
+      expect(history_items).to match_array [
         described_class::HistoryItem.new(choice3.provider.name, :becoming_a_teacher, 'Amazing', 'reasons_for_rejection'),
         described_class::HistoryItem.new(choice2.provider.name, :becoming_a_teacher, 'Good', 'reasons_for_rejection'),
         described_class::HistoryItem.new(choice1.provider.name, :becoming_a_teacher, 'Bad', 'reasons_for_rejection'),
@@ -51,9 +51,9 @@ RSpec.describe CandidateInterface::RejectionReasonsHistory do
         let(:rejection_reasons) { { selected_reasons: [{ id: 'course_full', label: 'Course full' }] } }
 
         it 'returns nothing' do
-          feedback = described_class.all_previous_applications(current_application_form, :becoming_a_teacher)
+          history_items = described_class.all_previous_applications(current_application_form, :becoming_a_teacher)
 
-          expect(feedback).to be_empty
+          expect(history_items).to be_empty
         end
       end
 
@@ -88,10 +88,10 @@ RSpec.describe CandidateInterface::RejectionReasonsHistory do
         end
 
         it 'returns the related rejections in history items' do
-          feedback = described_class.all_previous_applications(current_application_form, :becoming_a_teacher)
+          history_items = described_class.all_previous_applications(current_application_form, :becoming_a_teacher)
 
-          history_item = feedback.first
-          expect(feedback.count).to eq(1)
+          history_item = history_items.first
+          expect(history_items.count).to eq(1)
           expect(history_item.provider_name).to eq(application_choice1.provider.name)
           expect(history_item.section).to eq(:becoming_a_teacher)
           expect(history_item.feedback.flat_map(&:details).map(&:text)).to contain_exactly('Quality Bad', 'Personal statement Bad')
@@ -122,10 +122,10 @@ RSpec.describe CandidateInterface::RejectionReasonsHistory do
         end
 
         it 'returns the related rejections in history items' do
-          feedback = described_class.all_previous_applications(current_application_form, :subject_knowledge)
+          history_items = described_class.all_previous_applications(current_application_form, :subject_knowledge)
 
-          history_item = feedback.first
-          expect(feedback.count).to eq(1)
+          history_item = history_items.first
+          expect(history_items.count).to eq(1)
           expect(history_item.provider_name).to eq(application_choice1.provider.name)
           expect(history_item.section).to eq(:subject_knowledge)
           expect(history_item.feedback.flat_map(&:details).map(&:text)).to contain_exactly('Subject knowledge bad')
@@ -141,9 +141,9 @@ RSpec.describe CandidateInterface::RejectionReasonsHistory do
       create(:application_choice, application_form: previous_application_form)
       current_application_form = apply_again!(previous_application_form)
 
-      feedback = described_class.all_previous_applications(current_application_form, :becoming_a_teacher)
+      history_items = described_class.all_previous_applications(current_application_form, :becoming_a_teacher)
 
-      expect(feedback).to match_array [
+      expect(history_items).to match_array [
         described_class::HistoryItem.new(choice.provider.name, :becoming_a_teacher, 'Use a spellchecker', 'reasons_for_rejection'),
       ]
     end

--- a/spec/models/rejection_reasons_spec.rb
+++ b/spec/models/rejection_reasons_spec.rb
@@ -75,6 +75,53 @@ RSpec.describe RejectionReasons do
     end
   end
 
+  describe '#find' do
+    it 'returns the selected reason with the matching id' do
+      reason = { id: 'rejection_reason_1', label: 'rejection_reason_label' }
+      instance = described_class.new(
+        selected_reasons: [reason],
+      )
+
+      expect(instance.find('rejection_reason_1').as_json).to eq(reason)
+    end
+
+    it 'returns the details with the matching id' do
+      details = { id: 'other_details', text: 'details_label' }
+
+      instance = described_class.new(
+        selected_reasons: [{ id: 'other', label: 'Other', details: details }],
+      )
+
+      expect(instance.find('other_details').as_json).to eq(details)
+    end
+
+    it 'returns the selected nested reason with the matching id' do
+      reason = { id: 'nested_rejection_reason_2', label: 'nested_rejection_reason_label' }
+      instance = described_class.new(
+        selected_reasons: [{ id: 'rejection_reason_1', label: 'rejection_reason_label', selected_reasons: [reason] }],
+      )
+
+      expect(instance.find('nested_rejection_reason_2').as_json).to eq(reason)
+    end
+
+    it 'returns the nested details with the matching id' do
+      details = { id: 'nested_details', text: 'details_label' }
+      instance = described_class.new(
+        selected_reasons: [{ id: 'rejection_reason_1', label: 'rejection_reason_label', selected_reasons: [{ id: 'nested_rejection_reason_2', label: 'nested_rejection_reason_label', details: details }] }],
+      )
+
+      expect(instance.find('nested_details').as_json).to eq(details)
+    end
+
+    it 'does not return a non existant id' do
+      instance = described_class.new(
+        selected_reasons: [{ id: 'rejection_reason_1', label: 'rejection_reason_label' }],
+      )
+
+      expect(instance.find('nonexistant-id').as_json).to be_nil
+    end
+  end
+
   describe '#single_attribute_names' do
     it 'returns an array of all single attribute names' do
       expect(instance.single_attribute_names.sort).to eq(%i[ad bd])

--- a/spec/system/candidate_interface/apply_again/candidate_applies_again_and_views_redesigned_rejection_reasons_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_applies_again_and_views_redesigned_rejection_reasons_spec.rb
@@ -16,8 +16,12 @@ RSpec.feature 'Apply again' do
     when_i_apply_again
     then_subject_knowledge_needs_review
     then_becoming_a_teacher_needs_review
-    and_i_can_review_subject_knowledge
-    and_i_can_review_becoming_a_teacher
+
+    when_i_review_subject_knowledge
+    then_i_can_see_subject_knowledge_feedback
+
+    when_i_review_becoming_a_teacher
+    then_i_can_see_becoming_a_teacher_feedback
 
     when_i_confirm_i_have_reviewed_becoming_a_teacher
     then_becoming_a_teacher_no_longer_needs_review
@@ -83,19 +87,26 @@ RSpec.feature 'Apply again' do
     end
   end
 
-  def and_i_can_review_subject_knowledge
+  def when_i_review_subject_knowledge
     click_link 'Your suitability to teach a subject or age group'
-    expect(page).to have_content 'Subject knowledge needs improving'
-    visit candidate_interface_application_form_path
   end
 
-  def and_i_can_review_becoming_a_teacher
-    click_link 'Why you want to teach'
-    expect(page).to have_content 'We do not accept applications written in Old Norse.'
+  def then_i_can_see_subject_knowledge_feedback
+    expect(page).to have_content 'Subject knowledge needs improving'
+  end
+
+  def when_i_review_becoming_a_teacher
     visit candidate_interface_application_form_path
+    click_link 'Why you want to teach'
+  end
+
+  def then_i_can_see_becoming_a_teacher_feedback
+    expect(page).to have_content 'We do not accept applications written in Old Norse.'
   end
 
   def when_i_confirm_i_have_reviewed_becoming_a_teacher
+    visit candidate_interface_application_form_path
+
     click_link 'Why you want to teach'
     choose t('application_form.reviewed_radio')
     click_on t('continue')

--- a/spec/system/candidate_interface/apply_again/candidate_applies_again_and_views_redesigned_rejection_reasons_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_applies_again_and_views_redesigned_rejection_reasons_spec.rb
@@ -1,0 +1,181 @@
+require 'rails_helper'
+
+RSpec.feature 'Apply again' do
+  include CandidateHelper
+  include CycleTimetableHelper
+
+  around do |example|
+    Timecop.travel(mid_cycle) do
+      example.run
+    end
+  end
+
+  scenario 'Candidate applies again and reviews rejection reason from previous cycle' do
+    given_i_am_signed_in_as_a_candidate
+    and_i_have_an_unsuccessful_application_with_rejection_reasons
+    when_i_apply_again
+    then_subject_knowledge_needs_review
+    then_becoming_a_teacher_needs_review
+    and_i_can_review_subject_knowledge
+    and_i_can_review_becoming_a_teacher
+
+    when_i_confirm_i_have_reviewed_becoming_a_teacher
+    then_becoming_a_teacher_no_longer_needs_review
+    and_i_can_set_it_back_to_unreviewed
+
+    when_i_submit_my_application
+    then_i_am_informed_that_i_have_not_reviewed_these_sections
+    and_i_can_submit_once_i_have_reviewed
+  end
+
+  def given_i_am_signed_in_as_a_candidate
+    @candidate = create(:candidate)
+    login_as(@candidate)
+  end
+
+  def and_i_have_an_unsuccessful_application_with_rejection_reasons
+    application = create(
+      :completed_application_form,
+      :with_gcses,
+      :with_completed_references,
+      references_count: 2,
+      candidate: @candidate,
+    )
+    application.application_references.update_all(selected: true)
+    choice = create(:application_choice, :with_redesigned_rejection_reasons, application_form: application)
+
+    reasons = choice.structured_rejection_reasons
+    reasons['selected_reasons'].insert(2, { 'id' => 'teaching_knowledge', 'selected_reasons' => [
+      { 'id' => 'subject_knowledge', 'details' => { 'id' => 'subject_knowledge_details', 'text' => 'Subject knowledge needs improving' } },
+    ] })
+    choice.update!(structured_rejection_reasons: reasons)
+  end
+
+  def when_i_apply_again
+    given_courses_exist
+
+    visit candidate_interface_application_complete_path
+    click_on 'Apply again'
+
+    click_link 'Choose your course'
+    candidate_fills_in_apply_again_with_three_course_choices
+    candidate_completes_the_section
+
+    click_link 'Select 2 references'
+    choose 'Yes, I have completed this section'
+    click_button t('save_and_continue')
+  end
+
+  def candidate_completes_the_section
+    choose 'Yes, I have completed this section'
+    click_button 'Continue'
+  end
+
+  def then_subject_knowledge_needs_review
+    within_task_list_item('Your suitability to teach a subject or age group') do
+      expect(page).to have_css('.govuk-tag', text: 'Review')
+    end
+  end
+
+  def then_becoming_a_teacher_needs_review
+    within_task_list_item('Why you want to teach') do
+      expect(page).to have_css('.govuk-tag', text: 'Review')
+    end
+  end
+
+  def and_i_can_review_subject_knowledge
+    click_link 'Your suitability to teach a subject or age group'
+    expect(page).to have_content 'Subject knowledge needs improving'
+    visit candidate_interface_application_form_path
+  end
+
+  def and_i_can_review_becoming_a_teacher
+    click_link 'Why you want to teach'
+    expect(page).to have_content 'We do not accept applications written in Old Norse.'
+    visit candidate_interface_application_form_path
+  end
+
+  def when_i_confirm_i_have_reviewed_becoming_a_teacher
+    click_link 'Why you want to teach'
+    choose t('application_form.reviewed_radio')
+    click_on t('continue')
+  end
+
+  def then_becoming_a_teacher_no_longer_needs_review
+    within_task_list_item('Why you want to teach') do
+      expect(page).to have_css('.govuk-tag', text: 'Completed')
+    end
+  end
+
+  def and_i_can_set_it_back_to_unreviewed
+    click_link 'Why you want to teach'
+    choose t('application_form.incomplete_radio')
+    click_button t('continue')
+  end
+
+  def when_i_submit_my_application
+    click_on 'Check and submit your application'
+    click_on t('continue')
+  end
+
+  def then_i_am_informed_that_i_have_not_reviewed_these_sections
+    within becoming_a_teacher_error_container do
+      expect(page).to have_content 'Why you want to teach not marked as reviewed'
+    end
+
+    within subject_knowledge_error_container do
+      expect(page).to have_content 'Suitability to teach your subjects or age group not marked as reviewed'
+    end
+  end
+
+  def and_i_can_submit_once_i_have_reviewed
+    click_link 'Why do you want to be a teacher'
+    click_on t('continue')
+    choose t('application_form.reviewed_radio')
+    click_on t('continue')
+    click_link 'Your suitability to teach a subject or age group'
+    choose t('application_form.reviewed_radio')
+    click_on t('continue')
+
+    click_on 'Check and submit'
+    expect(page).not_to have_css becoming_a_teacher_error_container
+    expect(page).not_to have_css subject_knowledge_error_container
+    click_on t('continue')
+
+    # Equality and diversity questions intro
+    click_link t('continue')
+
+    # What is your sex?
+    choose 'Prefer not to say'
+    click_button t('continue')
+
+    # Are you disabled?
+    choose 'Prefer not to say'
+    click_button t('continue')
+
+    # What is your ethnic group?
+    choose 'Prefer not to say'
+    click_button t('continue')
+
+    # Review page
+    click_link t('continue')
+
+    # Is there anything else you would like to tell us about your application?
+    choose 'No'
+    click_button 'Send application'
+
+    click_on t('continue')
+
+    expect(page).to have_content 'Application successfully submitted'
+  end
+
+private
+
+  def becoming_a_teacher_error_container
+    '#incomplete-becoming_a_teacher-error'
+  end
+
+  def subject_knowledge_error_container
+    '#incomplete-subject_knowledge-error'
+  end
+end


### PR DESCRIPTION
## Context

We show candidates who are applying again the feedback they have received from their previous rejected application.
This feedback is specifically the personal statement and subject knowledge reasons for rejection.
The redesigned SR4R form and JSON format stores this information in a different way to we need to be able to work with both formats when presenting the candidate with this information.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Adds ability for `RejectionReasonsHistory` to present new R4R data.
- Adds conditional logic around 'Other' details.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/lDefSjFC/4889-sr4r-redesign-candidate-apply-2-review-presentation-when-previous-application-was-rejected
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
