### PR TITLE
Return the first two characters of a compound ISO-3166 code

### DIFF
--- a/app/presenters/concerns/contact_details_api_data.rb
+++ b/app/presenters/concerns/contact_details_api_data.rb
@@ -1,4 +1,6 @@
 module ContactDetailsAPIData
+  delegate :country, to: :application_form
+
   def contact_details
     if application_form.international_address?
       address_line1 = application_form.address_line1 || application_form.international_address
@@ -9,7 +11,7 @@ module ContactDetailsAPIData
         address_line2: application_form.address_line2,
         address_line3: application_form.address_line3,
         address_line4: application_form.address_line4,
-        country: application_form.country,
+        country: country,
         email: application_form.candidate.email_address,
       }
     else
@@ -20,7 +22,7 @@ module ContactDetailsAPIData
         address_line3: application_form.address_line3,
         address_line4: application_form.address_line4,
         postcode: application_form.postcode,
-        country: application_form.country,
+        country: country,
         email: application_form.candidate.email_address,
       }
     end

--- a/app/presenters/vendor_api/application_presenter.rb
+++ b/app/presenters/vendor_api/application_presenter.rb
@@ -112,7 +112,7 @@ module VendorAPI
     end
 
     def country
-      application_form.country[0..1]
+      application_form.country[0..1] if application_form.country.present?
     end
   end
 end

--- a/app/presenters/vendor_api/application_presenter.rb
+++ b/app/presenters/vendor_api/application_presenter.rb
@@ -110,5 +110,9 @@ module VendorAPI
 
       application_form.domicile
     end
+
+    def country
+      application_form.country[0..1]
+    end
   end
 end

--- a/spec/presenters/vendor_api/v1.0/application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.0/application_presenter_spec.rb
@@ -193,12 +193,16 @@ RSpec.describe VendorAPI::ApplicationPresenter do
     end
   end
 
-  describe 'domicile from compound country code' do
+  describe 'compound ISO-3166 country codes' do
     let!(:application_choice) { create(:application_choice, :awaiting_provider_decision, application_form: application_form) }
     let(:application_form) { create(:application_form, :minimum_info, :international_address, country: 'AE-AZ') }
 
-    it 'returns HESA code for unknown' do
+    it 'returns domicile HESA code for unknown' do
       expect(attributes[:candidate][:domicile]).to eq('ZZ')
+    end
+
+    it 'returns a 2 character code for country' do
+      expect(attributes[:contact_details][:country]).to eq('AE')
     end
   end
 end


### PR DESCRIPTION
## Context

![image](https://user-images.githubusercontent.com/93511/168033280-fb3f7bea-c56b-42ce-8b06-197295ccec47.png)

We specify `contact_details.country` as a 2 character max string in the API spec.
We capture compound ISO-3166 codes such as `AE-AZ` via the country autocomplete component.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Truncate compound codes to 2 chars.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

Ongoing support issue. https://trello.com/c/R5LYBMqM/1389-applicant-data-causing-refresh-error-for-lsbu
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
