### PR TITLE
Sort the provider ids returned from `FindApplicationChoicesWithOutOfDateProviderIds`

### DIFF
--- a/app/workers/detect_invariants_daily_check.rb
+++ b/app/workers/detect_invariants_daily_check.rb
@@ -125,7 +125,7 @@ class DetectInvariantsDailyCheck
     out_of_date_choices = FindApplicationChoicesWithOutOfDateProviderIds.call
 
     if out_of_date_choices.present?
-      message = "Out-of-date application choices: #{out_of_date_choices.map(&:id).join(', ')}"
+      message = "Out-of-date application choices: #{out_of_date_choices.map(&:id).sort.join(', ')}"
       Sentry.capture_exception(ApplicationChoicesWithOutOfDateProviderIds.new(message))
     end
   end

--- a/spec/workers/detect_invariants_daily_check_spec.rb
+++ b/spec/workers/detect_invariants_daily_check_spec.rb
@@ -163,7 +163,9 @@ RSpec.describe DetectInvariantsDailyCheck do
 
       described_class.new.perform
 
-      message = "Out-of-date application choices: #{empty_ids.id}, #{wrong_ids.id}" # reverse order ignored
+      expected_ids = [empty_ids.id, wrong_ids.id].sort.join(', ')
+
+      message = "Out-of-date application choices: #{expected_ids}" # reverse order ignored
       expect(Sentry).to have_received(:capture_exception)
                         .with(described_class::ApplicationChoicesWithOutOfDateProviderIds.new(message))
     end


### PR DESCRIPTION
## Context

Result set order isn't ensured from this query class, so don't rely on it in the spec.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

![image](https://user-images.githubusercontent.com/93511/174040895-7047786a-d66d-4232-835c-536c9244269e.png)


Sort the ids returned from the query so we can expect the correct error message.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
