### PR TITLE
Amend application header for RBD'd applications when the user cannot give feedback 

### DIFF
--- a/app/components/provider_interface/application_choice_header_component.html.erb
+++ b/app/components/provider_interface/application_choice_header_component.html.erb
@@ -7,67 +7,7 @@
   <div class="govuk-grid-row govuk-!-display-none-print">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <%= govuk_inset_text(classes: 'govuk-!-margin-top-0') do %>
-        <% if set_up_interview? || respond_to_application? || waiting_for_interview? -%>
-          <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-            <%= inset_text_title %>
-          </h2>
-          <p class="govuk-body">
-            <% if time_is_today_or_tomorrow?(application_choice.reject_by_default_at) -%>
-              This application will be automatically rejected if a decision has not been made by the end of <%= date_and_time_today_or_tomorrow(application_choice.reject_by_default_at) %>.
-            <% else -%>
-              This application will be automatically rejected if a decision has not been made within <%= days_until(application_choice.reject_by_default_at.to_date) %> (<%= application_choice.reject_by_default_at.to_fs(:govuk_date_and_time) %>).
-            <% end -%>
-          </p>
-
-          <div class="govuk-button-group">
-            <% if set_up_interview? %>
-              <%= govuk_button_link_to 'Set up interview', new_provider_interface_application_choice_interview_path(application_choice), class: 'govuk-!-margin-bottom-0' %>
-            <% end %>
-            <% if respond_to_application? %>
-              <%= govuk_button_link_to 'Make decision', new_provider_interface_application_choice_decision_path(application_choice), class: make_decision_button_class %>
-            <% end %>
-          </div>
-        <% elsif awaiting_decision_but_cannot_respond? -%>
-          <p class="govuk-body">
-            <% if time_is_today_or_tomorrow?(application_choice.reject_by_default_at) -%>
-              This application will be automatically rejected at <%= time_today_or_tomorrow(application_choice.reject_by_default_at) %>.
-            <% else -%>
-              <%= "There are #{days_until(application_choice.reject_by_default_at.to_date)} to respond." %>
-              This application will be automatically rejected on <%= application_choice.reject_by_default_at.to_fs(:govuk_date) %>.
-            <% end -%>
-          </p>
-        <% elsif offer_will_be_declined_by_default? -%>
-          <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-            Waiting for candidate’s response
-          </h2>
-          <p class="govuk-body">
-            Your offer will be automatically declined <%= decline_by_default_text %> if the candidate does not respond.
-          </p>
-        <% elsif deferred_offer_wizard_applicable? -%>
-          <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-            Confirm deferred offer
-          </h2>
-
-          <p class="govuk-body">
-            You need to confirm your deferred offer.
-          </p>
-
-          <%= govuk_button_link_to 'Confirm deferred offer', provider_interface_reconfirm_deferred_offer_path(application_choice) %>
-
-        <% elsif rejection_reason_required? -%>
-          <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-            Give feedback
-          </h2>
-
-          <p class="govuk-body">
-            You did not make a decision about the application within <%= application_choice.reject_by_default_days %> working days. Tell the candidate why their application was unsuccessful.
-          </p>
-          <%= govuk_button_link_to 'Give feedback', new_provider_interface_rejection_path(application_choice) %>
-        <% elsif deferred_offer_in_current_cycle? -%>
-          Your offer will need to be confirmed at the start of the next recruitment cycle.
-        <% elsif deferred_offer_but_cannot_respond? -%>
-          The deferred offer needs to be confirmed.
-        <% end -%>
+        <%= render header_component %>
       <% end %>
     </div>
   </div>

--- a/app/components/provider_interface/application_choice_header_component.rb
+++ b/app/components/provider_interface/application_choice_header_component.rb
@@ -10,6 +10,28 @@ module ProviderInterface
       @provider_can_set_up_interviews = provider_can_set_up_interviews
     end
 
