### PR TITLE
Make offer flow - content update

### DIFF
--- a/app/components/provider_interface/change_course_details_component.rb
+++ b/app/components/provider_interface/change_course_details_component.rb
@@ -5,7 +5,7 @@ module ProviderInterface
 
     FUNDING_TYPES = { apprenticeship: :apprenticeship, salary: :salaried, fee: :fee_paying }.freeze
 
-    attr_reader :application_choice, :provider_name_and_code, :course_name_and_code,
+    attr_reader :application_choice, :provider_name, :course_name_and_code,
                 :cycle, :preferred_location, :study_mode, :qualification, :available_providers,
                 :available_courses, :course, :available_course_options, :course_option
 
@@ -18,7 +18,7 @@ module ProviderInterface
 
       @course = course_option.course
 
-      @provider_name_and_code = course.provider.name_and_code
+      @provider_name = course.provider.name
       @course_name_and_code = course.name_and_code
       @cycle = course.recruitment_cycle_year
       @preferred_location = preferred_location_text
@@ -28,7 +28,7 @@ module ProviderInterface
 
     def rows
       [
-        { key: 'Training provider', value: provider_name_and_code, action: { href: change_provider_path } },
+        { key: 'Training provider', value: provider_name, action: { href: change_provider_path } },
         { key: 'Course', value: course_name_and_code, action: { href: change_course_path } },
         { key: 'Full time or part time', value: study_mode, action: { href: change_study_mode_path } },
         { key: 'Location', value: preferred_location, action: { href: change_location_path } },
@@ -45,7 +45,7 @@ module ProviderInterface
 
     def accredited_body
       accredited_body = course.accredited_provider
-      accredited_body.present? ? accredited_body.name_and_code : provider_name_and_code
+      accredited_body.present? ? accredited_body.name : provider_name
     end
 
     def funding_type
@@ -57,8 +57,8 @@ module ProviderInterface
 
     def formatted_address
       site = course_option.site
-      "#{site.address_line1}, " \
-        "#{site.address_line2}, " \
+      "#{site.address_line1}\n" \
+        "#{site.address_line2}\n" \
         "#{site.address_line3}\n" \
         "#{site.postcode}"
     end

--- a/app/components/provider_interface/check_course_details_component.rb
+++ b/app/components/provider_interface/check_course_details_component.rb
@@ -2,10 +2,10 @@ module ProviderInterface
   class CheckCourseDetailsComponent < ChangeCourseDetailsComponent
     def rows
       [
-        { key: 'Training provider', value: course_option.provider.name_and_code, action: { href: change_provider_path } },
+        { key: 'Training provider', value: course_option.provider.name, action: { href: change_provider_path } },
         { key: 'Course', value: course_option.course.name_and_code, action: { href: change_course_path } },
         { key: 'Full time or part time', value: course_option.study_mode.humanize, action: { href: change_study_mode_path } },
-        { key: 'Location', value: course_option.site.name_and_address, action: { href: change_location_path } },
+        { key: 'Location', value: course_option.site.name_and_address("\n"), action: { href: change_location_path } },
         { key: 'Accredited body', value: accredited_body },
         { key: 'Qualification', value: qualification_text(course_option) },
         { key: 'Funding type', value: course.funding_type.humanize },
@@ -14,7 +14,7 @@ module ProviderInterface
 
     def accredited_body
       accredited_body = course_option.course.accredited_provider
-      accredited_body.present? ? accredited_body.name_and_code : provider_name_and_code
+      accredited_body.present? ? accredited_body.name : provider_name
     end
   end
 end

--- a/app/components/provider_interface/completed_offer_summary_component.rb
+++ b/app/components/provider_interface/completed_offer_summary_component.rb
@@ -29,7 +29,7 @@ module ProviderInterface
         },
         {
           key: 'Location',
-          value: course_option.site.name_and_address,
+          value: course_option.site.name_and_address("\n"),
           action: {
             href: change_location_path,
           },

--- a/app/components/provider_interface/conditions_form_component.html.erb
+++ b/app/components/provider_interface/conditions_form_component.html.erb
@@ -1,2 +1,2 @@
 <%# We render a partial here due to a bug in ViewComponent around context and form_for. See https://github.com/github/view_component/pull/240 for details %>
-<%= render 'provider_interface/offer/conditions/form', form_object: form_object, application_choice: application_choice, form_method: form_method, form_heading: form_heading %>
+<%= render 'provider_interface/offer/conditions/form', form_object: form_object, application_choice: application_choice, form_method: form_method, form_caption: form_caption, form_heading: form_heading %>

--- a/app/components/provider_interface/conditions_form_component.rb
+++ b/app/components/provider_interface/conditions_form_component.rb
@@ -1,12 +1,13 @@
 module ProviderInterface
   class ConditionsFormComponent < ViewComponent::Base
     include CheckboxOptionsHelper
-    attr_reader :form_object, :application_choice, :form_method, :form_heading
+    attr_reader :form_object, :application_choice, :form_method, :form_caption, :form_heading
 
-    def initialize(form_object:, application_choice:, form_method:, form_heading:)
+    def initialize(form_object:, application_choice:, form_method:, form_caption:, form_heading:)
       @form_object = form_object
       @application_choice = application_choice
       @form_method = form_method
+      @form_caption = form_caption
       @form_heading = form_heading
     end
   end

--- a/app/components/provider_interface/course_change_warning_text_component.html.erb
+++ b/app/components/provider_interface/course_change_warning_text_component.html.erb
@@ -2,7 +2,7 @@
   <%= govuk_warning_text(text: 'The candidate will be sent an email to tell them that the course has been updated.') %>
 <% elsif application_choice.interviewing? %>
   <%= govuk_warning_text(
-    text: "The upcoming interview will be updated with the new course details.\n
-    The candidate will be sent emails to tell them that the course and the upcoming interview have been updated.",
+    text: "The upcoming #{'interview'.pluralize(application_choice.interviews.size)} will be updated with the new course details.<br><br>
+    The candidate will be sent emails to tell them that the course and the upcoming #{'interview'.pluralize(application_choice.interviews.size)} have been updated.".html_safe,
   ) %>
 <% end %>

--- a/app/components/provider_interface/course_details_component.rb
+++ b/app/components/provider_interface/course_details_component.rb
@@ -2,7 +2,7 @@ module ProviderInterface
   class CourseDetailsComponent < ChangeCourseDetailsComponent
     def rows
       [
-        { key: 'Training provider', value: provider_name_and_code },
+        { key: 'Training provider', value: provider_name },
         { key: 'Course', value: course_name_and_code },
         { key: 'Cycle', value: cycle },
         { key: 'Full or part time', value: study_mode },

--- a/app/components/provider_interface/course_summary_component.rb
+++ b/app/components/provider_interface/course_summary_component.rb
@@ -10,7 +10,7 @@ module ProviderInterface
       @course_option = course_option
       @provider_name = course_option.provider.name
       @course_name_and_code = course_option.course.name_and_code
-      @location_name_and_address = course_option.site.name_and_address
+      @location_name_and_address = course_option.site.name_and_address("\n")
       @study_mode = course_option.study_mode.humanize
       @funding_type = course_option.course.funding_type.humanize
     end

--- a/app/components/provider_interface/offer_summary_component.rb
+++ b/app/components/provider_interface/offer_summary_component.rb
@@ -44,7 +44,7 @@ module ProviderInterface
         },
         {
           key: 'Location',
-          value: course_option.site.name_and_address,
+          value: course_option.site.name_and_address("\n"),
           action: {
             href: change_location_path,
           },

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -11,15 +11,15 @@ class Site < ApplicationRecord
     "#{name} (#{code})"
   end
 
-  def full_address
+  def full_address(join_by = ', ')
     [address_line1, address_line2, address_line3, address_line4, postcode]
       .compact_blank
-      .join(', ')
+      .join(join_by)
   end
 
-  def name_and_address
+  def name_and_address(join_by = ', ')
     if full_address.present?
-      [name, full_address].join(', ')
+      [name, full_address(join_by)].join(join_by)
     else
       name
     end

--- a/app/views/provider_interface/offer/checks/edit.html.erb
+++ b/app/views/provider_interface/offer/checks/edit.html.erb
@@ -3,7 +3,7 @@
 
 <%= form_with model: @wizard, url: provider_interface_application_choice_offer_path(@application_choice), method: :put do |f| %>
   <h1 class="govuk-heading-l">
-    <span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
+    <span class="govuk-caption-l"><%= t('caption.update_offer', name: @application_choice.application_form.full_name) %></span>
     <%= t('.title') %>
   </h1>
 

--- a/app/views/provider_interface/offer/checks/new.html.erb
+++ b/app/views/provider_interface/offer/checks/new.html.erb
@@ -3,7 +3,7 @@
 
 <%= form_with model: @wizard, url: provider_interface_application_choice_offer_path(@application_choice), method: :post do |f| %>
   <h1 class="govuk-heading-l">
-    <span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
+    <span class="govuk-caption-l"><%= t('caption.make_offer', name: @application_choice.application_form.full_name) %></span>
     <%= t('.title') %>
   </h1>
 

--- a/app/views/provider_interface/offer/conditions/_form.html.erb
+++ b/app/views/provider_interface/offer/conditions/_form.html.erb
@@ -2,7 +2,7 @@
   <%= f.govuk_error_summary %>
 
   <h1 class="govuk-heading-l">
-    <span class="govuk-caption-l"><%= application_choice.application_form.full_name %></span>
+  <span class="govuk-caption-l"><%= form_caption %></span>
     <%= form_heading %>
   </h1>
 

--- a/app/views/provider_interface/offer/conditions/edit.html.erb
+++ b/app/views/provider_interface/offer/conditions/edit.html.erb
@@ -1,4 +1,4 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, :edit, back: true)) %>
 
-<%= render ProviderInterface::ConditionsFormComponent.new(form_object: @wizard, application_choice: @application_choice, form_method: :put, form_heading: t('.title')) %>
+<%= render ProviderInterface::ConditionsFormComponent.new(form_object: @wizard, application_choice: @application_choice, form_method: :put, form_caption: t('caption.update_offer', name: @application_choice.application_form.full_name), form_heading: t('.title')) %>

--- a/app/views/provider_interface/offer/conditions/new.html.erb
+++ b/app/views/provider_interface/offer/conditions/new.html.erb
@@ -1,4 +1,4 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, :new, back: true)) %>
 
