### PR TITLE
Degree flow bug

### DIFF
--- a/app/components/candidate_interface/degree_new_review_component.rb
+++ b/app/components/candidate_interface/degree_new_review_component.rb
@@ -269,6 +269,8 @@ module CandidateInterface
     end
 
     def formatted_degree_type(degree)
+      return if degree.qualification_type.nil?
+
       reference_data = DfE::ReferenceData::Degrees::TYPES.some_by_field(:name).keys.select { |type| degree.qualification_type.include?(type) }
       if reference_data.present?
         degree.qualification_type.split.first

--- a/app/controllers/candidate_interface/degrees/degree/destroy_controller.rb
+++ b/app/controllers/candidate_interface/degrees/degree/destroy_controller.rb
@@ -11,9 +11,11 @@ module CandidateInterface
 
         def destroy
           current_degree.destroy!
+          @wizard = DegreeWizard.new(degree_store)
 
           if current_application.application_qualifications.degrees.blank?
             current_application.update!(degrees_completed: nil)
+            @wizard.clear_state!
           end
           redirect_to candidate_interface_new_degree_review_path
         end
@@ -22,6 +24,11 @@ module CandidateInterface
 
         def redirect_to_old_degree_flow_unless_feature_flag_is_active
           redirect_to candidate_interface_new_degree_path unless FeatureFlag.active?(:new_degree_flow)
+        end
+
+        def degree_store
+          key = "degree_wizard_store_#{current_user.id}_#{current_application.id}"
+          WizardStateStores::RedisStore.new(key: key)
         end
       end
     end

--- a/spec/components/candidate_interface/degree_new_review_component_spec.rb
+++ b/spec/components/candidate_interface/degree_new_review_component_spec.rb
@@ -301,6 +301,28 @@ RSpec.describe CandidateInterface::DegreeNewReviewComponent, type: :component do
     end
   end
 
