### PR TITLE
Bring v1.1 spec up to date with draft spec

### DIFF
--- a/app/controllers/concerns/vendor_api/application_data_concerns.rb
+++ b/app/controllers/concerns/vendor_api/application_data_concerns.rb
@@ -15,7 +15,7 @@ module VendorAPI
     end
 
     def application_json
-      %({"data":#{ApplicationPresenter.new(version_number, application_choice).serialized_json}})
+      SingleApplicationPresenter.new(version_number, application_choice).serialized_json
     end
 
     def application_choices_visible_to_provider(includes = include_properties)

--- a/config/vendor_api/draft.yml
+++ b/config/vendor_api/draft.yml
@@ -526,11 +526,13 @@ components:
           maxLength: 10240
         cancelled_at:
           type: string
+          nullable: true
           format: date-time
           description: Date and time of cancellation, if cancelled.
           example: 2019-09-18T16:33:49.216Z
         cancellation_reason:
           type: string
+          nullable: true
           description: The reason for the cancellation. If none are yet provided for an application rejected by default, the value `Not entered` is returned
           example: 'Candidate has accepted an alternative offer'
           maxLength: 2000

--- a/config/vendor_api/v1.1.yml
+++ b/config/vendor_api/v1.1.yml
@@ -538,11 +538,13 @@ components:
           maxLength: 10240
         cancelled_at:
           type: string
+          nullable: true
           format: date-time
           description: Date and time of cancellation, if cancelled.
           example: 2019-09-18T16:33:49.216Z
         cancellation_reason:
           type: string
+          nullable: true
           description: The reason for the cancellation. If none are yet provided for an application rejected by default, the value `Not entered` is returned
           example: 'Candidate has accepted an alternative offer'
           maxLength: 2000

--- a/config/vendor_api/v1.1.yml
+++ b/config/vendor_api/v1.1.yml
@@ -16,6 +16,72 @@ servers:
 - description: Production
   url: https://www.apply-for-teacher-training.service.gov.uk/api/v1.1
 paths:
+  "/applications":
+    get:
+      tags:
+      - Application management
+      summary: Get many applications
+      description: |
+        This endpoint can be used to retrieve applications for the authenticating
+        provider. Applications are returned with the most recently updated ones first.
+
+        Use the `since` parameter to limit the number of results. This is intended
+        to make it possible to check for new or updated applications regularly.
+      parameters:
+      - name: since
+        description: Include only applications changed or created on or since a date
+          and time. Times should be in ISO 8601 format.
+        in: query
+        required: true
+        example: 2019-12-13T12:00:00Z
+        schema:
+          type: string
+          format: date-time
+      - name: page
+        description: Page number
+        in: query
+        required: false
+        example: 1
+        schema:
+          type: integer
+      - name: per_page
+        description: Number of records to return per page (e.g. 50)
+        in: query
+        required: false
+        example: 100
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: An array of applications
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/MultipleApplicationsResponse"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '422':
+          "$ref": "#/components/responses/ParameterMissing"
+  "/applications/{application_id}":
+    get:
+      tags:
+      - Application management
+      summary: Get a single application
+      parameters:
+      - "$ref": "#/components/parameters/application_id"
+      responses:
+        '200':
+          description: An application
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SingleApplicationResponse"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '404':
+          "$ref": "#/components/responses/NotFound"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
   "/applications/{application_id}/defer-offer":
     post:
       tags:
@@ -95,6 +161,8 @@ paths:
       summary: Withdraw an application
       description: |
         Withdraws an application or declines an offer at the candidate’s request.
+
+        This will transition the application to the [withdrawn state](/api-docs/lifecycle#withdrawn) or the [declined state](/api-docs/lifecycle#declined).
       parameters:
       - "$ref": "#/components/parameters/application_id"
       requestBody:
@@ -269,12 +337,73 @@ paths:
         '422':
           "$ref": "#/components/responses/UnprocessableEntity"
 components:
+  responses:
+    PageParameterInvalidResponse:
+      description: Returned when the parameter was invalid
+      content:
+        application/json:
+          schema:
+            "$ref": "#/components/schemas/PageParameterInvalidResponse"
+    PerPageParameterInvalidResponse:
+      description: Returned when the parameter was invalid
+      content:
+        application/json:
+          schema:
+            "$ref": "#/components/schemas/PerPageParameterInvalidResponse"
   schemas:
+    MultipleApplicationsResponse:
+      type: object
+      required:
+      - data
+      - links
+      - meta
+      properties:
+        data:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Application"
+        links:
+          "$ref": "#/components/schemas/Links"
+        meta:
+          "$ref": "#/components/schemas/ResponseMetaMultiple"
+    SingleApplicationResponse:
+      type: object
+      required:
+      - data
+      - meta
+      properties:
+        data:
+          "$ref": "#/components/schemas/Application"
+        meta:
+          "$ref": "#/components/schemas/ResponseMetaSingle"
     ApplicationAttributes:
       type: object
       additionalProperties: false
       required:
-        - withdrawn_or_declined_for_candidate
+      - application_url
+      - support_reference
+      - candidate
+      - phase
+      - contact_details
+      - course
+      - offer
+      - notes
+      - personal_statement
+      - interview_preferences
+      - qualifications
+      - references
+      - rejection
+      - status
+      - withdrawn_or_declined_for_candidate
+      - submitted_at
+      - updated_at
+      - reject_by_default_at
+      - recruited_at
+      - withdrawal
+      - further_information
+      - work_experience
+      - safeguarding_issues_status
+      - safeguarding_issues_details_url
       properties:
         interviews:
           type: array
@@ -324,11 +453,13 @@ components:
           description: |
             A string describing where or how the interview will take place.
           example: 'Zoom call'
+          maxLength: 10240
         additional_details:
           type: string
           description: |
             Optional string for additional notes.
           example: 'Candidate requires a parking space'
+          maxLength: 10240
     UpdateInterview:
       type: object
       additionalProperties: false
@@ -347,14 +478,14 @@ components:
           type: string
           description: |
             An optional string describing where or how the interview will take place.
-          maxLength: 10240
           example: 'Zoom call'
+          maxLength: 10240
         additional_details:
           type: string
           description: |
             Optional string for additional notes.
-          maxLength: 10240
           example: 'Candidate requires a parking space'
+          maxLength: 10240
     CancelInterview:
       type: object
       additionalProperties: false
@@ -364,36 +495,8 @@ components:
         reason:
           type: string
           description: The reason for the cancellation. If none are yet provided for an application rejected by default, the value `Not entered` is returned
-          maxLength: 10240
+          maxLength: 2000
           example: The candidate has accepted an alternative offer
-    ConfirmDeferredOffer:
-      type: object
-      additionalProperties: false
-      required:
-      - conditions_met
-      properties:
-        conditions_met:
-          type: boolean
-          description: Determines the status of the confirmed deferred application (recruited vs. pending_conditions)
-          example: true
-    Withdrawal:
-      type: object
-      additionalProperties: false
-      required:
-      - reason
-      - date
-      properties:
-        reason:
-          type: string
-          description: Optional. The candidate’s reason for withdrawing. This field is deprecated because the Apply service does not collect this information
-          maxLength: 10240
-          nullable: true
-          deprecated: true
-        date:
-          type: string
-          format: date-time
-          description: Time of the withdrawal
-          example: 2019-09-18T15:33:49.216Z
     Interview:
       type: object
       additionalProperties: false
@@ -409,7 +512,7 @@ components:
           type: string
           description: |
             The unique ID of this interview. Automatically generated by our service.
-          maxLength: 10
+          maxLength: 18
           example: 11fc0d3b2f
         provider_code:
           type: string
@@ -426,24 +529,23 @@ components:
           description: |
             An optional string describing where or how the interview will take place.
           example: 'Zoom call'
+          maxLength: 10240
         additional_details:
           type: string
           description: |
             Optional string for additional notes.
           example: 'Candidate requires a parking space'
-          nullable: true
+          maxLength: 10240
         cancelled_at:
           type: string
           format: date-time
           description: Date and time of cancellation, if cancelled.
           example: 2019-09-18T16:33:49.216Z
-          nullable: true
         cancellation_reason:
           type: string
           description: The reason for the cancellation. If none are yet provided for an application rejected by default, the value `Not entered` is returned
-          maxLength: 10240
           example: 'Candidate has accepted an alternative offer'
-          nullable: true
+          maxLength: 2000
         created_at:
           type: string
           format: date-time
@@ -480,6 +582,7 @@ components:
           description: |
             The unique ID of this note. Automatically generated by our service.
           example: 123456
+          maxLength: 18
         message:
           type: string
           description: The content of the note
@@ -499,6 +602,7 @@ components:
           type: string
           description: Author’s name
           example: John Smith
+          maxLength: 100
     Offer:
       type: object
       additionalProperties: false
@@ -531,6 +635,114 @@ components:
           nullable: true
           description: When this application was deferred
           example: 2019-06-10T23:59:59Z
+    ConfirmDeferredOffer:
+      type: object
+      additionalProperties: false
+      required:
+      - conditions_met
+      properties:
+        conditions_met:
+          type: boolean
+          description: Determines the status of the confirmed deferred application (recruited vs. pending_conditions)
+          example: true
+    Links:
+      type: object
+      description: Links to navigate through the paginated results
+      additionalProperties: false
+      required:
+      - first
+      - last
+      - prev
+      - self
+      - next
+      properties:
+        first:
+          type: string
+          description: The first page of the results
+          example: https://www.apply-for-teacher-training.service.gov.uk/api/v1.1/applications?since=2021-10-20T12:00:00Z&page=1
+        last:
+          type: string
+          description: The last page of the results
+          example: https://www.apply-for-teacher-training.service.gov.uk/api/v1.1/applications?since=2021-10-20T12:00:00Z&page=20
+        prev:
+          type: string
+          description: The previous page of the results
+          example: https://www.apply-for-teacher-training.service.gov.uk/api/v1.1/applications?since=2021-10-20T12:00:00Z&page=1
+        self:
+          type: string
+          description: The current page of the results
+          example: https://www.apply-for-teacher-training.service.gov.uk/api/v1.1/applications?since=2021-10-20T12:00:00Z&page=2
+        next:
+          type: string
+          description: The next page of the results
+          example: https://www.apply-for-teacher-training.service.gov.uk/api/v1.1/applications?since=2021-10-20T12:00:00Z&page=3
+    ResponseMetaMultiple:
+      type: object
+      description: API version and count metadata in multiple application responses
+      additionalProperties: false
+      required:
+      - api_version
+      - timestamp
+      - total_count
+      properties:
+        api_version:
+          type: string
+          description: API version that produced this response
+          example: 'v1.1'
+        timestamp:
+          type: string
+          format: date-time
+          description: When this response was generated
+          example: 2021-12-01T11:03:12Z
+        total_count:
+          type: integer
+          description: Total number of changed applications for this `since` value
+          example: 1000
+    ResponseMetaSingle:
+      type: object
+      description: API version and count metadata in single application responses
+      additionalProperties: false
+      required:
+      - api_version
+      - timestamp
+      properties:
+        api_version:
+          type: string
+          description: API version that produced this response
+          example: 'v1.1'
+        timestamp:
+          type: string
+          format: date-time
+          description: When this response was generated
+          example: 2021-12-01T11:03:12Z
+    PageParameterInvalidResponse:
+      type: object
+      required:
+      - errors
+      properties:
+        errors:
+          type: array
+          minItems: 1
+          description: Error objects describing the problem
+          items:
+            "$ref": "#/components/schemas/Error"
+          example:
+          - error: PageParameterInvalid
+            message: "expected 'page' parameter to be between 1 and 1, got 2"
+    PerPageParameterInvalidResponse:
+      type: object
+      required:
+      - errors
+      properties:
+        errors:
+          type: array
+          minItems: 1
+          description: Error objects describing the problem
+          items:
+            "$ref": "#/components/schemas/Error"
+          example:
+          - error: PerPageParamterInvalid
+            message: "the 'per_page' parameter cannot exceed 100 results per page"
   parameters:
     interview_id:
       name: interview_id

--- a/spec/requests/vendor_api/versioning_spec.rb
+++ b/spec/requests/vendor_api/versioning_spec.rb
@@ -86,7 +86,8 @@ RSpec.describe 'Versioning', type: :request do
       it 'the route is processed' do
         stub_const('VendorAPI::VERSIONS', { '1.0' => [VendorAPI::Changes::RetrieveApplications],
                                             '1.1' => [VendorAPI::Changes::AddNotesToApplication,
-                                                      VendorAPI::Changes::CreateNote] })
+                                                      VendorAPI::Changes::CreateNote,
+                                                      VendorAPI::Changes::AddMetaToApplication] })
         post_api_request "/api/v1.1/applications/#{application_choice.id}/notes/create", params: note_payload
 
         expect(response.status).to eq(200)


### PR DESCRIPTION
## Context

The Vendor API v1.1 spec has fallen behind the draft spec.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Apply changes to v1.1 spec present in draft spec.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

We've switched to using `SingleApplicationPresenter` in order to mix in the `meta` object which is a required property of **v1.1** `SingleApplicationResponse` so this PR becomes a bit less trivial than just updating docs...

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/tOhwxQeV/4818-api-cleanup-update-v11-spec
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
