### PR TITLE
Fix flakey spec json data

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -222,6 +222,9 @@ jobs:
           file_text=$(cat /app/tmp/rspec-retry-flakey-specs.log)
           if [ ! -z "$file_text" ]
           then
+            file_text="${file_text//'%'/'%25'}"
+            file_text="${file_text//$'\n'/'%0A'}"
+            file_text="${file_text//$'\r'/'%0D'}"
             echo "::set-output name=flakey_tests::$file_text"
           else
             echo "No flakey tests logged"

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -225,6 +225,8 @@ jobs:
             file_text="${file_text//'%'/'%25'}"
             file_text="${file_text//$'\n'/'%0A'}"
             file_text="${file_text//$'\r'/'%0D'}"
+            file_text="${file_text//'\u003c'/'&lt;'}"
+            file_text="${file_text//'\u003e'/'&gt;'}"
             echo "::set-output name=flakey_tests::$file_text"
           else
             echo "No flakey tests logged"

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -249,9 +249,6 @@ jobs:
     needs: [test]
     runs-on: ubuntu-latest
     steps:
-      - name: Echo flakey test output
-        run: echo "${{ needs.test.outputs.flakey_tests }}"
-
       - name: Checkout source
         uses: actions/checkout@v2
 


### PR DESCRIPTION
## Context

The `echo` step is failing because of quote escaping issues with more complex JSON output from the retry logs.
It's not an essential part of the build or the flakey spec reporting.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Remove `echo` flakey specs output.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
