### PR TITLE
Make 404 not found a consistent set of responses

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -2,7 +2,22 @@ class ErrorsController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def not_found
-    render 'not_found', status: :not_found, formats: :html
+    respond_to do |format|
+      format.json do
+        render json: {
+          errors: [
+            {
+              error: 'NotFound',
+              message: 'Not Found',
+            },
+          ],
+        }, status: :not_found
+      end
+
+      format.any do
+        render 'not_found', status: :not_found, formats: %i[html]
+      end
+    end
   end
 
   def unprocessable_entity

--- a/config/application.rb
+++ b/config/application.rb
@@ -77,7 +77,7 @@ module ApplyForPostgraduateTeacherTraining
     config.skylight.environments = ENV['SKYLIGHT_ENABLE'].to_s == 'true' ? [Rails.env] : []
 
     config.after_initialize do |app|
-      app.routes.append { get '*path', to: 'errors#not_found' }
+      app.routes.append { match '*path', to: 'errors#not_found', via: :all }
     end
 
     config.analytics = config_for(:analytics)

--- a/spec/requests/errors_controller_spec.rb
+++ b/spec/requests/errors_controller_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe ErrorsController do
+  describe '#not_found' do
+    it 'responds with json for a json request' do
+      post '/api/v666/some/cats', headers: { 'HTTP_ACCEPT' => 'application/json' }
+
+      expect(response.status).to eq(404)
+      expect(response.header['Content-Type']).to match('application/json')
+      expect(JSON.parse(response.body)).to eq({ 'errors' => [{ 'error' => 'NotFound', 'message' => 'Not Found' }] })
+    end
+
+    it 'responds with html for all other requests' do
+      get '/some/cats', headers: { 'HTTP_ACCEPT' => 'text/plain' }
+
+      expect(response.status).to eq(404)
+      expect(response.header['Content-Type']).to match('text/html')
+      expect(response.body).to match('Page not found')
+    end
+  end
+end

--- a/spec/requests/vendor_api/versioning_spec.rb
+++ b/spec/requests/vendor_api/versioning_spec.rb
@@ -29,12 +29,13 @@ RSpec.describe 'Versioning', type: :request do
 
     shared_examples_for 'denies access to the pre-release version' do
       it 'raises a routing error' do
-        expect {
-          post_api_request(
-            "/api/v1/applications/#{application_choice.id}/notes/create",
-            params: note_payload,
-          )
-        }.to raise_error(ActionController::RoutingError)
+        post_api_request(
+          "/api/v1/applications/#{application_choice.id}/notes/create",
+          params: note_payload,
+        )
+
+        expect(response.status).to eq(404)
+        expect(error_response).to eq({ 'error' => 'NotFound', 'message' => 'Not Found' })
       end
     end
 

--- a/spec/support/vendor_api/vendor_api_spec_helpers.rb
+++ b/spec/support/vendor_api/vendor_api_spec_helpers.rb
@@ -36,6 +36,7 @@ module VendorAPISpecHelpers
       headers: {
         'Authorization' => auth_header,
         'Content-Type' => 'application/json',
+        'HTTP_ACCEPT' => 'application/json',
       },
     }.deep_merge(options)
 


### PR DESCRIPTION

## Context

We should serve a JSON error for application/json 404s and HTML otherwise. This is true of GETs and POSTs.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Appends a route to `errors#not_found` for any HTTP method.
- Amends `ErrorsController#not_found` to respond with JSON if the format demands it, otherwise the existing HTML.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/uX0jJIIj/4817-api-cleanup-investigate-why-v1-access-to-unreachable-url-returns-500
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
