### PR TITLE
Make professional email address hint text more descriptive

### DIFF
--- a/config/locales/candidate_interface/references.yml
+++ b/config/locales/candidate_interface/references.yml
@@ -18,7 +18,7 @@ en:
         label: What is the referee’s name?
       email_address:
         label: What is the referee’s email address?
-        hint_text: In most cases, this should be a work email address.
+        hint_text: Use their professional email address if they have one.
       relationship:
         label: How do you know this referee and how long have you known them?
         hint_text:
@@ -62,7 +62,7 @@ en:
         confirm: Send reference request
         email_address:
           label: Referee’s email address
-          hint_text: In most cases, this should be a work email address.
+          hint_text: Use their professional email address if they have one.
       send_reminder:
         action: Send a reminder to this referee
         confirm: Yes I’m sure - send a reminder

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -10,7 +10,7 @@ en:
         label: What is the referee’s name?
       email_address:
         label: What is the referee’s email address?
-        hint_text: In most cases, this should be a work email address.
+        hint_text: Use their professional email address if they have one.
       relationship:
         label: What is the referee’s relationship to the candidate?
       feedback:


### PR DESCRIPTION
## Context

We've had comments from providers about the volume of references from Gmail accounts. They prefer professionally based emails for referees, so we want to make this stronger.

## Changes proposed in this pull request

Changing help text to support candidates to provide professional emails.

## Guidance to review

Does this make sense. I don't think there are any tests to amend, but worth checking.

## Link to Trello card

https://trello.com/c/tmhXAal9/4643-make-it-clearer-references-should-come-from-professional-email-address

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
