### PR TITLE
Add Incomplete tag alongside 'Request your references' link

### DIFF
--- a/app/components/candidate_interface/task_list_item_references_component.html.erb
+++ b/app/components/candidate_interface/task_list_item_references_component.html.erb
@@ -1,21 +1,22 @@
-<div class="app-task-list__content">
-  <p class="govuk-body govuk-!-margin-bottom-1 govuk-!-margin-top-1">
-    <% if references.feedback_provided.count >= ApplicationForm::REQUIRED_REFERENCE_SELECTIONS %>
-      <%= govuk_link_to t('page_titles.references_review'), references_path, 'aria-describedby': "#{t('page_titles.references_review').parameterize}-badge-id" %>
-    <% elsif references.requested_or_provided.count >= ApplicationForm::REQUIRED_REFERENCE_SELECTIONS %>
-      <%= render(TaskListItemComponent.new(
-        text: 'Request your references',
-        path: references_path,
-        completed: false,
-        show_incomplete: false,
-      )) %>
-    <% else %>
-      <%= render(TaskListItemComponent.new(
-        text: 'Request your references',
-        path: references_path,
-        completed: false,
-        show_incomplete: true,
-      )) %>
-    <% end %>
-  </p>
-</div>
+<% if references.feedback_provided.count >= ApplicationForm::REQUIRED_REFERENCE_SELECTIONS %>
+  <%= render(TaskListItemComponent.new(
+    text: t('page_titles.references_review'),
+    path: references_path,
+    completed: false,
+    show_incomplete: false,
+  )) %>
+<% elsif references.requested_or_provided.count >= ApplicationForm::REQUIRED_REFERENCE_SELECTIONS %>
+  <%= render(TaskListItemComponent.new(
+    text: 'Request your references',
+    path: references_path,
+    completed: false,
+    show_incomplete: false,
+  )) %>
+<% else %>
+  <%= render(TaskListItemComponent.new(
+    text: 'Request your references',
+    path: references_path,
+    completed: false,
+    show_incomplete: true,
+  )) %>
+<% end %>

--- a/app/components/candidate_interface/task_list_item_references_component.html.erb
+++ b/app/components/candidate_interface/task_list_item_references_component.html.erb
@@ -2,8 +2,20 @@
   <p class="govuk-body govuk-!-margin-bottom-1 govuk-!-margin-top-1">
     <% if references.feedback_provided.count >= ApplicationForm::REQUIRED_REFERENCE_SELECTIONS %>
       <%= govuk_link_to t('page_titles.references_review'), references_path, 'aria-describedby': "#{t('page_titles.references_review').parameterize}-badge-id" %>
+    <% elsif references.requested_or_provided.count >= ApplicationForm::REQUIRED_REFERENCE_SELECTIONS %>
+      <%= render(TaskListItemComponent.new(
+        text: 'Request your references',
+        path: references_path,
+        completed: false,
+        show_incomplete: false,
+      )) %>
     <% else %>
-      <%= govuk_link_to 'Request your references', references_path, 'aria-describedby': "#{t('page_titles.references_review').parameterize}-badge-id" %>
+      <%= render(TaskListItemComponent.new(
+        text: 'Request your references',
+        path: references_path,
+        completed: false,
+        show_incomplete: true,
+      )) %>
     <% end %>
   </p>
 </div>

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -37,6 +37,10 @@ class ApplicationReference < ApplicationRecord
     never_asked: 'never_asked',
   }
 
+  def self.requested_or_provided
+    where(feedback_status: %i[feedback_requested feedback_provided])
+  end
+
   def self.failed
     where(feedback_status: %i[feedback_refused cancelled cancelled_at_end_of_cycle])
   end

--- a/spec/components/candidate_interface/task_list_item_references_component_spec.rb
+++ b/spec/components/candidate_interface/task_list_item_references_component_spec.rb
@@ -10,13 +10,36 @@ RSpec.describe CandidateInterface::TaskListItemReferencesComponent do
     expect(page).to have_link('Review your references', href: Rails.application.routes.url_helpers.candidate_interface_references_review_path)
   end
 
-  it 'renders a `Request your references` link which goes to the review page when one than two references have been provided' do
+  it 'renders a `Request your references` link which goes to the review page but not incomplete tag when less than two references have been provided but two have been requested' do
+    application_form = create(:application_form)
+    create(:reference, :feedback_requested, application_form: application_form)
+    create(:reference, :feedback_provided, application_form: application_form)
+
+    render_inline(described_class.new(references: application_form.application_references))
+
+    expect(page).to have_link('Request your references', href: Rails.application.routes.url_helpers.candidate_interface_references_review_path)
+    expect(page).not_to have_content('Incomplete')
+  end
+
+  it 'renders a `Request your references` link which goes to the review page and incomplete tag when less than two references have been requested' do
     application_form = create(:application_form)
     create(:reference, :feedback_provided, application_form: application_form)
 
     render_inline(described_class.new(references: application_form.application_references))
 
     expect(page).to have_link('Request your references', href: Rails.application.routes.url_helpers.candidate_interface_references_review_path)
+    expect(page).to have_content('Incomplete')
+  end
+
+  it 'renders a `Request your references` link which goes to the review page and incomplete tag when there are less than two active references' do
+    application_form = create(:application_form)
+    create(:reference, :feedback_refused, application_form: application_form)
+    create(:reference, :not_requested_yet, application_form: application_form)
+
+    render_inline(described_class.new(references: application_form.application_references))
+
+    expect(page).to have_link('Request your references', href: Rails.application.routes.url_helpers.candidate_interface_references_review_path)
+    expect(page).to have_content('Incomplete')
   end
 
   it 'renders a `Request your references` link which goes to the start page when noreferences have been provided' do


### PR DESCRIPTION
## Context

A new _Incomplete_ tag should appear to candidates on the references task list when they have less than the required number of reference requests in flights or provided. It indicates that the candidate needs to take action (to request enough references).

## Changes proposed in this pull request

When candidates have less than 2 requested or provided references:

<img width="682" alt="image" src="https://user-images.githubusercontent.com/450843/167123575-f45ab270-53a8-4019-ba5e-3171aed35229.png">

There is no change when 2 requests have been made:

<img width="682" alt="image" src="https://user-images.githubusercontent.com/450843/167123688-16a88290-70ad-47c9-a01d-240782aecac7.png">

<img width="682" alt="image" src="https://user-images.githubusercontent.com/450843/166943048-d9d9d358-78d4-4a03-b70b-6eae13d5a290.png">

## Guidance to review

- Are the component specs sufficient?

## Link to Trello card

https://trello.com/c/lLEqM4rt/4653-add-an-incomplete-tag-to-request-your-references-to-make-clear-there-is-an-action-that-can-be-taken

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
