### PR TITLE
Course Change - expose provider_ids from original_course_option

### DIFF
--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -221,6 +221,8 @@ private
 
   def provider_ids_for_access
     [
+      original_course_option.course.provider.id,
+      original_course_option.course.accredited_provider&.id,
       course_option.course.provider.id,
       course_option.course.accredited_provider&.id,
       current_course_option.course.provider.id,

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -352,18 +352,21 @@ RSpec.describe ApplicationChoice, type: :model do
           .to change(application_choice, :provider_ids).to(expected_ids)
       end
 
-      it 'updates provider_ids if the course is updated' do
+      it 'updates course_option and current_course_option provider_ids if new courses are provided' do
+        new_course = create(:course, :with_accredited_provider)
+        new_course_option = create(:course_option, course: new_course)
         changed_course = create(:course, :with_accredited_provider)
         changed_course_option = create(:course_option, course: changed_course)
 
         expected_ids = [
+          application_choice.original_course_option.course.provider.id,
           changed_course_option.provider.id,
           changed_course_option.accredited_provider.id,
-          course.provider.id,
-          course.accredited_provider.id,
+          new_course.provider.id,
+          new_course.accredited_provider.id,
         ]
 
-        expect { application_choice.update_course_option_and_associated_fields!(course_option, other_fields: { course_option: changed_course_option }) }
+        expect { application_choice.update_course_option_and_associated_fields!(new_course_option, other_fields: { course_option: changed_course_option }) }
           .to change(application_choice, :provider_ids).to(expected_ids)
       end
     end


### PR DESCRIPTION
## Context

We added a new attribute to an application choice: `original_course_option` . This attribute includes the associated provider/accredited provider ids. We are currently only writing to these attributes, but not reading them.

## Changes proposed in this pull request

add
```
original_course_option.course.provider.id,
original_course_option.course.accredited_provider&.id,
```
to `provider_ids_for_access`

## Link to Trello card

https://trello.com/c/y10MFm3U

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
