### PR TITLE
Reduce content and remove terms of use checkbox on Sign up page

### DIFF
--- a/app/controllers/candidate_interface/sign_up_controller.rb
+++ b/app/controllers/candidate_interface/sign_up_controller.rb
@@ -39,7 +39,7 @@ module CandidateInterface
     end
 
     def candidate_sign_up_form_params
-      params.require(:candidate_interface_sign_up_form).permit(:email_address, :accept_ts_and_cs).merge(course_from_find_id: course_id)
+      params.require(:candidate_interface_sign_up_form).permit(:email_address).merge(course_from_find_id: course_id)
     end
 
     def course_id

--- a/app/forms/candidate_interface/sign_up_form.rb
+++ b/app/forms/candidate_interface/sign_up_form.rb
@@ -1,9 +1,9 @@
 module CandidateInterface
   class SignUpForm
     include ActiveModel::Model
-    attr_accessor :email_address, :accept_ts_and_cs, :candidate, :course_from_find_id
+    attr_accessor :email_address, :candidate, :course_from_find_id
 
-    validates :email_address, :accept_ts_and_cs, presence: true
+    validates :email_address, presence: true
     validates :email_address, length: { maximum: 100 }
 
     validate :candidate_email_address_has_access
@@ -11,7 +11,6 @@ module CandidateInterface
 
     def initialize(params = {})
       @email_address = params[:email_address]
-      @accept_ts_and_cs = params[:accept_ts_and_cs]
       @candidate = Candidate.for_email @email_address
       @course_from_find_id = params[:course_from_find_id]
     end

--- a/app/views/candidate_interface/shared/_check_your_email.html.erb
+++ b/app/views/candidate_interface/shared/_check_your_email.html.erb
@@ -5,11 +5,11 @@
     <h1 class="govuk-heading-xl">
       <%= t('authentication.check_your_email') %>
     </h1>
-    <p class="govuk-body-l">
-      We’ve sent you an email. Click on the link to confirm your address and return to this service.
+    <p class="govuk-body-m">
+      You should have recieved a link by email. Follow the link confirm your email address.
     </p>
     <p class="govuk-body">
-      If our email does not arrive within 5 minutes, check your spam and trash folder, or <%= govuk_link_to 'try again', candidate_interface_create_account_or_sign_in_path %>.
+      If it does not arrive in 5 minutes, check your junk folder or <%= govuk_link_to 'try again', candidate_interface_create_account_or_sign_in_path %>.
     </p>
   </div>
 </div>

--- a/app/views/candidate_interface/sign_up/new.html.erb
+++ b/app/views/candidate_interface/sign_up/new.html.erb
@@ -13,9 +13,7 @@
 
       <%= f.govuk_email_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, hint: { text: t('authentication.sign_up.email_address.hint_label') }, width: 'two-thirds', autocomplete: 'email', spellcheck: false %>
 
-      <p class="govuk-body">Your email address will be looked after by the Department for Education and shared with the training providers you apply to.</p>
-
-      <p class="govuk-body govuk-!-margin-bottom-6">Our <%= govuk_link_to 'privacy policy', candidate_interface_privacy_policy_path %> describes how we use your data.</p>
+      <p class="govuk-body govuk-!-margin-bottom-6">Check you understand our <%= govuk_link_to 'privacy policy', candidate_interface_privacy_policy_path %> and <a href="#" class="https://www.apply-for-teacher-training.service.gov.uk/candidate/terms-of-use">terms of use</a> before you continue.</p>
 
       <%= f.hidden_field :accept_ts_and_cs, value: 'true' %>
 

--- a/app/views/candidate_interface/sign_up/new.html.erb
+++ b/app/views/candidate_interface/sign_up/new.html.erb
@@ -11,26 +11,14 @@
         <%= t('authentication.sign_up.heading') %>
       </h1>
 
