### PR TITLE
experiments to promote tta service better

### DIFF
--- a/app/components/candidate_interface/application_dashboard_guidance_component.html.erb
+++ b/app/components/candidate_interface/application_dashboard_guidance_component.html.erb
@@ -6,17 +6,17 @@
     <p class="govuk-body">Your application has been submitted and is with the training provider.</p>
   <% end %>
 
-  <p class="govuk-body">Our <%= govuk_link_to('teacher training advisers', I18n.t('get_into_teaching.url_get_an_adviser')) %> can help you prepare for any interviews.</p>
+  <p class="govuk-body govuk-!-margin-bottom-6">A <%= govuk_link_to('teacher training adviser', I18n.t('get_into_teaching.url_get_an_adviser')) %> can help you prepare for any interviews.</p>
 
 <% elsif multiple_offers_but_awaiting_decisions? %>
 
   <p class="govuk-body">2 of your training providers have made a decision on your application.</p>
-  <p class="govuk-body">Our <%= govuk_link_to('teacher training advisers', I18n.t('get_into_teaching.url_get_an_adviser')) %> can help you prepare for any interviews.</p>
+  <p class="govuk-body govuk-!-margin-bottom-6">A <%= govuk_link_to('teacher training adviser', I18n.t('get_into_teaching.url_get_an_adviser')) %> can help you prepare for any interviews.</p>
 
 <% elsif single_offer_but_awaiting_decisions? %>
 
   <p class="govuk-body">One of your training providers has made a decision on your application.</p>
-  <p class="govuk-body">Our <%= govuk_link_to('teacher training advisers', I18n.t('get_into_teaching.url_get_an_adviser')) %> can help you prepare for any interviews.</p>
+  <p class="govuk-body govuk-!-margin-bottom-6">A <%= govuk_link_to('teacher training adviser', I18n.t('get_into_teaching.url_get_an_adviser')) %> can help you prepare for any interviews.</p>
 
 <% elsif offer_accepted? %>
 

--- a/app/views/candidate_interface/personal_statement/_form.html.erb
+++ b/app/views/candidate_interface/personal_statement/_form.html.erb
@@ -4,19 +4,21 @@
   <%= t('page_titles.becoming_a_teacher') %>
 </h1>
 
-<p class="govuk-body">Explain why you want to be a teacher. You could talk about:</p>
+<p class="govuk-body">Explain why you want to be a teacher.</p>
+
+<p class="govuk-body">You could talk about:</p>
 
 <ul class="govuk-list govuk-list--bullet">
   <li>what inspired you to apply</li>
-  <li>your understanding of the demands and rewards of teaching</li>
   <li>the personal qualities that would make you a good teacher</li>
-  <li>how you could contribute to a school outside of the classroom - for example, running extra-curricular activities and clubs</li>
   <li>any experience you have working with children and what you learnt</li>
+  <li>your understanding of the demands and rewards of teaching</li>
+  <li>how you could contribute to a school outside of the classroom - for example, running extra-curricular activities and clubs</li>
   <li>your thoughts on children’s wellbeing and the education system</li>
 </ul>
 
 <%= govuk_inset_text do %>
-  <p class="govuk-body"><%= govuk_link_to 'Find out if you’re eligible for a teacher training adviser', t('get_into_teaching.url_get_an_adviser') %> to get advice on your application from an experienced teacher.</p>
+  <p class="govuk-body">A <%= govuk_link_to 'teacher training adviser', t('get_into_teaching.url_get_an_adviser') %> can help you with this section.</p>
 <% end %>
 
 <%= f.govuk_text_area :becoming_a_teacher, label: { text: t('application_form.personal_statement.becoming_a_teacher.label'), size: 'm' }, rows: 20, max_words: 600 %>

--- a/app/views/candidate_interface/subject_knowledge/_form.html.erb
+++ b/app/views/candidate_interface/subject_knowledge/_form.html.erb
@@ -9,14 +9,18 @@
 
 <p class="govuk-body">If you're applying for a primary course with a subject specialism, or you're particularly interested in certain primary subjects, you can also talk about that.</p>
 
-<p class="govuk-body">You could include details about:</p>
+<p class="govuk-body">You could talk about your:</p>
 <ul class="govuk-list govuk-list--bullet">
-  <li>any relevant work experience</li>
-  <li>your degrees and degree modules</li>
-  <li>your other relevant qualifications, such as A levels</li>
-  <li>any relevant skills, interests or achievements</li>
-  <li>your understanding of the national curriculum</li>
+  <li>work experience</li>
+  <li>degree and degree modules</li>
+  <li>qualifications, such as A levels</li>
+  <li>skills, interests or achievements</li>
+  <li>understanding of the national curriculum</li>
 </ul>
+
+<%= govuk_inset_text do %>
+  <p class="govuk-body">A <%= govuk_link_to 'teacher training adviser', t('get_into_teaching.url_get_an_adviser') %> can help you with this section.</p>
+<% end %>
 
 <%= f.govuk_text_area :subject_knowledge, label: { text: t('application_form.personal_statement.subject_knowledge.label'), size: 'm' }, rows: 20, max_words: 400 %>
 <%= f.govuk_submit t('continue') %>


### PR DESCRIPTION
Before:

(we don't mention TTA on suitability to teach page) 

![Screenshot 2022-04-22 at 12 19 32](https://user-images.githubusercontent.com/56349171/164704752-cf9ac27c-bbe4-47df-abd6-e19a24ca4437.png)

After:

(mention TTA service)

also - edit bullets to remove repetition of 'your' and 'relevant'

![Screenshot 2022-04-22 at 12 20 09](https://user-images.githubusercontent.com/56349171/164704831-a3ab867a-82c9-438f-940e-b34fa4fe6059.png)

Before:

(TTA link is squished up next to summary card component - probably not great for visibility) 

![Screenshot 2022-04-22 at 12 21 10](https://user-images.githubusercontent.com/56349171/164704989-c5345c3c-e9d9-4bc7-9ef9-eb469082a86f.png)

After:

(add a touch more space) 

![Screenshot 2022-04-22 at 12 22 14](https://user-images.githubusercontent.com/56349171/164705133-23302263-7b34-48a6-b253-34091e8d9d67.png)

Before: 

while I'm here, I've also looked at the order of these bullets 

some of the bullets seem quite hard to answer

![Screenshot 2022-04-22 at 12 27 36](https://user-images.githubusercontent.com/56349171/164705902-d3a9b310-0ae4-4e1f-aabb-c30520b0f68d.png)

After: 

shift the bullets that seem harder to answer the the bottom of the list!

![Screenshot 2022-04-22 at 12 29 57](https://user-images.githubusercontent.com/56349171/164706233-a99d99f0-94f3-4217-991c-c6c566eb830a.png)

