### PR TITLE
Update copy to reflect duplicate matching email

### DIFF
--- a/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
@@ -38,10 +38,10 @@
 <%= render partial: 'candidate_interface/application_form/review', locals: { application_form: @application_form, editable: true } %>
 
 <% if @application_form.candidate&.submission_blocked? %>
-  <p class='govuk-body'>We’ve noticed that you’ve started multiple applications.</p>
-  <p class='govuk-body'>Submitting applications for more than 3 courses at a time is not allowed, as stated in our terms of use.</p>
-  <p class='govuk-body'>We have halted this application and you will be unable to submit.</p>
-  <p class='govuk-body'>If you think this is a mistake, please let us know at becomingateacher@digital.education.gov.uk.</p>
+  <p class='govuk-body'>You’ve created more than one account.</p>
+  <p class='govuk-body'>You can no longer submit applications from this account. Visit your other account to continue your application.</p>
+  <p class='govuk-body'>You can apply for up to 3 courses at a time.</p>
+  <p class='govuk-body'>Email becomingateacher@digital.education.gov.uk if you have any questions.</p>
 <% elsif !CycleTimetable.between_cycles?(@application_form.phase) %>
   <%= govuk_button_link_to t('continue'), candidate_interface_start_equality_and_diversity_path %>
 <% end %>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -60,10 +60,10 @@
     <% end %>
 
     <% if @application_form_presenter.application_form.candidate&.submission_blocked? %>
-      <p class='govuk-body'>We’ve noticed that you’ve started multiple applications.</p>
-      <p class='govuk-body'>Submitting applications for more than 3 courses at a time is not allowed, as stated in our terms of use.</p>
-      <p class='govuk-body'>We have halted this application and you will be unable to submit.</p>
-      <p class='govuk-body'>If you think this is a mistake, please let us know at becomingateacher@digital.education.gov.uk.</p>
+      <p class='govuk-body'>You’ve created more than one account.</p>
+      <p class='govuk-body'>You can no longer submit applications from this account. Visit your other account to continue your application.</p>
+      <p class='govuk-body'>You can apply for up to 3 courses at a time.</p>
+      <p class='govuk-body'>Email becomingateacher@digital.education.gov.uk if you have any questions.</p>
     <% else %>
       <%= render(CandidateInterface::ReviewApplicationComponent.new(application_form: @application_form_presenter.application_form)) %>
     <% end %>

--- a/spec/system/candidate_interface/references/candidate_submits_a_duplicate_application_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_submits_a_duplicate_application_spec.rb
@@ -74,7 +74,7 @@ RSpec.feature 'Submitting an application' do
 
   def then_i_can_see_a_warning_message
     visit candidate_interface_application_form_path
-    expect(page).to have_content('We’ve noticed that you’ve started multiple applications')
+    expect(page).to have_content('You’ve created more than one account.')
     expect(page).not_to have_button('Check and submit')
   end
 end


### PR DESCRIPTION
## Context

This is a bug ticket that was identified by @EmmaFrith. Now we have a new mechanism for duplicate matches, we should look to align the copy as much as possible between comms we send the candidate, and what we show on the App form.

## Changes proposed in this pull request

Copy update.

## Guidance to review

Does this content render correctly?

## Link to Trello card

https://trello.com/c/UXxbMmoX/4445-dev-apply-make-interface-duplicate-match-content-more-consistent-with-the-email-content

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
