### PR TITLE
Change form data type from boolean to string

### DIFF
--- a/app/views/candidate_interface/volunteering/role/_form.html.erb
+++ b/app/views/candidate_interface/volunteering/role/_form.html.erb
@@ -14,8 +14,8 @@
 <div class="app-work-experience__start-date" data-qa="start-date">
   <%= f.govuk_date_field :start_date, omit_day: true, legend: { text: t('application_form.volunteering.start_date_restructured_work_history.label'), size: 'm' }, hint: { text: t('application_form.volunteering.start_date_restructured_work_history.hint_text') } %>
   <div class="govuk-form-group">
-    <%= f.hidden_field :start_date_unknown, value: false %>
-    <%= f.govuk_check_box :start_date_unknown, true, multiple: false, label: { text: t('application_form.volunteering.start_date_unknown_checkbox') } %>
+    <%= f.hidden_field :start_date_unknown, value: 'false' %>
+    <%= f.govuk_check_box :start_date_unknown, 'true', multiple: false, label: { text: t('application_form.volunteering.start_date_unknown_checkbox') } %>
   </div>
 </div>
 <div class="app-work-experience__currently_working" data-qa="currently-working">
@@ -25,8 +25,8 @@
       <div class="app-work-experience__start-date" data-qa="end-date">
         <%= f.govuk_date_field :end_date, omit_day: true, legend: { text: t('application_form.volunteering.end_date_restructured_work_history.label'), size: 'm' }, hint: { text: t('application_form.volunteering.end_date_restructured_work_history.hint_text') } %>
         <div class="govuk-form-group">
-          <%= f.hidden_field :end_date_unknown, value: false %>
-          <%= f.govuk_check_box :end_date_unknown, true, multiple: false, label: { text: t('application_form.volunteering.end_date_unknown_checkbox') } %>
+          <%= f.hidden_field :end_date_unknown, value: 'false' %>
+          <%= f.govuk_check_box :end_date_unknown, 'true', multiple: false, label: { text: t('application_form.volunteering.end_date_unknown_checkbox') } %>
         </div>
       </div>
     <% end %>

--- a/app/views/candidate_interface/volunteering/role/_form.html.erb
+++ b/app/views/candidate_interface/volunteering/role/_form.html.erb
@@ -14,8 +14,7 @@
 <div class="app-work-experience__start-date" data-qa="start-date">
   <%= f.govuk_date_field :start_date, omit_day: true, legend: { text: t('application_form.volunteering.start_date_restructured_work_history.label'), size: 'm' }, hint: { text: t('application_form.volunteering.start_date_restructured_work_history.hint_text') } %>
   <div class="govuk-form-group">
-    <%= f.hidden_field :start_date_unknown, value: 'false' %>
-    <%= f.govuk_check_box :start_date_unknown, 'true', multiple: false, label: { text: t('application_form.volunteering.start_date_unknown_checkbox') } %>
+    <%= f.govuk_check_box :start_date_unknown, 'true', 'false', multiple: false, label: { text: t('application_form.volunteering.start_date_unknown_checkbox') } %>
   </div>
 </div>
 <div class="app-work-experience__currently_working" data-qa="currently-working">
@@ -25,8 +24,7 @@
       <div class="app-work-experience__start-date" data-qa="end-date">
         <%= f.govuk_date_field :end_date, omit_day: true, legend: { text: t('application_form.volunteering.end_date_restructured_work_history.label'), size: 'm' }, hint: { text: t('application_form.volunteering.end_date_restructured_work_history.hint_text') } %>
         <div class="govuk-form-group">
-          <%= f.hidden_field :end_date_unknown, value: 'false' %>
-          <%= f.govuk_check_box :end_date_unknown, 'true', multiple: false, label: { text: t('application_form.volunteering.end_date_unknown_checkbox') } %>
+          <%= f.govuk_check_box :end_date_unknown, 'true', 'false', multiple: false, label: { text: t('application_form.volunteering.end_date_unknown_checkbox') } %>
         </div>
       </div>
     <% end %>

--- a/spec/system/candidate_interface/entering_details/candidate_entering_volunteering_experience_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_volunteering_experience_spec.rb
@@ -15,7 +15,10 @@ RSpec.feature 'Entering volunteering experience' do
     then_i_see_the_add_volunteering_role_form
 
     when_i_fill_in_the_job_form_with_incorrect_date_fields
+    and_i_check_both_estimate_boxes
+    and_i_submit_the_form
     then_i_should_see_date_validation_errors
+    and_both_estimate_boxes_should_remain_checked
     and_i_should_see_the_incorrect_date_values
 
     when_i_fill_in_the_job_form_with_valid_details
@@ -61,8 +64,20 @@ RSpec.feature 'Entering volunteering experience' do
       fill_in 'Month', with: '33'
       fill_in 'Year', with: '1999'
     end
+  end
 
+  def and_i_check_both_estimate_boxes
+    find(:label, for: 'candidate-interface-volunteering-role-form-start-date-unknown-true-field').click
+    find(:label, for: 'candidate-interface-volunteering-role-form-end-date-unknown-true-field').click
+  end
+
+  def and_i_submit_the_form
     click_button t('save_and_continue')
+  end
+
+  def and_both_estimate_boxes_should_remain_checked
+    expect(page).to have_checked_field('candidate-interface-volunteering-role-form-start-date-unknown-true-field')
+    expect(page).to have_checked_field('candidate-interface-volunteering-role-form-end-date-unknown-true-field')
   end
 
   def then_i_should_see_date_validation_errors


### PR DESCRIPTION
## Context

There is a bug on the volunteering page where the estimation checkboxes do not remain checked after submitting the form when the validation fails.

## Changes proposed in this pull request

 Change the form data type from a boolean to a string, in the form object we use `to_s`.

## Guidance to review

**See Trello card for repro GIF**

- Navigate to the volunteering page 
- Check any or both of the estimation check boxes
- Submit the form
- The estimation checkboxes should remain checked

## Link to Trello card

https://trello.com/c/wAX43kFT/4650-im-not-sure-the-exact-month-or-year-i-started-is-not-checked-when-editing-a-volunteering-role-or-after-validation-error
