### PR TITLE
Course Change - email candidates about upcoming interviews

### DIFF
--- a/app/components/provider_interface/course_change_warning_text_component.rb
+++ b/app/components/provider_interface/course_change_warning_text_component.rb
@@ -8,9 +8,9 @@ module ProviderInterface
     end
 
     def only_location_or_study_mode_change?
-      application_choice.course.id == wizard.course_id &&
-        application_choice.provider.id == wizard.provider_id &&
-        (application_choice.site.id != wizard.location_id || application_choice.course_option.study_mode != wizard.study_mode)
+      application_choice.course.id == wizard.course_option.course.id &&
+        application_choice.provider.id == wizard.course_option.provider.id &&
+        (application_choice.site.id != wizard.course_option.site.id || application_choice.course_option.study_mode != wizard.course_option.study_mode)
     end
   end
 end

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -56,11 +56,11 @@ class CandidateMailer < ApplicationMailer
     @application_form = application_choice.application_form
     @interview = interview
     @provider_name = interview.provider.name
-    @course_name = application_choice.current_course_option.course.name
+    @course_name_and_code = application_choice.current_course_option.course.name_and_code
 
     email_for_candidate(
       @application_form,
-      subject: I18n.t!('candidate_mailer.interview_updated.subject', provider_name: @provider_name),
+      subject: I18n.t!('candidate_mailer.interview_updated.subject', course_name_and_code: @course_name_and_code),
     )
   end
 

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -302,9 +302,9 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
-  def change_course(application_choice)
+  def change_course(application_choice, old_course)
     @application_choice = application_choice
-    @course_option = @application_choice.course_option
+    @course_option = old_course
     @current_course_option = @application_choice.current_course_option
     @qualification = qualification_text(@current_course_option)
 

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -21,4 +21,8 @@ class Interview < ApplicationRecord
   def date
     date_and_time.to_fs(:govuk_date)
   end
+
+  def time
+    date_and_time.to_fs(:govuk_time)
+  end
 end

--- a/app/services/change_course.rb
+++ b/app/services/change_course.rb
@@ -28,6 +28,7 @@ class ChangeCourse
           )
           update_interviews_provider_service.save!
         end
+        update_interviews_provider_service.notify
 
         CandidateMailer.change_course(application_choice).deliver_later
       end

--- a/app/services/change_course.rb
+++ b/app/services/change_course.rb
@@ -16,6 +16,8 @@ class ChangeCourse
   def save!
     auth.assert_can_make_decisions!(application_choice: application_choice, course_option: course_option)
 
+    old_course = application_choice.course_option
+
     if course.valid?
       audit(actor) do
         ActiveRecord::Base.transaction do
@@ -30,7 +32,7 @@ class ChangeCourse
         end
         update_interviews_provider_service.notify
 
-        CandidateMailer.change_course(application_choice).deliver_later
+        CandidateMailer.change_course(application_choice, old_course).deliver_later
       end
     else
       raise ValidationException, course.errors.map(&:message)

--- a/app/views/candidate_mailer/interview_updated.text.erb
+++ b/app/views/candidate_mailer/interview_updated.text.erb
@@ -1,13 +1,14 @@
 Dear <%= @application_form.first_name %>
 
-<%= @provider_name %> has updated the details of your interview for <%= @course_name %>.
+The details of your interview for <%= @course_name_and_code %> have been updated.
 
-The new details are as follows:
+The new details are:
 
-^ <%= @interview.date_and_time.to_fs(:govuk_date_and_time) %>
-
-^ <%= @interview.location %>
-
-^ <%= @interview.additional_details %>
+^ Training provider: <%= @provider_name %>
+^ Course: <%= @course_name_and_code %>
+^ Date: <%= @interview.date %>
+^ Time: <%= @interview.time %>
+^ Address or online meeting details: <%= @interview.location %>
+^ Additional details: <%= @interview.additional_details %>
 
 Contact <%= @provider_name %> if you have any questions. Let them know if you cannot attend the interview.

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -105,7 +105,7 @@ en:
     new_interview:
       subject: Interview arranged - %{provider_name}
     interview_updated:
-      subject: Interview details updated - %{provider_name}
+      subject: Interview details updated for %{course_name_and_code}
     interview_cancelled:
       subject: Interview cancelled - %{provider_name}
     approaching_eoc_deadline:

--- a/spec/components/provider_interface/course_change_warning_text_component_spec.rb
+++ b/spec/components/provider_interface/course_change_warning_text_component_spec.rb
@@ -23,6 +23,10 @@ RSpec.describe ProviderInterface::CourseChangeWarningTextComponent do
                   ))
   end
 
+  before do
+    allow(course_wizard).to receive(:course_option).and_return(course_option)
+  end
+
   context 'when there is an interview' do
     let(:application_choice) { create(:application_choice, :with_scheduled_interview) }
 
@@ -55,7 +59,8 @@ RSpec.describe ProviderInterface::CourseChangeWarningTextComponent do
     end
 
     it 'renders the warning text' do
