### PR TITLE
do not render interview warning text if no change

### DIFF
--- a/app/components/provider_interface/course_change_warning_text_component.html.erb
+++ b/app/components/provider_interface/course_change_warning_text_component.html.erb
@@ -1,4 +1,4 @@
-<% if only_location_or_study_mode_change? || !application_choice.interviewing? %>
+<% if only_location_or_study_mode_change? || !application_choice.interviewing? || identical_to_existing_course? %>
   <%= govuk_warning_text(text: 'The candidate will be sent an email to tell them that the course has been updated.') %>
 <% elsif application_choice.interviewing? %>
   <%= govuk_warning_text(

--- a/app/components/provider_interface/course_change_warning_text_component.rb
+++ b/app/components/provider_interface/course_change_warning_text_component.rb
@@ -12,5 +12,9 @@ module ProviderInterface
         application_choice.provider.id == wizard.course_option.provider.id &&
         (application_choice.site.id != wizard.course_option.site.id || application_choice.course_option.study_mode != wizard.course_option.study_mode)
     end
+
+    def identical_to_existing_course?
+      application_choice.current_course_option == wizard.course_option
+    end
   end
 end

--- a/spec/components/provider_interface/course_change_warning_text_component_spec.rb
+++ b/spec/components/provider_interface/course_change_warning_text_component_spec.rb
@@ -83,6 +83,25 @@ RSpec.describe ProviderInterface::CourseChangeWarningTextComponent do
     end
   end
 
+  context 'when the course is identical' do
+    let(:course_wizard) do
+      instance_double(
+        ProviderInterface::CourseWizard,
+        application_choice_id: application_choice.id,
+        course_id: application_choice.course_option.course.id,
+        course_option_id: application_choice.course_option.id,
+        provider_id: application_choice.course_option.provider.id,
+        study_mode: application_choice.course_option.study_mode,
+        location_id: application_choice.site.id,
+      )
+    end
+
+    it 'renders the warning text' do
+      expect(render.css('.govuk-warning-text').text).not_to include '!WarningThe upcoming interview will be updated with the new course details.'
+      expect(render.css('.govuk-warning-text').text).to include '!WarningThe candidate will be sent an email to tell them that the course has been updated.'
+    end
+  end
+
   it 'renders the warning text' do
     expect(render.css('.govuk-warning-text').text).to eq '!WarningThe candidate will be sent an email to tell them that the course has been updated.'
   end


### PR DESCRIPTION
## Context

If the user makes no change to the course, but goes through the flow, we should not show the warning text that informs them about the interview change

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
