### PR TITLE
Remove application_number_replacement feature flag uses

### DIFF
--- a/app/components/provider_interface/application_card_component.html.erb
+++ b/app/components/provider_interface/application_card_component.html.erb
@@ -3,7 +3,7 @@
     <h3 class="govuk-heading-s">
       <%= govuk_link_to candidate_name, provider_interface_application_choice_path(application_choice), no_visited_state: true %>
       <span class="app-application-card__caption">
-        <%= FeatureFlag.active?(:application_number_replacement) ? application_choice.id : application_choice.application_form.support_reference %>
+        <%= application_choice.id %>
       </span>
     </h3>
     <%= render ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice) %>

--- a/app/components/provider_interface/application_summary_component.rb
+++ b/app/components/provider_interface/application_summary_component.rb
@@ -12,19 +12,11 @@ module ProviderInterface
     end
 
     def rows
-      if FeatureFlag.active?(:application_number_replacement)
-        [
-          submitted_row,
-          recruitment_cycle_year,
-          application_number_row,
-        ].compact
-      else
-        [
-          submitted_row,
-          recruitment_cycle_year,
-          support_reference_row,
-        ].compact
-      end
+      [
+        submitted_row,
+        recruitment_cycle_year,
+        application_number_row,
+      ].compact
     end
 
   private

--- a/app/components/provider_interface/personal_information_component.rb
+++ b/app/components/provider_interface/personal_information_component.rb
@@ -26,7 +26,6 @@ module ProviderInterface
         nationality_row,
         right_to_work_or_study_row,
         residency_details_row,
-        candidate_id_row,
       ].compact
     end
 
@@ -75,15 +74,6 @@ module ProviderInterface
       {
         key: 'Date of birth',
         value: application_form.date_of_birth ? application_form.date_of_birth.to_fs(:govuk_date) : MISSING,
-      }
-    end
-
-    def candidate_id_row
-      return if FeatureFlag.active?(:application_number_replacement)
-
-      {
-        key: 'Candidate ID',
-        value: candidate.public_id,
       }
     end
 

--- a/app/components/utility/filter_component.html.erb
+++ b/app/components/utility/filter_component.html.erb
@@ -115,11 +115,7 @@
           <% end %>
           <div class="govuk-form-group">
             <label class="govuk-label app-search__label govuk-label--m" for="<%= primary_filter[:name] %>">
-              <% if FeatureFlag.active?(:application_number_replacement) %>
-                Search by candidate name or application number
-              <% else %>
-                Search by candidate name or reference
-              <% end %>
+              Search by candidate name or application number
             </label>
 
             <input class="govuk-input app-search__input <%= primary_filter[:css_classes] %>" id="<%= primary_filter[:name] %>" name="<%= primary_filter[:name] %>" type="text" value="<%= primary_filter[:value] %>" aria-labelledby="filter-legend-<%= primary_filter[:name] %>" autocomplete="off">

--- a/app/services/data_migrations/remove_application_number_replacement_feature_flag.rb
+++ b/app/services/data_migrations/remove_application_number_replacement_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class RemoveApplicationNumberReplacementFeatureFlag
+    TIMESTAMP = 20220420120234
+    MANUAL_RUN = false
+
+    def change
+      Feature.find_by(name: :application_number_replacement)&.destroy
+    end
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -33,7 +33,6 @@ class FeatureFlag
     [:support_user_revert_withdrawn_offer, 'Allows a support user to revert an application withdrawn by the candidate', 'James Glenn'],
     [:draft_vendor_api_specification, 'The specification for Draft Vendor API v1.1', 'Abeer Salameh'],
     [:new_degree_flow, 'Allows us to use the new degree flow', 'Jon Filar'],
-    [:application_number_replacement, 'Replaces reference number and candidate ID with application choice ID', 'Carlos Martinez'],
     [:data_exports, 'Iterating the format of the applications data export', 'Steve Laing'],
   ].freeze
 

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -1,5 +1,4 @@
 class FilterApplicationChoicesForProviders
-  CANDIDATE_REFERENCE_REGEX = /^[a-zA-Z]{2}\d{1,}$/.freeze
   CANDIDATE_APPLICATION_NUMBER_REGEX = /^\d+$/.freeze
 
   def self.call(application_choices:, filters:)
