### PR TITLE
Switch `to_s` to `to_fs` due to deprecation warnings

### DIFF
--- a/lib/generators/data_migration_generator.rb
+++ b/lib/generators/data_migration_generator.rb
@@ -6,7 +6,7 @@ class DataMigrationGenerator < Rails::Generators::NamedBase
     name = "DataMigrations::#{file_name.camelize}"
     copy_file 'data_migration.rb.tt', "app/services/data_migrations/#{file_name}.rb"
     gsub_file "app/services/data_migrations/#{file_name}.rb", '%{service_name}', file_name.camelize
-    gsub_file "app/services/data_migrations/#{file_name}.rb", '%{timestamp}', Time.zone.now.to_s(:number)
+    gsub_file "app/services/data_migrations/#{file_name}.rb", '%{timestamp}', Time.zone.now.to_fs(:number)
 
     copy_file 'data_migration_spec.rb.tt', "spec/services/data_migrations/#{file_name}_spec.rb"
     gsub_file "spec/services/data_migrations/#{file_name}_spec.rb", '%{service_name}', file_name.camelize

--- a/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
+++ b/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe CandidateInterface::ApplicationDashboardCourseChoicesComponent, t
 
       render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
 
-      expect(rendered_component).to summarise(key: 'Status', value: "Offer received What to do if you’re unable to start training in #{application_choice.course_option.course.start_date.to_s(:month_and_year)} Some providers allow you to defer your offer. This means that you could start your course a year later. Every provider is different, so it may or may not be possible to do this. Find out by contacting #{application_choice.course_option.course.provider.name}. Asking if it’s possible to defer will not affect your existing offer. If your provider agrees to defer your offer, you’ll need to accept the offer on your account first.")
+      expect(rendered_component).to summarise(key: 'Status', value: "Offer received What to do if you’re unable to start training in #{application_choice.course_option.course.start_date.to_fs(:month_and_year)} Some providers allow you to defer your offer. This means that you could start your course a year later. Every provider is different, so it may or may not be possible to do this. Find out by contacting #{application_choice.course_option.course.provider.name}. Asking if it’s possible to defer will not affect your existing offer. If your provider agrees to defer your offer, you’ll need to accept the offer on your account first.")
       expect(rendered_component).to summarise(key: 'Conditions', value: 'DBS check Get a haircut Contact the provider to find out more about these conditions. You should also have received full terms and conditions from the provider.')
     end
 

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true
 
       expect(rendered_component).to summarise(
         key: 'Date course starts',
-        value: application_choice.course.start_date.to_s(:month_and_year),
+        value: application_choice.course.start_date.to_fs(:month_and_year),
       )
 
       expect(rendered_component).to have_css('.app-summary-card__title', text: application_choice.provider.name)

--- a/spec/components/provider_interface/application_rejection_feedback_component_spec.rb
+++ b/spec/components/provider_interface/application_rejection_feedback_component_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe ProviderInterface::ApplicationRejectionFeedbackComponent do
     before { FeatureFlag.activate(:structured_reasons_for_rejection_redesign) }
 
     it 'renders the date of rejection' do
-      expect(render.text).to include("This application was rejected on #{application_choice.rejected_at.to_s(:govuk_date)}")
+      expect(render.text).to include("This application was rejected on #{application_choice.rejected_at.to_fs(:govuk_date)}")
     end
 
     it 'renders the reasons for rejection' do


### PR DESCRIPTION
## Context
We are getting deprecations warnings on `t_s`:
DEPRECATION WARNING: TimeWithZone#to_s(:number) is deprecated. Please use TimeWithZone#to_fs(:number) instead.

## Changes proposed in this pull request

Update all occurrences to `to_fs`

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