+    def header_component
+      header_component_class.new(
+        application_choice: application_choice,
+        provider_can_respond: provider_can_respond,
+        provider_can_set_up_interviews: provider_can_set_up_interviews,
+      )
+    end
+
+    def header_component_class
+      if set_up_interview? || respond_to_application? || waiting_for_interview?
+        ApplicationHeaderComponents::RespondComponent
+      elsif awaiting_decision_but_cannot_respond?
+        ApplicationHeaderComponents::AwaitingDecisionCannotRespondComponent
+      elsif offer_will_be_declined_by_default?
+        ApplicationHeaderComponents::OfferWillBeDeclinedByDefaultComponent
+      elsif deferred_offer_wizard_applicable? || deferred_offer_in_current_cycle? || deferred_offer_but_cannot_respond?
+        ApplicationHeaderComponents::DeferredOfferComponent
+      elsif rejection_reason_required?
+        ApplicationHeaderComponents::RejectionReasonRequiredComponent
+      end
+    end
+
     def sub_navigation_items
       sub_navigation_items = [application_navigation_item]
 
@@ -69,12 +91,6 @@ module ProviderInterface
 
     def set_up_interview?
       application_choice.decision_pending? && provider_can_set_up_interviews && !application_choice.interviewing?
-    end
-
-    def inset_text_title
-      return 'Set up an interview or make a decision' if set_up_interview? && respond_to_application?
-      return 'Set up an interview' if set_up_interview?
-      return 'Make a decision' if respond_to_application?
     end
 
     def waiting_for_interview?

--- a/app/components/provider_interface/application_header_components/awaiting_decision_cannot_respond_component.html.erb
+++ b/app/components/provider_interface/application_header_components/awaiting_decision_cannot_respond_component.html.erb
@@ -1,0 +1,8 @@
+<p class="govuk-body">
+  <% if time_is_today_or_tomorrow?(application_choice.reject_by_default_at) -%>
+    This application will be automatically rejected at <%= time_today_or_tomorrow(application_choice.reject_by_default_at) %>.
+  <% else -%>
+    <%= "There are #{days_until(application_choice.reject_by_default_at.to_date)} to respond." %>
+    This application will be automatically rejected on <%= application_choice.reject_by_default_at.to_fs(:govuk_date) %>.
+  <% end -%>
+</p>

--- a/app/components/provider_interface/application_header_components/awaiting_decision_cannot_respond_component.rb
+++ b/app/components/provider_interface/application_header_components/awaiting_decision_cannot_respond_component.rb
@@ -1,0 +1,6 @@
+module ProviderInterface
+  module ApplicationHeaderComponents
+    class AwaitingDecisionCannotRespondComponent < ApplicationChoiceHeaderComponent
+    end
+  end
+end

--- a/app/components/provider_interface/application_header_components/deferred_offer_component.html.erb
+++ b/app/components/provider_interface/application_header_components/deferred_offer_component.html.erb
@@ -1,0 +1,15 @@
+<% if deferred_offer_wizard_applicable? -%>
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+    Confirm deferred offer
+  </h2>
+
+  <p class="govuk-body">
+    You need to confirm your deferred offer.
+  </p>
+
+  <%= govuk_button_link_to 'Confirm deferred offer', provider_interface_reconfirm_deferred_offer_path(application_choice) %>
+<% elsif deferred_offer_in_current_cycle? -%>
+  Your offer will need to be confirmed at the start of the next recruitment cycle.
+<% elsif deferred_offer_but_cannot_respond? -%>
+  The deferred offer needs to be confirmed.
+<% end -%>

--- a/app/components/provider_interface/application_header_components/deferred_offer_component.rb
+++ b/app/components/provider_interface/application_header_components/deferred_offer_component.rb
@@ -1,0 +1,6 @@
+module ProviderInterface
+  module ApplicationHeaderComponents
+    class DeferredOfferComponent < ApplicationChoiceHeaderComponent
+    end
+  end
+end

--- a/app/components/provider_interface/application_header_components/deferred_offer_component.rb
+++ b/app/components/provider_interface/application_header_components/deferred_offer_component.rb
@@ -1,6 +1,23 @@
 module ProviderInterface
   module ApplicationHeaderComponents
     class DeferredOfferComponent < ApplicationChoiceHeaderComponent
+      def deferred_offer_wizard_applicable?
+        provider_can_respond &&
+          application_choice.status == 'offer_deferred' &&
+          application_choice.recruitment_cycle == RecruitmentCycle.previous_year
+      end
+
+      def deferred_offer_in_current_cycle?
+        application_choice.status == 'offer_deferred' &&
+          application_choice.recruitment_cycle == RecruitmentCycle.current_year &&
+          !application_choice.current_course_option.in_next_cycle
+      end
+
+      def deferred_offer_but_cannot_respond?
+        !provider_can_respond &&
+          application_choice.status == 'offer_deferred' &&
+          application_choice.recruitment_cycle == RecruitmentCycle.previous_year
+      end
     end
   end
 end

