### PR TITLE
Add return to review page behaviour to the degree wizard

### DIFF
--- a/app/components/candidate_interface/degree_new_review_component.rb
+++ b/app/components/candidate_interface/degree_new_review_component.rb
@@ -200,7 +200,7 @@ module CandidateInterface
         value: degree.start_year,
         action: {
           href: candidate_interface_new_degree_edit_path(degree.id, :start_year),
-          visually_hidden_text: generate_action(degree: degree, attribute: t('application_form.degree.start_year.change_action')),
+          visually_hidden_text: generate_action(degree: degree, attribute: t('application_form.degree.start_year.new_change_action')),
         },
         html_attributes: {
           data: {
@@ -216,7 +216,7 @@ module CandidateInterface
         value: degree.award_year || t('application_form.degree.review.not_specified'),
         action: {
           href: candidate_interface_new_degree_edit_path(degree.id, :award_year),
-          visually_hidden_text: generate_action(degree: degree, attribute: t('application_form.degree.award_year.change_action')),
+          visually_hidden_text: generate_action(degree: degree, attribute: t('application_form.degree.award_year.new_change_action')),
         },
         html_attributes: {
           data: {

--- a/app/controllers/candidate_interface/degrees/degree/destroy_controller.rb
+++ b/app/controllers/candidate_interface/degrees/degree/destroy_controller.rb
@@ -14,10 +14,8 @@ module CandidateInterface
 
           if current_application.application_qualifications.degrees.blank?
             current_application.update!(degrees_completed: nil)
-            redirect_to candidate_interface_new_degree_country_path
-          else
-            redirect_to candidate_interface_new_degree_review_path
           end
+          redirect_to candidate_interface_new_degree_review_path
         end
 
       private

--- a/app/controllers/candidate_interface/degrees/degree_controller.rb
+++ b/app/controllers/candidate_interface/degrees/degree_controller.rb
@@ -45,42 +45,14 @@ module CandidateInterface
 
         if @wizard.valid_for_current_step?
           @wizard.save_state!
-          redirect_to [:candidate_interface, :new, :degree, @wizard.next_step]
+          next_step!
         else
           render :"new_#{current_step}"
         end
       end
 
-      def update_country
-        update(:country)
-      end
-
-      def update_degree_level
-        update(:degree_level)
-      end
-
-      def update_subject
-        update(:subject)
-      end
-
-      def update_type
-        update(:type)
-      end
-
-      def update_university
-        update(:university)
-      end
-
-      def update_completed
-        update(:completed)
-      end
-
-      def update_grade
-        update(:grade)
-      end
-
-      def update_start_year
-        update(:start_year)
+      %i[country degree_level subject type university completed grade start_year enic].each do |step|
+        define_method("update_#{step}") { update(step) }
       end
 
       def update_award_year
@@ -91,17 +63,6 @@ module CandidateInterface
           next_step!
         else
           render :new_award_year
-        end
-      end
-
-      def update_enic
-        @wizard = DegreeWizard.new(degree_store, degree_params.merge({ current_step: :enic }))
-
-        if @wizard.valid_for_current_step?
-          @wizard.save_state!
-          next_step!
-        else
-          render :new_enic
         end
       end
 

--- a/app/views/candidate_interface/degrees/degree/new_university.html.erb
+++ b/app/views/candidate_interface/degrees/degree/new_university.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
   <% content_for :title, title_with_error_prefix(t('page_titles.degree_university'), @wizard.errors.any?) %>
-  <% content_for :before_content, govuk_back_link_to(@wizard.level_options? ? candidate_interface_new_degree_subject_path : candidate_interface_new_degree_type_path) %>
+  <% content_for :before_content, govuk_back_link_to(@wizard.degree_has_type? ? candidate_interface_new_degree_type_path : candidate_interface_new_degree_subject_path) %>
   <%= form_with model: @wizard, url: candidate_interface_new_degree_university_path do |f| %>
     <%= f.govuk_error_summary %>
     <%= f.govuk_fieldset legend: { text: t('page_titles.degree_university'), size: 'l' } do %>

--- a/config/locales/candidate_interface/degree.yml
+++ b/config/locales/candidate_interface/degree.yml
@@ -71,11 +71,13 @@ en:
         hint_text: "For example, %{example_year}"
         review_label: Start year
         change_action: year
+        new_change_action: start year
       award_year:
         label: Graduation year
         hint_text: "For example, %{example_year}"
         review_label: Graduation year
-        change_action: year 
+        change_action: year
+        new_change_action: graduation year
         new_label: What year %{did_or_will} you graduate?
         new_hint: For example, 2019
       review:

--- a/spec/components/candidate_interface/degree_new_review_component_spec.rb
+++ b/spec/components/candidate_interface/degree_new_review_component_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe CandidateInterface::DegreeNewReviewComponent, type: :component do
         key: t('application_form.degree.start_year.review_label'),
         value: '2005',
         action: {
-          text: "Change #{t('application_form.degree.start_year.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
+          text: "Change #{t('application_form.degree.start_year.new_change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
           href: Rails.application.routes.url_helpers.candidate_interface_new_degree_edit_path(degree1, :start_year),
         },
       )
@@ -156,7 +156,7 @@ RSpec.describe CandidateInterface::DegreeNewReviewComponent, type: :component do
         key: t('application_form.degree.award_year.review_label'),
         value: '2008',
         action: {
-          text: "Change #{t('application_form.degree.award_year.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
+          text: "Change #{t('application_form.degree.award_year.new_change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
           href: Rails.application.routes.url_helpers.candidate_interface_new_degree_edit_path(degree1, :award_year),
         },
       )

--- a/spec/system/candidate_interface/entering_details/degrees/new_degree_flow/candidate_editing_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/new_degree_flow/candidate_editing_degrees_spec.rb
@@ -60,6 +60,12 @@ RSpec.feature 'Editing a degree' do
 
     when_i_change_my_undergraduate_degree_type_to_a_diploma
     then_i_can_check_my_revised_undergraduate_degree_type_again
+
+    when_i_click_to_change_my_undergraduate_country
+    then_i_see_my_chosen_undergraduate_country
+    when_i_change_my_undergraduate_country_to_another_country
+    and_i_click_on_save_and_continue
+    then_i_can_check_my_undergraduate_subject_has_been_cleared
   end
 
   def given_i_am_signed_in
@@ -76,7 +82,8 @@ RSpec.feature 'Editing a degree' do
            award_year: '2009',
            predicted_grade: false,
            subject: 'Computer Science',
-           institution_name: 'MIT',
+           institution_name: 'University of Cambridge',
+           institution_country: nil,
            grade: 'A',
            application_form: @application_form)
     @application_form.update!(degrees_completed: true)
@@ -131,6 +138,10 @@ RSpec.feature 'Editing a degree' do
     click_change_link('institution')
   end
 
+  def when_i_click_to_change_my_undergraduate_country
+    click_change_link('country')
+  end
+
   def then_i_see_my_chosen_undergraduate_degree_type
     expect(page.find_field('Bachelor degree')).to be_checked
   end
@@ -148,12 +159,16 @@ RSpec.feature 'Editing a degree' do
   end
 
   def then_i_see_my_undergraduate_degree_institution_filled_in
-    expect(page).to have_selector("input[value='MIT']")
+    expect(page).to have_selector("input[value='University of Cambridge']")
   end
 
   def then_i_see_my_undergraduate_degree_grade_filled_in
     expect(page.find_field('Other')).to be_checked
     expect(page.find_field('Enter your degree grade').value).to eq('A')
+  end
+
+  def then_i_see_my_chosen_undergraduate_country
+    expect(page.find_field('United Kingdom')).to be_checked
   end
 
   def when_i_change_my_undergraduate_degree_type
@@ -178,11 +193,16 @@ RSpec.feature 'Editing a degree' do
   end
 
   def when_i_change_my_undergraduate_degree_institution
-    fill_in 'candidate-interface-degree-wizard-university-field', with: 'Stanford'
+    fill_in 'candidate-interface-degree-wizard-university-field', with: 'University of Oxford'
   end
 
   def when_i_change_my_undergraduate_degree_grade
     choose 'Lower second-class honours (2:2)'
+  end
+
+  def when_i_change_my_undergraduate_country_to_another_country
+    choose 'Another country'
+    select 'France'
   end
 
   def then_i_can_check_my_revised_undergraduate_degree_type
@@ -215,10 +235,15 @@ RSpec.feature 'Editing a degree' do
   end
 
   def then_i_can_check_my_revised_completion_status_and_award_year
-    completion_status_row = page.all('.govuk-summary-list__row').find { |r| r.has_link? 'Change completion status' }
+    completion_status_row = page.all('.govuk-summary-list__row').find { |row| row.has_link? 'Change completion status' }
     expect(completion_status_row).to have_content 'No'
 
     expect(page).to have_content RecruitmentCycle.current_year.to_s
+  end
+
+  def then_i_can_check_my_undergraduate_subject_has_been_cleared
+    expect(page).to have_content 'What subject is your degree?'
+    expect(page).not_to have_content 'Computer Science and AI'
   end
 
   def and_i_click_on_continue

--- a/spec/system/candidate_interface/entering_details/degrees/new_degree_flow/candidate_editing_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/new_degree_flow/candidate_editing_degrees_spec.rb
@@ -1,0 +1,248 @@
+require 'rails_helper'
+
+RSpec.feature 'Editing a degree' do
+  include CandidateHelper
+
+  before do
+    FeatureFlag.activate(:new_degree_flow)
+    allow(CycleTimetable).to receive(:current_year).and_return(2022)
+  end
+
+  scenario 'Candidate edits their degree' do
+    given_i_am_signed_in
+    and_i_have_completed_the_degree_section
+    when_i_view_the_degree_section
+    and_i_click_to_change_my_undergraduate_degree_type
+    then_i_see_my_chosen_undergraduate_degree_type
+
+    when_i_change_my_undergraduate_degree_type
+    and_i_click_on_save_and_continue
+    and_i_choose_my_specific_undergraduate_degree_type
+    and_i_click_on_save_and_continue
+    then_i_can_check_my_revised_undergraduate_degree_type
+
+    when_i_click_to_change_my_undergraduate_degree_start_year
+    then_i_see_my_undergraduate_degree_start_year_filled_in
+    when_i_change_my_undergraduate_degree_start_year
+    and_i_click_on_save_and_continue
+    then_i_can_check_my_revised_undergraduate_degree_start_year
+
+    when_i_click_to_change_my_undergraduate_degree_award_year
+    then_i_see_my_undergraduate_degree_award_year_filled_in
+    when_i_change_my_undergraduate_degree_award_year
+    and_i_click_on_save_and_continue
+    then_i_can_check_my_revised_undergraduate_degree_award_year
+
+    when_i_click_to_change_my_undergraduate_degree_subject
+    then_i_see_my_undergraduate_degree_subject_filled_in
+    when_i_change_my_undergraduate_degree_subject
+    and_i_click_on_save_and_continue
+    then_i_can_check_my_revised_undergraduate_degree_subject
+
+    when_i_click_to_change_my_completion_status
+    then_i_can_change_my_completion_status
+    and_i_click_on_save_and_continue
+    when_i_change_my_undergraduate_degree_award_year_again
+    and_i_click_on_save_and_continue
+    then_i_can_check_my_revised_completion_status_and_award_year
+
+    when_i_click_to_change_my_undergraduate_degree_institution
+    then_i_see_my_undergraduate_degree_institution_filled_in
+    when_i_change_my_undergraduate_degree_institution
+    and_i_click_on_save_and_continue
+    then_i_can_check_my_revised_undergraduate_degree_institution
+
+    when_i_click_to_change_my_undergraduate_degree_grade
+    then_i_see_my_undergraduate_degree_grade_filled_in
+    when_i_change_my_undergraduate_degree_grade
+    and_i_click_on_save_and_continue
+    then_i_can_check_my_revised_undergraduate_degree_grade
+
+    when_i_change_my_undergraduate_degree_type_to_a_diploma
+    then_i_can_check_my_revised_undergraduate_degree_type_again
+  end
+
+  def given_i_am_signed_in
+    @candidate = create(:candidate)
+    login_as(@candidate)
+  end
+
+  def and_i_have_completed_the_degree_section
+    @application_form = create(:application_form, candidate: @candidate)
+    create(:application_qualification,
+           level: 'degree',
+           qualification_type: 'Bachelor of Arts',
+           start_year: '2006',
+           award_year: '2009',
+           predicted_grade: false,
+           subject: 'Computer Science',
+           institution_name: 'MIT',
+           grade: 'A',
+           application_form: @application_form)
+    @application_form.update!(degrees_completed: true)
+  end
+
+  def when_i_view_the_degree_section
+    visit candidate_interface_application_form_path
+    when_i_click_on_degree
+  end
+
+  def when_i_click_on_degree
+    click_link 'Degree'
+  end
+
+  def then_i_can_check_my_undergraduate_degree
+    expect(page).to have_current_path candidate_interface_degrees_review_path
+  end
+
+  def and_i_click_on_save_and_continue
+    click_button t('save_and_continue')
+  end
+
+  def when_i_click_on_continue
+    click_button t('continue')
+  end
+
+  def and_i_click_on_continue
+    when_i_click_on_continue
+  end
+
+  def and_i_click_to_change_my_undergraduate_degree_type
+    click_change_link('qualification')
+  end
+
+  def when_i_click_to_change_my_undergraduate_degree_start_year
+    click_change_link('start year')
+  end
+
+  def when_i_click_to_change_my_undergraduate_degree_award_year
+    click_change_link('graduation year')
+  end
+
+  def when_i_click_to_change_my_undergraduate_degree_grade
+    click_change_link('grade')
+  end
+
+  def when_i_click_to_change_my_undergraduate_degree_subject
+    click_change_link('subject')
+  end
+
+  def when_i_click_to_change_my_undergraduate_degree_institution
+    click_change_link('institution')
+  end
+
+  def then_i_see_my_chosen_undergraduate_degree_type
+    expect(page.find_field('Bachelor degree')).to be_checked
+  end
+
+  def then_i_see_my_undergraduate_degree_start_year_filled_in
+    expect(page).to have_selector("input[name='candidate_interface_degree_wizard[start_year]'][value='2006']")
+  end
+
+  def then_i_see_my_undergraduate_degree_award_year_filled_in
+    expect(page).to have_selector("input[name='candidate_interface_degree_wizard[award_year]'][value='2009']")
+  end
+
+  def then_i_see_my_undergraduate_degree_subject_filled_in
+    expect(page).to have_selector("input[value='Computer Science']")
+  end
+
+  def then_i_see_my_undergraduate_degree_institution_filled_in
+    expect(page).to have_selector("input[value='MIT']")
+  end
+
+  def then_i_see_my_undergraduate_degree_grade_filled_in
+    expect(page.find_field('Other')).to be_checked
+    expect(page.find_field('Enter your degree grade').value).to eq('A')
+  end
+
+  def when_i_change_my_undergraduate_degree_type
+    choose 'Master’s degree'
+  end
+
+  def when_i_change_my_undergraduate_degree_start_year
+    fill_in t('page_titles.what_year_did_you_start_your_degree'), with: '2008'
+  end
+
+  def when_i_change_my_undergraduate_degree_award_year
+    fill_in t('page_titles.what_year_did_you_graduate'), with: '2011'
+  end
+
+  def when_i_change_my_undergraduate_degree_award_year_again
+    graduation_year = RecruitmentCycle.current_year.to_s
+    fill_in t('page_titles.what_year_will_you_graduate'), with: graduation_year
+  end
+
+  def when_i_change_my_undergraduate_degree_subject
+    fill_in 'candidate-interface-degree-wizard-subject-field', with: 'Computer Science and AI'
+  end
+
+  def when_i_change_my_undergraduate_degree_institution
+    fill_in 'candidate-interface-degree-wizard-university-field', with: 'Stanford'
+  end
+
+  def when_i_change_my_undergraduate_degree_grade
+    choose 'Lower second-class honours (2:2)'
+  end
+
+  def then_i_can_check_my_revised_undergraduate_degree_type
+    expect(page).to have_content 'Master of Arts'
+    expect(page).to have_content 'MA'
+  end
+
+  def and_i_choose_my_specific_undergraduate_degree_type
+    choose 'Master of Arts (MA)'
+  end
+
+  def then_i_can_check_my_revised_undergraduate_degree_start_year
+    expect(page).to have_content '2008'
+  end
+
+  def then_i_can_check_my_revised_undergraduate_degree_award_year
+    expect(page).to have_content '2011'
+  end
+
+  def then_i_can_check_my_revised_undergraduate_degree_subject
+    expect(page).to have_content 'Computer Science and AI'
+  end
+
+  def then_i_can_check_my_revised_undergraduate_degree_institution
+    expect(page).to have_content 'Computer Science and AI'
+  end
+
+  def then_i_can_check_my_revised_undergraduate_degree_grade
+    expect(page).to have_content 'Lower second-class honours (2:2)'
+  end
+
+  def then_i_can_check_my_revised_completion_status_and_award_year
+    completion_status_row = page.all('.govuk-summary-list__row').find { |r| r.has_link? 'Change completion status' }
+    expect(completion_status_row).to have_content 'No'
+
+    expect(page).to have_content RecruitmentCycle.current_year.to_s
+  end
+
+  def and_i_click_on_continue
+    when_i_click_on_continue
+  end
+
+  def when_i_click_to_change_my_completion_status
+    click_change_link('completion status')
+  end
+
+  def then_i_can_change_my_completion_status
+    expect(page).to have_content 'Have you completed your degree?'
+    choose 'No'
+  end
+
+  def when_i_change_my_undergraduate_degree_type_to_a_diploma
+    click_change_link('qualification')
+    choose 'Level 6 Diploma'
+    and_i_click_on_save_and_continue
+  end
+
+  def then_i_can_check_my_revised_undergraduate_degree_type_again
+    expect(page).to have_content 'Level 6 Diploma'
+    expect(page).not_to have_content 'Master of Arts'
+    expect(page).not_to have_content 'MA'
+  end
+end


### PR DESCRIPTION
## Context
Adds return to review page after edit functionality to the new degree flow. 

## Changes proposed in this pull request
* If user changes from uk to international degree and vice versa, wizard will take user back through the degree flow
* If user changes degree level (e.g Foundation degree => Bachelor degree), wizard will take user to the type page to pick their specific degree type. If the degree doesn't have a type, user will instead be taken to the review page
* If user changes from a complete to an incomplete degree and vice versa, wizard will take user to award year to enter a new year, then to review page.
* If user changes from an incomplete to an complete degree and it is an international degree, wizard will take user to award year page and also the enic page, then to review page.
* If there are no dependent answers, the user will be taken to review page after answer is edited
* Adds a feature test for editing degree
* Refactor to DRY degree controller

## Guidance to review
Verify that the degree has expected behaviour

## Link to Trello card

https://trello.com/c/X5jPv4jJ/4561-add-return-to-review-page-behaviour-to-the-degree-wizard

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