-<%= render ProviderInterface::ConditionsFormComponent.new(form_object: @wizard, application_choice: @application_choice, form_method: :post, form_heading: t('.title')) %>
+<%= render ProviderInterface::ConditionsFormComponent.new(form_object: @wizard, application_choice: @application_choice, form_method: :post, form_caption: t('caption.make_offer', name: @application_choice.application_form.full_name), form_heading: t('.title')) %>

--- a/app/views/provider_interface/offer/courses/edit.html.erb
+++ b/app/views/provider_interface/offer/courses/edit.html.erb
@@ -11,7 +11,7 @@
                                          form_path: provider_interface_application_choice_offer_courses_path,
                                          form_method: :put,
                                          page_title: t('.title'),
-                                         caption: @application_choice.application_form.full_name) do %>
+                                         caption: t('caption.update_offer', name: @application_choice.application_form.full_name)) do %>
   <p class="govuk-body">
     <%= govuk_link_to t('cancel'), provider_interface_application_choice_offer_path(@application_choice) %>
   </p>

--- a/app/views/provider_interface/offer/courses/new.html.erb
+++ b/app/views/provider_interface/offer/courses/new.html.erb
@@ -10,7 +10,7 @@
                                          form_object: @wizard,
                                          form_path: provider_interface_application_choice_offer_courses_path,
                                          page_title: t('.title'),
