### PR TITLE
Migration to create `email_clicks` table

### DIFF
--- a/db/migrate/20220426165723_create_email_clicks.rb
+++ b/db/migrate/20220426165723_create_email_clicks.rb
@@ -1,0 +1,9 @@
+class CreateEmailClicks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :email_clicks do |t|
+      t.references :email, null: false, foreign_key: true
+      t.string :path, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_14_193807) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_26_165723) do
   create_sequence "qualifications_public_id_seq", start: 120000
 
   # These are extensions that must be enabled in order to support this database
@@ -419,6 +419,14 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_14_193807) do
     t.index ["service_name", "timestamp"], name: "index_data_migrations_on_service_name_and_timestamp", unique: true
   end
 
+  create_table "email_clicks", force: :cascade do |t|
+    t.bigint "email_id", null: false
+    t.string "path", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email_id"], name: "index_email_clicks_on_email_id"
+  end
+
   create_table "emails", force: :cascade do |t|
     t.string "to", null: false
     t.string "subject", null: false
@@ -786,6 +794,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_14_193807) do
   add_foreign_key "course_subjects", "courses"
   add_foreign_key "course_subjects", "subjects"
   add_foreign_key "courses", "providers"
+  add_foreign_key "email_clicks", "emails"
   add_foreign_key "emails", "application_forms", on_delete: :cascade
   add_foreign_key "interviews", "application_choices", on_delete: :cascade
   add_foreign_key "interviews", "providers", on_delete: :cascade


### PR DESCRIPTION
## Context

This is a migration-only PR that is the first step for email click tracking in candidate emails.

## Changes proposed in this pull request

Create an `email_clicks` table with standard primary key and timestamp columns as well as a foreign key to the `emails` table and a `path` column to store the path of the target URL.

## Guidance to review

- Is there anything missing from this table?

## Link to Trello card

https://trello.com/c/iUCJNzHM/4645-placeholder-make-email-tracking-production-ready

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
