### PR TITLE
Course Change - Validations

### DIFF
--- a/app/forms/provider_interface/course_wizard.rb
+++ b/app/forms/provider_interface/course_wizard.rb
@@ -10,7 +10,7 @@ module ProviderInterface
                   :location_id
 
     validates :course_id, presence: true, on: %i[courses save]
-    validates :study_mode, presence: true, on: %i[study_mode save]
+    validates :study_mode, presence: true, on: %i[study_modes save]
     validates :course_option_id, presence: true, on: %i[locations save]
 
     def self.build_from_application_choice(state_store, application_choice, options = {})

--- a/config/locales/provider_interface/change_course.yml
+++ b/config/locales/provider_interface/change_course.yml
@@ -24,9 +24,19 @@ en:
           submit: Update course
       update:
         success: Course updated
-        failure: Unable to update course
+        failure: Course not updated
   activemodel:
     errors:
       models:
         course_validations:
           different_ratifying_provider: The course's ratifying provider must be the same as the one originally requested
+        provider_interface/course_wizard:
+          attributes:
+            course_option_id:
+              blank: Select location
+            study_mode:
+              blank: Select full time or part time
+            course_id:
+              blank: Select course
+            provider_id:
+              blank: Select provider

--- a/spec/forms/provider_interface/course_wizard_spec.rb
+++ b/spec/forms/provider_interface/course_wizard_spec.rb
@@ -19,9 +19,12 @@ RSpec.describe ProviderInterface::CourseWizard do
   before { allow(store).to receive(:read) }
 
   describe 'validations' do
-    it { is_expected.to validate_presence_of(:course_id).on(:courses).on(:save) }
-    it { is_expected.to validate_presence_of(:study_mode).on(:study_modes).on(:save) }
-    it { is_expected.to validate_presence_of(:course_option_id).on(:locations).on(:save) }
+    it { is_expected.to validate_presence_of(:course_id).on(:courses) }
+    it { is_expected.to validate_presence_of(:course_id).on(:save) }
+    it { is_expected.to validate_presence_of(:study_mode).on(:study_modes) }
+    it { is_expected.to validate_presence_of(:study_mode).on(:save) }
+    it { is_expected.to validate_presence_of(:course_option_id).on(:locations) }
+    it { is_expected.to validate_presence_of(:course_option_id).on(:save) }
   end
 
   describe '#initialize' do

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -44,9 +44,12 @@ RSpec.describe ProviderInterface::OfferWizard do
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:decision).on(:select_option) }
-    it { is_expected.to validate_presence_of(:course_option_id).on(:locations).on(:save) }
-    it { is_expected.to validate_presence_of(:study_mode).on(:study_modes).on(:save) }
-    it { is_expected.to validate_presence_of(:course_id).on(:courses).on(:save) }
+    it { is_expected.to validate_presence_of(:course_option_id).on(:locations) }
+    it { is_expected.to validate_presence_of(:course_option_id).on(:save) }
+    it { is_expected.to validate_presence_of(:study_mode).on(:study_modes) }
+    it { is_expected.to validate_presence_of(:study_mode).on(:save) }
+    it { is_expected.to validate_presence_of(:course_id).on(:courses) }
+    it { is_expected.to validate_presence_of(:course_id).on(:save) }
 
     context 'if a further condition is too long' do
       let(:further_condition_1) { Faker::Lorem.paragraph_by_chars(number: 300) }


### PR DESCRIPTION
## Context

In the change course flow, each page renders the generic "can't be blank" validation message. These need to be replaced with the page specific error messages to provider clearer guidance to the user.

## Changes proposed in this pull request

Each page now follows a similar pattern of:

|Before|After|
|---|---|
|<img width="701" alt="image" src="https://user-images.githubusercontent.com/47917431/162448500-62bdbbb6-caad-47a5-b969-f991dfba6022.png">|<img width="694" alt="image" src="https://user-images.githubusercontent.com/47917431/162448643-25f30ee9-f6e0-45d0-b1a9-4e71e42a3b34.png">|

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/mjpRcwCa

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
