### PR TITLE
Remove branch coverage comparison

### DIFF
--- a/.github/scripts/compare_coverage.js
+++ b/.github/scripts/compare_coverage.js
@@ -28,37 +28,17 @@ module.exports = ({github, context}) => {
     }
   }
 
-  const baseBranchCoverage = BASE_COVERAGE_OBJ.result.branch;
   const baseLineCoverage = BASE_COVERAGE_OBJ.result.line;
-  const prBranchCoverage = PR_COVERAGE_OBJ.result.branch;
   const prLineCoverage = PR_COVERAGE_OBJ.result.line;
-  const branchDifference = compareCoverage(baseBranchCoverage, prBranchCoverage);
   const lineDifference = compareCoverage(baseLineCoverage, prLineCoverage);
   const reportedLineCoverage = reportedCoverage(baseLineCoverage, prLineCoverage, lineDifference);
-  const reportedBranchCoverage = reportedCoverage(baseBranchCoverage, prBranchCoverage, branchDifference);
 
-  if (reportedLineCoverage != baseLineCoverage || reportedBranchCoverage != baseBranchCoverage) {
-    const coverageExplanation = `<details><summary><b>Line vs. Branch coverage</b></summary>
-        <p>Branch coverage concerns itself with whether a particular branch of a condition had been executed.<br>
-        Line coverage is only interested in whether a line of code has been executed.<br>
-        This comes in handy for measuring one line conditionals.<br>
-        eg.</p>
-        <p><pre>
-          def do_something_with_even_numbers(number)
-            return if number.odd?
-            ...
-        </pre></p>
-        <p>If all the code in the method was covered you would never know if the guard clause was ever triggered with line coverage as just evaluating the condition marks it as covered.</p>
-      </details>`;
-
+  if (reportedLineCoverage != baseLineCoverage) {
     let coverageBody = '<h2>Code Coverage</h2>'
     coverageBody += '<table><thead><tr><th></th><th>Coverage type</th><th>From</th><th>To</th></tr></thead><tbody>';
     coverageBody += `<tr><td>${emoji(lineDifference)}</td><td>Lines covered</td><td><b>${baseLineCoverage}%</b></td>`;
     coverageBody += `<td><b>${reportedLineCoverage}%</b></td></tr>`;
-    coverageBody += `<tr><td>${emoji(branchDifference)}</td><td>Branches covered</td><td><b>${baseBranchCoverage}%</b></td>`;
-    coverageBody += `<td><b>${reportedBranchCoverage}%</b></td></tr>`;
-    coverageBody += '</tbody></table><br>';
-    coverageBody += coverageExplanation;
+    coverageBody += '</tbody></table>';
 
     github.issues.createComment({ issue_number, owner, repo, body: coverageBody });
   }


### PR DESCRIPTION
## Context

Branch coverage differences are becoming increasingly verbose and the results are opaque, ideally we'd need to know why coverage dropped.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Disable comparison and reporting of branch coverage differences.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review


<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/QoRuT1JF/5091-disable-branch-coverage-comparison
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
