### PR TITLE
Show primary navigation on provider content pages

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -34,7 +34,7 @@
     <%= render(PhaseBannerComponent.new(
       feedback_link: ProviderInterface::FEEDBACK_LINK,
     )) %>
-  <% elsif controller.controller_name.in? %w[sessions content provider_agreements] %>
+  <% elsif controller.controller_name.in? %w[sessions provider_agreements] %>
     <%= render(PhaseBannerComponent.new(
       feedback_link: ProviderInterface::FEEDBACK_LINK,
     )) %>


### PR DESCRIPTION
When navigating to links in the footer, and a provider is signed in, they
should see the main navigation bar

[Trello](https://trello.com/c/cevEWEzQ/4926-missing-primary-navigation-when-signed-on-some-pages-such-as-how-the-service-works-and-dates-and-deadlines)