### PR TITLE
update links to GIT

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,12 +33,12 @@ en:
     url_applying: https://getintoteaching.education.gov.uk/steps-to-become-a-teacher#step-5
     url_get_an_adviser: https://adviser-getintoteaching.education.gov.uk
     url_get_an_adviser_start: https://getintoteaching.education.gov.uk/teacher-training-advisers
-    url_international_candidates: https://getintoteaching.education.gov.uk/international-candidates
-    url_training_with_a_disability: https://getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#training-to-teach-if-you-have-a-disability
+    url_international_candidates: https://getintoteaching.education.gov.uk/non-uk-teachers
+    url_training_with_a_disability: https://getintoteaching.education.gov.uk/get-support-training-to-teach-if-you-are-disabled
     url_support_if_you_are_disabled: https://getintoteaching.education.gov.uk/get-support-training-to-teach-if-you-are-disabled
     url_online_chat: https://getintoteaching.education.gov.uk/#talk-to-us
-    url_get_school_experience: https://getintoteaching.education.gov.uk/get-school-experience
-    url_ways_to_train: https://getintoteaching.education.gov.uk/ways-to-train
+    url_get_school_experience: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/get-school-experience
+    url_ways_to_train: https://getintoteaching.education.gov.uk/train-to-be-a-teacher
     url_choose_your_referees: https://getintoteaching.education.gov.uk/tips-on-applying-for-teacher-training#choose-your-referees
   train_to_teach_in_england:
     url: https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,7 +34,6 @@ en:
     url_get_an_adviser: https://adviser-getintoteaching.education.gov.uk
     url_get_an_adviser_start: https://getintoteaching.education.gov.uk/teacher-training-advisers
     url_international_candidates: https://getintoteaching.education.gov.uk/non-uk-teachers
-    url_training_with_a_disability: https://getintoteaching.education.gov.uk/get-support-training-to-teach-if-you-are-disabled
     url_support_if_you_are_disabled: https://getintoteaching.education.gov.uk/get-support-training-to-teach-if-you-are-disabled
     url_online_chat: https://getintoteaching.education.gov.uk/#talk-to-us
     url_get_school_experience: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/get-school-experience


### PR DESCRIPTION
## Context

Adjusting some old links to new pages on Get Into Teaching that have replaced them.

## Guidance to review

It appears we don't actually link to some of these, is that true? If so, why do we still have them?

Given that these are defined URLs in code, do we need to amend any tests?

## Link to Trello card

https://trello.com/c/QSepcH4z/283-update-our-urls-in-our-enyml-file-for-get-into-teaching

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
