### PR TITLE
Format GCSE qualification summaries in exports

### DIFF
--- a/app/decorators/application_choice_export_decorator.rb
+++ b/app/decorators/application_choice_export_decorator.rb
@@ -58,14 +58,23 @@ private
 
     qualification = ApplicationQualificationDecorator.new(gcse)
     qualification_type = formatted_qualification_type(qualification.qualification_type)
-    if qualification.start_year.present?
-      "#{qualification_type} #{qualification.subject.capitalize}, #{qualification.grade_details.join(' ')}, #{qualification.start_year}-#{qualification.award_year}"
-    else
-      "#{qualification_type} #{qualification.subject.capitalize}, #{qualification.grade_details.join(' ')}, #{qualification.award_year}"
-    end
+    qualification_subject = formatted_qualification_subject(qualification.subject)
+
+    "#{qualification_type} #{qualification_subject}, #{qualification.grade_details.join(' ')}, #{qualification_period(qualification)}"
   end
 
   def formatted_qualification_type(qualification_type)
-    qualification_type.humanize.sub('Gcse', 'GCSE')
+    substitutions = { 'Gcse' => 'GCSE', 'Gce o' => 'O', 'Uk' => 'UK', 'uk' => 'UK' }
+    qualification_type.humanize.gsub(/(Gcse|Gce o|Uk|uk)/, substitutions)
+  end
+
+  def formatted_qualification_subject(subject)
+    return 'English' if subject == 'english'
+
+    subject
+  end
+
+  def qualification_period(qualification)
+    [qualification.start_year, qualification.award_year].compact.join('-')
   end
 end

--- a/app/decorators/application_choice_export_decorator.rb
+++ b/app/decorators/application_choice_export_decorator.rb
@@ -64,8 +64,8 @@ private
   end
 
   def formatted_qualification_type(qualification_type)
-    substitutions = { 'Gcse' => 'GCSE', 'Gce o' => 'O', 'Uk' => 'UK', 'uk' => 'UK' }
-    qualification_type.humanize.gsub(/(Gcse|Gce o|Uk|uk)/, substitutions)
+    substitutions = { 'Gcse' => 'GCSE', 'Gce o' => 'O', 'Non uk' => 'Non-UK', 'Other uk' => 'Other UK' }
+    qualification_type.humanize.gsub(/(Gcse|Gce o|Non uk|Other uk)/, substitutions)
   end
 
   def formatted_qualification_subject(subject)

--- a/app/decorators/application_qualification_decorator.rb
+++ b/app/decorators/application_qualification_decorator.rb
@@ -1,10 +1,10 @@
 class ApplicationQualificationDecorator < SimpleDelegator
   attr_reader :qualification
 
-  ENGLISH_AWARDS = { english_single_award: 'English Single award',
-                     english_double_award: 'English Double award',
-                     english_studies_single_award: 'English Studies Single award',
-                     english_studies_double_award: 'English Studies Double award' }.freeze
+  ENGLISH_AWARDS = { english_single_award: 'English single award',
+                     english_double_award: 'English souble award',
+                     english_studies_single_award: 'English Studies single award',
+                     english_studies_double_award: 'English Studies double award' }.freeze
 
   def initialize(qualification)
     @qualification = qualification
@@ -16,14 +16,14 @@ class ApplicationQualificationDecorator < SimpleDelegator
     when ApplicationQualification::SCIENCE_TRIPLE_AWARD
       grades = qualification.constituent_grades
       [
-        "#{grades['biology']['grade']} (Biology)",
-        "#{grades['chemistry']['grade']} (Chemistry)",
-        "#{grades['physics']['grade']} (Physics)",
+        "#{grades['biology']['grade']} (biology)",
+        "#{grades['chemistry']['grade']} (chemistry)",
+        "#{grades['physics']['grade']} (physics)",
       ]
     when ApplicationQualification::SCIENCE_DOUBLE_AWARD
