### PR TITLE
Fix degree section bug

### DIFF
--- a/app/components/candidate_interface/degree_new_review_component.html.erb
+++ b/app/components/candidate_interface/degree_new_review_component.html.erb
@@ -13,5 +13,5 @@
 <% end %>
 
 <% if show_missing_banner? %>
-  <%= render(CandidateInterface::IncompleteSectionComponent.new(section: :degrees, section_path: candidate_interface_new_degree_path, error: @missing_error)) %>
+  <%= render(CandidateInterface::IncompleteSectionComponent.new(section: :degrees, section_path: candidate_interface_new_degree_review_path, error: @missing_error)) %>
 <% end %>

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -97,13 +97,23 @@
   )) %>
 
   <h3 class="govuk-heading-m"><%= t('page_titles.degree') %></h3>
-  <%= render(CandidateInterface::DegreesReviewComponent.new(
-    application_form: application_form,
-    editable: editable, heading_level: 4,
-    show_incomplete: true,
-    missing_error: missing_error,
-    return_to_application_review: true
-  )) %>
+  <% if FeatureFlag.active?(:new_degree_flow) %>
+    <%= render(CandidateInterface::DegreeNewReviewComponent.new(
+      application_form: application_form,
+      editable: editable, heading_level: 4,
+      show_incomplete: true,
+      missing_error: missing_error,
+      return_to_application_review: true
+    )) %>
+  <% else %>
+    <%= render(CandidateInterface::DegreesReviewComponent.new(
+      application_form: application_form,
+      editable: editable, heading_level: 4,
+      show_incomplete: true,
+      missing_error: missing_error,
+      return_to_application_review: true
+    )) %>
+  <% end %>
 </section>
 
 <section class="govuk-!-margin-bottom-8">


### PR DESCRIPTION
## Context
Users are able to bypass the new degree flow from the application review page

## Changes proposed in this pull request

* Replace old degree review component with new one on application review page

## Guidance to review

Visit /candidate/application/review and verify user can see new summary card component which links back to new flow and not old one

Note this means the backlinks and return to application review page after editing doesn't work correctly. Will be carded up

## Link to Trello card

https://trello.com/c/PXwOeZjl/4695-degree-section-bug

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
