### PR TITLE
Amend interviews page to be full width

### DIFF
--- a/app/views/provider_interface/interview_schedules/show.html.erb
+++ b/app/views/provider_interface/interview_schedules/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :browser_title, "Interview schedule - #{t('provider_interface.interviews.upcoming')}" %>
 
 <div class="govuk-grid-row govuk-body">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Interview schedule</h1>
 
     <%= render TabNavigationComponent.new(items: [


### PR DESCRIPTION
## Context

The interviews page should be full width, to match the prototype

## Changes proposed in this pull request

Set to full width

## Guidance to review

https://manage-applications-beta.herokuapp.com/interviews/past

## Link to Trello card

https://trello.com/c/knwpqYFL

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
