### PR TITLE
Ignore deleted provider user emails in exports

### DIFF
--- a/app/services/support_interface/provider_access_controls_stats.rb
+++ b/app/services/support_interface/provider_access_controls_stats.rb
@@ -167,7 +167,8 @@ module SupportInterface
 
     def provider_user_emails_who_made(permission_change)
       send("audits_for_#{permission_change}")
-        .map { |audit| audit.user.email_address }
+        .map { |audit| audit.user&.email_address }
+        .compact
         .uniq
         .sort
     end


### PR DESCRIPTION
## Context

Exports failed again due to another column looking at emails for deleted provider users. Protect against

## Changes proposed in this pull request

Guard against deleted provider users in export 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
