### PR TITLE
Update Vendor API v1 specs

### DIFF
--- a/app/controllers/api_docs/vendor_api_docs/reference_controller.rb
+++ b/app/controllers/api_docs/vendor_api_docs/reference_controller.rb
@@ -4,7 +4,7 @@ module APIDocs
       include VersioningHelpers
 
       def reference
-        return redirect_to(api_docs_production_version_reference_path, status: :moved_permanently) if api_version_params.nil?
+        return redirect_to(api_docs_production_version_reference_path, status: :moved_permanently) if api_version_param.nil?
 
         @api_reference = APIReference.new(VendorAPISpecification.new(version: version).as_hash, version: version)
       end
@@ -18,10 +18,10 @@ module APIDocs
     private
 
       def version
-        extract_version(api_version_params)
+        extract_version(api_version_param)
       end
 
-      def api_version_params
+      def api_version_param
         params[:api_version]
       end
 

--- a/app/controllers/api_docs/vendor_api_docs/reference_controller.rb
+++ b/app/controllers/api_docs/vendor_api_docs/reference_controller.rb
@@ -26,7 +26,7 @@ module APIDocs
       end
 
       def api_docs_production_version_reference_path
-        api_docs_versioned_reference_path("v#{VendorAPI.production_version}")
+        api_docs_versioned_reference_path("v#{AllowedCrossNamespaceUsage::VendorAPIInfo.production_version}")
       end
     end
   end

--- a/app/controllers/api_docs/vendor_api_docs/reference_controller.rb
+++ b/app/controllers/api_docs/vendor_api_docs/reference_controller.rb
@@ -4,6 +4,8 @@ module APIDocs
       include VersioningHelpers
 
       def reference
+        return redirect_to(api_docs_production_version_reference_path, status: :moved_permanently) if api_version_params.nil?
+
         @api_reference = APIReference.new(VendorAPISpecification.new(version: version).as_hash, version: version)
       end
 
@@ -16,7 +18,15 @@ module APIDocs
     private
 
       def version
-        extract_version(params[:api_version])
+        extract_version(api_version_params)
+      end
+
+      def api_version_params
+        params[:api_version]
+      end
+
+      def api_docs_production_version_reference_path
+        api_docs_versioned_reference_path("v#{VendorAPI.production_version}")
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1169,7 +1169,7 @@ Rails.application.routes.draw do
     scope module: :vendor_api_docs, path: '/api-docs' do
       get '/' => 'pages#home', as: :home
       get '/usage-scenarios' => 'pages#usage', as: :usage
-      get '/reference' => redirect("/api-docs/v#{VendorAPI.production_version}/reference"), as: :reference
+      get '/reference' => 'reference#reference', as: :reference
       get '/:api_version/reference' => 'reference#reference', constraints: { api_version: /v[.0-9]+/ }, as: :versioned_reference
       get '/release-notes' => 'pages#release_notes', as: :release_notes
       get '/alpha-release-notes' => 'pages#alpha_release_notes'

--- a/spec/controllers/concerns/vendor_api/application_data_concerns_spec.rb
+++ b/spec/controllers/concerns/vendor_api/application_data_concerns_spec.rb
@@ -24,6 +24,9 @@ RSpec.describe VendorAPI::ApplicationDataConcerns do
       let(:version) { 'v1' }
 
       it 'excludes deferrals' do
+        stub_const('VendorAPI::VERSION', '1.1')
+        stub_const('VendorAPI::VERSIONS', { '1.0' => [], '1.1pre' => [] })
+
         application_data_concerns.send(:application_choices_visible_to_provider)
 
         expect(GetApplicationChoicesForProviders)

