### PR TITLE
Change nationalities data for deprecated options

### DIFF
--- a/app/services/data_migrations/change_english_nationality_data.rb
+++ b/app/services/data_migrations/change_english_nationality_data.rb
@@ -1,0 +1,18 @@
+module DataMigrations
+  class ChangeEnglishNationalityData
+    TIMESTAMP = 20220525155807
+    MANUAL_RUN = false
+
+    def change
+      ApplicationForm.where(first_nationality: %w[English Welsh Scottish], recruitment_cycle_year: 2022).each do |nationality|
+        nationality.update!(first_nationality: 'British')
+      end
+    end
+
+    def dry_run
+      total_number = ApplicationForm.where(first_nationality: %w[English Welsh Scottish], recruitment_cycle_year: 2022)
+
+      Rails.logger.debug { "There are #{total_number.size} records with English, Welsh or Scottish as their first nationality" }
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::ChangeEnglishNationalityData',
   'DataMigrations::BackfillInternationalDegreesSubjectsUuid',
   'DataMigrations::DeleteRetiredNudgeFeatureFlags',
   'DataMigrations::RemoveStructuredReasonsForRejectionRedesignFeatureFlag',

--- a/spec/services/data_migrations/change_english_nationality_data_spec.rb
+++ b/spec/services/data_migrations/change_english_nationality_data_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::ChangeEnglishNationalityData do
+  context 'old country nationalities' do
+    %w[English Scottish Welsh].each do |nationality|
+      it "changes #{nationality} first nationality to British" do
+        application_form = create(:application_form, :minimum_info, first_nationality: nationality, recruitment_cycle_year: 2022)
+
+        described_class.new.change
+
+        expect(application_form.reload.first_nationality).to eq('British')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context
There was a support issue where a user had their application carried over twice. They had old nationalities data, namely 'English' which is no longer offered. This caused an issue on review pages where a right to work row would render that was not easily editable as it was detecting them as a citizen of another country.

## Changes proposed in this pull request

* Data migration to change 'English', 'Scottish' and 'Welsh' first_nationality data to British in this recruitment cycle. Unable to change in historic cycles due to exception thrown (by design).

## Guidance to review

Run data migration against database snapshot. Dry run will show the number of affected records. Is there any way of changing this for historic cycles, as we will get this problem every year if we don't, and will need to rerun the migration

## Link to Trello card
https://trello.com/c/fhjV5nVL/234-right-to-work-bug-carried-over-applications

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
