### PR TITLE
Amend offered at data export column heading

### DIFF
--- a/app/decorators/application_choice_export_decorator.rb
+++ b/app/decorators/application_choice_export_decorator.rb
@@ -48,7 +48,8 @@ class ApplicationChoiceExportDecorator < SimpleDelegator
     return if reasons.nil?
 
     reasons = reasons.transform_values(&:compact)
-    reasons&.map { |k, v| %(#{k.upcase}\n\n#{Array(v).join("\n\n")}) }&.join("\n\n")
+    result = reasons&.map { |k, v| %(#{k.upcase}\n\n#{Array(v).join("\n\n")}) }&.join("\n\n")
+    result.gsub(/^WHY YOUR APPLICATION WAS UNSUCCESSFUL\n\n/, '')
   end
 
   def domicile_country

--- a/app/decorators/application_choice_export_decorator.rb
+++ b/app/decorators/application_choice_export_decorator.rb
@@ -105,6 +105,6 @@ private
   end
 
   def qualification_period(qualification)
-    [qualification.start_year, qualification.award_year].compact.join('-')
+    [qualification.start_year, qualification.award_year].compact.join(' to ')
   end
 end

--- a/app/services/provider_interface/application_data_export.rb
+++ b/app/services/provider_interface/application_data_export.rb
@@ -53,7 +53,7 @@ module ProviderInterface
           'Equivalency details for international degree' => replace_smart_quotes(application.formatted_equivalency_details),
           'GCSEs' => replace_smart_quotes(application.gcse_qualifications_summary),
           'Explanation for missing GCSEs' => replace_smart_quotes(application.missing_gcses_explanation),
-          'Offered at' => application.offered_at,
+          'Offered date' => application.offered_at,
           'Recruited date' => application.recruited_at,
           'Rejected date' => application.rejected_at,
           'Was automatically rejected' => application.rejected_by_default ? 'TRUE' : 'FALSE',

--- a/spec/decorators/application_choice_export_decorator_spec.rb
+++ b/spec/decorators/application_choice_export_decorator_spec.rb
@@ -177,6 +177,17 @@ RSpec.describe ApplicationChoiceExportDecorator do
 
       expect(described_class.new(application_choice).rejection_reasons.split("\n\n")).to eq(expected)
     end
+
+    context 'where the only reason is WHY YOUR APPLICATION WAS UNSUCCESSFUL' do
+      it 'strips the reason heading' do
+        presenter = instance_double(RejectedApplicationChoicePresenter)
+        allow(presenter).to receive(:rejection_reasons).and_return({
+          'why your application was unsuccessful' => ["We don't accept applications written in invisible ink."],
+        })
+        allow(RejectedApplicationChoicePresenter).to receive(:new).and_return(presenter)
+        expect(described_class.new(application_choice).rejection_reasons).to eq("We don't accept applications written in invisible ink.")
+      end
+    end
   end
 
   describe 'formatted_equivalency_details' do

--- a/spec/decorators/application_choice_export_decorator_spec.rb
+++ b/spec/decorators/application_choice_export_decorator_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ApplicationChoiceExportDecorator do
 
       summary = described_class.new(application_choice).gcse_qualifications_summary
 
-      expect(summary).to match(/^GCSE maths, [ABCD], \d{4}-\d{4}$/)
+      expect(summary).to match(/^GCSE maths, [ABCD], \d{4} to \d{4}$/)
     end
 
     it 'does not include GCSEs in other subjects' do

--- a/spec/services/provider_interface/application_data_export_spec.rb
+++ b/spec/services/provider_interface/application_data_export_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe ProviderInterface::ApplicationDataExport do
         'Equivalency details for international degree' => first_degree&.composite_equivalency_details,
         'GCSEs' => 'GCSE maths, B, 2019; GCSE English, A, 2019',
         'Explanation for missing GCSEs' => nil,
-        'Offered at' => application_choice.offered_at,
+        'Offered date' => application_choice.offered_at,
         'Recruited date' => application_choice.recruited_at,
         'Rejected date' => application_choice.rejected_at,
         'Was automatically rejected' => 'FALSE',


### PR DESCRIPTION
## Context

A couple of small inconsistencies were spotted with data exports on QA.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Update `Offered at` to `Offered date`
- Amend format of qualification period where a start date is present: eg. `2011 to 2014`
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