--- a/spec/requests/vendor_api/v1.0/audit_trail_spec.rb
+++ b/spec/requests/vendor_api/v1.0/audit_trail_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Vendor API - audit trail', type: :request, with_audited: true do
     }
 
     expect {
-      post_api_request "/api/v1/applications/#{application_choice.id}/reject", params: request_body
+      post_api_request "/api/v1.0/applications/#{application_choice.id}/reject", params: request_body
     }.to(change { application_choice.audits.count })
     expect(application_choice.audits.last.user).to be_present
     expect(application_choice.audits.last.user.full_name).to eq(
@@ -48,7 +48,7 @@ RSpec.describe 'Vendor API - audit trail', type: :request, with_audited: true do
 
     expect {
       post_api_request(
-        "/api/v1/applications/#{application_choice.id}/reject",
+        "/api/v1.0/applications/#{application_choice.id}/reject",
         params: request_body,
       )
     }.to(change { VendorApiUser.count }.by(0))

--- a/spec/requests/vendor_api/v1.0/get_multiple_applications_spec.rb
+++ b/spec/requests/vendor_api/v1.0/get_multiple_applications_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
+RSpec.describe 'Vendor API - GET /api/v1.0/applications', type: :request do
   include VendorAPISpecHelpers
   include CourseOptionHelpers
 
@@ -22,7 +22,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
       status: 'awaiting_provider_decision',
     )
 
-    get_api_request "/api/v1/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
+    get_api_request "/api/v1.0/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
     expect(parsed_response['data'].size).to eq(2)
   end
 
@@ -37,7 +37,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
       status: 'awaiting_provider_decision',
     )
 
-    get_api_request "/api/v1/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
+    get_api_request "/api/v1.0/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
 
     expect(parsed_response['data'].size).to eq(1)
   end
@@ -47,13 +47,13 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
       status: 'awaiting_provider_decision',
     )
 
-    get_api_request "/api/v1/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
+    get_api_request "/api/v1.0/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
 
     expect(parsed_response).to be_valid_against_openapi_schema('MultipleApplicationsResponse')
   end
 
   it 'returns a ParameterMissingResponse if the `since` parameter is missing' do
-    get_api_request '/api/v1/applications'
+    get_api_request '/api/v1.0/applications'
 
     expect(response).to have_http_status(:unprocessable_entity)
     expect(parsed_response).to contain_schema_with_error('ParameterMissingResponse',
@@ -61,7 +61,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
   end
 
   it 'returns HTTP status 422 given an unparseable `since` date value' do
-    get_api_request '/api/v1/applications?since=17/07/2020T12:00:42Z'
+    get_api_request '/api/v1.0/applications?since=17/07/2020T12:00:42Z'
 
     expect(response).to have_http_status(:unprocessable_entity)
     expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
@@ -69,7 +69,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
   end
 
   it 'returns HTTP status 422 when encountering a KeyError from ActiveSupport::TimeZone' do
-    get_api_request '/api/v1/applications?since=12936'
+    get_api_request '/api/v1.0/applications?since=12936'
 
     expect(response).to have_http_status(:unprocessable_entity)
     expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse',
@@ -77,7 +77,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
   end
 
   it 'returns HTTP status 422 given a parseable but nonsensensical `since` date value' do
-    get_api_request '/api/v1/applications?since=-004713-03-23T11:52:19.448Z' # this happened
+    get_api_request '/api/v1.0/applications?since=-004713-03-23T11:52:19.448Z' # this happened
 
     expect(response).to have_http_status(:unprocessable_entity)
 
@@ -101,7 +101,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
       status: :unsubmitted,
     )
 
-    get_api_request "/api/v1/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
+    get_api_request "/api/v1.0/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
 
     expect(parsed_response['data'].size).to eq(2)
   end
@@ -118,7 +118,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
     application_choices.second.update(updated_at: 1.minute.ago)
     application_choices.last.update(updated_at: 10.minutes.ago)
 
-    get_api_request "/api/v1/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
+    get_api_request "/api/v1.0/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
 
     response_data = parsed_response['data']
     expect(response_data.size).to eq(3)
@@ -129,7 +129,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
 
     application_choices.first.update(updated_at: 10.seconds.ago)
 
-    get_api_request "/api/v1/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
+    get_api_request "/api/v1.0/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
 
     response_data = parsed_response['data']
 

