### PR TITLE
Add original_course_option to ApplicationChoices - Backfill

### DIFF
--- a/app/services/data_migrations/backfill_original_course_option.rb
+++ b/app/services/data_migrations/backfill_original_course_option.rb
@@ -1,0 +1,12 @@
+module DataMigrations
+  class BackfillOriginalCourseOption
+    TIMESTAMP = 20220407082738
+    MANUAL_RUN = false
+
+    def change
+      ApplicationChoice.where(original_course_option: nil).find_each(batch_size: 100) do |application|
+        application.update_columns(original_course_option_id: application.course_option.id)
+      end
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillOriginalCourseOption',
   'DataMigrations::BackfillRejectionReasonsTypeField',
   'DataMigrations::DropExpandedQualsExportFeatureFlag',
   'DataMigrations::DropImmigrationEntryDateFeatureFlag',

--- a/spec/services/data_migrations/backfill_original_course_option_spec.rb
+++ b/spec/services/data_migrations/backfill_original_course_option_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillOriginalCourseOption do
+  context 'when original_course_option is nil' do
+    let(:application_without_original_course_option) { create(:application_choice) }
+
+    before do
+      application_without_original_course_option.update!(original_course_option: nil)
+    end
+
+    it 'backfills original_course_option column' do
+      described_class.new.change
+
+      expect(application_without_original_course_option.reload.original_course_option).to eq(application_without_original_course_option.course_option)
+    end
+
+    it 'does not touch updated_at' do
+      expect { described_class.new.change }.not_to(change { application_without_original_course_option.updated_at })
+    end
+  end
+end


### PR DESCRIPTION
## Context

We need a new field to store the original course option on an application choice. This is because a provider will now be able to change a course choice before an offer and also at the point of offer, so we need the ability to store these three values

## Changes proposed in this pull request

- add a backfill for the `original_course_option`

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/JySK2e9j

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
