### PR TITLE
Hide cancelled interviews from the candidate application view

### DIFF
--- a/app/components/candidate_interface/interview_bookings_component.html.erb
+++ b/app/components/candidate_interface/interview_bookings_component.html.erb
@@ -1,6 +1,6 @@
 <% if interviews.kept.many? %>
   <ul class='govuk-list govuk-list--number'>
-    <% interviews.each do |interview| %>
+    <% interviews.kept.each do |interview| %>
       <li>
         <%= render CandidateInterface::InterviewBookingsItemComponent.new(interview) %>
       </li>


### PR DESCRIPTION
## Context

Reported by a vendor: if a candidate has many upcoming interviews and has a cancelled interview we are surfacing the cancelled interview as part of that list

## Changes proposed in this pull request

Only surface upcoming and past interviews that have not been cancelled

## Guidance to review

Did I miss anything?

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
