### PR TITLE
Drop pattern attribute from text fields

### DIFF
--- a/app/views/candidate_interface/english_foreign_language/ielts/_form_fields.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/ielts/_form_fields.html.erb
@@ -17,7 +17,6 @@
   :award_year,
   label: { text: 'When did you complete the assessment?', size: 'm' },
   hint: { text: 'Give the year, for example: ‘2020’' },
-  pattern: '[0-9]*',
   inputmode: 'numeric',
   width: 4,
 ) %>

--- a/app/views/candidate_interface/english_foreign_language/other_efl_qualification/_form_fields.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/other_efl_qualification/_form_fields.html.erb
@@ -14,7 +14,6 @@
   :award_year,
   label: { text: 'When did you complete the assessment?', size: 'm' },
   hint: { text: 'Give the year, for example: ‘2020’' },
-  pattern: '[0-9]*',
   inputmode: 'numeric',
   width: 4,
 ) %>

--- a/app/views/candidate_interface/english_foreign_language/toefl/_form_fields.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/toefl/_form_fields.html.erb
@@ -18,7 +18,6 @@
   :award_year,
   label: { text: 'When did you complete the assessment?', size: 'm' },
   hint: { text: 'Give the year, for example: ‘2020’' },
-  pattern: '[0-9]*',
   inputmode: 'numeric',
   width: 4,
 ) %>


### PR DESCRIPTION
This was required to trigger the numeric keypad in early versions of iOS Safari. However since Safari 12.2, `inputmode` is the preferred way to specify this.

`govuk-frontend` has now dropped the pattern attribute, as usage of iOS Safari prior to version 12.2 has dropped to insignificant levels: https://github.com/alphagov/govuk-frontend/pull/2599

The pattern attribute will also be dropped from date input fields via merging #6993 which updates the `govuk_design_system_formbuilder` gem.