### PR TITLE
Upgrade Vendor API to v1.1

### DIFF
--- a/app/controllers/api_docs/vendor_api_docs/pages_controller.rb
+++ b/app/controllers/api_docs/vendor_api_docs/pages_controller.rb
@@ -2,7 +2,7 @@ module APIDocs
   module VendorAPIDocs
     class PagesController < APIDocsController
       def home
-        render_content_page :home
+        render_content_page :home, locals: { current_api_version: current_api_version, next_api_version: next_api_version }
       end
 
       def usage
@@ -27,11 +27,24 @@ module APIDocs
 
     private
 
-      def render_content_page(page_name)
-        @converted_markdown = GovukMarkdown.render(File.read("app/views/api_docs/vendor_api_docs/pages/#{page_name}.md")).html_safe
+      def render_content_page(page_name, locals: {})
+        raw_content = File.read("app/views/api_docs/vendor_api_docs/pages/#{page_name}.md")
+        content_with_erb_tags_replaced = ApplicationController.renderer.render(
+          inline: raw_content,
+          locals: locals,
+        )
+        @converted_markdown = GovukMarkdown.render(content_with_erb_tags_replaced).html_safe
         @page_name = page_name
 
         render 'rendered_markdown_template'
+      end
+
+      def current_api_version
+        VendorAPI.production_version.to_f
+      end
+
+      def next_api_version
+        (current_api_version + 0.1).round(1)
       end
     end
   end

--- a/app/controllers/api_docs/vendor_api_docs/pages_controller.rb
+++ b/app/controllers/api_docs/vendor_api_docs/pages_controller.rb
@@ -40,7 +40,7 @@ module APIDocs
       end
 
       def current_api_version
-        VendorAPI.production_version.to_f
+        AllowedCrossNamespaceUsage::VendorAPIInfo.production_version.to_f
       end
 
       def next_api_version

--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -24,7 +24,7 @@ module VendorAPI
       Changes::ExperimentalClearTestData,
       Changes::ExperimentalGenerateTestData,
     ],