--- a/spec/requests/vendor_api/v1.0/get_reference_data_spec.rb
+++ b/spec/requests/vendor_api/v1.0/get_reference_data_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
-RSpec.describe 'Vendor API - GET /api/v1/reference-data', type: :request do
+RSpec.describe 'Vendor API - GET /api/v1.0/reference-data', type: :request do
   include VendorAPISpecHelpers
 
   describe '/gcse-subjects' do
     before do
-      get_api_request '/api/v1/reference-data/gcse-subjects'
+      get_api_request '/api/v1.0/reference-data/gcse-subjects'
     end
 
     it 'returns a response that is valid according to the OpenAPI schema' do
@@ -19,7 +19,7 @@ RSpec.describe 'Vendor API - GET /api/v1/reference-data', type: :request do
 
   describe '/a-and-as-level-subjects' do
     before do
-      get_api_request '/api/v1/reference-data/a-and-as-level-subjects'
+      get_api_request '/api/v1.0/reference-data/a-and-as-level-subjects'
     end
 
     it 'returns a response that is valid according to the OpenAPI schema' do
@@ -33,7 +33,7 @@ RSpec.describe 'Vendor API - GET /api/v1/reference-data', type: :request do
 
   describe '/gcse-grades' do
     before do
-      get_api_request '/api/v1/reference-data/gcse-grades'
+      get_api_request '/api/v1.0/reference-data/gcse-grades'
     end
 
     it 'returns a response that is valid according to the OpenAPI schema' do
@@ -47,7 +47,7 @@ RSpec.describe 'Vendor API - GET /api/v1/reference-data', type: :request do
 
   describe '/a-and-as-level-grades' do
     before do
-      get_api_request '/api/v1/reference-data/a-and-as-level-grades'
+      get_api_request '/api/v1.0/reference-data/a-and-as-level-grades'
     end
 
     it 'returns a response that is valid according to the OpenAPI schema' do

--- a/spec/requests/vendor_api/v1.0/get_single_application_spec.rb
+++ b/spec/requests/vendor_api/v1.0/get_single_application_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Vendor API - GET /api/v1/applications/:application_id', type: :request do
+RSpec.describe 'Vendor API - GET /api/v1.0/applications/:application_id', type: :request do
   include VendorAPISpecHelpers
   include CourseOptionHelpers
 
@@ -9,13 +9,13 @@ RSpec.describe 'Vendor API - GET /api/v1/applications/:application_id', type: :r
       status: 'awaiting_provider_decision',
     )
 
-    get_api_request "/api/v1/applications/#{application_choice.id}"
+    get_api_request "/api/v1.0/applications/#{application_choice.id}"
 
     expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse')
   end
 
   it 'returns a NotFoundResponse if the application cannot be found' do
-    get_api_request '/api/v1/applications/asu7dvt87asd'
+    get_api_request '/api/v1.0/applications/asu7dvt87asd'
 
     expect(response).to have_http_status(:not_found)
     expect(parsed_response).to contain_schema_with_error('NotFoundResponse', 'Unable to find Application(s)')
@@ -24,7 +24,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications/:application_id', type: :r
   it 'returns a NotFoundResponse if the application does not belong to the provider' do
     application_choice = create(:application_choice)
 
-    get_api_request "/api/v1/applications/#{application_choice.id}"
+    get_api_request "/api/v1.0/applications/#{application_choice.id}"
 
     expect(response).to have_http_status(:not_found)
     expect(parsed_response).to contain_schema_with_error('NotFoundResponse', 'Unable to find Application(s)')

--- a/spec/requests/vendor_api/v1.0/headers_spec.rb
+++ b/spec/requests/vendor_api/v1.0/headers_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Vendor API - headers for all requests', type: :request do
   include VendorAPISpecHelpers
 
   it 'does not include Feature-Policy headers' do
-    get_api_request "/api/v1/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
+    get_api_request "/api/v1.0/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
 
     expect(response.headers['Feature-Policy']).not_to be_present
   end

--- a/spec/requests/vendor_api/v1.0/post_conditions_met_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_conditions_met_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/confirm-conditio
     application_choice = create_application_choice_for_currently_authenticated_provider(attributes)
     create(:offer, application_choice: application_choice)
 
