### PR TITLE
Export boolean values in FIRSTDEG column

### DIFF
--- a/app/services/provider_interface/application_data_export.rb
+++ b/app/services/provider_interface/application_data_export.rb
@@ -40,7 +40,7 @@ module ProviderInterface
         'site_code' => application.current_site.code,
         'study_mode' => application.current_course_option.study_mode,
         'start_date' => application.current_course.start_date,
-        'FIRSTDEG' => application.degrees_completed_flag,
+        'FIRSTDEG' => application.degrees_completed_flag == 1 ? 'TRUE' : 'FALSE',
         'qualification_type' => application.first_degree&.qualification_type,
         'non_uk_qualification_type' => application.first_degree&.non_uk_qualification_type,
         'subject' => application.first_degree&.subject,

--- a/spec/services/provider_interface/application_data_export_spec.rb
+++ b/spec/services/provider_interface/application_data_export_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe ProviderInterface::ApplicationDataExport do
         'site_code' => application_choice.current_site.code,
         'study_mode' => application_choice.current_course.study_mode,
         'start_date' => application_choice.current_course.start_date,
-        'FIRSTDEG' => application_choice.application_form.degrees_completed ? 1 : 0,
+        'FIRSTDEG' => application_choice.application_form.degrees_completed ? 'TRUE' : 'FALSE',
         'qualification_type' => first_degree&.qualification_type,
         'non_uk_qualification_type' => first_degree&.non_uk_qualification_type,
         'subject' => first_degree&.subject,


### PR DESCRIPTION
## Context

`FIRSTDEG` values are currently exported as `1` or `0`
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Change values of `FIRSTDEG` to `TRUE` or `FALSE`
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

We'll be renaming and reordering columns in another PR.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/Ky3B4BVX/5054-remove-firstdeg-export-column
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
