### PR TITLE
Applications should match if no postcode provided

### DIFF
--- a/app/models/duplicate_match.rb
+++ b/app/models/duplicate_match.rb
@@ -5,12 +5,18 @@ class DuplicateMatch < ApplicationRecord
   has_many :candidates, foreign_key: 'fraud_match_id'
 
   def self.match_for(last_name:, postcode:, date_of_birth:)
-    DuplicateMatch.where(
+    duplicate_match_query = DuplicateMatch.where(
       'TRIM(UPPER(last_name)) = ?',
       last_name.upcase.strip,
-    ).where(
-      "REPLACE(UPPER(postcode), ' ', '') = ?",
-      postcode&.upcase&.gsub(' ', ''),
-    ).where(date_of_birth: date_of_birth).first
+    ).where(date_of_birth: date_of_birth)
+
+    if postcode.present?
+      duplicate_match_query = duplicate_match_query.where(
+        "REPLACE(UPPER(postcode), ' ', '') = ?",
+        postcode.upcase.gsub(' ', ''),
+      )
+    end
+
+    duplicate_match_query.first
   end
 end

--- a/app/models/duplicate_match.rb
+++ b/app/models/duplicate_match.rb
@@ -10,7 +10,7 @@ class DuplicateMatch < ApplicationRecord
       last_name.upcase.strip,
     ).where(
       "REPLACE(UPPER(postcode), ' ', '') = ?",
-      postcode.upcase.gsub(' ', ''),
+      postcode&.upcase&.gsub(' ', ''),
     ).where(date_of_birth: date_of_birth).first
   end
 end

--- a/app/queries/get_duplicate_matches.rb
+++ b/app/queries/get_duplicate_matches.rb
@@ -10,21 +10,21 @@ class GetDuplicateMatches
           submitted_at
         FROM application_forms application_details
         JOIN(
-          SELECT TRIM(UPPER(application_forms.last_name)) last_name, application_forms.date_of_birth, REPLACE(UPPER(application_forms.postcode), ' ', '') postcode
+          SELECT TRIM(UPPER(application_forms.last_name)) last_name, application_forms.date_of_birth, COALESCE(REPLACE(UPPER(application_forms.postcode), ' ', ''), '') postcode
           FROM application_forms
           WHERE application_forms.previous_application_form_id IS NULL
           GROUP BY TRIM(UPPER(application_forms.last_name)), application_forms.date_of_birth, REPLACE(UPPER(application_forms.postcode), ' ', '')
           HAVING (count(*) > 1)
         ) duplicate_attributes
-        ON REPLACE(UPPER(application_details.postcode), ' ', '') = duplicate_attributes.postcode
+        ON COALESCE(REPLACE(UPPER(application_details.postcode), ' ', ''), '') = duplicate_attributes.postcode
         AND application_details.date_of_birth = duplicate_attributes.date_of_birth
         AND TRIM(UPPER(application_details.last_name)) = duplicate_attributes.last_name
         JOIN(
-          SELECT TRIM(UPPER(application_forms.last_name)) last_name, application_forms.date_of_birth, REPLACE(UPPER(application_forms.postcode), ' ', '') postcode
+          SELECT TRIM(UPPER(application_forms.last_name)) last_name, application_forms.date_of_birth, COALESCE(REPLACE(UPPER(application_forms.postcode), ' ', ''), '') postcode
           FROM application_forms
           WHERE application_forms.previous_application_form_id IS NULL
         ) duplicate_submitted_attributes
