### PR TITLE
Stop scheduling weekly vendor alerts

### DIFF
--- a/config/clock.rb
+++ b/config/clock.rb
@@ -55,12 +55,5 @@ class Clock
   every(7.days, 'ApplicationsBySubjectRouteAndDegreeGradeExport', at: 'Sunday 23:59') { SupportInterface::ApplicationsBySubjectRouteAndDegreeGradeExport.run_weekly }
   every(7.days, 'ApplicationsByDemographicDomicileAndDegreeClassExport', at: 'Sunday 23:59') { SupportInterface::ApplicationsByDemographicDomicileAndDegreeClassExport.run_weekly }
 
-  every(7.days, 'VendorIntegrationStatsWorker', at: 'Monday 09:00') do
-    VendorIntegrationStatsWorker.perform_async('tribal')
-    VendorIntegrationStatsWorker.perform_async('ellucian')
-    VendorIntegrationStatsWorker.perform_async('unit4')
-    VendorIntegrationStatsWorker.perform_async('oracle')
-  end
-
   every(1.day, 'NudgeCandidatesWorker', at: '10:00') { NudgeCandidatesWorker.perform_async }
 end


### PR DESCRIPTION
## Context

We have asked vendors if they still require those alerts and the mentioned that they are no longer required

## Changes proposed in this pull request

Remove scheduling Vendor alerts every week. We don't want to remove the original code incase we need to reinstate later

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
