### PR TITLE
Course Change - Only render change links for applicable application states

### DIFF
--- a/app/components/provider_interface/change_course_details_component.html.erb
+++ b/app/components/provider_interface/change_course_details_component.html.erb
@@ -1,4 +1,4 @@
-<section class="app-section govuk-!-width-two-thirds">
+<section class="app-section govuk-!-width-two-thirds" data-qa="course-details">
   <h2 class="govuk-heading-m govuk-!-font-size-27" id="course-details">Course</h2>
 
   <%= render SummaryListComponent.new(rows: rows) %>

--- a/app/components/provider_interface/course_details_component.html.erb
+++ b/app/components/provider_interface/course_details_component.html.erb
@@ -1,4 +1,4 @@
-<section class="app-section govuk-!-width-two-thirds">
+<section class="app-section govuk-!-width-two-thirds" data-qa="course-details">
   <h2 class="govuk-heading-m govuk-!-font-size-27" id="course-details">Course</h2>
 
   <%= render SummaryListComponent.new(rows: rows) %>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -47,7 +47,7 @@
   </div>
 <% end %>
 
-<% if @provider_can_respond && FeatureFlag.active?(:change_course_details_before_offer) %>
+<% if @provider_can_respond && FeatureFlag.active?(:change_course_details_before_offer) && ApplicationStateChange::DECISION_PENDING_STATUSES.include?(@application_choice.status.to_sym) %>
   <%= render ProviderInterface::ChangeCourseDetailsComponent.new(
     application_choice: @application_choice,
     course_option: @application_choice.course_option,

--- a/spec/system/provider_interface/provider_changes_a_course_before_point_of_offer_spec.rb
+++ b/spec/system/provider_interface/provider_changes_a_course_before_point_of_offer_spec.rb
@@ -17,6 +17,8 @@ RSpec.feature 'Provider changes a course' do
     build(:course, :full_time, provider: provider, accredited_provider: ratifying_provider)
   end
   let(:course_option) { build(:course_option, course: course) }
+  let!(:recruited_application_choice) { create(:application_choice, :with_completed_application_form, :with_recruited, course_option: course_option) }
+  let!(:application_choice_with_offer) { create(:application_choice, :with_completed_application_form, :with_offer, course_option: course_option) }
 
   scenario 'Changing a course choice before point of offer' do
     given_i_am_a_provider_user
@@ -25,6 +27,14 @@ RSpec.feature 'Provider changes a course' do
     and_i_sign_in_to_the_provider_interface
     and_the_provider_has_multiple_courses
     and_the_provider_user_can_offer_multiple_provider_courses
+
+    when_i_visit_the_provider_interface
+    and_i_click_an_application_choice_that_is_recruited
+    then_i_cannot_change_the_course
+
+    when_i_visit_the_provider_interface
+    and_i_click_an_application_choice_that_has_an_offer
+    then_i_cannot_change_the_course
 
     when_i_visit_the_provider_interface
     and_i_click_an_application_choice_that_is_interviewing
@@ -139,6 +149,20 @@ RSpec.feature 'Provider changes a course' do
 
   def and_i_click_an_application_choice_that_is_interviewing
     click_on application_choice.application_form.full_name
+  end
+
+  def and_i_click_an_application_choice_that_is_recruited
+    click_on recruited_application_choice.application_form.full_name
+  end
+
+  def and_i_click_an_application_choice_that_has_an_offer
+    click_on application_choice_with_offer.application_form.full_name
+  end
+
+  def then_i_cannot_change_the_course
+    within('[data-qa="course-details"]') do
+      expect(page).not_to have_content 'Change'
+    end
   end
 
   def and_i_click_on_change_the_training_provider


### PR DESCRIPTION
## Context

A provider user shouldn't have the option to change a course if a candidate has been recruited or if they have an offer (we have a separate service for this)

## Changes proposed in this pull request

Add a condition to stop the change links from rendering unless the application choice is either `awaiting_provider_decision` or `interviewing`.

## Guidance to review

Use the review app to see if the change links appear for the different states.

## Link to Trello card

https://trello.com/c/lsUXo2LN

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
