### PR TITLE
Update `ApplicationChoicesWithOutOfDateProviderIds` invariant check

### DIFF
--- a/app/queries/find_application_choices_with_out_of_date_provider_ids.rb
+++ b/app/queries/find_application_choices_with_out_of_date_provider_ids.rb
@@ -2,9 +2,9 @@ class FindApplicationChoicesWithOutOfDateProviderIds
   def self.call
     with_course_joins = ApplicationChoice
                           .joins('INNER JOIN course_options AS current_course_option ON current_course_option_id = current_course_option.id')
-                          .joins('INNER JOIN course_options AS original_option ON course_option_id = original_option.id')
+                          .joins('INNER JOIN course_options AS course_option ON course_option_id = course_option.id')
                           .joins('INNER JOIN courses AS current_course ON current_course_option.course_id = current_course.id')
-                          .joins('INNER JOIN courses AS original_course ON original_option.course_id = original_course.id')
+                          .joins('INNER JOIN courses AS course ON course_option.course_id = course.id')
 
     # SQL equivalent for .compact.uniq
     get_expected_provider_ids_sql = <<~GET_EXPECTED_PROVIDER_IDS_SQL.squish
@@ -12,8 +12,8 @@ class FindApplicationChoicesWithOutOfDateProviderIds
       ARRAY(
         SELECT DISTINCT i FROM unnest(
           ARRAY[
-            original_course.provider_id,
-            original_course.accredited_provider_id,
+            course.provider_id,
+            course.accredited_provider_id,
             current_course.provider_id,
             current_course.accredited_provider_id
           ]

--- a/app/queries/find_application_choices_with_out_of_date_provider_ids.rb
+++ b/app/queries/find_application_choices_with_out_of_date_provider_ids.rb
@@ -3,8 +3,10 @@ class FindApplicationChoicesWithOutOfDateProviderIds
     with_course_joins = ApplicationChoice
                           .joins('INNER JOIN course_options AS current_course_option ON current_course_option_id = current_course_option.id')
                           .joins('INNER JOIN course_options AS course_option ON course_option_id = course_option.id')
+                          .joins('INNER JOIN course_options AS original_course_option ON original_course_option_id = original_course_option.id')
                           .joins('INNER JOIN courses AS current_course ON current_course_option.course_id = current_course.id')
                           .joins('INNER JOIN courses AS course ON course_option.course_id = course.id')
+                          .joins('INNER JOIN courses AS original_course ON original_course_option.course_id = original_course.id')
 
     # SQL equivalent for .compact.uniq
     get_expected_provider_ids_sql = <<~GET_EXPECTED_PROVIDER_IDS_SQL.squish
@@ -12,6 +14,8 @@ class FindApplicationChoicesWithOutOfDateProviderIds
       ARRAY(
         SELECT DISTINCT i FROM unnest(
           ARRAY[
+            original_course.provider_id,
+            original_course.accredited_provider_id,
             course.provider_id,
             course.accredited_provider_id,
             current_course.provider_id,

--- a/spec/queries/find_application_choices_with_out_of_date_provider_ids_spec.rb
+++ b/spec/queries/find_application_choices_with_out_of_date_provider_ids_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe FindApplicationChoicesWithOutOfDateProviderIds do
       expect(described_class.call).to eq([wrong_ids])
     end
 
+    it 'returns application choices with provider ids that do not include original course providers' do
+      application_with_wrong_ids = application_choices.second
+      application_with_wrong_ids.update(original_course_option: create(:course_option))
+      expect(described_class.call).to eq([application_with_wrong_ids])
+    end
+
     it 'does not mind if provider_ids are in a different order' do
       accredited_course = create(:course, :with_accredited_provider)
       accredited_option = create(:course_option, course: accredited_course)


### PR DESCRIPTION
## Context

We recently added a new `original_course_option_id` to applications which capture the original course an applicant applied to. This is due to adding a new feature to amend a course before an offer, meaning we lose this data along the way.

We have an invariant check to alert if any of our denormalised data goes out of sync. This has now become outdated as we are not including the new original course option field
## Changes proposed in this pull request

Add the original course option field to the query which finds applications where the `provder_ids` does not match the following course options: `original_course_option_id`, `course_option_id`,  `current_course_option_id`

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

[<!-- http://trello.com/123-example-card -->](https://trello.com/c/75kcaGGe/5035-fix-applicationchoiceswithoutofdateproviderids-invariant-check)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
