### PR TITLE
Correct URLs in emails sent locally using Sidekiq

### DIFF
--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -13,7 +13,12 @@ module HostingEnvironment
     if Rails.env.production?
       "https://#{hostname}"
     else
-      "http://localhost:#{ENV.fetch('PORT', 3000)}"
+      # Foreman will override $PORT to 3100, 3200 etc depending on position in
+      # the Procfile. This means that e.g. emails sent via Sidekiq in
+      # development will have the wrong port number on them and the links won't
+      # work. Go back to .env and friends for the original port so the URL is
+      # consistent across processes.
+      "http://localhost:#{Dotenv.parse.fetch('PORT', 3000)}"
     end
   end
 


### PR DESCRIPTION
## Context

Emails sent locally under foreman/sidekiq have URLs pointing to `localhost:3100`, not `localhost:3000` (your original port number may vary, but the point is they're different)

## Changes proposed in this pull request

Ignore the `$PORT` Foreman sets for its processes and go back to `.env` or a default value for the application URL

Inherited `3000` as a default from existing code, which is in line what what's in `.env.example`.

## Guidance to review

Try it locally!

## Things to check

- [X] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
