### PR TITLE
Add fee or salary information to course offer pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,10 @@ gem 'discard'
 
 gem 'json-schema'
 gem 'json_api_client'
+
+# Render smart quotes
+gem 'rubypants'
+
 # Oj is faster at rendering JSON than the default Rails JSON serializer
 gem 'oj'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -592,6 +592,7 @@ GEM
     ruby-next-core (0.14.1)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
+    rubypants (0.7.1)
     rubyzip (2.3.2)
     safely_block (0.3.0)
       errbase (>= 0.1.1)
@@ -816,6 +817,7 @@ DEPENDENCIES
   rubocop-rspec
   ruby-graphviz
   ruby-jmeter
+  rubypants
   selenium-webdriver
   sentry-rails
   sentry-sidekiq

--- a/app/components/candidate_interface/offer_review_component.rb
+++ b/app/components/candidate_interface/offer_review_component.rb
@@ -12,7 +12,7 @@ module CandidateInterface
       ]
       rows << conditions_row if @course_choice.offer.conditions.any?
       rows.insert(2, fee_row) if @course_choice.current_course.fee?
-      rows.insert(2, salary_row) if @course_choice.current_course.salary?
+      rows.insert(2, salary_row) if @course_choice.current_course.salary? || @course_choice.current_course.apprenticeship?
       rows
     end
 

--- a/app/components/candidate_interface/offer_review_component.rb
+++ b/app/components/candidate_interface/offer_review_component.rb
@@ -1,5 +1,6 @@
 module CandidateInterface
   class OfferReviewComponent < SummaryListComponent
+    include ApplicationHelper
     def initialize(course_choice:)
       @course_choice = course_choice
     end
@@ -78,14 +79,30 @@ module CandidateInterface
     end
 
     def fee_row_value
-      course = @course_choice.current_course
+      if @course_choice.current_course.fee_details
+        fee_value_row_with_fee_details
+      else
+        fee_value_row_without_fee_details
+      end
+    end
 
-      if course.fee_international && course.fee_domestic
-        tag.p("UK Students: £#{course.fee_domestic}") + tag.br("International Students: £#{course.fee_international}") + tag.br(course.fee_details, class: 'govuk-body')
-      elsif course.fee_domestic
-        tag.p("UK Students: £#{course.fee_domestic}") + tag.br(course.fee_details, class: 'govuk-body')
-      elsif course.fee_international
-        tag.br("International Students: £#{course.fee_international}") + tag.br(course.fee_details, class: 'govuk-body')
+    def fee_value_row_with_fee_details
+      if @course_choice.current_course.fee_international && @course_choice.current_course.fee_domestic
+        tag.p("UK Students: £#{@course_choice.current_course.fee_domestic}") + tag.br + tag.p("International Students: £#{@course_choice.current_course.fee_international}", class: 'govuk-body') + tag.br + markdown(@course_choice.current_course.fee_details)
+      elsif @course_choice.current_course.fee_domestic
+        tag.p("UK Students: £#{@course_choice.current_course.fee_domestic}", class: 'govuk-body') + tag.br + markdown(@course_choice.current_course.fee_details)
+      elsif @course_choice.current_course.fee_international
+        tag.p("International Students: £#{@course_choice.current_course.fee_international}", class: 'govuk-body') + tag.br + markdown(@course_choice.current_course.fee_details)
+      end
+    end
+
+    def fee_value_row_without_fee_details
+      if @course_choice.current_course.fee_international && @course_choice.current_course.fee_domestic
+        tag.p("UK Students: £#{@course_choice.current_course.fee_domestic}") + tag.br + tag.p("International Students: £#{@course_choice.current_course.fee_international}", class: 'govuk-body')
+      elsif @course_choice.current_course.fee_domestic
+        tag.p("UK Students: £#{@course_choice.current_course.fee_domestic}", class: 'govuk-body')
+      elsif @course_choice.current_course.fee_international
+        tag.p("International Students: £#{@course_choice.current_course.fee_international}", class: 'govuk-body')
       end
     end
   end

