### PR TITLE
Only surface non cancelled interviews

### DIFF
--- a/app/components/candidate_interface/interview_bookings_component.html.erb
+++ b/app/components/candidate_interface/interview_bookings_component.html.erb
@@ -7,7 +7,7 @@
     <% end %>
   </ul>
 <% elsif interviews.kept.any? %>
-  <% interviews.first.tap do |interview| %>
+  <% interviews.kept.first.tap do |interview| %>
     <%= render CandidateInterface::InterviewBookingsItemComponent.new(interview) %>
   <% end %>
 <% elsif @application_choice.awaiting_provider_decision? %>

--- a/spec/components/candidate_interface/interview_bookings_component_spec.rb
+++ b/spec/components/candidate_interface/interview_bookings_component_spec.rb
@@ -144,6 +144,44 @@ RSpec.describe CandidateInterface::InterviewBookingsComponent, type: :component 
     end
   end
 
+  context 'when there is an upcoming interview and cancelled interviews' do
+    let!(:cancelled_interview) do
+      create(
+        :interview,
+        :cancelled,
+        additional_details: 'This is the cancelled interview',
+        date_and_time: Time.zone.local(2020, 6, 6, 18, 30),
+      )
+    end
+
+    let!(:another_cancelled_interview) do
+      create(
+        :interview,
+        :cancelled,
+        additional_details: 'This is another cancelled interview',
+        date_and_time: Time.zone.local(2020, 6, 6, 18, 30),
+        application_choice: cancelled_interview.application_choice,
+      )
+    end
+
+    let(:interview) do
+      create(
+        :interview,
+        additional_details: 'This is the upcoming interview',
+        date_and_time: Time.zone.local(2020, 6, 6, 18, 30),
+        application_choice: cancelled_interview.application_choice,
+      )
+    end
+
+    it 'renders the upcoming interview only' do
+      result = render_inline(described_class.new(interview.application_choice))
+
+      expect(result.text).to include 'This is the upcoming interview'
+      expect(result.text).not_to include 'This is the cancelled interview'
+      expect(result.text).not_to include 'This is another cancelled interview'
+    end
+  end
+
   context 'when the interview is in the past' do
     it 'renders interview details including date and time on the same day as the interview' do
       Timecop.freeze(2020, 6, 6, 23, 0, 0) do


### PR DESCRIPTION
## Context

A vendor flagged we are surfacing cancelled interviews if there is only one upcoming interview. 

## Changes proposed in this pull request

Only show upcoming interviews if there is only one

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
