### PR TITLE
Fix name in support playbook

### DIFF
--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -120,7 +120,7 @@ If the course doesn't exist in the previous cycle we'll need them to confirm the
 
 ### Make or change offer
 
-If the current application status is `awaiting_provider_decision` use MakeAnOffer service.
+If the current application status is `awaiting_provider_decision` use MakeOffer service.
 
 If the current application status is `offer` use ChangeOffer service.
 


### PR DESCRIPTION
## Context

This updates the support playbook with the right name of the service class.

MakeAnOffer was renamed to MakeOffer.