### PR TITLE
5028 replace application number in application search

### DIFF
--- a/app/components/provider_interface/application_card_component.html.erb
+++ b/app/components/provider_interface/application_card_component.html.erb
@@ -2,7 +2,9 @@
   <header class="app-application-card__header">
     <h3 class="govuk-heading-s">
       <%= govuk_link_to candidate_name, provider_interface_application_choice_path(application_choice), no_visited_state: true %>
-      <span class="app-application-card__caption"><%= application_choice.application_form.support_reference %></span>
+      <span class="app-application-card__caption">
+        <%= FeatureFlag.active?(:application_number_replacement) ? application_choice.id : application_choice.application_form.support_reference %>
+      </span>
     </h3>
     <%= render ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice) %>
   </header>

--- a/app/components/utility/filter_component.html.erb
+++ b/app/components/utility/filter_component.html.erb
@@ -115,7 +115,11 @@
           <% end %>
           <div class="govuk-form-group">
             <label class="govuk-label app-search__label govuk-label--m" for="<%= primary_filter[:name] %>">
-              Search by candidate name or reference
+              <% if FeatureFlag.active?(:application_number_replacement) %>
+                Search by candidate name or application number
+              <% else %>
+                Search by candidate name or reference
+              <% end %>
             </label>
 
             <input class="govuk-input app-search__input <%= primary_filter[:css_classes] %>" id="<%= primary_filter[:name] %>" name="<%= primary_filter[:name] %>" type="text" value="<%= primary_filter[:value] %>" aria-labelledby="filter-legend-<%= primary_filter[:name] %>" autocomplete="off">

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -73,6 +73,10 @@ class FeatureFlag
     feature_statuses[feature_name].presence || false
   end
 
+  def self.inactive?(feature_name)
+    !active?(feature_name)
+  end
+
   def self.sync_with_database(feature_name, active)
     feature = Feature.find_or_initialize_by(name: feature_name)
     feature.active = active

--- a/spec/components/provider_interface/application_card_component_spec.rb
+++ b/spec/components/provider_interface/application_card_component_spec.rb
@@ -147,6 +147,22 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
         expect(result.css('[data-qa="provider"]').text).to include('Hoth Teacher Training')
       end
     end
+
+    context 'when the application_number_replacement flag is active' do
+      before { FeatureFlag.activate(:application_number_replacement) }
+
+      it 'renders the application number' do
+        expect(card).to include(application_choice.id.to_fs)
+      end
+    end
+
+    context 'when the application_number_replacement flag is inactive' do
+      before { FeatureFlag.deactivate(:application_number_replacement) }
+
+      it 'renders the support reference' do
+        expect(card).to include(application_choice.application_form.support_reference)
+      end
+    end
   end
 
   describe '#days_to_respond_text' do

--- a/spec/services/feature_flag_spec.rb
+++ b/spec/services/feature_flag_spec.rb
@@ -34,4 +34,46 @@ RSpec.describe FeatureFlag do
       )
     end
   end
+
+  describe '.active?' do
+    let(:feature) { Feature.create_or_find_by(name: 'dfe_sign_in_fallback') }
+
+    subject { described_class.active?(:dfe_sign_in_fallback) }
+
+    context 'feature is inactive' do
+      before { feature.update!(active: false) }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'feature is active' do
+      before { feature.update!(active: true) }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'feature does not exist' do
+      it do
+        expect { described_class.active?(:not_a_real_feature) }.to raise_error(StandardError)
+      end
+    end
+  end
+
+  describe '.inactive?' do
+    let(:feature) { Feature.create_or_find_by(name: 'dfe_sign_in_fallback') }
+
+    subject { described_class.inactive?(:dfe_sign_in_fallback) }
+
+    context 'feature is inactive' do
+      before { feature.update!(active: false) }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'feature is active' do
+      before { feature.update!(active: true) }
+
+      it { is_expected.to be_falsey }
+    end
+  end
 end

--- a/spec/system/provider_interface/provider_applications_search_spec.rb
+++ b/spec/system/provider_interface/provider_applications_search_spec.rb
@@ -13,6 +13,7 @@ RSpec.feature 'Providers should be able to filter applications' do
     and_i_am_permitted_to_see_applications_from_multiple_providers
     and_my_organisation_has_courses_with_applications
     and_i_sign_in_to_the_provider_interface
+    and_the_application_number_feature_flag_is_deactivated
 
     when_i_visit_the_provider_page
 
@@ -60,8 +61,37 @@ RSpec.feature 'Providers should be able to filter applications' do
     and_the_relevant_tags_should_be_visible
   end
 
+  scenario 'can search applications by application number' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_am_permitted_to_see_applications_from_multiple_providers
+    and_my_organisation_has_courses_with_applications
+    and_i_sign_in_to_the_provider_interface
+    and_the_application_number_feature_flag_is_activated
+    when_i_visit_the_provider_page
+    and_i_search_by_application_number
+    then_the_application_with_that_id_should_be_visible
+  end
+
+  def then_the_application_with_that_id_should_be_visible
+    card = find(:css, '.app-application-cards')
+    expect(card).to have_text(current_provider.application_choices.first.application_form.full_name)
+  end
+
   def when_i_search_for_part_of_a_candidate_name
     fill_in 'Search by candidate name or reference', with: 'ame'
+    click_button('Search')
+  end
+
+  def and_the_application_number_feature_flag_is_activated
+    FeatureFlag.activate(:application_number_replacement)
+  end
+
+  def and_the_application_number_feature_flag_is_deactivated
+    FeatureFlag.deactivate(:application_number_replacement)
+  end
+
+  def and_i_search_by_application_number
+    fill_in 'Search by candidate name or application number', with: current_provider.application_choices.first.id
     click_button('Search')
   end
 


### PR DESCRIPTION
## Context

https://trello.com/c/70yEAIev/5028-replace-application-number-in-application-search

## Changes proposed in this pull request

Adding the application number to the application search. Behind the
:application_number_replacement feature flag.

## Guidance to review

With the `:application_number_replacement` feature flag switched on, search for an application by application number (`application_choice.id`). This should return the corresponding application. 

We've also left in the support_reference search rather than removing it, as it didn't make much sense to remove it.
