### PR TITLE
Add created_at and updated_at to References in Candidate API v1.2

### DIFF
--- a/app/services/candidate_api/serializers/v1_2.rb
+++ b/app/services/candidate_api/serializers/v1_2.rb
@@ -54,6 +54,8 @@ module CandidateAPI
                 requested_at: reference.requested_at&.iso8601,
                 feedback_status: reference.feedback_status,
                 referee_type: reference.referee_type,
+                created_at: reference.created_at.iso8601,
+                updated_at: reference.updated_at.iso8601,
               }
             end,
         }

--- a/config/candidate_api/v1.1.yml
+++ b/config/candidate_api/v1.1.yml
@@ -73,6 +73,7 @@ components:
   schemas:
     CandidateList:
       type: object
+      additionalProperties: false
       required:
       - data
       properties:
@@ -82,6 +83,7 @@ components:
             "$ref": "#/components/schemas/Candidate"
     Candidate:
       type: object
+      additionalProperties: false
       required:
         - id
         - type
@@ -99,6 +101,7 @@ components:
           "$ref": "#/components/schemas/CandidateAttributes"
     CandidateAttributes:
       type: object
+      additionalProperties: false
       required:
         - email_address
         - created_at
@@ -125,6 +128,7 @@ components:
             "$ref": "#/components/schemas/ApplicationForm"
     ApplicationForm:
       type: object
+      additionalProperties: false
       required:
         - id
         - created_at
@@ -184,6 +188,7 @@ components:
           example: 2021-05-20T12:34:00Z
     UnauthorizedResponse:
       type: object
+      additionalProperties: false
       required:
       - errors
       properties:
@@ -198,6 +203,7 @@ components:
             message: Please provide a valid authentication token
     ParameterMissingResponse:
       type: object
+      additionalProperties: false
       required:
       - errors
       properties:
@@ -212,6 +218,7 @@ components:
             message: "param is missing or the value is empty: updated_since"
     ParameterInvalidResponse:
       type: object
+      additionalProperties: false
       required:
       - errors
       properties:
@@ -226,6 +233,7 @@ components:
             message: "Parameter is invalid: updated_since"
     PageParameterInvalidResponse:
       type: object
+      additionalProperties: false
       required:
         - errors
       properties:
@@ -240,6 +248,7 @@ components:
             message: "expected 'page' parameter to be between 1 and 1, got 2"
     PerPageParameterInvalidResponse:
       type: object
+      additionalProperties: false
       required:
         - errors
       properties:
@@ -254,6 +263,7 @@ components:
             message: "the 'per_page' parameter cannot exceed 500 results per page"
     Error:
       type: object
+      additionalProperties: false
       additionalProperties: false
       properties:
         error:

--- a/config/candidate_api/v1.2.yml
+++ b/config/candidate_api/v1.2.yml
@@ -73,6 +73,7 @@ components:
   schemas:
     CandidateList:
       type: object
+      additionalProperties: false
       required:
       - data
       properties:
@@ -82,6 +83,7 @@ components:
             "$ref": "#/components/schemas/Candidate"
     Candidate:
       type: object
+      additionalProperties: false
       required:
         - id
         - type
@@ -99,6 +101,7 @@ components:
           "$ref": "#/components/schemas/CandidateAttributes"
     CandidateAttributes:
       type: object
+      additionalProperties: false
       required:
         - email_address
         - created_at
@@ -125,6 +128,7 @@ components:
             "$ref": "#/components/schemas/ApplicationForm"
     ApplicationForm:
       type: object
+      additionalProperties: false
       required:
         - id
         - created_at
@@ -192,6 +196,7 @@ components:
           "$ref": "#/components/schemas/PersonalStatement"
     ApplicationChoices:
       type: object
+      additionalProperties: false
       description: The course choices that the candidate has selected and their completion status
       required:
         - completed
@@ -208,6 +213,7 @@ components:
           description: The collection of course choices that the candidate has selected
     ApplicationChoice:
       type: object
+      additionalProperties: false
       required:
         - id
         - created_at
@@ -259,6 +265,7 @@ components:
             "$ref": "#/components/schemas/Interview"
     Course:
       type: object
+      additionalProperties: false
       required:
         - uuid
         - name
@@ -273,6 +280,7 @@ components:
           example: Mathematics
     Provider:
       type: object
+      additionalProperties: false
       required:
         - name
       properties:
@@ -282,6 +290,7 @@ components:
           example: University of West Anglia
     Interview:
       type: object
+      additionalProperties: false
       required:
         - id
         - created_at
@@ -314,6 +323,7 @@ components:
           example: 2021-05-20T12:34:00Z
     References:
       type: object
+      additionalProperties: false
       description: The reference requests that the candidate has entered and their completion status
       required:
         - completed
@@ -330,6 +340,7 @@ components:
           description: The collection of reference requests that the candidate has entered
     Reference:
       type: object
+      additionalProperties: false
       required:
         - id
         - feedback_status
@@ -366,6 +377,7 @@ components:
           example: academic
     Qualifications:
       type: object
+      additionalProperties: false
       description: The completion status of the qualifications section
       required:
         - completed
@@ -376,6 +388,7 @@ components:
           example: true
     PersonalStatement:
       type: object
+      additionalProperties: false
       description: completion status of the personal statement section
       required:
         - completed
@@ -386,6 +399,7 @@ components:
           example: true
     UnauthorizedResponse:
       type: object
