### PR TITLE
Fix bugs in referee flow

### DIFF
--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -27,13 +27,7 @@ module RefereeInterface
       @relationship_form.candidate = reference.application_form.full_name
 
       if @relationship_form.save(reference)
-        if reference.safeguarding_concerns.blank? || reference.never_asked?
-          redirect_to referee_interface_safeguarding_path(token: @token_param)
-        elsif reference.feedback.blank?
-          redirect_to referee_interface_reference_feedback_path(token: @token_param)
-        else
-          redirect_to referee_interface_reference_review_path(token: @token_param)
-        end
+        redirect_to referee_interface_safeguarding_path(token: @token_param)
       else
         render :relationship
       end
@@ -52,11 +46,7 @@ module RefereeInterface
       @safeguarding_form.candidate = reference.application_form.full_name
 
       if @safeguarding_form.save(reference)
-        if reference.feedback.nil?
-          redirect_to referee_interface_reference_feedback_path(token: @token_param)
-        else
-          redirect_to referee_interface_reference_review_path(token: @token_param)
-        end
+        redirect_to referee_interface_reference_feedback_path(token: @token_param)
       else
         render :safeguarding
       end

--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -27,7 +27,7 @@ module RefereeInterface
       @relationship_form.candidate = reference.application_form.full_name
 
       if @relationship_form.save(reference)
-        redirect_to referee_interface_safeguarding_path(token: @token_param)
+        redirect_to review_path_or(referee_interface_safeguarding_path(token: @token_param))
       else
         render :relationship
       end
@@ -46,7 +46,7 @@ module RefereeInterface
       @safeguarding_form.candidate = reference.application_form.full_name
 
       if @safeguarding_form.save(reference)
-        redirect_to referee_interface_reference_feedback_path(token: @token_param)
+        redirect_to review_path_or(referee_interface_reference_feedback_path(token: @token_param))
       else
         render :safeguarding
       end
@@ -155,6 +155,14 @@ module RefereeInterface
         referee_interface_refuse_feedback_path(token: @token_param)
       elsif previous_path_in_flow
         previous_path_in_flow
+      end
+    end
+
+    def review_path_or(default_path)
+      if params[:from] == 'review'
+        referee_interface_reference_review_path(token: @token_param)
+      else
+        default_path
       end
     end
 

--- a/app/views/referee_interface/reference/confirm_decline.html.erb
+++ b/app/views/referee_interface/reference/confirm_decline.html.erb
@@ -7,7 +7,7 @@
     </h1>
     <%= form_with(
       model: @confirm_refuse_feedback_form,
-      url: referee_interface_decline_reference_path(token: @token_param),
+      url: referee_interface_decline_reference_path(token: @token_param, from: params[:from]),
       method: :patch,
     ) do |f| %>
       <%= f.govuk_submit 'Yes, I am unable to give a reference' %>

--- a/app/views/referee_interface/reference/confirmation.html.erb
+++ b/app/views/referee_interface/reference/confirmation.html.erb
@@ -20,7 +20,7 @@
     <div class="govuk-grid-column-two-thirds">
       <%= form_with(
         model: @questionnaire_form,
-        url: referee_interface_submit_questionnaire_path(token: @token_param),
+        url: referee_interface_submit_questionnaire_path(token: @token_param, from: params[:from]),
         method: :patch,
       ) do |f| %>
         <h2 class="govuk-heading-l">Tell us about your experience of giving a reference</h2>

--- a/app/views/referee_interface/reference/feedback.html.erb
+++ b/app/views/referee_interface/reference/feedback.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(
       model: @reference_form,
-      url: referee_interface_submit_feedback_path(token: @token_param),
+      url: referee_interface_submit_feedback_path(token: @token_param, from: params[:from]),
       method: :patch,
     ) do |f| %>
       <%= f.govuk_error_summary %>

--- a/app/views/referee_interface/reference/refuse_feedback.html.erb
+++ b/app/views/referee_interface/reference/refuse_feedback.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(
       model: @refuse_feedback_form,
-      url: referee_interface_refuse_feedback_path(token: @token_param),
+      url: referee_interface_refuse_feedback_path(token: @token_param, from: params[:from]),
       method: :patch,
     ) do |f| %>
       <%= f.govuk_error_summary %>

--- a/app/views/referee_interface/reference/relationship.html.erb
+++ b/app/views/referee_interface/reference/relationship.html.erb
@@ -6,7 +6,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(
       model: @relationship_form,
-      url: referee_interface_confirm_relationship_path(token: @token_param),
+      url: referee_interface_confirm_relationship_path(token: @token_param, from: params[:from]),
       method: :patch,
     ) do |f| %>
       <%= f.govuk_error_summary %>

--- a/app/views/referee_interface/reference/safeguarding.html.erb
+++ b/app/views/referee_interface/reference/safeguarding.html.erb
@@ -6,7 +6,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(
       model: @safeguarding_form,
-      url: referee_interface_confirm_safeguarding_path(token: @token_param),
+      url: referee_interface_confirm_safeguarding_path(token: @token_param, from: params[:from]),
       method: :patch,
     ) do |f| %>
       <%= f.govuk_error_summary %>

