### PR TITLE
Specify permission to view criminal record and professional misconduct

### DIFF
--- a/app/components/provider_interface/safeguarding_declaration_component.html.erb
+++ b/app/components/provider_interface/safeguarding_declaration_component.html.erb
@@ -2,7 +2,7 @@
 
 <% if display_safeguarding_issues? %>
   <section class="app-section govuk-!-width-two-thirds">
-    <h2 class="govuk-heading-m govuk-!-font-size-27" id="criminal-convictions-and-professional-misconduct">Criminal convictions and professional misconduct</h2>
+    <h2 class="govuk-heading-m govuk-!-font-size-27" id="criminal-convictions-and-professional-misconduct">Criminal record and professional misconduct</h2>
 
     <%= render SummaryListComponent.new(rows: rows) %>
   </section>

--- a/app/components/provider_interface/safeguarding_declaration_component.html.erb
+++ b/app/components/provider_interface/safeguarding_declaration_component.html.erb
@@ -1,72 +1,9 @@
 <%= render ProviderInterface::PermissionsDebugCommentComponent.new(auth_analysis: @analysis) %>
 
-<section class="app-section govuk-!-width-two-thirds">
-  <h2 class="govuk-heading-m govuk-!-font-size-27" id="criminal-convictions-and-professional-misconduct">Criminal convictions and professional misconduct</h2>
+<% if display_safeguarding_issues? %>
+  <section class="app-section govuk-!-width-two-thirds">
+    <h2 class="govuk-heading-m govuk-!-font-size-27" id="criminal-convictions-and-professional-misconduct">Criminal convictions and professional misconduct</h2>
 
-  <% if message %><p class="govuk-body"><%= message %></p><% end %>
-
-  <% if display_safeguarding_issues_details? %>
-    <%= govuk_details(
-      summary_text: 'View information disclosed by the candidate',
-      classes: 'govuk-!-margin-bottom-2',
-    ) do %>
-      <%= details %>
-    <% end %>
-
-  <% elsif safeguarding_issues_declared? %>
-    <% if @analysis.provider_relationship_allows_access? %>
-      <p class="govuk-body">
-        The candidate has disclosed information related to safeguarding but you do not have permission to view sensitive material.
-      </p>
-    <% elsif @analysis.provider_relationship_has_been_set_up? %>
-      <% if @analysis.provider_user_has_user_level_access? %>
-        <p class="govuk-body">
-          This candidate has disclosed information related to safeguarding.
-        </p>
-
-        <% if @analysis.provider_user_associated_with_training_provider? %>
-          <p class="govuk-body">
-            You have permission to see safeguarding information for <%= @analysis.training_provider.name %>. However, <%= @analysis.training_provider.name %> does not have permission to see safeguarding information for applications to courses ratified by <%= @analysis.ratifying_provider.name %>.
-          </p>
-        <% else %>
-          <p class="govuk-body">
-            You have permission to see safeguarding information for <%= @analysis.ratifying_provider.name %>. However, <%= @analysis.ratifying_provider.name %> does not have permission to see safeguarding information for applications to courses run by <%= @analysis.training_provider.name %>.
-          </p>
-        <% end %>
-      <% else %>
-        <p class="govuk-body">
-          The candidate has disclosed information related to safeguarding but you do not have permission to view sensitive material.
-        </p>
-      <% end %>
-    <% else %>
-      <p class="govuk-body">
-        The candidate has disclosed information related to safeguarding but you cannot see it.
-      </p>
-
-      <% if @analysis.training_provider_users_who_can_manage_organisations.present? %>
-        <% others = @analysis.training_provider_users_who_can_manage_organisations %>
-        <p class="govuk-body">
-          This is because organisation permissions have not been set up. Contact
-          <% if others.one? %>
-            <% user = others.first %>
-            <%= user.full_name %> at <%= govuk_mail_to user.email_address, user.email_address %>.
-          <% else %>
-            one of the following people:
-            <ul class="govuk-list govuk-list--bullet">
-            <% others.each do |user| %>
-              <li>
-                <%= user.full_name %> at <%= govuk_mail_to user.email_address, user.email_address %>
-              </li>
-            <% end %>
-            </ul>
-          <% end %>
-        </p>
-      <% else %>
-        <p class="govuk-body">
-          This is because organisation permissions have not been set up.
-          Contact support at <%= bat_contact_mail_to %>
-        </p>
-      <% end %>
-    <% end %>
-  <% end %>
-</section>
+    <%= render SummaryListComponent.new(rows: rows) %>
+  </section>
+<% end %>

