### PR TITLE
Allow data exports to handle `nil` email addresses

### DIFF
--- a/app/services/support_interface/provider_access_controls_stats.rb
+++ b/app/services/support_interface/provider_access_controls_stats.rb
@@ -27,7 +27,8 @@ module SupportInterface
 
     def user_permissions_changed_by
       user_permissions_audits
-        .map { |audit| audit.user.email_address }
+        .map { |audit| audit.user&.email_address }
+        .compact
         .uniq
         .sort
     end

--- a/app/services/support_interface/who_ran_which_export_export.rb
+++ b/app/services/support_interface/who_ran_which_export_export.rb
@@ -10,7 +10,7 @@ module SupportInterface
         {
           export_type: export.export_type,
           created_at: export.created_at,
-          initiated_by: export.initiator.email_address,
+          initiated_by: export.initiator&.email_address,
         }
       end
     end

--- a/spec/services/support_interface/provider_access_controls_stats_spec.rb
+++ b/spec/services/support_interface/provider_access_controls_stats_spec.rb
@@ -166,6 +166,20 @@ RSpec.describe SupportInterface::ProviderAccessControlsStats, with_audited: true
 
       expect(access_controls.user_permissions_changed_by).to eq []
     end
+
+    it 'ignores changes if provider user has been deleted' do
+      provider = create(:provider)
+      provider_user = create(:provider_user, providers: [provider])
+
+      Audited.audit_class.as_user(provider_user) do
+        provider_user.provider_permissions.last.update!(view_diversity_information: true)
+      end
+
+      provider_user.delete
+      access_controls = described_class.new(provider)
+
+      expect(access_controls.user_permissions_changed_by).to be_empty
+    end
   end
 
   describe '#total_manage_users_users' do

--- a/spec/services/support_interface/who_ran_which_export_export_spec.rb
+++ b/spec/services/support_interface/who_ran_which_export_export_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe SupportInterface::WhoRanWhichExportExport do
       latest_provider_user_export = create(:data_export, initiator: support_user2)
       earliest_provider_user_export = create(:data_export, initiator: support_user1, created_at: 3.days.ago)
       work_history_export = create(:data_export, initiator: support_user1, created_at: 1.day.ago, export_type: 'work_history_break', name: 'Work history break')
+      tad_report = create(:data_export, initiator: nil, export_type: 'tad_applications')
 
       expect(described_class.new.data_for_export).to contain_exactly(
         {
@@ -33,6 +34,11 @@ RSpec.describe SupportInterface::WhoRanWhichExportExport do
           export_type: work_history_export.export_type,
           created_at: work_history_export.created_at,
           initiated_by: support_user1.email_address,
+        },
+        {
+          export_type: tad_report.export_type,
+          created_at: tad_report.created_at,
+          initiated_by: nil,
         },
       )
     end


### PR DESCRIPTION
## Context

Sentry errors have been raised when downloading the following exports:
`ProviderAccessControlsStats` and `WhoRanWhichExportExport`.

https://sentry.io/organizations/dfe-teacher-services/issues/3283541149/?environment=production&project=1765973&query=is%3Aunresolved

https://sentry.io/organizations/dfe-teacher-services/issues/3283562742/?environment=production&project=1765973&query=is%3Aunresolved

## Changes proposed in this pull request

Amend both exports to handle no email addresses.
`ProviderAccessControlsStats` needs to handle provider users that have been deleted

`WhoRanWhichExportExport` needs to handle `nil` initiators for tad exports

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/LqUwt7SK/207-amend

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
