### PR TITLE
Export the same application status label value as presented in Manage

### DIFF
--- a/app/services/provider_interface/application_data_export.rb
+++ b/app/services/provider_interface/application_data_export.rb
@@ -9,7 +9,7 @@ module ProviderInterface
         'application_choice_id' => application.id,
         'candidate_id' => application.application_form.candidate.public_id,
         'support_reference' => application.application_form.support_reference,
-        'status' => application.status,
+        'status' => I18n.t("provider_application_states.#{application.status}", default: application.status),
         'submitted_at' => application.application_form.submitted_at,
         'updated_at' => application.updated_at,
         'recruited_at' => application.recruited_at,

--- a/spec/services/provider_interface/application_data_export_spec.rb
+++ b/spec/services/provider_interface/application_data_export_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe ProviderInterface::ApplicationDataExport do
         'application_choice_id' => application_choice.id,
         'candidate_id' => application_choice.application_form.candidate.public_id,
         'support_reference' => application_choice.application_form.support_reference,
-        'status' => application_choice.status,
+        'status' => I18n.t("provider_application_states.#{application_choice.status}", default: application_choice.status),
         'submitted_at' => application_choice.application_form.submitted_at,
         'updated_at' => application_choice.updated_at,
         'recruited_at' => application_choice.recruited_at,


### PR DESCRIPTION
## Context

Application status export values differ from those visible in Manage
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Sync exported values with those presented in Manage.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/LzY1Hs3L/5051-sync-data-export-status-labels-with-manage

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
