### PR TITLE
Course Change - Hide support tooling

### DIFF
--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -181,7 +181,7 @@ module SupportInterface
     end
 
     def change_course_choice_link
-      return {} unless @application_choice.application_form.editable? && ApplicationStateChange::DECISION_PENDING_STATUSES.include?(application_choice.status.to_sym)
+      return {} unless FeatureFlag.inactive?(:change_course_details_before_offer) && @application_choice.application_form.editable? && ApplicationStateChange::DECISION_PENDING_STATUSES.include?(application_choice.status.to_sym)
 
       {
         action: {

--- a/spec/components/support_interface/application_choice_component_spec.rb
+++ b/spec/components/support_interface/application_choice_component_spec.rb
@@ -159,16 +159,30 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
   end
 
   context 'Changing a course choice' do
-    it 'Renders a link when the application is awaiting provider decision' do
-      course_option = create(:course_option)
-      application_choice = create(
+    let(:course_option) { create(:course_option) }
+    let(:application_choice) do
+      create(
         :application_choice,
         :with_completed_application_form,
         :awaiting_provider_decision,
         course_option: course_option,
         current_course_option: course_option,
       )
+    end
 
+    before do
+      FeatureFlag.deactivate(:change_course_details_before_offer)
+    end
+
+    it 'does not render a link if the feature flag is on' do
+      FeatureFlag.activate(:change_course_details_before_offer)
+
+      result = render_inline(described_class.new(application_choice))
+
+      expect(result.css('.govuk-summary-list__actions').text.strip).not_to include('Change course choice')
+    end
+
+    it 'Renders a link when the application is awaiting provider decision' do
       result = render_inline(described_class.new(application_choice))
 
       expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(

--- a/spec/system/support_interface/change_course_choice_spec.rb
+++ b/spec/system/support_interface/change_course_choice_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Change course choice' do
 
   scenario 'Change the course choice on an application form', with_audited: true do
     given_i_am_a_support_user
+    and_the_feature_flag_is_off
     and_there_is_an_application_choice_awaiting_provider_decision
 
     when_i_visit_the_application_page
@@ -23,6 +24,10 @@ RSpec.feature 'Change course choice' do
 
   def given_i_am_a_support_user
     sign_in_as_support_user
+  end
+
+  def and_the_feature_flag_is_off
+    FeatureFlag.deactivate(:change_course_details_before_offer)
   end
 
   def and_there_is_an_application_choice_awaiting_provider_decision


### PR DESCRIPTION
## Context

The new change course service is intended to replace the one we have in the support UI. Once this service goes live we need the hide the support tool behind its own feature flag and clean up the code to remove the change course feature flag.

## Changes proposed in this pull request

Hide the 'Change course choice' link if the `:change_course_details_before_offer` feature flag is on

## Guidance to review

https://trello.com/c/b4YUsS7V

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
