### PR TITLE
Add candidate authentication bypass for load test plan

### DIFF
--- a/app/controllers/candidate_interface/sign_up_controller.rb
+++ b/app/controllers/candidate_interface/sign_up_controller.rb
@@ -11,15 +11,15 @@ module CandidateInterface
       @sign_up_form = CandidateInterface::SignUpForm.new(candidate_sign_up_form_params)
 
       if @sign_up_form.existing_candidate?
-        CandidateInterface::RequestMagicLink.for_sign_in(candidate: @sign_up_form.candidate)
+        magic_link_token = CandidateInterface::RequestMagicLink.for_sign_in(candidate: @sign_up_form.candidate)
         set_user_context @sign_up_form.candidate.id
         candidate = @sign_up_form.candidate
         candidate.update!(course_from_find_id: @sign_up_form.course_from_find_id)
-        redirect_to candidate_interface_check_email_sign_up_path
+        redirect_after_signup(candidate, magic_link_token)
       elsif @sign_up_form.save
-        CandidateInterface::RequestMagicLink.for_sign_up(candidate: @sign_up_form.candidate)
+        magic_link_token = CandidateInterface::RequestMagicLink.for_sign_up(candidate: @sign_up_form.candidate)
         set_user_context @sign_up_form.candidate.id
-        redirect_to candidate_interface_check_email_sign_up_path
+        redirect_after_signup(@sign_up_form.candidate, magic_link_token)
       else
         track_validation_error(@sign_up_form)
         redirect_to candidate_interface_external_sign_up_forbidden_path and return if external_sign_up_forbidden?
@@ -33,6 +33,14 @@ module CandidateInterface
     def external_sign_up_forbidden; end
 
   private
+
+    def redirect_after_signup(candidate, magic_link_token)
+      if candidate.load_tester?
+        redirect_to candidate_interface_authenticate_url(token: magic_link_token)
+      else
+        redirect_to candidate_interface_check_email_sign_up_path
+      end
+    end
 
     def external_sign_up_forbidden?
       @sign_up_form.errors.details[:email_address].include?(error: :dfe_signup_only)

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -67,6 +67,10 @@ class Candidate < ApplicationRecord
     application_forms.current_cycle.exists?(phase: 'apply_2')
   end
 
+  def load_tester?
+    email_address.ends_with?('@loadtest.example.com') && !HostingEnvironment.production?
+  end
+
 private
 
   def downcase_email

--- a/app/services/candidate_interface/request_magic_link.rb
+++ b/app/services/candidate_interface/request_magic_link.rb
@@ -3,12 +3,14 @@ module CandidateInterface
     def self.for_sign_in(candidate:, path: nil)
       magic_link_token = candidate.create_magic_link_token!(path: path)
       AuthenticationMailer.sign_in_email(candidate: candidate, token: magic_link_token).deliver_later
+      magic_link_token
     end
 
     def self.for_sign_up(candidate:)
       magic_link_token = candidate.create_magic_link_token!
       AuthenticationMailer.sign_up_email(candidate: candidate, token: magic_link_token).deliver_later
       StateChangeNotifier.sign_up(candidate)
+      magic_link_token
     end
   end
 end

--- a/jmeter/plans/apply.rb
+++ b/jmeter/plans/apply.rb
@@ -9,6 +9,7 @@ def url(path)
   BASEURL + path
 end
 
+# rubocop:disable Lint/SymbolConversion
 test do
   cookies clear_each_iteration: true
   view_results_tree
@@ -47,7 +48,7 @@ test do
       'DO_MULTIPART_POST': 'true',
       name: 'Sign up page - submit email', url: url('/candidate/sign-up?courseCode=${courseCode}&providerCode=${providerCode}'),
       fill_in: {
-        'candidate_interface_sign_up_form[email_address]': '${candidate_uuid}' + '@loadtest.example.com',
+        'candidate_interface_sign_up_form[email_address]': '${candidate_uuid}@loadtest.example.com',
         'authenticity_token': '${authenticity_token}',
         'commit': 'Continue',
       }
@@ -77,7 +78,7 @@ test do
       name: 'You selected a course - confirm course selection', url: url('/candidate/application/courses/complete-selection/${course_id}'),
       fill_in: {
         'authenticity_token': '${authenticity_token}',
-        "candidate_interface_course_selection_form[confirm]": "true"
+        'candidate_interface_course_selection_form[confirm]': 'true',
       }
     ) do
       extract name: 'authenticity_token', regex: 'name="authenticity_token" value="(.+?)"'
@@ -153,3 +154,4 @@ test do
     visit name: 'Personal statement', url: url('/candidate/application/personal-statement')
   end
 end.jmx
+# rubocop:enable Lint/SymbolConversion

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -229,4 +229,31 @@ RSpec.describe Candidate, type: :model do
       end
     end
   end
+
+  describe '#load_tester?' do
+    context 'environment is production' do
+      before { allow(HostingEnvironment).to receive(:production?).and_return true }
+
+      it 'returns false regardless of the email address pattern' do
+        candidate = build(:candidate, email_address: 'someone@loadtest.example.com')
+        expect(candidate).not_to be_load_tester
+        candidate.email_address = 'someone@example.com'
+        expect(candidate).not_to be_load_tester
+      end
+    end
+
+    context 'environment is not production' do
+      before { allow(HostingEnvironment).to receive(:production?).and_return false }
+
+      it 'returns true if email address is for load testing' do
+        candidate = build(:candidate, email_address: 'someone@loadtest.example.com')
+        expect(candidate).to be_load_tester
+      end
+
+      it 'returns false if email is not for load testing' do
+        candidate = build(:candidate, email_address: 'someone@example.com')
+        expect(candidate).not_to be_load_tester
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

In order to run the Apply load test plan we need a way to bypass the usual candidate authentication.
This was done in previous load tests via the magic link in emails. A check was made against the hosting environment to ensure this shortcut would never be active in production.


<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Cherry-picks authentication shortcut previously used in load testing complete with checks on hosting environment.

We'd like to make load testing part of our codebase instead of parking it on a branch, so this PR brings the necessary changes into `main`.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/tchws88V/296-review-load-test-plans
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
