### PR TITLE
Add deprecation notice for support_reference to Vendor API

### DIFF
--- a/app/views/api_docs/vendor_api_docs/pages/release_notes.md
+++ b/app/views/api_docs/vendor_api_docs/pages/release_notes.md
@@ -1,3 +1,9 @@
+## 19th April 2022
+
+Documentation:
+
+Mark `support_reference` as deprecated. Application `id` is the recommended identifier that should be used going forward to identify an application
+
 ## 28th March 2022
 
 Documentation:

--- a/config/vendor_api/v1.0.yml
+++ b/config/vendor_api/v1.0.yml
@@ -422,11 +422,12 @@ components:
       properties:
         application_url:
           type: string
-          description: The URL of this application as seen in the Manage teacher training applications web interface.
+          description: 'The URL of this application as seen in the Manage teacher training applications web interface.'
           example: 'https://www.apply-for-teacher-training.service.gov.uk/provider/applications/1234'
         support_reference:
           type: string
-          description: The candidate’s reference number for their application form carrying this application choice in the Apply system. Candidates can have multiple application forms. For instance, when a candidate moves from Apply 1 to Apply again their candidate ID will stay the same, but that’s a new application form so the `support_reference` will be different.
+          deprecated: true
+          description: 'The candidate’s reference number for their application form carrying this application choice in the Apply system. Candidates can have multiple application forms. For instance, when a candidate moves from Apply 1 to Apply again their candidate ID will stay the same, but that’s a new application form so the `support_reference` will be different.  DEPRECATED: this field is being deprecated as applications should be identified using the application id.'
           maxLength: 10
           example: AB1234
         status:


### PR DESCRIPTION
## Context

https://trello.com/c/0Jnahuts/5032-replace-reference-number-in-exports-and-api-with-application-number

## Changes proposed in this pull request

Added a deprecation notice to the `support_reference` field in the API. Could someone take a look at the wording for the notice, in case we missed something!