-                                         caption: @application_choice.application_form.full_name) do %>
+                                         caption: t('caption.make_offer', name: @application_choice.application_form.full_name)) do %>
   <p class="govuk-body">
     <%= govuk_link_to t('cancel'), provider_interface_application_choice_path(@application_choice) %>
   </p>

--- a/app/views/provider_interface/offer/locations/edit.html.erb
+++ b/app/views/provider_interface/offer/locations/edit.html.erb
@@ -10,7 +10,7 @@
                                          form_path: provider_interface_application_choice_offer_locations_path,
                                          form_method: :put,
                                          page_title: t('.title'),
-                                         caption: @application_choice.application_form.full_name) do %>
+                                         caption: t('caption.update_offer', name: @application_choice.application_form.full_name)) do %>
   <p class="govuk-body">
     <%= govuk_link_to t('cancel'), provider_interface_application_choice_offer_path(@application_choice) %>
   </p>

--- a/app/views/provider_interface/offer/locations/new.html.erb
+++ b/app/views/provider_interface/offer/locations/new.html.erb
@@ -9,7 +9,7 @@
                                          form_object: @wizard,
                                          form_path: provider_interface_application_choice_offer_locations_path,
                                          page_title: t('.title'),
-                                         caption: @application_choice.application_form.full_name) do %>
+                                         caption: t('caption.make_offer', name: @application_choice.application_form.full_name)) do %>
   <p class="govuk-body">
     <%= govuk_link_to t('cancel'), provider_interface_application_choice_path(@application_choice) %>
   </p>

