### PR TITLE
Replace application number on provider application page

### DIFF
--- a/app/components/provider_interface/application_summary_component.rb
+++ b/app/components/provider_interface/application_summary_component.rb
@@ -6,16 +6,25 @@ module ProviderInterface
              :submitted_at,
              to: :application_form
 
-    def initialize(application_form:)
-      @application_form = application_form
+    def initialize(application_choice:)
+      @application_choice = application_choice
+      @application_form = application_choice.application_form
     end
 
     def rows
-      [
-        submitted_row,
-        recruitment_cycle_year,
-        support_reference_row,
-      ].compact
+      if FeatureFlag.active?(:application_number_replacement)
+        [
+          submitted_row,
+          recruitment_cycle_year,
+          application_number_row,
+        ].compact
+      else
+        [
+          submitted_row,
+          recruitment_cycle_year,
+          support_reference_row,
+        ].compact
+      end
     end
 
   private
@@ -43,10 +52,17 @@ module ProviderInterface
       }
     end
 
+    def application_number_row
+      {
+        key: 'Application number',
+        value: application_choice.id,
+      }
+    end
+
     def recruitment_cycle_year_name
       RecruitmentCycle.cycle_string(application_form.recruitment_cycle_year)
     end
 
-    attr_reader :application_form
+    attr_reader :application_form, :application_choice
   end
 end

--- a/app/components/provider_interface/personal_information_component.rb
+++ b/app/components/provider_interface/personal_information_component.rb
@@ -79,6 +79,8 @@ module ProviderInterface
     end
 
     def candidate_id_row
+      return if FeatureFlag.active?(:application_number_replacement)
+
       {
         key: 'Candidate ID',
         value: candidate.public_id,

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -36,6 +36,7 @@ class FeatureFlag
     [:structured_reasons_for_rejection_redesign, 'Latest iteration of structured reasons for rejection', 'Steve Laing'],
     [:candidate_nudge_emails, 'Sends nudge emails to candidates that have unsubmitted but completed applications', 'Steve Hook'],
     [:new_degree_flow, 'Allows us to use the new degree flow', 'Jon Filar'],
+    [:application_number_replacement, 'Replaces reference number and candidate ID with application choice ID', 'Carlos Martinez'],
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -29,7 +29,7 @@
   <h2 class="govuk-heading-m govuk-!-font-size-27">Application details</h2>
 
   <div class="govuk-!-width-two-thirds">
-    <%= render ProviderInterface::ApplicationSummaryComponent.new(application_form: @application_choice.application_form) %>
+    <%= render ProviderInterface::ApplicationSummaryComponent.new(application_choice: @application_choice) %>
   </div>
 </section>
 

--- a/spec/components/provider_interface/application_summary_component_spec.rb
+++ b/spec/components/provider_interface/application_summary_component_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ApplicationSummaryComponent do
+  describe '#rows' do
+    let(:application_choice) { create(:application_choice, :with_completed_application_form) }
+
+    subject { described_class.new(application_choice: application_choice).rows }
+
+    context 'application_number_replacement feature activated' do
+      before { FeatureFlag.activate(:application_number_replacement) }
+
+      let(:expected) { { key: 'Application number', value: application_choice.id } }
+
+      it { is_expected.to include(expected) }
+    end
+
+    context 'application_number_replacement feature deactivated' do
+      before { FeatureFlag.deactivate(:application_number_replacement) }
+
+      let(:expected) { { key: 'Reference', value: application_choice.application_form.support_reference } }
+
+      it { is_expected.to include(expected) }
+    end
+  end
+end

--- a/spec/components/provider_interface/personal_information_component_spec.rb
+++ b/spec/components/provider_interface/personal_information_component_spec.rb
@@ -14,9 +14,31 @@ RSpec.describe ProviderInterface::PersonalInformationComponent do
 
   subject(:result) { render_inline(described_class.new(application_form: application_form)) }
 
-  it 'renders component with correct labels' do
-    ['First name', 'Last name', 'Date of birth', 'Nationality', 'Candidate ID'].each do |key|
-      expect(result.css('.govuk-summary-list__key').text).to include(key)
+  context 'application_number_replacement feature deactivated' do
+    before { FeatureFlag.deactivate(:application_number_replacement) }
+
+    it 'renders component with correct labels' do
+      ['First name', 'Last name', 'Date of birth', 'Nationality', 'Candidate ID'].each do |key|
+        expect(result.css('.govuk-summary-list__key').text).to include(key)
+      end
+    end
+
+    it 'renders the candidate’s public ID' do
+      expect(result.css('.govuk-summary-list__value').text).to include("C#{application_form.candidate.id}")
+    end
+  end
+
+  context 'application_number_replacement feature activated' do
+    before { FeatureFlag.activate(:application_number_replacement) }
+
+    it 'renders component with correct labels' do
+      ['First name', 'Last name', 'Date of birth', 'Nationality'].each do |key|
+        expect(result.css('.govuk-summary-list__key').text).to include(key)
+      end
+    end
+
+    it 'does not render the candidate’s public ID' do
+      expect(result.css('.govuk-summary-list__value').text).not_to include("C#{application_form.candidate.id}")
     end
   end
 
@@ -34,10 +56,6 @@ RSpec.describe ProviderInterface::PersonalInformationComponent do
 
   it 'renders the candidates nationalities' do
     expect(result.css('.govuk-summary-list__value').text).to include('British, Irish and Spanish')
-  end
-
-  it 'renders the candidate’s public ID' do
-    expect(result.css('.govuk-summary-list__value').text).to include("C#{application_form.candidate.id}")
   end
 
   it 'does not render right to work fields if nationality is British or Irish' do

--- a/spec/system/provider_interface/provider_changes_a_course_before_point_of_offer_spec.rb
+++ b/spec/system/provider_interface/provider_changes_a_course_before_point_of_offer_spec.rb
@@ -142,7 +142,7 @@ RSpec.feature 'Provider changes a course' do
   end
 
   def and_i_click_on_change_the_training_provider
-    within(all('.govuk-summary-list__row')[11]) do
+    within(all('.govuk-summary-list__row').find { |e| e.text.include?('Training provider') }) do
       click_on 'Change'
     end
   end

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -77,7 +77,12 @@ RSpec.feature 'See applications' do
   end
 
   def then_i_should_be_on_the_application_view_page
-    expect(page).to have_content @my_provider_choice1.application_form.support_reference
+    if FeatureFlag.active?(:application_number_replacement)
+      expect(page).to have_content @my_provider_choice1.id
+    else
+      expect(page).to have_content @my_provider_choice1.application_form.support_reference
+    end
+
     expect(page).to have_content @my_provider_choice1.application_form.full_name
   end
 end


### PR DESCRIPTION
## Context

Research shows that providers find the reference numbers confusing.

## Changes proposed in this pull request

In the provider application detail page, behind a feature flag (`:application_number_replacement`):

1. Remove ”reference number“
2. Add “application number”
3. Remove “candidate ID”

## Guidance to review

- Go to a provider application detail page
- View with feature application_number_replacement activated 
- View with feature application_number_replacement deactivated 

## Link to Trello card

https://trello.com/c/8AnslFdH/5007-feature-flag-for-application-number-replacement
https://trello.com/c/0JIbH4aX/5008-replace-application-number-for-application-page

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
