### PR TITLE
Increase char limit for job role from 60 to 100

### DIFF
--- a/app/forms/candidate_interface/restructured_work_history/job_form.rb
+++ b/app/forms/candidate_interface/restructured_work_history/job_form.rb
@@ -22,7 +22,7 @@ module CandidateInterface
                 :role,
                 :commitment,
                 presence: true
-      validates :role, :organisation, length: { maximum: 60 }
+      validates :role, :organisation, length: { maximum: 100 }
       validates :start_date, date: { future: true, month_and_year: true, presence: true, before: :end_date }
       validates :end_date, date: { future: true, month_and_year: true, presence: true }, if: :not_currently_employed_in_this_role?
       validates :start_date_unknown, inclusion: { in: %w[true false] }

--- a/app/forms/candidate_interface/volunteering_role_form.rb
+++ b/app/forms/candidate_interface/volunteering_role_form.rb
@@ -23,7 +23,7 @@ module CandidateInterface
               :working_with_children,
               presence: true
 
-    validates :role, :organisation, length: { maximum: 100 }
+    validates :role, :organisation, length: { maximum: 60 }
     validates :start_date, date: { presence: true, future: true, month_and_year: true, before: :end_date }
 
     validates :start_date_unknown, inclusion: { in: %w[true false] }

--- a/app/forms/candidate_interface/volunteering_role_form.rb
+++ b/app/forms/candidate_interface/volunteering_role_form.rb
@@ -23,7 +23,7 @@ module CandidateInterface
               :working_with_children,
               presence: true
 
-    validates :role, :organisation, length: { maximum: 60 }
+    validates :role, :organisation, length: { maximum: 100 }
     validates :start_date, date: { presence: true, future: true, month_and_year: true, before: :end_date }
 
     validates :start_date_unknown, inclusion: { in: %w[true false] }

--- a/spec/forms/candidate_interface/restructured_work_history/job_form_spec.rb
+++ b/spec/forms/candidate_interface/restructured_work_history/job_form_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::JobForm, type: :mode
     it { is_expected.to validate_presence_of(:organisation) }
     it { is_expected.to validate_presence_of(:commitment) }
 
-    it { is_expected.to validate_length_of(:role).is_at_most(60) }
+    it { is_expected.to validate_length_of(:role).is_at_most(100) }
     it { is_expected.to validate_length_of(:organisation).is_at_most(60) }
 
     context 'start_date validations' do

--- a/spec/forms/candidate_interface/restructured_work_history/job_form_spec.rb
+++ b/spec/forms/candidate_interface/restructured_work_history/job_form_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::JobForm, type: :mode
     it { is_expected.to validate_presence_of(:commitment) }
 
     it { is_expected.to validate_length_of(:role).is_at_most(100) }
-    it { is_expected.to validate_length_of(:organisation).is_at_most(60) }
+    it { is_expected.to validate_length_of(:organisation).is_at_most(100) }
 
     context 'start_date validations' do
       let(:model) do


### PR DESCRIPTION
Analysis of error messages shows that candidates often slightly exceed the (unstated) character limit by a small amount, for reasonable-sounding job titles.

They also sometimes vastly exceed the limit by adding a whole paragraph describing the job (which the field is not intended for). A separate Pull Request will alter the label to try and avoid this.

🗂️ [Trello card](https://trello.com/c/pxCK9E82/4677-can-we-help-users-who-are-writing-too-much-for-their-role-description-in-work-history)

See also: https://github.com/DFE-Digital/apply-for-teacher-training/pull/6918