--- a/app/components/provider_interface/application_header_components/offer_will_be_declined_by_default_component.html.erb
+++ b/app/components/provider_interface/application_header_components/offer_will_be_declined_by_default_component.html.erb
@@ -1,0 +1,6 @@
+<h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+  Waiting for candidate’s response
+</h2>
+<p class="govuk-body">
+  Your offer will be automatically declined <%= decline_by_default_text %> if the candidate does not respond.
+</p>

--- a/app/components/provider_interface/application_header_components/offer_will_be_declined_by_default_component.rb
+++ b/app/components/provider_interface/application_header_components/offer_will_be_declined_by_default_component.rb
@@ -1,0 +1,6 @@
+module ProviderInterface
+  module ApplicationHeaderComponents
+    class OfferWillBeDeclinedByDefaultComponent < ApplicationChoiceHeaderComponent
+    end
+  end
+end

--- a/app/components/provider_interface/application_header_components/offer_will_be_declined_by_default_component.rb
+++ b/app/components/provider_interface/application_header_components/offer_will_be_declined_by_default_component.rb
@@ -1,6 +1,16 @@
 module ProviderInterface
   module ApplicationHeaderComponents
     class OfferWillBeDeclinedByDefaultComponent < ApplicationChoiceHeaderComponent
+      def decline_by_default_text
+        return unless offer_will_be_declined_by_default?
+
+        if time_is_today_or_tomorrow?(application_choice.decline_by_default_at)
+          "at the end of #{date_and_time_today_or_tomorrow(application_choice.decline_by_default_at)}"
+        else
+          days_remaining = days_until(application_choice.decline_by_default_at.to_date)
+          "in #{days_remaining} (#{application_choice.decline_by_default_at.to_fs(:govuk_date_and_time)})"
+        end
+      end
     end
   end
 end

--- a/app/components/provider_interface/application_header_components/rejection_reason_required_component.html.erb
+++ b/app/components/provider_interface/application_header_components/rejection_reason_required_component.html.erb
@@ -1,8 +1,3 @@
-<h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-  Give feedback
-</h2>
-
 <p class="govuk-body">
-  You did not make a decision about the application within <%= application_choice.reject_by_default_days %> working days. Tell the candidate why their application was unsuccessful.
+  This application was automatically rejected on <%= application_choice.rejected_by_default_at %>. Feedback has not been sent to the candidate.
 </p>
-<%= govuk_button_link_to 'Give feedback', new_provider_interface_rejection_path(application_choice) %>

--- a/app/components/provider_interface/application_header_components/rejection_reason_required_component.html.erb
+++ b/app/components/provider_interface/application_header_components/rejection_reason_required_component.html.erb
@@ -1,3 +1,14 @@
-<p class="govuk-body">
-  This application was automatically rejected on <%= application_choice.rejected_by_default_at %>. Feedback has not been sent to the candidate.
-</p>
+<% if provider_can_respond %>
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+    Give feedback
+  </h2>
+
+  <p class="govuk-body">
+    You did not make a decision about the application within <%= application_choice.reject_by_default_days %> working days. Tell the candidate why their application was unsuccessful.
+  </p>
+  <%= govuk_button_link_to 'Give feedback', new_provider_interface_rejection_path(application_choice) %>
+<% else %>
+  <p class="govuk-body">
+    This application was automatically rejected on <%= application_choice.rejected_at.to_fs(:govuk_date) %>. Feedback has not been sent to the candidate.
+  </p>
+<% end %>

--- a/app/components/provider_interface/application_header_components/rejection_reason_required_component.html.erb
+++ b/app/components/provider_interface/application_header_components/rejection_reason_required_component.html.erb
@@ -1,0 +1,8 @@
+<h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+  Give feedback
+</h2>
+
+<p class="govuk-body">
+  You did not make a decision about the application within <%= application_choice.reject_by_default_days %> working days. Tell the candidate why their application was unsuccessful.
+</p>
+<%= govuk_button_link_to 'Give feedback', new_provider_interface_rejection_path(application_choice) %>