+      additionalProperties: false
       required:
       - errors
       properties:
@@ -400,6 +414,7 @@ components:
             message: Please provide a valid authentication token
     ParameterMissingResponse:
       type: object
+      additionalProperties: false
       required:
       - errors
       properties:
@@ -414,6 +429,7 @@ components:
             message: "param is missing or the value is empty: updated_since"
     ParameterInvalidResponse:
       type: object
+      additionalProperties: false
       required:
       - errors
       properties:
@@ -428,6 +444,7 @@ components:
             message: "Parameter is invalid: updated_since"
     PageParameterInvalidResponse:
       type: object
+      additionalProperties: false
       required:
         - errors
       properties:
@@ -442,6 +459,7 @@ components:
             message: "expected 'page' parameter to be between 1 and 1, got 2"
     PerPageParameterInvalidResponse:
       type: object
+      additionalProperties: false
       required:
         - errors
       properties:

--- a/config/candidate_api/v1.2.yml
+++ b/config/candidate_api/v1.2.yml
@@ -345,11 +345,23 @@ components:
         - id
         - feedback_status
         - referee_type
+        - created_at
+        - updated_at
       properties:
         id:
           type: integer
           description: The unique ID of the reference
           example: 10
+        created_at:
+          type: string
+          format: date-time
+          description: The date and time the reference was created
+          example: 2021-05-20T12:34:00Z
+        updated_at:
+          type: string
+          format: date-time
+          description: The date and time the reference was last updated
+          example: 2021-05-20T12:34:00Z
         requested_at:
           type: string
           format: date-time

--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -182,6 +182,7 @@ FactoryBot.define do
       becoming_a_teacher_completed { true }
       subject_knowledge_completed { true }
       interview_preferences_completed { true }
+      references_completed { true }
 
       transient do
         application_choices_count { 0 }

--- a/spec/requests/candidate_api/get_candidates_v1_1_spec.rb
+++ b/spec/requests/candidate_api/get_candidates_v1_1_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'GET /candidate-api/candidates', type: :request do
   include CandidateAPISpecHelper
 
   it_behaves_like 'an API endpoint requiring a date param', '/candidate-api/candidates', 'updated_since', ServiceAPIUser.candidate_user.create_magic_link_token!
-  it_behaves_like 'a candidate API endpoint', '/candidate-api/candidates', 'updated_since'
+  it_behaves_like 'a candidate API endpoint', '/candidate-api/candidates', 'updated_since', 'v1.1'
 
   it 'returns applications ordered by created_at timestamp' do
     allow(ProcessState).to receive(:new).and_return(instance_double(ProcessState, state: :unsubmitted_not_started_form))

--- a/spec/requests/candidate_api/get_candidates_v1_2_spec.rb
+++ b/spec/requests/candidate_api/get_candidates_v1_2_spec.rb
@@ -67,6 +67,8 @@ RSpec.describe 'GET /candidate-api/v1.2/candidates', type: :request do
         requested_at: first_reference.requested_at.iso8601,
         feedback_status: first_reference.feedback_status,
         referee_type: first_reference.referee_type,
+        created_at: first_reference.created_at.iso8601,
+        updated_at: first_reference.updated_at.iso8601,
       },
     )
 

--- a/spec/requests/candidate_api/get_candidates_v1_2_spec.rb
+++ b/spec/requests/candidate_api/get_candidates_v1_2_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'GET /candidate-api/v1.2/candidates', type: :request do
   let(:root_path) { '/candidate-api/v1.2/candidates' }
 
   it_behaves_like 'an API endpoint requiring a date param', '/candidate-api/v1.2/candidates', 'updated_since', ServiceAPIUser.candidate_user.create_magic_link_token!
-  it_behaves_like 'a candidate API endpoint', '/candidate-api/v1.2/candidates', 'updated_since'
+  it_behaves_like 'a candidate API endpoint', '/candidate-api/v1.2/candidates', 'updated_since', 'v1.2'
 
   it 'returns applications ordered by created_at timestamp' do
     allow(ProcessState).to receive(:new).and_return(instance_double(ProcessState, state: :unsubmitted_not_started_form))

--- a/spec/support/candidate_api/candidate_api_spec_helper.rb
+++ b/spec/support/candidate_api/candidate_api_spec_helper.rb
@@ -21,7 +21,8 @@ module CandidateAPISpecHelper
     parsed_response['errors'].first
   end
 
-  def be_valid_against_openapi_schema(expected)
-    ValidAgainstOpenAPISchemaMatcher.new(expected, CandidateAPISpecification.as_hash)
+  def be_valid_against_openapi_schema(expected, version = nil)
+    version ||= CandidateAPISpecification::CURRENT_VERSION
+    ValidAgainstOpenAPISchemaMatcher.new(expected, CandidateAPISpecification.as_hash(version))
   end
 end


### PR DESCRIPTION
## Context

Following discussion with GIT CRM team, who would like to know more about references over the API.

## Changes proposed in this pull request

We weren't validating API versions against the schema, so 

- add `additionalProperties: false` to all Candidate API schemas so specs fail if documentation diverges from implementation
- let specs specify which version to validate against
- see specs fail when you change a field without changing the docs (or vice versa) 🎉 

then

- add the new fields

I had to fix a factory too, because we were returning an unrealistic `nil` for a field which would have had to be true for the application to be submitted (`references_completed`) — above spec caught this.

## Guidance to review

Commit by commit

## Things to check

- [X] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