-    '1.1pre' => [
+    '1.1' => [
       Changes::DeferOffer,
       Changes::ConfirmDeferredOffer,
       Changes::CreateNote,

--- a/app/views/api_docs/vendor_api_docs/pages/home.md
+++ b/app/views/api_docs/vendor_api_docs/pages/home.md
@@ -112,7 +112,7 @@ The first number indicates a major version. This is incremented each time breaki
 
 The number after the decimal point indicates a minor version. This is incremented each time non-breaking changes are made, for example `1.2` changes to `1.3`.
 
-The current version of this API is `1.0`. The next version will be `1.1`.
+The current version of this API is `<%= current_api_version %>`. The next minor version will be `<%= next_api_version %>`.
 
 Changes are documented in our [release notes](/api-docs/release-notes).
 

--- a/app/views/api_docs/vendor_api_docs/pages/home.md
+++ b/app/views/api_docs/vendor_api_docs/pages/home.md
@@ -19,11 +19,8 @@ To get an idea of how the API works, we recommend you [review the example usage 
 
 The API currently doesn’t support the following features:
 
-- Deferring offers
-- Interview scheduling and status
 - Decision codes (e.g. to provide structured reasons for rejection, or conditions)
 - Tracking and confirming individual conditions
-- Notes
 
 We are exploring the addition of those features, and may support them in later API versions.
 

--- a/app/views/api_docs/vendor_api_docs/pages/release_notes.md
+++ b/app/views/api_docs/vendor_api_docs/pages/release_notes.md
@@ -1,3 +1,9 @@
+## v1.1 — 9th May 2022
+
+Minor Version Upgrade:
+
+Release API version `v1.1` to production. Please refer to the [API Reference](/api-docs/v1.1/reference) for details.
+
 ## 19th April 2022
 
 Documentation:

--- a/app/views/api_docs/vendor_api_docs/reference/reference.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/reference.html.erb
@@ -35,6 +35,101 @@
 
 <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-6 govuk-!-margin-bottom-6">
 
+<h2 class="govuk-heading-l" id="important">Version 1.1 changes</h2>
+
+<p class="govuk-heading-s">Interviews</p>
+<p class="govuk-body">
+  We now support <%= govuk_link_to 'creating', '#post-applications-application_id-interviews-create' %>, <%= govuk_link_to 'updating', '#post-applications-application_id-interviews-interview_id-update' %> and <%= govuk_link_to 'cancelling', '#post-applications-application_id-interviews-interview_id-cancel' %> interviews.
+</p>
+
+<p class="govuk-body">A nested <code>interviews</code> array will become populated if an interview is created. Each <%= govuk_link_to 'interview', '#interview-object' %> within the array will hold a unique <code>id</code>, which allows the update or cancelling of a specific interview.</p>
+
+<p class="govuk-body">To update an interview, the <%= govuk_link_to 'update endpoint', '#post-applications-application_id-interviews-interview_id-update' %> can be invoked with only the fields that require update. Any field that is not included will retain the current value and will not be overwritten.</p>
+
+<p class="govuk-body">To cancel an interview, the <%= govuk_link_to 'cancel endpoint', '#post-applications-application_id-interviews-interview_id-cancel' %> can be invoked with the cancellation reason. If an interview is cancelled the <code>cancelled_at</code> and <code>cancellation_reason</code> attributes will be populated.</p>
+
+<p class="govuk-body">If an applicant has an interview, the <code>interviews</code> array in the application response will be populated and can be used to determine the presence of any interviews, including cancelled ones. The status of the application will remain as <code>awaiting_provider_decision</code>.</p>
+
+<p class="govuk-body">When an applicant withdraws or declines an application, or if the application is made an offer or rejected, all upcoming interviews on that application are automatically cancelled.</p>
+
+<p class="govuk-heading-s">Notes</p>
+<p class="govuk-body">
+  We now support <%= govuk_link_to 'creating', '#post-applications-application_id-notes-create' %> notes.
+</p>
+<p class="govuk-body">To create a note the <%= govuk_link_to 'create endpoint', '#post-applications-application_id-notes-create' %> can be invoked with the message of the note.</p>
+
+<p class="govuk-body">If an applicant has any notes attached to the application, the <code>notes</code> array in the application response will be populated and can be used to determine the presence of any notes. The author of the note will be determined from the <code>full_name</code> provided in the <%= govuk_link_to 'Attribution Object', '#attribution-object' %> when making the API call.</p>
+
+<p class="govuk-body">It is not possible to update or delete existing notes.</p>
+
+<p class="govuk-heading-s">Deferring applications</p>
+<p class="govuk-body">
+  We now support <%= govuk_link_to 'deferring', '#post-applications-application_id-defer-offer' %> an offer to the next cycle, as well as <%= govuk_link_to 'confirming', '#post-applications-application_id-confirm-deferred-offer' %> a deferred offer in the next cycle.
+</p>
+<p class="govuk-body">To defer an application, the state of the application will need to either be <code>pending_conditions</code> or <code>recruited</code>, then the <%= govuk_link_to 'defer offer endpoint', '#post-applications-application_id-defer-offer' %> can be invoked. This will change the status of the application to a <b>new</b> status: <code>offer_deferred</code>. It will also populate the fields <code>offer_deferred_at</code>, <code>deferred_to_recruitment_cycle_year</code> with the year this deferred application can be confirmed, as well as maintain the status before deferral of the application in the field <code>status_before_deferral</code>. Please note that deferred applications did not previously appear in the application lists and will start appearing now when syncing with the API. If an application is deferred it can only be confirmed in the next cycle.
+</p>
+<p class="govuk-body">To confirm a deferred application in the next cycle, the <%= govuk_link_to 'confirm deferred offer endpoint', '#post-applications-application_id-confirm-deferred-offer' %> can be invoked. For successfully confirming an offer, the same course, location and study mode should be present in the new cycle. To determine success the conditions will be required to be set as met or not met, which will transition the state of the application accordingly to <code>recruited</code> or <code>pending_conditions</code>. The field <code>deferred_to_recruitment_cycle_year</code> will now be set to <code>null</code> as the application will no longer be in the <code>offer_deferred</code> status. Please note that deferred applications from the previous cycle will start appearing in the new cycle when syncing applications, with courses from the previous year initially set until confirmed.
+</p>
+<p class="govuk-body">If an application is confirmed successfully, the new course from the cycle will appear under the <%= govuk_link_to 'OfferObject', '#offer-object' %>.
+</p>
+<p class="govuk-heading-s">Withdrawing applications</p>
+<p class="govuk-body">
+  We now support <%= govuk_link_to 'withdrawing', '#post-applications-application_id-withdraw' %> an application at the candidate's request. If an application is withdrawn at a candidate's request, it will either transition to the <code>declined</code> state if the application is in the <code>offer</code> state, or the <code>withdrawn</code> state if it's in any other state. We currently don't require a reason for when an application is withdrawn at a candidate's request.
+</p>
+<p class="govuk-body">
+  If an application is withdrawn at a candidate's request the field <code>withdrawn_or_declined_for_candidate</code> will be set to true to determine the difference between a normal withdrawal and one at a candidate's request. Also either the <code>offer_declined_at</code> field or the <code>date</code> field, inside the existing <%= govuk_link_to 'Withdrawal Object', '#withdrawal-object' %>, will be populated with the timestamp the application was withdrawn or declined.
+</p>
+
+<p class="govuk-body">Only applications in the <code>offer</code> state will transition to the <code>declined</code> state.</p>
+
+<p class="govuk-body">Applications in the following states will transition to the <code>withdrawn</code> state:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <% (ApplicationStateChange::SUCCESSFUL_STATES + ApplicationStateChange::DECISION_PENDING_STATUSES).each do |state| %>
+    <li><code><%= state %></code></li>
+  <% end %>
+</ul>
+
+<p class="govuk-body">Please refer to the <%= govuk_link_to 'Application lifecycle', api_docs_lifecycle_path %> for details of application state transitions.</p>
+
+<p class="govuk-heading-s">Pagination</p>
+<p class="govuk-body">
+  Pagination has been added to the API through a <code>page</code> parameter as well as a <code>per_page</code> parameter. These parameters are both optional on the <%= govuk_link_to 'GET applications endpoint', '#get-applications' %>. If not supplied, the endpoint will return all records updated since the timestamp passed into the <code>since</code> parameter.
+</p>
+
+<p class="govuk-body">
+When using pagination, we recommend setting <code>per_page</code> to <code>50</code> and using overlapping time periods with previous application syncs for the <code>since</code> parameter. One possible strategy could be to always set <code>since</code> to two (or more) syncs ago. For example:
+</p>
+
+<p class="govuk-body">
+First GET /applications: (at time <code>D</code>, using <code>since=B</code>)
+<pre>
+A     --->    B    --->    C    --->    D    --->    E
+                           |            |
+                       last sync       now
+------------------------------------------------------
+since:                     A            B
+
+</pre>
+</p>
+
+<p class="govuk-body">
+Second GET /applications: (at time <code>E</code>, using <code>since=C</code>)
+<pre>
+A     --->    B    --->    C    --->    D    --->    E
+                                        |            |
+                                    last sync       now
+-------------------------------------------------------
+since:                                  B            C
+
+</pre>
+</p>
+
+<p class="govuk-body">
+To assist pagination for applications two new sections have been added to the response: a <%= govuk_link_to 'links', '#links-object' %> as well as a <%= govuk_link_to 'meta', '#responsemetamultiple-object' %> section. Both sections will always be returned in the API if the pagination parameters are supplied or not. The links section will determine the navigation through the API, and if no pagination is set, only the relevant fields will be populated and it can be ignored. The meta section will hold the API version, the total number of applications listed as well as the timestamp of the API call.
+</p>
+
+<hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-6 govuk-!-margin-bottom-6">
+
 <h2 class="govuk-heading-l" id="developing">Developing on the API</h2>
 
 <p class="govuk-body">


### PR DESCRIPTION
## Context

We are upgrading the Vendor API to v1.1 on May the 9th. 

## Changes proposed in this pull request

- Remove prerelease tag and update release notes
- Update docs in homepage and API reference to point to new version
- turn off draft featureflag

## Guidance to review

Please check the review app deployed to see if there are any missing issues with the docs or the API itself

## Link to Trello card

https://trello.com/c/U2FJ0Otj/5066-release-api-v11-to-production

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