--- a/app/components/provider_interface/application_header_components/rejection_reason_required_component.rb
+++ b/app/components/provider_interface/application_header_components/rejection_reason_required_component.rb
@@ -1,0 +1,6 @@
+module ProviderInterface
+  module ApplicationHeaderComponents
+    class RejectionReasonRequiredComponent < ApplicationChoiceHeaderComponent
+    end
+  end
+end

--- a/app/components/provider_interface/application_header_components/respond_component.html.erb
+++ b/app/components/provider_interface/application_header_components/respond_component.html.erb
@@ -1,0 +1,25 @@
+<h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+  <% if set_up_interview? && respond_to_application? -%>
+    Set up an interview or make a decision
+  <% elsif set_up_interview? -%>
+    Set up an interview
+  <% else -%>
+    Make a decision
+  <% end -%>
+</h2>
+<p class="govuk-body">
+  <% if time_is_today_or_tomorrow?(application_choice.reject_by_default_at) -%>
+    This application will be automatically rejected if a decision has not been made by the end of <%= date_and_time_today_or_tomorrow(application_choice.reject_by_default_at) %>.
+  <% else -%>
+    This application will be automatically rejected if a decision has not been made within <%= days_until(application_choice.reject_by_default_at.to_date) %> (<%= application_choice.reject_by_default_at.to_fs(:govuk_date_and_time) %>).
+  <% end -%>
+</p>
+
+<div class="govuk-button-group">
+  <% if set_up_interview? %>
+    <%= govuk_button_link_to 'Set up interview', new_provider_interface_application_choice_interview_path(application_choice), class: 'govuk-!-margin-bottom-0' %>
+  <% end %>
+  <% if respond_to_application? %>
+    <%= govuk_button_link_to 'Make decision', new_provider_interface_application_choice_decision_path(application_choice), class: make_decision_button_class %>
+  <% end %>
+</div>

--- a/app/components/provider_interface/application_header_components/respond_component.rb
+++ b/app/components/provider_interface/application_header_components/respond_component.rb
@@ -1,6 +1,9 @@
 module ProviderInterface
   module ApplicationHeaderComponents
     class RespondComponent < ApplicationChoiceHeaderComponent
+      def make_decision_button_class
+        "govuk-!-margin-bottom-0#{' govuk-button--secondary' if set_up_interview?}"
+      end
     end
   end
 end

--- a/app/components/provider_interface/application_header_components/respond_component.rb
+++ b/app/components/provider_interface/application_header_components/respond_component.rb
@@ -1,0 +1,6 @@
+module ProviderInterface
+  module ApplicationHeaderComponents
+    class RespondComponent < ApplicationChoiceHeaderComponent
+    end
+  end
+end

--- a/spec/components/provider_interface/application_header_components/awaiting_decision_cannot_respond_component_spec.rb
+++ b/spec/components/provider_interface/application_header_components/awaiting_decision_cannot_respond_component_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ApplicationHeaderComponents::AwaitingDecisionCannotRespondComponent do
+  describe 'rendered component' do
+    it 'renders days left to respond' do
+      application_choice = build_stubbed(:application_choice, :awaiting_provider_decision, reject_by_default_at: 3.days.from_now)
+      result = render_inline(described_class.new(application_choice: application_choice, provider_can_respond: true))
+
+      expect(result.css('.govuk-body').text).to match(/There are \d+ days to respond/)
+      expect(result.css('.govuk-body').text).to match(/This application will be automatically rejected on/)
+    end
+
+    it 'omits days left to respond if the application is about to be rejected' do
+      application_choice = build_stubbed(:application_choice, :awaiting_provider_decision, reject_by_default_at: 1.day.from_now)
+      result = render_inline(described_class.new(application_choice: application_choice, provider_can_respond: true))
+
+      expect(result.css('.govuk-body').text).not_to match(/There are \d+ days to respond/)
+      expect(result.css('.govuk-body').text).to match(/This application will be automatically rejected at/)
+    end
+  end
+end

--- a/spec/components/provider_interface/application_header_components/deferred_offer_component_spec.rb
+++ b/spec/components/provider_interface/application_header_components/deferred_offer_component_spec.rb
@@ -1,6 +1,40 @@
 require 'rails_helper'
 
 RSpec.describe ProviderInterface::ApplicationHeaderComponents::DeferredOfferComponent do
