### PR TITLE
Remove `:export_application_data` feature flag

### DIFF
--- a/app/controllers/provider_interface/application_data_export_controller.rb
+++ b/app/controllers/provider_interface/application_data_export_controller.rb
@@ -5,8 +5,6 @@ module ProviderInterface
 
     BATCH_SIZE = 300
 
-    before_action :redirect_to_hesa_export_unless_feature_enabled
-
     def new
       @application_data_export_form = ApplicationDataExportForm.new(current_provider_user: current_provider_user)
     end
@@ -60,10 +58,6 @@ module ProviderInterface
 
     def application_data_export_params
       params.require(:provider_interface_application_data_export_form).permit(:application_status_choice, statuses: [], provider_ids: [], recruitment_cycle_years: [])
-    end
-
-    def redirect_to_hesa_export_unless_feature_enabled
-      redirect_to provider_interface_new_hesa_export_path unless FeatureFlag.active?(:export_application_data)
     end
   end
 end

--- a/app/services/data_migrations/remove_export_application_data_feature_flag.rb
+++ b/app/services/data_migrations/remove_export_application_data_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class RemoveExportApplicationDataFeatureFlag
+    TIMESTAMP = 20220613105031
+    MANUAL_RUN = false
+
+    def change
+      Feature.find_by(name: :export_application_data)&.destroy
+    end
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -25,7 +25,6 @@ class FeatureFlag
 
   TEMPORARY_FEATURE_FLAGS = [
     [:provider_activity_log, 'Show provider users a log of all application activity', 'Michael Nacos'],
-    [:export_application_data, 'Providers can export a customised selection of application data', 'Ben Swannack'],
     [:unconditional_offers_via_api, 'Activates the ability to accept unconditional offers via the API', 'Steve Laing'],
     [:support_user_reinstate_offer, 'Allows a support users to reinstate a declined course choice offer', 'James Glenn'],
     [:withdraw_at_candidates_request, "Allows providers to withdraw an application at the candidate's request", 'Steve Laing'],

--- a/app/views/provider_interface/reports/index.html.erb
+++ b/app/views/provider_interface/reports/index.html.erb
@@ -6,11 +6,9 @@
       <%= t('page_titles.provider.reports') %>
     </h1>
     <ul class="govuk-list govuk-list--spaced">
-      <% if FeatureFlag.active?(:export_application_data) %>
-        <li>
-          <%= govuk_link_to t('page_titles.provider.export_application_data'), provider_interface_new_application_data_export_path %>
-        </li>
-      <% end %>
+      <li>
+        <%= govuk_link_to t('page_titles.provider.export_application_data'), provider_interface_new_application_data_export_path %>
+      </li>
       <li>
         <%= govuk_link_to t('page_titles.provider.export_hesa_data'), provider_interface_reports_hesa_exports_path %>
       </li>

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveExportApplicationDataFeatureFlag',
   'DataMigrations::RemoveSummerRecruitmentBannerFeatureFlag',
   'DataMigrations::ChangeEnglishNationalityData',
   'DataMigrations::CreateMissingTempSites',

--- a/spec/services/data_migrations/remove_export_application_data_feature_flag_spec.rb
+++ b/spec/services/data_migrations/remove_export_application_data_feature_flag_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveExportApplicationDataFeatureFlag do
+  context 'when the feature flag exists' do
+    it 'removes the feature flag' do
+      create(:feature, name: 'export_application_data')
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: 'export_application_data')).to be_blank
+    end
+  end
+
+  context 'when the feature flag has already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end

--- a/spec/system/provider_interface/provider_reports_page_spec.rb
+++ b/spec/system/provider_interface/provider_reports_page_spec.rb
@@ -5,8 +5,7 @@ RSpec.feature 'Provider reports page' do
   include DfESignInHelpers
 
   scenario 'the application data and HESA export pages are linked correctly' do
-    given_the_application_data_export_feature_flag_is_on
-    and_i_am_a_provider_user_with_permissions_to_see_applications_for_my_provider
+    given_i_am_a_provider_user_with_permissions_to_see_applications_for_my_provider
     and_i_sign_in_to_the_provider_interface
 
     when_i_visit_the_reports_page
@@ -21,11 +20,7 @@ RSpec.feature 'Provider reports page' do
     then_i_should_see_links_for_all_the_provider_status_application_records
   end
 
-  def given_the_application_data_export_feature_flag_is_on
-    FeatureFlag.activate(:export_application_data)
-  end
-
-  def and_i_am_a_provider_user_with_permissions_to_see_applications_for_my_provider
+  def given_i_am_a_provider_user_with_permissions_to_see_applications_for_my_provider
     provider_exists_in_dfe_sign_in
     @provider_user = provider_user_exists_in_apply_database
   end
@@ -55,10 +50,6 @@ RSpec.feature 'Provider reports page' do
     within '.govuk-breadcrumbs' do
       expect(page).to have_link('Reports')
     end
-  end
-
-  def given_the_data_export_feature_flag_is_on
-    FeatureFlag.activate(:export_application_data)
   end
 
   def then_i_should_be_redirected_to_the_hesa_export_page

--- a/spec/system/provider_interface/provider_user_exports_applications_to_csv_spec.rb
+++ b/spec/system/provider_interface/provider_user_exports_applications_to_csv_spec.rb
@@ -7,8 +7,7 @@ RSpec.feature 'Provider user exports applications to a csv', mid_cycle: false do
   scenario 'download a CSV of application data' do
     FeatureFlag.deactivate(:data_exports)
 
-    given_the_application_data_export_feature_flag_is_on
-    and_i_am_a_provider_user_with_permissions_to_see_applications_for_my_provider
+    given_i_am_a_provider_user_with_permissions_to_see_applications_for_my_provider
     and_my_organisation_has_courses_with_applications
     and_i_sign_in_to_the_provider_interface
 
@@ -25,11 +24,7 @@ RSpec.feature 'Provider user exports applications to a csv', mid_cycle: false do
     then_the_downloaded_file_includes_applications_all_years_of_deferred_and_accepted_offers_for_the_first_provider
   end
 
-  def given_the_application_data_export_feature_flag_is_on
-    FeatureFlag.activate(:export_application_data)
-  end
-
-  def and_i_am_a_provider_user_with_permissions_to_see_applications_for_my_provider
+  def given_i_am_a_provider_user_with_permissions_to_see_applications_for_my_provider
     provider_exists_in_dfe_sign_in
     provider_user_exists_in_apply_database
   end


### PR DESCRIPTION
## Context

This is an old feature flag which has evidently not been flipped recently as [the redirect on the exports controller it controls would break the application as the redirect route no longer exists](https://github.com/DFE-Digital/apply-for-teacher-training/pull/7082/commits/550b941dd5d6b47019f90ee9a3590a4297935b30#diff-ea0dcf62e754cd05f929d7d0126c4cb38d30fafcec58f98d2f66744edccde1c9L66).

I found this when reviewing load test plans when a test run complained 
```
NameError (undefined local variable or method `provider_interface_new_hesa_export_path'
```

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Remove `:export_application_data` feature flag.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/tchws88V/296-review-load-test-plans
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
