### PR TITLE
Update disability support and interview needs section

### DIFF
--- a/app/components/provider_interface/training_with_disability_component.html.erb
+++ b/app/components/provider_interface/training_with_disability_component.html.erb
@@ -1,5 +1,5 @@
 <section class="app-section govuk-!-width-two-thirds" id="disability-access-and-other-needs">
-  <h2 class="govuk-heading-m govuk-!-font-size-27">Disability Support</h2>
+  <h2 class="govuk-heading-m govuk-!-font-size-27">Disability support</h2>
 
   <%= render SummaryListComponent.new(rows: rows) %>
 </section>

--- a/app/components/provider_interface/training_with_disability_component.html.erb
+++ b/app/components/provider_interface/training_with_disability_component.html.erb
@@ -1,5 +1,5 @@
 <section class="app-section govuk-!-width-two-thirds" id="disability-access-and-other-needs">
-  <h2 class="govuk-heading-m govuk-!-font-size-27">Disability, access and other needs</h2>
+  <h2 class="govuk-heading-m govuk-!-font-size-27">Disability Support</h2>
 
-  <p class="govuk-body"><%= disability_disclosure %></p>
+  <%= render SummaryListComponent.new(rows: rows) %>
 </section>

--- a/app/components/provider_interface/training_with_disability_component.rb
+++ b/app/components/provider_interface/training_with_disability_component.rb
@@ -3,15 +3,34 @@ module ProviderInterface
     include ViewHelper
 
     attr_reader :application_form
+    delegate :disclose_disability?, :disability_disclosure, to: :application_form
 
     def initialize(application_form:)
       @application_form = application_form
     end
 
-    def disability_disclosure
-      return application_form.disability_disclosure if application_form.disclose_disability? && application_form.disability_disclosure.present?
+    def rows
+      rows = [{ key: 'Do you want to ask for help to become a teacher?', value: disability_disclosure_support }]
 
-      'No information shared.'
+      if disclose_information?
+        rows << { key: 'Give any relevant information', value: disability_disclosure }
+      end
+
+      rows
+    end
+
+  private
+
+    def disclose_information?
+      disclose_disability? && disability_disclosure.present?
+    end
+
+    def disability_disclosure_support
+      if disclose_information?
+        'Yes, I want to share information about myself so my provider can take steps to support me'
+      else
+        'No'
+      end
     end
   end
 end

--- a/app/components/provider_interface/training_with_disability_component.rb
+++ b/app/components/provider_interface/training_with_disability_component.rb
@@ -10,10 +10,10 @@ module ProviderInterface
     end
 
     def rows
-      rows = [{ key: 'Do you want to ask for help to become a teacher?', value: disability_disclosure_support }]
+      rows = [{ key: I18n.t('application_form.training_with_a_disability.disclose_disability.label'), value: disability_disclosure_support }]
 
       if disclose_information?
-        rows << { key: 'Give any relevant information', value: disability_disclosure }
+        rows << { key: I18n.t('application_form.training_with_a_disability.disability_disclosure.label'), value: disability_disclosure }
       end
 
       rows
@@ -27,9 +27,9 @@ module ProviderInterface
 
     def disability_disclosure_support
       if disclose_information?
-        'Yes, I want to share information about myself so my provider can take steps to support me'
+        I18n.t('application_form.training_with_a_disability.disclose_disability.yes')
       else
-        'No'
+        I18n.t('application_form.training_with_a_disability.disclose_disability.no')
       end
     end
   end

--- a/app/components/shared/interview_preferences_component.html.erb
+++ b/app/components/shared/interview_preferences_component.html.erb
@@ -1,5 +1,5 @@
 <section class="app-section govuk-!-width-two-thirds">
   <h2 class="govuk-heading-m govuk-!-font-size-27" id="interview">Interview needs</h2>
 
-  <%= simple_format interview_preferences, class: 'govuk-body' %>
+  <%= render SummaryListComponent.new(rows: rows) %>
 </section>

--- a/app/components/shared/interview_preferences_component.rb
+++ b/app/components/shared/interview_preferences_component.rb
@@ -1,14 +1,29 @@
 # NOTE: This component is used by both provider and support UIs
 class InterviewPreferencesComponent < ViewComponent::Base
   attr_reader :application_form
+  delegate :interview_preferences, to: :application_form
 
   def initialize(application_form:)
     @application_form = application_form
   end
 
-  def interview_preferences
-    return application_form.interview_preferences if application_form.interview_preferences.present?
+  def rows
+    rows = [{ key: 'Do you have any interview needs?', value: interview_needs_message }]
 
-    'None given.'
+    if application_form.interview_preferences.present?
+      rows << { key: 'What are your interview needs?', value: interview_preferences }
+    end
+
+    rows
+  end
+
+private
+
+  def interview_needs_message
+    if application_form.interview_preferences.present?
+      'Yes'
+    else
+      'No'
+    end
   end
 end

--- a/spec/components/provider_interface/training_with_disability_component_spec.rb
+++ b/spec/components/provider_interface/training_with_disability_component_spec.rb
@@ -1,43 +1,42 @@
 require 'rails_helper'
 
 RSpec.describe ProviderInterface::TrainingWithDisabilityComponent do