--- a/app/components/candidate_interface/offer_review_component.rb
+++ b/app/components/candidate_interface/offer_review_component.rb
@@ -45,7 +45,7 @@ module CandidateInterface
     def salary_row
       {
         key: 'Salary',
-        value: @course_choice.current_course.salary_details,
+        value: salary_row_value,
       }
     end
 
@@ -75,6 +75,12 @@ module CandidateInterface
           rel: 'noopener',
         ) +
           tag.p(@course_choice.current_course.description, class: 'govuk-body')
+      end
+    end
+
+    def salary_row_value
+      if @course_choice.current_course.salary_details
+        markdown(@course_choice.current_course.salary_details)
       end
     end
 

--- a/app/components/candidate_interface/offer_review_component.rb
+++ b/app/components/candidate_interface/offer_review_component.rb
@@ -11,6 +11,8 @@ module CandidateInterface
         location_row,
       ]
       rows << conditions_row if @course_choice.offer.conditions.any?
+      rows.insert(2, fee_row) if @course_choice.current_course.fee?
+      rows.insert(2, salary_row) if @course_choice.current_course.salary?
       rows
     end
 
@@ -29,6 +31,20 @@ module CandidateInterface
       {
         key: 'Course',
         value: course_row_value,
+      }
+    end
+
+    def fee_row
+      {
+        key: 'Fees',
+        value: fee_row_value,
+      }
+    end
+
+    def salary_row
+      {
+        key: 'Salary',
+        value: @course_choice.current_course.salary_details,
       }
     end
 
@@ -58,6 +74,18 @@ module CandidateInterface
           rel: 'noopener',
         ) +
           tag.p(@course_choice.current_course.description, class: 'govuk-body')
+      end
+    end
+
+    def fee_row_value
+      course = @course_choice.current_course
+
+      if course.fee_international && course.fee_domestic
+        tag.p("UK Students: £#{course.fee_domestic}") + tag.br("International Students: £#{course.fee_international}") + tag.br(course.fee_details, class: 'govuk-body')
+      elsif course.fee_domestic
+        tag.p("UK Students: £#{course.fee_domestic}") + tag.br(course.fee_details, class: 'govuk-body')
+      elsif course.fee_international
+        tag.br("International Students: £#{course.fee_international}") + tag.br(course.fee_details, class: 'govuk-body')
       end
     end
   end

--- a/app/components/candidate_interface/offer_review_component.rb
+++ b/app/components/candidate_interface/offer_review_component.rb
@@ -94,17 +94,17 @@ module CandidateInterface
 
     def fee_value_row_with_fee_details
       if @course_choice.current_course.fee_international && @course_choice.current_course.fee_domestic
-        tag.p("UK Students: £#{@course_choice.current_course.fee_domestic}") + tag.br + tag.p("International Students: £#{@course_choice.current_course.fee_international}", class: 'govuk-body') + tag.br + markdown(@course_choice.current_course.fee_details)
+        tag.p("UK Students: £#{@course_choice.current_course.fee_domestic}") + tag.p("International Students: £#{@course_choice.current_course.fee_international}", class: 'govuk-body') + markdown(@course_choice.current_course.fee_details)
       elsif @course_choice.current_course.fee_domestic
-        tag.p("UK Students: £#{@course_choice.current_course.fee_domestic}", class: 'govuk-body') + tag.br + markdown(@course_choice.current_course.fee_details)
+        tag.p("UK Students: £#{@course_choice.current_course.fee_domestic}", class: 'govuk-body') + markdown(@course_choice.current_course.fee_details)
       elsif @course_choice.current_course.fee_international
-        tag.p("International Students: £#{@course_choice.current_course.fee_international}", class: 'govuk-body') + tag.br + markdown(@course_choice.current_course.fee_details)
+        tag.p("International Students: £#{@course_choice.current_course.fee_international}", class: 'govuk-body') + markdown(@course_choice.current_course.fee_details)
       end
     end
 
     def fee_value_row_without_fee_details
       if @course_choice.current_course.fee_international && @course_choice.current_course.fee_domestic