--- a/app/components/provider_interface/safeguarding_declaration_component.html.erb
+++ b/app/components/provider_interface/safeguarding_declaration_component.html.erb
@@ -1,6 +1,6 @@
 <%= render ProviderInterface::PermissionsDebugCommentComponent.new(auth_analysis: @analysis) %>
 
-<% if display_safeguarding_issues? %>
+<% unless hiding_safeguarding_issues? %>
   <section class="app-section govuk-!-width-two-thirds">
     <h2 class="govuk-heading-m govuk-!-font-size-27" id="criminal-convictions-and-professional-misconduct">Criminal record and professional misconduct</h2>
 

--- a/app/components/provider_interface/safeguarding_declaration_component.rb
+++ b/app/components/provider_interface/safeguarding_declaration_component.rb
@@ -17,30 +17,37 @@ module ProviderInterface
       )
     end
 
-    def message
-      return if status == 'has_safeguarding_issues_to_declare_no_permissions'
+    def rows
+      rows = [{ key: I18n.t('provider_interface.safeguarding_declaration_component.declare_safeguarding_issues'), value: declare_safeguarding_issues }]
 
-      SafeguardingStatus.new(
-        status: status,
-        i18n_key: 'provider_interface.safeguarding_declaration_component',
-      ).message
-    end
+      if safeguarding_issues_declared?
+        rows << { key: I18n.t('provider_interface.safeguarding_declaration_component.safeguarding_information'), value: safeguarding_information }
+      end
 
-    def display_safeguarding_issues_details?
-      safeguarding_issues_declared? && current_user_has_permission_to_view_safeguarding_information?
-    end
-
-    def details
-      application_choice.application_form.safeguarding_issues
+      rows
     end
 
   private
 
-    def status
-      if safeguarding_issues_declared? && !current_user_has_permission_to_view_safeguarding_information?
-        'has_safeguarding_issues_to_declare_no_permissions'
+    def declare_safeguarding_issues
+      if safeguarding_issues_declared?
+        I18n.t('provider_interface.safeguarding_declaration_component.has_safeguarding_issues_to_declare')
       else
-        application_choice.application_form.safeguarding_issues_status
+        I18n.t('provider_interface.safeguarding_declaration_component.no_safeguarding_issues_to_declare')
+      end
+    end
+
+    def display_safeguarding_issues?
+      [ApplicationForm.safeguarding_issues_statuses['never_asked']].exclude?(
+        application_choice.application_form.safeguarding_issues_status,
+      )
+    end
+
+    def safeguarding_information
+      if current_user_has_permission_to_view_safeguarding_information?
+        application_choice.application_form.safeguarding_issues
+      else
+        I18n.t('provider_interface.safeguarding_declaration_component.cannot_see_safeguarding_information')
       end
     end
 

--- a/app/components/provider_interface/safeguarding_declaration_component.rb
+++ b/app/components/provider_interface/safeguarding_declaration_component.rb
@@ -37,10 +37,8 @@ module ProviderInterface
       end
     end
 
-    def display_safeguarding_issues?
-      [ApplicationForm.safeguarding_issues_statuses['never_asked']].exclude?(
-        application_choice.application_form.safeguarding_issues_status,
-      )
+    def hiding_safeguarding_issues?
+      application_choice.application_form.never_asked?
     end
 
     def safeguarding_information

