### PR TITLE
Fix degree type free text bug

### DIFF
--- a/app/components/candidate_interface/degree_new_review_component.rb
+++ b/app/components/candidate_interface/degree_new_review_component.rb
@@ -280,8 +280,10 @@ module CandidateInterface
     end
 
     def append_degree(degree)
-      if formatted_degree_type(degree) == 'Doctor'
-        'Doctorate'
+      return DegreeWizard::DOCTORATE.downcase if formatted_degree_type(degree) == 'Doctor' || degree.qualification_level == 'doctor'
+
+      if degree.qualification_level.present?
+        formatted_degree_type(degree).to_s.downcase
       else
         "#{formatted_degree_type(degree)} degree"
       end

--- a/app/components/candidate_interface/degree_new_review_component.rb
+++ b/app/components/candidate_interface/degree_new_review_component.rb
@@ -271,9 +271,11 @@ module CandidateInterface
     def formatted_degree_type(degree)
       return if degree.qualification_type.nil?
 
-      reference_data = DfE::ReferenceData::Degrees::TYPES.some_by_field(:name).keys.select { |type| degree.qualification_type.include?(type) }
-      if reference_data.present?
-        degree.qualification_type.split.first
+      if degree.qualification_level.present?
+        DegreeWizard::QUALIFICATION_LEVEL[degree.qualification_level]
+      else
+        reference_data = DfE::ReferenceData::Degrees::TYPES.some_by_field(:name).keys.select { |type| degree.qualification_type.include?(type) }
+        degree.qualification_type.split.first if reference_data.present?
       end
     end
 