-        ON REPLACE(UPPER(application_details.postcode), ' ', '') = duplicate_submitted_attributes.postcode
+        ON COALESCE(REPLACE(UPPER(application_details.postcode), ' ', ''), '') = duplicate_submitted_attributes.postcode
         AND application_details.date_of_birth = duplicate_submitted_attributes.date_of_birth
         AND TRIM(UPPER(application_details.last_name)) = duplicate_submitted_attributes.last_name
         JOIN(

--- a/app/queries/get_duplicate_matches.rb
+++ b/app/queries/get_duplicate_matches.rb
@@ -4,7 +4,7 @@ class GetDuplicateMatches
       "SELECT DISTINCT application_details.candidate_id,
           application_details.first_name,
           application_details.last_name last_name,
-          TRIM(UPPER(application_details.postcode)) postcode,
+          COALESCE(TRIM(UPPER(application_details.postcode)), '') postcode,
           application_details.date_of_birth,
           email_address,
           submitted_at
@@ -13,7 +13,7 @@ class GetDuplicateMatches
           SELECT TRIM(UPPER(application_forms.last_name)) last_name, application_forms.date_of_birth, COALESCE(REPLACE(UPPER(application_forms.postcode), ' ', ''), '') postcode
           FROM application_forms
           WHERE application_forms.previous_application_form_id IS NULL
-          GROUP BY TRIM(UPPER(application_forms.last_name)), application_forms.date_of_birth, REPLACE(UPPER(application_forms.postcode), ' ', '')
+          GROUP BY TRIM(UPPER(application_forms.last_name)), application_forms.date_of_birth, COALESCE(REPLACE(UPPER(application_forms.postcode), ' ', ''), '')
           HAVING (count(*) > 1)
         ) duplicate_attributes
         ON COALESCE(REPLACE(UPPER(application_details.postcode), ' ', ''), '') = duplicate_attributes.postcode

--- a/app/services/update_duplicate_matches.rb
+++ b/app/services/update_duplicate_matches.rb
@@ -1,6 +1,8 @@
 class UpdateDuplicateMatches
-  def initialize
-    @matches = GetDuplicateMatches.call
+  def initialize(matches: GetDuplicateMatches.call, send_email: true, block_submission: true)
+    @matches = matches
+    @send_email = send_email
+    @block_submission = block_submission
   end
 
   def save!
@@ -67,8 +69,8 @@ private
   end
 
   def process_match(candidate, duplicate_match)
-    notify_candidate(candidate, duplicate_match)
-    block_submission(candidate)
+    notify_candidate(candidate, duplicate_match) if @send_email
+    block_submission(candidate) if @block_submission
   end
 
   def block_submission(candidate)

--- a/spec/queries/get_duplicate_matches_spec.rb
+++ b/spec/queries/get_duplicate_matches_spec.rb
@@ -90,5 +90,35 @@ RSpec.describe GetDuplicateMatches do
         expect(candidate_ids).to include(candidate1.id, candidate2.id)
       end
     end
+
+    context 'when duplicated applications and international candidates have not provided a postcode' do
+      let(:candidate_ids) { returned_array_of_hashes.map { |element| element['candidate_id'] } }
+
+      before do
+        Timecop.freeze(Time.zone.local(2020, 8, 23, 12)) do
+          create(:application_form, candidate: candidate1, first_name: 'Calina', last_name: 'Rosario', date_of_birth: '1998-08-08', address_type: 'international')
+          create(:application_form, candidate: candidate2, first_name: 'Calona', last_name: 'Rosario', date_of_birth: '1998-08-08', address_type: 'international')
+        end
+      end
+
+      it 'matches without the postcode, returning all duplicates' do
+        expect(candidate_ids).to include(candidate1.id, candidate2.id)
+      end
+    end
+
+    context 'when duplicated applications and international candidates have provided a postcode' do
+      let(:candidate_ids) { returned_array_of_hashes.map { |element| element['candidate_id'] } }
+
+      before do
+        Timecop.freeze(Time.zone.local(2020, 8, 23, 12)) do
+          create(:application_form, candidate: candidate1, first_name: 'Calina', last_name: 'Rosario', date_of_birth: '1998-08-08', postcode: '35004', address_type: 'international')
+          create(:application_form, candidate: candidate2, first_name: 'Calona', last_name: 'Rosario', date_of_birth: '1998-08-08', postcode: '35004', address_type: 'international')
+        end
+      end
+
+      it 'matches with the postcode, returning all duplicates' do
+        expect(candidate_ids).to include(candidate1.id, candidate2.id)
+      end
+    end
   end
 end

