### PR TITLE
Prevent user from creating unfinished degree

### DIFF
--- a/app/forms/candidate_interface/degree_wizard.rb
+++ b/app/forms/candidate_interface/degree_wizard.rb
@@ -228,12 +228,9 @@ module CandidateInterface
       if existing_degree.present?
         existing_degree.update(attributes_for_persistence)
         clear_state!
-      else
-        # Avoid jumping steps
-        unless attributes_for_persistence.slice(:qualification_type, :institution_name, :subject, :grade, :start_year, :award_year).values.any?(&:blank?)
-          ApplicationQualification.create!(attributes_for_persistence)
-          clear_state!
-        end
+      elsif all_attributes_for_persistence_present?
+        ApplicationQualification.create!(attributes_for_persistence)
+        clear_state!
       end
     end
 
@@ -437,6 +434,12 @@ module CandidateInterface
         NO => NOT_APPLICABLE,
         I_DO_NOT_KNOW => UNKNOWN,
       }[grade]
+    end
+
+    def all_attributes_for_persistence_present?
+      attributes_for_persistence.slice(
+        :qualification_type, :institution_name, :subject, :grade, :start_year, :award_year
+      ).values.all?(&:present?)
     end
 
     def self.map_completed(application_qualification)

--- a/spec/forms/candidate_interface/degree_wizard_spec.rb
+++ b/spec/forms/candidate_interface/degree_wizard_spec.rb
@@ -269,7 +269,7 @@ RSpec.describe CandidateInterface::DegreeWizard do
     end
 
     context 'enic step' do
-      let(:degree_params) { { uk_or_non_uk: 'non_uk', current_step: :enic } }
+      let(:degree_params) { { current_step: :enic } }
 
       it 'redirects to the review page' do
         expect(wizard.next_step).to be(:review)
@@ -954,11 +954,41 @@ RSpec.describe CandidateInterface::DegreeWizard do
       end
     end
 
-    context 'creates new degree if it does not exist' do
-      let(:degree_params) { { id: nil, award_year: '2011', application_form_id: application_form.id } }
+    context 'creates new international degree only if most fields are not blank' do
+      let(:degree_params) {
+        { id: nil, uk_or_non_uk: 'non_uk', subject: 'History', start_year: '2007', award_year: '2011', international_type: 'Bachelor of Arts',
+          university: 'University of Paris', other_grade: '94%', application_form_id: application_form.id }
+      }
 
       it 'creates new degree entry' do
         expect { wizard.persist! }.to change { ApplicationQualification.count }.from(1).to(2)
+      end
+    end
+
+    context 'does not create new international degree if specific fields are blank' do
+      let(:degree_params) { { id: nil, have_enic_reference: 'No', application_form_id: application_form.id } }
+
+      it 'does not create new degree entry' do
+        expect { wizard.persist! }.not_to(change { ApplicationQualification.count })
+      end
+    end
+
+    context 'creates new uk degree only if most fields are not blank' do
+      let(:degree_params) {
+        { id: nil, uk_or_non_uk: 'uk', subject: 'Geography', start_year: '2007', award_year: '2011', degree_level: 'Bachelor', type: 'Master of Arts',
+          university: 'University of Warwick', grade: 'First-class honours', application_form_id: application_form.id }
+      }
+
+      it 'creates new degree entry' do
+        expect { wizard.persist! }.to change { ApplicationQualification.count }.from(1).to(2)
+      end
+    end
+
+    context 'does not create new uk degree if specific fields are blank' do
+      let(:degree_params) { { id: nil, award_year: '2011', application_form_id: application_form.id } }
+
+      it 'does not create new degree entry' do
+        expect { wizard.persist! }.not_to(change { ApplicationQualification.count })
       end
     end
   end

--- a/spec/system/candidate_interface/entering_details/degrees/new_degree_flow/candidate_editing_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/new_degree_flow/candidate_editing_degrees_spec.rb
@@ -75,6 +75,15 @@ RSpec.feature 'Editing a degree' do
     then_i_see_another_masters_degree_selected
   end
 
+  scenario 'editing international degree' do
+    given_i_am_signed_in
+    when_i_view_the_degree_section
+    and_i_create_an_international_degree
+    and_when_i_click_the_browser_back_button
+    and_i_click_on_save_and_continue
+    then_i_can_check_an_additional_degree_is_not_created
+  end
+
   def given_i_am_signed_in
     @candidate = create(:candidate)
     login_as(@candidate)
@@ -103,10 +112,6 @@ RSpec.feature 'Editing a degree' do
 
   def when_i_click_on_degree
     click_link 'Degree'
