### PR TITLE
Use workflow concurrency for build and deploy

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
 name: Build and Deploy
+concurrency: build_and_deploy_${{ github.ref_name }}
 
 on:
   push:
@@ -418,7 +419,6 @@ jobs:
 
   deploy-all:
     name: Deployment To All
-    concurrency: deploy_all
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     environment:
       name: ${{ matrix.environment }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,5 @@
 name: Deploy
+concurrency: build_and_deploy_${{ github.ref_name }} # ensures that the job waits for any deployments triggered by the build workflow to finish
 
 on:
   workflow_dispatch:
@@ -19,7 +20,6 @@ on:
 jobs:
   deploy:
     name: ${{ github.event.inputs.environment }} deployment
-    concurrency: deploy_all # ensures that the job waits for any deployments triggered by the build workflow to finish
     runs-on: ubuntu-latest
     environment:
       name: ${{ github.event.inputs.environment }}


### PR DESCRIPTION
## Context
Currently the deploy-all matrix job has a concurrency group to prevent concurrent deployments.  Observed behaviour is that each job within the matrix is treated as a separate job rather all the jobs in the matrix being treated as a single element.  This prod deployments occurring after earlier environments have been skipped.

## Changes proposed in this pull request
- Switch to workflow concurrency to ensure that only 1 `deploy-all` job can run at any one time but that all jobs in that matrix are executed in order
- Retain job concurrency for deploy and delete of review app to prevent the delete job running at the same time as the review app deployment

## Guidance to review

- The concurrency groups have been tested in a [sandbox repo](https://github.com/NickGraham101/actions-sandbox)

## Link to Trello card

https://trello.com/c/zCmvKchC

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
