### PR TITLE
Amend LEFT OUTER JOIN so it operates on current course

### DIFF
--- a/app/queries/get_application_progress_data_by_course.rb
+++ b/app/queries/get_application_progress_data_by_course.rb
@@ -6,7 +6,8 @@ class GetApplicationProgressDataByCourse
   end
 
   def call
-    Course.left_outer_joins(:application_choices)
+    Course.joins(:course_options)
+      .joins('LEFT OUTER JOIN application_choices ON application_choices.current_course_option_id = course_options.id')
       .joins(:provider)
       .left_joins(:accredited_provider)
       .where(recruitment_cycle_year: RecruitmentCycle.current_year, provider_id: provider.id)

--- a/spec/queries/get_application_progress_data_by_course_spec.rb
+++ b/spec/queries/get_application_progress_data_by_course_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe GetApplicationProgressDataByCourse do
     let(:accredited_provider) { create(:provider) }
     let(:course) { create(:course, name: 'Alpha Physics', code: '2AIC', provider: report_provider, accredited_provider: nil) }
     let(:course_option) { create(:course_option, course: course) }
+    let(:previous_course) { create(:course, name: 'Yoga', provider: report_provider) }
+    let(:previous_course_option) { create(:course_option, course: previous_course) }
     let(:accredited_course) { create(:course, name: 'Beta Physics', accredited_provider: report_provider, provider: accredited_provider) }
     let(:accredited_course_option) { create(:course_option, course: accredited_course) }
     let(:third_course) { create(:course, name: 'Alpha Physics', code: '1ABX', provider: report_provider, accredited_provider: nil) }
@@ -14,11 +16,11 @@ RSpec.describe GetApplicationProgressDataByCourse do
     let!(:empty_course_option) { create(:course_option, course: empty_course) }
 
     before do
-      create_list(:application_choice, 10, status: :interviewing, course_option: accredited_course_option)
-      create_list(:application_choice, 5, status: :pending_conditions, course_option: accredited_course_option)
-      create_list(:application_choice, 8, status: :interviewing, course_option: course_option)
-      create_list(:application_choice, 3, status: :pending_conditions, course_option: course_option)
-      create_list(:application_choice, 6, status: :awaiting_provider_decision, course_option: third_option)
+      create_list(:application_choice, 10, status: :interviewing, current_course_option: accredited_course_option)
+      create_list(:application_choice, 5, status: :pending_conditions, current_course_option: accredited_course_option)
+      create_list(:application_choice, 8, status: :interviewing, current_course_option: course_option)
+      create_list(:application_choice, 3, status: :pending_conditions, current_course_option: course_option)
+      create_list(:application_choice, 6, status: :awaiting_provider_decision, current_course_option: third_option)
     end
 
     subject(:progress_data) { described_class.new(provider: report_provider).call }
@@ -32,10 +34,7 @@ RSpec.describe GetApplicationProgressDataByCourse do
     end
 
     it 'retrieves the courses in alphabetical order' do
-      expect(progress_data.first).to eq(third_course)
-      expect(progress_data.second).to eq(course)
-      expect(progress_data.fourth).to eq(accredited_course)
-      expect(progress_data.last).to eq(empty_course)
+      expect(progress_data.map(&:name).uniq).to eq(['Alpha Physics', 'Beta Physics', 'Cappa'])
     end
 
     it 'can group the courses by id' do
@@ -48,6 +47,14 @@ RSpec.describe GetApplicationProgressDataByCourse do
 
       expect(accredited_provider_courses.find { |c| c.status == 'interviewing' }.count).to eq(10)
       expect(accredited_provider_courses.find { |c| c.status == 'pending_conditions' }.count).to eq(5)
+    end
+
+    it 'returns the status for current course associations with applications' do
+      create(:application_choice, :with_recruited, course_option: previous_course_option, current_course_option: course_option)
+      create(:application_choice, :with_recruited, course_option: previous_course_option, current_course_option: accredited_course_option)
+      create(:application_choice, :with_recruited, course_option: previous_course_option, current_course_option: create(:course_option))
+
+      expect(progress_data.select { |c| c.status == 'recruited' }.size).to eq(2)
     end
 
     it 'only shows results for the current recuitment cycle year' do


### PR DESCRIPTION
## Context

Status of active applications export does not join course to applications via the current course association.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Amend relevant SQL join to use current course.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/xOtvbUYE/4942-status-of-active-applications-report-uses-course-instead-of-currentcourse
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
