### PR TITLE
Remove nudge feature flags

### DIFF
--- a/app/services/data_migrations/delete_retired_nudge_feature_flags.rb
+++ b/app/services/data_migrations/delete_retired_nudge_feature_flags.rb
@@ -1,0 +1,11 @@
+module DataMigrations
+  class DeleteRetiredNudgeFeatureFlags
+    TIMESTAMP = 20220509095913
+    MANUAL_RUN = false
+
+    def change
+      Feature.where(name: :candidate_nudge_emails).first&.destroy
+      Feature.where(name: :candidate_nudge_course_choice_and_personal_statement).first&.destroy
+    end
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -32,7 +32,6 @@ class FeatureFlag
     [:summer_recruitment_banner, 'Show a banner to indicate a shorter recruitment timeframe during summer', 'Richard Pattinson'],
     [:support_user_revert_withdrawn_offer, 'Allows a support user to revert an application withdrawn by the candidate', 'James Glenn'],
     [:draft_vendor_api_specification, 'The specification for Draft Vendor API v1.1', 'Abeer Salameh'],
-    [:candidate_nudge_emails, 'Sends nudge emails to candidates that have unsubmitted but completed applications', 'Steve Hook'],
     [:new_degree_flow, 'Allows us to use the new degree flow', 'Jon Filar'],
     [:application_number_replacement, 'Replaces reference number and candidate ID with application choice ID', 'Carlos Martinez'],
     [:candidate_nudge_course_choice_and_personal_statement, 'Sends nudge emails to candidates that have no course choices or did not mark the personal statement as complete', 'Tomas Destefi & Steve Hook'],

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -34,7 +34,6 @@ class FeatureFlag
     [:draft_vendor_api_specification, 'The specification for Draft Vendor API v1.1', 'Abeer Salameh'],
     [:new_degree_flow, 'Allows us to use the new degree flow', 'Jon Filar'],
     [:application_number_replacement, 'Replaces reference number and candidate ID with application choice ID', 'Carlos Martinez'],
-    [:candidate_nudge_course_choice_and_personal_statement, 'Sends nudge emails to candidates that have no course choices or did not mark the personal statement as complete', 'Tomas Destefi & Steve Hook'],
     [:data_exports, 'Iterating the format of the applications data export', 'Steve Laing'],
   ].freeze
 

--- a/app/workers/nudge_candidates_worker.rb
+++ b/app/workers/nudge_candidates_worker.rb
@@ -7,7 +7,7 @@ class NudgeCandidatesWorker
     Nudge.new(
       GetUnsubmittedApplicationsReadyToNudge,
       :nudge_unsubmitted,
-      :candidate_nudge_emails,
+      nil,
     ),
     Nudge.new(
       GetIncompleteCourseChoiceApplicationsReadyToNudge,

--- a/app/workers/nudge_candidates_worker.rb
+++ b/app/workers/nudge_candidates_worker.rb
@@ -12,12 +12,12 @@ class NudgeCandidatesWorker
     Nudge.new(
       GetIncompleteCourseChoiceApplicationsReadyToNudge,
       :nudge_unsubmitted_with_incomplete_courses,
-      :candidate_nudge_course_choice_and_personal_statement,
+      nil,
     ),
     Nudge.new(
       GetIncompletePersonalStatementApplicationsReadyToNudge,
       :nudge_unsubmitted_with_incomplete_personal_statement,
-      :candidate_nudge_course_choice_and_personal_statement,
+      nil,
     ),
   ].freeze
 

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::DeleteRetiredNudgeFeatureFlags',
   'DataMigrations::RemoveStructuredReasonsForRejectionRedesignFeatureFlag',
   'DataMigrations::DropChangeCourseDetailsBeforeOfferFeatureFlag',
   'DataMigrations::BackfillOriginalCourseOption',

--- a/spec/services/data_migrations/delete_retired_nudge_feature_flags_spec.rb
+++ b/spec/services/data_migrations/delete_retired_nudge_feature_flags_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::DeleteRetiredNudgeFeatureFlags do
+  context 'when the feature flags exist' do
+    it 'removes both feature flags' do
+      create(:feature, name: 'candidate_nudge_emails')
+      create(:feature, name: 'candidate_nudge_course_choice_and_personal_statement')
+
+      expect { described_class.new.change }.to change { Feature.count }.by(-2)
+      expect(Feature.where(name: 'candidate_nudge_emails')).to be_blank
+      expect(Feature.where(name: 'candidate_nudge_course_choice_and_personal_statement')).to be_blank
+    end
+  end
+
+  context 'when the feature flags have already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end

--- a/spec/workers/nudge_candidates_worker_spec.rb
+++ b/spec/workers/nudge_candidates_worker_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe NudgeCandidatesWorker, sidekiq: true do
 
     context 'when the feature flag is active' do
       before do
-        FeatureFlag.activate(:candidate_nudge_emails)
         FeatureFlag.activate(:candidate_nudge_course_choice_and_personal_statement)
       end
 
@@ -60,16 +59,6 @@ RSpec.describe NudgeCandidatesWorker, sidekiq: true do
         expect(email.subject).to include(
           I18n.t!('candidate_mailer.nudge_unsubmitted_with_incomplete_personal_statement.subject'),
         )
-      end
-    end
-
-    context 'when the feature flag is inactive' do
-      before { FeatureFlag.deactivate(:candidate_nudge_emails) }
-
-      it 'does not send any emails to the candidate' do
-        described_class.new.perform
-
-        expect(email_for_candidate(application_form.candidate)).not_to be_present
       end
     end
   end


### PR DESCRIPTION
## Context

We've used feature flags for the first couple of rounds of nudge emails. These can now be removed as the nudges are live.

## Changes proposed in this pull request

- [x] Remove the `candidate_nudge_emails` and `candidate_nudge_course_choice_and_personal_statement`
- [x] Data migration to remove the records from the `features` table

## Guidance to review

- Have I missed a step?

## Link to Trello card

Related to https://trello.com/c/9JFNW3sy/4685-implement-references-nudge

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
