### PR TITLE
Change summer recruitment date/time

### DIFF
--- a/app/lib/time_limit_config.rb
+++ b/app/lib/time_limit_config.rb
@@ -45,14 +45,14 @@ class TimeLimitConfig
     {
       reject_by_default: [
         Rule.new(nil, nil, 40),
-        Rule.new(Time.zone.local(RecruitmentCycle.current_year, 7, 1), nil, 20),
+        Rule.new(Time.zone.local(RecruitmentCycle.current_year, 6, 30, 23, 59, 59), nil, 20),
       ],
       decline_by_default: [
         Rule.new(nil, nil, 10),
       ],
       chase_provider_before_rbd: [
         Rule.new(nil, nil, 20),
-        Rule.new(Time.zone.local(RecruitmentCycle.current_year, 7, 1), nil, 10),
+        Rule.new(Time.zone.local(RecruitmentCycle.current_year, 6, 30, 23, 59, 59), nil, 10),
       ],
       chase_candidate_before_dbd: [
         Rule.new(nil, nil, 5),


### PR DESCRIPTION
## Context

On the 1st July, the number of days that providers have to make a decision reduces from 40 to 20 working days. In our EOC calendar, this currently happens at midnight on the 1st July. We'd like to amend this to  23:59pm the night before, to make it easier for users to understand and also to fit in with how the cycle will end (at 23:59pm on 4 October 2022).

## Changes proposed in this pull request

Change RBD summer recruitment and chaser dates to new dates at 23:59 pm on the 30th June 2022

## Guidance to review

Did I miss anything?

## Link to Trello card

https://trello.com/c/qxl2CiYd/16-amend-the-start-time-of-summer-recruitment-period-within-the-eoc-timetable-to-2359-on-the-30th-june-2022

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