-      expect(render.css('.govuk-warning-text').text).to eq '!WarningThe candidate will be sent an email to tell them that the course has been updated.'
+      expect(render.css('.govuk-warning-text').text).not_to include '!WarningThe upcoming interview will be updated with the new course details.'
+      expect(render.css('.govuk-warning-text').text).to include '!WarningThe candidate will be sent an email to tell them that the course has been updated.'
     end
   end
 
@@ -73,7 +78,8 @@ RSpec.describe ProviderInterface::CourseChangeWarningTextComponent do
     end
 
     it 'renders the warning text' do
-      expect(render.css('.govuk-warning-text').text).to eq '!WarningThe candidate will be sent an email to tell them that the course has been updated.'
+      expect(render.css('.govuk-warning-text').text).not_to include '!WarningThe upcoming interview will be updated with the new course details.'
+      expect(render.css('.govuk-warning-text').text).to include '!WarningThe candidate will be sent an email to tell them that the course has been updated.'
     end
   end
 

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -367,6 +367,8 @@ RSpec.describe CandidateMailer, type: :mailer do
                     first_name: 'Fred',
                     candidate: candidate,
                     application_choices: [application_choice_with_interview])
+
+      application_choice_with_interview.current_course_option = course_option
     end
 
     describe '.new_interview' do
@@ -388,10 +390,11 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       it_behaves_like(
         'a mail with subject and content',
-        'Interview details updated - Hogwards',
+        'Interview details updated for Mathematics (M101)',
         'greeting' => 'Dear Fred',
-        'details' => 'Hogwards has updated the details of your interview',
-        'interview date and time' => '15 January 2021 at 9:30am',
+        'details' => 'The details of your interview for Mathematics (M101) have been updated.',
+        'interview date' => '15 January 2021',
+        'interview time' => '9:30am',
         'interview location' => 'Hogwarts Castle',
         'additional interview details' => 'Bring your magic wand for the spells test',
       )

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -414,18 +414,17 @@ RSpec.describe CandidateMailer, type: :mailer do
   end
 
   describe '.change_course' do
-    # TODO: swap out course_option with original_course_option once implemented.
     let(:application_choice) do
       create(
         :application_choice,
-        course_option: course_option,
+        original_course_option: original_course_option,
         current_course_option: current_course_option,
         site: site,
         application_form: create(:application_form, first_name: 'Fred'),
       )
     end
-    let(:email) { mailer.change_course(application_choice) }
-    let(:course_option) do
+    let(:email) { mailer.change_course(application_choice, original_course_option) }
+    let(:original_course_option) do
       create(
         :course_option,
         course: create(

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -352,23 +352,23 @@ RSpec.describe CandidateMailer, type: :mailer do
   end
 
   context 'Interview emails' do
-    let(:provider)  { create(:provider, name: 'Hogwards') }
+    let(:provider) { create(:provider, name: 'Hogwards') }
+    let(:application_choice_with_interview) { build_stubbed(:application_choice, course_option: course_option) }
+
     let(:interview) do
-      create(:interview,
-             date_and_time: Time.zone.local(2021, 1, 15, 9, 30),
-             location: 'Hogwarts Castle',
-             additional_details: 'Bring your magic wand for the spells test',
-             provider: provider)
+      build_stubbed(:interview,
+                    date_and_time: Time.zone.local(2021, 1, 15, 9, 30),
+                    location: 'Hogwarts Castle',
+                    additional_details: 'Bring your magic wand for the spells test',
+                    provider: provider,
+                    application_choice: application_choice_with_interview)
     end
-    let(:application_choice_with_interview) { interview.application_choice }
 
     before do
       build_stubbed(:application_form,
                     first_name: 'Fred',
                     candidate: candidate,
                     application_choices: [application_choice_with_interview])
-
-      application_choice_with_interview.current_course_option = course_option
     end
 
     describe '.new_interview' do
@@ -418,6 +418,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       create(
         :application_choice,
         original_course_option: original_course_option,
+        course_option: current_course_option,
         current_course_option: current_course_option,
         site: site,
         application_form: create(:application_form, first_name: 'Fred'),

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -23,15 +23,11 @@ class CandidateMailerPreview < ActionMailer::Preview
   end
 
   def change_course
-    application_form = application_form_with_course_choices([application_choice_with_offer, application_choice_with_offer])
     application_choice = FactoryBot.build_stubbed(:submitted_application_choice,
-                                                  :with_offer,
                                                   course_option: course_option,
-                                                  application_form: application_form,
-                                                  current_course_option: course_option,
-                                                  decline_by_default_at: 10.business_days.from_now)
+                                                  current_course_option: course_option)
 
-    CandidateMailer.change_course(application_choice)
+    CandidateMailer.change_course(application_choice, application_choice.original_course_option)
   end
 
   def changed_unconditional_offer

--- a/spec/services/change_course_spec.rb
+++ b/spec/services/change_course_spec.rb
@@ -12,8 +12,7 @@ RSpec.describe ChangeCourse do
     )
   end
   let(:course_option) { course_option_for_provider(provider: application_choice.current_course_option.provider, course: application_choice.current_course_option.course) }
-  let(:update_interviews_provider_service) { instance_double(UpdateInterviewsProvider, save!: true) }
-
+  let(:update_interviews_provider_service) { instance_double(UpdateInterviewsProvider) }
   let(:change_course) do
     described_class.new(
       actor: provider_user,
@@ -21,6 +20,11 @@ RSpec.describe ChangeCourse do
       course_option: course_option,
       update_interviews_provider_service: update_interviews_provider_service,
     )
+  end
+
+  before do
+    allow(update_interviews_provider_service).to receive(:save!).and_return(true)
+    allow(update_interviews_provider_service).to receive(:notify).and_return(true)
   end
 
   describe '#save!' do
@@ -55,6 +59,7 @@ RSpec.describe ChangeCourse do
 
         expect(application_choice).to have_received(:update_course_option_and_associated_fields!)
         expect(update_interviews_provider_service).to have_received(:save!)
+        expect(update_interviews_provider_service).to have_received(:notify)
       end
 
       it 'sets the course_changed_at attribute' do

--- a/spec/services/update_interviews_provider_spec.rb
+++ b/spec/services/update_interviews_provider_spec.rb
@@ -31,6 +31,11 @@ RSpec.describe UpdateInterviewsProvider do
     }
   end
 