--- a/spec/system/referee_interface/referee_can_submit_a_reference_after_revisiting_signin_link_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_after_revisiting_signin_link_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+
+RSpec.feature 'Referee can submit reference', with_audited: true do
+  include CandidateHelper
+
+  scenario 'Referee submits a reference for a candidate with relationship, safeguarding and review page' do
+    given_i_am_a_referee_of_an_application_and_i_received_the_email
+
+    when_i_click_on_the_link_within_the_email
+    and_i_select_yes_to_giving_a_reference
+
+    when_i_confirm_that_the_described_relationship_is_correct
+    then_i_see_the_safeguarding_page
+
+    when_i_choose_the_candidate_is_suitable_for_working_with_children
+    then_i_see_the_reference_comment_page
+
+    when_i_fill_in_the_reference_field
+    then_i_see_the_reference_review_page
+
+    when_i_click_on_the_link_within_the_email
+    and_i_select_yes_to_giving_a_reference
+
+    when_i_confirm_that_the_described_relationship_is_correct
+    then_i_see_the_safeguarding_page
+
+    when_i_choose_the_candidate_is_suitable_for_working_with_children
+    then_i_see_the_reference_comment_page
+    
+    when_i_fill_in_the_reference_field
+    then_i_see_the_reference_review_page
+
+    and_i_click_the_submit_reference_button
+    then_i_see_am_told_i_submitted_my_reference
+    then_i_see_the_confirmation_page
+  end
+
+  def given_i_am_a_referee_of_an_application_and_i_received_the_email
+    @reference = create(:reference, :feedback_requested, email_address: 'terri@example.com', name: 'Terri Tudor')
+    @application = create(
+      :completed_application_form,
+      references_count: 0,
+      application_references: [@reference],
+      candidate: current_candidate,
+    )
+    RefereeMailer.reference_request_email(@reference).deliver_now
+    open_email('terri@example.com')
+  end
+
+  def when_i_click_on_the_link_within_the_email
+    click_sign_in_link(current_email)
+  end
+
+  def and_i_select_yes_to_giving_a_reference
+    choose 'Yes, I can give them a reference'
+    click_button t('continue')
+  end
+
+  def when_i_confirm_that_the_described_relationship_is_correct
+    expect(page).to have_content("Confirm how you know #{@application.full_name}")
+    within_fieldset('Is this correct?') do
+      choose 'Yes'
+    end
+    click_button t('save_and_continue')
+  end
+
+  def then_i_see_the_safeguarding_page
+    expect(page).to have_content("Do you know of any reason why #{@application.full_name} should not work with children?")
+  end
+
+  def when_i_choose_the_candidate_is_suitable_for_working_with_children
+    choose 'No'
+    click_button t('save_and_continue')
+  end
+
+  def then_i_see_the_reference_comment_page
+    expect(page).to have_content("Does #{@application.full_name} have the potential to teach?")
+  end
+
+  def when_i_fill_in_the_reference_field
+    fill_in 'Your reference', with: 'This is a reference for the candidate.'
+    click_button t('save')
+  end
+
+  def then_i_see_the_reference_review_page
+    expect(page).to have_content("Your reference for #{@application.full_name}")
+    expect(page).to have_content('If you’re not ready to submit yet, you can return using the link in your email.')
+  end
+
+  def and_i_click_the_submit_reference_button
+    click_button t('referee.review.submit')
+  end
+
+  def then_i_see_am_told_i_submitted_my_reference
+    expect(page).to have_content("Your reference for #{@application.full_name}")
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_current_path(referee_interface_confirmation_path(token: @token))
+  end
+end

--- a/spec/system/referee_interface/referee_can_submit_a_reference_after_revisiting_signin_link_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_after_revisiting_signin_link_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
 
     when_i_choose_the_candidate_is_suitable_for_working_with_children
     then_i_see_the_reference_comment_page
-    
+
     when_i_fill_in_the_reference_field
     then_i_see_the_reference_review_page
 

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
@@ -233,7 +233,6 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
   end
 
   def then_i_can_review_the_amended_relationship
-    click_button t('save_and_continue')
     expect(page).to have_content('he is not my friend')
   end
 


### PR DESCRIPTION
## Context

If a referee clicks on a magic link for a second time after partially completing the reference on the first attempt they will be redirected to the review page rather than the next page in the flow.

## Changes proposed in this pull request

- Change the flow so that we only redirect straight back to the review page if the `from=review` URL param is given (this was already set on links from the review page).
- Add a new system spec to cover multiple attempts to fill the reference.

## Guidance to review

- Does this change alter any of the existing functionality other than the issue of multiple attempts?
- Are the tests sufficient?

## Link to Trello card

https://trello.com/c/H2HsGhyZ/4446-bugs-in-referee-flow

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
