### PR TITLE
Remove summer recruitment banner feature flag

### DIFF
--- a/app/services/data_migrations/remove_summer_recruitment_banner_feature_flag.rb
+++ b/app/services/data_migrations/remove_summer_recruitment_banner_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class RemoveSummerRecruitmentBannerFeatureFlag
+    TIMESTAMP = 20220610155527
+    MANUAL_RUN = false
+
+    def change
+      Feature.find_by(name: :summer_recruitment_banner)&.destroy
+    end
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -29,7 +29,6 @@ class FeatureFlag
     [:unconditional_offers_via_api, 'Activates the ability to accept unconditional offers via the API', 'Steve Laing'],
     [:support_user_reinstate_offer, 'Allows a support users to reinstate a declined course choice offer', 'James Glenn'],
     [:withdraw_at_candidates_request, "Allows providers to withdraw an application at the candidate's request", 'Steve Laing'],
-    [:summer_recruitment_banner, 'Show a banner to indicate a shorter recruitment timeframe during summer', 'Richard Pattinson'],
     [:support_user_revert_withdrawn_offer, 'Allows a support user to revert an application withdrawn by the candidate', 'James Glenn'],
     [:draft_vendor_api_specification, 'The specification for Draft Vendor API v1.1', 'Abeer Salameh'],
     [:new_degree_flow, 'Allows us to use the new degree flow', 'Jon Filar'],

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveSummerRecruitmentBannerFeatureFlag',
   'DataMigrations::ChangeEnglishNationalityData',
   'DataMigrations::CreateMissingTempSites',
   'DataMigrations::BackfillQualificationLevel',

--- a/spec/services/data_migrations/remove_summer_recruitment_banner_feature_flag_spec.rb
+++ b/spec/services/data_migrations/remove_summer_recruitment_banner_feature_flag_spec.rb
@@ -4,8 +4,10 @@ RSpec.describe DataMigrations::RemoveSummerRecruitmentBannerFeatureFlag do
   context 'when the feature flag exists' do
     it 'removes the feature flag' do
       create(:feature, name: 'summer_recruitment_banner')
-      expect { described_class.new.change }.to change { Feature.count }.by(-1)
-      expect(Feature.where(name: 'summer_recruitment_banner')).to be_blank
+      expect { described_class.new.change }
+        .to change { Feature.where(name: 'summer_recruitment_banner').any? }
+        .from(true)
+        .to(false)
     end
   end
 

--- a/spec/services/data_migrations/remove_summer_recruitment_banner_feature_flag_spec.rb
+++ b/spec/services/data_migrations/remove_summer_recruitment_banner_feature_flag_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveSummerRecruitmentBannerFeatureFlag do
+  context 'when the feature flag exists' do
+    it 'removes the feature flag' do
+      create(:feature, name: 'summer_recruitment_banner')
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: 'summer_recruitment_banner')).to be_blank
+    end
+  end
+
+  context 'when the feature flag has already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end


### PR DESCRIPTION
## Context

This removes the feature flag summer recruitment banner.

## Guidance to review

1. Are we using the feature flag in any other place?

## Link to Trello card

https://trello.com/c/W3hpLsJO/233-update-summer-recruitment-banner

## Things to check

- [ x ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database