### PR TITLE
Fix IMAGE_TAG for rollover and sandbox deployments

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -449,7 +449,7 @@ jobs:
     environment:
       name: ${{ matrix.environment }}
       url: ${{ steps.deploy_app_parallel.outputs.deploy-url }}
-    needs: [deploy-main]
+    needs: [lint, test, deploy-main]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION

## Context

Rollover and sandbox deploys are not setting IMAGE_TAG correctly 

## Changes proposed in this pull request

Add lint, test to needs to build-and-deploy workflow

## Guidance to review

check config is correct

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
