### PR TITLE
Handle missing end dates gracefully in JobComponent

### DIFF
--- a/app/components/shared/restructured_work_history/job_component.rb
+++ b/app/components/shared/restructured_work_history/job_component.rb
@@ -26,7 +26,7 @@ module RestructuredWorkHistory
     end
 
     def formatted_end_date
-      if @work_experience.currently_working
+      if @work_experience.currently_working || @work_experience.end_date.nil?
         'to Present'
       elsif @work_experience.start_date == @work_experience.end_date
         nil

--- a/spec/components/shared/restructured_work_history/job_component_spec.rb
+++ b/spec/components/shared/restructured_work_history/job_component_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe RestructuredWorkHistory::JobComponent do
+  describe 'when the start and end date are set' do
+    let(:work_experience) do
+      build_stubbed(
+        :application_work_experience,
+        start_date_unknown: true,
+        start_date: Date.new(2020, 1, 1),
+        end_date_unknown: false,
+        end_date: Date.new(2021, 12, 31),
+      )
+    end
+
+    it 'renders the start and end dates' do
+      result = render_inline(described_class.new(work_experience: work_experience))
+      expect(result.text.strip).to include('Jan 2020 (estimate) to Dec 2021')
+    end
+  end
+
+  describe 'when only the start date is set' do
+    let(:work_experience) do
+      build_stubbed(
+        :application_work_experience,
+        start_date_unknown: false,
+        start_date: Date.new(2020, 1, 1),
+        end_date_unknown: nil,
+        end_date: nil,
+      )
+    end
+
+    it 'renders the start date correctly' do
+      result = render_inline(described_class.new(work_experience: work_experience))
+      expect(result.text.strip).to include('Jan 2020 to Present')
+    end
+  end
+end


### PR DESCRIPTION
## Context

The `JobComponent` is handling older records now that https://github.com/DFE-Digital/apply-for-teacher-training/pull/6797 has been merged. In production there are a number of older work experience records that have both `end_date` and `currently_working` set to `nil`. 

https://sentry.io/organizations/dfe-teacher-services/issues/3192889751/?project=1765973&referrer=slack

## Changes proposed in this pull request

This PR adds a bit of defensive code handle `nil` values for `end_date` in the same way that volunteering experiences are handled, e.g. https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/app/components/shared/work_history_item_component.rb#L560

All `start_date` values in the production DB are set so I don't think we have to do anything similar there.

## Guidance to review

- Does this handle all the possible combinations?

## Link to Trello card

https://trello.com/c/448bICpz/4604-errors-in-support-provider-interface-viewing-work-experience-with-missing-start-end-dates

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
