### PR TITLE
Vendor API return latest minor version

### DIFF
--- a/app/lib/concerns/versioning_helpers.rb
+++ b/app/lib/concerns/versioning_helpers.rb
@@ -10,7 +10,7 @@ module VersioningHelpers
   end
 
   def minor_version_number(version)
-    Gem::Version.new(version).segments[1] || 0
+    Gem::Version.new(version).segments[1] || Gem::Version.new(released_version).segments[1]
   end
 
   def prerelease_suffix?(version)

--- a/app/lib/concerns/versioning_helpers.rb
+++ b/app/lib/concerns/versioning_helpers.rb
@@ -10,7 +10,7 @@ module VersioningHelpers
   end
 
   def minor_version_number(version)
-    Gem::Version.new(version).segments[1] || Gem::Version.new(released_version).segments[1]
+    Gem::Version.new(version).segments[1] || Gem::Version.new(production_version).segments[1]
   end
 
   def prerelease_suffix?(version)
@@ -18,10 +18,10 @@ module VersioningHelpers
   end
 
   def released_versions
-    ordered_versions.reject { |version| prerelease?(version_number(version)) }
+    ordered_versions.reject { |version| prerelease?(full_version_number_from(version)) }
   end
 
-  def version_number(version)
+  def full_version_number_from(version)
     "#{major_version_number(version)}.#{minor_version_number(version)}"
   end
 
@@ -30,7 +30,7 @@ module VersioningHelpers
   end
 
   def production_version
-    ordered_versions.keys.reverse.find { |version| !prerelease?(version_number(version)) }
+    ordered_versions.keys.reverse.find { |version| !prerelease?(full_version_number_from(version)) }
   end
 
   def released_version
@@ -41,7 +41,7 @@ module VersioningHelpers
   end
 
   def development_version
-    version_number(ordered_versions.keys.last)
+    full_version_number_from(ordered_versions.keys.last)
   end
 
   def ordered_versions

--- a/app/presenters/vendor_api/base.rb
+++ b/app/presenters/vendor_api/base.rb
@@ -39,7 +39,7 @@ module VendorAPI
     end
 
     def active_version_not_available
-      (Gem::Version.new(version_number(released_version)) <=> Gem::Version.new(active_version)).negative?
+      (Gem::Version.new(full_version_number_from(released_version)) <=> Gem::Version.new(active_version)).negative?
     end
 
     def active_version_in_retrieved_version?(version)

--- a/lib/tasks/version.rake
+++ b/lib/tasks/version.rake
@@ -17,7 +17,7 @@ namespace :version do
     task :changes, %i[version] => :environment do |_, args|
       specified_version = args.fetch(:version, nil)
       VendorAPI.ordered_versions.each do |version, version_changes|
-        next if version.present? && specified_version != VendorAPI.version_number(version)
+        next if version.present? && specified_version != VendorAPI.full_version_number_from(version)
 
         STDOUT.puts "Version v#{version}\n\n"
         version_changes.each do |change_class|

--- a/spec/lib/concerns/versioning_helpers_spec.rb
+++ b/spec/lib/concerns/versioning_helpers_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe VersioningHelpers do
+  include described_class
+
+  describe '#minor_version_number' do
+    before do
+      stub_const('VendorAPI::VERSION', '1.2')
+      stub_const(
+        'VendorAPI::VERSIONS',
+        {
+          '1.0' => [],
+          '1.1' => [],
+          '1.2pre' => [],
+          '1.3pre' => [],
+        },
+      )
+    end
+
+    context 'no minor version specified' do
+      context 'production env' do
+        before { allow(HostingEnvironment).to receive(:production?).and_return(true) }
+
+        it 'returns the latest released minor version' do
+          expect(minor_version_number('1')).to eq 1
+        end
+      end
+
+      context 'sandbox env' do
+        before do
+          allow(HostingEnvironment).to receive(:production?).and_return(false)
+          allow(HostingEnvironment).to receive(:sandbox_mode?).and_return(true)
+        end
+
+        it 'returns the default minor version' do
+          expect(minor_version_number('1')).to eq 2
+        end
+      end
+
+      context 'development env' do
+        before do
+          allow(HostingEnvironment).to receive(:production?).and_return(false)
+          allow(HostingEnvironment).to receive(:sandbox_mode?).and_return(false)
+        end
+
+        it 'returns the latest minor version' do
+          expect(minor_version_number('1')).to eq 3
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/concerns/versioning_helpers_spec.rb
+++ b/spec/lib/concerns/versioning_helpers_spec.rb
@@ -18,34 +18,8 @@ RSpec.describe VersioningHelpers do
     end
 
     context 'no minor version specified' do