-  it 'renders `No information shared` if `#disclose_disability` is false' do
-    application_form = instance_double(
-      ApplicationForm,
-      disclose_disability?: false,
-      disability_disclosure: nil,
-    )
-    result = render_inline(described_class.new(application_form: application_form))
-    expect(result.text).to include('No information shared.')
+  context 'when the candidate has not disclose disability support' do
+    it 'renders that no help is required' do
+      application_form = instance_double(
+        ApplicationForm,
+        disclose_disability?: false,
+        disability_disclosure: nil,
+      )
+      result = render_inline(described_class.new(application_form: application_form))
+      expect(result.text).to include('Do you want to ask for help to become a teacher?No')
+      expect(result.text).not_to include('Give any relevant information')
+    end
   end
 
-  it 'renders `No information shared` if `#disclose_disability` is true but there is no disclosure' do
-    application_form = instance_double(
-      ApplicationForm,
-      disclose_disability?: true,
-      disability_disclosure: '',
-    )
-    result = render_inline(described_class.new(application_form: application_form))
-    expect(result.text).to include('No information shared.')
+  context 'when the candidate has disclose disability support' do
+    it 'renders the disability disclosure' do
+      application_form = instance_double(
+        ApplicationForm,
+        disclose_disability?: true,
+        disability_disclosure: 'I am hard of hearing',
+      )
+      result = render_inline(described_class.new(application_form: application_form))
+      expect(result.text).to include('Do you want to ask for help to become a teacher?Yes, I want to share information about myself so my provider can take steps to support me')
+      expect(result.text).to include('Give any relevant informationI am hard of hearing')
+    end
   end
 
-  it 'renders `No information shared` if `#disclose_disability` is nil' do
-    application_form = instance_double(
-      ApplicationForm,
-      disclose_disability?: nil,
-      disability_disclosure: nil,
-    )
-    result = render_inline(described_class.new(application_form: application_form))
-    expect(result.text).to include('No information shared.')
-  end
-
-  it 'renders disclosure if `#disclose_disability` is true' do
-    application_form = instance_double(
-      ApplicationForm,
-      disclose_disability?: true,
-      disability_disclosure: 'I am hard of hearing',
-    )
-    result = render_inline(described_class.new(application_form: application_form))
-    expect(result.text).to include('I am hard of hearing')
+  context 'when the candidate has an empty disclose disability support' do
+    it 'renders that no help is required' do
+      application_form = instance_double(
+        ApplicationForm,
+        disclose_disability?: true,
+        disability_disclosure: '',
+      )
+      result = render_inline(described_class.new(application_form: application_form))
+      expect(result.text).to include('Do you want to ask for help to become a teacher?No')
+      expect(result.text).not_to include('Give any relevant information')
+    end
   end
 end

--- a/spec/components/utility/interview_preferences_component_spec.rb
+++ b/spec/components/utility/interview_preferences_component_spec.rb
@@ -1,30 +1,39 @@
 require 'rails_helper'
 
 RSpec.describe InterviewPreferencesComponent do
-  it 'renders `None given` if `#interview_preferences` is nil' do
-    application_form = instance_double(
-      ApplicationForm,
-      interview_preferences: nil,
-    )
-    result = render_inline(described_class.new(application_form: application_form))
-    expect(result.text).to include('None given.')
+  context 'when there are no interview needs' do
+    it 'rendes no interview needs message' do
+      application_form = instance_double(
+        ApplicationForm,
+        interview_preferences: nil,
+      )
+      result = render_inline(described_class.new(application_form: application_form))
+      expect(result.text).to include('Do you have any interview needs?No')
+      expect(result.text).not_to include('What are your interview needs?')
+    end
   end
 
-  it 'renders `None given` if `#interview_preferences` is blank' do
-    application_form = instance_double(
-      ApplicationForm,
-      interview_preferences: '',
-    )
-    result = render_inline(described_class.new(application_form: application_form))
-    expect(result.text).to include('None given.')
+  context 'when interview needs are left blank' do
+    it 'rendes no interview needs message' do
+      application_form = instance_double(
+        ApplicationForm,
+        interview_preferences: '',
+      )
+      result = render_inline(described_class.new(application_form: application_form))
+      expect(result.text).to include('Do you have any interview needs?No')
+      expect(result.text).not_to include('What are your interview needs?')
+    end
   end
 
-  it 'renders interview preferences if there are any' do
-    application_form = instance_double(
-      ApplicationForm,
-      interview_preferences: 'Fridays are best for me.',
-    )
-    result = render_inline(described_class.new(application_form: application_form))
-    expect(result.text).to include('Fridays are best for me.')
+  context 'when there are interview needs' do
+    it 'renders interview preferences' do
+      application_form = instance_double(
+        ApplicationForm,
+        interview_preferences: 'Fridays are best for me.',
+      )
+      result = render_inline(described_class.new(application_form: application_form))
+      expect(result.text).to include('Do you have any interview needs?Yes')
+      expect(result.text).to include('What are your interview needs?Fridays are best for me.')
+    end
   end
 end


### PR DESCRIPTION
## Context

The application page on prod currently has a `Disability, access and other needs` and an `Interview` section - these should be replaced with the new `Disability Support` section and the `Interview needs` section

## Changes proposed in this pull request

Replace those two new sections

## Guidance to review

1. Is the disability support section worked correctly for both Yes and No?
2. Is the interview needs section worked correctly for both Yes and No?

## Link to Trello card

https://trello.com/c/vvMPhmKg/18-update-disability-support-text
