### PR TITLE
[Spike] Store redesigned R4R data as JSON Array

### DIFF
--- a/app/components/shared/rejections_component.rb
+++ b/app/components/shared/rejections_component.rb
@@ -31,7 +31,7 @@ class RejectionsComponent < ViewComponent::Base
     if application_choice.rejection_reasons_type == 'reasons_for_rejection'
       ReasonsForRejection.new(application_choice.structured_rejection_reasons)
     else
-      RejectionReasons.new(application_choice.structured_rejection_reasons)
+      RejectionReasons.from_json_array(application_choice.structured_rejection_reasons)
     end
   end
 end

--- a/app/models/rejection_reasons.rb
+++ b/app/models/rejection_reasons.rb
@@ -14,6 +14,10 @@ class RejectionReasons
       instance
     end
 
+    def from_json_array(json_array = [])
+      new({ selected_reasons: json_array })
+    end
+
     def inflate(model)
       instance = new
       instance.selected_reasons = from_config.reasons.dup
@@ -37,6 +41,10 @@ class RejectionReasons
     super(attrs)
 
     @selected_reasons = attrs[:selected_reasons].map { |rattrs| Reason.new(rattrs) } if attrs.key?(:selected_reasons)
+  end
+
+  def as_json
+    selected_reasons
   end
 
   def single_attribute_names

--- a/app/presenters/rejection_reasons/rejection_reasons_presenter.rb
+++ b/app/presenters/rejection_reasons/rejection_reasons_presenter.rb
@@ -16,7 +16,7 @@ class RejectionReasons
     end
 
     def reasons
-      @reasons ||= RejectionReasons.new(structured_rejection_reasons).selected_reasons
+      @reasons ||= RejectionReasons.from_json_array(structured_rejection_reasons).selected_reasons
     end
 
     def nested_reasons(reason)

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -181,35 +181,33 @@ FactoryBot.define do
     trait :with_redesigned_rejection_reasons do
       with_rejection_by_default
       structured_rejection_reasons do
