### PR TITLE
Surface the full API version if the major version passed in

### DIFF
--- a/app/presenters/vendor_api/meta_presenter.rb
+++ b/app/presenters/vendor_api/meta_presenter.rb
@@ -9,7 +9,7 @@ module VendorAPI
 
     def as_json
       meta_hash = {
-        api_version: "v#{active_version}",
+        api_version: "v#{full_version_number_from(active_version)}",
         timestamp: Time.zone.now.iso8601,
       }
       meta_hash[:total_count] = count if count

--- a/spec/presenters/vendor_api/v1.1/meta_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.1/meta_presenter_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe VendorAPI::MetaPresenter do
+  subject(:meta_json) { JSON.parse(described_class.new(version, count).as_json) }
+
+  let(:count) { nil }
+
+  before do
+    stub_const('VendorAPI::VERSION', '1.0')
+    stub_const(
+      'VendorAPI::VERSIONS',
+      {
+        '1.0' => [VendorAPI::Changes::AddMetaToApplication],
+      },
+    )
+  end
+
+  context 'with major and minor version' do
+    let(:version) { '1.0' }
+
+    it 'includes the full API version' do
+      expect(meta_json['api_version']).to eq('v1.0')
+    end
+
+    it 'does not include the count' do
+      expect(meta_json).not_to have_key('total_count')
+    end
+  end
+
+  context 'with major version' do
+    let(:version) { '1' }
+
+    it 'includes the full API version' do
+      expect(meta_json['api_version']).to eq('v1.0')
+    end
+
+    it 'does not include the count' do
+      expect(meta_json).not_to have_key('total_count')
+    end
+  end
+
+  context 'with a count' do
+    let(:count) { 5 }
+    let(:version) { '1' }
+
+    it 'includes the `total_count`' do
+      expect(meta_json['total_count']).to eq(5)
+    end
+  end
+end


### PR DESCRIPTION
## Context

In vendor API v1.1 we surface the current version in the metadata section of the response JSON. When specifying only the major version in the URL instead of returning the full version in the response we are returning 'v1'

## Changes proposed in this pull request

Surface the full API version if the major version is passed into the URL only

## Guidance to review

Did I miss anything?

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
