### PR TITLE
Update label for Role to Job title or role

### DIFF
--- a/config/locales/candidate_interface/restructured_work_history.yml
+++ b/config/locales/candidate_interface/restructured_work_history.yml
@@ -15,9 +15,9 @@ en:
         review_label: Explanation of why you’ve been out of the workplace
         change_action: explanation of why you’ve been out of the workplace
       role:
-        label: Role
-        review_label: Role
-        change_action: role
+        label: Job title or role
+        review_label: Job title or role
+        change_action: job title or role
         hint_text: If you had more than one role with this employer, enter your last role.
       employer:
         label: Name of employer
@@ -68,8 +68,8 @@ en:
         candidate_interface/restructured_work_history/job_form:
           attributes:
             role:
-              blank: Enter role
-              too_long: Role must be %{count} characters or fewer
+              blank: Enter job title or role
+              too_long: Job title or role must be %{count} characters or fewer
             organisation:
               blank: Enter name of employer
               too_long: Name of the employer must be %{count} characters or fewer


### PR DESCRIPTION
This aims to make it clearer that candidates should enter a short job title rather than a lengthy description of their roles and responsibilities, to avoid them exceeding the character limit, or writing more content than is necessary (as previous experience can be described in personal statement).

🗂️ [Trello card](https://trello.com/c/pxCK9E82/4677-can-we-help-users-who-are-writing-too-much-for-their-role-description-in-work-history)

See also: #6916