-        tag.p("UK Students: £#{@course_choice.current_course.fee_domestic}") + tag.br + tag.p("International Students: £#{@course_choice.current_course.fee_international}", class: 'govuk-body')
+        tag.p("UK Students: £#{@course_choice.current_course.fee_domestic}") + tag.p("International Students: £#{@course_choice.current_course.fee_international}", class: 'govuk-body')
       elsif @course_choice.current_course.fee_domestic
         tag.p("UK Students: £#{@course_choice.current_course.fee_domestic}", class: 'govuk-body')
       elsif @course_choice.current_course.fee_international

--- a/app/components/candidate_interface/offer_review_component.rb
+++ b/app/components/candidate_interface/offer_review_component.rb
@@ -13,7 +13,7 @@ module CandidateInterface
       ]
       rows << conditions_row if @course_choice.offer.conditions.any?
       rows.insert(2, fee_row) if @course_choice.current_course.fee?
-      rows.insert(2, salary_row) if @course_choice.current_course.salary? || @course_choice.current_course.apprenticeship?
+      rows.insert(2, salary_row) if @course_choice.current_course.salary_details
       rows
     end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -57,4 +57,46 @@ module ApplicationHelper
       "#{section}_interface"
     end
   end
+
+  def markdown(source)
+    render = Govuk::MarkdownRenderer
+    # Options: https://github.com/vmg/redcarpet#and-its-like-really-simple-to-use
+    # lax_spacing: HTML blocks do not require to be surrounded by an empty line as in the Markdown standard.
+    # autolink: parse links even when they are not enclosed in <> characters
+    options = { autolink: true, lax_spacing: true }
+    markdown = Redcarpet::Markdown.new(render, options)
+
+    # Fix common markdown errors:
+    # - using bullets rather than *
+    # - not putting a space between * and word
+    source = source.gsub(/•\s?/, '* ').gsub(/^\*(?![\s*])/, '* ')
+
+    # Convert quotes to smart quotes
+    source_with_smart_quotes = smart_quotes(source)
+    markdown.render(source_with_smart_quotes).html_safe
+  end
+
+  def smart_quotes(string)
+    return '' if string.blank?
+
+    RubyPants.new(string, [2, :dashes], ruby_pants_options).to_html
+  end
+
+private
+
+  # Use characters rather than HTML entities for smart quotes this matches how
+  # we write smart quotes in templates and allows us to use them in <title>
+  # elements
+  # https://github.com/jmcnevin/rubypants/blob/master/lib/rubypants.rb
+  def ruby_pants_options
+    {
+      double_left_quote: '“',
+      double_right_quote: '”',
+      single_left_quote: '‘',
+      single_right_quote: '’',
+      ellipsis: '…',
+      em_dash: '—',
+      en_dash: '–',
+    }
+  end
 end

