### PR TITLE
Enable emails to candidates when rejecting applications using new R4R…

### DIFF
--- a/app/services/reject_application.rb
+++ b/app/services/reject_application.rb
@@ -34,7 +34,7 @@ class RejectApplication
 
       CancelUpcomingInterviews.new(actor: @auth.actor, application_choice: @application_choice, cancellation_reason: I18n.t('interview_cancellation.reason.application_rejected')).call!
 
-      SendCandidateRejectionEmail.new(application_choice: @application_choice).call unless FeatureFlag.active?(:structured_reasons_for_rejection_redesign)
+      SendCandidateRejectionEmail.new(application_choice: @application_choice).call
     end
 
     true

--- a/app/services/reject_by_default_feedback.rb
+++ b/app/services/reject_by_default_feedback.rb
@@ -22,9 +22,7 @@ class RejectByDefaultFeedback
 
       show_apply_again_guidance = unsuccessful_application_choices? && not_applied_again?
 
-      unless FeatureFlag.active?(:structured_reasons_for_rejection_redesign)
-        CandidateMailer.feedback_received_for_application_rejected_by_default(application_choice, show_apply_again_guidance).deliver_later
-      end
+      CandidateMailer.feedback_received_for_application_rejected_by_default(application_choice, show_apply_again_guidance).deliver_later
 
       notify_slack
     end

--- a/spec/services/reject_application_spec.rb
+++ b/spec/services/reject_application_spec.rb
@@ -86,8 +86,6 @@ RSpec.describe RejectApplication do
     end
 
     it 'emails the candidate' do
-      FeatureFlag.deactivate(:structured_reasons_for_rejection_redesign)
-
       email_service = instance_double(SendCandidateRejectionEmail, call: true)
       allow(SendCandidateRejectionEmail).to receive(:new).and_return(email_service)
 

--- a/spec/services/reject_by_default_feedback_spec.rb
+++ b/spec/services/reject_by_default_feedback_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe RejectByDefaultFeedback, sidekiq: true do
-  before { FeatureFlag.deactivate(:structured_reasons_for_rejection_redesign) }
-
   let(:application_choice) { create(:application_choice, :with_rejection_by_default) }
   let(:rejection_reason) { 'The course became full' }
   let(:actor) { create(:provider_user) }
@@ -26,6 +24,8 @@ RSpec.describe RejectByDefaultFeedback, sidekiq: true do
   end
 
   it 'changes structured_rejection_reasons for the application choice when provided' do
+    FeatureFlag.deactivate(:structured_reasons_for_rejection_redesign)
+
     reasons_for_rejection_attrs = {
       candidate_behaviour_y_n: 'Yes',
       candidate_behaviour_what_did_the_candidate_do: %w[other],


### PR DESCRIPTION
… flow.


## Context

These were disabled while the feature was in development. We'd like to test the feature on QA now.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Enable emails to candidates notifying them of rejected applications.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