-      <%= f.govuk_email_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, hint: { text: t('authentication.sign_up.email_address.hint_label') }, width: 'two-thirds', autocomplete: 'email', spellcheck: false %>
+      <%= f.govuk_email_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 's' }, hint: { text: t('authentication.sign_up.email_address.hint_label') }, width: 'two-thirds', autocomplete: 'email', spellcheck: false %>
 
-      <h2 class="govuk-heading-m">You will not need a password to use this service</h2>
-      <p class="govuk-body">Instead, you’ll sign in using your email address. Each time you sign in, we will send you a link so you can return to your application.</p>
+      <p class="govuk-body">Your email address will be looked after by the Department for Education and shared with the training providers you apply to.</p>
 
-      <h2 class="govuk-heading-m">How we look after your data</h2>
-      <p class="govuk-body">Your data will be looked after by the Department for Education and the training providers you apply to.</p>
-      <p class="govuk-body">We use it to process your application, build a better service and improve teacher recruitment and retention.</p>
-      <p class="govuk-body govuk-!-margin-bottom-6">Take a look at our <%= govuk_link_to 'privacy policy', candidate_interface_privacy_policy_path %> before starting your application to check you understand how we use your data.</p>
+      <p class="govuk-body govuk-!-margin-bottom-6">Our <%= govuk_link_to 'privacy policy', candidate_interface_privacy_policy_path %> describes how we use your data.</p>
 
-      <%= f.govuk_check_boxes_fieldset :accept_ts_and_cs, legend: { text: 'Terms of use' } do %>
-        <p class="govuk-body">Our <%= govuk_link_to 'terms of use', candidate_interface_terms_path %> contain information about:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>the application process</li>
-          <li>contacting us</li>
-          <li>checking you’re safe to work with children</li>
-        </ul>
+      <%= f.hidden_field :accept_ts_and_cs, value: 'true' %>
 
-        <%= f.govuk_check_box :accept_ts_and_cs, 'true', multiple: false, label: { text: t('authentication.sign_up.accept_terms_checkbox') }, link_errors: true %>
-      <% end %>
       <%= f.govuk_submit t('continue') %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/sign_up/new.html.erb
+++ b/app/views/candidate_interface/sign_up/new.html.erb
@@ -11,7 +11,7 @@
         <%= t('authentication.sign_up.heading') %>
       </h1>
 
-      <%= f.govuk_email_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 's' }, hint: { text: t('authentication.sign_up.email_address.hint_label') }, width: 'two-thirds', autocomplete: 'email', spellcheck: false %>
+      <%= f.govuk_email_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, hint: { text: t('authentication.sign_up.email_address.hint_label') }, width: 'two-thirds', autocomplete: 'email', spellcheck: false %>
 
       <p class="govuk-body">Your email address will be looked after by the Department for Education and shared with the training providers you apply to.</p>
 

--- a/app/views/candidate_interface/sign_up/new.html.erb
+++ b/app/views/candidate_interface/sign_up/new.html.erb
@@ -13,7 +13,7 @@
 
       <%= f.govuk_email_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, hint: { text: t('authentication.sign_up.email_address.hint_label') }, width: 'two-thirds', autocomplete: 'email', spellcheck: false %>
 
-      <p class="govuk-body govuk-!-margin-bottom-6">Check you understand our <%= govuk_link_to 'privacy policy', candidate_interface_privacy_policy_path %> and <%= govuk_link_to 'terms of use', candidate_interface_terms_path %> before you continue.</p>
+      <p class="govuk-body govuk-!-margin-bottom-6">By continuing, you agree to our <%= govuk_link_to 'terms of use', candidate_interface_terms_path %> and <%= govuk_link_to 'privacy policy', candidate_interface_privacy_policy_path %>.</p>
 
       <%= f.hidden_field :accept_ts_and_cs, value: 'true' %>
 

--- a/app/views/candidate_interface/sign_up/new.html.erb
+++ b/app/views/candidate_interface/sign_up/new.html.erb
@@ -13,7 +13,7 @@
 
       <%= f.govuk_email_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, hint: { text: t('authentication.sign_up.email_address.hint_label') }, width: 'two-thirds', autocomplete: 'email', spellcheck: false %>
 