@@ -20,18 +19,15 @@ class FilterApplicationChoicesForProviders
   class << self
   private
 
-    def search(application_choices, candidates_name_or_reference)
-      return application_choices if candidates_name_or_reference.blank?
+    def search(application_choices, candidates_name_or_number)
+      return application_choices if candidates_name_or_number.blank?
 
-      candidate_ref_match = candidates_name_or_reference.strip.match(CANDIDATE_REFERENCE_REGEX)
-      candidate_application_number_match = candidates_name_or_reference.strip.match(CANDIDATE_APPLICATION_NUMBER_REGEX)
+      candidate_application_number_match = candidates_name_or_number.strip.match(CANDIDATE_APPLICATION_NUMBER_REGEX)
 
-      if candidate_ref_match && FeatureFlag.inactive?(:application_number_replacement)
-        application_choices.joins(:application_form).where('support_reference ILIKE ?', "#{candidate_ref_match[0]}%")
-      elsif candidate_application_number_match && FeatureFlag.active?(:application_number_replacement)
+      if candidate_application_number_match
         application_choices.where(id: candidate_application_number_match[0])
       else
-        application_choices.joins(:application_form).where("CONCAT(first_name, ' ', last_name) ILIKE ?", "%#{candidates_name_or_reference.squish}%")
+        application_choices.joins(:application_form).where("CONCAT(first_name, ' ', last_name) ILIKE ?", "%#{candidates_name_or_number.squish}%")
       end
     end
 

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -3,6 +3,7 @@ DATA_MIGRATION_SERVICES = [
   'DataMigrations::DeleteRetiredNudgeFeatureFlags',
   'DataMigrations::RemoveStructuredReasonsForRejectionRedesignFeatureFlag',
   'DataMigrations::DropChangeCourseDetailsBeforeOfferFeatureFlag',
+  'DataMigrations::RemoveApplicationNumberReplacementFeatureFlag',
   'DataMigrations::BackfillOriginalCourseOption',
   'DataMigrations::BackfillRejectionReasonsTypeField',
   'DataMigrations::DropExpandedQualsExportFeatureFlag',

--- a/spec/components/provider_interface/application_card_component_spec.rb
+++ b/spec/components/provider_interface/application_card_component_spec.rb
@@ -148,20 +148,8 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
       end
     end
 
-    context 'when the application_number_replacement flag is active' do
-      before { FeatureFlag.activate(:application_number_replacement) }
-
-      it 'renders the application number' do
-        expect(card).to include(application_choice.id.to_fs)
-      end
-    end
-
-    context 'when the application_number_replacement flag is inactive' do
-      before { FeatureFlag.deactivate(:application_number_replacement) }
-
-      it 'renders the support reference' do
-        expect(card).to include(application_choice.application_form.support_reference)
-      end
+    it 'renders the application number' do
+      expect(card).to include(application_choice.id.to_fs)
     end
   end
 

--- a/spec/components/provider_interface/application_summary_component_spec.rb
+++ b/spec/components/provider_interface/application_summary_component_spec.rb
@@ -3,23 +3,10 @@ require 'rails_helper'
 RSpec.describe ProviderInterface::ApplicationSummaryComponent do
   describe '#rows' do
     let(:application_choice) { create(:application_choice, :with_completed_application_form) }
+    let(:expected) { { key: 'Application number', value: application_choice.id } }
 
     subject { described_class.new(application_choice: application_choice).rows }
 
-    context 'application_number_replacement feature activated' do
-      before { FeatureFlag.activate(:application_number_replacement) }
-
-      let(:expected) { { key: 'Application number', value: application_choice.id } }
-
-      it { is_expected.to include(expected) }
-    end
-
-    context 'application_number_replacement feature deactivated' do
-      before { FeatureFlag.deactivate(:application_number_replacement) }
-
-      let(:expected) { { key: 'Reference', value: application_choice.application_form.support_reference } }
-
-      it { is_expected.to include(expected) }
-    end
+    it { is_expected.to include(expected) }
   end
 end

--- a/spec/components/provider_interface/personal_information_component_spec.rb
+++ b/spec/components/provider_interface/personal_information_component_spec.rb
@@ -14,31 +14,9 @@ RSpec.describe ProviderInterface::PersonalInformationComponent do
 
   subject(:result) { render_inline(described_class.new(application_form: application_form)) }
 
-  context 'application_number_replacement feature deactivated' do
-    before { FeatureFlag.deactivate(:application_number_replacement) }
-
-    it 'renders component with correct labels' do
-      ['First name', 'Last name', 'Date of birth', 'Nationality', 'Candidate ID'].each do |key|
-        expect(result.css('.govuk-summary-list__key').text).to include(key)
-      end
-    end
-
-    it 'renders the candidate’s public ID' do
-      expect(result.css('.govuk-summary-list__value').text).to include("C#{application_form.candidate.id}")
-    end
-  end
-
-  context 'application_number_replacement feature activated' do
-    before { FeatureFlag.activate(:application_number_replacement) }
-
-    it 'renders component with correct labels' do
-      ['First name', 'Last name', 'Date of birth', 'Nationality'].each do |key|
-        expect(result.css('.govuk-summary-list__key').text).to include(key)
-      end
-    end
-
-    it 'does not render the candidate’s public ID' do
-      expect(result.css('.govuk-summary-list__value').text).not_to include("C#{application_form.candidate.id}")
+  it 'renders component with correct labels' do
+    ['First name', 'Last name', 'Date of birth', 'Nationality'].each do |key|
+      expect(result.css('.govuk-summary-list__key').text).to include(key)
     end
   end
 

--- a/spec/services/data_migrations/remove_application_number_replacement_feature_flag_spec.rb
+++ b/spec/services/data_migrations/remove_application_number_replacement_feature_flag_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveApplicationNumberReplacementFeatureFlag do
+  context 'when the feature flag exists' do
+    it 'removes the feature flag' do
+      create(:feature, name: 'application_number_replacement')
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: 'application_number_replacement')).to be_blank
+    end
+  end
+
+  context 'when the feature flag has already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end

