### PR TITLE
Scope Site code lookup in Vendor API

### DIFF
--- a/app/queries/get_course_option_from_codes.rb
+++ b/app/queries/get_course_option_from_codes.rb
@@ -35,7 +35,7 @@ class GetCourseOptionFromCodes
 
   validates_each :site_code do |record, attr, value|
     if record.provider && value.present?
-      record.site ||= record.provider.sites.find_by(code: value)
+      record.site ||= record.provider.sites.for_recruitment_cycle_years([RecruitmentCycle.current_year]).find_by(code: value)
       record.errors.add(attr, "Site #{value} does not exist for provider #{record.provider.code}") unless record.site
     end
   end

--- a/spec/factories/site.rb
+++ b/spec/factories/site.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :site, class: 'TempSite' do
     provider
 
-    initialize_with { TempSite.find_or_initialize_by(provider: provider, code: code) }
+    initialize_with { TempSite.find_or_initialize_by(provider: provider, uuid: uuid) }
     code { Faker::Alphanumeric.unique.alphanumeric(number: 5).upcase }
     name { "#{Faker::Educator.secondary_school} #{rand(100..999)}" }
     uuid { Faker::Internet.uuid }

--- a/spec/queries/get_course_option_from_codes_spec.rb
+++ b/spec/queries/get_course_option_from_codes_spec.rb
@@ -57,6 +57,19 @@ RSpec.describe GetCourseOptionFromCodes, type: :model do
         expect(service.errors[:course_option]).to contain_exactly(expected_message)
       end
     end
+
+    context 'when the site code exists in a different cycle year' do
+      let(:course) { create(:course) }
+      let(:course_previous_year) { create(:course, :previous_year, provider: course.provider) }
+      let(:site_from_previous_year) { create(:site, code: '-', provider: course.provider) }
+      let(:site_from_current_year) { create(:site, code: '-', provider: course.provider) }
+      let!(:course_option) { create(:course_option, site: site_from_current_year, course: course) }
+      let!(:course_option_from_previous_year) { create(:course_option, :previous_year, site: site_from_previous_year, course: course_previous_year) }
+
+      it 'is valid' do
+        expect(service).to be_valid
+      end
+    end
   end
 
   describe '#call' do


### PR DESCRIPTION
## Context

We currently look up course options when making an offer in the vendor API using the site code scoped to all cycle years per provider. This is no longer correct and might attempt to lookup the wrong site mapped to the course option.

We also no longer rely on code being unique per provider.
## Changes proposed in this pull request

- Scope the site to the current cycle year as we only use this service to make/change offers
- Add an error if there are duplicate site codes per provider in the cycle
- 
## Guidance to review

Did I miss anything?

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
