### PR TITLE
Select specific fields when returning a list of TAD exports

### DIFF
--- a/app/controllers/data_api/tad_data_exports_controller.rb
+++ b/app/controllers/data_api/tad_data_exports_controller.rb
@@ -94,6 +94,7 @@ module DataAPI
 
     def exports
       DataAPI::TADExport.all
+      .select(:completed_at, :name, :id, :updated_at)
       .where('updated_at > ?', updated_since_params)
     end
 


### PR DESCRIPTION
## Context

TAD have reported a query to list exports since an updated date timing out: ‘https://www.apply-for-teacher-training.service.gov.uk/data-api/tad-data-exports?updated_since=2022-01-01’

Although there are only 90 records available, we are retrieving records with the data field populated which takes time and the endpoint times out

## Changes proposed in this pull request

Select the specific fields we would like to surface on the application list page to ensure the query is timely
## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