--- a/app/views/provider_interface/offer/providers/edit.html.erb
+++ b/app/views/provider_interface/offer/providers/edit.html.erb
@@ -10,7 +10,7 @@
                                          form_path: provider_interface_application_choice_offer_providers_path,
                                          form_method: :put,
                                          page_title: t('.title'),
-                                         caption: @application_choice.application_form.full_name) do %>
+                                         caption: t('caption.update_offer', name: @application_choice.application_form.full_name)) do %>
   <p class="govuk-body">
     <%= govuk_link_to t('cancel'), provider_interface_application_choice_offer_path(@application_choice) %>
   </p>

--- a/app/views/provider_interface/offer/providers/new.html.erb
+++ b/app/views/provider_interface/offer/providers/new.html.erb
@@ -9,7 +9,7 @@
                                          form_object: @wizard,
                                          form_path: provider_interface_application_choice_offer_providers_path,
                                          page_title: t('.title'),
-                                         caption: @application_choice.application_form.full_name) do %>
+                                         caption: t('caption.make_offer', name: @application_choice.application_form.full_name)) do %>
   <p class="govuk-body">
     <%= govuk_link_to t('cancel'), provider_interface_application_choice_path(@application_choice) %>
   </p>

--- a/app/views/provider_interface/offer/study_modes/edit.html.erb
+++ b/app/views/provider_interface/offer/study_modes/edit.html.erb
@@ -10,7 +10,7 @@
                                          form_path: provider_interface_application_choice_offer_study_modes_path,
                                          form_method: :put,
                                          page_title: t('.title'),
-                                         caption: @application_choice.application_form.full_name) do %>
+                                         caption: t('caption.update_offer', name: @application_choice.application_form.full_name)) do %>
   <p class="govuk-body">
     <%= govuk_link_to t('cancel'), provider_interface_application_choice_offer_path(@application_choice) %>
   </p>

--- a/app/views/provider_interface/offer/study_modes/new.html.erb
+++ b/app/views/provider_interface/offer/study_modes/new.html.erb
@@ -9,7 +9,7 @@
                                          form_object: @wizard,
                                          form_path: provider_interface_application_choice_offer_study_modes_path,
                                          page_title: t('.title'),
