### PR TITLE
Replace accredited provider with accredited body

### DIFF
--- a/app/models/provider_interface/provider_applications_filter.rb
+++ b/app/models/provider_interface/provider_applications_filter.rb
@@ -137,7 +137,7 @@ module ProviderInterface
 
       {
         type: :checkboxes,
-        heading: 'Accredited provider',
+        heading: 'Accredited body',
         name: 'accredited_provider',
         options: accredited_providers_options,
       }

--- a/app/models/support_interface/providers_filter.rb
+++ b/app/models/support_interface/providers_filter.rb
@@ -44,7 +44,7 @@ module SupportInterface
         },
         {
           type: :search,
-          heading: 'Name or code of accredited provider',
+          heading: 'Name or code of accredited body',
           value: applied_filters[:accredited_provider],
           name: 'accredited_provider',
         },

--- a/spec/components/previews/provider_interface/filter_component_preview.rb
+++ b/spec/components/previews/provider_interface/filter_component_preview.rb
@@ -41,7 +41,7 @@ module ProviderInterface
          name: 'provider',
          options: [{ value: 1, label: 'Gorse SCITT', checked: false }] },
        { type: :checkboxes,
-         heading: 'Accredited provider',
+         heading: 'Accredited body',
          name: 'accredited_provider',
          options: [{ value: 5, label: 'Coventry University', checked: nil }] }]
     end
@@ -66,7 +66,7 @@ module ProviderInterface
          name: 'provider',
          options: [{ value: 1, label: 'Gorse SCITT', checked: false }] },
        { type: :checkboxes,
-         heading: 'Accredited provider',
+         heading: 'Accredited body',
          name: 'accredited_provider',
          options: [{ value: 5, label: 'Coventry University', checked: nil }] },
        { type: :checkboxes,

--- a/spec/components/utility/filter_component_spec.rb
+++ b/spec/components/utility/filter_component_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe FilterComponent do
        name: 'provider',
        options: [{ value: 1, label: 'Gorse SCITT', checked: false }] },
      { type: :checkboxes,
-       heading: 'Accredited provider',
+       heading: 'Accredited body',
        name: 'accredited_provider',
        options: [{ value: 5, label: 'Coventry University', checked: nil }] }]
   end


### PR DESCRIPTION
## Context

We use the term 'accredited body' in most of the content for Manage, including the new permissions guidance. We want to search for when we might use 'accredited provider' instead to fix this so it is consistent with the rest of the service.

We also want to check Support, as what the Support team sees here may influence the language they use when interacting with provider users.

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="357" alt="image" src="https://user-images.githubusercontent.com/47917431/166443914-d97b61f8-2940-4591-95db-2bbfc86ccd27.png">|<img width="354" alt="image" src="https://user-images.githubusercontent.com/47917431/166443959-10aa9e08-fb86-4f35-9c8a-756febfeee0e.png">|

## Link to Trello card

https://trello.com/c/mbUJJreT

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
