### PR TITLE
Fix flakey degree spec

### DIFF
--- a/spec/components/candidate_interface/degree_empty_component_spec.rb
+++ b/spec/components/candidate_interface/degree_empty_component_spec.rb
@@ -5,12 +5,6 @@ RSpec.describe CandidateInterface::DegreeEmptyComponent, type: :component do
   let(:component) { described_class.new(application_form: application_form) }
 
   describe '#render?' do
-    context 'if application form has application qualifications at degree level' do
-      it 'does not render' do
-        expect(component.render?).to be_falsey
-      end
-    end
-
     context 'if application form has no application qualifications at degree level' do
       let(:application_form) { create(:application_form, :with_gcses) }
 
@@ -19,14 +13,14 @@ RSpec.describe CandidateInterface::DegreeEmptyComponent, type: :component do
       end
     end
 
-    context 'if qualification_type is only foundation degrees' do
+    context 'if qualification type is only foundation degrees' do
       it 'renders' do
         application_form.application_qualifications.first.update!(qualification_type: 'Foundation of Arts')
         expect(component.render?).to be_truthy
       end
     end
 
-    context 'if qualification type has a bachelor degree' do
+    context 'if qualification type is not a foundation degree' do
       it 'does not render' do
         application_form.application_qualifications.first.update!(qualification_type: 'Bachelor of Arts')
         expect(component.render?).to be_falsey


### PR DESCRIPTION
## Context
There is a flakey spec on the degree empty component. This is because once in a while a degree with a foundation degree type is created in the factory causing the degree empty component to render.

<!-- Why are you making this change? What might surprise someone about it? -->
The test is however redundant as it is essentially a copy of the test starting on line 23 in another context, so it has been removed


<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
