### PR TITLE
Add domicile to applications data export

### DIFF
--- a/app/decorators/application_choice_export_decorator.rb
+++ b/app/decorators/application_choice_export_decorator.rb
@@ -43,6 +43,14 @@ class ApplicationChoiceExportDecorator < SimpleDelegator
       .sort.partition { |e| %w[GB IE].include? e }.flatten
   end
 
+  def rejection_reasons
+    reasons = RejectedApplicationChoicePresenter.new(__getobj__).rejection_reasons
+    return if reasons.nil?
+
+    reasons = reasons.transform_values(&:compact)
+    reasons&.map { |k, v| %(#{k.upcase}\n\n#{Array(v).join("\n\n")}) }&.join("\n\n")
+  end
+
 private
 
   def gcse_explanation(gcse)

--- a/app/decorators/application_choice_export_decorator.rb
+++ b/app/decorators/application_choice_export_decorator.rb
@@ -51,6 +51,10 @@ class ApplicationChoiceExportDecorator < SimpleDelegator
     reasons&.map { |k, v| %(#{k.upcase}\n\n#{Array(v).join("\n\n")}) }&.join("\n\n")
   end
 
+  def domicile_country
+    DomicileResolver.country_for_hesa_code(application_form.domicile)
+  end
+
 private
 
   def gcse_explanation(gcse)

--- a/app/lib/domicile_resolver.rb
+++ b/app/lib/domicile_resolver.rb
@@ -1,27 +1,45 @@
 class DomicileResolver
-  def self.hesa_code_for_country(iso_country_code)
-    case iso_country_code
-    when nil then 'ZZ'
-    when 'AQ' then 'XX'
-    when 'CY' then 'XC'
-    when 'XK' then 'QO'
-    else
-      iso_country_code
+  class << self
+    def hesa_code_for_country(iso_country_code)
+      case iso_country_code
+      when nil then 'ZZ'
+      when 'AQ' then 'XX'
+      when 'CY' then 'XC'
+      when 'XK' then 'QO'
+      else
+        iso_country_code
+      end
     end
-  end
 
-  def self.hesa_code_for_postcode(uk_postcode)
-    prefix = uk_postcode.scan(/^[a-zA-Z]+/).first if uk_postcode.present?
+    def hesa_code_for_postcode(uk_postcode)
+      prefix = uk_postcode.scan(/^[a-zA-Z]+/).first if uk_postcode.present?
 
-    case prefix
-    when nil then 'ZZ'
-    when *POSTCODE_PREFIXES['England'] then 'XF'
-    when *POSTCODE_PREFIXES['Wales'] then 'XI'
-    when *POSTCODE_PREFIXES['Scotland'] then 'XH'
-    when *POSTCODE_PREFIXES['Northern Ireland'] then 'XG'
-    when *POSTCODE_PREFIXES['Channel Islands'] then 'XL'
-    else
-      'XK'
+      case prefix
+      when nil then 'ZZ'
+      when *POSTCODE_PREFIXES['England'] then 'XF'
+      when *POSTCODE_PREFIXES['Wales'] then 'XI'
+      when *POSTCODE_PREFIXES['Scotland'] then 'XH'
+      when *POSTCODE_PREFIXES['Northern Ireland'] then 'XG'
+      when *POSTCODE_PREFIXES['Channel Islands'] then 'XL'
+      else
+        'XK'
+      end
+    end
+
+    def country_for_hesa_code(hesa_code)
+      case hesa_code
+      when 'ZZ' then nil
+      when 'XX' then 'Antarctica'
+      when 'XC' then 'Cyprus'
+      when 'QO' then 'Kosovo'
+      when 'XF' then 'England'
+      when 'XI' then 'Wales'
+      when 'XH' then 'Scotland'
+      when 'XG' then 'Northern Ireland'
+      when 'XL' then 'Channel Islands'
+      else
+        COUNTRIES_AND_TERRITORIES[hesa_code]
+      end
     end
   end
 

--- a/app/lib/domicile_resolver.rb
+++ b/app/lib/domicile_resolver.rb
@@ -37,6 +37,7 @@ class DomicileResolver
       when 'XH' then 'Scotland'
       when 'XG' then 'Northern Ireland'
       when 'XL' then 'Channel Islands'
+      when 'XK' then 'United Kingdom'
       else
         COUNTRIES_AND_TERRITORIES[hesa_code]
       end

--- a/app/services/provider_interface/application_data_export.rb
+++ b/app/services/provider_interface/application_data_export.rb
@@ -56,7 +56,7 @@ module ProviderInterface
           'Recruited date' => application.recruited_at,
           'Rejected date' => application.rejected_at,
           'Was automatically rejected' => application.rejected_by_default ? 'TRUE' : 'FALSE',
-          'Rejection reasons' => rejection_reasons(application_choice),
+          'Rejection reasons' => application.rejection_reasons,
           'Candidate ID' => application.application_form.candidate.public_id,
           'Support reference' => application.application_form.support_reference,
         }
@@ -64,14 +64,6 @@ module ProviderInterface
 
       def replace_smart_quotes(text)
         text&.gsub(/(“|”)/, '"')&.gsub(/(‘|’)/, "'")
-      end
-
-      def rejection_reasons(application_choice)
-        reasons = RejectedApplicationChoicePresenter.new(application_choice).rejection_reasons
-        return if reasons.nil?
-
-        reasons = reasons.transform_values(&:compact)
-        reasons&.map { |k, v| %(#{k.upcase}\n\n#{Array(v).join("\n\n")}) }&.join("\n\n")
       end
     end
   end

--- a/app/services/provider_interface/application_data_export.rb
+++ b/app/services/provider_interface/application_data_export.rb
@@ -28,6 +28,7 @@ module ProviderInterface
           'Contact postcode' => application.application_form.postcode,
           'Contact country' => COUNTRIES_AND_TERRITORIES[application_choice.application_form.country],
           'Contact country code' => application_choice.application_form.country,
+          'Domicile' => application.domicile_country,
           'Domicile code' => application.application_form.domicile,
           'English is main language' => application.application_form.english_main_language.to_s.upcase,
           'English as a foreign language assessment details' => replace_smart_quotes(application.application_form.english_language_details),

--- a/spec/decorators/application_choice_export_decorator_spec.rb
+++ b/spec/decorators/application_choice_export_decorator_spec.rb
@@ -124,4 +124,33 @@ RSpec.describe ApplicationChoiceExportDecorator do
       expect(result).to eq(%w[GB IE US])
     end
   end
+
+  describe '.rejection_reasons' do
+    let(:application_choice) { create(:application_choice, :with_structured_rejection_reasons) }
+
+    it 'returns a list of rejection reasons' do
+      expected = ['SOMETHING YOU DID',
+                  'Didn’t reply to our interview offer',
+                  'Didn’t attend interview',
+                  'Persistent scratching',
+                  'Not scratch so much',
+                  'QUALITY OF APPLICATION',
+                  'Use a spellchecker',
+                  "Claiming to be the 'world's leading expert' seemed a bit strong",
+                  'Lights on but nobody home',
+                  'Study harder',
+                  'QUALIFICATIONS',
+                  'No English GCSE grade 4 (C) or above, or valid equivalent',
+                  'All the other stuff',
+                  'PERFORMANCE AT INTERVIEW',
+                  'Be fully dressed',
+                  'HONESTY AND PROFESSIONALISM',
+                  'Fake news',
+                  'Clearly not a popular student',
+                  'SAFEGUARDING ISSUES',
+                  'We need to run further checks']
+
+      expect(described_class.new(application_choice).rejection_reasons.split("\n\n")).to eq(expected)
+    end
+  end
 end

--- a/spec/lib/domicile_resolver_spec.rb
+++ b/spec/lib/domicile_resolver_spec.rb
@@ -1,13 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe DomicileResolver do
-  def hesa_code_for_country(iso_country_code)
-    DomicileResolver.hesa_code_for_country iso_country_code
-  end
-
-  def hesa_code_for_postcode(uk_postcode)
-    DomicileResolver.hesa_code_for_postcode uk_postcode
-  end
+  delegate :hesa_code_for_country, :hesa_code_for_postcode, to: :described_class
 
   it 'returns ZZ if it receives a nil argument' do
     expect(hesa_code_for_country(nil)).to eq('ZZ')
@@ -59,6 +53,29 @@ RSpec.describe DomicileResolver do
 
     it 'returns XK for postcode prefixes spanning two countries' do
       expect(hesa_code_for_postcode('HR1 2LX')).to eq('XK')
+    end
+  end
+
+  describe 'country_for_hesa_code' do
+    it 'returns nil for ZZ HESA code' do
+      expect(described_class.country_for_hesa_code('ZZ')).to be_nil
+    end
+
+    it 'returns countries for exceptional HESA codes' do
+      expect(described_class.country_for_hesa_code('XX')).to eq('Antarctica')
+      expect(described_class.country_for_hesa_code('XC')).to eq('Cyprus')
+      expect(described_class.country_for_hesa_code('XK')).to eq('Kosovo')
+      expect(described_class.country_for_hesa_code('XF')).to eq('England')
+      expect(described_class.country_for_hesa_code('XI')).to eq('Wales')
+      expect(described_class.country_for_hesa_code('XH')).to eq('Scotland')
+      expect(described_class.country_for_hesa_code('XG')).to eq('Northern Ireland')
+      expect(described_class.country_for_hesa_code('XL')).to eq('Channel Islands')
+    end
+
+    it 'returns countries for HESA codes which match ISO-3166-2 codes' do
+      COUNTRIES_AND_TERRITORIES.each do |iso_code, country_name|
+        expect(described_class.country_for_hesa_code(iso_code)).to eq(country_name)
+      end
     end
   end
 end

--- a/spec/lib/domicile_resolver_spec.rb
+++ b/spec/lib/domicile_resolver_spec.rb
@@ -64,16 +64,17 @@ RSpec.describe DomicileResolver do
     it 'returns countries for exceptional HESA codes' do
       expect(described_class.country_for_hesa_code('XX')).to eq('Antarctica')
       expect(described_class.country_for_hesa_code('XC')).to eq('Cyprus')
-      expect(described_class.country_for_hesa_code('XK')).to eq('Kosovo')
+      expect(described_class.country_for_hesa_code('QO')).to eq('Kosovo')
       expect(described_class.country_for_hesa_code('XF')).to eq('England')
       expect(described_class.country_for_hesa_code('XI')).to eq('Wales')
       expect(described_class.country_for_hesa_code('XH')).to eq('Scotland')
       expect(described_class.country_for_hesa_code('XG')).to eq('Northern Ireland')
       expect(described_class.country_for_hesa_code('XL')).to eq('Channel Islands')
+      expect(described_class.country_for_hesa_code('XK')).to eq('United Kingdom')
     end
 
     it 'returns countries for HESA codes which match ISO-3166-2 codes' do
-      COUNTRIES_AND_TERRITORIES.each do |iso_code, country_name|
+      COUNTRIES_AND_TERRITORIES.except(*%w[AQ CY XK]).each do |iso_code, country_name|
         expect(described_class.country_for_hesa_code(iso_code)).to eq(country_name)
       end
     end

--- a/spec/services/provider_interface/application_data_export_spec.rb
+++ b/spec/services/provider_interface/application_data_export_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe ProviderInterface::ApplicationDataExport do
         'Contact postcode' => application_choice.application_form.postcode,
         'Contact country' => 'United Kingdom',
         'Contact country code' => 'GB',
+        'Domicile' => DomicileResolver.country_for_hesa_code(application_choice.application_form.domicile),
         'Domicile code' => application_choice.application_form.domicile,
         'English is main language' => 'TRUE',
         'English as a foreign language assessment details' => application_choice.application_form.english_language_details,
@@ -94,7 +95,7 @@ RSpec.describe ProviderInterface::ApplicationDataExport do
         'Recruited date' => application_choice.recruited_at,
         'Rejected date' => application_choice.rejected_at,
         'Was automatically rejected' => 'FALSE',
-        'Rejection reasons' => described_class.rejection_reasons(application_choice),
+        'Rejection reasons' => ApplicationChoiceExportDecorator.new(application_choice).rejection_reasons,
         'Candidate ID' => application_choice.application_form.candidate.public_id,
         'Support reference' => application_choice.application_form.support_reference,
       }
@@ -108,35 +109,6 @@ RSpec.describe ProviderInterface::ApplicationDataExport do
   describe '.replace_smart_quotes' do
     it 'replaces smart quotes in text' do
       expect(described_class.replace_smart_quotes(%(“double-quote” ‘single-quote’))).to eq(%("double-quote" 'single-quote'))
-    end
-  end
-
-  describe '.rejection_reasons' do
-    let(:application_choice) { create(:application_choice, :with_structured_rejection_reasons) }
-
-    it 'returns a list of rejection reasons' do
-      expected = ['SOMETHING YOU DID',
-                  'Didn’t reply to our interview offer',
-                  'Didn’t attend interview',
-                  'Persistent scratching',
-                  'Not scratch so much',
-                  'QUALITY OF APPLICATION',
-                  'Use a spellchecker',
-                  "Claiming to be the 'world's leading expert' seemed a bit strong",
-                  'Lights on but nobody home',
-                  'Study harder',
-                  'QUALIFICATIONS',
-                  'No English GCSE grade 4 (C) or above, or valid equivalent',
-                  'All the other stuff',
-                  'PERFORMANCE AT INTERVIEW',
-                  'Be fully dressed',
-                  'HONESTY AND PROFESSIONALISM',
-                  'Fake news',
-                  'Clearly not a popular student',
-                  'SAFEGUARDING ISSUES',
-                  'We need to run further checks']
-
-      expect(described_class.rejection_reasons(application_choice).split("\n\n")).to eq(expected)
     end
   end
 end


### PR DESCRIPTION
## Context

The proposed changes to columns and headings in the applications data export includes the 'Domicile' country name.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Adds a way to derive country name from HESA domicile code.
- Exports domicile country name

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Rebased with https://github.com/DFE-Digital/apply-for-teacher-training/pull/6933 so the last 3 commits are actual changes for this PR. 
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/lnb26Gsh/5089-add-domicile-to-applications-data-export
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
