### PR TITLE
Allow words to be used to input the month

### DIFF
--- a/app/helpers/date_validation_helper.rb
+++ b/app/helpers/date_validation_helper.rb
@@ -3,6 +3,11 @@ module DateValidationHelper
     raise ArgumentError if year.blank?
 
     date_args = [year, month, 1].map(&:to_i)
+
+    if date_args[1].zero?
+      date_args[1] = Date.parse(month).month
+    end
+
     Date.new(*date_args)
   rescue ArgumentError, RangeError
     Struct.new(:day, :month, :year).new(1, month, year)

--- a/spec/helpers/date_validation_helper_spec.rb
+++ b/spec/helpers/date_validation_helper_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe DateValidationHelper, type: :helper do
     let(:month) { '12' }
     let(:expected_month) { month }
 
-    subject { valid_or_invalid_date(year, month) }
+    subject(:date) { valid_or_invalid_date(year, month) }
 
     it_behaves_like 'a date that is valid'
 
@@ -49,12 +49,6 @@ RSpec.describe DateValidationHelper, type: :helper do
       it_behaves_like 'a date that is invalid'
     end
 
-    context 'when the month includes non-numerics' do
-      let(:month) { 'december' }
-
-      it_behaves_like 'a date that is invalid'
-    end
-
     context 'when the year is blank' do
       let(:year) { '' }
 
@@ -75,6 +69,39 @@ RSpec.describe DateValidationHelper, type: :helper do
 
     context 'when the year includes non-numerics' do
       let(:month) { 'last year' }
+
+      it_behaves_like 'a date that is invalid'
+    end
+
+    context 'when the month is written in words' do
+      let(:month) { 'december' }
+
+      it 'returns a valid date' do
+        expect(date).to be_a(Date)
+        expect(date).to have_attributes(year: year.to_i, month: 12, day: 1)
+      end
+    end
+
+    context 'when the short hand month is written in words' do
+      let(:month) { 'jun' }
+
+      it 'returns a valid date' do
+        expect(date).to be_a(Date)
+        expect(date).to have_attributes(year: year.to_i, month: 6, day: 1)
+      end
+    end
+
+    context 'when the short hand month is written in caps' do
+      let(:month) { 'FEB' }
+
+      it 'returns a valid date' do
+        expect(date).to be_a(Date)
+        expect(date).to have_attributes(year: year.to_i, month: 2, day: 1)
+      end
+    end
+
+    context 'when the month is not a human readable month' do
+      let(:month) { 'foo' }
 
       it_behaves_like 'a date that is invalid'
     end


### PR DESCRIPTION
## Context

We've found, from a regular review of error messages, that many candidates are struggling with inputting months into their job and volunteering history pages. For example, they're typing `September` or `Sep`.

## Changes proposed in this pull request

- Allow shorthand words to be used to input the month
- Allow longhand words to be used to input the month
- The word will still be saved in `Date` format in the database
- Utilise `Date.parse` in `DateValidationHelper`
- This will affect the following forms: `job_form`, `work_history_break_form` and `volunteering_role_form`

## Guidance to review

- Is it OK to use `date_args[1].zero?` as the checker? 

## Link to Trello card

https://trello.com/c/ZJgvW3x4/4555-on-our-volunteering-and-job-info-pages-allow-candidates-to-use-shortened-month-names-or-whole-month-names-instead-of-a-number