--- a/spec/services/filter_application_choices_for_providers_spec.rb
+++ b/spec/services/filter_application_choices_for_providers_spec.rb
@@ -24,44 +24,6 @@ RSpec.describe FilterApplicationChoicesForProviders do
       ApplicationChoice.all
     end
 
-    describe 'filtering by candidate reference' do
-      let(:candidate_name) { application_choices.first.application_form.support_reference }
-
-      subject do
-        described_class.call(
-          application_choices: application_choices,
-          filters: { candidate_name: " #{candidate_name}" },
-        )
-      end
-
-      context 'application_number_replacement feature deactivated' do
-        before { FeatureFlag.deactivate(:application_number_replacement) }
-
-        it { is_expected.to eq [application_choices.first] }
-      end
-
-      context 'application_number_replacement feature activated' do
-        before { FeatureFlag.activate(:application_number_replacement) }
-
-        it { is_expected.to be_empty }
-      end
-    end
-
-    describe 'filtering by partial candidate reference' do
-      let(:candidate_name) { application_choices.first.application_form.support_reference[0...3] }
-
-      subject do
-        described_class.call(
-          application_choices: application_choices,
-          filters: { candidate_name: " #{candidate_name}" },
-        )
-      end
-
-      before { FeatureFlag.deactivate(:application_number_replacement) }
-
-      it { is_expected.to eq [application_choices.first] }
-    end
-
     describe 'filtering by application choice id' do
       subject do
         described_class.call(
@@ -70,17 +32,7 @@ RSpec.describe FilterApplicationChoicesForProviders do
         )
       end
 
-      context 'application_number_replacement feature activated' do
-        before { FeatureFlag.activate(:application_number_replacement) }
-
-        it { is_expected.to eq [application_choices.first] }
-      end
-
-      context 'application_number_replacement feature deactivated' do
-        before { FeatureFlag.deactivate(:application_number_replacement) }
-
-        it { is_expected.to be_empty }
-      end
+      it { is_expected.to eq [application_choices.first] }
     end
 
     it 'filters by candidate name' do

--- a/spec/system/provider_interface/provider_applications_search_spec.rb
+++ b/spec/system/provider_interface/provider_applications_search_spec.rb
@@ -13,7 +13,6 @@ RSpec.feature 'Providers should be able to filter applications' do
     and_i_am_permitted_to_see_applications_from_multiple_providers
     and_my_organisation_has_courses_with_applications
     and_i_sign_in_to_the_provider_interface
-    and_the_application_number_feature_flag_is_deactivated
 
     when_i_visit_the_provider_page
 
