### PR TITLE
Fix qualification type bugs

### DIFF
--- a/app/forms/candidate_interface/degree_wizard.rb
+++ b/app/forms/candidate_interface/degree_wizard.rb
@@ -358,7 +358,16 @@ module CandidateInterface
       return if application_qualification.international
       return if map_to_equivalent_level(application_qualification).present?
 
-      "Another #{application_qualification.qualification_type.split.first.downcase} degree type"
+      level = Hesa::DegreeType&.find_by_name(application_qualification.qualification_type)&.level
+
+      map_option = {
+        master: 'master’s degree',
+        bachelor: 'bachelor degree',
+        foundation: 'foundation degree',
+        doctor: DOCTORATE,
+      }[level]
+
+      "Another #{map_option} type"
     end
 
     private_class_method :another_degree_type_option
@@ -494,6 +503,7 @@ module CandidateInterface
     def sanitize_type(attrs)
       if attrs[:type] != "Another #{dynamic_type(last_saved_state[:degree_level])} type" && attrs[:current_step] == :type
         attrs[:other_type] = nil
+        attrs[:other_type_raw] = nil
       end
     end
 

--- a/spec/system/candidate_interface/entering_details/degrees/new_degree_flow/candidate_editing_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/new_degree_flow/candidate_editing_degrees_spec.rb
@@ -66,6 +66,13 @@ RSpec.feature 'Editing a degree' do
     when_i_change_my_undergraduate_country_to_another_country
     and_i_click_on_save_and_continue
     then_i_can_check_my_undergraduate_subject_has_been_cleared
+
+    when_i_click_to_change_my_undergraduate_degree_type_again
+    and_i_change_my_degree_to_another_masters_degree_type
+    and_i_click_on_save_and_continue
+    then_i_can_check_my_revised_masters_undergraduate_degree
+    when_i_click_to_change_my_masters_undergraduate_degree_type
+    then_i_see_another_masters_degree_selected
   end
 
   def given_i_am_signed_in
@@ -273,5 +280,30 @@ RSpec.feature 'Editing a degree' do
     expect(page).to have_content 'Level 6 Diploma'
     expect(page).not_to have_content 'Master of Arts'
     expect(page).not_to have_content 'MA'
+  end
+
+  def when_i_click_to_change_my_undergraduate_degree_type_again
+    visit candidate_interface_new_degree_review_path
+    click_change_link('qualification')
+  end
+
+  def and_i_change_my_degree_to_another_masters_degree_type
+    choose 'Master’s degree'
+    and_i_click_on_save_and_continue
+    choose 'Another master’s degree type'
+    select 'Master of Business Administration'
+  end
+
+  def then_i_can_check_my_revised_masters_undergraduate_degree
+    expect(page).to have_content 'Master of Business Administration'
+    expect(page).to have_content 'MBA (Hons)'
+  end
+
+  def when_i_click_to_change_my_masters_undergraduate_degree_type
+    click_change_link('specific type of degree')
+  end
+
+  def then_i_see_another_masters_degree_selected
+    expect(page.find_field('Another master’s degree type')).to be_checked
   end
 end


### PR DESCRIPTION
## Context
There were two bugs:
1) Picks of common degree type options were not being persisted
2) Mapping to 'another degree type option' to redis from db was broken for masters/doctorate

## Changes proposed in this pull request
- Add unit & systems specs to ensure degree type options persisted & mapping works
- Method to enable mapping of qualification type to type + other_type in redis

## Guidance to review

Ensure common degree type options e.g Master of Science can be persisted
Check 'Another masters degree type' (and doctorate etc) is automatically selected after clicking change link from review page (if one of these degrees was persisted)

## Link to Trello card

https://trello.com/c/yBpb8XQL/4660-degree-flow-bug

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