-                                         caption: @application_choice.application_form.full_name) do %>
+                                         caption: t('caption.make_offer', name: @application_choice.application_form.full_name)) do %>
   <p class="govuk-body">
     <%= govuk_link_to t('cancel'), provider_interface_application_choice_path(@application_choice) %>
   </p>

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -3,28 +3,28 @@ en:
     decisions:
       new:
         title: Make a decision
-        select:  Select decision
+        select:  Decision
     offer:
       providers:
         new:
-          title: Select training provider
+          title: Training provider
         edit:
-          title: Select training provider
+          title: Training provider
       courses:
         new:
-          title: Select course
+          title: Course
         edit:
-          title: Select course
+          title: Course
       locations:
         new:
-          title: Select location
+          title: Location
         edit:
-          title: Select location
+          title: Location
       study_modes:
         new:
-          title: Select full time or part time
+          title: Full time or part time
         edit:
-          title: Select full time or part time
+          title: Full time or part time
       conditions:
         new:
           title: Conditions of offer

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -1,4 +1,7 @@
 en:
+  caption:
+      make_offer: Make offer - %{name}
+      update_offer: Update offer - %{name}
   provider_interface:
     decisions:
       new:

--- a/spec/components/provider_interface/change_course_details_component_spec.rb
+++ b/spec/components/provider_interface/change_course_details_component_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
       render_text = row_text_selector(:provider, render)
 
       expect(render_text).to include('Training provider')
-      expect(render_text).to include('Best Training (B54)')
+      expect(render_text).to include('Best Training')
       expect(render_text).to include('Change')
     end
   end
@@ -113,7 +113,7 @@ RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
       render_text = row_text_selector(:provider, render)
 
       expect(render_text).to include('Training provider')
-      expect(render_text).to include('Best Training (B54)')
+      expect(render_text).to include('Best Training')
       expect(render_text).not_to include('Change')
     end
   end
@@ -168,7 +168,7 @@ RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
 
       expect(render_text).to include('Location')
       expect(render_text).to include('First Road (F34)')
-      expect(render_text).to include('Fountain Street, Morley, Leeds')
+      expect(render_text).to include("Fountain Street\nMorley\nLeeds")
       expect(render_text).to include('LS27 OPD')
       expect(render_text).not_to include('Change')
     end
@@ -182,7 +182,7 @@ RSpec.describe ProviderInterface::ChangeCourseDetailsComponent do
 
       expect(render_text).to include('Location')
       expect(render_text).to include('First Road (F34)')
-      expect(render_text).to include('Fountain Street, Morley, Leeds')
+      expect(render_text).to include("Fountain Street\nMorley\nLeeds")
       expect(render_text).to include('LS27 OPD')
       expect(render_text).to include('Change')
     end

--- a/spec/components/provider_interface/completed_offer_summary_component_spec.rb
+++ b/spec/components/provider_interface/completed_offer_summary_component_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe ProviderInterface::CompletedOfferSummaryComponent do
   it 'renders the new course option details' do
     expect(row_text_selector(:provider, render)).to include(course_option.provider.name)
     expect(row_text_selector(:course, render)).to include(course_option.course.name_and_code)
-    expect(row_text_selector(:location, render)).to include(course_option.site.name_and_address)
+    expect(row_text_selector(:location, render)).to include(course_option.site.full_address("\n"))
     expect(row_text_selector(:full_or_part_time, render)).to include(course_option.study_mode.humanize)
     expect(row_text_selector(:accredited_provider, render)).to include(course_option.course.accredited_provider.name_and_code)
     expect(row_text_selector(:qualification, render)).to include('PGCE with QTS')

--- a/spec/components/provider_interface/conditions_form_component_spec.rb
+++ b/spec/components/provider_interface/conditions_form_component_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe ProviderInterface::ConditionsFormComponent do
       application_choice: application_choice,
       form_object: form_object,
       form_method: :post,
+      form_caption: 'Caption',
       form_heading: 'Title',
     )
   end

