### PR TITLE
Ensure we preload the current course

### DIFF
--- a/app/components/support_interface/application_card_component.html.erb
+++ b/app/components/support_interface/application_card_component.html.erb
@@ -12,7 +12,7 @@
     <% application_choices.each do |application_choice| %>
       <li class="govuk-list__item govuk-body-s">
         <%= render SupportInterface::ApplicationStatusTagComponent.new(status: application_choice.status) %>
-        <%= application_choice.course_option.course.name_and_code %> at <%= application_choice.course_option.provider.name %>
+        <%= application_choice.current_course_option.course.name_and_code %> at <%= application_choice.current_course_option.provider.name %>
       </li>
     <% end %>
   </ul>

--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -15,7 +15,7 @@ module SupportInterface
         )
         .preload(
           :candidate,
-          application_choices: { course_option: { course: :provider } },
+          application_choices: { current_course_option: { course: :provider } },
         )
         .distinct
         .order(updated_at: :desc)


### PR DESCRIPTION
## Context

When filtering applications in the support UI we preload courses via the `course_option` association, this doesn't correctly reflect course choices that may have changed over time.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Preload courses via the `current_course_option` which ensures the information we see in the results is up to date.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/muJ4qN11/168-support-interface-fix-bug-with-current-course-option-vs-original-course-option
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