--- a/spec/queries/get_duplicate_matches_spec.rb
+++ b/spec/queries/get_duplicate_matches_spec.rb
@@ -135,5 +135,20 @@ RSpec.describe GetDuplicateMatches do
         expect(candidate_ids).not_to include(candidate1.id, candidate2.id)
       end
     end
+
+    context 'when two duplicated applications one with a null postcode and one with an empty string' do
+      let(:candidate_ids) { returned_array_of_hashes.map { |element| element['candidate_id'] } }
+
+      before do
+        Timecop.freeze(Time.zone.local(2020, 8, 23, 12)) do
+          create(:application_form, candidate: candidate1, first_name: 'Calina', last_name: 'Rosario', date_of_birth: '1998-08-08', postcode: ' ')
+          create(:application_form, candidate: candidate2, first_name: 'Calona', last_name: 'Rosario', date_of_birth: '1998-08-08', postcode: nil)
+        end
+      end
+
+      it 'returns all duplicates' do
+        expect(candidate_ids).to include(candidate1.id, candidate2.id)
+      end
+    end
   end
 end

--- a/spec/queries/get_duplicate_matches_spec.rb
+++ b/spec/queries/get_duplicate_matches_spec.rb
@@ -91,28 +91,13 @@ RSpec.describe GetDuplicateMatches do
       end
     end
 
-    context 'when duplicated applications and international candidates have not provided a postcode' do
+    context 'when duplicated applications are both international' do
       let(:candidate_ids) { returned_array_of_hashes.map { |element| element['candidate_id'] } }
 
       before do
         Timecop.freeze(Time.zone.local(2020, 8, 23, 12)) do
           create(:application_form, candidate: candidate1, first_name: 'Calina', last_name: 'Rosario', date_of_birth: '1998-08-08', address_type: 'international')
           create(:application_form, candidate: candidate2, first_name: 'Calona', last_name: 'Rosario', date_of_birth: '1998-08-08', address_type: 'international')
-        end
-      end
-
-      it 'matches, returning all duplicates' do
-        expect(candidate_ids).to include(candidate1.id, candidate2.id)
-      end
-    end
-
-    context 'when duplicated applications and international candidates have provided a postcode' do
-      let(:candidate_ids) { returned_array_of_hashes.map { |element| element['candidate_id'] } }
-
-      before do
-        Timecop.freeze(Time.zone.local(2020, 8, 23, 12)) do
-          create(:application_form, candidate: candidate1, first_name: 'Calina', last_name: 'Rosario', date_of_birth: '1998-08-08', postcode: '35004', address_type: 'international')
-          create(:application_form, candidate: candidate2, first_name: 'Calona', last_name: 'Rosario', date_of_birth: '1998-08-08', postcode: '35004', address_type: 'international')
         end
       end
 
@@ -136,21 +121,6 @@ RSpec.describe GetDuplicateMatches do
       end
     end
 
-    context 'when two duplicated applications with uk addresses, with no postcodes' do
-      let(:candidate_ids) { returned_array_of_hashes.map { |element| element['candidate_id'] } }
-
-      before do
-        Timecop.freeze(Time.zone.local(2020, 8, 23, 12)) do
-          create(:application_form, candidate: candidate1, first_name: 'Calina', last_name: 'Rosario', date_of_birth: '1998-08-08', address_type: 'uk')
-          create(:application_form, candidate: candidate2, first_name: 'Calona', last_name: 'Rosario', date_of_birth: '1998-08-08', address_type: 'uk')
-        end
-      end
-
-      it 'matches, returning all duplicates' do
-        expect(candidate_ids).to include(candidate1.id, candidate2.id)
-      end
-    end
-
     context 'when two non duplicated applications one uk with postcode and one international with no postcode' do
       let(:candidate_ids) { returned_array_of_hashes.map { |element| element['candidate_id'] } }
 
