### PR TITLE
Amend regex which strips superfluous REASONS heading

### DIFF
--- a/app/decorators/application_choice_export_decorator.rb
+++ b/app/decorators/application_choice_export_decorator.rb
@@ -49,7 +49,7 @@ class ApplicationChoiceExportDecorator < SimpleDelegator
 
     reasons = reasons.transform_values(&:compact)
     result = reasons&.map { |k, v| %(#{k.upcase}\n\n#{Array(v).join("\n\n")}) }&.join("\n\n")
-    result.gsub(/^WHY YOUR APPLICATION WAS UNSUCCESSFUL\n\n/, '')
+    result.gsub(/^REASONS WHY YOUR APPLICATION WAS UNSUCCESSFUL\n\n/, '')
   end
 
   def domicile_country

--- a/spec/decorators/application_choice_export_decorator_spec.rb
+++ b/spec/decorators/application_choice_export_decorator_spec.rb
@@ -178,11 +178,11 @@ RSpec.describe ApplicationChoiceExportDecorator do
       expect(described_class.new(application_choice).rejection_reasons.split("\n\n")).to eq(expected)
     end
 
-    context 'where the only reason is WHY YOUR APPLICATION WAS UNSUCCESSFUL' do
+    context 'where the only reason is REASONS WHY YOUR APPLICATION WAS UNSUCCESSFUL' do
       it 'strips the reason heading' do
         presenter = instance_double(RejectedApplicationChoicePresenter)
         allow(presenter).to receive(:rejection_reasons).and_return({
-          'why your application was unsuccessful' => ["We don't accept applications written in invisible ink."],
+          'reasons why your application was unsuccessful' => ["We don't accept applications written in invisible ink."],
         })
         allow(RejectedApplicationChoicePresenter).to receive(:new).and_return(presenter)
         expect(described_class.new(application_choice).rejection_reasons).to eq("We don't accept applications written in invisible ink.")


### PR DESCRIPTION
## Context

https://github.com/DFE-Digital/apply-for-teacher-training/pull/7024 contained the wrong string to match the category heading `REASONS WHY YOUR APPLICATION WAS UNSUCCESSFUL` 
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
![image](https://user-images.githubusercontent.com/93511/170974808-5a417c05-317b-4630-8061-64cb60d51e67.png)

Amend the regex to match the category heading
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
