### PR TITLE
Fix download in collate-and-compare-coverage job

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -302,6 +302,20 @@ jobs:
           path: coverage/.last_run.json
           retention-days: 5
 
+      # Workaround for https://github.com/dawidd6/action-download-artifact/issues/147
+      - name: Get Run ID
+        id: get_run_id
+        run: |
+          echo "::set-output name=run_id::$(\
+            gh run list \
+              --workflow build-and-deploy.yml \
+              --limit 100 \
+              --json conclusion,status,databaseId,headBranch \
+              --jq ". | map(select( .conclusion == \"success\" and .headBranch == \"main\")) | first(.[]).databaseId" \
+          )"
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
       - name: Download main branch coverage artifact
         id: download-base-coverage
         uses: dawidd6/action-download-artifact@v2
@@ -309,10 +323,9 @@ jobs:
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           workflow: build-and-deploy.yml
-          workflow_conclusion: success
-          branch: main
           name: base-coverage
           path: base-coverage/
+          run_id: ${{steps.get_run_id.outputs.run_id}} # Woraround for https://github.com/dawidd6/action-download-artifact/issues/147, revert to workflow_conclusion & branch when no longer needed
 
       - name: Output base coverage results
         id: output_base_coverage


### PR DESCRIPTION
## Context
The download step in collate-and-compare-coverage workflow is failing due to an issue with GitHub indexes. 

https://github.com/dawidd6/action-download-artifact/issues/147

## Changes proposed in this pull request
This workaround uses `gh` utility to get the workflow that the artifact is downloaded from.

## Guidance to review
- Check correct run_id is used to get base-coverage artifact

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