+  describe 'rendered component' do
+    context 'when the deferred offer is from the previous cycle and the provider user can respond' do
+      it 'renders Confirm deferred offer content' do
+        application_choice = build_stubbed(:application_choice, :with_deferred_offer)
+        allow(application_choice).to receive(:recruitment_cycle).and_return(RecruitmentCycle.previous_year)
+        result = render_inline(described_class.new(application_choice: application_choice, provider_can_respond: true))
+
+        expect(result.css('h2').text.strip).to eq('Confirm deferred offer')
+        expect(result.css('.govuk-body').text.strip).to eq('You need to confirm your deferred offer.')
+        expect(result.css('.govuk-button').text.strip).to eq('Confirm deferred offer')
+      end
+    end
+
+    context 'when the deferred offer is in the current cycle' do
+      it 'explains the deferred offer will need to be confirmed at the start of the next cycle' do
+        application_choice = build_stubbed(:application_choice, :with_deferred_offer)
+        allow(application_choice).to receive(:recruitment_cycle).and_return(RecruitmentCycle.current_year)
+        result = render_inline(described_class.new(application_choice: application_choice, provider_can_respond: true))
+
+        expect(result.text.strip).to eq('Your offer will need to be confirmed at the start of the next recruitment cycle.')
+      end
+    end
+
+    context 'when the provider user cannot respond' do
+      it 'explains that the deferred offer needs to be confirmed' do
+        application_choice = build_stubbed(:application_choice, :with_deferred_offer)
+        allow(application_choice).to receive(:recruitment_cycle).and_return(RecruitmentCycle.previous_year)
+        result = render_inline(described_class.new(application_choice: application_choice))
+
+        expect(result.text.strip).to eq('The deferred offer needs to be confirmed.')
+      end
+    end
+  end
+
   describe '#deferred_offer_wizard_applicable?' do
     it 'is true for a deferred offer belonging to the previous recruitment cycle' do
       application_choice = instance_double(ApplicationChoice, status: 'offer_deferred')

--- a/spec/components/provider_interface/application_header_components/deferred_offer_component_spec.rb
+++ b/spec/components/provider_interface/application_header_components/deferred_offer_component_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ApplicationHeaderComponents::DeferredOfferComponent do
+  describe '#deferred_offer_wizard_applicable?' do
+    it 'is true for a deferred offer belonging to the previous recruitment cycle' do
+      application_choice = instance_double(ApplicationChoice, status: 'offer_deferred')
+      allow(application_choice).to receive(:recruitment_cycle).and_return(RecruitmentCycle.previous_year)
+
+      expect(described_class.new(application_choice: application_choice, provider_can_respond: true).deferred_offer_wizard_applicable?).to be true
+    end
+
+    it 'is false if the provider cannot respond to the application' do
+      application_choice = instance_double(ApplicationChoice, status: 'offer_deferred')
+      allow(application_choice).to receive(:recruitment_cycle).and_return(RecruitmentCycle.previous_year)
+
+      expect(described_class.new(application_choice: application_choice, provider_can_respond: false).deferred_offer_wizard_applicable?).to be false
+    end
+
+    it 'is false when the application status is not deferred' do
+      application_choice = instance_double(ApplicationChoice, status: 'withdrawn')
+      allow(application_choice).to receive(:recruitment_cycle).and_return(RecruitmentCycle.previous_year)
+
+      expect(described_class.new(application_choice: application_choice, provider_can_respond: true).deferred_offer_wizard_applicable?).to be false
+    end
+
+    it 'is false when the application recruitment cycle is current' do
+      application_choice = instance_double(ApplicationChoice, status: 'offer_deferred')
+      allow(application_choice).to receive(:recruitment_cycle).and_return(RecruitmentCycle.current_year)
+
+      expect(described_class.new(application_choice: application_choice, provider_can_respond: true).deferred_offer_wizard_applicable?).to be false
+    end
+  end
+
+  describe '#deferred_offer_but_cannot_respond?' do
+    it 'is true if the provider cannot respond to the application' do
+      application_choice = instance_double(ApplicationChoice, status: 'offer_deferred')
+      allow(application_choice).to receive(:recruitment_cycle).and_return(RecruitmentCycle.previous_year)
+
+      expect(described_class.new(application_choice: application_choice, provider_can_respond: false).deferred_offer_but_cannot_respond?).to be true
+    end
+  end
+
+  describe '#deferred_offer_in_current_cycle?' do
+    it 'is true for a deferred offer without an open offered option' do
+      course_option = instance_double(CourseOption, course: instance_double(Course, open_on_apply: false))
+      application_choice = instance_double(ApplicationChoice, status: 'offer_deferred', recruitment_cycle: RecruitmentCycle.current_year)
+      allow(course_option).to receive(:in_next_cycle).and_return(false)
+      allow(application_choice).to receive(:current_course_option).and_return(course_option)
+
+      expect(described_class.new(application_choice: application_choice).deferred_offer_in_current_cycle?).to be true
+    end
+
+    it 'is false for a deferred offer with an open offered option' do
+      course_option = instance_double(CourseOption, course: instance_double(Course, open_on_apply: false))
+      application_choice = instance_double(ApplicationChoice, status: 'offer_deferred', recruitment_cycle: RecruitmentCycle.current_year)
+      allow(course_option).to receive(:in_next_cycle).and_return(course_option)
+      allow(application_choice).to receive(:current_course_option).and_return(course_option)
+
+      expect(described_class.new(application_choice: application_choice).deferred_offer_in_current_cycle?).to be false
+    end
+
+    it 'is false for a deferred offer from the previous cycle' do
+      course_option = instance_double(CourseOption, course: instance_double(Course, open_on_apply: false))
+      application_choice = instance_double(ApplicationChoice, status: 'offer_deferred', recruitment_cycle: RecruitmentCycle.previous_year)
+      allow(course_option).to receive(:in_next_cycle).and_return(course_option)
+      allow(application_choice).to receive(:current_course_option).and_return(course_option)
+
+      expect(described_class.new(application_choice: application_choice).deferred_offer_in_current_cycle?).to be false
+    end
+  end
+end

