### PR TITLE
Make error type visible to the support layout

### DIFF
--- a/app/views/errors/account_locked.html.erb
+++ b/app/views/errors/account_locked.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :title, t('page_titles.account_locked') %>
+<%= content_for :error_type, 'account_locked' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :title, t('page_titles.forbidden') %>
+<%= content_for :error_type, 'forbidden' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :title, t('page_titles.internal_server_error') %>
+<%= content_for :error_type, 'internal_server_error' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :title, t('page_titles.not_found') %>
+<%= content_for :error_type, 'not_found' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/errors/service_unavailable.html.erb
+++ b/app/views/errors/service_unavailable.html.erb
@@ -1,1 +1,2 @@
+<%= content_for :error_type, 'service_unavailable' %>
 <%= render ServiceUnavailableComponent.new %>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :title, t('page_titles.unprocessable_entity') %>
+<%= content_for :error_type, 'unprocessable_entity' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/layouts/support_layout.html.erb
+++ b/app/views/layouts/support_layout.html.erb
@@ -5,7 +5,7 @@
     <span class="govuk-caption-l"><%= yield :context %></span>
   <% end %>
 
-  <% if yield(:title).present? && controller_name != 'errors' %>
+  <% if yield(:title).present? && yield(:error_type).blank? %>
     <h1 class="govuk-heading-l"><%= yield :title %></h1>
   <% end %>
 


### PR DESCRIPTION
## Context

The support layout uses the page title as a H1 heading but error pages already contain this heading in the template body.
We prevented a double rendering of the H1 title by checking if the controller_name was 'errors' but this does not work for
ActiveRecord::QueryCanceled errors emanating from the ApplicationController as we explicitly want the actual controller name
to propagate into error tracing.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Be explicit about the error type and check for the presence of this in the support layout.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

I think this is foolproof, but I wrote it, so I am biased.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/WOxdOD1E/239-double-sorry-there-is-a-problem-with-this-service-message
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
