### PR TITLE
Cancel link added to the export application data page

### DIFF
--- a/app/views/provider_interface/application_data_export/new.html.erb
+++ b/app/views/provider_interface/application_data_export/new.html.erb
@@ -42,6 +42,10 @@
       </div>
 
       <%= f.govuk_submit 'Export application data (CSV)' %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to 'Cancel', provider_interface_reports_path %>
+      </p>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
## Context

Missing cancel link on the 'export application data page'

## Changes proposed in this pull request

<img width="485" alt="image" src="https://user-images.githubusercontent.com/47917431/168021541-12db06ff-e740-4fd1-8821-41328f2172bc.png">

## Link to Trello card

https://trello.com/c/bDx4zVK1

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
