### PR TITLE
Add dr docs data loss

### DIFF
--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -2,12 +2,18 @@ name: Backup Database to Azure Storage
 
 on:
   workflow_dispatch:
+    inputs:
+    overwriteThisMorningsBackup:
+      required: true
+      type: boolean
+      default: false
   schedule: # 01:00 UTC
     - cron: '0 1 * * *'
 
 jobs:
   backup:
     name: Backup PaaS Database (production)
+    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.overwriteThisMorningsBackup == 'true') }}
     runs-on: ubuntu-latest
     environment:
       name: production
@@ -24,7 +30,7 @@ jobs:
       uses: DFE-Digital/github-actions/install-postgres-client@master
 
     - name: Set environment variable
-      run: echo "BACKUP_FILE_NAME=apply_prod_$(date +"%F-%H-%M-%S")" >> $GITHUB_ENV
+      run: echo "BACKUP_FILE_NAME=apply_prod_$(date +"%F")" >> $GITHUB_ENV
 
     - name: Backup Prod DB
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@
 /db/*.sqlite3
 /db/*.sqlite3-journal
 
+# Ignore SQL backups
+*.sql
+*.tar.gz
+
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,7 @@
 ruby 2.7.5
 nodejs 16.13.0
 yarn 1.22.10
+cf 7.4.0
+az 2.36.0
+jq 1.6
+make 4.2.1

--- a/bin/download-nightly-backup
+++ b/bin/download-nightly-backup
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -eu
+
+BACKUP_STORAGE_SECRET_NAME=$1
+KEY_VAULT_NAME=$2
+AZURE_BACKUP_STORAGE_CONTAINER_NAME=$3
+BACKUP_FILENAME_PREFIX=$4
+BACKUP_DATE=$5 #yyyy-mm-dd
+
+
+if [[ -z "${BACKUP_STORAGE_SECRET_NAME}" ]]; then
+  echo "BACKUP_STORAGE_SECRET_NAME environment variable not set"
+  exit 1
+fi
+
+if [[ -z "${KEY_VAULT_NAME}" ]]; then
+  echo "KEY_VAULT_NAME environment variable not set"
+  exit 1
+fi
+
+if [[ -z "${AZURE_BACKUP_STORAGE_CONTAINER_NAME}" ]]; then
+  echo "AZURE_BACKUP_STORAGE_CONTAINER_NAME environment variable not set"
+  exit 1
+fi
+
+if [[ -z "${BACKUP_FILENAME_PREFIX}" ]]; then
+  echo "BACKUP_FILENAME_PREFIX environment variable not set"
+  exit 1
+fi
+
+if [[ -z "${BACKUP_DATE}" ]]; then
+  echo "BACKUP_DATE environment variable not set"
+  exit 1
+fi
+
+STORAGE_CONN_STR="$(az keyvault secret show --name ${BACKUP_STORAGE_SECRET_NAME} --vault-name ${KEY_VAULT_NAME} | jq -r .value)"
+
+BACKUP_ARCHIVE_FILENAME=$(az storage blob list --connection-string ${STORAGE_CONN_STR} --container-name ${AZURE_BACKUP_STORAGE_CONTAINER_NAME} --prefix ${BACKUP_FILENAME_PREFIX}${BACKUP_DATE} --output json --query [-1].name | jq -r)
+if [[ -z ${BACKUP_ARCHIVE_FILENAME} ]]; then
+  echo "There are no files found matching the prefix ${BACKUP_FILENAME_PREFIX}${BACKUP_DATE} in container ${AZURE_BACKUP_STORAGE_CONTAINER_NAME}"
+  exit 1
+else
+  echo "Downloading ${BACKUP_ARCHIVE_FILENAME} ..."
+  az storage blob download --connection-string ${STORAGE_CONN_STR} -c ${AZURE_BACKUP_STORAGE_CONTAINER_NAME} -n ${BACKUP_ARCHIVE_FILENAME} -f ${BACKUP_ARCHIVE_FILENAME} --output none
+fi

--- a/bin/restore-nightly-backup
+++ b/bin/restore-nightly-backup
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -eu
+
+CF_ORG_NAME='dfe'
+SPACE=$1
+POSTGRES_DATABASE_NAME=$2
+BACKUP_FILENAME_PREFIX=$3
+BACKUP_DATE=$4 #yyyy-mm-dd
+
+if [[ -z "${SPACE}" ]]; then
+  echo "SPACE environment variable not set"
+  exit 1
+fi
+
+BACKUP_ARCHIVE_FILENAME=${BACKUP_FILENAME_PREFIX}${BACKUP_DATE}.tar.gz
+echo "File(s) extracted from ${BACKUP_ARCHIVE_FILENAME}:"
+tar -xvzf "${BACKUP_ARCHIVE_FILENAME}"
+
+if [[ ! -f "${BACKUP_FILENAME_PREFIX}${BACKUP_DATE}.sql" ]]; then
+  echo "${BACKUP_FILENAME_PREFIX}${BACKUP_DATE}.sql does not exist."
+  exit 1
+else
+  echo "Restoring ${BACKUP_FILENAME_PREFIX}${BACKUP_DATE}.sql to ${POSTGRES_DATABASE_NAME} in ${CF_ORG_NAME}/${SPACE}"
+  cf target -o "${CF_ORG_NAME}" -s "${SPACE}"
+  cf conduit ${POSTGRES_DATABASE_NAME} -- psql < "${BACKUP_FILENAME_PREFIX}${BACKUP_DATE}.sql"
+fi

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -1,0 +1,78 @@
+# Disaster recovery
+
+This documentation covers one scenario:
+
+- [Data loss](#data-loss)
+
+In case of any of the above disaster scenario, please do the following:
+
+### Freeze pipeline
+
+Alert all developers that no one should merge to main branch.
+
+### Local Dependencies
+
+You will need the [az](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) and [cf](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html) CLIs installed as well as [jq](https://stedolan.github.io/jq/download/), [make](https://www.gnu.org/software/make/) and either [Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli) or [tfenv](https://github.com/tfutils/tfenv#installation).
+
+### Maintenance mode
+
+In the instance of data loss it will probably be desirable to enable [Maintenance mode](maintenance-mode.md) to ensure that the database is only read from and written to when it is back in it's expected state.
+
+### Set up a virtual meeting
+
+Set up virtual meeting via Zoom, Slack, Teams or Google Hangout, inviting all the relevant technical stakeholders. Regularly provide updates on
+the #twd_publish Slack channel to keep product owners abreast of developments.
+
+### Internet Connection
+
+Ensure whoever is executing the process has a reliable and reasonably fast Internet connection.
+
+## Loss of database instance
+
+In case the database instance is lost, the objectives are:
+
+- Recreate the lost postgres database instance
+- Restore data from nightly backup stored in Azure.  The point-in-time and snapshot backups created by the PaaS Postgres service will not be available if it's been deleted.
+
+### Recreate the lost postgres database instance
+
+Please note, this process should take about 25 mins* to complete. In case the database service is deleted or in an inconsistent state we must recreate it and repopulate it.
+First make sure it is fully gone by running
+
+```
+cf services | grep apply-postgres
+# check output for lost or corrupted instance
+cf delete-service <instance-name>
+```
+Then recreate the lost postgres database instance using the following make recipes `deploy-plan` and `deploy`.  To see the proposed changes:
+
+```
+TAG=$(cf app apply-<env> | awk -F : '$1 == "docker image" {print $3}')
+make <env> deploy-plan PASSCODE=<my-passcode> IMAGE_TAG=${TAG} [CONFIRM_PRODUCTION=YES]
+```
+To apply proposed changes i.e. create new database instance:
+```
+TAG=$(cf app apply-<env> | awk -F : '$1 == "docker image" {print $3}')
+make <env> deploy PASSCODE=<my-passcode> IMAGE_TAG=${TAG} [CONFIRM_PRODUCTION=YES]
+```
+This will create a new postgres database instance as described in the terraform configuration file.
+
+\* based on ~20 minutes to recreate postgres instance and ~5 min restore time when testing process in QA
+
+### Restore Data From Nightly Backup
+
+You will need to be logged into GovUK PaaS and Azure using the `az` and `cf` CLIs.  You will need to raise a [PIM](https://docs.microsoft.com/en-us/azure/active-directory/privileged-identity-management/pim-resource-roles-activate-your-roles) request to elevate your credentials for a production restore.  A collegue will need to approve this for you.
+
+Once the lost database instance has been recreated, the last nightly backup will need to be restored. To achieve this, use the following makefile recipe: `restore-data-from-nightly-backup`. The following will need to be set: `CONFIRM_PRODUCTION=YES`,  `CONFIRM_RESTORE=YES` and `BACKUP_DATE="yyyy-mm-dd"`.
+
+The make recipe `restore-data-from-nightly-backup` executes 2 scripts, these should be committed with the execute permission (755) set but these may have been inadvertently altered.  If you get a permissions error executing them run `chmod +x <path/to/script>`.
+
+```
+# space is the name of the environment in GOV.UK PaaS, eg 'bat-prod'
+# env is the target environment in the make file e.g. 'production'
+az login
+cf login -o dfe -s <space> -u my.name@digital.education.gov.uk
+make <env> restore-data-from-nightly-backup BACKUP_DATE="yyyy-mm-dd" CONFIRM_PRODUCTION=YES CONFIRM_RESTORE=YES
+```
+
+This will download the latest daily backup from Azure Storage and then populate the new database with data.  If more than one backup has been created on the date specified the script will select the most recent from that date.

--- a/docs/maintenance-mode.md
+++ b/docs/maintenance-mode.md
@@ -1,0 +1,13 @@
+# Maintenance mode
+
+The repo includes a simple service unavailable page page that can be pushed to a cf app.  Traffic can be rerouted to it instead of the main application. This is handy in case of a critical bug being discovered where we need to take the service offline, or in case of maintenance where we want to avoid users interacting with the service.
+
+When enabled, all requests will receive the [service unavailable page](/service_unavailable_page/web/public/internal/index.html).
+
+### Enable Maintenance mode
+
+Login to PaaS: `cf login --sso` or `cf login -o dfe -u my.name@digital.education.gov.uk`
+
+Run the make command: `make prod enable-maintenance CONFIRM_PRODUCTION=y`
+
+To bring the application back up: `make prod disable-maintenance CONFIRM_PRODUCTION=y`


### PR DESCRIPTION
## Context

A DR process is required to handle the loss of the database instance.

## Changes proposed in this pull request

- Remove the timestamp on the database backup
- Add a DR process to docs and supporting make recipe and scripts to execute it
- Document the maintenance page process

## Guidance to review

Ensure the process meets the requirements in [technical guidance](https://technical-guidance.education.gov.uk/infrastructure/disaster-recovery/#loss-of-database-instance).

## Link to Trello card

https://trello.com/c/RFQySePB

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
