### PR TITLE
Don't attempt to export current R4R data

### DIFF
--- a/app/services/support_interface/structured_reasons_for_rejection_export.rb
+++ b/app/services/support_interface/structured_reasons_for_rejection_export.rb
@@ -21,7 +21,9 @@ module SupportInterface
   private
 
     def application_choices
-      ApplicationChoice.where.not(structured_rejection_reasons: nil)
+      ApplicationChoice
+        .where.not(structured_rejection_reasons: nil)
+        .where(rejection_reasons_type: 'reasons_for_rejection')
     end
   end
 end

--- a/spec/services/support_interface/structured_reasons_for_rejection_export_spec.rb
+++ b/spec/services/support_interface/structured_reasons_for_rejection_export_spec.rb
@@ -67,6 +67,8 @@ RSpec.describe SupportInterface::StructuredReasonsForRejectionExport do
         },
       )
 
+      create(:application_choice, :with_current_rejection_reasons)
+
       expect(described_class.new.data_for_export).to eq(
         [{
           candidate_id: application_choice_one.application_form.candidate.id,


### PR DESCRIPTION
## Context

The support interface SR4R exporter is opinionated about rejections data, it doesn't work with the redesigned reasons.
Exports were not in scope for the R4R redesign.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Excludes applications which do not conform to the legacy Reasons for Rejection data format.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1652108382332279
https://sentry.io/organizations/dfe-teacher-services/issues/3260117897/?referrer=slack
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
