### PR TITLE
Add pagination to Register API

### DIFF
--- a/app/controllers/register_api/applications_controller.rb
+++ b/app/controllers/register_api/applications_controller.rb
@@ -2,6 +2,7 @@ module RegisterAPI
   class ApplicationsController < ActionController::API
     include ServiceAPIUserAuthentication
     include RemoveBrowserOnlyHeaders
+    include Pagy::Backend
 
     rescue_from ActionController::ParameterMissing, with: :parameter_missing
     rescue_from ParameterInvalid, with: :parameter_invalid
@@ -10,6 +11,12 @@ module RegisterAPI
     # against the controller action that triggered them
     # instead of bundling them with every other ErrorsController#internal_server_error
     rescue_from ActiveRecord::QueryCanceled, with: :statement_timeout
+
+    rescue_from Pagy::OverflowError, with: :page_parameter_invalid
+    rescue_from PerPageParameterInvalid, with: :per_page_parameter_invalid
+
+    DEFAULT_PER_PAGE = 50
+    MAX_PER_PAGE = 50
 
     def index
       render json: { data: serialized_application_choices }
@@ -35,10 +42,51 @@ module RegisterAPI
       }, status: :internal_server_error
     end
 
+    def page_parameter_invalid(e)
+      last_page = e.message.scan(/\d+/)[1]
+      error_message = "expected 'page' parameter to be between 1 and #{last_page}, got #{params[:page]}"
+      render json: {
+        errors: [
+          {
+            error: 'PageParameterInvalid',
+            message: error_message,
+          },
+        ],
+      }, status: :unprocessable_entity
+    end
+
+    def per_page_parameter_invalid
+      render json: {
+        errors: [
+          {
+            error: 'PerPageParameterInvalid',
+            message: "the 'per_page' parameter cannot exceed #{MAX_PER_PAGE} results per page",
+          },
+        ],
+      }, status: :unprocessable_entity
+    end
+
   private
 
+    def paginate(scope)
+      pagy, paginated_records = pagy(scope, items: per_page, page: page)
+      pagy_headers_merge(pagy)
+
+      paginated_records
+    end
+
+    def per_page
+      raise PerPageParameterInvalid unless params[:per_page].to_i <= MAX_PER_PAGE
+
+      [(params[:per_page] || DEFAULT_PER_PAGE).to_i, MAX_PER_PAGE].min
+    end
+
+    def page
+      (params[:page] || 1).to_i
+    end
+
     def serialized_application_choices
-      recruited_application_choices.find_each(batch_size: 100).map do |application_choice|
+      paginate(recruited_application_choices).map do |application_choice|
         SingleApplicationPresenter.new(application_choice).as_json
       end
     end

--- a/app/queries/get_recruited_application_choices.rb
+++ b/app/queries/get_recruited_application_choices.rb
@@ -1,7 +1,7 @@
 class GetRecruitedApplicationChoices
   INCLUDES = [
     application_form: %i[candidate english_proficiency application_qualifications],
-    current_course_option: [{ course: %i[provider] }, :site],
+    current_course_option: [{ course: %i[provider accredited_provider] }, :site],
   ].freeze
 
   def self.call(recruitment_cycle_year:, changed_since: nil)
@@ -13,5 +13,6 @@ class GetRecruitedApplicationChoices
       .joins(:current_course)
       .merge(Course.in_cycle(recruitment_cycle_year))
       .where.not(recruited_at: nil)
+      .order(:updated_at)
   end
 end

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -353,5 +353,9 @@ FactoryBot.define do
         choice.application_form.update_columns(recruitment_cycle_year: RecruitmentCycle.previous_year)
       end
     end
+
+    trait :with_course_uuid do
+      association :course_option, :open_on_apply, :with_course_uuid
+    end
   end
 end


### PR DESCRIPTION
## Context

Register imports applications from the Apply Register API. This endpoint has an `updated_since` parameter that used to limit the returned results. However the result sets can still be quite large (there is a backlog of ~2K 2022 applications to import) and these requests are failing.

A quick investigation showed that the query behind the API runs pretty quickly, e.g.

```
SELECT application_choices.*
FROM application_choices
INNER JOIN course_options ON course_options.id = application_choices.current_course_option_id
INNER JOIN courses ON courses.id = course_options.course_id
WHERE (application_choices.updated_at > '2021-01-01')
AND courses.recruitment_cycle_year = 2022
AND application_choices.recruited_at IS NOT NULL;
```

However running the API itself crashed after a few seconds trying. Serialising ~2K quite complex records is probably not practical.

## Changes proposed in this pull request

- Use `pagy` to add pagination just as we already do for the Candidate API.
- Update existing specs to cover the pagination functionality including a couple of error cases.
- Add `courses.accredited_providers` to query includes because Bullet identified this as an issue.
- Add and an explicit `ORDER BY` clause to the query to make the pagination work properly.

## Guidance to review

- I'm not sure whether using `ApplicationChoice.updated_at` to select applications and to order them is a great idea. It could cause some odd behaviour when paginating if there are changes during between page requests. It also means that the same application could be imported into Register several times. I did wonder whether we should just use `recruited_at` but that causes other issues - because applications can be withdrawn or deferred after recruitment and we probably need to know about that on the Register side. Any thoughts welcome.
- Are there any other tests I should be updating?

## Link to Trello card

Original card from Register:
https://trello.com/c/ZZyyJYAM/4243-2022-apply-applications-not-being-requested-properly-fixes-to-apply-api

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