-      context 'production env' do
-        before { allow(HostingEnvironment).to receive(:production?).and_return(true) }
-
-        it 'returns the latest released minor version' do
-          expect(minor_version_number('1')).to eq 1
-        end
-      end
-
-      context 'sandbox env' do
-        before do
-          allow(HostingEnvironment).to receive(:production?).and_return(false)
-          allow(HostingEnvironment).to receive(:sandbox_mode?).and_return(true)
-        end
-
-        it 'returns the default minor version' do
-          expect(minor_version_number('1')).to eq 2
-        end
-      end
-
-      context 'development env' do
-        before do
-          allow(HostingEnvironment).to receive(:production?).and_return(false)
-          allow(HostingEnvironment).to receive(:sandbox_mode?).and_return(false)
-        end
-
-        it 'returns the latest minor version' do
-          expect(minor_version_number('1')).to eq 3
-        end
+      it 'returns the latest released minor version' do
+        expect(minor_version_number('1')).to eq 1
       end
     end
   end

--- a/spec/requests/api_docs/reference_spec.rb
+++ b/spec/requests/api_docs/reference_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'API Docs - GET /api-docs/reference', type: :request do
     it "returns paths and components for version #{version}" do
       stub_const('VendorAPI::VERSION', version)
 
-      get api_docs_versioned_reference_path("v#{VendorAPI.version_number(version)}")
+      get api_docs_versioned_reference_path("v#{VendorAPI.full_version_number_from(version)}")
 
       expect(response).to have_http_status(:ok)
       expect(response.body).to match 'API reference'

--- a/spec/requests/vendor_api/versioning_spec.rb
+++ b/spec/requests/vendor_api/versioning_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe 'Versioning', type: :request do
     context 'when a route is not available for the specified version' do
       it 'returns a not found error' do
         stub_const('VendorAPI::VERSIONS', { '1.2' => [VendorAPI::Changes::RetrieveSingleApplication] })
-        get_api_request "/api/v1/applications/#{application_choice.id}"
+        get_api_request "/api/v1.1/applications/#{application_choice.id}"
 
         expect(response).to have_http_status(:not_found)
       end

--- a/spec/support/vendor_api/shared_examples.rb
+++ b/spec/support/vendor_api/shared_examples.rb
@@ -7,7 +7,7 @@ RSpec.shared_examples 'an endpoint that requires metadata' do |action, version =
     post_api_request "/api/v#{version}/applications/#{application_choice.id}/#{action}", params: { 'meta' => nil }
 
     expect(response).to have_http_status(:unprocessable_entity)
-    expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse', version_number(version))
+    expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse', full_version_number_from(version))
   end
 
   it 'returns an error when Metadata is invalid' do
@@ -18,7 +18,7 @@ RSpec.shared_examples 'an endpoint that requires metadata' do |action, version =
     post_api_request "/api/v#{version}/applications/#{application_choice.id}/#{action}", params: { 'meta' => invalid_metadata }
 
     expect(response).to have_http_status(:unprocessable_entity)
-    expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse', version_number(version))
+    expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse', full_version_number_from(version))
 
     errors = parsed_response['errors']
 


### PR DESCRIPTION
Update versioning system to point to the latest fully-released minor version
if the v1 API URL is requested

## Context

[Trello](https://trello.com/c/UktWpPAd/5037-surface-latest-api-version-when-requesting-major-version-in-url)