### PR TITLE
Additional details on an interview are optional

### DIFF
--- a/config/vendor_api/draft.yml
+++ b/config/vendor_api/draft.yml
@@ -520,6 +520,7 @@ components:
           maxLength: 10240
         additional_details:
           type: string
+          nullable: true
           description: |
             Optional string for additional notes.
           example: 'Candidate requires a parking space'

--- a/config/vendor_api/v1.1.yml
+++ b/config/vendor_api/v1.1.yml
@@ -456,6 +456,7 @@ components:
           maxLength: 10240
         additional_details:
           type: string
+          nullable: true
           description: |
             Optional string for additional notes.
           example: 'Candidate requires a parking space'


### PR DESCRIPTION
## Context

Additional details are not required when setting up an interview, mark as nullable in v1.1 spec

## Changes proposed in this pull request

Set the nullable value on the additional details field in both draft and v1.1 spec
## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
