### PR TITLE
Include SR4R in application data exports

### DIFF
--- a/app/services/provider_interface/application_data_export.rb
+++ b/app/services/provider_interface/application_data_export.rb
@@ -1,66 +1,76 @@
 module ProviderInterface
   class ApplicationDataExport
-    def self.export_row(application_choice)
-      return {} if application_choice.blank?
+    class << self
+      def export_row(application_choice)
+        return {} if application_choice.blank?
 
-      application = ApplicationChoiceExportDecorator.new(application_choice)
+        application = ApplicationChoiceExportDecorator.new(application_choice)
 
-      {
-        'application_choice_id' => application.id,
-        'candidate_id' => application.application_form.candidate.public_id,
-        'support_reference' => application.application_form.support_reference,
-        'status' => I18n.t("provider_application_states.#{application.status}", default: application.status),
-        'submitted_at' => application.application_form.submitted_at,
-        'updated_at' => application.updated_at,
-        'recruited_at' => application.recruited_at,
-        'rejection_reason' => application.rejection_reason,
-        'rejected_at' => application.rejected_at,
-        'reject_by_default_at' => application.reject_by_default_at,
-        'first_name' => application.application_form.first_name,
-        'last_name' => application.application_form.last_name,
-        'date_of_birth' => application.application_form.date_of_birth,
-        'nationality' => application.nationalities.join(' '),
-        'domicile' => application.application_form.domicile,
-        'uk_residency_status' => application.application_form.uk_residency_status,
-        'english_main_language' => application.application_form.english_main_language,
-        'english_language_qualifications' => replace_smart_quotes(application.application_form.english_language_details),
-        'email' => application.application_form.candidate.email_address,
-        'phone_number' => application.application_form.phone_number,
-        'address_line1' => application.application_form.address_line1,
-        'address_line2' => application.application_form.address_line2,
-        'address_line3' => application.application_form.address_line3,
-        'address_line4' => application.application_form.address_line4,
-        'postcode' => application.application_form.postcode,
-        'country' => application.application_form.country,
-        'recruitment_cycle' => RecruitmentCycle.cycle_name(application.application_form.recruitment_cycle_year),
-        'provider_name' => application.current_provider.name,
-        'provider_code' => application.current_provider.code,
-        'accredited_provider_name' => application.current_accredited_provider&.name,
-        'accredited_provider_code' => application.current_accredited_provider&.code,
-        'course_name' => application.current_course.name,
-        'course_code' => application.current_course.code,
-        'site_name' => application.current_site.name,
-        'site_code' => application.current_site.code,
-        'study_mode' => application.current_course_option.study_mode,
-        'start_date' => application.current_course.start_date,
-        'FIRSTDEG' => application.degrees_completed_flag == 1 ? 'TRUE' : 'FALSE',
-        'qualification_type' => application.first_degree&.qualification_type,
-        'non_uk_qualification_type' => application.first_degree&.non_uk_qualification_type,
-        'subject' => application.first_degree&.subject,
-        'grade' => application.first_degree&.grade,
-        'start_year' => application.first_degree&.start_year,
-        'award_year' => application.first_degree&.award_year,
-        'institution_details' => application.first_degree&.institution_name,
-        'equivalency_details' => replace_smart_quotes(application.first_degree&.composite_equivalency_details),
-        'awarding_body' => nil, # included for backwards compatibility. This column is always blank
-        'gcse_qualifications_summary' => replace_smart_quotes(application.gcse_qualifications_summary),
-        'missing_gcses_explanation' => replace_smart_quotes(application.missing_gcses_explanation),
-        'disability_disclosure' => application.application_form.disability_disclosure,
-      }
-    end
+        {
+          'application_choice_id' => application.id,
+          'candidate_id' => application.application_form.candidate.public_id,
+          'support_reference' => application.application_form.support_reference,
+          'status' => I18n.t("provider_application_states.#{application.status}", default: application.status),
+          'submitted_at' => application.application_form.submitted_at,
+          'updated_at' => application.updated_at,
+          'recruited_at' => application.recruited_at,
+          'rejection_reason' => rejection_reasons(application_choice),
+          'rejected_at' => application.rejected_at,
+          'reject_by_default_at' => application.reject_by_default_at,
+          'first_name' => application.application_form.first_name,
+          'last_name' => application.application_form.last_name,
+          'date_of_birth' => application.application_form.date_of_birth,
+          'nationality' => application.nationalities.join(' '),
+          'domicile' => application.application_form.domicile,
+          'uk_residency_status' => application.application_form.uk_residency_status,
+          'english_main_language' => application.application_form.english_main_language,
+          'english_language_qualifications' => replace_smart_quotes(application.application_form.english_language_details),
+          'email' => application.application_form.candidate.email_address,
+          'phone_number' => application.application_form.phone_number,
+          'address_line1' => application.application_form.address_line1,
+          'address_line2' => application.application_form.address_line2,
+          'address_line3' => application.application_form.address_line3,
+          'address_line4' => application.application_form.address_line4,
+          'postcode' => application.application_form.postcode,
+          'country' => application.application_form.country,
+          'recruitment_cycle' => RecruitmentCycle.cycle_name(application.application_form.recruitment_cycle_year),
+          'provider_name' => application.current_provider.name,
+          'provider_code' => application.current_provider.code,
+          'accredited_provider_name' => application.current_accredited_provider&.name,
+          'accredited_provider_code' => application.current_accredited_provider&.code,
+          'course_name' => application.current_course.name,
+          'course_code' => application.current_course.code,
+          'site_name' => application.current_site.name,
+          'site_code' => application.current_site.code,
+          'study_mode' => application.current_course_option.study_mode,
+          'start_date' => application.current_course.start_date,
+          'FIRSTDEG' => application.degrees_completed_flag == 1 ? 'TRUE' : 'FALSE',
+          'qualification_type' => application.first_degree&.qualification_type,
+          'non_uk_qualification_type' => application.first_degree&.non_uk_qualification_type,
+          'subject' => application.first_degree&.subject,
+          'grade' => application.first_degree&.grade,
+          'start_year' => application.first_degree&.start_year,
+          'award_year' => application.first_degree&.award_year,
+          'institution_details' => application.first_degree&.institution_name,
+          'equivalency_details' => replace_smart_quotes(application.first_degree&.composite_equivalency_details),
+          'awarding_body' => nil, # included for backwards compatibility. This column is always blank
+          'gcse_qualifications_summary' => replace_smart_quotes(application.gcse_qualifications_summary),
+          'missing_gcses_explanation' => replace_smart_quotes(application.missing_gcses_explanation),
+          'disability_disclosure' => application.application_form.disability_disclosure,
+        }
+      end
 