-  end
-
-  def then_i_can_check_my_undergraduate_degree
-    expect(page).to have_current_path candidate_interface_degrees_review_path
   end
 
   def and_i_click_on_save_and_continue
@@ -305,5 +310,110 @@ RSpec.feature 'Editing a degree' do
 
   def then_i_see_another_masters_degree_selected
     expect(page.find_field('Another master’s degree type')).to be_checked
+  end
+
+  def and_when_i_click_the_browser_back_button
+    visit candidate_interface_new_degree_enic_path
+  end
+
+  def then_i_can_check_an_additional_degree_is_not_created
+    expect(page.all('.app-summary-card__header').count).to eq(1)
+  end
+
+  def when_i_view_the_degree_section
+    visit candidate_interface_application_form_path
+    when_i_click_on_degree
+  end
+
+  def when_i_click_on_degree
+    click_link 'Degree'
+  end
+
+  def and_i_click_add_degree
+    click_link 'Add a degree'
+  end
+
+  def when_i_select_another_country
+    choose 'Another country'
+    select 'France'
+  end
+
+  def when_i_fill_in_the_type
+    choose 'Bachelor degree'
+  end
+
+  def when_i_fill_in_the_subject
+    select 'History', from: 'What subject is your degree?'
+  end
+
+  def when_i_fill_in_the_type_of_degree
+    fill_in 'candidate_interface_degree_wizard[international_type]', with: 'Diplôme'
+  end
+
+  def when_i_fill_in_the_university
+    fill_in 'candidate_interface_degree_wizard[university]', with: 'University of Paris'
+  end
+
+  def when_i_choose_whether_degree_is_completed
+    choose 'Yes'
+  end
+
+  def when_i_choose_whether_grade_was_given
+    choose 'Yes'
+  end
+
+  def and_i_fill_in_the_grade
+    fill_in 'What grade did you get?', with: '94%'
+  end
+
+  def when_i_fill_in_the_start_year
+    fill_in t('page_titles.what_year_did_you_start_your_degree'), with: '2006'
+  end
+
+  def when_i_fill_in_the_award_year
+    fill_in t('page_titles.what_year_did_you_graduate'), with: '2009'
+  end
+
+  def when_i_check_yes_for_enic_statement
+    choose 'Yes'
+  end
+
+  def and_i_fill_in_enic_reference
+    fill_in 'UK ENIC reference number', with: '0123456789'
+  end
+
+  def and_i_fill_in_comparable_uk_degree_type
+    choose 'Doctor of Philosophy degree'
+  end
+
+  def then_i_can_check_my_undergraduate_degree
+    expect(page).to have_current_path candidate_interface_new_degree_review_path
+    expect(page).to have_content 'History'
+  end
+
+  def and_i_create_an_international_degree
+    and_i_click_add_degree
+    when_i_select_another_country
+    and_i_click_on_save_and_continue
+    when_i_fill_in_the_subject
+    and_i_click_on_save_and_continue
+    when_i_fill_in_the_type_of_degree
+    and_i_click_on_save_and_continue
+    when_i_fill_in_the_university
+    and_i_click_on_save_and_continue
+    when_i_choose_whether_degree_is_completed
+    and_i_click_on_save_and_continue
+    when_i_choose_whether_grade_was_given
+    and_i_fill_in_the_grade
+    and_i_click_on_save_and_continue
+    when_i_fill_in_the_start_year
+    and_i_click_on_save_and_continue
+    when_i_fill_in_the_award_year
+    and_i_click_on_save_and_continue
+    when_i_check_yes_for_enic_statement
+    and_i_fill_in_enic_reference
+    and_i_fill_in_comparable_uk_degree_type
+    and_i_click_on_save_and_continue
+    then_i_can_check_my_undergraduate_degree
   end
 end

--- a/spec/system/candidate_interface/entering_details/degrees/new_degree_flow/candidate_editing_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/new_degree_flow/candidate_editing_degrees_spec.rb
@@ -75,15 +75,6 @@ RSpec.feature 'Editing a degree' do
     then_i_see_another_masters_degree_selected
   end
 
-  scenario 'editing international degree' do
-    given_i_am_signed_in
-    when_i_view_the_degree_section
-    and_i_create_an_international_degree
-    and_when_i_click_the_browser_back_button
-    and_i_click_on_save_and_continue
-    then_i_can_check_an_additional_degree_is_not_created
-  end
-
   def given_i_am_signed_in
     @candidate = create(:candidate)
     login_as(@candidate)