--- a/spec/components/provider_interface/course_change_warning_text_component_spec.rb
+++ b/spec/components/provider_interface/course_change_warning_text_component_spec.rb
@@ -23,12 +23,21 @@ RSpec.describe ProviderInterface::CourseChangeWarningTextComponent do
                   ))
   end
 
-  context 'when there are interviews' do
+  context 'when there is an interview' do
     let(:application_choice) { create(:application_choice, :with_scheduled_interview) }
 
     it 'renders the warning text' do
-      expect(render.css('.govuk-warning-text').text).to eq "!WarningThe upcoming interview will be updated with the new course details.\n
-    The candidate will be sent emails to tell them that the course and the upcoming interview have been updated."
+      expect(render.css('.govuk-warning-text').text).to include '!WarningThe upcoming interview will be updated with the new course details.'
+      expect(render.css('.govuk-warning-text').text).to include 'The candidate will be sent emails to tell them that the course and the upcoming interview have been updated.'
+    end
+  end
+
+  context 'when there are multiple interviews' do
+    let(:application_choice) { create(:application_choice, status: :interviewing, interviews: create_list(:interview, 2)) }
+
+    it 'renders the warning text' do
+      expect(render.css('.govuk-warning-text').text).to include '!WarningThe upcoming interviews will be updated with the new course details.'
+      expect(render.css('.govuk-warning-text').text).to include 'The candidate will be sent emails to tell them that the course and the upcoming interviews have been updated.'
     end
   end
 

--- a/spec/components/provider_interface/course_details_component_spec.rb
+++ b/spec/components/provider_interface/course_details_component_spec.rb
@@ -105,11 +105,11 @@ RSpec.describe ProviderInterface::CourseDetailsComponent do
     render.css('.govuk-summary-list__row')[rows[row_name]].text
   end
 
-  it 'renders the provider name and code' do
+  it 'renders the provider name' do
     render_text = row_text_selector(:provider, render)
 
     expect(render_text).to include('Training provider')
-    expect(render_text).to include('Best Training (B54)')
+    expect(render_text).to include('Best Training')
   end
 
   context 'when an accredited body is present' do
@@ -119,7 +119,7 @@ RSpec.describe ProviderInterface::CourseDetailsComponent do
       render_text = row_text_selector(:accredited_body, render)
 
       expect(render_text).to include('Accredited body')
-      expect(render_text).to include('Accredit Now (A78)')
+      expect(render_text).to include('Accredit Now')
     end
   end
 
@@ -128,7 +128,7 @@ RSpec.describe ProviderInterface::CourseDetailsComponent do
       render_text = row_text_selector(:accredited_body, render)
 
       expect(render_text).to include('Accredited body')
-      expect(render_text).to include('Best Training (B54)')
+      expect(render_text).to include('Best Training')
     end
   end
 
@@ -151,7 +151,7 @@ RSpec.describe ProviderInterface::CourseDetailsComponent do
 
     expect(render_text).to include('Location')
     expect(render_text).to include('First Road (F34)')
-    expect(render_text).to include('Fountain Street, Morley, Leeds')
+    expect(render_text).to include("Fountain Street\nMorley\nLeeds")
     expect(render_text).to include('LS27 OPD')
   end
 

--- a/spec/components/provider_interface/course_summary_component_spec.rb
+++ b/spec/components/provider_interface/course_summary_component_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe ProviderInterface::CourseSummaryComponent do
     render_text = row_text_selector(:location, render)
 
     expect(render_text).to include('Location')
-    expect(render_text).to include('First Road, Fountain Street, Morley, Leeds, LS27 OPD')
+    expect(render_text).to include("Fountain Street\nMorley\nLeeds\nLS27 OPD")
   end
 
   it 'renders the study mode' do

--- a/spec/components/provider_interface/offer_summary_component_spec.rb
+++ b/spec/components/provider_interface/offer_summary_component_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe ProviderInterface::OfferSummaryComponent do
   it 'renders the new course option details' do
     expect(row_text_selector(:provider, render)).to include(course_option.provider.name)
     expect(row_text_selector(:course, render)).to include(course_option.course.name_and_code)
