### PR TITLE
Format non UK equivalency details

### DIFF
--- a/app/decorators/application_choice_export_decorator.rb
+++ b/app/decorators/application_choice_export_decorator.rb
@@ -55,6 +55,24 @@ class ApplicationChoiceExportDecorator < SimpleDelegator
     DomicileResolver.country_for_hesa_code(application_form.domicile)
   end
 
+  def formatted_equivalency_details
+    return unless first_degree
+
+    enic_reference = "ENIC: #{first_degree.enic_reference}" if first_degree.enic_reference
+
+    comparable_uk_qualification = first_degree.comparable_uk_qualification
+
+    unless comparable_uk_qualification
+      comparable_uk_qualification = first_degree.comparable_uk_degree
+      comparable_uk_qualification = I18n.t("application_qualification.comparable_uk_degree.#{comparable_uk_qualification}") if comparable_uk_qualification
+    end
+
+    [enic_reference, comparable_uk_qualification, first_degree.equivalency_details]
+      .compact
+      .map(&:strip)
+      .join(' - ')
+  end
+
 private
 
   def gcse_explanation(gcse)

--- a/app/services/provider_interface/application_data_export.rb
+++ b/app/services/provider_interface/application_data_export.rb
@@ -50,7 +50,7 @@ module ProviderInterface
           'Award year of degree' => application.first_degree&.award_year,
           'Institution of degree' => application.first_degree&.institution_name,
           'Type of international degree' => application.first_degree&.non_uk_qualification_type,
-          'Equivalency details for international degree' => replace_smart_quotes(application.first_degree&.composite_equivalency_details),
+          'Equivalency details for international degree' => replace_smart_quotes(application.formatted_equivalency_details),
           'GCSEs' => replace_smart_quotes(application.gcse_qualifications_summary),
           'Explanation for missing GCSEs' => replace_smart_quotes(application.missing_gcses_explanation),
           'Offered at' => application.offered_at,

--- a/config/locales/provider_interface/application_data_export.yml
+++ b/config/locales/provider_interface/application_data_export.yml
@@ -12,3 +12,12 @@ en:
               blank: Select at least one status
             provider_ids:
               blank: Select at least one organisation
+  application_qualification:
+    comparable_uk_degree:
+      bachelor_ordinary_degree: Bachelor's degree (ordinary)
+      bachelor_honours_degree: Bachelor's degree (honours)
+      postgraduate_certificate_or_diploma: Postgraduate certificate or diploma
+      masters_degree: Master's degree
+      doctor_of_philosophy: Doctor of philosophy
+      post_doctoral_award: Post doctoral award
+      unspecified: Unspecified

--- a/spec/decorators/application_choice_export_decorator_spec.rb
+++ b/spec/decorators/application_choice_export_decorator_spec.rb
@@ -178,4 +178,16 @@ RSpec.describe ApplicationChoiceExportDecorator do
       expect(described_class.new(application_choice).rejection_reasons.split("\n\n")).to eq(expected)
     end
   end
+
+  describe 'formatted_equivalency_details' do
+    it 'translates comparable uk degrees' do
+      application_form = create(:application_form)
+      application_choice = create(:application_choice, application_form: application_form)
+      create(:non_uk_degree_qualification, application_form: application_form)
+
+      summary = described_class.new(application_choice).formatted_equivalency_details
+
+      expect(summary).to match(/^ENIC: \d+ - Bachelor's degree \(ordinary\) - /)
+    end
+  end
 end


### PR DESCRIPTION
## Context

We don't reformat `comparable_uk_degree` enum values when exporting applications data.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Format equivalency details so that comparable uk degree values are more human friendly.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/J9Geyq2Y/238-format-data-export-equalivalency-details
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
