### PR TITLE
Amend application ID to number in Support interface

### DIFF
--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -90,7 +90,7 @@ module SupportInterface
       {
         type: :search,
         css_classes: 'govuk-input--width-5',
-        heading: 'Provider application ID',
+        heading: 'Provider application number',
         value: applied_filters[:application_choice_id],
         name: 'application_choice_id',
       }


### PR DESCRIPTION
## Context

We've moved away from support reference to use application number. In support we refer to this as application ID

## Changes proposed in this pull request

Ensure we are consistent with our naming for identifiers and rename application ID to application number

## Guidance to review

Did I miss anything?

## Link to Trello card

[<!-- http://trello.com/123-example-card -->
](https://trello.com/b/5IiPW0Ok/provendor-team-board)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
