### PR TITLE
Remove condition validation when updating met conditions

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -11,10 +11,6 @@ class Offer < ApplicationRecord
     conditions.none?
   end
 
-  def non_pending_conditions?
-    conditions.not_pending.any?
-  end
-
   def conditions_text
     conditions.pluck(:text)
   end

--- a/app/services/save_offer_conditions_from_params.rb
+++ b/app/services/save_offer_conditions_from_params.rb
@@ -11,8 +11,6 @@ class SaveOfferConditionsFromParams
     ActiveRecord::Base.transaction do
       @offer = Offer.find_or_create_by(application_choice: application_choice)
 
-      raise ValidationException, 'Cannot edit conditions of offer when they are not all pending' if @offer.non_pending_conditions?
-
       serialize_standard_conditions
       serialize_further_conditions
     end

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -36,26 +36,6 @@ RSpec.describe Offer do
     end
   end
 
-  describe '#non_pending_conditions?' do
-    it 'returns false when there are no conditions' do
-      offer = create(:unconditional_offer)
-
-      expect(offer.non_pending_conditions?).to be false
-    end
-
-    it 'returns false if all conditions are pending' do
-      offer = create(:offer, conditions: [build(:offer_condition), build(:offer_condition)])
-
-      expect(offer.non_pending_conditions?).to be false
-    end
-
-    it 'returns true if there is a non-pending condition' do
-      offer = create(:offer, conditions: [build(:offer_condition, status: :met), build(:offer_condition)])
-
-      expect(offer.non_pending_conditions?).to be true
-    end
-  end
-
   context 'delegators' do
     let(:offer) { create(:offer, course_option: create(:course_option)) }
 

--- a/spec/services/save_offer_conditions_from_params_spec.rb
+++ b/spec/services/save_offer_conditions_from_params_spec.rb
@@ -44,19 +44,6 @@ RSpec.describe SaveOfferConditionsFromParams do
       end
     end
 
-    context 'when there is an existing offer with non-pending conditions' do
-      let!(:application_choice) { create(:application_choice, :with_offer, offer: offer) }
-      let(:offer) do
-        build(:offer, conditions: [build(:offer_condition, text: OfferCondition::STANDARD_CONDITIONS.first, status: :met),
-                                   build(:offer_condition, text: 'Red hair')])
-      end
-
-      it 'raises a validation error' do
-        expect { service.save }.to raise_error(ValidationException)
-                                     .and change(offer.conditions, :count).by(0)
-      end
-    end
-
     context 'when we have standard and further conditions' do
       context 'when we make changes to further conditions' do
         let!(:application_choice) { create(:application_choice, :with_offer, offer: offer) }

--- a/spec/system/support_interface/change_offer_conditions_spec.rb
+++ b/spec/system/support_interface/change_offer_conditions_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature 'Add course to submitted application' do
         candidate: candidate,
       )
 
-      conditions = [build(:offer_condition, text: 'Be cool')]
+      conditions = [build(:offer_condition, text: 'Be cool', status: 'met')]
       @application_choice = create(
         :application_choice,
         :with_offer,


### PR DESCRIPTION
## Context

We recently amended the conditions change link in the support interface to only appear when an application is in a conditions pending state, and removed the need for all conditions to still be pending. This caused an error to be raised when updating conditions due to a validation being in place added here: https://github.com/DFE-Digital/apply-for-teacher-training/pull/4965/files

We do want to allow editing conditions even if some are met as we get consent from providers and candidates

## Changes proposed in this pull request

Remove the validation in place as it was only added for the purpose of the support tool
https://trello.com/c/pzCQobQX/2070-support-interface-do-not-allow-editing-of-non-pending-conditions

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/7HOGUM5I/208-remove-condition-validation-when-updating-met-conditions

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