-    post_api_request "/api/v1/applications/#{application_choice.id}/confirm-conditions-met"
+    post_api_request "/api/v1.0/applications/#{application_choice.id}/confirm-conditions-met"
 
     expect(response).to have_http_status(:ok)
     expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse')
@@ -21,7 +21,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/confirm-conditio
   it 'returns an UnprocessableEntityResponse when trying to transition to an invalid state' do
     application_choice = create_application_choice_for_currently_authenticated_provider(status: 'rejected')
 
-    post_api_request "/api/v1/applications/#{application_choice.id}/confirm-conditions-met", params: {}
+    post_api_request "/api/v1.0/applications/#{application_choice.id}/confirm-conditions-met", params: {}
 
     expect(response).to have_http_status(:unprocessable_entity)
     expect(parsed_response)
@@ -30,7 +30,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/confirm-conditio
   end
 
   it 'returns a NotFoundResponse when the application was not found' do
-    post_api_request '/api/v1/applications/non-existent-id/confirm-conditions-met'
+    post_api_request '/api/v1.0/applications/non-existent-id/confirm-conditions-met'
 
     expect(response).to have_http_status(:not_found)
     expect(parsed_response).to contain_schema_with_error('NotFoundResponse', 'Unable to find Application(s)')

--- a/spec/requests/vendor_api/v1.0/post_conditions_not_met_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_conditions_not_met_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/conditions-not-m
     application_choice = create_application_choice_for_currently_authenticated_provider(attributes)
     create(:offer, application_choice: application_choice)
 
-    post_api_request "/api/v1/applications/#{application_choice.id}/conditions-not-met"
+    post_api_request "/api/v1.0/applications/#{application_choice.id}/conditions-not-met"
 
     expect(response).to have_http_status(:ok)
     expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse')

--- a/spec/requests/vendor_api/v1.0/post_confirm_enrolment_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_confirm_enrolment_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/confirm-enrolmen
   it 'is a noop' do
     application_choice = create_application_choice_for_currently_authenticated_provider({}, :with_recruited)
 
-    post_api_request "/api/v1/applications/#{application_choice.id}/confirm-enrolment"
+    post_api_request "/api/v1.0/applications/#{application_choice.id}/confirm-enrolment"
 
     expect(response).to have_http_status(:ok)
     expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse')
@@ -21,13 +21,13 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/confirm-enrolmen
 
     allow(Sentry).to receive(:capture_exception)
 
-    post_api_request "/api/v1/applications/#{application_choice.id}/confirm-enrolment"
+    post_api_request "/api/v1.0/applications/#{application_choice.id}/confirm-enrolment"
 
     expect(Sentry).to have_received(:capture_exception)
   end
 
   it 'returns a NotFoundResponse when the application was not found' do
-    post_api_request '/api/v1/applications/non-existent-id/confirm-enrolment'
+    post_api_request '/api/v1.0/applications/non-existent-id/confirm-enrolment'
 
     expect(response).to have_http_status(:not_found)
     expect(parsed_response).to contain_schema_with_error('NotFoundResponse', 'Unable to find Application(s)')

--- a/spec/requests/vendor_api/v1.0/post_experimental_endpoints_moved_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_experimental_endpoints_moved_spec.rb
@@ -1,21 +1,21 @@
 require 'rails_helper'
 
-RSpec.describe 'Vendor API - POST /api/v1/experimental/test-data/*', type: :request do
+RSpec.describe 'Vendor API - POST /api/v1.0/experimental/test-data/*', type: :request do
   include VendorAPISpecHelpers
 
   it 'responds with 410 Gone' do
-    post_api_request('/api/v1/experimental/test-data/clear')
+    post_api_request('/api/v1.0/experimental/test-data/clear')
     expect(response.status).to eq(410)
 
-    post_api_request('/api/v1/experimental/test-data/generate')
+    post_api_request('/api/v1.0/experimental/test-data/generate')
     expect(response.status).to eq(410)
   end
 
   it 'responds with a message containing the new endpoint path' do
