### PR TITLE
4664 relax limits on how many times a referee can be reminded

### DIFF
--- a/app/lib/time_limit_config.rb
+++ b/app/lib/time_limit_config.rb
@@ -21,8 +21,8 @@ class TimeLimitConfig
 
   Rule = Struct.new(:from_date, :to_date, :limit)
 
-  def self.minimum_time_between_chaser_emails
-    2
+  def self.minimum_hours_between_chaser_emails
+    48
   end
 
   def self.chase_referee_by

--- a/app/lib/time_limit_config.rb
+++ b/app/lib/time_limit_config.rb
@@ -21,7 +21,7 @@ class TimeLimitConfig
 
   Rule = Struct.new(:from_date, :to_date, :limit)
 
-  def self.referee_chaser_limit
+  def self.minimum_time_between_chaser_emails
     2
   end
 

--- a/app/lib/time_limit_config.rb
+++ b/app/lib/time_limit_config.rb
@@ -21,6 +21,10 @@ class TimeLimitConfig
 
   Rule = Struct.new(:from_date, :to_date, :limit)
 
+  def self.referee_chaser_limit
+    2
+  end
+
   def self.chase_referee_by
     7
   end

--- a/app/lib/time_limit_config.rb
+++ b/app/lib/time_limit_config.rb
@@ -29,6 +29,10 @@ class TimeLimitConfig
     14
   end
 
+  def self.second_chase_referee_by
+    21
+  end
+
   def self.additional_reference_chase_calendar_days
     28
   end

--- a/app/models/chaser_sent.rb
+++ b/app/models/chaser_sent.rb
@@ -5,6 +5,7 @@ class ChaserSent < ApplicationRecord
     reference_request: 'reference_request',
     reference_replacement: 'reference_replacement',
     follow_up_missing_references: 'follow_up_missing_references',
+    reminder_reference_nudge: 'reminder_reference_nudge',
     provider_decision_request: 'provider_decision_request',
     candidate_decision_request: 'candidate_decision_request',
     course_unavailable_notification: 'course_unavailable_notification',

--- a/app/services/reference_actions_policy.rb
+++ b/app/services/reference_actions_policy.rb
@@ -16,7 +16,7 @@ class ReferenceActionsPolicy
   end
 
   def can_send_reminder?
-    reference.feedback_requested? && (reference.reminder_sent_at.nil? || reference.reminder_sent_at < TimeLimitConfig.referee_chaser_limit.days.ago)
+    reference.feedback_requested? && (reference.reminder_sent_at.nil? || reference.reminder_sent_at < TimeLimitConfig.minimum_time_between_chaser_emails.days.ago)
   end
 
   def can_request?

--- a/app/services/reference_actions_policy.rb
+++ b/app/services/reference_actions_policy.rb
@@ -16,7 +16,7 @@ class ReferenceActionsPolicy
   end
 
   def can_send_reminder?
-    reference.feedback_requested? && reference.reminder_sent_at.nil?
+    reference.feedback_requested? && (reference.reminder_sent_at.nil? || reference.reminder_sent_at < 2.days.ago)
   end
 
   def can_request?

--- a/app/services/reference_actions_policy.rb
+++ b/app/services/reference_actions_policy.rb
@@ -16,7 +16,7 @@ class ReferenceActionsPolicy
   end
 
   def can_send_reminder?
-    reference.feedback_requested? && (reference.reminder_sent_at.nil? || reference.reminder_sent_at < 2.days.ago)
+    reference.feedback_requested? && (reference.reminder_sent_at.nil? || reference.reminder_sent_at < TimeLimitConfig.referee_chaser_limit.days.ago)
   end
 
   def can_request?

--- a/app/services/reference_actions_policy.rb
+++ b/app/services/reference_actions_policy.rb
@@ -16,7 +16,7 @@ class ReferenceActionsPolicy
   end
 
   def can_send_reminder?
-    reference.feedback_requested? && (reference.reminder_sent_at.nil? || reference.reminder_sent_at < TimeLimitConfig.minimum_time_between_chaser_emails.days.ago)
+    reference.feedback_requested? && (reference.reminder_sent_at.nil? || reference.reminder_sent_at < TimeLimitConfig.minimum_hours_between_chaser_emails.hours.ago)
   end
 
   def can_request?

--- a/app/workers/chase_references.rb
+++ b/app/workers/chase_references.rb
@@ -1,3 +1,6 @@
+# An email is sent to the candidate at 7 days, 14 days and 28 days
+# An email is sent to the referee at 7 days, 21 days and 28 days
+
 class ChaseReferences
   include Sidekiq::Worker
 

--- a/spec/services/reference_actions_policy_spec.rb
+++ b/spec/services/reference_actions_policy_spec.rb
@@ -21,13 +21,28 @@ RSpec.describe ReferenceActionsPolicy do
       expect(policy(reference).can_send_reminder?).to be true
     end
 
-    it 'is false when state is not feedback_requested' do
-      reference = build(:reference, :not_requested_yet, reminder_sent_at: nil)
+    it 'is true when state is feedback_requested and last reminder was sent 2 days ago' do
+      reference = build(:reference, :feedback_requested, reminder_sent_at: 2.days.ago)
+      expect(policy(reference).can_send_reminder?).to be true
+    end
+
+    it 'is true when state is feedback_requested and last reminder was sent 3 days ago' do
+      reference = build(:reference, :feedback_requested, reminder_sent_at: 3.days.ago)
+      expect(policy(reference).can_send_reminder?).to be true
+    end
+
+    it 'is false when state is feedback_requested and last reminder was sent now' do
+      reference = build(:reference, :feedback_requested, reminder_sent_at: Time.zone.now)
       expect(policy(reference).can_send_reminder?).to be false
     end
 
-    it 'is false when reminder_sent_at is filled' do
-      reference = build(:reference, :feedback_requested, reminder_sent_at: Time.zone.now)
+    it 'is false when state is feedback_requested and last reminder was sent 1 day ago' do
+      reference = build(:reference, :feedback_requested, reminder_sent_at: 1.day.ago)
+      expect(policy(reference).can_send_reminder?).to be false
+    end
+
+    it 'is false when state is not feedback_requested' do
+      reference = build(:reference, :not_requested_yet, reminder_sent_at: nil)
       expect(policy(reference).can_send_reminder?).to be false
     end
   end


### PR DESCRIPTION
## Context

- Allow further reminders to be sent if the last reminder was sent over 2 days ago.

- Add an automated reminder nudge to referee at 21 days.


## Link to Trello card

https://trello.com/c/RzQ5OPRa/4664-relax-limits-on-how-many-times-a-referee-can-be-reminded