@@ -36,6 +35,9 @@ RSpec.feature 'Providers should be able to filter applications' do
 
     when_i_search_for_candidate_name_with_extra_spaces
     then_only_applications_of_that_name_should_be_visible
+
+    when_i_search_by_application_number
+    then_the_application_with_that_id_should_be_visible
 
     when_i_clear_the_filters
     then_i_filter_for_withdrawn_and_offered_applications
@@ -61,36 +63,17 @@ RSpec.feature 'Providers should be able to filter applications' do
     and_the_relevant_tags_should_be_visible
   end
 
-  scenario 'can search applications by application number' do
-    given_i_am_a_provider_user_with_dfe_sign_in
-    and_i_am_permitted_to_see_applications_from_multiple_providers
-    and_my_organisation_has_courses_with_applications
-    and_i_sign_in_to_the_provider_interface
-    and_the_application_number_feature_flag_is_activated
-    when_i_visit_the_provider_page
-    and_i_search_by_application_number
-    then_the_application_with_that_id_should_be_visible
-  end
-
   def then_the_application_with_that_id_should_be_visible
     card = find(:css, '.app-application-cards')
     expect(card).to have_text(current_provider.application_choices.first.application_form.full_name)
   end
 
   def when_i_search_for_part_of_a_candidate_name
-    fill_in 'Search by candidate name or reference', with: 'ame'
+    fill_in 'Search by candidate name or application number', with: 'ame'
     click_button('Search')
   end
 
-  def and_the_application_number_feature_flag_is_activated
-    FeatureFlag.activate(:application_number_replacement)
-  end
-
-  def and_the_application_number_feature_flag_is_deactivated
-    FeatureFlag.deactivate(:application_number_replacement)
-  end
-
-  def and_i_search_by_application_number
+  def when_i_search_by_application_number
     fill_in 'Search by candidate name or application number', with: current_provider.application_choices.first.id
     click_button('Search')
   end
@@ -149,12 +132,12 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def when_i_search_for_candidate_name
-    fill_in 'Search by candidate name or reference', with: 'Jim James'
+    fill_in 'Search by candidate name or application number', with: 'Jim James'
     click_button('Search')
   end
 
   def when_i_search_for_a_candidate_that_does_not_exist
-    fill_in 'Search by candidate name or reference', with: 'Simon Says'
+    fill_in 'Search by candidate name or application number', with: 'Simon Says'
     click_button('Search')
   end
 
@@ -169,7 +152,7 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def when_i_manually_clear_all_filters_and_apply_them
-    fill_in 'Search by candidate name or reference', with: ''
+    fill_in 'Search by candidate name or application number', with: ''
     click_button('Search')
     find(:css, '#status-withdrawn').set(false)
     find(:css, '#status-offer').set(false)
@@ -177,12 +160,12 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def when_i_search_for_candidate_name_with_odd_casing
-    fill_in 'Search by candidate name or reference', with: 'jiM JAmeS'
+    fill_in 'Search by candidate name or application number', with: 'jiM JAmeS'
     click_button('Search')
   end
 
   def when_i_search_for_candidate_name_with_extra_spaces
-    fill_in 'Search by candidate name or reference', with: '  Jim  James  '
+    fill_in 'Search by candidate name or application number', with: '  Jim  James  '
     click_button('Search')
   end
 
@@ -198,7 +181,7 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def then_i_expect_to_see_the_search_input
-    expect(page).to have_content('Search by candidate name or reference')
+    expect(page).to have_content('Search by candidate name or application number')
   end
 
   def when_i_visit_the_provider_page

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -77,11 +77,7 @@ RSpec.feature 'See applications' do
   end
 
   def then_i_should_be_on_the_application_view_page
-    if FeatureFlag.active?(:application_number_replacement)
-      expect(page).to have_content @my_provider_choice1.id
-    else
-      expect(page).to have_content @my_provider_choice1.application_form.support_reference
-    end
+    expect(page).to have_content @my_provider_choice1.id
 
     expect(page).to have_content @my_provider_choice1.application_form.full_name
   end


### PR DESCRIPTION
## Changes proposed in this pull request

https://trello.com/c/VjYLj2Tb/5033-remove-the-applicationnumberreplacement-feature-flag
Removing the `application_number_replacement` feature flag
