### PR TITLE
Fix Available courses failing to scope to current cycle bug

### DIFF
--- a/app/forms/support_interface/application_forms/pick_course_form.rb
+++ b/app/forms/support_interface/application_forms/pick_course_form.rb
@@ -104,7 +104,7 @@ module SupportInterface
           .open_on_apply
           .includes(course_options: [:site])
           .where(provider_id: provider.id)
-          .or(Course.where(accredited_provider_id: provider.id))
+          .or(Course.current_cycle.where(accredited_provider_id: provider.id))
           .where(code: sanitize(course_code))
       end
 


### PR DESCRIPTION
## Context

There is a bug where a course option for both 2022 and 2021 is being surfaced to the support UI.

The reason is that the query that gets the courses doesn't scope for the current cycle, just gets the courses from the given accredited provider. This PR addresses this issue.

## Guidance to review

1. Does it shows only the courses from the current cycle?

## Link to Trello card

https://trello.com/c/152pAmh0/4663-available-courses-failing-to-scope-to-current-cycle-bug