-    post_api_request('/api/v1/experimental/test-data/clear')
-    expect(parsed_response['data']['message']).to include('has moved to /api/v1/test-data/clear')
+    post_api_request('/api/v1.0/experimental/test-data/clear')
+    expect(parsed_response['data']['message']).to include('has moved to /api/v1.0/test-data/clear')
 
-    post_api_request('/api/v1/experimental/test-data/generate')
-    expect(parsed_response['data']['message']).to include('has moved to /api/v1/test-data/generate')
+    post_api_request('/api/v1.0/experimental/test-data/generate')
+    expect(parsed_response['data']['message']).to include('has moved to /api/v1.0/test-data/generate')
   end
 end

--- a/spec/requests/vendor_api/v1.0/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_make_an_offer_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', type: :request do
+RSpec.describe 'Vendor API - POST /api/v1.0/applications/:application_id/offer', type: :request do
   include VendorAPISpecHelpers
   include CourseOptionHelpers
 
@@ -21,7 +21,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       }
       expect(request_body[:data]).to be_valid_against_openapi_schema('MakeOffer')
 
-      post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: request_body
+      post_api_request "/api/v1.0/applications/#{application_choice.id}/offer", params: request_body
 
       course_option = application_choice.course_option
       expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse')
@@ -51,7 +51,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
         },
       }
 
-      post_path = "/api/v1/applications/#{application_choice.id}/offer"
+      post_path = "/api/v1.0/applications/#{application_choice.id}/offer"
 
       expect {
         post_api_request post_path, params: request_body
@@ -76,7 +76,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       }
       expect(request_body[:data]).to be_valid_against_openapi_schema('MakeOffer')
 
-      post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: request_body
+      post_api_request "/api/v1.0/applications/#{application_choice.id}/offer", params: request_body
 
       course_option = application_choice.course_option
       expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse')
@@ -102,7 +102,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
 
       other_course_option = course_option_for_provider(provider: currently_authenticated_provider)
 
