### PR TITLE
Scope to current and previous year and filter on name and code

### DIFF
--- a/app/models/provider_interface/provider_applications_filter.rb
+++ b/app/models/provider_interface/provider_applications_filter.rb
@@ -151,17 +151,17 @@ module ProviderInterface
       providers = ProviderOptionsService.new(provider_user).providers_with_sites(provider_ids: selected_provider_ids)
 
       providers.map do |provider|
-        next unless provider.sites.count > 1
+        next unless provider.sites.for_recruitment_cycle_years([CycleTimetable.current_year, CycleTimetable.previous_year]).count > 1
 
         {
           type: :checkboxes,
           heading: "Locations for #{provider.name}",
           name: 'provider_location',
-          options: provider.sites.map do |site|
+          options: provider.sites.for_recruitment_cycle_years([CycleTimetable.current_year, CycleTimetable.previous_year]).uniq { |site| [site.code, site.name] }.map do |site|
             {
-              value: site.id,
-              label: site.name,
-              checked: applied_filters[:provider_location]&.include?(site.id.to_s),
+              value: "#{site.name}|#{site.code}",
+              label: site.name_and_code,
+              checked: applied_filters[:provider_location]&.include?("#{site.name}|#{site.code}"),
             }
           end,
         }

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -60,7 +60,9 @@ class FilterApplicationChoicesForProviders
     def provider_location(application_choices, provider_location)
       return application_choices if provider_location.blank?
 
-      application_choices.where(site: { id: provider_location })
+      name, code = provider_location[0].split('|')
+
+      application_choices.where(site: { name: name, code: code })
     end
 
     def course_subject(application_choices, subject_ids)

--- a/spec/models/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/models/provider_interface/provider_applications_filter_spec.rb
@@ -11,10 +11,12 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
   let(:course3) { create(:course, subjects: provider_3_subjects) }
   let(:accredited_course) { create(:course, subjects: accredited_provider_subjects, accredited_provider: accredited_provider) }
 
-  let(:site1) { create(:site) }
-  let(:site2) { create(:site) }
+  let(:site1) { create(:site, provider: provider1) }
+  let(:site2) { create(:site, provider: provider1) }
+  let!(:course_option) { create(:course_option, course: course1, site: site1) }
+  let!(:course_option2) { create(:course_option, course: course1, site: site2) }
 
-  let(:provider1) { create(:provider, courses: [course1], sites: [site1, site2]) }
+  let(:provider1) { create(:provider, courses: [course1]) }
   let(:provider2) { create(:provider, courses: [course2]) }
   let(:provider3) { create(:provider, courses: [course3]) }
   let(:accredited_provider) { create(:provider) }
@@ -76,15 +78,34 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
         end
 
         it 'displays the location filter by default' do
-          relevant_provider_ids = [provider1.sites.first.id, provider1.sites.last.id]
-          relevant_provider_names = [provider1.sites.first.name, provider1.sites.last.name]
+          relevant_provider_name_and_code = ["#{provider1.sites.first.name}|#{provider1.sites.first.code}", "#{provider1.sites.last.name}|#{provider1.sites.last.code}"]
+          relevant_provider_labels = [provider1.sites.first.name_and_code, provider1.sites.last.name_and_code]
 
           expect(headings).to include("Locations for #{provider1.name}")
-          expect(relevant_provider_ids).to include(filter.filters[5][:options][0][:value])
-          expect(relevant_provider_ids).to include(filter.filters[5][:options][1][:value])
+          expect(relevant_provider_name_and_code).to include(filter.filters[5][:options][0][:value])
+          expect(relevant_provider_name_and_code).to include(filter.filters[5][:options][1][:value])
 
-          expect(relevant_provider_names).to include(filter.filters[5][:options][0][:label])
-          expect(relevant_provider_names).to include(filter.filters[5][:options][1][:label])
+          expect(relevant_provider_labels).to include(filter.filters[5][:options][0][:label])
+          expect(relevant_provider_labels).to include(filter.filters[5][:options][1][:label])
+        end
+      end
+
+      context 'when a site belongs to an old cycle year' do
+        let(:filter) do
+          described_class.new(params: params,
+                              provider_user: another_provider_user,
+                              state_store: state_store)
+        end
+
+        let(:old_site) { create(:site, provider: provider1) }
+
+        it 'does not appear as an option' do
+          old_site_name_and_code = "#{old_site.name}|#{old_site.code}"
+          old_site_label = old_site.name_and_code
+
+          expect(headings).to include("Locations for #{provider1.name}")
+          expect(old_site_name_and_code).not_to include(filter.filters[5][:options][0][:value])
+          expect(old_site_label).not_to include(filter.filters[5][:options][0][:label])
         end
       end
     end
@@ -98,16 +119,16 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
       end
 
       it 'can return filter config for a list of provider locations' do
-        relevant_provider_ids = [provider1.sites.first.id, provider1.sites.last.id]
-        relevant_provider_names = [provider1.sites.first.name, provider1.sites.last.name]
+        relevant_provider_name_and_code = ["#{provider1.sites.first.name}|#{provider1.sites.first.code}", "#{provider1.sites.last.name}|#{provider1.sites.last.code}"]
+        relevant_provider_labels = [provider1.sites.first.name_and_code, provider1.sites.last.name_and_code]
 
         expect(headings).to include("Locations for #{provider1.name}")
 
-        expect(relevant_provider_ids).to include(filter.filters[6][:options][0][:value])
-        expect(relevant_provider_ids).to include(filter.filters[6][:options][1][:value])
+        expect(relevant_provider_name_and_code).to include(filter.filters[6][:options][0][:value])
+        expect(relevant_provider_name_and_code).to include(filter.filters[6][:options][1][:value])
 
-        expect(relevant_provider_names).to include(filter.filters[6][:options][0][:label])
-        expect(relevant_provider_names).to include(filter.filters[6][:options][1][:label])
+        expect(relevant_provider_labels).to include(filter.filters[6][:options][0][:label])
+        expect(relevant_provider_labels).to include(filter.filters[6][:options][1][:label])
       end
     end
 


### PR DESCRIPTION
## Context

Now site objects are unique across recruitment cycle years we need to scope them to the associated year. This needs to happen on the providers applications filters, otherwise it appears that we have duplicated sites.

## Changes proposed in this pull request
- Scope provider sites to previous and current year
- Display location options as the site name and code
- Use this as the filter value

## Link to Trello card

[<!-- http://trello.com/123-example-card -->](https://trello.com/c/oKHTDsPK/289-site-uuids-year-scoping-provider-applications-filter)

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