-    def self.replace_smart_quotes(text)
-      text&.gsub(/(“|”)/, '"')&.gsub(/(‘|’)/, "'")
+      def replace_smart_quotes(text)
+        text&.gsub(/(“|”)/, '"')&.gsub(/(‘|’)/, "'")
+      end
+
+      def rejection_reasons(application_choice)
+        reasons = RejectedApplicationChoicePresenter.new(application_choice).rejection_reasons
+        return if reasons.nil?
+
+        reasons = reasons.transform_values(&:compact)
+        reasons&.map { |k, v| %(#{k.upcase}\n\n#{Array(v).join("\n\n")}) }&.join("\n\n")
+      end
     end
   end
 end

--- a/spec/services/provider_interface/application_data_export_spec.rb
+++ b/spec/services/provider_interface/application_data_export_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe ProviderInterface::ApplicationDataExport do
         'submitted_at' => application_choice.application_form.submitted_at,
         'updated_at' => application_choice.updated_at,
         'recruited_at' => application_choice.recruited_at,
-        'rejection_reason' => application_choice.rejection_reason,
+        'rejection_reason' => described_class.rejection_reasons(application_choice),
         'rejected_at' => application_choice.rejected_at,
         'reject_by_default_at' => application_choice.reject_by_default_at,
         'first_name' => application_choice.application_form.first_name,
@@ -99,9 +99,38 @@ RSpec.describe ProviderInterface::ApplicationDataExport do
     end
   end
 
-  describe 'replace_smart_quotes' do
+  describe '.replace_smart_quotes' do
     it 'replaces smart quotes in text' do
       expect(described_class.replace_smart_quotes(%(“double-quote” ‘single-quote’))).to eq(%("double-quote" 'single-quote'))
+    end
+  end
+
+  describe '.rejection_reasons' do
+    let(:application_choice) { create(:application_choice, :with_structured_rejection_reasons) }
+
+    it 'returns a list of rejection reasons' do
+      expected = ['SOMETHING YOU DID',
+                  'Didn’t reply to our interview offer',
+                  'Didn’t attend interview',
+                  'Persistent scratching',
+                  'Not scratch so much',
+                  'QUALITY OF APPLICATION',
+                  'Use a spellchecker',
+                  "Claiming to be the 'world's leading expert' seemed a bit strong",
+                  'Lights on but nobody home',
+                  'Study harder',
+                  'QUALIFICATIONS',
+                  'No English GCSE grade 4 (C) or above, or valid equivalent',
+                  'All the other stuff',
+                  'PERFORMANCE AT INTERVIEW',
+                  'Be fully dressed',
+                  'HONESTY AND PROFESSIONALISM',
+                  'Fake news',
+                  'Clearly not a popular student',
+                  'SAFEGUARDING ISSUES',
+                  'We need to run further checks']
+
+      expect(described_class.rejection_reasons(application_choice).split("\n\n")).to eq(expected)
     end
   end
 end


### PR DESCRIPTION
## Context
https://trello.com/c/Nq9Pj5MX/5074-add-reasons-for-rejection-to-data-export
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Adding the structured reasons for rejection as a data export column

The formatting is identical to the email formats, with the exception that the top level headings are uppercased - this is to separate them from sub-headings in the CSV, as there isn't a way to introduce any further formatting
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
Logging in as a provider, run a data export that includes applications in the rejected state. The test data should contain some applications with SR4R, but you can also reject applications as that provider with specific rejection reasons you want to try out
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

Here's how the column appears 
<img width="355" alt="image" src="https://user-images.githubusercontent.com/25597009/167371076-ab071b97-5a96-48a6-b735-c7940fa22e2f.png">


## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
