### PR TITLE
Fix mismatch between label and radio button

### DIFF
--- a/app/components/candidate_interface/degree_grade_component.html.erb
+++ b/app/components/candidate_interface/degree_grade_component.html.erb
@@ -3,8 +3,8 @@
   <%= form.govuk_error_summary %>
   <%= form.govuk_radio_buttons_fieldset :grade, legend: { text: legend_helper, size: 'l' }, hint: { text: t('application_form.degree.grade.international.grade_examples') } do %>
     <% if @model.uk? %>
-      <% UK_DEGREE_GRADES.each do |grade| %>
-        <%= form.govuk_radio_button :grade, grade, label: { text: grade }, link_errors: true do %>
+      <% UK_DEGREE_GRADES.each_with_index do |grade, index| %>
+        <%= form.govuk_radio_button :grade, grade, label: { text: grade }, link_errors: index.zero? do %>
           <% if grade == 'Other' %>
               <%= render DfE::Autocomplete::View.new(
                 form,
@@ -20,8 +20,8 @@
         <% end %>
       <% end %>
     <% else %>
-      <% ['Yes', 'No', 'I do not know'].each do |decision| %>
-        <%= form.govuk_radio_button :grade, decision, label: { text: decision }, link_errors: true do %>
+      <% ['Yes', 'No', 'I do not know'].each_with_index do |decision, index| %>
+        <%= form.govuk_radio_button :grade, decision, label: { text: decision }, link_errors: index.zero? do %>
           <%= form.govuk_text_field :other_grade, label: { text: label_helper }, hint: { text: hint_helper } if decision == 'Yes' %>
         <% end %>
       <% end %>

--- a/app/components/candidate_interface/degree_type_component.html.erb
+++ b/app/components/candidate_interface/degree_type_component.html.erb
@@ -4,8 +4,8 @@
   <% if @wizard.uk? %>
     <%= form.govuk_radio_buttons_fieldset :type, legend: { text: "What type of #{dynamic_types} is it?", size: 'l' } do %>
 
-      <% find_degree_type_options.each do |type| %>
-        <%= form.govuk_radio_button :type, type[:name], label: { text: name_and_abbr(type) }, link_errors: true %>
+      <% find_degree_type_options.each_with_index do |type, index| %>
+        <%= form.govuk_radio_button :type, type[:name], label: { text: name_and_abbr(type) }, link_errors: index.zero? %>
       <% end %>
 
       <%= form.govuk_radio_divider %>

--- a/app/views/candidate_interface/degrees/degree/new_degree_level.html.erb
+++ b/app/views/candidate_interface/degrees/degree/new_degree_level.html.erb
@@ -8,8 +8,8 @@
 
     <%= f.govuk_radio_buttons_fieldset :degree_level, legend: { text: 'What type of degree is it?', size: 'l' } do %>
 
-      <% CandidateInterface::DegreeWizard::DEGREE_LEVEL.each do |name| %>
-        <%= f.govuk_radio_button :degree_level, name, label: { text: name }, hint: -> { tag.span(t('application_form.degree.level.bachelor_degree')) if name == 'Bachelor degree' }, link_errors: true %>
+      <% CandidateInterface::DegreeWizard::DEGREE_LEVEL.each_with_index do |name, index| %>
+        <%= f.govuk_radio_button :degree_level, name, label: { text: name }, hint: -> { tag.span(t('application_form.degree.level.bachelor_degree')) if name == 'Bachelor degree' }, link_errors: index.zero? %>
       <% end %>
 
       <%= f.govuk_radio_divider %>


### PR DESCRIPTION
## Context
There was a bug on some views in degree flow. In its error state, on selection of radio button label, choice would always default to first option. This was because `link_errors: true` wasn't only on the first radio button option. 

## Changes proposed in this pull request
* `link errors: true` is now set only to first radio button as per docs

## Guidance to review

Ensure radio button labels select correct radio button in error state

## Link to Trello card

https://trello.com/c/kLcROy6Q/4687-degree-error-state-label-bug

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