-    expect(row_text_selector(:location, render)).to include(course_option.site.name_and_address)
+    expect(row_text_selector(:location, render)).to include(course_option.site.full_address("\n"))
     expect(row_text_selector(:full_or_part_time, render)).to include(course_option.study_mode.humanize)
     expect(row_text_selector(:qualification, render)).to include('PGCE with QTS')
     expect(row_text_selector(:funding_type, render)).to include(course_option.course.funding_type.humanize)

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Site, type: :model do
   end
 
   describe '#full_address' do
-    it 'concatenates the address lines and postcode' do
-      site = build(
+    let(:site) do
+      build(
         :site,
         address_line1: 'Gorse SCITT',
         address_line2: 'C/O The Bruntcliffe Academy',
@@ -18,7 +18,9 @@ RSpec.describe Site, type: :model do
         address_line4: 'MORLEY, LEEDS',
         postcode: 'LS27 0LZ',
       )
+    end
 
+    it 'concatenates the address lines and postcode' do
       expect(site.full_address).to eq('Gorse SCITT, C/O The Bruntcliffe Academy, Bruntcliffe Lane, MORLEY, LEEDS, LS27 0LZ')
     end
 
@@ -33,6 +35,10 @@ RSpec.describe Site, type: :model do
       )
 
       expect(site.full_address).to eq('C/O The Bruntcliffe Academy, MORLEY, LEEDS, LS27 0LZ')
+    end
+
+    it 'concatenates by new lines if passed in' do
+      expect(site.full_address("\n")).to eq("Gorse SCITT\nC/O The Bruntcliffe Academy\nBruntcliffe Lane\nMORLEY, LEEDS\nLS27 0LZ")
     end
   end
 

--- a/spec/system/provider_interface/change_existing_offer_spec.rb
+++ b/spec/system/provider_interface/change_existing_offer_spec.rb
@@ -140,7 +140,7 @@ RSpec.feature 'Provider changes an existing offer' do
   end
 
   def then_i_am_taken_to_the_change_provider_page
-    expect(page).to have_content('Select training provider')
+    expect(page).to have_content('Training provider')
   end
 
   def when_i_select_a_different_provider
@@ -202,7 +202,7 @@ RSpec.feature 'Provider changes an existing offer' do
       expect(page).to have_content(@selected_provider.name_and_code)
       expect(page).to have_content(@selected_course.name_and_code)
       expect(page).to have_content(@selected_course_option.study_mode.humanize)
-      expect(page).to have_content(@selected_course_option.site.name_and_address)
+      expect(page).to have_content(@selected_course_option.site.name_and_address(' '))
       expect(page).to have_content('Fitness to train to teach check')
       expect(page).to have_content('Be cool')
       expect(page).to have_content('A* on Maths A Level')

--- a/spec/system/provider_interface/change_make_offer_spec.rb
+++ b/spec/system/provider_interface/change_make_offer_spec.rb
@@ -176,7 +176,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def then_i_am_taken_to_the_change_provider_page
-    expect(page).to have_content('Select training provider')
+    expect(page).to have_content('Training provider')
   end
 
   def when_i_select_a_different_provider
@@ -188,7 +188,7 @@ RSpec.feature 'Provider makes an offer' do
       expect(page).to have_content(@selected_provider.name_and_code)
       expect(page).to have_content(@selected_course.name_and_code)
       expect(page).to have_content(@selected_course_option.study_mode.humanize)
-      expect(page).to have_content(@selected_course_option.site.name_and_address)
+      expect(page).to have_content(@selected_course_option.site.name_and_address(' '))
     end
   end
 

--- a/spec/system/provider_interface/make_offer_spec.rb
+++ b/spec/system/provider_interface/make_offer_spec.rb
@@ -154,7 +154,7 @@ RSpec.feature 'Provider makes an offer' do
 
   def and_i_can_confirm_the_new_location_selection
     within(all('.govuk-summary-list__row')[3]) do
