### PR TITLE
Return ZZ domicile for compound ISO-3166 codes

### DIFF
--- a/app/presenters/concerns/candidate_api_data.rb
+++ b/app/presenters/concerns/candidate_api_data.rb
@@ -15,6 +15,8 @@ module CandidateAPIData
     uk_residency: 'D',
   }.freeze
 
+  delegate :domicile, to: :application_form
+
   def candidate
     {
       id: application_form.candidate.public_id,
@@ -22,7 +24,7 @@ module CandidateAPIData
       last_name: application_form.last_name,
       date_of_birth: application_form.date_of_birth,
       nationality: application_choice.nationalities,
-      domicile: application_form.domicile,
+      domicile: domicile,
       uk_residency_status: truncate_if_over_advertised_limit(UK_RESIDENCY_STATUS_FIELD, uk_residency_status),
       uk_residency_status_code: uk_residency_status_code,
       fee_payer: provisional_fee_payer_status,

--- a/app/presenters/vendor_api/application_presenter.rb
+++ b/app/presenters/vendor_api/application_presenter.rb
@@ -104,5 +104,11 @@ module VendorAPI
         safeguarding_concerns: reference.has_safeguarding_concerns_to_declare?,
       }
     end
+
+    def domicile
+      return 'ZZ' if application_form.domicile.size > 2
+
+      application_form.domicile
+    end
   end
 end

--- a/spec/presenters/vendor_api/v1.0/application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.0/application_presenter_spec.rb
@@ -192,4 +192,13 @@ RSpec.describe VendorAPI::ApplicationPresenter do
       expect(attributes[:recruited_at]).not_to be_nil
     end
   end
+
+  describe 'domicile from compound country code' do
+    let!(:application_choice) { create(:application_choice, :awaiting_provider_decision, application_form: application_form) }
+    let(:application_form) { create(:application_form, :minimum_info, :international_address, country: 'AE-AZ') }
+
+    it 'returns HESA code for unknown' do
+      expect(attributes[:candidate][:domicile]).to eq('ZZ')
+    end
+  end
 end


### PR DESCRIPTION
## Context

The ISO-3166 country codes we save on the application form are used to generate the HESA domicile code.
Some of these are compounds eg. `AE-AZ` which do not produce valid HESA codes and do not conform to our Vendor API spec.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull reques

Return `ZZ` where the ISO code is over 2 characters long.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

This is causing issues with vendors consuming API responses as our docs state that `domicile` is restricted to 2 chars.

![image](https://user-images.githubusercontent.com/93511/167833196-5f092728-3c3c-4040-8bf0-00bccb7c0fc2.png)


<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/R5LYBMqM/1389-applicant-data-causing-refresh-error-for-lsbu
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
