### PR TITLE
Parse json data from rspec retry

### DIFF
--- a/.github/scripts/comment_on_flakey_specs.js
+++ b/.github/scripts/comment_on_flakey_specs.js
@@ -11,24 +11,14 @@ module.exports = ({github, context}) => {
     const { issue: { number: issue_number }, repo: { owner, repo } } = context;
     const heading = 'You have one or more flakey tests on this branch!';
     let commentBody = `<h2>${heading} :snowflake: :snowflake: :snowflake:</h2>`;
-    let dataStr, dataAry, attempts, retryCount, errorLocation, errorPath, errorMessages, errorLink;
     let branchName = GITHUB_HEAD_REF.split('/').pop();
     let createComment = false;
-    let rows = FLAKEY_TEST_DATA.split("\n");
-    let rowsLength = rows.length;
-    for (var idx = 0; idx < rowsLength; idx++) {
-      dataStr = rows[idx];
-      if (dataStr.length) {
-        dataAry = dataStr.split(',');
-        if (dataAry.length >= 4) {
-          [attempts, retryCount, errorLocation, ...errorMessages] = dataAry;
-          errorPath = `/${owner}/${repo}/blob/${branchName}/${errorLocation.replace(':', '#L')}`;
-          errorLink = `<a href="${errorPath}">${errorLocation}</a>`;
-          commentBody += `Failed ${attempts} out of ${retryCount} times at ${errorLink}: :warning: ${errorMessages.toString()}<br>`;
-          createComment = true;
-        }
-      }
-    }
+    JSON.parse(FLAKEY_TEST_DATA).forEach(function(error) {
+      let errorPath = `/${owner}/${repo}/blob/${branchName}/${error['location'].replace(':', '#L')}`;
+      let errorLink = `<a href="${errorPath}">${error['location']}</a>`;
+      commentBody += `Failed ${error['attempts']} out of ${error['retry_count']} times at ${errorLink}: :warning: ${error['messages'].toString()}<br>`;
+      createComment = true;
+    })
     if (createComment) {
       github.issues.createComment({ issue_number, owner, repo, body: commentBody });
       throw new FlakeySpecError(heading);

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -222,8 +222,6 @@ jobs:
           file_text=$(cat /app/tmp/rspec-retry-flakey-specs.log)
           if [ ! -z "$file_text" ]
           then
-            file_text="${file_text//$'\n'/%0A}"
-            file_text="${file_text//\"/\'}"
             echo "::set-output name=flakey_tests::$file_text"
           else
             echo "No flakey tests logged"

--- a/Gemfile
+++ b/Gemfile
@@ -161,7 +161,7 @@ group :test do
   gem 'deepsort'
   gem 'ruby-jmeter'
   gem 'super_diff'
-  gem 'rspec-retry', git: 'https://github.com/DFE-Digital/rspec-retry.git', branch: 'main'
+  gem 'rspec-retry', git: 'https://github.com/DFE-Digital/rspec-retry.git', branch: 'write-json-to-flakey-spec-log'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/rspec-retry.git
-  revision: a561012b32484035105ed1df6dcedfe4af6ae614
+  revision: b802e070a2c57cad452e1093f7d4788f9d43b21c
   branch: write-json-to-flakey-spec-log
   specs:
     rspec-retry (0.6.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,8 +20,8 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/rspec-retry.git
-  revision: 6f40fcb95186ab13a9b2348936c29f2c0f910d0a
-  branch: main
+  revision: a561012b32484035105ed1df6dcedfe4af6ae614
+  branch: write-json-to-flakey-spec-log
   specs:
     rspec-retry (0.6.2)
       rspec-core (> 3.3)


### PR DESCRIPTION
## Context

We'd like to export indeterminate test data as JSON see https://github.com/DFE-Digital/rspec-retry/pull/13
This data should be simpler to consume in our Github workflow as the flakey spec commenter is written in Javascript.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Amends the flakey spec reporter to work with JSON.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

We will point to the rspec-retry `write-json-to-flakey-spec-log` branch until the relevant PR has been merged.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/y6EYtsni/5083-export-flakey-spec-log-as-json
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
