### PR TITLE
Depend on v0.1.0 of dfe-reference-data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -121,7 +121,7 @@ gem 'archive-zip'
 # Geocoding
 gem 'geocoder'
 
-gem 'dfe-reference-data', require: 'dfe/reference_data', github: 'DFE-Digital/dfe-reference-data', branch: 'main'
+gem 'dfe-reference-data', require: 'dfe/reference_data', github: 'DFE-Digital/dfe-reference-data', tag: 'v0.1.0'
 gem 'dfe-autocomplete', require: 'dfe/autocomplete', github: 'DFE-Digital/dfe-autocomplete', branch: 'main'
 
 gem 'strip_attributes'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,8 +12,8 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/dfe-reference-data.git
-  revision: d5c6283b8653a792c1e0a3424018a4ca9cad443a
-  branch: main
+  revision: bff087e5208c75811619cb65f80633272e792d7f
+  tag: v0.1.0
   specs:
     dfe-reference-data (0.1.0)
       activesupport


### PR DESCRIPTION
## Context

We were depending on `main` so potentially different environments could run different versions depending on when they pulled 🤪 

## Changes proposed in this pull request

Depend on freshly-tagged `v0.1.0` — see https://github.com/DFE-Digital/dfe-reference-data/pull/11

## Guidance to review

tbh I have no idea what the sha in the `Gemfile.lock` refers to. It's not in the repo either locally or in GitHub. The gem is still installed — `bundle open` works etc, and the local copy _is_ at the same SHA as the tag. Probably of academic interest only... still, any ideas?

## Things to check

- [X] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
