### PR TITLE
[598] Do not fail silently if imagetag not provided

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -440,7 +440,7 @@ jobs:
           arm-access-key: ${{ secrets.ARM_ACCESS_KEY }}
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ matrix.environment }}
-          sha: ${{ needs.test.outputs.IMAGE_TAG }}
+          sha: ${{ github.sha }}
           slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
 
   deploy-secondary:
@@ -449,7 +449,7 @@ jobs:
     environment:
       name: ${{ matrix.environment }}
       url: ${{ steps.deploy_app_parallel.outputs.deploy-url }}
-    needs: [lint, test, deploy-main]
+    needs: [deploy-main]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -466,5 +466,5 @@ jobs:
           arm-access-key: ${{ secrets.ARM_ACCESS_KEY }}
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
           environment: ${{ matrix.environment }}
-          sha: ${{ needs.test.outputs.IMAGE_TAG }}
+          sha: ${{ github.sha }}
           slack-webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,7 @@ ci:
 	$(eval export CONFIRM_DELETE=true)
 	$(eval export DISABLE_PASSCODE=true)
 	$(eval export AUTO_APPROVE=-auto-approve)
+	$(eval export NO_IMAGE_TAG_DEFAULT=true)
 
 azure-login:
 	az account set -s $(AZURE_SUBSCRIPTION)
@@ -157,7 +158,8 @@ shell: ## Open a shell on the app instance on PaaS, eg: make qa shell
 	cf ssh apply-clock-${APP_NAME_SUFFIX} -t -c 'cd /app && /usr/local/bin/bundle exec rails c'
 
 deploy-init:
-	$(if $(IMAGE_TAG), , $(eval export IMAGE_TAG=main))
+	$(if $(or $(IMAGE_TAG), $(NO_IMAGE_TAG_DEFAULT)), , $(eval export IMAGE_TAG=main))
+	$(if $(IMAGE_TAG), , $(error Missing environment variable "IMAGE_TAG"))
 	$(if $(or $(DISABLE_PASSCODE),$(PASSCODE)), , $(error Missing environment variable "PASSCODE", retrieve from https://login.london.cloud.service.gov.uk/passcode))
 	$(eval export TF_VAR_paas_sso_code=$(PASSCODE))
 	$(eval export TF_VAR_paas_docker_image=ghcr.io/dfe-digital/apply-teacher-training:$(IMAGE_TAG))


### PR DESCRIPTION
## Context
After a workflow update, the sandbox and rollover environments deployments were failing silently

## Changes proposed in this pull request
Fail explicitly if the image tag is empty

## Guidance to review
Compare `make qa deploy-plan` and `make qa ci deploy-plan`

## Link to Trello card
https://trello.com/c/Wi5TkJ2d

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
