### PR TITLE
Removed conditon from build job in workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -29,9 +29,6 @@ jobs:
       IMAGE_TAG: ${{ env.IMAGE_TAG }}
       GIT_BRANCH: ${{ env.GIT_BRANCH }}
 
-    # When a pull_request event occurs, we want to prevent the build from running each time a label is added, unless it is the deploy label.
-    if: github.event_name != 'pull_request' ||  github.event_name == 'pull_request' && ( github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize' || github.event.label.name == 'deploy' )
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -395,7 +392,7 @@ jobs:
           ref: ${{ github.head_ref }}
           step:  start
           token: ${{ secrets.GITHUB_TOKEN }}
-          
+
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -417,7 +414,7 @@ jobs:
           env:  review-${{ github.event.pull_request.number }}
           ref: ${{ github.head_ref }}
           step: finish
-          token:  ${{ secrets.GITHUB_TOKEN }} 
+          token:  ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
           env_url: ${{ steps.deploy_review.outputs.deploy-url }}


### PR DESCRIPTION
## Context

A condition was added to the build workflow to prevent duplicate runs when labels were added.  The same effect is now achieved with workflow concurrency.

## Changes proposed in this pull request

Removed condition from build workflow.

## Guidance to review

Check workflow runs as expected.

## Link to Trello card

https://trello.com/c/NLziz08t

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
