### PR TITLE
Add a header and inset text for note guidance

### DIFF
--- a/app/views/provider_interface/notes/index.html.erb
+++ b/app/views/provider_interface/notes/index.html.erb
@@ -5,6 +5,11 @@
   provider_can_respond: @provider_can_respond,
   provider_can_set_up_interviews: @provider_can_set_up_interviews,
 ) %>
+<h1 class="govuk-heading-l">Notes</h1>
+
+<div class="govuk-inset-text">
+  Candidates cannot view notes.
+</div>
 
 <%= govuk_button_link_to 'Add note', new_provider_interface_application_choice_note_path(@application_choice), secondary: true %>
 


### PR DESCRIPTION
## Context

Research & analysis suggests that some users are reluctant to add a note because they're not sure if it'll be sent to the candidate. We want to add copy to reassure users that notes won't be sent to candidates

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="730" alt="image" src="https://user-images.githubusercontent.com/47917431/166446746-54fb401f-4cc5-4d4e-a57c-74e0a4b296a9.png">|<img width="778" alt="image" src="https://user-images.githubusercontent.com/47917431/166446706-d3b56bb2-5d5b-4096-b277-2b5896f209f3.png">|

## Guidance to review

[Prototype](https://manage-applications-beta.herokuapp.com/applications/497434/notes)

## Link to Trello card

https://trello.com/c/4B4KjFpF

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
