### PR TITLE
Experimental: summarise error messages by message

### DIFF
--- a/app/models/validation_error.rb
+++ b/app/models/validation_error.rb
@@ -8,6 +8,13 @@ class ValidationError < ApplicationRecord
 
   belongs_to :user, polymorphic: true, optional: true
 
+  def self.errors_by_count(attribute)
+    where('details->? is not null', attribute)
+    .group('details->\'' + attribute + '\'->\'messages\'->0')
+    .order('count_all desc')
+    .count
+  end
+
   def self.list_of_distinct_errors_with_count
     distinct_errors = all.flat_map do |e|
       e.details.flat_map do |attribute, details|

--- a/app/views/support_interface/validation_errors/candidate/search.html.erb
+++ b/app/views/support_interface/validation_errors/candidate/search.html.erb
@@ -20,6 +20,27 @@
   <% end %>
 </p>
 
+
+<% if params[:attribute] %>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">Message</th>
+        <th scope="col" class="govuk-table__header">Error count</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% ValidationError.errors_by_count(params[:attribute]).each do |row| %>
+        <tr class="govuk-table__row">
+          <th class="govuk-table__cell govuk-!-font-weight-regular"><%= row[0] %></th>
+          <td class="govuk-table__cell"><%= row[1] %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>
+
+
 <% @validation_errors.each do |validation_error| %>
   <section class="app-summary-card govuk-!-margin-bottom-6">
     <%= render(SummaryCardHeaderComponent.new(title: "Validation error #{govuk_link_to("##{validation_error.id}", support_interface_validation_errors_candidate_search_path(id: validation_error.id))}".html_safe)) do %>


### PR DESCRIPTION
This is a quick attempt to try and see how we might summarise the individual error messages by each field.

Currently we can see counts of errors by form and by field, but not be each individual message. This makes it slightly hard to analyse which are the most significant errors where there are fields that have multiple different error messages depending upon the content entered.

Ideally this table might have the same columns as the previous table, ie All time / Last month / Last week, broken down by total error count and unique users? (Although we could possibly reduce this)

## Screenshot

<img width="1143" alt="Screenshot 2022-04-27 at 15 18 31" src="https://user-images.githubusercontent.com/30665/165539783-13ac81b1-0d89-4e69-96a1-a978ab20f749.png">
