### PR TITLE
Fiz support interface edit references feedback bug

### DIFF
--- a/app/controllers/support_interface/application_forms/references_controller.rb
+++ b/app/controllers/support_interface/application_forms/references_controller.rb
@@ -24,7 +24,7 @@ module SupportInterface
         @feedback_form = EditReferenceFeedbackForm.new(edit_reference_feedback_params)
 
         if @feedback_form.save(reference)
-          SubmitReference.new(reference: reference, send_emails: send_emails).save!
+          SubmitReference.new(reference: reference, send_emails: send_emails, selected: reference.selected?).save!
           flash[:success] = 'Reference updated'
           redirect_to support_interface_application_form_path(@reference.application_form)
         else

--- a/app/services/submit_reference.rb
+++ b/app/services/submit_reference.rb
@@ -1,14 +1,19 @@
 class SubmitReference
-  attr_reader :reference
+  attr_reader :reference, :selected
   delegate :application_form, to: :reference
 
-  def initialize(reference:, send_emails: true)
+  def initialize(reference:, send_emails: true, selected: false)
     @reference = reference
     @send_emails = send_emails
+    @selected = selected
   end
 
   def save!
-    @reference.update!(feedback_status: :feedback_provided, feedback_provided_at: Time.zone.now, selected: false)
+    @reference.update!(
+      feedback_status: :feedback_provided,
+      feedback_provided_at: Time.zone.now,
+      selected: selected,
+    )
 
     if @send_emails
       CandidateMailer.reference_received(reference).deliver_later

--- a/spec/requests/support_interface/update_reference_feedback_spec.rb
+++ b/spec/requests/support_interface/update_reference_feedback_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe 'Support interface - POST /support/applications/:application_id/references/:reference_id/feedback', type: :request do
+  def support_user
+    @support_user ||= SupportUser.new(
+      email_address: 'alice@example.com',
+      dfe_sign_in_uid: 'ABC',
+    )
+  end
+
+  def set_support_user_permission
+    allow(SupportUser).to receive(:load_from_session).and_return(support_user)
+  end
+
+  it 'does not change the selected attribute' do
+    set_support_user_permission
+
+    application_form = create(:application_form)
+    reference = create(:reference, application_form: application_form, selected: true)
+
+    post(
+      support_interface_application_form_update_reference_feedback_path(
+        support_interface_application_forms_edit_reference_feedback_form: {
+          feedback: 'some feedback',
+          audit_comment: 'ticket',
+          send_emails: 'false',
+        },
+        application_form_id: application_form.id,
+        reference_id: reference.id,
+      ),
+    )
+
+    expect(reference.reload.selected).to be(true)
+    expect(response).to redirect_to(
+      support_interface_application_form_path(application_form),
+    )
+  end
+end

--- a/spec/services/submit_reference_spec.rb
+++ b/spec/services/submit_reference_spec.rb
@@ -22,6 +22,21 @@ RSpec.describe SubmitReference do
       end
     end
 
+    context 'when overriding the selected from a reference' do
+      it 'uses the selected on initialize' do
+        Timecop.freeze do
+          reference_one = create(:reference, :feedback_requested)
+          reference_two = create(:reference, :feedback_requested, application_form: reference_one.application_form)
+
+          described_class.new(reference: reference_one, selected: true).save!
+          described_class.new(reference: reference_two, selected: false).save!
+
+          expect(reference_one.selected).to be true
+          expect(reference_two.selected).to be false
+        end
+      end
+    end
+
     context 'when the second reference is received' do
       it 'does not alter the state of any outstanding references' do
         application_form = create(:application_form)


### PR DESCRIPTION
## Context

We allow support agents to edit a reference's feedback in the support interface.

After a reference is edited we send out an email to the candidate and referee. In that service: SubmitReference we are marking the reference as not selected, meaning if an agent edits this they are unselecting a reference for a candidate.

We should avoid unselecting a reference if edited by support and if already set as true

## Guidance to review

* Does it remain the same "selected" property when updating reference feedback in the support interface?

## Link to Trello card

https://trello.com/c/993Q30Of/225-support-tool-edit-references