--- a/app/components/candidate_interface/degree_new_review_component.rb
+++ b/app/components/candidate_interface/degree_new_review_component.rb
@@ -92,7 +92,7 @@ module CandidateInterface
       return if formatted_degree_type(degree).nil?
 
       {
-        key: t('application_form.degree.type_of_degree.review_label', degree: append_degree(degree)),
+        key: t('application_form.degree.type_of_degree.review_label', degree: append_degree(degree).to_s.downcase),
         value: degree.qualification_type,
         action: {
           href: candidate_interface_new_degree_edit_path(degree.id, :type),

--- a/app/forms/candidate_interface/degree_wizard.rb
+++ b/app/forms/candidate_interface/degree_wizard.rb
@@ -530,7 +530,9 @@ module CandidateInterface
     private_class_method :map_to_uk_or_non_uk
 
     def self.select_uk_degree_level(application_qualification)
-      DEGREE_LEVEL.select { |type| type.include?(application_qualification.qualification_type.split.first) }.join
+      QUALIFICATION_LEVEL[
+        Hesa::DegreeType.find_by_name(application_qualification.qualification_type)&.level.to_s
+      ]
     end
 
     private_class_method :select_uk_degree_level

--- a/app/forms/candidate_interface/degree_wizard.rb
+++ b/app/forms/candidate_interface/degree_wizard.rb
@@ -537,6 +537,7 @@ module CandidateInterface
 
     def self.map_to_degree_level(application_qualification)
       return if application_qualification.international
+      return QUALIFICATION_LEVEL[application_qualification.qualification_level] if application_qualification.qualification_level
       return 'Level 6 Diploma' if application_qualification.qualification_type == 'Level 6 Diploma'
 
       select_uk_degree_level(application_qualification).presence || equivalent_or_degree_level(application_qualification)

--- a/app/forms/candidate_interface/degree_wizard.rb
+++ b/app/forms/candidate_interface/degree_wizard.rb
@@ -29,6 +29,14 @@ module CandidateInterface
       'master' => 'Master’s degree',
       'doctor' => 'Doctorate (PhD)',
     }.freeze
+    QUALIFICATION_LEVEL_MAP_OPTIONS = ActiveSupport::HashWithIndifferentAccess.new(
+      {
+        master: 'master’s degree',
+        bachelor: 'bachelor degree',
+        foundation: 'foundation degree',
+        doctor: DOCTORATE,
+      },
+    ).freeze
 
     attr_accessor :uk_or_non_uk, :degree_level, :equivalent_level, :country,
                   :subject_raw, :other_type_raw, :university_raw, :other_grade_raw,
@@ -501,16 +509,9 @@ module CandidateInterface
       return if application_qualification.international
       return if map_to_equivalent_level(application_qualification).present?
 
-      level = Hesa::DegreeType&.find_by_name(application_qualification.qualification_type)&.level
+      level = application_qualification.qualification_level || Hesa::DegreeType.find_by_name(application_qualification.qualification_type)&.level
 
-      map_option = {
-        master: 'master’s degree',
-        bachelor: 'bachelor degree',
-        foundation: 'foundation degree',
-        doctor: DOCTORATE,
-      }[level]
-
-      "Another #{map_option} type"
+      "Another #{QUALIFICATION_LEVEL_MAP_OPTIONS[level]} type"
     end
 
     private_class_method :another_degree_type_option

--- a/app/forms/candidate_interface/degree_wizard.rb
+++ b/app/forms/candidate_interface/degree_wizard.rb
@@ -23,6 +23,12 @@ module CandidateInterface
     NOT_APPLICABLE = 'N/A'.freeze
     UNKNOWN = 'Unknown'.freeze
     I_DO_NOT_KNOW = 'I do not know'.freeze
+    QUALIFICATION_LEVEL = {
+      'foundation' => 'Foundation degree',
+      'bachelor' => 'Bachelor degree',
+      'master' => 'Master’s degree',
+      'doctor' => 'Doctorate (PhD)',
+    }.freeze
 
     attr_accessor :uk_or_non_uk, :degree_level, :equivalent_level, :country,
                   :subject_raw, :other_type_raw, :university_raw, :other_grade_raw,
@@ -252,6 +258,8 @@ module CandidateInterface
           institution_country: nil,
           qualification_type: qualification_type_attributes,
           qualification_type_hesa_code: hesa_type_code,
+          qualification_level: qualification_level,
+          qualification_level_uuid: qualification_level_uuid,
           degree_type_uuid: degree_type_uuid,
           institution_name: university,
           institution_hesa_code: hesa_institution_code,
@@ -413,6 +421,14 @@ module CandidateInterface
 
     def hesa_grade
       Hesa::Grade.find_by_description(grade_attributes)
+    end
+
+    def qualification_level
+      QUALIFICATION_LEVEL.key(degree_level)
+    end
+
+    def qualification_level_uuid
+      DfE::ReferenceData::Qualifications::QUALIFICATIONS.some(degree: qualification_level.to_sym).first&.id if qualification_level.present?
     end
 
     def award_year_is_before_start_year

--- a/spec/components/candidate_interface/degree_new_review_component_spec.rb
+++ b/spec/components/candidate_interface/degree_new_review_component_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe CandidateInterface::DegreeNewReviewComponent, type: :component do
     build_stubbed(
       :degree_qualification,
       qualification_type: 'Bachelor of Arts in Architecture',
+      qualification_level: 'bachelor',
       subject: 'Woof',
       institution_name: 'University of Doge',
       grade: 'Upper second',
@@ -19,6 +20,7 @@ RSpec.describe CandidateInterface::DegreeNewReviewComponent, type: :component do
       :degree_qualification,
       level: 'degree',
       qualification_type: 'Bachelor of Arts Economics',
+      qualification_level: 'bachelor',
       subject: 'Meow',
       institution_name: 'University of Cate',
       grade: 'First',
@@ -80,7 +82,7 @@ RSpec.describe CandidateInterface::DegreeNewReviewComponent, type: :component do
 
       expect(rendered_component).to summarise(
         key: t('application_form.degree.qualification_type.review_label'),
-        value: 'Bachelor',
+        value: 'Bachelor degree',
         action: {
           text: "Change #{t('application_form.degree.qualification.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
           href: Rails.application.routes.url_helpers.candidate_interface_new_degree_edit_path(degree1, :degree_level),
@@ -92,7 +94,7 @@ RSpec.describe CandidateInterface::DegreeNewReviewComponent, type: :component do
       render_inline(described_class.new(application_form: application_form))
 
       expect(rendered_component).to summarise(
-        key: 'Type of Bachelor degree',
+        key: 'Type of bachelor degree',
         value: 'Bachelor of Arts in Architecture',
         action: {
           text: "Change #{t('application_form.degree.type_of_degree.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
@@ -102,7 +104,7 @@ RSpec.describe CandidateInterface::DegreeNewReviewComponent, type: :component do
 
       expect(rendered_component).to summarise(
         key: 'Degree type',
-        value: 'Bachelor',
+        value: 'Bachelor degree',
         action: {
           text: "Change #{t('application_form.degree.qualification.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
           href: Rails.application.routes.url_helpers.candidate_interface_new_degree_edit_path(degree1, :degree_level),
@@ -532,6 +534,38 @@ RSpec.describe CandidateInterface::DegreeNewReviewComponent, type: :component do
         action: {
           text: "Change #{t('application_form.degree.qualification.change_action')} for Bachelor of Hogwarts Studies, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
           href: Rails.application.routes.url_helpers.candidate_interface_new_degree_edit_path(degree1, :degree_level),
+        },
+      )
+    end
+  end
+
+  context 'doctorate degree' do
+    let(:degree1) do
+      create(
+        :degree_qualification,
+        qualification_type: 'Doctor of education',
+        qualification_level: 'doctor',
+      )
+    end
+
+    it 'render the doctorate degree' do
+      render_inline(described_class.new(application_form: application_form))
+
+      expect(rendered_component).to summarise(
+        key: t('application_form.degree.qualification_type.review_label'),
+        value: 'Doctorate (PhD)',
+        action: {
+          text: "Change #{t('application_form.degree.qualification.change_action')} for Doctor of education, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
+          href: Rails.application.routes.url_helpers.candidate_interface_new_degree_edit_path(degree1, :degree_level),
+        },
+      )
+
+      expect(rendered_component).to summarise(
+        key: 'Type of doctorate',
+        value: 'Doctor of education',
+        action: {
+          text: "Change specific type of degree for Doctor of education, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
+          href: Rails.application.routes.url_helpers.candidate_interface_new_degree_edit_path(degree1, :type),
         },
       )
     end

--- a/spec/components/candidate_interface/degree_new_review_component_spec.rb
+++ b/spec/components/candidate_interface/degree_new_review_component_spec.rb
@@ -489,7 +489,7 @@ RSpec.describe CandidateInterface::DegreeNewReviewComponent, type: :component do
       render_inline(described_class.new(application_form: application_form))
 
       expect(rendered_component).to summarise(
-        key: t('application_form.degree.type_of_degree.review_label', degree: 'Bachelor degree'),
+        key: t('application_form.degree.type_of_degree.review_label', degree: 'bachelor degree'),
         value: 'Bachelor of Arts',
         action: {
           text: "Change #{t('application_form.degree.type_of_degree.change_action')} for Bachelor of Arts, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",

--- a/spec/forms/candidate_interface/degree_wizard_spec.rb
+++ b/spec/forms/candidate_interface/degree_wizard_spec.rb
@@ -923,6 +923,21 @@ RSpec.describe CandidateInterface::DegreeWizard do
         end
       end
 
+      context 'uk degree with free text type' do
+        before do
+          application_qualification.qualification_level = 'master'
+          application_qualification.qualification_type = 'Master of Jedi'
+        end
+
+        it 'rehydrates the correct attributes' do
+          expect(wizard.degree_level).to eq('Master’s degree')
+          expect(wizard.equivalent_level).to be_nil
+          expect(wizard.type).to eq('Another master’s degree type')
+          expect(wizard.international_type).to be_nil
+          expect(wizard.other_type).to eq('Master of Jedi')
+        end
+      end
+
       context 'uk degree with equivalent level' do
         before do
           application_qualification.qualification_type = 'A different degree'

--- a/spec/forms/candidate_interface/degree_wizard_spec.rb
+++ b/spec/forms/candidate_interface/degree_wizard_spec.rb
@@ -515,6 +515,8 @@ RSpec.describe CandidateInterface::DegreeWizard do
             institution_country: nil,
             qualification_type: 'Bachelor of Arts',
             qualification_type_hesa_code: '51',
+            qualification_level: 'bachelor',
+            qualification_level_uuid: DfE::ReferenceData::Qualifications::QUALIFICATIONS.some(name: 'bachelors degree').first.id,
             degree_type_uuid: Hesa::DegreeType.find_by_hesa_code('51').id,
             institution_name: 'The University of Cambridge',
             institution_hesa_code: '114',
@@ -635,6 +637,52 @@ RSpec.describe CandidateInterface::DegreeWizard do
         expect(wizard.attributes_for_persistence).to include(
           {
             qualification_type: 'Master of Science',
+            qualification_level: 'master',
+            qualification_level_uuid: DfE::ReferenceData::Qualifications::QUALIFICATIONS.some(degree: :master).first.id,
+          },
+        )
+      end
+    end
+
+    context 'when unknown degree level is chosen' do
+      let(:wizard_attrs) do
+        {
+          uk_or_non_uk: 'uk',
+          degree_level: 'Jedi Knight',
+          type: 'Jedi lightsaber fight',
+        }
+      end
+
+      let(:wizard) { described_class.new(store, wizard_attrs) }
+
+      it 'persists type to qualification type field' do
+        expect(wizard.attributes_for_persistence).to include(
+          {
+            qualification_type: 'Jedi lightsaber fight',
+            qualification_level: nil,
+            qualification_level_uuid: nil,
+          },
+        )
+      end
+    end
+
+    context 'when unknown degree type is chosen' do
+      let(:wizard_attrs) do
+        {
+          uk_or_non_uk: 'uk',
+          degree_level: 'Bachelor degree',
+          type: 'Jedi lightsaber fight',
+        }
+      end
+
+      let(:wizard) { described_class.new(store, wizard_attrs) }
+
+      it 'persists type to qualification type field' do
+        expect(wizard.attributes_for_persistence).to include(
+          {
+            qualification_type: 'Jedi lightsaber fight',
+            qualification_level: 'bachelor',
+            qualification_level_uuid: DfE::ReferenceData::Qualifications::QUALIFICATIONS.some(degree: :bachelor).first.id,
           },
         )
       end

--- a/spec/forms/candidate_interface/degree_wizard_spec.rb
+++ b/spec/forms/candidate_interface/degree_wizard_spec.rb
@@ -858,7 +858,7 @@ RSpec.describe CandidateInterface::DegreeWizard do
     end
   end
 
-  describe '#from_application_qualification' do
+  describe '.from_application_qualification' do
     let(:wizard) do
       described_class.from_application_qualification(store, application_qualification)
     end
@@ -934,6 +934,20 @@ RSpec.describe CandidateInterface::DegreeWizard do
           expect(wizard.type).to be_nil
           expect(wizard.international_type).to be_nil
           expect(wizard.other_type).to be_nil
+        end
+      end
+
+      context 'uk degree with free text as level 6 diploma' do
+        before do
+          application_qualification.qualification_level = 'bachelor'
+          application_qualification.qualification_type = 'Level 6 diploma'
+        end
+
+        it 'rehydrates the degree wizard' do
+          expect(wizard.degree_level).to eq('Bachelor degree')
+          expect(wizard.equivalent_level).to be_nil
+          expect(wizard.international_type).to be_nil
+          expect(wizard.other_type).to eq('Level 6 diploma')
         end
       end
     end

--- a/spec/forms/candidate_interface/degree_wizard_spec.rb
+++ b/spec/forms/candidate_interface/degree_wizard_spec.rb
@@ -937,6 +937,19 @@ RSpec.describe CandidateInterface::DegreeWizard do
         end
       end
 
+      context 'uk degree level with free text' do
+        before do
+          application_qualification.qualification_type = 'Diploma of life'
+        end
+
+        it 'rehydrates the degree wizard' do
+          expect(wizard.degree_level).to eq('Another qualification equivalent to a degree')
+          expect(wizard.equivalent_level).to eq('Diploma of life')
+          expect(wizard.international_type).to be_nil
+          expect(wizard.other_type).to be_nil
+        end
+      end
+
       context 'uk degree with free text as level 6 diploma' do
         before do
           application_qualification.qualification_level = 'bachelor'

--- a/spec/system/candidate_interface/entering_details/degrees/new_degree_flow/candidate_adding_unknown_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/new_degree_flow/candidate_adding_unknown_degrees_spec.rb
@@ -1,0 +1,216 @@
+require 'rails_helper'
+
+RSpec.feature 'Adding an unknown degree', js: true do
+  include CandidateHelper
+
+  before do
+    FeatureFlag.activate(:new_degree_flow)
+  end
+
+  scenario 'Candidate enters their degree' do
+    given_i_am_signed_in
+    when_i_view_the_degree_section
+
+    # Add degree
+    and_i_click_add_degree
+
+    # Add country
+    then_i_can_see_the_country_page
+    when_i_choose_united_kingdom
+    and_i_click_on_save_and_continue
+
+    # Add degree level
+    then_i_can_see_the_level_page
+    when_i_choose_the_level
+    and_i_click_on_save_and_continue
+
+    # Add subject
+    then_i_can_see_the_subject_page
+    when_i_fill_in_the_subject
+    and_i_click_on_save_and_continue
+
+    # Add degree type
+    then_i_can_see_the_type_page
+    when_i_choose_an_unknown_type_of_degree
+    and_i_click_on_save_and_continue
+
+    # Add university
+    then_i_can_see_the_university_page
+    when_i_fill_in_the_university
+    and_i_click_on_save_and_continue
+
+    # Add completion
+    then_i_can_see_the_completion_page
+    when_i_choose_whether_degree_is_completed
+    and_i_click_on_save_and_continue
+
+    # Add grade
+    then_i_can_see_the_grade_page
+    when_i_select_the_grade
+    and_i_click_on_save_and_continue
+
+    # Add start year
+    then_i_can_see_the_start_year_page
+    when_i_fill_in_the_start_year
+    and_i_click_on_save_and_continue
+
+    # Add award year
+    then_i_can_see_the_award_year_page
+    when_i_fill_in_the_award_year
+    and_i_click_on_save_and_continue
+
+    # Review
+    then_i_can_check_my_undergraduate_degree
+
+    # Mark section as complete
+    when_i_mark_this_section_as_completed
+    and_i_click_on_continue
+    then_i_should_see_the_form
+    and_that_the_section_is_completed
+    when_i_click_on_degree
+    then_i_can_check_my_answers
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def when_i_view_the_degree_section
+    visit candidate_interface_application_form_path
+    when_i_click_on_degree
+  end
+
+  def when_i_click_on_degree
+    click_link 'Degree'
+  end
+
+  def and_i_click_add_degree
+    click_link 'Add a degree'
+  end
+
+  def then_i_can_see_the_country_page
+    expect(page).to have_content('Which country was the degree from?')
+  end
+
+  def when_i_choose_united_kingdom
+    choose 'United Kingdom', visible: false
+  end
+
+  def and_i_click_on_save_and_continue
+    click_button t('save_and_continue')
+  end
+
+  def when_i_click_on_save_and_continue
+    click_button t('save_and_continue')
+  end
+
+  def then_i_can_see_the_level_page
+    expect(page).to have_content 'What type of degree is it?'
+  end
+
+  def when_i_choose_the_level
+    choose 'Bachelor', visible: false
+  end
+
+  def then_i_can_see_the_subject_page
+    expect(page).to have_content 'What subject is your degree?'
+  end
+
+  def when_i_fill_in_the_subject
+    fill_in 'What subject is your degree?', with: 'History'
+    # Triggering the autocomplete
+    find('input[name="candidate_interface_degree_wizard[subject_raw]"]').native.send_keys(:return)
+  end
+
+  def then_i_can_see_the_type_page
+    expect(page).to have_content 'What type of bachelor degree is it?'
+  end
+
+  def when_i_choose_an_unknown_type_of_degree
+    choose 'Another bachelor degree type', visible: false
+    fill_in 'Degree type', with: 'Jedi Knight'
+    # Triggering the autocomplete
+    find('input[name="candidate_interface_degree_wizard[other_type_raw]"]').native.send_keys(:return)
+  end
+
+  def then_i_can_see_the_university_page
+    expect(page).to have_content 'Which university awarded your degree?'
+  end
+
+  def when_i_fill_in_the_university
+    fill_in 'candidate_interface_degree_wizard[university_raw]', with: 'University of Cambridge'
+    # Triggering the autocomplete
+    find('input[name="candidate_interface_degree_wizard[university_raw]"]').native.send_keys(:return)
+  end
+
+  def then_i_can_see_the_completion_page
+    expect(page).to have_content 'Have you completed your degree?'
+  end
+
+  def when_i_choose_whether_degree_is_completed
+    choose 'Yes', visible: false
+  end
+
+  def then_i_can_see_the_grade_page
+    expect(page).to have_content('What grade is your degree?')
+  end
+
+  def when_i_select_the_grade
+    choose 'First-class honours', visible: false
+  end
+
+  def then_i_can_see_the_start_year_page
+    expect(page).to have_content('What year did you start your degree?')
+  end
+
+  def when_i_fill_in_the_start_year
+    fill_in t('page_titles.what_year_did_you_start_your_degree'), with: '2006'
+  end
+
+  def then_i_can_see_the_award_year_page
+    expect(page).to have_content('What year did you graduate?')
+  end
+
+  def when_i_fill_in_the_award_year
+    fill_in t('page_titles.what_year_did_you_graduate'), with: '2009'
+  end
+
+  def then_i_can_check_my_undergraduate_degree
+    expect(page).to have_current_path candidate_interface_new_degree_review_path
+    expect(page).to have_content 'History'
+  end
+
+  def when_i_click_on_continue
+    click_button t('continue')
+  end
+
+  def and_i_click_on_continue
+    when_i_click_on_continue
+  end
+
+  def when_i_mark_this_section_as_completed
+    choose t('application_form.completed_radio'), visible: false
+  end
+
+  def and_i_click_on_continue
+    when_i_click_on_continue
+  end
+
+  def then_i_should_see_the_form
+    expect(page).to have_content(t('page_titles.application_form'))
+  end
+
+  def and_that_the_section_is_completed
+    expect(page.find('#degree-badge-id').text).to eq('COMPLETED')
+  end
+
+  def then_i_can_check_my_answers
+    expect(page).to have_content 'United Kingdom'
+    expect(page).to have_content 'Bachelor degree'
+    expect(page).to have_content 'Jedi Knight'
+    expect(page).to have_content 'University of Cambridge'
+    expect(page).to have_content 'First-class honours'
+    expect(page).to have_content '2006'
+    expect(page).to have_content '2009'
+  end
+end


### PR DESCRIPTION
## Context

If you select a degree level like Bachelors, then enter a subject, but then enter a different type of bachelor as free text (eg "Bachelor of Things") then the summary table doesn't display both questions as separate rows, just "Degree type: Bachelor of Things".

Instead it should behave as if you selected Bachelor of Arts or another type, and summarise it as:

Degree type: Bachelor
Type of Bachelor degree: Bachelor of Things

## Data migrations

I decided to run manually the migration as will backfill approx 50k records in the database. Added the dry run to get more context before running it.

## Guidance to review

1. Does it work properly for newly added degrees?

## Link to Trello card

https://trello.com/c/dt10YnYp/55-degree-type-free-text-bug
