### PR TITLE
Switch back to main branch of rspec-retry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -161,7 +161,7 @@ group :test do
   gem 'deepsort'
   gem 'ruby-jmeter'
   gem 'super_diff'
-  gem 'rspec-retry', git: 'https://github.com/DFE-Digital/rspec-retry.git', branch: 'write-json-to-flakey-spec-log'
+  gem 'rspec-retry', git: 'https://github.com/DFE-Digital/rspec-retry.git', branch: 'main'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,8 +20,8 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/rspec-retry.git
-  revision: b802e070a2c57cad452e1093f7d4788f9d43b21c
-  branch: write-json-to-flakey-spec-log
+  revision: 79a15ea3974093482557b145a2bba36fddd68aa8
+  branch: main
   specs:
     rspec-retry (0.6.2)
       rspec-core (> 3.3)


### PR DESCRIPTION

## Context

[Exporting flakey spec data as JSON has been merged into main branch upstream](https://github.com/DFE-Digital/rspec-retry/pull/15/files/d4da8853e8396703f114252afb3dda43a6c44de3).

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Point to rspec-retry main branch again.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/y6EYtsni/78-export-flakey-spec-log-as-json
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
