### PR TITLE
Fix error message on export application data

### DIFF
--- a/app/forms/provider_interface/application_data_export_form.rb
+++ b/app/forms/provider_interface/application_data_export_form.rb
@@ -2,6 +2,8 @@ module ProviderInterface
   class ApplicationDataExportForm
     include ActiveModel::Model
 
+    TRANSLATION_KEY_PREFIX = 'activemodel.errors.models.provider_interface/application_data_export_form.attributes'.freeze
+
     attr_accessor :current_provider_user, :provider_ids, :recruitment_cycle_years, :application_status_choice, :statuses
 
     validate :at_least_one_recruitment_cycle_year_is_selected
@@ -37,19 +39,19 @@ module ProviderInterface
 
     def at_least_one_recruitment_cycle_year_is_selected
       if recruitment_cycle_years.all?(&:blank?)
-        errors.add(:recruitment_cycle_years, 'Select at least one year')
+        errors.add(:recruitment_cycle_years, I18n.t("#{TRANSLATION_KEY_PREFIX}.recruitment_cycle_years.blank"))
       end
     end
 
     def at_least_one_status_is_selected
       if statuses.all?(&:blank?)
-        errors.add(:statuses, 'Select at least one status')
+        errors.add(:statuses, I18n.t("#{TRANSLATION_KEY_PREFIX}.statuses.blank"))
       end
     end
 
     def at_least_one_provider_is_selected
       if selected_providers.none?
-        errors.add(:provider_ids, 'Select at least one organisation')
+        errors.add(:provider_ids, I18n.t("#{TRANSLATION_KEY_PREFIX}.provider_ids.blank"))
       end
     end
   end

--- a/app/views/provider_interface/application_data_export/new.html.erb
+++ b/app/views/provider_interface/application_data_export/new.html.erb
@@ -4,9 +4,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">
-      <%= t('page_titles.provider.export_application_data') %>
-    </h1>
 
     <%= form_with(
       model: @application_data_export_form,
@@ -14,6 +11,10 @@
       method: :get,
     ) do |f| %>
       <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        <%= t('page_titles.provider.export_application_data') %>
+      </h1>
 
       <%= f.govuk_check_boxes_fieldset :recruitment_cycle_years, legend: { text: 'Recruitment cycle', size: 'm' } do %>
         <% RecruitmentCycle.years_visible_to_providers.each do |year| %>

--- a/config/locales/provider_interface/application_data_export.yml
+++ b/config/locales/provider_interface/application_data_export.yml
@@ -1,0 +1,14 @@
+en:
+  activemodel:
+    errors:
+      models:
+        provider_interface/application_data_export_form:
+          attributes:
+            application_status_choice:
+              blank: Select a status type
+            recruitment_cycle_years:
+              blank: Select at least one year
+            statuses:
+              blank: Select at least one status
+            provider_ids:
+              blank: Select at least one organisation

--- a/spec/system/provider_interface/provider_user_exports_applications_to_csv_spec.rb
+++ b/spec/system/provider_interface/provider_user_exports_applications_to_csv_spec.rb
@@ -65,14 +65,13 @@ RSpec.feature 'Provider user exports applications to a csv', mid_cycle: false do
   end
 
   def and_i_fill_in_the_form_incorrectly
-    choose 'All statuses'
-
     click_export_data
   end
 
   def then_i_get_validation_errors
     expect(page).to have_content('Select at least one year')
     expect(page).to have_content('Select at least one organisation')
+    expect(page).to have_content('Select a status type')
   end
 
   def and_i_fill_out_the_form_for_applications_this_year_of_any_status_for_the_first_provider


### PR DESCRIPTION
Instead of generic "can't be blank", give clear message that a status
type must be selected.

Move error message above the H1 title.

## Context

When you try to export application data without specifying the status question on the form, it just states 'can't be blank'.

## Changes proposed in this pull request

- The error message appears above the H1.
- The content for 'can't be blank' has been fixed.

## Link to Trello card

Hello, [Trello](https://trello.com/c/YBKKSZ0a/4963-fix-error-message-on-export-application-data)

## Before

![CleanShot 2022-05-03 at 18 00 05](https://user-images.githubusercontent.com/168365/166502794-60b0a995-53e6-4d78-a28d-5f531fb3d552.png)

## After

![CleanShot 2022-05-03 at 17 59 47](https://user-images.githubusercontent.com/168365/166502817-c5b1e5b3-e10f-49b9-8196-346924905d74.png)
