### PR TITLE
Don't render conditions if the status is 'met'

### DIFF
--- a/app/views/candidate_mailer/_offer_conditions.text.erb
+++ b/app/views/candidate_mailer/_offer_conditions.text.erb
@@ -1,7 +1,7 @@
 You still need to meet the following <%= 'condition'.pluralize(@conditions.count) %>:
 
 <% @application_choice.offer.conditions.each do |condition| %>
-<% unless condition.status == 'met' %>
+<% unless condition.met? %>
   - <%= condition.text %>
  <%end %>
 <% end %>

--- a/app/views/candidate_mailer/_offer_conditions.text.erb
+++ b/app/views/candidate_mailer/_offer_conditions.text.erb
@@ -1,5 +1,7 @@
-The provider has set the following <%= 'condition'.pluralize(@conditions.count) %>:
+You still need to meet the following <%= 'condition'.pluralize(@conditions.count) %>:
 
-<% @conditions.each do |condition| %>
-  - <%= condition %>
+<% @application_choice.offer.conditions.each do |condition| %>
+<% unless condition.status == 'met' %>
+  - <%= condition.text %>
+ <%end %>
 <% end %>

--- a/app/views/candidate_mailer/reinstated_offer.text.erb
+++ b/app/views/candidate_mailer/reinstated_offer.text.erb
@@ -4,8 +4,11 @@ Dear <%= @application_form.first_name %>
 
 The course starts in <%= @course_option.course.start_date.to_fs(:month_and_year) %>.
 
-<% if @conditions.any? %>
+
+<% if @application_choice.offer.conditions.any? { |condition| condition.status != 'met'} %>
+
   <%= render "candidate_mailer/offer_conditions" %>
+
 <% else %>
   They’ll let you know if they need further information before you start training.
 <% end %>

--- a/app/views/candidate_mailer/reinstated_offer.text.erb
+++ b/app/views/candidate_mailer/reinstated_offer.text.erb
@@ -5,7 +5,7 @@ Dear <%= @application_form.first_name %>
 The course starts in <%= @course_option.course.start_date.to_fs(:month_and_year) %>.
 
 
-<% if @application_choice.offer.conditions.any? { |condition| condition.status != 'met'} %>
+<% if @application_choice.offer.conditions.where(status: 'met').count.zero? %>
 
   <%= render "candidate_mailer/offer_conditions" %>
 

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -331,6 +331,29 @@ RSpec.describe CandidateMailer, type: :mailer do
     )
   end
 
+  describe '.reinstated_offer' do
+    let(:offer) do
+      build_stubbed(:application_choice, :with_offer,
+                    sent_to_provider_at: Time.zone.today,
+                    course_option: course_option)
+    end
+    let(:application_choices) { [offer] }
+    let(:email) do
+      described_class.reinstated_offer(
+        application_form.application_choices.first,
+      )
+    end
+
+    it_behaves_like(
+      'a mail with subject and content',
+      'Your deferred offer has been confirmed',
+      'greeting' => 'Dear Fred',
+      'details' => 'Arithmetic College has confirmed your deferred offer to study',
+      'pending condition text' => 'You still need to meet the following condition',
+      'pending condition' => 'Be cool',
+    )
+  end
+
   describe '.unconditional_offer_accepted' do
     let(:email) { described_class.unconditional_offer_accepted(application_form.application_choices.first) }
     let(:application_choices) do


### PR DESCRIPTION
## Context

We only want to list conditions that require the candidate to take action. We shouldn't send conditions that have already been met. 

## Changes proposed in this pull request

<img width="671" alt="image" src="https://user-images.githubusercontent.com/50492247/167178600-351a200e-86b2-435e-a1ae-a52b882ca742.png">


## Guidance to review

This change will also show conditions which are 'unmet', is this the behaviour that we want?

## Link to Trello card

https://trello.com/c/qVf5RjFH/4473-dev-only-show-outstanding-conditions-in-offer-reinstated-email