-        {
-          selected_reasons: [
-            { id: 'qualifications', label: 'Qualifications', selected_reasons: [
-              { id: 'no_maths_gcse', label: 'No maths GCSE at minimum grade 4 or C, or equivalent' },
-              { id: 'no_english_gcse', label: 'No English GCSE at minimum grade 4 or C, or equivalent' },
-              { id: 'no_science_gcse', label: 'No science GCSE at minimum grade 4 or C, or equivalent' },
-              { id: 'no_degree', label: 'No bachelor’s degree or equivalent' },
-              { id: 'unverified_qualifications',
-                label: 'Could not verify qualifications',
-                details: { id: 'unverified_qualifications_details', text: 'We could find no record of your GCSEs.' } },
+        [
+          { id: 'qualifications', label: 'Qualifications', selected_reasons: [
+            { id: 'no_maths_gcse', label: 'No maths GCSE at minimum grade 4 or C, or equivalent' },
+            { id: 'no_english_gcse', label: 'No English GCSE at minimum grade 4 or C, or equivalent' },
+            { id: 'no_science_gcse', label: 'No science GCSE at minimum grade 4 or C, or equivalent' },
+            { id: 'no_degree', label: 'No bachelor’s degree or equivalent' },
+            { id: 'unverified_qualifications',
+              label: 'Could not verify qualifications',
+              details: { id: 'unverified_qualifications_details', text: 'We could find no record of your GCSEs.' } },
+          ] },
+          { id: 'personal_statement',
+            label: 'Personal statement',
+            selected_reasons: [
+              { id: 'quality_of_writing',
+                label: 'Quality of writing',
+                details: { id: 'quality_of_writing_details', text: 'We do not accept applications written in Old Norse.' } },
             ] },
-            { id: 'personal_statement',
-              label: 'Personal statement',
-              selected_reasons: [
-                { id: 'quality_of_writing',
-                  label: 'Quality of writing',
-                  details: { id: 'quality_of_writing_details', text: 'We do not accept applications written in Old Norse.' } },
-              ] },
-            {
-              id: 'references', label: 'References',
-              details: {
-                id: 'references_details',
-                text: 'We do not accept references from close family members, such as your mum.',
-              }
-            },
-            { id: 'course_full',  label: 'Course full' },
-            { id: 'other', label: 'Other', details: { id: 'other_details', text: 'So many other things were wrong...' } },
-          ],
-        }
+          {
+            id: 'references', label: 'References',
+            details: {
+              id: 'references_details',
+              text: 'We do not accept references from close family members, such as your mum.',
+            }
+          },
+          { id: 'course_full',  label: 'Course full' },
+          { id: 'other', label: 'Other', details: { id: 'other_details', text: 'So many other things were wrong...' } },
+        ]
       end
       rejection_reasons_type { 'rejection_reasons' }
       reject_by_default_feedback_sent_at { Time.zone.now }

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -262,7 +262,7 @@ class CandidateMailerPreview < ActionMailer::Preview
   def application_rejected_one_offer_one_awaiting_decision_redesigned_reasons
     # Creates an example where 'other' details are the only selected reason as there are rendering rules for this.
     reasons = rejection_reasons
-    reasons[:selected_reasons].first[:selected_reasons] = [qualifications_other]
+    reasons.first[:selected_reasons] = [qualifications_other]
 
     application_rejected_one_offer_one_awaiting_decision(reasons)
   end
@@ -923,36 +923,34 @@ private
   end
 
   def rejection_reasons
-    {
-      selected_reasons: [
-        { id: 'qualifications', label: 'Qualifications', selected_reasons: [
-          { id: 'no_maths_gcse', label: 'No maths GCSE at minimum grade 4 or C, or equivalent' },
-          { id: 'no_english_gcse', label: 'No English GCSE at minimum grade 4 or C, or equivalent' },
-          { id: 'no_science_gcse', label: 'No science GCSE at minimum grade 4 or C, or equivalent' },
-          { id: 'no_degree', label: 'No bachelor’s degree or equivalent' },
-          { id: 'unverified_qualifications',
-            label: 'Could not verify qualifications',
-            details: { id: 'unverified_qualifications_details', text: 'We could find no record of your GCSEs.' } },
-          qualifications_other,
+    [
+      { id: 'qualifications', label: 'Qualifications', selected_reasons: [
+        { id: 'no_maths_gcse', label: 'No maths GCSE at minimum grade 4 or C, or equivalent' },
+        { id: 'no_english_gcse', label: 'No English GCSE at minimum grade 4 or C, or equivalent' },
+        { id: 'no_science_gcse', label: 'No science GCSE at minimum grade 4 or C, or equivalent' },
+        { id: 'no_degree', label: 'No bachelor’s degree or equivalent' },
+        { id: 'unverified_qualifications',
+          label: 'Could not verify qualifications',
+          details: { id: 'unverified_qualifications_details', text: 'We could find no record of your GCSEs.' } },
+        qualifications_other,
+      ] },
+      { id: 'personal_statement',
+        label: 'Personal statement',
+        selected_reasons: [
+          { id: 'quality_of_writing',
+            label: 'Quality of writing',
+            details: { id: 'quality_of_writing_details', text: 'We do not accept applications written in Old Norse.' } },
         ] },
-        { id: 'personal_statement',
-          label: 'Personal statement',
-          selected_reasons: [
-            { id: 'quality_of_writing',
-              label: 'Quality of writing',
-              details: { id: 'quality_of_writing_details', text: 'We do not accept applications written in Old Norse.' } },
-          ] },
-        {
-          id: 'references', label: 'References',
-          details: {
-            id: 'references_details',
-            text: 'We do not accept references from close family members, such as your mum.',
-          }
-        },
-        { id: 'course_full',  label: 'Course full' },
-        { id: 'other', label: 'Other', details: { id: 'other_details', text: 'So many other things were wrong...' } },
-      ],
-    }
+      {
+        id: 'references', label: 'References',
+        details: {
+          id: 'references_details',
+          text: 'We do not accept references from close family members, such as your mum.',
+        }
+      },
+      { id: 'course_full',  label: 'Course full' },
+      { id: 'other', label: 'Other', details: { id: 'other_details', text: 'So many other things were wrong...' } },
+    ]
   end
 
   def qualifications_other
@@ -964,7 +962,7 @@ private
   end
 
   def reasons_type(reasons)
-    return 'rejection_reasons' if reasons.key?(:selected_reasons)
+    return 'rejection_reasons' if reasons.is_a?(Array)
 
     'reasons_for_rejection'
   end

--- a/spec/presenters/rejected_application_choice_presenter_spec.rb
+++ b/spec/presenters/rejected_application_choice_presenter_spec.rb
@@ -67,11 +67,9 @@ RSpec.describe RejectedApplicationChoicePresenter do
 
       it 'returns a hash with the relevant title and reasons for redesigned rejection reasons' do
         application_choice.rejection_reasons_type = 'rejection_reasons'
-        application_choice.structured_rejection_reasons = {
-          selected_reasons: [
-            { id: 'other', label: 'Other', details: { id: 'other_details', text: 'Some text?' } },
-          ],
-        }
+        application_choice.structured_rejection_reasons = [
+          { id: 'other', label: 'Other', details: { id: 'other_details', text: 'Some text?' } },
+        ]
         expect(rejected_application_choice.rejection_reasons).to eq({ 'Other' => ['Some text?'] })
       end
     end

--- a/spec/presenters/vendor_api/v1.0/rejection_reason_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.0/rejection_reason_presenter_spec.rb
@@ -79,20 +79,18 @@ RSpec.describe VendorAPI::RejectionReasonPresenter do
 
     context 'redesigned rejection reasons' do
       let(:structured_rejection_reasons) do
-        {
-          selected_reasons: [
-            { id: 'qualifications', label: 'Qualifications', selected_reasons: [
-              { id: 'no_maths_gcse', label: 'No maths GCSE at minimum grade 4 or C, or equivalent' },
-              { id: 'qualifications_other', label: 'Other', details: { id: 'qualifications_other_details', text: 'Some text about qualifications.' } },
-            ] },
-            { id: 'personal_statement', label: 'Personal statement', selected_reasons: [
-              { id: 'quality_of_writing', label: 'Quality of writing', details: { id: 'quality_of_writing_details', text: 'We could not read your handwriting.' } },
-            ] },
-            { id: 'references', label: 'References', details: { id: 'references_details', text: 'We cannot accept references from your mother.' } },
-            { id: 'course_full', label: 'Course full' },
-            { id: 'other', label: 'Other', details: { id: 'other_details', text: 'Some additional details.' } },
-          ],
-        }
+        [
+          { id: 'qualifications', label: 'Qualifications', selected_reasons: [
+            { id: 'no_maths_gcse', label: 'No maths GCSE at minimum grade 4 or C, or equivalent' },
+            { id: 'qualifications_other', label: 'Other', details: { id: 'qualifications_other_details', text: 'Some text about qualifications.' } },
+          ] },
+          { id: 'personal_statement', label: 'Personal statement', selected_reasons: [
+            { id: 'quality_of_writing', label: 'Quality of writing', details: { id: 'quality_of_writing_details', text: 'We could not read your handwriting.' } },
+          ] },
+          { id: 'references', label: 'References', details: { id: 'references_details', text: 'We cannot accept references from your mother.' } },
+          { id: 'course_full', label: 'Course full' },
+          { id: 'other', label: 'Other', details: { id: 'other_details', text: 'Some additional details.' } },
+        ]
       end
 
       let(:rejection_reasons_type) { 'rejection_reasons' }

--- a/spec/services/reject_application_spec.rb
+++ b/spec/services/reject_application_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe RejectApplication do
 
       service.save
 
-      expect(application_choice.structured_rejection_reasons.deep_symbolize_keys).to eq(rejection_reasons_attrs)
+      expect(application_choice.structured_rejection_reasons.map(&:deep_symbolize_keys)).to eq(rejection_reasons_attrs[:selected_reasons])
       expect(application_choice.rejection_reasons_type).to eq('rejection_reasons')
     end
 


### PR DESCRIPTION
## Context

We propose to store structured reasons for rejection in a JSON Object but this object only has one key, the value is Array data.
Investigate simplifying to store Array data only.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/vF3Nal9Q/4994-spike-r4r-array-data
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
