### PR TITLE
Add data migration to backfill the qualification level

### DIFF
--- a/app/services/data_migrations/backfill_qualification_level.rb
+++ b/app/services/data_migrations/backfill_qualification_level.rb
@@ -1,0 +1,68 @@
+module DataMigrations
+  class BackfillQualificationLevel
+    TIMESTAMP = 20220523143800
+    MANUAL_RUN = true
+
+    def change
+      records.find_each do |qualification|
+        qualification_level = find_qualification_level(qualification)
+        qualification_level_uuid = find_qualification_level_uuid(qualification)
+
+        if qualification_level.present? || qualification_level_uuid.present?
+          qualification.update_columns(
+            qualification_level: qualification_level,
+            qualification_level_uuid: qualification_level_uuid,
+          )
+        end
+      end
+    end
+
+    # rubocop:disable Rails/Output
+    def dry_run
+      found = 0
+      not_found = 0
+      not_found_data = []
+
+      records.find_each do |qualification|
+        qualification_level = find_qualification_level(qualification)
+        qualification_level_uuid = find_qualification_level_uuid(qualification)
+
+        if qualification_level.present?
+          message = "'#{qualification.qualification_type}' with #{qualification_level}"
+          message << " From reference data: '#{DfE::ReferenceData::Qualifications::QUALIFICATIONS.one(qualification_level_uuid)&.name}' '#{qualification_level_uuid}'" if qualification_level_uuid.present?
+          puts message
+          found += 1
+        else
+          not_found_data << qualification.qualification_type
+          not_found += 1
+        end
+      end
+
+      puts "Qualification records updated: #{found} records"
+      puts "Qualification records that do not have a level: #{not_found} records"
+      puts "Not found data: #{not_found_data.join(', ')}"
+    end
+    # rubocop:enable Rails/Output
+
+    def records
+      ApplicationQualification.degree
+    end
+
+  private
+
+    def find_qualification_level(qualification)
+      degree_type_for(qualification)&.level
+    end
+
+    def find_qualification_level_uuid(qualification)
+      degree_type_for(qualification)&.qualification
+    end
+
+    def degree_type_for(qualification)
+      return if qualification.qualification_type.blank?
+
+      Hesa::DegreeType.find_by_abbreviation_or_name(qualification.qualification_type) ||
+        Hesa::DegreeType.find_by_hesa_code(qualification.qualification_type_hesa_code)
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -2,6 +2,7 @@ DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
   'DataMigrations::ChangeEnglishNationalityData',
   'DataMigrations::CreateMissingTempSites',
+  'DataMigrations::BackfillQualificationLevel',
   'DataMigrations::BackfillInternationalDegreesSubjectsUuid',
   'DataMigrations::BackfillTempSites',
   'DataMigrations::DeleteRetiredNudgeFeatureFlags',

--- a/spec/services/data_migrations/backfill_qualification_level_spec.rb
+++ b/spec/services/data_migrations/backfill_qualification_level_spec.rb
@@ -1,0 +1,139 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillQualificationLevel do
+  context 'when bachelor' do
+    let(:bachelor_of_arts) do
+      DfE::ReferenceData::Degrees::TYPES.some(abbreviation: 'BA').first
+    end
+    let(:bachelor) do
+      DfE::ReferenceData::Qualifications::QUALIFICATIONS.some(name: 'bachelors degree').first
+    end
+
+    it 'saves qualification level and qualification level UUID' do
+      degree_qualification = create(
+        :degree_qualification,
+        qualification_type: bachelor_of_arts.name,
+      )
+
+      described_class.new.change
+
+      expect(degree_qualification.reload.attributes).to include(
+        {
+          'qualification_level' => 'bachelor',
+          'qualification_level_uuid' => bachelor.id,
+        },
+      )
+    end
+  end
+
+  context 'when master' do
+    let(:master_of_arts) do
+      DfE::ReferenceData::Degrees::TYPES.some(abbreviation: 'MA').first
+    end
+    let(:master) do
+      DfE::ReferenceData::Qualifications::QUALIFICATIONS.some(name: "master's degree").first
+    end
+
+    it 'saves qualification level and qualification level UUID' do
+      degree_qualification = create(
+        :degree_qualification,
+        qualification_type: master_of_arts.name,
+      )
+
+      described_class.new.change
+
+      expect(degree_qualification.reload.attributes).to include(
+        {
+          'qualification_level' => 'master',
+          'qualification_level_uuid' => master.id,
+        },
+      )
+    end
+  end
+
+  context 'when doctor' do
+    let(:doctor_of_music) do
+      DfE::ReferenceData::Degrees::TYPES.some(abbreviation: 'DMu').first
+    end
+    let(:doctor) do
+      DfE::ReferenceData::Qualifications::QUALIFICATIONS.some(name: 'doctorate').first
+    end
+
+    it 'saves qualification level and qualification level UUID' do
+      degree_qualification = create(
+        :degree_qualification,
+        qualification_type: doctor_of_music.name,
+      )
+
+      described_class.new.change
+
+      expect(degree_qualification.reload.attributes).to include(
+        {
+          'qualification_level' => 'doctor',
+          'qualification_level_uuid' => doctor.id,
+        },
+      )
+    end
+  end
+
+  context 'when foundation' do
+    let(:foundation_of_sciences) do
+      DfE::ReferenceData::Degrees::TYPES.some(abbreviation: 'FdSs').first
+    end
+    let(:foundation) do
+      DfE::ReferenceData::Qualifications::QUALIFICATIONS.some(name: 'foundation degree').first
+    end
+
+    it 'saves qualification level and qualification level UUID' do
+      degree_qualification = create(
+        :degree_qualification,
+        qualification_type: foundation_of_sciences.name,
+      )
+
+      described_class.new.change
+
+      expect(degree_qualification.reload.attributes).to include(
+        {
+          'qualification_level' => 'foundation',
+          'qualification_level_uuid' => foundation.id,
+        },
+      )
+    end
+  end
+
+  context 'when degree is nil' do
+    it 'does not save any qualification level' do
+      degree_qualification = create(
+        :degree_qualification,
+        qualification_type: nil,
+      )
+
+      described_class.new.change
+
+      expect(degree_qualification.reload.attributes).to include(
+        {
+          'qualification_level' => nil,
+          'qualification_level_uuid' => nil,
+        },
+      )
+    end
+  end
+
+  context 'when degree is not found in the data' do
+    it 'does not save any qualification level' do
+      degree_qualification = create(
+        :degree_qualification,
+        qualification_type: 'My awesome degree',
+      )
+
+      described_class.new.change
+
+      expect(degree_qualification.reload.attributes).to include(
+        {
+          'qualification_level' => nil,
+          'qualification_level_uuid' => nil,
+        },
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Context

Backfill all degrees and find in reference data what kind of degree it is:

These are the levels that will be saved:

* bachelor
* master
* foundation
* doctor

## Guidance to review

1. Does the dry-run runs successfully against the snapshot?

## Link to Trello card

https://trello.com/c/dt10YnYp/55-degree-type-free-text-bug
