### PR TITLE
Relabel estimate checkboxes

### DIFF
--- a/config/locales/candidate_interface/restructured_work_history.yml
+++ b/config/locales/candidate_interface/restructured_work_history.yml
@@ -33,11 +33,11 @@ en:
       start_date:
         label: When did you start this job?
         hint_text: For example, 5 2018. If you cannot remember the exact month or year, enter an estimate.
-      start_date_unknown_checkbox: I’m not sure the exact month or year I started
+      start_date_unknown_checkbox: The month or year I started is an estimate
       end_date:
         label: When did you leave this job?
         hint_text: For example, 5 2018. If you cannot remember the exact month or year, enter an estimate.
-      end_date_unknown_checkbox: I’m not sure the exact month or year I left
+      end_date_unknown_checkbox: The month or year I left is an estimate
       currently_working:
         label: Are you still working in this job?
       relevant_skills:

--- a/config/locales/candidate_interface/restructured_work_history.yml
+++ b/config/locales/candidate_interface/restructured_work_history.yml
@@ -33,11 +33,11 @@ en:
       start_date:
         label: When did you start this job?
         hint_text: For example, 5 2018. If you cannot remember the exact month or year, enter an estimate.
-      start_date_unknown_checkbox: The month or year I started is an estimate
+      start_date_unknown_checkbox: This is an estimate
       end_date:
         label: When did you leave this job?
         hint_text: For example, 5 2018. If you cannot remember the exact month or year, enter an estimate.
-      end_date_unknown_checkbox: The month or year I left is an estimate
+      end_date_unknown_checkbox: This is an estimate
       currently_working:
         label: Are you still working in this job?
       relevant_skills:

--- a/config/locales/candidate_interface/volunteering.yml
+++ b/config/locales/candidate_interface/volunteering.yml
@@ -48,7 +48,7 @@ en:
         label: When did you start this role?
         hint_text: For example, 5 2018. If you cannot remember the exact month or year, enter an estimate.
       start_date_unknown_checkbox: The month or year I started is an estimate
-      end_date_unknown_checkbox: The month or year I left is an estimate
+      end_date_unknown_checkbox: The month or year I finished is an estimate
       currently_working:
         label: Are you still working in this role?
       end_date_restructured_work_history:

--- a/config/locales/candidate_interface/volunteering.yml
+++ b/config/locales/candidate_interface/volunteering.yml
@@ -6,7 +6,7 @@ en:
         change_action: relevant unpaid experience
       no_experience:
         summary_card_title: 'Children and young people: no volunteering or experience in school roles entered'
-        get_experience: Learn about how to get school experience 
+        get_experience: Learn about how to get school experience
       role:
         label: Your role
         review_label: Role
@@ -47,8 +47,8 @@ en:
       start_date_restructured_work_history:
         label: When did you start this role?
         hint_text: For example, 5 2018. If you cannot remember the exact month or year, enter an estimate.
-      start_date_unknown_checkbox: I’m not sure the exact month or year I started
-      end_date_unknown_checkbox: I’m not sure the exact month or year I left
+      start_date_unknown_checkbox: The month or year I started is an estimate
+      end_date_unknown_checkbox: The month or year I left is an estimate
       currently_working:
         label: Are you still working in this role?
       end_date_restructured_work_history:

--- a/config/locales/candidate_interface/volunteering.yml
+++ b/config/locales/candidate_interface/volunteering.yml
@@ -47,8 +47,8 @@ en:
       start_date_restructured_work_history:
         label: When did you start this role?
         hint_text: For example, 5 2018. If you cannot remember the exact month or year, enter an estimate.
-      start_date_unknown_checkbox: The month or year I started is an estimate
-      end_date_unknown_checkbox: The month or year I finished is an estimate
+      start_date_unknown_checkbox: This is an estimate
+      end_date_unknown_checkbox: This is an estimate
       currently_working:
         label: Are you still working in this role?
       end_date_restructured_work_history:


### PR DESCRIPTION
## Context

Analysis of the error messages seen by candidate shows that candidate frequently omit either the month or year or both from the start and end dates in the work experience and volunteering forms:

### Work experience
| Error | count |
|---|---|
| Enter the month and year you started this job | 4,000 |
| The start date must include a month | 3,350 |
| The start date must include a year | 110 |
| Enter the month and year you left this job | 2,900 |
| The end date must include a month | 2,800 |
| The end date must include a year | 70 |

### Volunteering
| Error | count |
|---|---|
| Enter a start date | 8,800 |
| The start date must include a month | 4,000 |
| The start date must include a year | 50 |
| Enter an end date | 6,600 |
| The end date must include a month | 3,500 |
| The end date must include a year | 60 |

Unfortunately we can't tell how often this happens in conjunction with also checking the "I’m not sure the exact month or year I started" checkbox. However our hypothesis is that candidates are often doing this, assuming that checking the checkbox allows them to omit one or both parts of the date.  

Unfortunately, both month and year are current required, even if given as estimates, because:

* The API expects a full date (although we set the `day` part to be first of every month)
* The months and years are used to calculate whether there is a 'break' in the work history which needs to be explained (although this isn't the case for volunteering).

🗂️  [Trello card](https://trello.com/c/r3PkuJBq/2958-can-we-help-users-who-are-uncertain-in-their-job-volunteering-months)

## Changes proposed in this pull request

We could consider:

1. Removing the checkboxes. These were added so that candidates could explicitly tell providers if the date was an estimate, to avoid them feeling uncomfortable with having to give an estimate which may be inaccurate. However this may not be required given that we explicitly say that estimates can be entered.

2. Allowing the month to be blank. This would be easier for the volunteering form than for the work experience form, but could be done for both.

However, in the short term we can try and alleviate the problem by rewording the checkbox to try and make it clearer that the year and months still need to be entered.

Suggested wording is:

> This is an estimate

### Screenshots

| Before | After|
|----|----|
|  ![estimate-checkbox-before](https://user-images.githubusercontent.com/30665/164702721-61b87142-60fe-45b1-8f7d-fc1d395fd477.png) |  ![estimate-checkbox-after](https://user-images.githubusercontent.com/30665/165118575-6668dc4a-cd22-49e2-a9a7-0ffaf49269cc.png) |
|  ![volunteering-before](https://user-images.githubusercontent.com/30665/164702858-97b6744f-4fc9-4a89-85f7-5de431b6cd47.png) | ![volunteering-after](https://user-images.githubusercontent.com/30665/165118560-1008c7f4-28cd-4ab4-b04d-02f38ff7e31c.png) |