@@ -312,14 +303,6 @@ RSpec.feature 'Editing a degree' do
     expect(page.find_field('Another master’s degree type')).to be_checked
   end
 
-  def and_when_i_click_the_browser_back_button
-    visit candidate_interface_new_degree_enic_path
-  end
-
-  def then_i_can_check_an_additional_degree_is_not_created
-    expect(page.all('.app-summary-card__header').count).to eq(1)
-  end
-
   def when_i_view_the_degree_section
     visit candidate_interface_application_form_path
     when_i_click_on_degree
@@ -327,93 +310,5 @@ RSpec.feature 'Editing a degree' do
 
   def when_i_click_on_degree
     click_link 'Degree'
-  end
-
-  def and_i_click_add_degree
-    click_link 'Add a degree'
-  end
-
-  def when_i_select_another_country
-    choose 'Another country'
-    select 'France'
-  end
-
-  def when_i_fill_in_the_type
-    choose 'Bachelor degree'
-  end
-
-  def when_i_fill_in_the_subject
-    select 'History', from: 'What subject is your degree?'
-  end
-
-  def when_i_fill_in_the_type_of_degree
-    fill_in 'candidate_interface_degree_wizard[international_type]', with: 'Diplôme'
-  end
-
-  def when_i_fill_in_the_university
-    fill_in 'candidate_interface_degree_wizard[university]', with: 'University of Paris'
-  end
-
-  def when_i_choose_whether_degree_is_completed
-    choose 'Yes'
-  end
-
-  def when_i_choose_whether_grade_was_given
-    choose 'Yes'
-  end
-
-  def and_i_fill_in_the_grade
-    fill_in 'What grade did you get?', with: '94%'
-  end
-
-  def when_i_fill_in_the_start_year
-    fill_in t('page_titles.what_year_did_you_start_your_degree'), with: '2006'
-  end
-
-  def when_i_fill_in_the_award_year
-    fill_in t('page_titles.what_year_did_you_graduate'), with: '2009'
-  end
-
-  def when_i_check_yes_for_enic_statement
-    choose 'Yes'
-  end
-
-  def and_i_fill_in_enic_reference
-    fill_in 'UK ENIC reference number', with: '0123456789'
-  end
-
-  def and_i_fill_in_comparable_uk_degree_type
-    choose 'Doctor of Philosophy degree'
-  end
-
-  def then_i_can_check_my_undergraduate_degree
-    expect(page).to have_current_path candidate_interface_new_degree_review_path
-    expect(page).to have_content 'History'
-  end
-
-  def and_i_create_an_international_degree
-    and_i_click_add_degree
-    when_i_select_another_country
-    and_i_click_on_save_and_continue
-    when_i_fill_in_the_subject
-    and_i_click_on_save_and_continue
-    when_i_fill_in_the_type_of_degree
-    and_i_click_on_save_and_continue
-    when_i_fill_in_the_university
-    and_i_click_on_save_and_continue
-    when_i_choose_whether_degree_is_completed
-    and_i_click_on_save_and_continue
-    when_i_choose_whether_grade_was_given
-    and_i_fill_in_the_grade
-    and_i_click_on_save_and_continue
-    when_i_fill_in_the_start_year
-    and_i_click_on_save_and_continue
-    when_i_fill_in_the_award_year
-    and_i_click_on_save_and_continue
-    when_i_check_yes_for_enic_statement
-    and_i_fill_in_enic_reference
-    and_i_fill_in_comparable_uk_degree_type
-    and_i_click_on_save_and_continue
-    then_i_can_check_my_undergraduate_degree
   end
 end