-      <p class="govuk-body govuk-!-margin-bottom-6">Check you understand our <%= govuk_link_to 'privacy policy', candidate_interface_privacy_policy_path %> and <a href="#" class="https://www.apply-for-teacher-training.service.gov.uk/candidate/terms-of-use">terms of use</a> before you continue.</p>
+      <p class="govuk-body govuk-!-margin-bottom-6">Check you understand our <%= govuk_link_to 'privacy policy', candidate_interface_privacy_policy_path %> and <%= govuk_link_to 'terms of use', candidate_interface_terms_path %> before you continue.</p>
 
       <%= f.hidden_field :accept_ts_and_cs, value: 'true' %>
 

--- a/app/views/candidate_interface/sign_up/new.html.erb
+++ b/app/views/candidate_interface/sign_up/new.html.erb
@@ -15,8 +15,6 @@
 
       <p class="govuk-body govuk-!-margin-bottom-6">By continuing, you agree to our <%= govuk_link_to 'terms of use', candidate_interface_terms_path %> and <%= govuk_link_to 'privacy policy', candidate_interface_privacy_policy_path %>.</p>
 
-      <%= f.hidden_field :accept_ts_and_cs, value: 'true' %>
-
       <%= f.govuk_submit t('continue') %>
     <% end %>
   </div>

--- a/config/locales/candidate_interface/authentication.yml
+++ b/config/locales/candidate_interface/authentication.yml
@@ -2,7 +2,6 @@ en:
   authentication:
     sign_up:
       heading: Create an account
-      accept_terms_checkbox: I agree to the terms of use
       email_address:
         label: Email address
         hint_label: Do not use a work or university email address you might lose access to.
@@ -33,8 +32,6 @@ en:
               blank: Enter your email address
               too_long: Email address must be %{count} characters or fewer
               dfe_signup_only: Only DfE users can sign up in this test environment
-            accept_ts_and_cs:
-              blank: You must agree to the terms of use
         candidate_interface/create_account_or_sign_in_form:
           attributes:
             email:

--- a/config/locales/candidate_interface/authentication.yml
+++ b/config/locales/candidate_interface/authentication.yml
@@ -5,7 +5,7 @@ en:
       accept_terms_checkbox: I agree to the terms of use
       email_address:
         label: Email address
-        hint_label: Do not use a work or university email address you might lose access to
+        hint_label: Do not use a work or university email address you might lose access to.
       email:
         subject: Please confirm your email address
     check_your_email: Check your email

--- a/config/locales/candidate_interface/authentication.yml
+++ b/config/locales/candidate_interface/authentication.yml
@@ -1,10 +1,10 @@
 en:
   authentication:
     sign_up:
-      heading: Create an Apply for teacher training account
+      heading: Create an account
       accept_terms_checkbox: I agree to the terms of use
       email_address:
-        label: Enter your email address
+        label: Email address
         hint_label: Do not use a work or university email address you might lose access to
       email:
         subject: Please confirm your email address