-      ["#{qualification.grade} (Double award)"]
+      ["#{qualification.grade} (double award)"]
     when ApplicationQualification::SCIENCE_SINGLE_AWARD
-      ["#{qualification.grade} (Single award)"]
+      ["#{qualification.grade} (single award)"]
     when ->(_n) { qualification.constituent_grades }
       present_constituent_grades
     else
@@ -38,7 +38,7 @@ private
     grades.map do |award, details|
       return "#{details['grade']} (#{ENGLISH_AWARDS[award]})" if ENGLISH_AWARDS.include?(award)
 
-      "#{details['grade']} (#{award.humanize.titleize})"
+      "#{details['grade']} (#{award.humanize(capitalize: false).sub('english', 'English')})"
     end
   end
 end

--- a/app/decorators/application_qualification_decorator.rb
+++ b/app/decorators/application_qualification_decorator.rb
@@ -2,7 +2,7 @@ class ApplicationQualificationDecorator < SimpleDelegator
   attr_reader :qualification
 
   ENGLISH_AWARDS = { english_single_award: 'English single award',
-                     english_double_award: 'English souble award',
+                     english_double_award: 'English double award',
                      english_studies_single_award: 'English Studies single award',
                      english_studies_double_award: 'English Studies double award' }.freeze
 

--- a/spec/components/utility/gcse_qualification_cards_component_spec.rb
+++ b/spec/components/utility/gcse_qualification_cards_component_spec.rb
@@ -192,9 +192,9 @@ RSpec.describe GcseQualificationCardsComponent, type: :component do
 
       card = result.css('.app-card--outline')
 
-      expect(card.text).to include 'E (English Language)'
-      expect(card.text).to include 'E (English Literature)'
-      expect(card.text).to include 'A* (Cockney Rhyming Slang)'
+      expect(card.text).to include 'E (English language)'
+      expect(card.text).to include 'E (English literature)'
+      expect(card.text).to include 'A* (cockney rhyming slang)'
     end
   end
 
@@ -219,9 +219,9 @@ RSpec.describe GcseQualificationCardsComponent, type: :component do
 
       card = result.css('.app-card--outline')
 
-      expect(card.text).to include 'A (Biology)'
-      expect(card.text).to include 'B (Chemistry)'
-      expect(card.text).to include 'C (Physics)'
+      expect(card.text).to include 'A (biology)'
+      expect(card.text).to include 'B (chemistry)'
+      expect(card.text).to include 'C (physics)'
     end
   end
 end

--- a/spec/decorators/application_choice_export_decorator_spec.rb
+++ b/spec/decorators/application_choice_export_decorator_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ApplicationChoiceExportDecorator do
 
       summary = described_class.new(application_choice).gcse_qualifications_summary
 
-      expect(summary).to match('GCSE Maths, A, 2000; GCSE English, B (English Language) C (English Literature), 2000; GCSE Science double award, AB (Double award), 2000')
+      expect(summary).to match('GCSE maths, A, 2000; GCSE English, B (English Language) C (English Literature), 2000; GCSE science double award, AB (Double award), 2000')
     end
 
     it 'returns the GCSE start year if present' do
@@ -21,7 +21,7 @@ RSpec.describe ApplicationChoiceExportDecorator do
 
       summary = described_class.new(application_choice).gcse_qualifications_summary
 
-      expect(summary).to match(/^GCSE Maths, [ABCD], \d{4}-\d{4}$/)
+      expect(summary).to match(/^GCSE maths, [ABCD], \d{4}-\d{4}$/)
     end
 
     it 'does not include GCSEs in other subjects' do
@@ -42,7 +42,7 @@ RSpec.describe ApplicationChoiceExportDecorator do
 
       summary = described_class.new(application_choice).gcse_qualifications_summary
 
-      expect(summary).to include('Gce o level Maths', o_level.grade)
+      expect(summary).to include('O level maths', o_level.grade)
     end
 
     it 'returns nil if a form has no relevant GCSEs' do

