### PR TITLE
Amend confirm email content

### DIFF
--- a/app/controllers/dfe_sign_in_controller.rb
+++ b/app/controllers/dfe_sign_in_controller.rb
@@ -85,10 +85,7 @@ private
 
     ProviderMailer.confirm_sign_in(
       @local_user,
-      device: {
-        user_agent: request.user_agent,
-        ip_address: request.remote_ip,
-      },
+      timestamp: Time.zone.now,
     ).deliver_later
   end
 

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -1,9 +1,10 @@
 class ProviderMailer < ApplicationMailer
   layout 'provider_email'
 
-  def confirm_sign_in(provider_user, device:)
+  def confirm_sign_in(provider_user, timestamp:)
     @provider_user = provider_user
-    @device = device
+    @date = timestamp.to_fs(:govuk_date)
+    @time = timestamp.to_fs(:govuk_time)
 
     provider_notify_email(
       to: provider_user.email_address,

--- a/app/views/provider_mailer/confirm_sign_in.text.erb
+++ b/app/views/provider_mailer/confirm_sign_in.text.erb
@@ -1,10 +1,12 @@
-Dear <%= @provider_user.display_name %>
+Dear <%= @provider_user.first_name %>
 
-A new device has been used to sign in to your account.
+Your account details were used to sign in to manage teacher training applications on <%= @date %> at <%= @time %>.
 
-IP address: <%= @device[:ip_address] %>
-Browser: <%= @device[:user_agent] %>
+You can ignore this email if you signed in. Contact us immediately if you did not sign in.
 
-You can ignore this email if this was you.
+You’ve received this email because it looks like you signed in from a new device. It could also be because you used the same device as usual but:
 
-Contact us immediately if it was not you.
+- you’ve recently changed your internet browser
+- you’ve cleared the cookies on your device
+- the cookies for the service have expired on your device - this happens automatically every 6 months and you do not need to take any action
+

--- a/spec/mailers/previews/provider_mailer_preview.rb
+++ b/spec/mailers/previews/provider_mailer_preview.rb
@@ -2,10 +2,7 @@ class ProviderMailerPreview < ActionMailer::Preview
   def confirm_sign_in
     ProviderMailer.confirm_sign_in(
       FactoryBot.build_stubbed(:provider_user),
-      device: {
-        ip_address: Faker::Internet.ip_v4_address,
-        user_agent: Faker::Internet.user_agent,
-      },
+      timestamp: Time.zone.now,
     )
   end
 

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -533,4 +533,17 @@ RSpec.describe ProviderMailer, type: :mailer do
                     'link to sign in' => 'http://localhost:3000/provider/sign-in-by-email?token=token',
                     'footer' => 'Get help, report a problem or give feedback')
   end
+
+  describe 'confirm_sign_in' do
+    let(:provider_user) { build_stubbed(:provider_user, first_name: 'Johny', last_name: 'English') }
+    let(:email) { described_class.confirm_sign_in(provider_user, timestamp: timestamp) }
+    let(:timestamp) { Date.parse('22-02-2022').midnight }
+
+    it_behaves_like('a mail with subject and content',
+                    'Sign in from new device detected - manage teacher training applications',
+                    'salutation' => 'Dear Johny',
+                    'date' => '22 February 2022',
+                    'time' => '12am',
+                    'footer' => 'Get help, report a problem or give feedback')
+  end
 end

--- a/spec/system/provider_interface/provider_signs_in_from_new_device_spec.rb
+++ b/spec/system/provider_interface/provider_signs_in_from_new_device_spec.rb
@@ -54,20 +54,13 @@ RSpec.describe 'A provider authenticates via DfE Sign-in from two separate devic
     browser = Capybara.current_session.driver.browser
     browser.clear_cookies
 
-    # rubocop:disable RSpec/AnyInstance
-    allow_any_instance_of(ActionDispatch::Request).to receive(:remote_ip).and_return('192.168.0.1')
-    allow_any_instance_of(ActionDispatch::Request).to receive(:user_agent).and_return('Firefox')
-    # rubocop:enable RSpec/AnyInstance
-
     visit provider_interface_applications_path
     click_button 'Sign in using DfE Sign-in'
   end
 
   def then_i_receive_a_confirmation_email_with_correct_details
     open_email('provider@example.com')
-    expect(current_email).to have_content('A new device has been used to sign in to your account.')
-    expect(current_email).to have_content('192.168.0.1')
-    expect(current_email).to have_content('Firefox')
+    expect(current_email).to have_content('Your account details were used to sign in to manage teacher training applications')
   end
 
   def and_i_sign_in_again_from_the_same_device


### PR DESCRIPTION
## Context

To avoid getting queries in support around providers worrying someone signed in using their account, amend
content for email to make it clearer the other reasons they might receive it.

## Changes proposed in this pull request

Amend email content to include date and time and remove IP and device

## Guidance to review

Did I miss anything

## Link to Trello card

[<!-- http://trello.com/123-example-card -->
](https://trello.com/c/tLCmMEZn/4990-update-confirm-sign-in-email-content)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