--- a/app/lib/govuk/markdown_renderer.rb
+++ b/app/lib/govuk/markdown_renderer.rb
@@ -1,0 +1,61 @@
+module Govuk
+  class MarkdownRenderer < ::Redcarpet::Render::Safe
+    def block_html(raw_html)
+      # No user input HTML please
+    end
+
+    def raw_html(raw_html)
+      # No user input HTML please
+    end
+
+    def emphasis(text)
+      # Disable feature
+    end
+
+    def double_emphasis(text)
+      # Disable feature
+    end
+
+    def triple_emphasis(text)
+      # Disable feature
+    end
+
+    def list(content, list_type)
+      case list_type
+      when :ordered
+        <<~HTML
+          <ol class="govuk-list govuk-list--number">
+            #{content}
+          </ol>
+        HTML
+      when :unordered
+        <<~HTML
+          <ul class="govuk-list govuk-list--bullet">
+            #{content}
+          </ul>
+        HTML
+      end
+    end
+
+    def link(link, _title, content)
+      %(<a href="#{link}" class="govuk-link">#{content}</a>)
+    end
+
+    def autolink(link, _link_type)
+      %(<a href="#{link}" class="govuk-link">#{link}</a>)
+    end
+
+    def paragraph(text)
+      %(<p class="govuk-body">#{text}</p>)
+    end
+
+    # Force all headers to <h3> to maintain semantic markup
+    def header(text, _heading_level)
+      %(<h3 class="govuk-heading-m">#{text}</h3>)
+    end
+
+    def self.render(content)
+      Redcarpet::Markdown.new(self).render(content)
+    end
+  end
+end

--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -79,6 +79,10 @@ module TeacherTrainingPublicAPI
       course.accept_maths_gcse_equivalency = course_from_api.accept_maths_gcse_equivalency
       course.accept_science_gcse_equivalency = course_from_api.accept_science_gcse_equivalency
       course.additional_gcse_equivalencies = course_from_api.additional_gcse_equivalencies
+      course.fee_details = course_from_api.fee_details
+      course.fee_international = course_from_api.fee_international
+      course.fee_domestic = course_from_api.fee_domestic
+      course.salary_details = course_from_api.salary_details
       course_from_api.subject_codes.each do |code|
         subject = ::Subject.find_or_initialize_by(code: code)
         course.subjects << subject unless course.course_subjects.exists?(subject_id: subject.id)

--- a/spec/components/candidate_interface/offer_review_component_spec.rb
+++ b/spec/components/candidate_interface/offer_review_component_spec.rb
@@ -80,4 +80,54 @@ RSpec.describe CandidateInterface::OfferReviewComponent do
       expect(result.css('.govuk-summary-list__key').text).not_to include('Conditions')
     end
   end
+
+  context 'when the course is salaried' do
+    let(:course) { create(:course, :salaried) }
+    let(:application_choice) do
+      create(:application_choice,
+             :with_offer,
+             course_option: create(:course_option, course: course),
+             application_form: application_form)
+    end
+
+    it 'renders a salary row' do
+      result = render_inline(described_class.new(course_choice: application_choice))
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Salary')
+    end
+  end
+
+  context 'when the course is an apprenticeship' do
+    let(:course) { create(:course, :apprenticeship) }
+    let(:application_choice) do
+      create(:application_choice,
+             :with_offer,
+             offer: build(:unconditional_offer),
+             course_option: create(:course_option, course: course),
+             application_form: application_form)
+    end
+
+    it 'renders a salaried row' do
+      result = render_inline(described_class.new(course_choice: application_choice))
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Salary')
+    end
+  end
+
+  context 'when the course is fee paying' do
+    let(:course) { create(:course, :fee_paying) }
+    let(:application_choice) do
+      create(:application_choice,
+             :with_offer,
+             offer: build(:unconditional_offer),
+             course_option: create(:course_option, course: course),
+             application_form: application_form)
+    end
+
+    it 'renders a fees row' do
+      result = render_inline(described_class.new(course_choice: application_choice))
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Fees')
+    end
+  end
 end

--- a/spec/components/candidate_interface/offer_review_component_spec.rb
+++ b/spec/components/candidate_interface/offer_review_component_spec.rb
@@ -82,7 +82,8 @@ RSpec.describe CandidateInterface::OfferReviewComponent do
   end
 
   context 'when the course is salaried' do
-    let(:course) { create(:course, :salaried) }
+    let(:course) { create(:course, :salaried, salary_details: salary_details) }
+    let(:salary_details) { 'foo-bar' }
     let(:application_choice) do
       create(:application_choice,
              :with_offer,
@@ -98,7 +99,8 @@ RSpec.describe CandidateInterface::OfferReviewComponent do
   end
 
   context 'when the course is an apprenticeship' do
-    let(:course) { create(:course, :apprenticeship) }
+    let(:course) { create(:course, :apprenticeship, salary_details: salary_details) }
+    let(:salary_details) { 'foo-bar' }
     let(:application_choice) do
       create(:application_choice,
              :with_offer,
@@ -111,6 +113,22 @@ RSpec.describe CandidateInterface::OfferReviewComponent do
       result = render_inline(described_class.new(course_choice: application_choice))
 
       expect(result.css('.govuk-summary-list__key').text).to include('Salary')
+    end
+  end
+
+  context 'when no salary details are provided but the course is salaried' do
+    let(:course) { create(:course, :salaried) }
+    let(:application_choice) do
+      create(:application_choice,
+             :with_offer,
+             course_option: create(:course_option, course: course),
+             application_form: application_form)
+    end
+
+    it 'does not render a salary row' do
+      result = render_inline(described_class.new(course_choice: application_choice))
+
+      expect(result.css('.govuk-summary-list__key').text).not_to include('Salary')
     end
   end
 

--- a/spec/factories/course.rb
+++ b/spec/factories/course.rb
@@ -83,5 +83,17 @@ FactoryBot.define do
         new_course.save
       end
     end
+
+    trait :fee_paying do
+      funding_type { 'fee' }
+    end
+
+    trait :salaried do
+      funding_type { 'salary' }
+    end
+
+    trait :apprenticeship do
+      funding_type { 'apprenticeship' }
+    end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -29,4 +29,66 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
   # rubocop:enable RSpec/AnyInstance
+
+  describe '#markdown' do
+    it 'converts markdown to HTML' do
+      expect(helper.markdown('test')).to eq('<p class="govuk-body">test</p>')
+    end
+
+    it 'converts markdown lists to HTML lists' do
+      expect(helper.markdown("* test\n* another test")).to include('<li>test</li>')
+    end
+
+    it 'converts bullets into HTML lists' do
+      output = helper.markdown("* test\n• bullet\n•bullet without space")
+
+      expect(output).to include('<li>test</li>')
+      expect(output).to include('<li>bullet</li>')
+      expect(output).to include('<li>bullet without space</li>')
+    end
+
+    it 'converts markdown lists into HTML when space missed between * and word' do
+      output = helper.markdown("* test\n*no space here\n*also *here*")
+
+      expect(output).to include('<li>test</li>')
+      expect(output).to include('<li>no space here</li>')
+      expect(output).to include('<li>also *here*</li>')
+    end
+
+    it 'ignores emphasis markdown' do
+      output = helper.markdown("This does not have *emphasis*\n**something important**\n***super***")
+      expect(output).to include('This does not have *emphasis*')
+      expect(output).to include('**something important**')
+      expect(output).to include('***super***')
+    end
+
+    it 'converts quotes to smart quotes' do
+      output = helper.markdown("\"Wow – what's this...\", O'connor asked.")
+      expect(output).to eq('<p class="govuk-body">“Wow – what’s this…”, O’connor asked.</p>')
+    end
+
+    # Redcarpet fixes out of the box
+    it 'fixes incorrect markdown links' do
+      output = helper.markdown('[Google] (https://www.google.com)')
+      expect(output).to include('<a href="https://www.google.com" class="govuk-link">Google</a>')
+    end
+  end
+
+  describe '#smart_quotes' do
+    it 'converts quotes to smart quotes' do
+      output = helper.smart_quotes("\"Wow – what's this...\", O'connor asked.")
+      expect(output).to include('“Wow – what’s this…”, O’connor asked.')
+    end
+
+    it 'does not convert three consecutive dashes to an em dash' do
+      output = helper.smart_quotes('https://www.londonmet.ac.uk/courses/postgraduate/pgce-secondary-science-with-biology---pgce')
+      expect(output).to include('https://www.londonmet.ac.uk/courses/postgraduate/pgce-secondary-science-with-biology---pgce')
+    end
+
+    context 'when nil' do
+      it 'returns empty string' do
+        expect(helper.smart_quotes(nil)).to be_blank
+      end
+    end
+  end
 end

--- a/spec/lib/govuk/markdown_renderer_spec.rb
+++ b/spec/lib/govuk/markdown_renderer_spec.rb
@@ -1,0 +1,228 @@
+require 'rails_helper'
+
+# Ignore whitespace
+def expect_equal_ignoring_ws(first, second)
+  expect(first.lines.map(&:strip).join).to eq(second.lines.map(&:strip).join)
+end
+
+RSpec.describe Govuk::MarkdownRenderer do
+  let(:html) { described_class.render(markdown) }
+
+  describe 'ul' do
+    let(:markdown) do
+      <<~MD
+        - item
+        - item
+        - item
+      MD
+    end
+
+    it 'renders correct HTML' do
+      expected_html = <<~HTML
+        <ul class="govuk-list govuk-list--bullet">
+          <li>item</li>
+          <li>item</li>
+          <li>item</li>
+        </ul>
+      HTML
+
+      expect_equal_ignoring_ws(html, expected_html)
+    end
+  end
+
+  describe 'ol' do
+    let(:markdown) do
+      <<~MD
+        1. item
+        1. item
+        1. item
+      MD
+    end
+
+    it 'renders correct HTML' do
+      expected_html = <<~HTML
+        <ol class="govuk-list govuk-list--number">
+          <li>item</li>
+          <li>item</li>
+          <li>item</li>
+        </ol>
+      HTML
+
+      expect_equal_ignoring_ws(html, expected_html)
+    end
+  end
+
+  describe 'link' do
+    let(:markdown) do
+      <<~MD
+        [link](https://href)
+      MD
+    end
+
+    it 'renders correct HTML' do
+      expected_html = <<~HTML
+        <p class="govuk-body">
+          <a href="https://href" class="govuk-link">link</a>
+        </p>
+      HTML
+
+      expect_equal_ignoring_ws(html, expected_html)
+    end
+  end
+
+  describe 'script safe' do
+    let(:markdown) do
+      <<~MD
+        <script>alert(1);</script>
+      MD
+    end
+
+    it 'renders correct HTML' do
+      expect(html).to eq('')
+    end
+  end
+
+  describe 'h1' do
+    let(:markdown) do
+      <<~MD
+        # heading level 1
+      MD
+    end
+
+    it 'renders correct HTML' do
+      expected_html = <<~HTML
+        <h3 class="govuk-heading-m">heading level 1</h3>
+      HTML
+
+      expect_equal_ignoring_ws(html, expected_html)
+    end
+  end
+
+  describe 'h2' do
+    let(:markdown) do
+      <<~MD
+        ## heading level 2
+      MD
+    end
+
+    it 'renders correct HTML' do
+      expected_html = <<~HTML
+        <h3 class="govuk-heading-m">heading level 2</h3>
+      HTML
+
+      expect_equal_ignoring_ws(html, expected_html)
+    end
+  end
+
+  describe 'h3' do
+    let(:markdown) do
+      <<~MD
+        ### heading level 3
+      MD
+    end
+
+    it 'renders correct HTML' do
+      expected_html = <<~HTML
+        <h3 class="govuk-heading-m">heading level 3</h3>
+      HTML
+
+      expect_equal_ignoring_ws(html, expected_html)
+    end
+  end
+
+  describe 'h4' do
+    let(:markdown) do
+      <<~MD
+        #### heading level 4
+      MD
+    end
+
+    it 'renders correct HTML' do
+      expected_html = <<~HTML
+        <h3 class="govuk-heading-m">heading level 4</h3>
+      HTML
+
+      expect_equal_ignoring_ws(html, expected_html)
+    end
+  end
+
+  describe 'h5' do
+    let(:markdown) do
+      <<~MD
+        ##### heading level 5
+      MD
+    end
+
+    it 'renders correct HTML' do
+      expected_html = <<~HTML
+        <h3 class="govuk-heading-m">heading level 5</h3>
+      HTML
+
+      expect_equal_ignoring_ws(html, expected_html)
+    end
+  end
+
+  describe 'h6' do
+    let(:markdown) do
+      <<~MD
+        ###### heading level 6
+      MD
+    end
+
+    it 'renders correct HTML' do
+      expected_html = <<~HTML
+        <h3 class="govuk-heading-m">heading level 6</h3>
+      HTML
+
+      expect_equal_ignoring_ws(html, expected_html)
+    end
+  end
+
+  describe 'em' do
+    let(:markdown) do
+      <<~MD
+        *emphasis*
+      MD
+    end
+
+    it 'does not render emphasis tags' do
+      expected_html = <<~HTML
+        <p class="govuk-body">*emphasis*</p>
+      HTML
+
+      expect_equal_ignoring_ws(html, expected_html)
+    end
+  end
+
+  describe 'strong' do
+    let(:markdown) do
+      <<~MD
+        **strong**
+      MD
+    end
+
+    it 'does not render strong tags' do
+      expected_html = <<~HTML
+        <p class="govuk-body">**strong**</p>
+      HTML
+
+      expect_equal_ignoring_ws(html, expected_html)
+    end
+  end
+
+  describe 'strong emphasis' do
+    let(:markdown) do
+      <<~MD
+        ***strong emphasis***
+      MD
+    end
+
+    it 'does not render strong or emphasis tags' do
+      expected_html = <<~HTML
+        <p class="govuk-body">***strong emphasis***</p>
+      HTML
+
+      expect_equal_ignoring_ws(html, expected_html)
+    end
+  end
+end

--- a/spec/services/teacher_training_public_api/sync_provider_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_provider_spec.rb
@@ -32,6 +32,15 @@ RSpec.describe TeacherTrainingPublicAPI::SyncProvider, sidekiq: true do
       it 'syncs the provider courses' do
         expect(TeacherTrainingPublicAPI::SyncCourses).to have_received(:perform_in).exactly(1).time
       end
+
+      context 'when latitude and longitude values are missing' do
+        let(:provider_from_api) { fake_api_provider({ code: 'ABC', latitude: nil, longitude: nil }) }
+
+        it 'handles missing latitude and longitude values' do
+          provider = Provider.find_by(code: 'ABC')
+          expect(provider.latitude).to be_blank
+        end
+      end
     end
 
     context 'ingesting an existing provider when incremental_sync is off' do


### PR DESCRIPTION
## Context

In order to remind candidates what the fee or salary is for a course at the point they accept an offer (entering into a "contract"), we should repeat the information from Find within the offer page on Apply.

## Changes proposed in this pull request

 - Add the following columns to the TTAPI course sync: `fee_details`, `fee_international`, `fee_domestic` and `salary_details`

 - Render Fees row which contains `fee_international` with `fee_details` (if fee_details is provided) alongside the amount and the `fee_domestic` on a new line if the international fee is not `nil`, otherwise only render the `fee_domestic` with `fee details` (if provided) on the same line.

- Render the Salary row if the course is `salary` or `apprenticeship`. This is just the `salary_details` column.

## Guidance to review
- Does the logic make sense, is it what we want?
- I don't think it's possible for a fee paying course to have neither a `fee_domestic` and a `fee_international` so the `if` statement without the `else` should be ok, any thoughts or concerns?

## Screenshots

<img width="426" alt="image" src="https://user-images.githubusercontent.com/50492247/166712059-e876078b-e913-44c7-8524-069a969f7fd1.png">

<img width="368" alt="image" src="https://user-images.githubusercontent.com/50492247/166712138-982795ea-0458-42cf-a0ef-304af4facb3b.png">

<img width="484" alt="image" src="https://user-images.githubusercontent.com/50492247/166712229-47c077aa-b445-407f-9ee5-b9893a12e233.png">


## Link to Trello card

https://trello.com/c/4vI0TOO1/4364-add-fee-or-salary-information-to-course-offer-pages-on-apply

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