+  before do
+    mailer = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+    allow(CandidateMailer).to receive(:interview_updated).and_return(mailer)
+  end
+
   describe '#save!' do
     context 'when it is a valid provider' do
       it 'updates the existing interview with provided params' do
@@ -43,6 +48,12 @@ RSpec.describe UpdateInterviewsProvider do
         expect {
           described_class.new(new_provider_params).save!
         }.to change(application_choice, :updated_at)
+      end
+
+      it 'sends an email' do
+        described_class.new(new_provider_params).notify
+
+        expect(CandidateMailer).to have_received(:interview_updated).with(application_choice, interview)
       end
     end
 
@@ -57,6 +68,12 @@ RSpec.describe UpdateInterviewsProvider do
         expect {
           described_class.new(old_provider_params).save!
         }.not_to change(application_choice, :updated_at)
+      end
+
+      it 'does not send an email' do
+        described_class.new(old_provider_params).notify
+
+        expect(CandidateMailer).not_to have_received(:interview_updated).with(application_choice, interview)
       end
     end
 
@@ -73,6 +90,12 @@ RSpec.describe UpdateInterviewsProvider do
         expect {
           described_class.new(new_provider_params).save!
         }.not_to change(application_choice, :updated_at)
+      end
+
+      it 'does not send an email' do
+        described_class.new(new_provider_params).notify
+
+        expect(CandidateMailer).not_to have_received(:interview_updated).with(application_choice, interview)
       end
     end
 
@@ -96,6 +119,12 @@ RSpec.describe UpdateInterviewsProvider do
         expect {
           described_class.new(service_params).save!
         }.to change(application_choice, :updated_at)
+      end
+
+      it 'sends an email' do
+        described_class.new(service_params).notify
+
+        expect(CandidateMailer).to have_received(:interview_updated).with(application_choice, interview)
       end
     end
 
@@ -131,6 +160,12 @@ RSpec.describe UpdateInterviewsProvider do
           described_class.new(old_provider_params).save!
         }.not_to change(application_choice, :updated_at)
       end
+
+      it 'does not send an email' do
+        described_class.new(old_provider_params).notify
+
+        expect(CandidateMailer).not_to have_received(:interview_updated).with(application_choice, interview)
+      end
     end
 
     context 'when an interview has been cancelled' do
@@ -146,6 +181,12 @@ RSpec.describe UpdateInterviewsProvider do
         expect {
           described_class.new(old_provider_params).save!
         }.not_to change(application_choice, :updated_at)
+      end
+
+      it 'does not send an email' do
+        described_class.new(old_provider_params).notify
+
+        expect(CandidateMailer).not_to have_received(:interview_updated).with(application_choice, interview)
       end
     end
 


### PR DESCRIPTION
## Context

With the new change course service we need to notify candidates when the interview details get changed.

We already send an email to users when an interview is updated but it is not suitable for use when a course is changed. For example it does not mention both the old and new course.

We decided to revise the existing interview change email so that it works in all situations, rather than creating a separate email to use when the course has changed.

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="640" alt="image" src="https://user-images.githubusercontent.com/47917431/163982517-e8b10576-f797-4d57-b557-e28f2a7b282d.png">|<img width="582" alt="image" src="https://user-images.githubusercontent.com/47917431/163982625-99c27ce4-9a50-4af6-8681-a55ca63400b8.png">|

## Guidance to review

[Design history](https://bat-design-history.netlify.app/manage-teacher-training-applications/emailing-candidates-about-upcoming-interviews-when-their-course-is-changed/)

## Link to Trello card

https://trello.com/c/KnChJOuj

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
