### PR TITLE
Clear `CourseChange` wizard on entry from application page

### DIFF
--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -1,5 +1,7 @@
 module ProviderInterface
   class ApplicationChoicesController < ProviderInterfaceController
+    include ClearWizardCache
+
     before_action :set_application_choice, except: %i[index]
     before_action :set_workflow_flags, except: %i[index]
 
@@ -35,6 +37,8 @@ module ProviderInterface
 
     def show
       if FeatureFlag.active?(:change_course_details_before_offer)
+        clear_wizard_if_new_entry(CourseWizard.new(change_course_store, {}))
+
         @wizard = CourseWizard.build_from_application_choice(
           change_course_store,
           @application_choice,
@@ -123,6 +127,16 @@ module ProviderInterface
     def change_course_store
       key = "change_course_wizard_store_#{current_provider_user.id}_#{@application_choice.id}"
       WizardStateStores::RedisStore.new(key: key)
+    end
+
+    def wizard_entrypoint_paths
+      [
+        edit_provider_interface_application_choice_course_providers_path,
+        edit_provider_interface_application_choice_course_courses_path,
+        edit_provider_interface_application_choice_course_study_modes_path,
+        edit_provider_interface_application_choice_course_locations_path,
+        edit_provider_interface_application_choice_course_check_path,
+      ].freeze
     end
   end
 end

--- a/spec/system/provider_interface/provider_exits_journey_when_changing_a_course_before_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_exits_journey_when_changing_a_course_before_an_offer_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+RSpec.feature 'Provider exits journey when changing a course' do
+  include DfESignInHelpers
+  include ProviderUserPermissionsHelper
+
+  let(:provider_user) { create(:provider_user, :with_dfe_sign_in) }
+  let(:provider) { provider_user.providers.first }
+  let(:ratifying_provider) { create(:provider) }
+  let(:application_form) { build(:application_form, :minimum_info) }
+  let!(:application_choice) do
+    create(:application_choice, :awaiting_provider_decision,
+           application_form: application_form,
+           course_option: course_option)
+  end
+  let(:course) do
+    build(:course, :full_time, provider: provider, accredited_provider: ratifying_provider)
+  end
+  let(:course_option) { build(:course_option, course: course) }
+
+  scenario 'Cancelling journey when changing a course choice before point of offer' do
+    given_i_am_a_provider_user
+    and_the_feature_flag_is_enabled
+    and_i_am_permitted_to_make_decisions_for_my_provider
+    and_i_sign_in_to_the_provider_interface
+    and_the_provider_has_multiple_courses
+
+    when_i_visit_the_provider_interface
+    and_i_click_an_application_choice
+    and_i_click_on_change_the_course
+    and_i_select_a_different_course
+    and_i_click_continue
+    then_i_see_a_list_of_locations_to_select_from
+
+    when_i_click_cancel
+    and_i_click_on_change_the_location
+    then_i_see_a_list_of_locations_to_select_from
+  end
+
+  def given_i_am_a_provider_user
+    user_exists_in_dfe_sign_in(email_address: provider_user.email_address)
+  end
+
+  def and_the_feature_flag_is_enabled
+    FeatureFlag.activate(:change_course_details_before_offer)
+  end
+
+  def and_i_am_permitted_to_make_decisions_for_my_provider
+    permit_make_decisions!
+  end
+
+  def and_i_sign_in_to_the_provider_interface
+    provider_signs_in_using_dfe_sign_in
+  end
+
+  def and_the_provider_has_multiple_courses
+    @selected_course = create(:course, :open_on_apply, study_mode: :full_time, provider: application_choice.provider, accredited_provider: ratifying_provider)
+
+    create(:course_option, :full_time, course: course)
+    create(:course_option, :full_time, course: @selected_course)
+    create(:course_option, :full_time, course: @selected_course)
+
+    create(
+      :provider_relationship_permissions,
+      training_provider: provider,
+      ratifying_provider: ratifying_provider,
+      ratifying_provider_can_make_decisions: true,
+    )
+  end
+
+  def when_i_visit_the_provider_interface
+    visit provider_interface_applications_path
+  end
+
+  def and_i_click_an_application_choice
+    click_on application_choice.application_form.full_name
+  end
+
+  def and_i_click_on_change_the_course
+    within(all('.govuk-summary-list__row').find { |e| e.text.include?('Course') }) do
+      click_on 'Change'
+    end
+  end
+
+  def and_i_select_a_different_course
+    choose @selected_course.name_and_code
+  end
+
+  def and_i_click_continue
+    click_on t('continue')
+  end
+
+  def then_i_see_a_list_of_locations_to_select_from
+    expect(page).to have_content "Update course - #{application_form.full_name}"
+    expect(page).to have_content 'Location'
+    expect(page).to have_css('.govuk-radios__item')
+  end
+
+  def when_i_click_cancel
+    first(:link, 'Cancel').click
+  end
+
+  def and_i_click_on_change_the_location
+    within(all('.govuk-summary-list__row').find { |e| e.text.include?('Location') }) do
+      click_on 'Change'
+    end
+  end
+end


### PR DESCRIPTION
## Context

If a user selects a different option than what the candidate applied for and cancel mid journey, then attempt to enter the wizard again, they will see no options for steps later in the wizard.

This is due the state not being cleared on exit of the wizard. 

## Changes proposed in this pull request

Clear wizard state when defining attributes on the application page, and add the set of URLs required to clear the state

## Guidance to review

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
