### PR TITLE
Add backlinks to the change course flow

### DIFF
--- a/app/helpers/course_path_helper.rb
+++ b/app/helpers/course_path_helper.rb
@@ -1,0 +1,9 @@
+module CoursePathHelper
+  def course_path_for(application_choice, step, params = {})
+    if step.to_sym == :select_option
+      provider_interface_application_choice_path(application_choice, params)
+    else
+      [:edit, :provider_interface, application_choice, :course, step, params]
+    end
+  end
+end

--- a/app/views/provider_interface/courses/checks/edit.html.erb
+++ b/app/views/provider_interface/courses/checks/edit.html.erb
@@ -1,4 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(course_path_for(@application_choice, @wizard.previous_step, back: true)) %>
 
 <%= form_with model: @wizard, url: provider_interface_application_choice_course_path(@application_choice), method: :put do |f| %>
   <h1 class="govuk-heading-l">

--- a/app/views/provider_interface/courses/courses/edit.html.erb
+++ b/app/views/provider_interface/courses/courses/edit.html.erb
@@ -1,4 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(course_path_for(@application_choice, @wizard.previous_step, back: true)) %>
 
 <%= render CollectionSelectComponent.new(attribute: :course_id,
                                          collection: @courses,

--- a/app/views/provider_interface/courses/locations/edit.html.erb
+++ b/app/views/provider_interface/courses/locations/edit.html.erb
@@ -1,4 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(course_path_for(@application_choice, @wizard.previous_step, back: true)) %>
 
 <%= render CollectionSelectComponent.new(attribute: :course_option_id,
                                          collection: @course_options,

--- a/app/views/provider_interface/courses/providers/edit.html.erb
+++ b/app/views/provider_interface/courses/providers/edit.html.erb
@@ -1,4 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(course_path_for(@application_choice, @wizard.previous_step, back: true)) %>
 
 <%= render CollectionSelectComponent.new(attribute: :provider_id,
                                          collection: @providers,

--- a/app/views/provider_interface/courses/study_modes/edit.html.erb
+++ b/app/views/provider_interface/courses/study_modes/edit.html.erb
@@ -1,4 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(course_path_for(@application_choice, @wizard.previous_step, back: true)) %>
 
 <%= render CollectionSelectComponent.new(attribute: :study_mode,
                                          collection: @study_modes,

--- a/spec/helpers/course_path_helper_spec.rb
+++ b/spec/helpers/course_path_helper_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe CoursePathHelper do
+  let(:application_choice) { build_stubbed(:application_choice) }
+
+  describe '#offer_path_for' do
+    context 'when :select_option' do
+      it 'returns the application choice path' do
+        expect(helper.course_path_for(application_choice, 'select_option'))
+          .to eq(provider_interface_application_choice_path(application_choice, {}))
+      end
+    end
+
+    context 'when any other step' do
+      it 'returns the step edit path' do
+        expect(helper.course_path_for(application_choice, :other_step, foo: 'bar'))
+          .to eq([:edit, :provider_interface, application_choice, :course, :other_step, foo: 'bar'])
+      end
+    end
+  end
+end

--- a/spec/system/provider_interface/provider_changes_a_course_before_point_of_offer_spec.rb
+++ b/spec/system/provider_interface/provider_changes_a_course_before_point_of_offer_spec.rb
@@ -61,6 +61,12 @@ RSpec.feature 'Provider changes a course' do
     and_i_click_continue
     then_the_review_page_is_loaded
 
+    when_i_click_back
+    then_i_am_taken_to_the_change_course_page
+
+    when_i_click_continue
+    then_the_review_page_is_loaded
+
     when_i_click_update_course
     then_i_see_the_changed_offer_details
   end
@@ -154,6 +160,8 @@ RSpec.feature 'Provider changes a course' do
     click_on t('continue')
   end
 
+  alias_method :when_i_click_continue, :and_i_click_continue
+
   def then_i_see_a_list_of_courses_to_select_from
     expect(page).to have_content "Update course - #{application_form.full_name}"
     expect(page).to have_content 'Course'
@@ -213,6 +221,10 @@ RSpec.feature 'Provider changes a course' do
 
   def and_i_select_a_course_with_one_study_mode_and_one_location
     choose @one_mode_and_location_course.name_and_code
+  end
+
+  def when_i_click_back
+    click_on 'Back'
   end
 
   def when_i_click_update_course


### PR DESCRIPTION
## Context

Held off adding backlinks to this feature until the entire flow was in place. It's now time to add them.

## Changes proposed in this pull request

- add `CoursePathHelper`
- add a backlink to each stage of the flow

## Guidance to review

Found an existing bug if you follow this scenario:
- Change course
- Change location
- On the check page go back one step (to location)
- On the location page go back another step (to course)

This causes an error.

## Link to Trello card

https://trello.com/c/ivqYMCU4

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
