### PR TITLE
Add original_course_option to ApplicationChoices - Model update

### DIFF
--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -13,6 +13,8 @@ class ApplicationChoice < ApplicationRecord
   has_one :provider, through: :course
   has_one :accredited_provider, through: :course, class_name: 'Provider'
 
+  belongs_to :original_course_option, class_name: 'CourseOption', optional: true
+
   belongs_to :current_course_option, class_name: 'CourseOption'
   has_one :current_site, through: :current_course_option, source: :site
   has_one :current_course, through: :current_course_option, source: :course
@@ -186,11 +188,15 @@ class ApplicationChoice < ApplicationRecord
   end
 
   def configure_initial_course_choice!(course_option)
+    self.original_course_option = course_option
     self.course_option = course_option
 
     update_course_option_and_associated_fields!(
       course_option,
-      other_fields: { course_option: course_option },
+      other_fields: {
+        original_course_option: course_option,
+        course_option: course_option,
+      },
     )
   end
 

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -9,7 +9,7 @@ class SubmitApplication
   def call
     application_form.update!(submitted_at: Time.zone.now)
 
-    application_choices.includes(%i[course_option current_course_option provider accredited_provider application_form candidate]).each do |application_choice|
+    application_choices.includes(%i[original_course_option course_option current_course_option provider accredited_provider application_form candidate]).each do |application_choice|
       SendApplicationToProvider.call(application_choice)
     end
 

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -8,6 +8,10 @@ FactoryBot.define do
         application_choice.current_course_option = application_choice.course_option
       end
 
+      if application_choice.original_course_option.blank?
+        application_choice.original_course_option = application_choice.course_option
+      end
+
       if application_choice.current_recruitment_cycle_year.blank?
         application_choice.current_recruitment_cycle_year = application_choice.current_course_option.course.recruitment_cycle_year
       end

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -298,6 +298,18 @@ RSpec.describe ApplicationChoice, type: :model do
     end
   end
 
+  describe '#configure_initial_course_choice!' do
+    let(:application_choice) { create(:application_choice) }
+    let(:course_option) { create(:course_option) }
+
+    it 'sets original_course_option and course_option' do
+      expect { application_choice.configure_initial_course_choice! course_option }
+        .to change(application_choice, :original_course_option).to(course_option)
+        .and change(application_choice, :course_option).to(course_option)
+        .and change(application_choice, :current_course_option).to(course_option)
+    end
+  end
+
   describe '#update_course_option_and_associated_fields!' do
     let(:application_choice) { create(:application_choice, :awaiting_provider_decision) }
     let(:course) { create(:course, :with_accredited_provider, :previous_year) }
@@ -340,18 +352,18 @@ RSpec.describe ApplicationChoice, type: :model do
           .to change(application_choice, :provider_ids).to(expected_ids)
       end
 
-      it 'updates provider_ids if the original course is updated' do
-        original_course = create(:course, :with_accredited_provider)
-        original_course_option = create(:course_option, course: original_course)
+      it 'updates provider_ids if the course is updated' do
+        changed_course = create(:course, :with_accredited_provider)
+        changed_course_option = create(:course_option, course: changed_course)
 
         expected_ids = [
-          original_course_option.provider.id,
-          original_course_option.accredited_provider.id,
+          changed_course_option.provider.id,
+          changed_course_option.accredited_provider.id,
           course.provider.id,
           course.accredited_provider.id,
         ]
 
-        expect { application_choice.update_course_option_and_associated_fields!(course_option, other_fields: { course_option: original_course_option }) }
+        expect { application_choice.update_course_option_and_associated_fields!(course_option, other_fields: { course_option: changed_course_option }) }
           .to change(application_choice, :provider_ids).to(expected_ids)
       end
     end

--- a/spec/services/send_new_offer_email_to_candidate_spec.rb
+++ b/spec/services/send_new_offer_email_to_candidate_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe SendNewOfferEmailToCandidate do
       course_option = create(:course_option)
       @application_choice = @application_form.application_choices.create(
         application_form: @application_form,
+        original_course_option: course_option,
         course_option: course_option,
         current_course_option: course_option,
         status: :offer,
@@ -38,6 +39,7 @@ RSpec.describe SendNewOfferEmailToCandidate do
         other_course_option = create(:course_option)
         @application_form.application_choices.create(
           application_form: @application_form,
+          original_course_option: other_course_option,
           course_option: other_course_option,
           current_course_option: other_course_option,
           status: :offer,
@@ -58,6 +60,7 @@ RSpec.describe SendNewOfferEmailToCandidate do
         other_course_option = create(:course_option)
         @application_form.application_choices.create(
           application_form: @application_form,
+          original_course_option: other_course_option,
           course_option: other_course_option,
           current_course_option: other_course_option,
           status: :awaiting_provider_decision,
@@ -78,6 +81,7 @@ RSpec.describe SendNewOfferEmailToCandidate do
         other_course_option = create(:course_option)
         @application_form.application_choices.create(
           application_form: @application_form,
+          original_course_option: other_course_option,
           course_option: other_course_option,
           current_course_option: other_course_option,
           status: :interviewing,


### PR DESCRIPTION
## Context

We need a new field to store the original course option on an application choice. This is because a provider will now be able to change a course choice before an offer and also at the point of offer, so we need the ability to store these three values

## Changes proposed in this pull request

- Add `original_course_option` to the `ApplicationChoice` model
- Update the factory, services and specs

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/JySK2e9j

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
