### PR TITLE
Delimit GCSE qualifications summary with semicolons

### DIFF
--- a/app/decorators/application_choice_export_decorator.rb
+++ b/app/decorators/application_choice_export_decorator.rb
@@ -57,10 +57,15 @@ private
     return if gcse.blank?
 
     qualification = ApplicationQualificationDecorator.new(gcse)
+    qualification_type = formatted_qualification_type(qualification.qualification_type)
     if qualification.start_year.present?
-      "#{qualification.qualification_type.humanize} #{qualification.subject.capitalize}, #{qualification.grade_details.join(' ')}, #{qualification.start_year}-#{qualification.award_year}"
+      "#{qualification_type} #{qualification.subject.capitalize}, #{qualification.grade_details.join(' ')}, #{qualification.start_year}-#{qualification.award_year}"
     else
-      "#{qualification.qualification_type.humanize} #{qualification.subject.capitalize}, #{qualification.grade_details.join(' ')}, #{qualification.award_year}"
+      "#{qualification_type} #{qualification.subject.capitalize}, #{qualification.grade_details.join(' ')}, #{qualification.award_year}"
     end
+  end
+
+  def formatted_qualification_type(qualification_type)
+    qualification_type.humanize.sub('Gcse', 'GCSE')
   end
 end

--- a/app/decorators/application_choice_export_decorator.rb
+++ b/app/decorators/application_choice_export_decorator.rb
@@ -6,7 +6,7 @@ class ApplicationChoiceExportDecorator < SimpleDelegator
       .select { |qualification| qualification.gcse? && required_subjects.include?(qualification.subject) }
       .sort { |a, b| required_subjects.index(b.subject) <=> required_subjects.index(a.subject) }
       .map { |gcse| summary_for_gcse(gcse) }
-      .join(',')
+      .join('; ')
 
     summary_string.presence
   end

--- a/spec/decorators/application_choice_export_decorator_spec.rb
+++ b/spec/decorators/application_choice_export_decorator_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ApplicationChoiceExportDecorator do
 
       summary = described_class.new(application_choice).gcse_qualifications_summary
 
-      expect(summary).to match('Gcse Maths, A, 2000,Gcse English, B (English Language) C (English Literature), 2000,Gcse Science double award, AB (Double award), 2000')
+      expect(summary).to match('Gcse Maths, A, 2000; Gcse English, B (English Language) C (English Literature), 2000; Gcse Science double award, AB (Double award), 2000')
     end
 
     it 'returns the GCSE start year if present' do

--- a/spec/decorators/application_choice_export_decorator_spec.rb
+++ b/spec/decorators/application_choice_export_decorator_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ApplicationChoiceExportDecorator do
 
       summary = described_class.new(application_choice).gcse_qualifications_summary
 
-      expect(summary).to match('Gcse Maths, A, 2000; Gcse English, B (English Language) C (English Literature), 2000; Gcse Science double award, AB (Double award), 2000')
+      expect(summary).to match('GCSE Maths, A, 2000; GCSE English, B (English Language) C (English Literature), 2000; GCSE Science double award, AB (Double award), 2000')
     end
 
     it 'returns the GCSE start year if present' do
@@ -21,7 +21,7 @@ RSpec.describe ApplicationChoiceExportDecorator do
 
       summary = described_class.new(application_choice).gcse_qualifications_summary
 
-      expect(summary).to match(/^Gcse Maths, [ABCD], \d{4}-\d{4}$/)
+      expect(summary).to match(/^GCSE Maths, [ABCD], \d{4}-\d{4}$/)
     end
 
     it 'does not include GCSEs in other subjects' do


### PR DESCRIPTION
## Context

GCSE qualifications summary may contain multiple values which may contain commas, delimited by commas.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Delimited GCSE qualification summary items by semicolon.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/BhI8b3YD/5090-delimit-applications-data-export-gcse-values-by-semi-colon
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