--- a/config/locales/provider_interface/safeguarding.yml
+++ b/config/locales/provider_interface/safeguarding.yml
@@ -1,7 +1,8 @@
 en:
   provider_interface:
     safeguarding_declaration_component:
-      has_safeguarding_issues_to_declare: The candidate has disclosed sensitive material related to safeguarding.
-      not_answered_yet: Not answered yet.
-      never_asked: Never asked.
-      no_safeguarding_issues_to_declare: The candidate has declared no criminal convictions or other safeguarding issues.
+      declare_safeguarding_issues: Do you want to declare any safeguarding issues such as a criminal record or professional misconduct?
+      safeguarding_information: Give any relevant information
+      cannot_see_safeguarding_information: You cannot view this because you do not have permission to view criminal record and professional misconduct
+      has_safeguarding_issues_to_declare: Yes, I want to declare something
+      no_safeguarding_issues_to_declare: "No"

--- a/config/locales/provider_interface/safeguarding.yml
+++ b/config/locales/provider_interface/safeguarding.yml
@@ -3,6 +3,6 @@ en:
     safeguarding_declaration_component:
       declare_safeguarding_issues: Do you want to declare any safeguarding issues such as a criminal record or professional misconduct?
       safeguarding_information: Give any relevant information
-      cannot_see_safeguarding_information: You cannot view this because you do not have permission to view criminal record and professional misconduct
+      cannot_see_safeguarding_information: You cannot view this because you do not have permission to view criminal record and professional misconduct information.
       has_safeguarding_issues_to_declare: Yes, I want to declare something
       no_safeguarding_issues_to_declare: "No"

--- a/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
+++ b/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe ProviderInterface::SafeguardingDeclarationComponent do
           safeguarding_issues: nil,
           safeguarding_issues_status: 'never_asked',
         )
-        expect(result.text).not_to include('Criminal convictions and professional misconduct')
+        expect(result.text).not_to include('Criminal record and professional misconduct')
         expect(result.text).not_to include('Never asked')
       end
     end
@@ -135,7 +135,7 @@ RSpec.describe ProviderInterface::SafeguardingDeclarationComponent do
           safeguarding_issues: nil,
           safeguarding_issues_status: 'never_asked',
         )
-        expect(result).not_to include('Criminal convictions and professional misconduct')
+        expect(result).not_to include('Criminal record and professional misconduct')
         expect(result).not_to include('Never asked')
         expect(result).not_to include(I18n.t('provider_interface.safeguarding_declaration_component.declare_safeguarding_issues'))
       end

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -37,12 +37,12 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
   end
 
   def and_i_should_not_see_the_safeguarding_declaration_details
-    expect(page).to have_content('Criminal convictions and professional misconduct')
+    expect(page).to have_content('Criminal record and professional misconduct')
     expect(page).not_to have_content('View information disclosed by the candidate')
   end
 
   def then_i_should_see_the_safeguarding_declaration_section
-    expect(page).to have_content('Criminal convictions and professional misconduct')
+    expect(page).to have_content('Criminal record and professional misconduct')
     expect(page).to have_content(t('provider_interface.safeguarding_declaration_component.has_safeguarding_issues_to_declare'))
   end
 


### PR DESCRIPTION
## Context

Simplifying what we show to users who do not have permission to view criminal record and professional misconduct information.

## Changes proposed in this pull request

1. rename heading to “Criminal record and professional misconduct”
2. change to questions in the table
3. If the answer is no only show the one question
4. Do not show an answer if the user does not have relevant permissions

## Guidance to review

1. Does it show when the user has safeguarding issues and the provider user has permission to see it?
2. Does it show when the user has safeguarding issues and the provider user doesn't have permission to see it?
3. Does it work when a user doesn't have safeguarding issues?

## Link to Trello card

https://trello.com/c/ouU7tDRi/32-changing-what-we-show-to-users-who-do-not-have-permissions