--- a/spec/components/provider_interface/application_header_components/offer_will_be_declined_by_default_component_spec.rb
+++ b/spec/components/provider_interface/application_header_components/offer_will_be_declined_by_default_component_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ApplicationHeaderComponents::OfferWillBeDeclinedByDefaultComponent do
+  describe '#decline_by_default_text' do
+    it 'returns nil if the application is not in the offer state' do
+      application_choice = build_stubbed(:application_choice, status: 'awaiting_provider_decision')
+
+      expect(described_class.new(application_choice: application_choice).decline_by_default_text).to be_nil
+    end
+
+    describe 'returns the correct text when' do
+      it 'the dbd is today' do
+        application_choice = build_stubbed(
+          :application_choice,
+          status: 'offer',
+          decline_by_default_at: Time.zone.now.end_of_day,
+        )
+
+        expected_text = "at the end of today (#{application_choice.decline_by_default_at.to_fs(:govuk_date_and_time)})"
+        expect(described_class.new(application_choice: application_choice).decline_by_default_text).to eq(expected_text)
+      end
+
+      it 'the dbd is tomorrow' do
+        application_choice = build_stubbed(
+          :application_choice,
+          status: 'offer',
+          decline_by_default_at: 1.day.from_now.end_of_day,
+        )
+
+        expected_text = "at the end of tomorrow (#{application_choice.decline_by_default_at.to_fs(:govuk_date_and_time)})"
+        expect(described_class.new(application_choice: application_choice).decline_by_default_text).to eq(expected_text)
+      end
+
+      it 'the dbd is after tomorrow' do
+        application_choice = build_stubbed(
+          :application_choice,
+          status: 'offer',
+          decline_by_default_at: 3.days.from_now.end_of_day,
+        )
+
+        expected_text = "in 3 days (#{application_choice.decline_by_default_at.to_fs(:govuk_date_and_time)})"
+        expect(described_class.new(application_choice: application_choice).decline_by_default_text).to eq(expected_text)
+      end
+    end
+  end
+end

--- a/spec/components/provider_interface/application_header_components/offer_will_be_declined_by_default_component_spec.rb
+++ b/spec/components/provider_interface/application_header_components/offer_will_be_declined_by_default_component_spec.rb
@@ -1,6 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe ProviderInterface::ApplicationHeaderComponents::OfferWillBeDeclinedByDefaultComponent do
+  describe 'rendered component' do
+    it 'renders offer will be declined content' do
+      application_choice = build_stubbed(:application_choice, :with_offer)
+      result = render_inline(described_class.new(application_choice: application_choice, provider_can_respond: true))
+
+      expect(result.css('h2').text.strip).to eq('Waiting for candidate’s response')
+      expect(result.css('.govuk-body').text).to match(/Your offer will be automatically declined in \d+ days .*? if the candidate does not respond/)
+    end
+  end
+
   describe '#decline_by_default_text' do
     it 'returns nil if the application is not in the offer state' do
       application_choice = build_stubbed(:application_choice, status: 'awaiting_provider_decision')

