### PR TITLE
Deploy review apps for dependabot PRs

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -378,7 +378,7 @@ jobs:
   deploy-review-app:
     name: Deployment To Review
     concurrency: deploy_review_${{ github.event.pull_request.number }}
-    if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy') }}
+    if: ${{ github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'deploy') || contains(github.event.pull_request.labels.*.name, 'dependencies')) }}
     environment:
       name: review
     needs: [build]

--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -9,7 +9,7 @@ jobs:
   delete-review-app:
     name: Delete Review App ${{ github.event.pull_request.number }}
     concurrency: deploy_review_${{ github.event.pull_request.number }}
-    if: contains(github.event.pull_request.labels.*.name, 'deploy')
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'deploy') || contains(github.event.pull_request.labels.*.name, 'dependencies')) }}
     runs-on: ubuntu-latest
     environment: review
     steps:


### PR DESCRIPTION
## Context
To support automatic merging of dependabot PRs we need to deploy review apps for these PRs.

## Changes proposed in this pull request
This change deploys review apps for PRs with the dependencies label.  The required secrets have been added separately to the Dependabot context.

## Guidance to review

As dependabot PRs are created from the main branch it won't be possible to test this change until after it's been merged to main.

## Link to Trello card

https://trello.com/c/k1Ub6gI1

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