+  context 'when the degree has been saved without setting the value of qualification_type' do
+    let(:degree1) do
+      build_stubbed(
+        :degree_qualification,
+        qualification_type: nil,
+      )
+    end
+
+    it 'renders component with no value for degree type row' do
+      render_inline(described_class.new(application_form: application_form))
+
+      expect(rendered_component).to summarise(
+        key: 'Degree type',
+        value: '',
+        action: {
+          text: "Change #{t('application_form.degree.qualification.change_action')} for , #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
+          href: Rails.application.routes.url_helpers.candidate_interface_new_degree_edit_path(degree1, :degree_level),
+        },
+      )
+    end
+  end
+
   context 'when the degree has been saved without setting the value of predicted_grade' do
     let(:degree1) do
       build_stubbed(

--- a/spec/system/candidate_interface/entering_details/degrees/new_degree_flow/candidate_delete_and_replace_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/new_degree_flow/candidate_delete_and_replace_degrees_spec.rb
@@ -1,0 +1,224 @@
+require 'rails_helper'
+
+RSpec.feature 'Deleting and replacing a degree' do
+  include CandidateHelper
+
+  before do
+    FeatureFlag.activate(:new_degree_flow)
+  end
+
+  scenario 'Candidate deletes and replaces their degree' do
+    given_i_am_signed_in
+    and_i_have_completed_the_degree_section
+    when_i_view_the_degree_section
+    and_i_click_on_change_country
+    and_i_click_the_back_link
+    and_i_click_on_delete_degree
+    and_i_confirm_that_i_want_to_delete_my_degree
+    then_i_see_the_undergraduate_degree_form
+
+    when_i_click_add_degree
+    and_i_add_my_degree_back_in
+    and_i_mark_the_section_as_incomplete
+    and_i_click_on_continue
+    then_i_should_see_the_form_and_the_section_is_not_completed
+    when_i_click_on_degree
+    then_i_can_check_my_undergraduate_degree
+
+    when_i_add_another_degree
+    then_i_can_check_my_additional_degree
+
+    when_i_click_on_delete_degree
+    and_i_confirm_that_i_want_to_delete_my_additional_degree
+    then_i_can_only_see_my_undergraduate_degree
+  end
+
+  def given_i_am_signed_in
+    @candidate = create(:candidate)
+    login_as(@candidate)
+  end
+
+  def when_i_view_the_degree_section
+    visit candidate_interface_application_form_path
+    when_i_click_on_degree
+  end
+
+  def when_i_click_on_degree
+    click_link 'Degree'
+  end
+
+  def and_i_click_on_change_country
+    click_change_link('country')
+  end
+
+  def and_i_click_the_back_link
+    click_link 'Back'
+  end
+
+  def then_i_see_the_undergraduate_degree_form
+    expect(page).to have_content 'Degree'
+    expect(page).to have_content 'Add a degree'
+  end
+
+  def when_i_click_add_degree
+    click_link 'Add a degree'
+  end
+
+  def when_i_choose_united_kingdom
+    choose 'United Kingdom'
+  end
+
+  def when_i_choose_the_level
+    choose 'Bachelor'
+  end
+
+  def when_i_fill_in_the_subject
+    select 'History', from: 'What subject is your degree?'
+  end
+
+  def when_i_choose_the_type_of_degree
+    choose 'Bachelor of Arts (BA)'
+  end
+
+  def when_i_fill_in_the_university
+    select 'University of Cambridge', from: 'candidate_interface_degree_wizard[university]'
+  end
+
+  def when_i_choose_whether_degree_is_completed
+    choose 'Yes'
+  end
+
+  def when_i_select_the_grade
+    choose 'First-class honours'
+  end
+
+  def when_i_fill_in_the_start_year
+    fill_in t('page_titles.what_year_did_you_start_your_degree'), with: '2006'
+  end
+
+  def when_i_fill_in_the_award_year
+    fill_in t('page_titles.what_year_did_you_graduate'), with: '2009'
+  end
+
+  def and_i_click_on_save_and_continue
+    click_button t('save_and_continue')
+  end
+
+  def then_i_can_check_my_undergraduate_degree
+    expect(page).to have_current_path candidate_interface_new_degree_review_path
+  end
+
+  def when_i_add_another_degree
+    click_link t('application_form.degree.another.button')
+    when_i_choose_united_kingdom
+    and_i_click_on_save_and_continue
+    choose 'Doctorate (PhD)'
+    and_i_click_on_save_and_continue
+    select 'Philosophy', from: 'What subject is your degree?'
+    and_i_click_on_save_and_continue
+    choose 'Doctor of Philosophy (DPhil)'
+    and_i_click_on_save_and_continue
+    select 'University of Oxford', from: 'candidate_interface_degree_wizard[university]'
+    and_i_click_on_save_and_continue
+    when_i_choose_whether_degree_is_completed
+    and_i_click_on_save_and_continue
+    when_i_select_the_grade
+    and_i_click_on_save_and_continue
+    when_i_fill_in_the_start_year
+    and_i_click_on_save_and_continue
+    when_i_fill_in_the_award_year
+    and_i_click_on_save_and_continue
+  end
+
+  def when_i_click_on_continue
+    click_button t('continue')
+  end
+
+  def and_i_click_on_continue
+    when_i_click_on_continue
+  end
+
+  def then_i_should_see_the_form_and_the_section_is_not_completed
+    expect(page).to have_content(t('page_titles.application_form'))
+    expect(page).not_to have_css('#degree-badge-id', text: 'Completed')
+  end
+
+  def and_i_add_my_degree_back_in
+    when_i_choose_united_kingdom
+    and_i_click_on_save_and_continue
+
+    when_i_choose_the_level
+    and_i_click_on_save_and_continue
+
+    when_i_fill_in_the_subject
+    and_i_click_on_save_and_continue
+
+    when_i_choose_the_type_of_degree
+    and_i_click_on_save_and_continue
+
+    when_i_fill_in_the_university
+    and_i_click_on_save_and_continue
+
+    when_i_choose_whether_degree_is_completed
+    and_i_click_on_save_and_continue
+
+    when_i_select_the_grade
+    and_i_click_on_save_and_continue
+
+    when_i_fill_in_the_start_year
+    and_i_click_on_save_and_continue
+
+    when_i_fill_in_the_award_year
+    and_i_click_on_save_and_continue
+  end
+
+  def and_i_submit_the_add_another_degree_form
+    click_button t('save_and_continue')
+  end
+
+  def then_i_can_check_my_additional_degree
+    expect(page).to have_content 'Philosophy'
+    expect(page).to have_content 'University of Oxford'
+  end
+
+  def and_i_click_on_delete_degree
+    click_link(t('application_form.degree.delete'), match: :first)
+  end
+
+  def when_i_click_on_delete_degree
+    and_i_click_on_delete_degree
+  end
+
+  def and_i_confirm_that_i_want_to_delete_my_additional_degree
+    click_button t('application_form.degree.confirm_delete')
+  end
+
+  def and_i_confirm_that_i_want_to_delete_my_degree
+    and_i_confirm_that_i_want_to_delete_my_additional_degree
+  end
+
+  def then_i_can_only_see_my_undergraduate_degree
+    then_i_can_check_my_undergraduate_degree
+    expect(page).not_to have_content 'Philosophy'
+    expect(page).not_to have_content 'University of Oxford'
+  end
+
+  def and_i_click_on_continue
+    when_i_click_on_continue
+  end
+
+  def and_i_confirm_i_have_completed_my_degree
+    choose 'Yes'
+    and_i_click_on_save_and_continue
+  end
+
+  def and_i_mark_the_section_as_incomplete
+    choose t('application_form.incomplete_radio')
+  end
+
+  def and_i_have_completed_the_degree_section
+    @application_form = create(:application_form, candidate: @candidate)
+    create(:application_qualification, level: 'degree', application_form: @application_form)
+    @application_form.update!(degrees_completed: true)
+  end
+end


### PR DESCRIPTION
## Context
There was a bug where a user rehydrated redis with the id of degree by clicking change link but then deleted the degree. This meant that there was no record in the database to find that degree using the id in redis as it is put in 'edit mode'

There was a second bug where user is able to skip to a page after degree level/types via address bar and then continue to review page. The row will look to render qualification type but since it is nil an error occurs as there is no guard clause
## Changes proposed in this pull request
* After final degree is deleted, clear redis. 
* Add guard clause to method

## Guidance to review
Check that the bug no longer occurs and redis is cleared. Steps to replicate are in the card

## Link to Trello card

https://trello.com/c/eYjkKds2/4692-degree-bug

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