@@ -158,21 +128,6 @@ RSpec.describe GetDuplicateMatches do
         Timecop.freeze(Time.zone.local(2020, 8, 23, 12)) do
           create(:application_form, candidate: candidate1, first_name: 'Calina', last_name: 'Rosario', date_of_birth: '1998-08-08', postcode: 'w6 9bh ', address_type: 'uk')
           create(:application_form, candidate: candidate2, first_name: 'Calona', last_name: 'Rosario', date_of_birth: '1998-08-08', address_type: 'international')
-        end
-      end
-
-      it 'does not match' do
-        expect(candidate_ids).not_to include(candidate1.id, candidate2.id)
-      end
-    end
-
-    context 'when two non duplicated applications one uk with no postcode and one international with postcode' do
-      let(:candidate_ids) { returned_array_of_hashes.map { |element| element['candidate_id'] } }
-
-      before do
-        Timecop.freeze(Time.zone.local(2020, 8, 23, 12)) do
-          create(:application_form, candidate: candidate1, first_name: 'Calina', last_name: 'Rosario', date_of_birth: '1998-08-08', address_type: 'uk')
-          create(:application_form, candidate: candidate2, first_name: 'Calona', last_name: 'Rosario', date_of_birth: '1998-08-08', postcode: '35004', address_type: 'international')
         end
       end
 

--- a/spec/queries/get_duplicate_matches_spec.rb
+++ b/spec/queries/get_duplicate_matches_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe GetDuplicateMatches do
         end
       end
 
-      it 'matches without the postcode, returning all duplicates' do
+      it 'matches, returning all duplicates' do
         expect(candidate_ids).to include(candidate1.id, candidate2.id)
       end
     end
@@ -116,8 +116,68 @@ RSpec.describe GetDuplicateMatches do
         end
       end
 
-      it 'matches with the postcode, returning all duplicates' do
+      it 'matches, returning all duplicates' do
         expect(candidate_ids).to include(candidate1.id, candidate2.id)
+      end
+    end
+
+    context 'when duplicated applications, one UK and one international with no postcodes' do
+      let(:candidate_ids) { returned_array_of_hashes.map { |element| element['candidate_id'] } }
+
+      before do
+        Timecop.freeze(Time.zone.local(2020, 8, 23, 12)) do
+          create(:application_form, candidate: candidate1, first_name: 'Calina', last_name: 'Rosario', date_of_birth: '1998-08-08', address_type: 'uk')
+          create(:application_form, candidate: candidate2, first_name: 'Calona', last_name: 'Rosario', date_of_birth: '1998-08-08', address_type: 'international')
+        end
+      end
+
+      it 'matches, returning all duplicates' do
+        expect(candidate_ids).to include(candidate1.id, candidate2.id)
+      end
+    end
+
+    context 'when two duplicated applications with uk addresses, with no postcodes' do
+      let(:candidate_ids) { returned_array_of_hashes.map { |element| element['candidate_id'] } }
+
+      before do
+        Timecop.freeze(Time.zone.local(2020, 8, 23, 12)) do
+          create(:application_form, candidate: candidate1, first_name: 'Calina', last_name: 'Rosario', date_of_birth: '1998-08-08', address_type: 'uk')
+          create(:application_form, candidate: candidate2, first_name: 'Calona', last_name: 'Rosario', date_of_birth: '1998-08-08', address_type: 'uk')
+        end
+      end
+
+      it 'matches, returning all duplicates' do
+        expect(candidate_ids).to include(candidate1.id, candidate2.id)
+      end
+    end
+
+    context 'when two non duplicated applications one uk with postcode and one international with no postcode' do
+      let(:candidate_ids) { returned_array_of_hashes.map { |element| element['candidate_id'] } }
+
+      before do
+        Timecop.freeze(Time.zone.local(2020, 8, 23, 12)) do
+          create(:application_form, candidate: candidate1, first_name: 'Calina', last_name: 'Rosario', date_of_birth: '1998-08-08', postcode: 'w6 9bh ', address_type: 'uk')
+          create(:application_form, candidate: candidate2, first_name: 'Calona', last_name: 'Rosario', date_of_birth: '1998-08-08', address_type: 'international')
+        end
+      end
+
+      it 'does not match' do
+        expect(candidate_ids).not_to include(candidate1.id, candidate2.id)
+      end
+    end
+
+    context 'when two non duplicated applications one uk with no postcode and one international with postcode' do
+      let(:candidate_ids) { returned_array_of_hashes.map { |element| element['candidate_id'] } }
+
+      before do
+        Timecop.freeze(Time.zone.local(2020, 8, 23, 12)) do
+          create(:application_form, candidate: candidate1, first_name: 'Calina', last_name: 'Rosario', date_of_birth: '1998-08-08', address_type: 'uk')
+          create(:application_form, candidate: candidate2, first_name: 'Calona', last_name: 'Rosario', date_of_birth: '1998-08-08', postcode: '35004', address_type: 'international')
+        end
+      end
+
+      it 'does not match' do
+        expect(candidate_ids).not_to include(candidate1.id, candidate2.id)
       end
     end
   end