--- a/cypress/integration/candidate.spec.js
+++ b/cypress/integration/candidate.spec.js
@@ -12,7 +12,6 @@ describe(`[${ENVIRONMENT}] Candidate`, () => {
     thenICanCreateAnAccount();
 
     whenITypeInMyEmail();
-    andAgreeToTermsAndConditions();
     andIClickContinue();
     thenIAmToldToCheckMyEmail();
 
@@ -41,19 +40,13 @@ const andIClickContinue = () => {
 };
 
 const thenICanCreateAnAccount = () => {
-  cy.contains("Create an Apply for teacher training account");
+  cy.contains("Create an account");
 };
 
 const whenITypeInMyEmail = () => {
   cy.get("#candidate-interface-sign-up-form-email-address-field").type(
     CANDIDATE_EMAIL
   );
-};
-
-const andAgreeToTermsAndConditions = () => {
-  cy.get(
-    "#candidate-interface-sign-up-form-accept-ts-and-cs-true-field"
-  ).click();
 };
 
 const thenIAmToldToCheckMyEmail = () => {

--- a/jmeter/plans/apply.rb
+++ b/jmeter/plans/apply.rb
@@ -48,8 +48,6 @@ test do
       name: 'Sign up page - submit email', url: url('/candidate/sign-up?courseCode=${courseCode}&providerCode=${providerCode}'),
       fill_in: {
         'candidate_interface_sign_up_form[email_address]': '${candidate_uuid}' + '@loadtest.example.com',
-        'candidate_interface_sign_up_form[accept_ts_and_cs][]': '',
-        'candidate_interface_sign_up_form[accept_ts_and_cs]': 'true',
         'authenticity_token': '${authenticity_token}',
         'commit': 'Continue',
       }

--- a/spec/forms/candidate_interface/sign_up_form_spec.rb
+++ b/spec/forms/candidate_interface/sign_up_form_spec.rb
@@ -5,27 +5,20 @@ RSpec.describe CandidateInterface::SignUpForm, type: :model do
   let(:existing_candidate) { create(:candidate) }
   let(:existing_email) { existing_candidate.email_address }
 
-  def new_form(email:, accept_ts_and_cs:, course_id: nil)
-    described_class.new(email_address: email, accept_ts_and_cs: accept_ts_and_cs, course_from_find_id: course_id)
+  def new_form(email:, course_id: nil)
+    described_class.new(email_address: email, course_from_find_id: course_id)
   end
 
   describe '#save' do
     it 'returns true if it creates a new candidate' do
-      form = new_form(email: new_email, accept_ts_and_cs: true)
+      form = new_form(email: new_email)
       expect(form.existing_candidate?).to be(false)
       expect(form.save).to be(true)
       expect(form.existing_candidate?).to be(true)
     end
 
-    it 'returns false if :accept_ts_and_cs is not true' do
-      form = new_form(email: new_email, accept_ts_and_cs: false)
-      expect(form.existing_candidate?).to be(false)
-      expect(form.save).to be(false)
-      expect(form.existing_candidate?).to be(false)
-    end
-
     it 'returns false if candidate email_address validations fail' do
-      form = new_form(email: 'foo', accept_ts_and_cs: true)
+      form = new_form(email: 'foo')
       expect(form.existing_candidate?).to be(false)
       expect(form.save).to be(false)
       expect(form.errors[:email_address]).not_to be_empty
@@ -33,7 +26,7 @@ RSpec.describe CandidateInterface::SignUpForm, type: :model do
 
     it 'returns false if candidate attempts to use a non-DfE email address on a test environment' do
       ClimateControl.modify HOSTING_ENVIRONMENT_NAME: 'qa' do
-        form = new_form(email: 'alice@example.com', accept_ts_and_cs: true)
+        form = new_form(email: 'alice@example.com')
         expect(form.existing_candidate?).to be(false)
         expect(form.save).to be(false)
         expect(form.errors[:email_address]).not_to be_empty
@@ -41,26 +34,26 @@ RSpec.describe CandidateInterface::SignUpForm, type: :model do
     end
 
     it 'returns false if email_address belongs to existing candidate' do
-      form = new_form(email: existing_email, accept_ts_and_cs: true)
+      form = new_form(email: existing_email)
       expect(form.existing_candidate?).to be(true)
       expect(form.save).to be(false)
     end
 
     it 'returns false if email_address is upcased version of one that exists' do
-      form = new_form(email: existing_email.upcase, accept_ts_and_cs: true)
+      form = new_form(email: existing_email.upcase)
       expect(form.existing_candidate?).to be(true)
       expect(form.save).to be(false)
     end
 
     it 'returns true if course_from_find_id if a value is given for course_from_find_id' do
-      form = new_form(email: new_email, accept_ts_and_cs: true, course_id: 12)
+      form = new_form(email: new_email, course_id: 12)
       expect(form.save).to be(true)
       expect(form.course_from_find_id).to eq(12)
     end
 
     it 'includes an event tag for BigQuery' do
       FeatureFlag.activate(:send_request_data_to_bigquery)
-      form = new_form(email: new_email, accept_ts_and_cs: true)
+      form = new_form(email: new_email)
 
       form.save
 
@@ -71,7 +64,6 @@ RSpec.describe CandidateInterface::SignUpForm, type: :model do
   end
 
   describe 'validations' do
-    it { is_expected.to validate_presence_of(:accept_ts_and_cs) }
     it { is_expected.to validate_presence_of(:email_address) }
     it { is_expected.to validate_length_of(:email_address).is_at_most(100) }
   end

--- a/spec/system/candidate_api/candidate_api_application_state_change_triggers_update_spec.rb
+++ b/spec/system/candidate_api/candidate_api_application_state_change_triggers_update_spec.rb
@@ -51,7 +51,6 @@ RSpec.feature 'Candidate API application status change' do
   def when_i_sign_up
     @email = "#{SecureRandom.hex}@example.com"
     visit candidate_interface_sign_up_path
-    check t('authentication.sign_up.accept_terms_checkbox')
     fill_in t('authentication.sign_up.email_address.label'), with: @email
     click_on t('continue')
   end

--- a/spec/system/candidate_interface/course_selection/candidate_existing_submitted_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_existing_submitted_user_with_course_params_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
 
   def and_i_submit_my_email_address
     fill_in t('authentication.sign_up.email_address.label'), with: @email
-    check t('authentication.sign_up.accept_terms_checkbox')
     click_on t('continue')
   end
 

--- a/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_and_cancel_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_and_cancel_spec.rb
@@ -39,7 +39,6 @@ RSpec.feature 'Candidate tries to sign in after selecting a course in find witho
 
   def and_i_submit_my_email_address
     fill_in t('authentication.sign_up.email_address.label'), with: @email
-    check 'I agree to the terms of use'
     click_on t('continue')
   end
 

--- a/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_spec.rb
@@ -62,7 +62,6 @@ RSpec.feature 'A new candidate arriving from Find with a course and provider cod
   def when_i_submit_my_email_address
     @email = "#{SecureRandom.hex}@example.com"
     fill_in t('authentication.sign_up.email_address.label'), with: @email
-    check t('authentication.sign_up.accept_terms_checkbox')
     click_on t('continue')
   end
 

--- a/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_spec.rb
@@ -112,7 +112,6 @@ RSpec.feature 'An existing candidate arriving from Find with a course and provid
 
   def and_i_submit_my_email_address
     fill_in t('authentication.sign_up.email_address.label'), with: @email
-    check t('authentication.sign_up.accept_terms_checkbox')
     click_on t('continue')
   end
 

--- a/spec/system/candidate_interface/course_selection/sandbox_user_apply_from_find_spec.rb
+++ b/spec/system/candidate_interface/course_selection/sandbox_user_apply_from_find_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature 'A sandbox user arriving from Find with a course and provider code
   end
 
   def then_i_see_the_sign_up_page
-    expect(page).to have_content 'Create an Apply for teacher training account'
+    expect(page).to have_content 'Create an account'
   end
 
   def when_i_sign_up

--- a/spec/system/candidate_interface/course_selection/sandbox_user_apply_from_find_spec.rb
+++ b/spec/system/candidate_interface/course_selection/sandbox_user_apply_from_find_spec.rb
@@ -43,7 +43,6 @@ RSpec.feature 'A sandbox user arriving from Find with a course and provider code
   end
 
   def when_i_sign_up
-    check t('authentication.sign_up.accept_terms_checkbox')
     fill_in t('authentication.sign_up.email_address.label'), with: @email
     click_on t('continue')
 

--- a/spec/system/candidate_interface/signup_and_signin/candidate_account_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_account_spec.rb
@@ -7,17 +7,10 @@ RSpec.feature 'Candidate account' do
     given_i_am_a_candidate_without_an_account
 
     when_i_visit_the_signup_page
-    and_i_submit_my_email_address
-    then_i_should_see_validation_errors_for_the_terms_and_conditions
-
-    when_i_visit_the_signup_page
-    and_i_accept_the_ts_and_cs
     and_i_submit_without_entering_an_email
     then_i_see_form_errors_on_the_page
-    and_the_ts_and_cs_are_still_checked
 
     when_i_visit_the_signup_page
-    and_i_accept_the_ts_and_cs
     and_i_submit_my_email_address
     then_i_receive_an_email_with_a_signup_link
     when_i_click_on_the_link_in_my_email
@@ -64,14 +57,6 @@ RSpec.feature 'Candidate account' do
     visit candidate_interface_sign_up_path
   end
 
-  def then_i_should_see_validation_errors_for_the_terms_and_conditions
-    expect(page).to have_content t('activemodel.errors.models.candidate_interface/sign_up_form.attributes.accept_ts_and_cs.blank')
-  end
-
-  def and_i_accept_the_ts_and_cs
-    check t('authentication.sign_up.accept_terms_checkbox')
-  end
-
   def and_i_submit_my_email_address(email = @email)
     fill_in t('authentication.sign_up.email_address.label'), with: email
     click_on t('continue')
@@ -79,10 +64,6 @@ RSpec.feature 'Candidate account' do
 
   def and_i_submit_without_entering_an_email
     click_on t('continue')
-  end
-
-  def and_the_ts_and_cs_are_still_checked
-    expect(page).to have_checked_field t('authentication.sign_up.accept_terms_checkbox')
   end
 
   def and_i_submit_my_email_address_in_uppercase

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_using_legacy_email_link_with_u_param_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_using_legacy_email_link_with_u_param_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature 'Candidate account' do
 
   def when_i_sign_in_and_out
     visit candidate_interface_sign_in_path
-    fill_in 'Enter your email address', with: current_candidate.email_address
+    fill_in 'Email address', with: current_candidate.email_address
     click_button t('continue')
     open_email(current_candidate.email_address)
     expect(current_email.subject).to have_content t('authentication.sign_in.email.subject')

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_with_validation_errors_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_with_validation_errors_spec.rb
@@ -2,6 +2,9 @@ require 'rails_helper'
 
 RSpec.feature 'Candidate tries to sign up' do
   scenario 'Candidate attempts to sign up without filling in an email address' do
+    pending
+    # TODO: this test doesn't seem to follow its scenario - it's checking for lack of accepting
+    # terms rather than lack of email address. We should change it or delete it.
     given_i_am_a_candidate_without_an_account
 
     when_i_go_to_sign_up

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_with_validation_errors_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_with_validation_errors_spec.rb
@@ -2,39 +2,29 @@ require 'rails_helper'
 
 RSpec.feature 'Candidate tries to sign up' do
   scenario 'Candidate attempts to sign up without filling in an email address' do
-    pending
-    # TODO: this test doesn't seem to follow its scenario - it's checking for lack of accepting
-    # terms rather than lack of email address. We should change it or delete it.
-    given_i_am_a_candidate_without_an_account
-
     when_i_go_to_sign_up
-    and_i_submit_an_email_address_without_checking_terms_of_use
+    and_i_submit_the_form_without_entering_an_email
 
     then_i_see_a_validation_error
     and_the_validation_error_is_logged
-  end
-
-  def given_i_am_a_candidate_without_an_account
-    @email = "#{SecureRandom.hex}@example.com"
   end
 
   def when_i_go_to_sign_up
     visit candidate_interface_sign_up_path
   end
 
-  def and_i_submit_an_email_address_without_checking_terms_of_use
-    fill_in t('authentication.sign_up.email_address.label'), with: @email
-    click_on t('continue')
+  def and_i_submit_the_form_without_entering_an_email
+    click_on 'Continue'
   end
 
   def then_i_see_a_validation_error
-    expect(page).to have_content t('activemodel.errors.models.candidate_interface/sign_up_form.attributes.accept_ts_and_cs.blank')
+    expect(page).to have_content 'Error: Enter your email address'
   end
 
   def and_the_validation_error_is_logged
     validation_error = ValidationError.last
     expect(validation_error).to be_present
-    expect(validation_error.details).to have_key('accept_ts_and_cs')
+    expect(validation_error.details).to have_key('email_address')
     expect(validation_error.user).to be_nil
     expect(validation_error.request_path).to eq(candidate_interface_sign_up_path)
     expect(validation_error.service).to eq('apply')

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_up_to_test_environment_without_dfe_email_address_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_up_to_test_environment_without_dfe_email_address_spec.rb
@@ -48,7 +48,6 @@ RSpec.feature 'Candidate cannot sign up to a test environment (e.g. qa) without 
 
   def and_i_submit_my_email_address
     fill_in t('authentication.sign_up.email_address.label'), with: @email
-    check t('authentication.sign_up.accept_terms_checkbox')
     click_on t('continue')
   end
 

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
@@ -37,7 +37,6 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
 
   def and_i_submit_my_email_address
     fill_in t('authentication.sign_up.email_address.label'), with: @email
-    check t('authentication.sign_up.accept_terms_checkbox')
     click_on t('continue')
   end
 

--- a/spec/system/candidate_interface/signup_and_signin/candidate_tries_to_reuse_magic_link_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_tries_to_reuse_magic_link_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature 'Candidate account' do
 
   def when_i_sign_in_and_out
     visit candidate_interface_sign_in_path
-    fill_in 'Enter your email address', with: current_candidate.email_address
+    fill_in 'Email address', with: current_candidate.email_address
     click_button t('continue')
     open_email(current_candidate.email_address)
     expect(current_email.subject).to have_content t('authentication.sign_in.email.subject')

--- a/spec/system/candidate_interface/signup_and_signin/two_candidates_sign_in_on_same_machine_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/two_candidates_sign_in_on_same_machine_spec.rb
@@ -18,7 +18,6 @@ RSpec.feature 'Candidate account' do
 
   def then_i_can_sign_up_and_sign_out(email)
     when_i_visit_the_signup_page
-    and_i_accept_the_ts_and_cs
     and_i_submit_my_email_address(email)
     then_i_receive_an_email_with_a_signup_link(email)
 
@@ -47,10 +46,6 @@ RSpec.feature 'Candidate account' do
 
   def when_i_visit_the_signup_page
     visit candidate_interface_sign_up_path
-  end
-
-  def and_i_accept_the_ts_and_cs
-    check t('authentication.sign_up.accept_terms_checkbox')
   end
 
   def and_i_submit_my_email_address(email)


### PR DESCRIPTION
## Context

Tracking of error messages has shown that the error of not checking the terms of use checkbox on the Sign up page has been triggered 4,083 times.  Given that we have ~95,000 candidates who have used the service, this is an error rate of around 4%.

Probably, most users just didn't see the checkbox, as there's quite a lot of content on the page, and then had to check it after seeing the error. Not a huge deal, but also not a great introductory experience to the service.

It’s unclear that there's any legal reason for having to check a checkbox at the account creation stage, and so we can just link to the terms and conditions instead.

So the simplest fix is to remove the checkbox.

At the same time, we could also remove a lot of the rest of the content on this page, to simplify the flow and speed users along. The information about not needing a password might be helpful, but perhaps unnecessary as users will experience this for themselves directly.

The privacy information has been shortened and refocused on the email address rather than "data", as that's all that being provided at this point, and email addresses are quite privacy-sensitive given concerns about spam.

## Screenshots

### Before

![sign-up-before](https://user-images.githubusercontent.com/30665/164502049-ff80c90c-f26f-48e5-a3f5-1085172df11a.png)

### After

![sign-up](https://user-images.githubusercontent.com/30665/165110011-ccc77000-50e7-4078-8185-dbdc87cc45f0.png)


