### PR TITLE
Make support change conditions only appear in pending state

### DIFF
--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -102,7 +102,7 @@ module SupportInterface
         value: render(SupportInterface::ConditionsComponent.new(conditions: conditions)),
       }
 
-      return conditions_row if application_choice.offer.non_pending_conditions?
+      return conditions_row unless application_choice.pending_conditions?
 
       conditions_row.merge({
         action: {

--- a/spec/components/support_interface/application_choice_component_spec.rb
+++ b/spec/components/support_interface/application_choice_component_spec.rb
@@ -61,23 +61,21 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
 
       expect(result.css('.app-summary-card .govuk-summary-list__actions a')[1].text.squish).to eq 'Change conditions'
     end
+  end
 
-    context 'when one of the conditions is met' do
-      let(:conditions) { [build(:offer_condition, status: 'met'), build(:offer_condition)] }
-      let(:accepted_choice) do
-        create(
-          :application_choice,
-          :with_completed_application_form,
-          :with_accepted_offer,
-          offer: build(:offer, conditions: conditions),
-        )
-      end
+  context 'Recruited' do
+    let(:recruited_choice) do
+      create(
+        :application_choice,
+        :with_completed_application_form,
+        :with_recruited,
+      )
+    end
 
-      it 'does not render a link to the change the offered course choice when the`change_offered_course` flag is not active' do
-        result = render_inline(described_class.new(accepted_choice))
+    it 'does not render a link to change conditions' do
+      result = render_inline(described_class.new(recruited_choice))
 
-        expect(result.css('.app-summary-card .govuk-summary-list__actions a').text.squish).not_to include 'Change conditions'
-      end
+      expect(result.css('.app-summary-card .govuk-summary-list__actions a').text.squish).not_to include 'Change conditions'
     end
   end
 


### PR DESCRIPTION
## Context
https://trello.com/c/FUw88Tbm/3839-support-interface-removing-all-offer-conditions-of-an-offered-application-does-nothing

~~I haven't put any tests in, as this is removing a feature, and it didn't appear to have been tested in the first place under the offer state. Rather than add a negative test, I've just removed a test which broke based on a feature flag that doesn't exist anymore.~~

Repurposed a test (suggested by @cwrw) so that it checks that we're not showing the link once we're past the conditions checking stage i.e. `recruited`

## Changes proposed in this pull request
Removed the `Change conditions` link from the support interface when an application is in the `offer` state - so basically making it only appear in the `pending_conditions` state.

## Guidance to review

On support, go to an application in the offer state, and you shouldn't be able to find a change conditions link.