--- a/spec/decorators/application_choice_export_decorator_spec.rb
+++ b/spec/decorators/application_choice_export_decorator_spec.rb
@@ -53,6 +53,31 @@ RSpec.describe ApplicationChoiceExportDecorator do
 
       expect(summary).to be_nil
     end
+
+    it 'formats default qualification types' do
+      application_form = create(:application_form)
+      application_choice = create(:application_choice, application_form: application_form)
+      create(
+        :gcse_qualification,
+        qualification_type: 'non_uk',
+        grade: 'A',
+        subject: 'maths',
+        award_year: 2014,
+        application_form: application_form,
+      )
+      create(
+        :gcse_qualification,
+        qualification_type: 'other_uk',
+        grade: 'B',
+        subject: 'english',
+        application_form: application_form,
+        award_year: 2014,
+      )
+
+      summary = described_class.new(application_choice).gcse_qualifications_summary
+
+      expect(summary).to eq('Non-UK maths, A, 2014; Other UK English, B, 2014')
+    end
   end
 
   describe 'missing_gcses_explanation' do

--- a/spec/decorators/application_choice_export_decorator_spec.rb
+++ b/spec/decorators/application_choice_export_decorator_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ApplicationChoiceExportDecorator do
 
       summary = described_class.new(application_choice).gcse_qualifications_summary
 
-      expect(summary).to match('GCSE maths, A, 2000; GCSE English, B (English Language) C (English Literature), 2000; GCSE science double award, AB (Double award), 2000')
+      expect(summary).to match('GCSE maths, A, 2000; GCSE English, B (English language) C (English literature), 2000; GCSE science double award, AB (double award), 2000')
     end
 
     it 'returns the GCSE start year if present' do

--- a/spec/decorators/application_qualification_decorator_spec.rb
+++ b/spec/decorators/application_qualification_decorator_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe ApplicationQualificationDecorator do
       it 'renders grades for multiple English GCSEs' do
         grade_details = described_class.new(application_qualification).grade_details
 
-        expect(grade_details).to include 'E (English Language)'
-        expect(grade_details).to include 'E (English Literature)'
-        expect(grade_details).to include 'A* (Cockney Rhyming Slang)'
+        expect(grade_details).to include 'E (English language)'
+        expect(grade_details).to include 'E (English literature)'
+        expect(grade_details).to include 'A* (cockney rhyming slang)'
       end
     end
 
@@ -32,9 +32,9 @@ RSpec.describe ApplicationQualificationDecorator do
       it 'renders grades for multiple English GCSEs' do
         grade_details = described_class.new(application_qualification).grade_details
 
-        expect(grade_details).to include 'A (Biology)'
-        expect(grade_details).to include 'B (Chemistry)'
-        expect(grade_details).to include 'C (Physics)'
+        expect(grade_details).to include 'A (biology)'
+        expect(grade_details).to include 'B (chemistry)'
+        expect(grade_details).to include 'C (physics)'
       end
     end
   end

--- a/spec/services/provider_interface/application_data_export_spec.rb
+++ b/spec/services/provider_interface/application_data_export_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe ProviderInterface::ApplicationDataExport do
         'Institution of degree' => first_degree&.institution_name,
         'Type of international degree' => first_degree&.non_uk_qualification_type,
         'Equivalency details for international degree' => first_degree&.composite_equivalency_details,
-        'GCSEs' => 'GCSE Maths, B, 2019; GCSE English, A, 2019',
+        'GCSEs' => 'GCSE maths, B, 2019; GCSE English, A, 2019',
         'Explanation for missing GCSEs' => nil,
         'Offered at' => application_choice.offered_at,
         'Recruited date' => application_choice.recruited_at,


### PR DESCRIPTION
## Context

Some GCSE summary values are in incorrect case eg. `Gce o level`

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Don't capitalise subject unless it's `English`
- Substitute values like `Gce o level` for `O level`
- Capitalise where necessary eg. `UK`
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/yKkD2B8Q/196-data-exports-format-gcse-qualification-summaries
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