-      post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: {
+      post_api_request "/api/v1.0/applications/#{application_choice.id}/offer", params: {
         'data' => {
           'conditions' => [],
           'course' => course_option_to_course_payload(other_course_option),
@@ -126,7 +126,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
 
       other_course_option = course_option_for_provider(provider: create(:provider))
 
-      post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: {
+      post_api_request "/api/v1.0/applications/#{application_choice.id}/offer", params: {
         'data' => {
           'conditions' => [],
           'course' => {
@@ -151,7 +151,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
 
       other_course_option = course_option_for_provider(provider: create(:provider))
 
-      post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: {
+      post_api_request "/api/v1.0/applications/#{application_choice.id}/offer", params: {
         'data' => {
           'conditions' => [],
           'course' => course_option_to_course_payload(other_course_option),
@@ -172,7 +172,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       other_course_option = course_option_for_provider(provider: create(:provider))
 
       expect {
-        post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: {
+        post_api_request "/api/v1.0/applications/#{application_choice.id}/offer", params: {
           'data' => {
             'conditions' => [],
             'course' => course_option_to_course_payload(other_course_option),
@@ -192,7 +192,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
         status: 'awaiting_provider_decision',
       )
 
-      post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: {
+      post_api_request "/api/v1.0/applications/#{application_choice.id}/offer", params: {
         'data' => {
           'conditions' => [],
           'course' => {
@@ -223,7 +223,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
 
       course_payload = course_option_to_course_payload(other_course_option).except('site_code')
 
-      post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: {
+      post_api_request "/api/v1.0/applications/#{application_choice.id}/offer", params: {
         'data' => {
           'conditions' => [],
           'course' => course_payload,
@@ -241,7 +241,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
         status: 'withdrawn',
       )
 
-      post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: { data: { conditions: [] } }
+      post_api_request "/api/v1.0/applications/#{application_choice.id}/offer", params: { data: { conditions: [] } }
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(parsed_response)
@@ -259,7 +259,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
         },
       }
 
-      post_api_request '/api/v1/applications/non-existent-id/offer', params: request_body
+      post_api_request '/api/v1.0/applications/non-existent-id/offer', params: request_body
 
       expect(response).to have_http_status(:not_found)
       expect(parsed_response).to contain_schema_with_error('NotFoundResponse', 'Unable to find Application(s)')
@@ -272,7 +272,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
 
       other_course_option = course_option_for_provider(provider: currently_authenticated_provider)
 
-      post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: {
+      post_api_request "/api/v1.0/applications/#{application_choice.id}/offer", params: {
         data: {
           conditions: 'INVALID CONDITION FORMAT',
           'course' => course_option_to_course_payload(other_course_option).except(:start_date),
@@ -296,7 +296,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
 
       other_course_option = course_option_for_provider(provider: currently_authenticated_provider)
 
-      post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: {
+      post_api_request "/api/v1.0/applications/#{application_choice.id}/offer", params: {
         'data' => {
           'conditions' => [],
           'course' => course_option_to_course_payload(other_course_option).except(:start_date),
@@ -328,7 +328,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
         },
       }
 
-      post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: request_body
+      post_api_request "/api/v1.0/applications/#{application_choice.id}/offer", params: request_body
       expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse')
 
       new_course_option = course_option_for_provider(provider: currently_authenticated_provider)
@@ -344,7 +344,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
         },
       }
 
-      post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: request_body
+      post_api_request "/api/v1.0/applications/#{application_choice.id}/offer", params: request_body
 
       expect(parsed_response['data']['attributes']['offer']).to eq(
         'conditions' => [
@@ -365,7 +365,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       )
 
       request_body = { data: { conditions: ['DBS Check'] } }
-      post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: request_body
+      post_api_request "/api/v1.0/applications/#{application_choice.id}/offer", params: request_body
 
       expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse')
       expect(parsed_response['data']['attributes']['status']).to eq('offer')
@@ -378,7 +378,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
         status: 'awaiting_provider_decision',
       )
 
-      post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: {
+      post_api_request "/api/v1.0/applications/#{application_choice.id}/offer", params: {
         data: {
           conditions: [],
         },
@@ -413,7 +413,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
         },
       }
 
-      post_api_request "/api/v1/applications/#{choice.id}/offer", params: request_body
+      post_api_request "/api/v1.0/applications/#{choice.id}/offer", params: request_body
 
       expect(parsed_response['data']['attributes']['offer']).to eq(
         'conditions' => [
@@ -442,7 +442,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       }
 
       expect {
-        post_api_request "/api/v1/applications/#{choice.id}/offer", params: request_body
+        post_api_request "/api/v1.0/applications/#{choice.id}/offer", params: request_body
       }.not_to(change { choice.reload })
 
       expect(response).to have_http_status(:ok)

--- a/spec/requests/vendor_api/v1.0/post_reject_application_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_reject_application_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject', type: :
         },
       }
 
-      post_api_request "/api/v1/applications/#{application_choice.id}/reject", params: request_body
+      post_api_request "/api/v1.0/applications/#{application_choice.id}/reject", params: request_body
 
       expect(response).to have_http_status(:ok)
       expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse')
@@ -36,7 +36,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject', type: :
     it 'can reject an already offered application' do
       application_choice = create_application_choice_for_currently_authenticated_provider({}, :with_offer)
 
-      post_api_request "/api/v1/applications/#{application_choice.id}/reject", params: request_body
+      post_api_request "/api/v1.0/applications/#{application_choice.id}/reject", params: request_body
 
       expect(response).to have_http_status(:ok)
       expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse')
@@ -57,7 +57,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject', type: :
       },
     }
 
-    post_api_request "/api/v1/applications/#{application_choice.id}/reject", params: request_body
+    post_api_request "/api/v1.0/applications/#{application_choice.id}/reject", params: request_body
 
     expect(response).to have_http_status(:unprocessable_entity)
     expect(parsed_response)
@@ -70,7 +70,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject', type: :
       status: 'awaiting_provider_decision',
     )
 
-    post_api_request "/api/v1/applications/#{application_choice.id}/reject", params: {
+    post_api_request "/api/v1.0/applications/#{application_choice.id}/reject", params: {
       data: {
         reason: '',
       },
@@ -83,7 +83,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject', type: :
   end
 
   it 'returns not found error when the application was not found' do
-    post_api_request '/api/v1/applications/non-existent-id/reject'
+    post_api_request '/api/v1.0/applications/non-existent-id/reject'
 
     expect(response).to have_http_status(:not_found)
     expect(parsed_response)

--- a/spec/requests/vendor_api/v1.0/post_test_data_clear_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_test_data_clear_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Vendor API - POST /api/v1/test-data/clear', type: :request do
+RSpec.describe 'Vendor API - POST /api/v1.0/test-data/clear', type: :request do
   include VendorAPISpecHelpers
   include CourseOptionHelpers
 
@@ -13,9 +13,9 @@ RSpec.describe 'Vendor API - POST /api/v1/test-data/clear', type: :request do
     )
 
     expect {
-      post_api_request('/api/v1/test-data/clear')
+      post_api_request('/api/v1.0/test-data/clear')
     }.to change {
-      get_api_request('/api/v1/applications?since=1970-01-01')
+      get_api_request('/api/v1.0/applications?since=1970-01-01')
       parsed_response['data'].count
     }.from(1).to(0)
   end
@@ -28,7 +28,7 @@ RSpec.describe 'Vendor API - POST /api/v1/test-data/clear', type: :request do
     )
 
     expect {
-      post_api_request('/api/v1/test-data/clear')
+      post_api_request('/api/v1.0/test-data/clear')
     }.to change {
       Candidate.count
     }.from(1).to(0)
@@ -44,13 +44,13 @@ RSpec.describe 'Vendor API - POST /api/v1/test-data/clear', type: :request do
       ),
     )
 
-    expect { post_api_request('/api/v1/test-data/clear') }.to change(Candidate, :count).from(1).to(0)
+    expect { post_api_request('/api/v1.0/test-data/clear') }.to change(Candidate, :count).from(1).to(0)
       .and change(ApplicationForm, :count).from(1).to(0)
       .and change(ApplicationChoice, :count).from(1).to(0)
   end
 
   it 'returns responses conforming to the schema' do
-    post_api_request('/api/v1/test-data/clear')
+    post_api_request('/api/v1.0/test-data/clear')
     expect(parsed_response).to be_valid_against_openapi_schema('OkResponse')
   end
 end

--- a/spec/requests/vendor_api/v1.0/post_test_data_generate_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_test_data_generate_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
-RSpec.describe 'Vendor API - POST /api/v1/test-data/generate', type: :request, sidekiq: true do
+RSpec.describe 'Vendor API - POST /api/v1.0/test-data/generate', type: :request, sidekiq: true do
   include VendorAPISpecHelpers
 
   it 'generates test data' do
     create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
 
-    post_api_request '/api/v1/test-data/generate?count=1'
+    post_api_request '/api/v1.0/test-data/generate?count=1'
 
     expect(Candidate.count).to eq(1)
     expect(ApplicationChoice.count).to eq(1)
@@ -16,7 +16,7 @@ RSpec.describe 'Vendor API - POST /api/v1/test-data/generate', type: :request, s
     create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
     create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
 
-    post_api_request '/api/v1/test-data/generate?count=1&courses_per_application=2'
+    post_api_request '/api/v1.0/test-data/generate?count=1&courses_per_application=2'
 
     expect(Candidate.count).to eq(1)
     expect(ApplicationChoice.count).to eq(2)
@@ -28,7 +28,7 @@ RSpec.describe 'Vendor API - POST /api/v1/test-data/generate', type: :request, s
     create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
     create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
 
-    post_api_request '/api/v1/test-data/generate?count=1&courses_per_application=99'
+    post_api_request '/api/v1.0/test-data/generate?count=1&courses_per_application=99'
 
     expect(Candidate.count).to eq(1)
     expect(ApplicationChoice.count).to eq(3)
@@ -38,7 +38,7 @@ RSpec.describe 'Vendor API - POST /api/v1/test-data/generate', type: :request, s
     create(:course_option, course: create(:course, :open_on_apply, accredited_provider: currently_authenticated_provider))
     expected_option = create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
 
-    post_api_request '/api/v1/test-data/generate?count=1&courses_per_application=1&for_training_courses=true'
+    post_api_request '/api/v1.0/test-data/generate?count=1&courses_per_application=1&for_training_courses=true'
 
     expect(Candidate.count).to eq(1)
     expect(ApplicationChoice.count).to eq(1)
@@ -49,7 +49,7 @@ RSpec.describe 'Vendor API - POST /api/v1/test-data/generate', type: :request, s
     create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
     expected_option = create(:course_option, course: create(:course, :open_on_apply, accredited_provider: currently_authenticated_provider))
 
-    post_api_request '/api/v1/test-data/generate?count=1&courses_per_application=1&for_ratified_courses=true'
+    post_api_request '/api/v1.0/test-data/generate?count=1&courses_per_application=1&for_ratified_courses=true'
 
     expect(Candidate.count).to eq(1)
     expect(ApplicationChoice.count).to eq(1)
@@ -60,7 +60,7 @@ RSpec.describe 'Vendor API - POST /api/v1/test-data/generate', type: :request, s
     create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
     create(:course_option, course: create(:course, :open_on_apply, accredited_provider: currently_authenticated_provider))
 
-    post_api_request '/api/v1/test-data/generate?count=1&for_test_provider_courses=true'
+    post_api_request '/api/v1.0/test-data/generate?count=1&for_test_provider_courses=true'
 
     expect(Candidate.count).to eq(1)
     expect(ApplicationChoice.all.map(&:course_option).map(&:provider).map(&:code).compact).to contain_exactly('TEST')
@@ -69,7 +69,7 @@ RSpec.describe 'Vendor API - POST /api/v1/test-data/generate', type: :request, s
   it 'returns responses conforming to the schema' do
     create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
 
-    post_api_request '/api/v1/test-data/generate?count=1'
+    post_api_request '/api/v1.0/test-data/generate?count=1'
 
     expect(parsed_response).to be_valid_against_openapi_schema('OkResponse')
   end
@@ -77,7 +77,7 @@ RSpec.describe 'Vendor API - POST /api/v1/test-data/generate', type: :request, s
   it 'returns error responses on invalid input' do
     create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
 
-    post_api_request '/api/v1/test-data/generate?count=1&courses_per_application=2'
+    post_api_request '/api/v1.0/test-data/generate?count=1&courses_per_application=2'
 
     expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
   end
@@ -85,7 +85,7 @@ RSpec.describe 'Vendor API - POST /api/v1/test-data/generate', type: :request, s
   it 'returns error when you ask for zero courses per application' do
     create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
 
-    post_api_request '/api/v1/test-data/generate?count=1&courses_per_application=0'
+    post_api_request '/api/v1.0/test-data/generate?count=1&courses_per_application=0'
 
     expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
   end

--- a/spec/requests/vendor_api/v1.0/post_test_data_regenerate_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_test_data_regenerate_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Vendor API - POST /api/v1/test-data/regenerate', type: :request,
   include VendorAPISpecHelpers
 
   it 'returns an error' do
-    post_api_request '/api/v1/test-data/regenerate'
+    post_api_request '/api/v1.0/test-data/regenerate'
 
     expect(response).to have_http_status(:ok)
     expect(parsed_response['errors'][0]['error'])

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature 'Vendor receives the application' do
     api_token = VendorAPIToken.create_with_random_token!(provider: @provider)
     page.driver.header 'Authorization', "Bearer #{api_token}"
 
-    visit '/api/v1/applications?since=2019-01-01'
+    visit '/api/v1.0/applications?since=2019-01-01'
 
     @api_response = JSON.parse(page.body)
   end


### PR DESCRIPTION
## Context

We will be releasing v1.1 to production next week. Amending the constants to point to v1.1 causes many failures within our specs as we are pointing to `v1` in our paths, which previously pulled in the latest production version `v1.0`.
 
## Changes proposed in this pull request

- Point all our paths to `v1.0` if we are explicitly testing `v1.0`
- Amend the reference route and move logic to controller to allow testing

## Guidance to review

Did I miss anything

## Link to Trello card

https://trello.com/c/U2FJ0Otj/5066-release-api-v11-to-production

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
