### PR TITLE
Remove bold formatting from location labels

### DIFF
--- a/app/views/provider_interface/courses/locations/edit.html.erb
+++ b/app/views/provider_interface/courses/locations/edit.html.erb
@@ -6,6 +6,7 @@
                                          value_method: :id,
                                          text_method: :site_name,
                                          hint_method: :site_full_address,
+                                         bold_labels: false,
                                          form_object: @wizard,
                                          form_path: provider_interface_application_choice_course_locations_path,
                                          form_method: :put,

--- a/app/views/provider_interface/offer/locations/edit.html.erb
+++ b/app/views/provider_interface/offer/locations/edit.html.erb
@@ -6,6 +6,7 @@
                                          value_method: :id,
                                          text_method: :site_name,
                                          hint_method: :site_full_address,
+                                         bold_labels: false,
                                          form_object: @wizard,
                                          form_path: provider_interface_application_choice_offer_locations_path,
                                          form_method: :put,

--- a/app/views/provider_interface/offer/locations/new.html.erb
+++ b/app/views/provider_interface/offer/locations/new.html.erb
@@ -6,6 +6,7 @@
                                          value_method: :id,
                                          text_method: :site_name,
                                          hint_method: :site_full_address,
+                                         bold_labels: false,
                                          form_object: @wizard,
                                          form_path: provider_interface_application_choice_offer_locations_path,
                                          page_title: t('.title'),


### PR DESCRIPTION
## Context

During dev design it was highlighted that the location labels are in bold – this isn't inline with the prototype

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="628" alt="image" src="https://user-images.githubusercontent.com/47917431/165616323-35d24856-d726-48fc-bfb1-222e383349d4.png">|<img width="635" alt="image" src="https://user-images.githubusercontent.com/47917431/165616609-92e551a6-59d5-4cfe-9d63-a683d9d98c31.png">|

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
