### PR TITLE
Allow multiple application choices at different sites

### DIFF
--- a/spec/workers/detect_invariants_daily_check_spec.rb
+++ b/spec/workers/detect_invariants_daily_check_spec.rb
@@ -73,30 +73,6 @@ RSpec.describe DetectInvariantsDailyCheck do
       expect(Sentry).not_to have_received(:capture_exception)
     end
 
-    it 'detects applications submitted with the same course' do
-      allow(Sentry).to receive(:capture_exception).with(an_instance_of(described_class::ApplicationSubmittedWithTheSameCourse))
-
-      course = create(:course)
-      course_option1 = create(:course_option, course: course)
-      course_option2 = create(:course_option, course: course)
-      application_form = create(:completed_application_form)
-
-      create(:submitted_application_choice, application_form: application_form, course_option: course_option1)
-      create(:submitted_application_choice, application_form: application_form, course_option: course_option2)
-
-      described_class.new.perform
-
-      expect(Sentry).to have_received(:capture_exception).with(
-        described_class::ApplicationSubmittedWithTheSameCourse.new(
-          <<~MSG,
-            The following applications have been submitted containing the same course choice multiple times
-
-            #{HostingEnvironment.application_url}/support/applications/#{application_form.id}
-          MSG
-        ),
-      )
-    end
-
     it 'detects when a submitted application has more than 2 selected references' do
       allow(Sentry).to receive(:capture_exception).with(an_instance_of(described_class::ApplicationSubmittedWithMoreThanTwoSelectedReferences))
 


### PR DESCRIPTION
For a given application, allow the same course to be selected multiple
times as long as it's a different sites.

## Context

It has been agreed that we (Apply) will permit moving candidates to different location codes at the same provider.

## Changes proposed in this pull request

Don't raise an error in the daily checks if an application contains more than one of the same course, as long as they're at different sites.

## Link to Trello card

[https://trello.com/c/UxS9raOb/4916-update-detectinvariantsdailycheckapplicationsubmittedwiththesamecourse](https://trello.com/c/UxS9raOb/4916-update-detectinvariantsdailycheckapplicationsubmittedwiththesamecourse)