--- a/spec/system/candidate_interface/entering_details/degrees/new_degree_flow/candidate_editing_international_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/new_degree_flow/candidate_editing_international_degrees_spec.rb
@@ -1,0 +1,133 @@
+require 'rails_helper'
+
+RSpec.feature 'Editing a degree' do
+  include CandidateHelper
+
+  before do
+    FeatureFlag.activate(:new_degree_flow)
+    allow(CycleTimetable).to receive(:current_year).and_return(2022)
+  end
+
+  scenario 'editing international degree' do
+    given_i_am_signed_in
+    when_i_view_the_degree_section
+    and_i_create_an_international_degree
+    and_when_i_click_the_browser_back_button
+    and_i_click_on_save_and_continue
+    then_i_can_check_an_additional_degree_is_not_created
+  end
+
+  def given_i_am_signed_in
+    @candidate = create(:candidate)
+    login_as(@candidate)
+  end
+
+  def when_i_view_the_degree_section
+    visit candidate_interface_application_form_path
+    when_i_click_on_degree
+  end
+
+  def when_i_click_on_degree
+    click_link 'Degree'
+  end
+
+  def and_i_create_an_international_degree
+    and_i_click_add_degree
+    when_i_select_another_country
+    and_i_click_on_save_and_continue
+    when_i_fill_in_the_subject
+    and_i_click_on_save_and_continue
+    when_i_fill_in_the_type_of_degree
+    and_i_click_on_save_and_continue
+    when_i_fill_in_the_university
+    and_i_click_on_save_and_continue
+    when_i_choose_whether_degree_is_completed
+    and_i_click_on_save_and_continue
+    when_i_choose_whether_grade_was_given
+    and_i_fill_in_the_grade
+    and_i_click_on_save_and_continue
+    when_i_fill_in_the_start_year
+    and_i_click_on_save_and_continue
+    when_i_fill_in_the_award_year
+    and_i_click_on_save_and_continue
+    when_i_check_yes_for_enic_statement
+    and_i_fill_in_enic_reference
+    and_i_fill_in_comparable_uk_degree_type
+    and_i_click_on_save_and_continue
+    then_i_can_check_my_undergraduate_degree
+  end
+
+  def and_when_i_click_the_browser_back_button
+    visit candidate_interface_new_degree_enic_path
+  end
+
+  def and_i_click_on_save_and_continue
+    click_button t('save_and_continue')
+  end
+
+  def then_i_can_check_an_additional_degree_is_not_created
+    expect(page.all('.app-summary-card__header').count).to eq(1)
+  end
+
+  def and_i_click_add_degree
+    click_link 'Add a degree'
+  end
+
+  def when_i_select_another_country
+    choose 'Another country'
+    select 'France'
+  end
+
+  def when_i_fill_in_the_type
+    choose 'Bachelor degree'
+  end
+
+  def when_i_fill_in_the_subject
+    select 'History', from: 'What subject is your degree?'
+  end
+
+  def when_i_fill_in_the_type_of_degree
+    fill_in 'candidate_interface_degree_wizard[international_type]', with: 'Diplôme'
+  end
+
+  def when_i_fill_in_the_university
+    fill_in 'candidate_interface_degree_wizard[university]', with: 'University of Paris'
+  end
+
+  def and_i_fill_in_the_grade
+    fill_in 'What grade did you get?', with: '94%'
+  end
+
+  def when_i_fill_in_the_start_year
+    fill_in t('page_titles.what_year_did_you_start_your_degree'), with: '2006'
+  end
+
+  def when_i_fill_in_the_award_year
+    fill_in t('page_titles.what_year_did_you_graduate'), with: '2009'
+  end
+
+  def when_i_choose_whether_degree_is_completed
+    choose 'Yes'
+  end
+
+  def when_i_choose_whether_grade_was_given
+    choose 'Yes'
+  end
+
+  def when_i_check_yes_for_enic_statement
+    choose 'Yes'
+  end
+
+  def and_i_fill_in_enic_reference
+    fill_in 'UK ENIC reference number', with: '0123456789'
+  end
+
+  def and_i_fill_in_comparable_uk_degree_type
+    choose 'Doctor of Philosophy degree'
+  end
+
+  def then_i_can_check_my_undergraduate_degree
+    expect(page).to have_current_path candidate_interface_new_degree_review_path
+    expect(page).to have_content 'History'
+  end
+end


### PR DESCRIPTION
## Context
There was a bug where users could create unfinished degrees. The change link would try to rehydrate redis 
and there would be failures as values were nil. This fix should avoid need for a lot of guard clauses. It also meant that users saw empty degrees sometimes by accident (if they hit browser back and clicked continue)

There was a bug where if user hit browser back from review page on international degree, there is an error because there are no values stored in redis anymore
## Changes proposed in this pull request
* Add check that stops user from creating degree if they've somehow avoided necessary pages by navigating via the address bar
* Remove international check as its redundant anyway which was causing browser back error. They can't get to enic page without being international. 
* Add unit and system specs

## Guidance to review
Verify bugs no longer occur

Bug 1 - click button to add new degree, pick country for international degree, then via address bar navigate to `/enic` and then commit to db by clicking save and continue. Empty degree should not be created with PR changes.

Bug 2. create international degree as normal through ui, click browser back to enic page, then click save and continue. There should be no error nor an empty degree created.

## Link to Trello card

https://trello.com/c/Q6GDqTQ6/4696-prevent-user-from-creating-unfinished-degree

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
