### PR TITLE
Add `confirm_conditions_met` event to `offered` state

### DIFF
--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -61,6 +61,7 @@ class ApplicationStateChange
       event :accept_unconditional_offer, transitions_to: :recruited
       event :decline, transitions_to: :declined
       event :decline_by_default, transitions_to: :declined
+      event :confirm_conditions_met, transitions_to: :recruited
     end
 
     state :offer_withdrawn do


### PR DESCRIPTION
## Changes proposed in this pull request

Fix but whereby it's not possible to remove all offer conditions of an offered application.

## Link to Trello card

[Trello](https://trello.com/c/FUw88Tbm/3839-support-interface-removing-all-offer-conditions-of-an-offered-application-does-nothing)