### PR TITLE
Allow collate and compare coverage to fail

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -276,6 +276,7 @@ jobs:
     name: Collate test coverage reports
     needs: [test]
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -302,20 +303,10 @@ jobs:
           path: coverage/.last_run.json
           retention-days: 5
 
-      # Workaround for https://github.com/dawidd6/action-download-artifact/issues/147
-      - name: Get Run ID
-        id: get_run_id
-        run: |
-          echo "::set-output name=run_id::$(\
-            gh run list \
-              --workflow build-and-deploy.yml \
-              --limit 100 \
-              --json conclusion,status,databaseId,headBranch \
-              --jq ". | map(select( .conclusion == \"success\" and .headBranch == \"main\")) | first(.[]).databaseId" \
-          )"
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
+      # Download base-coverage artifact using criteria of status: 'success' and name: 'base-coverage'
+      # This will perform a paginated search of all workflow runs and then select the first successful run which has
+      # an artifact named 'base-coverage' and download this.
+      # We omit branch name in the config here as GitHub API search results filtered by branch name have proved to be incorrect.
       - name: Download main branch coverage artifact
         id: download-base-coverage
         uses: dawidd6/action-download-artifact@v2
@@ -323,9 +314,10 @@ jobs:
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           workflow: build-and-deploy.yml
+          workflow_conclusion: success
+          search_artifacts: true
           name: base-coverage
           path: base-coverage/
-          run_id: ${{steps.get_run_id.outputs.run_id}} # Woraround for https://github.com/dawidd6/action-download-artifact/issues/147, revert to workflow_conclusion & branch when no longer needed
 
       - name: Output base coverage results
         id: output_base_coverage


### PR DESCRIPTION
## Context

This job should not prevent a build from completing.

Coverage comparison relies on accurate search result responses from the GitHub API and failures can impact our ability to complete a build.

![image](https://user-images.githubusercontent.com/93511/163998897-fbc5bf83-9f99-4e4b-9e30-6ffdffd344a9.png)

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Omits the option to search on branch name as this is impacted by GH search index issues.
- Searches all successful workflow runs for the `base-coverage` artifact and downloads this.
- Adds `continue-on-error: true` to **collate-and-compare-coverage** job.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

This is less performant than searching by branch name but is not impacted by GitHub API issues. 
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
