### PR TITLE
Add guidance page for Organisation Permissions

### DIFF
--- a/app/controllers/provider_interface/content_controller.rb
+++ b/app/controllers/provider_interface/content_controller.rb
@@ -55,7 +55,9 @@ module ProviderInterface
     end
 
     def organisation_permissions
-      render_content_page :organisation_permissions
+      render_content_page :organisation_permissions,
+                          breadcrumb_title: 'service_guidance_provider',
+                          breadcrumb_path: provider_interface_service_guidance_path
     end
   end
 end

--- a/app/controllers/provider_interface/content_controller.rb
+++ b/app/controllers/provider_interface/content_controller.rb
@@ -53,5 +53,9 @@ module ProviderInterface
     def roadmap
       render_content_page :roadmap
     end
+
+    def organisation_permissions
+      render_content_page :organisation_permissions
+    end
   end
 end

--- a/app/views/content/organisation_permissions.md
+++ b/app/views/content/organisation_permissions.md
@@ -1,0 +1,27 @@
+Users can view applications to courses if they belong to the training provider or accredited body.
+
+If they have the appropriate user permissions, they can also:
+
+- manage interviews
+- manage users - this includes adding users and setting user permissions
+- manage organisations - this includes setting organisation permissions
+
+These user permissions are not affected by organisation permissions.
+
+## User permissions which are affected by organisation permissions
+
+Users can be given permission to:
+
+- make offers and reject applications
+- view criminal record and professional misconduct information
+- view sex, disability and ethnicity information
+
+These user permissions are affected by organisation permissions for courses run with partner organisations. Organisation permissions reflect the working relationship between 2 organisations.
+
+For example, a user will only be able to make an offer if both:
+
+- the user has the user permission to make offers and reject applications
+- the user’s organisation has the organisation permission to make offers and reject applications for courses it runs with its partner organisation
+
+There are no organisation permissions for courses run without partner organisations. Users only need to have the appropriate user permissions.
+

--- a/app/views/provider_interface/content/service_guidance_provider.html.erb
+++ b/app/views/provider_interface/content/service_guidance_provider.html.erb
@@ -7,6 +7,9 @@
       <li>
         <%= govuk_link_to('Dates and deadlines', provider_interface_service_guidance_dates_and_deadlines_path) %>
       </li>
+      <li>
+        <%= govuk_link_to('How organisation permissions affect what users can do', provider_interface_organisation_permissions_guidance_path) %>
+      </li>
     </ul>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -268,6 +268,7 @@ en:
     guidance: User guidance
     your_feedback: Your feedback
     dates_and_deadlines: Dates and deadlines
+    organisation_permissions: How organisation permissions affect what users can do
   section_groups:
     course: Course
     courses: Courses

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -684,6 +684,7 @@ Rails.application.routes.draw do
     get '/service-guidance', to: 'content#service_guidance_provider', as: :service_guidance
     get '/service-guidance/dates-and-deadlines', to: 'content#dates_and_deadlines'
     get '/covid-19-guidance', to: redirect('/')
+    get '/organisation-permissions-guidance', to: 'content#organisation_permissions'
 
     resources :cookie_preferences, only: 'create', path: 'cookie-preferences'
     post '/cookie-preferences-hide-confirmation', to: 'cookie_preferences#hide_confirmation', as: :cookie_preferences_hide_confirmation


### PR DESCRIPTION
## Context

The Permissions model, and the interplay betweeen user and organisation permissions is confusing. 
Until we have the capacity to improve the overall design, we'd like to add some guidance.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Add org permissions guidance page
Link to org permissions guidance page from service guidance page
<!-- If there are UI changes, please include Before and After screenshots. -->

![image](https://user-images.githubusercontent.com/93511/170459425-8ea3b743-f887-4077-9a9c-465c134a39e7.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/okzVrRPW/33-add-guidance-to-help-users-understand-how-permissions-work
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