--- a/spec/components/provider_interface/application_header_components/rejection_reason_required_component_spec.rb
+++ b/spec/components/provider_interface/application_header_components/rejection_reason_required_component_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ApplicationHeaderComponents::RejectionReasonRequiredComponent do
+  describe 'rendered component' do
+    let(:application_choice) { build_stubbed(:application_choice, status: 'rejected', rejected_by_default: true, rejected_at: rejected_at) }
+    let(:rejected_at) { DateTime.new(2022, 2, 22, 23, 59, 59) }
+
+    context 'when the provider user cannot give feedback' do
+      it 'displays text about RBD' do
+        result = render_inline(described_class.new(application_choice: application_choice, provider_can_respond: false))
+        expect(result.css('.govuk-body').text.strip).to eq('This application was automatically rejected on 22 February 2022. Feedback has not been sent to the candidate.')
+      end
+    end
+
+    context 'when the provder user can give feedback' do
+      it 'displays text about RBD' do
+        result = render_inline(described_class.new(application_choice: application_choice, provider_can_respond: true))
+        expect(result.css('h2').text.strip).to eq('Give feedback')
+        expect(result.css('.govuk-body').text.strip).to eq('You did not make a decision about the application within  working days. Tell the candidate why their application was unsuccessful.')
+        expect(result.css('.govuk-button').text.strip).to eq('Give feedback')
+      end
+    end
+  end
+end

--- a/spec/components/provider_interface/application_header_components/respond_component_spec.rb
+++ b/spec/components/provider_interface/application_header_components/respond_component_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ApplicationHeaderComponents::RespondComponent do
+  describe 'rendered component' do
+    context 'when the provider user can make a decision' do
+      let(:application_choice) { build_stubbed(:application_choice, :awaiting_provider_decision) }
+
+      it 'renders Make decision content' do
+        result = render_inline(described_class.new(application_choice: application_choice, provider_can_respond: true))
+
+        expect(result.css('h2').text.strip).to eq('Make a decision')
+        expect(result.css('.govuk-body').text.strip).to match(
+          /This application will be automatically rejected if a decision has not been made within \d+ days/,
+        )
+        expect(result.css('.govuk-button').text.strip).to eq('Make decision')
+      end
+    end
+
+    context 'when the provider user can set up interviews' do
+      let(:application_choice) { build_stubbed(:application_choice, :awaiting_provider_decision) }
+
+      it 'renders Set up interview content' do
+        result = render_inline(described_class.new(application_choice: application_choice, provider_can_set_up_interviews: true))
+
+        expect(result.css('h2').text.strip).to eq('Set up an interview')
+        expect(result.css('.govuk-body').text.strip).to match(
+          /This application will be automatically rejected if a decision has not been made within \d+ days/,
+        )
+        expect(result.css('.govuk-button').text.strip).to eq('Set up interview')
+      end
+    end
+
+    context 'when the provider user can make a decision and set up an interview' do
+      let(:application_choice) { build_stubbed(:application_choice, :awaiting_provider_decision) }
+
+      it 'renders Make decision content' do
+        result = render_inline(
+          described_class.new(
+            application_choice: application_choice,
+            provider_can_respond: true,
+            provider_can_set_up_interviews: true,
+          ),
+        )
+
+        expect(result.css('h2').text.strip).to eq('Set up an interview or make a decision')
+        expect(result.css('.govuk-body').text.strip).to match(
+          /This application will be automatically rejected if a decision has not been made within \d+ days/,
+        )
+        expect(result.css('.govuk-button').first.text.strip).to eq('Set up interview')
+        expect(result.css('.govuk-button').last.text.strip).to eq('Make decision')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

If the user doesn't have permissions to give feedback for a RBD'd application, we should present them with specific text rather than a button which doesn't work.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- `ApplicationChoiceHeaderComponent` was a ball of mud, with so many conditionals it seemed a good time to split it up.
- Add text for RBD applications where the user cannot give feedback.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Refactor klaxxon.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/EsDoVsxG/209-changing-what-we-show-to-users-who-do-not-have-make-decision-permissions
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
