### PR TITLE
Skip cypress tests for rollover deployment

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -118,11 +118,13 @@ runs:
         cf ssh apply-review-${{ inputs.pr-number }} -c "export DISABLE_DATABASE_ENVIRONMENT_CHECK=1 && cd /app && /usr/local/bin/bundle exec rake setup_review_app_data"
 
     - name: Set CYPRESS_BASE_URL
+      if: inputs.environment != 'rollover'
       shell: bash
       run: |
         echo "CYPRESS_BASE_URL=${{ steps.set_env_var.outputs.deploy_url }}" >> $GITHUB_ENV
 
     - name: Cypress run
+      if: inputs.environment != 'rollover'
       id: run_cypress
       uses: cypress-io/github-action@v2.3.10
       with:


### PR DESCRIPTION
## Context

The rollover environment doesn't need to run the cypress tests 

## Changes proposed in this pull request

Update the deploy action to skip cypress tests if the environment is rollover

## Guidance to review

check review app runs ok

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
