### PR TITLE
Removed aria-labelledby attribute from search box

### DIFF
--- a/app/components/utility/filter_component.html.erb
+++ b/app/components/utility/filter_component.html.erb
@@ -118,7 +118,7 @@
               Search by candidate name or application number
             </label>
 
-            <input class="govuk-input app-search__input <%= primary_filter[:css_classes] %>" id="<%= primary_filter[:name] %>" name="<%= primary_filter[:name] %>" type="text" value="<%= primary_filter[:value] %>" aria-labelledby="filter-legend-<%= primary_filter[:name] %>" autocomplete="off">
+            <input class="govuk-input app-search__input <%= primary_filter[:css_classes] %>" id="<%= primary_filter[:name] %>" name="<%= primary_filter[:name] %>" type="text" value="<%= primary_filter[:value] %>" autocomplete="off">
           </div>
           <button class="govuk-button app-search__button" data-module="govuk-button">
             Search


### PR DESCRIPTION
## Context

Accessibility changes following on from the report being issued.

## Changes proposed in this pull request

- Removed the `aria-labelledby` attribute from the search box on the applications page on Manage

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/4eRahdIE/228-remove-aria-labelledby-attribute-from-search-box-on-manage

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
