### PR TITLE
Backfill international subject UUIDS

### DIFF
--- a/app/forms/candidate_interface/degree_wizard.rb
+++ b/app/forms/candidate_interface/degree_wizard.rb
@@ -267,6 +267,7 @@ module CandidateInterface
           qualification_type: international_type,
           institution_name: university,
           subject: subject,
+          degree_subject_uuid: degree_subject_uuid,
           predicted_grade: predicted_grade,
           grade: other_grade || map_value_for_no_submitted_international_grade(grade),
           start_year: start_year,

--- a/app/services/data_migrations/backfill_international_degrees_subjects_uuid.rb
+++ b/app/services/data_migrations/backfill_international_degrees_subjects_uuid.rb
@@ -1,0 +1,41 @@
+module DataMigrations
+  class BackfillInternationalDegreesSubjectsUuid
+    TIMESTAMP = 20220519142519
+    MANUAL_RUN = false
+    AFTER_NEW_DEGREE_FLOW_RELEASE = '2022-05-04T13:51:00Z'.freeze
+
+    def change
+      records.find_each do |qualification|
+        subject = subject_for(qualification)
+
+        if subject.present?
+          qualification.update_columns(
+            degree_subject_uuid: subject.id,
+          )
+        end
+      end
+    end
+
+    def dry_run
+      total = records.select do |record|
+        subject_for(record).present?
+      end
+
+      # rubocop:disable Rails/Output
+      puts "There are #{total.size} international records with subject in the reference data"
+      # rubocop:enable Rails/Output
+    end
+
+  private
+
+    def records
+      ApplicationQualification.degree
+      .where.not(institution_country: nil)
+      .where('created_at > ?', AFTER_NEW_DEGREE_FLOW_RELEASE)
+    end
+
+    def subject_for(qualification)
+      Hesa::Subject.find_by_name(qualification.subject)
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillInternationalDegreesSubjectsUuid',
   'DataMigrations::DeleteRetiredNudgeFeatureFlags',
   'DataMigrations::RemoveStructuredReasonsForRejectionRedesignFeatureFlag',
   'DataMigrations::DropChangeCourseDetailsBeforeOfferFeatureFlag',

--- a/spec/forms/candidate_interface/degree_wizard_spec.rb
+++ b/spec/forms/candidate_interface/degree_wizard_spec.rb
@@ -565,6 +565,7 @@ RSpec.describe CandidateInterface::DegreeWizard do
             institution_name: 'Aix-Marseille University',
             institution_country: 'FR',
             subject: 'History',
+            degree_subject_uuid: Hesa::Subject.find_by_name('History').id,
             predicted_grade: false,
             grade: '94%',
             start_year: '2000',

--- a/spec/services/data_migrations/backfill_international_degrees_subjects_uuid_spec.rb
+++ b/spec/services/data_migrations/backfill_international_degrees_subjects_uuid_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillInternationalDegreesSubjectsUuid do
+  let(:animation) do
+    DfE::ReferenceData::Degrees::SUBJECTS.some(name: 'Animation').first
+  end
+
+  context 'when international' do
+    context 'when created after new degree flow' do
+      it 'saves the subject UUID' do
+        degree_qualification = create(
+          :non_uk_degree_qualification,
+          subject: 'Animation',
+          created_at: DateTime.new(2022, 5, 4, 14),
+        )
+
+        described_class.new.change
+
+        expect(degree_qualification.reload.degree_subject_uuid).to eq(animation.id)
+      end
+    end
+
+    context 'when subject is not in the reference data' do
+      it 'does not change the subject UUID' do
+        degree_qualification = create(
+          :non_uk_degree_qualification,
+          subject: 'Animatron',
+          created_at: DateTime.new(2022, 5, 4, 14),
+        )
+
+        described_class.new.change
+
+        expect(degree_qualification.reload.degree_subject_uuid).to be_nil
+      end
+    end
+
+    context 'when created before new degree flow' do
+      it 'does not change the subject UUID' do
+        degree_qualification = create(
+          :degree_qualification,
+          subject: 'Animation',
+          institution_country: 'BR',
+          created_at: DateTime.new(2022, 5, 4, 13),
+        )
+
+        described_class.new.change
+
+        expect(degree_qualification.reload.degree_subject_uuid).to be_nil
+      end
+    end
+  end
+
+  context 'when degree is from UK' do
+    it 'does not change the subject UUID' do
+      degree_qualification = create(
+        :degree_qualification,
+        subject: 'Animation',
+        institution_country: nil,
+        created_at: DateTime.new(2022, 5, 4, 14),
+      )
+
+      described_class.new.change
+
+      expect(degree_qualification.reload.degree_subject_uuid).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Context

We should be saving UUIDs for international degrees.
Otherwise, it'll be hard to analyze how well our autocompletes are working.

Also added the dry run so we can double-check the total of the degrees which we can find in the reference data.

## Guidance to review

1. We run the data migration against the snapshot database. Is it the subject UUIDs are saved properly? (ask me or Jon how to connect with the snapshot). Or does it save on your local DB?

## Link to Trello card

https://trello.com/c/KZOi0qkv/195-save-uuids-for-international-degrees