-      expect(page).to have_content(@selected_course_option.site.name_and_address)
+      expect(page).to have_content(@selected_course_option.site.name_and_address(' '))
     end
   end
 
@@ -194,7 +194,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def then_i_am_taken_to_the_change_course_page
-    expect(page).to have_content('Select course')
+    expect(page).to have_content('Course')
   end
 
   def and_i_can_confirm_the_new_course_selection
@@ -243,7 +243,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def then_i_am_taken_to_the_change_provider_page
-    expect(page).to have_content('Select training provider')
+    expect(page).to have_content('Training provider')
   end
 
   def when_i_select_a_different_provider

--- a/spec/system/provider_interface/provider_changes_a_course_before_point_of_offer_spec.rb
+++ b/spec/system/provider_interface/provider_changes_a_course_before_point_of_offer_spec.rb
@@ -232,8 +232,8 @@ RSpec.feature 'Provider changes a course' do
   end
 
   def then_i_see_the_changed_offer_details
-    within(all('.govuk-summary-list')[3]) do
-      expect(page).to have_content(@one_mode_and_location_course.provider.name_and_code)
+    within(all('.govuk-summary-list')[2]) do
+      expect(page).to have_content(@one_mode_and_location_course.provider.name)
       expect(page).to have_content(@one_mode_and_location_course.name_and_code)
       expect(page).to have_content(@one_mode_and_location_course.study_mode.humanize)
       expect(page).to have_content(@one_mode_and_location_course_option.site.name_and_code)

--- a/spec/system/provider_interface/provider_changes_a_course_before_point_of_offer_spec.rb
+++ b/spec/system/provider_interface/provider_changes_a_course_before_point_of_offer_spec.rb
@@ -232,7 +232,7 @@ RSpec.feature 'Provider changes a course' do
   end
 
   def then_i_see_the_changed_offer_details
-    within(all('.govuk-summary-list')[2]) do
+    within(all('.govuk-summary-list')[3]) do
       expect(page).to have_content(@one_mode_and_location_course.provider.name)
       expect(page).to have_content(@one_mode_and_location_course.name_and_code)
       expect(page).to have_content(@one_mode_and_location_course.study_mode.humanize)

--- a/spec/system/provider_interface/provider_reinstates_deferred_offer_spec.rb
+++ b/spec/system/provider_interface/provider_reinstates_deferred_offer_spec.rb
@@ -102,7 +102,7 @@ RSpec.feature 'Provider reinstates deferred offer' do
   end
 
   def then_i_can_see_the_details_of_the_deferred_offer
-    expect(page).to have_content choices[:reinstatable].current_course_option.site.name_and_address
+    expect(page).to have_content choices[:reinstatable].current_course_option.site.full_address
   end
 
   def and_i_can_specify_if_offer_conditions_are_still_met
@@ -116,7 +116,7 @@ RSpec.feature 'Provider reinstates deferred offer' do
   end
 
   def and_i_can_review_the_new_offer_conditions_and_details
-    expect(page).to have_content choices[:reinstatable].current_course_option.site.name_and_address
+    expect(page).to have_content choices[:reinstatable].current_course_option.site.full_address
   end
 
   def when_i_click_to_reinstate_the_offer


### PR DESCRIPTION
## Context

With the introduction of the change course flow we've updated how these components appear – this needs to be reflected in the make offer flow, which follows a similar pattern.

## Changes proposed in this pull request

Mainly small changes to the headers and captions but there's a slightly meatier change to a number of components as we no longer render the 'Locations' row with the provider name and it's also been changed to be separated by new lines, rather than commas.

## Guidance to review

[Design history](https://bat-design-history.netlify.app/manage-teacher-training-applications/updating-make-offer-and-change-offer/)

## Link to Trello card

https://trello.com/c/jCDeohpQ

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
