### PR TITLE
Add course_changed_at to ApplicationChoices - Update service

### DIFF
--- a/app/services/change_course.rb
+++ b/app/services/change_course.rb
@@ -21,7 +21,10 @@ class ChangeCourse
         ActiveRecord::Base.transaction do
           application_choice.update_course_option_and_associated_fields!(
             course_option,
-            other_fields: { course_option: course_option },
+            other_fields: {
+              course_option: course_option,
+              course_changed_at: Time.zone.now,
+            },
           )
           update_interviews_provider_service.save!
         end

--- a/spec/services/change_course_spec.rb
+++ b/spec/services/change_course_spec.rb
@@ -56,6 +56,15 @@ RSpec.describe ChangeCourse do
         expect(application_choice).to have_received(:update_course_option_and_associated_fields!)
         expect(update_interviews_provider_service).to have_received(:save!)
       end
+
+      it 'sets the course_changed_at attribute' do
+        time = Time.zone.now
+        Timecop.freeze(time) do
+          change_course.save!
+
+          expect(application_choice.reload.course_changed_at).to be_within(1.second).of(time)
+        end
+      end
     end
 
     describe 'if the change is invalid' do


### PR DESCRIPTION
## Context

We need to log when a user changes a course choice on an application, prior to an offer being made.

## Changes proposed in this pull request

Update the `ChangeCourse` `save!` method service to write the time of the action to `course_changed_at`.

## Link to Trello card

https://trello.com/c/4OAeVYKU/4999-course-change-add-timestamp

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