--- a/spec/services/update_duplicate_matches_spec.rb
+++ b/spec/services/update_duplicate_matches_spec.rb
@@ -156,5 +156,16 @@ RSpec.describe UpdateDuplicateMatches, sidekiq: true do
         expect(match.recruitment_cycle_year).to eq(RecruitmentCycle.current_year)
       end
     end
+
+    context 'when last name, date of birth matches and postcode is nil' do
+      before do
+        ApplicationForm.update_all(postcode: nil)
+      end
+
+      it 'saves one duplicate match' do
+        described_class.new.save!
+        expect(DuplicateMatch.count).to be(1)
+      end
+    end
   end
 end

--- a/spec/services/update_duplicate_matches_spec.rb
+++ b/spec/services/update_duplicate_matches_spec.rb
@@ -167,5 +167,25 @@ RSpec.describe UpdateDuplicateMatches, sidekiq: true do
         expect(DuplicateMatch.count).to be(1)
       end
     end
+
+    context 'when send email is manually set to false' do
+      it 'does not send the email' do
+        described_class.new(send_email: false).save!
+        expect(ActionMailer::Base.deliveries.map(&:to)).not_to match_array(
+          [
+            ['exemplar1@example.com'],
+            ['exemplar2@example.com'],
+          ],
+        )
+      end
+    end
+
+    context 'when block submission is manually set to false' do
+      it 'does not block submission' do
+        described_class.new(block_submission: false).save!
+        expect(candidate1.reload.submission_blocked).to be(false)
+        expect(candidate2.reload.submission_blocked).to be(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

**Note: Support has requested for this to be merged on or after 03/05/22 and should be merged after the job has run at 1pm**

It came to our attention that international candidates were not being flagged by the duplicate matching algorithm as they don't always enter a postcode. 

**Proposed plan of action:**

- Manually flag the new international matches using the new SQL script after 1pm (as thats when the service runs)
- Don't send the email or block submission on any of these by using the new switches, e.g. `UpdateDuplicateMatches.new(matches: GetDuplicateMatches.call, send_email: false, block_submission: false)`
- Support to manually action each match, blocking submission and sending the email as appropriate. 
- Going forwards international matches with have the email automated and submission blocked automatically, in the same way as the non international candidates.

## Changes proposed in this pull request

- Change the duplicate matching SQL query so that if there are no postcodes provided it still matches
- Add a switch so that we can manually flag all the duplicate matches without sending the email
- Add a switch so that we can manually flag all the duplicate matches without blocking submission

## Guidance to review

- Any flaws in the updates SQL script?

## Link to Trello card

https://trello.com/c/qHjKH8Nm/4634-consider-country-if-no-postcode-for-duplicate-matching
