### PR TITLE
Do not rely on order of results from `course_options_for_provider`

### DIFF
--- a/spec/forms/support_interface/application_forms/pick_course_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/pick_course_form_spec.rb
@@ -57,8 +57,7 @@ RSpec.describe SupportInterface::ApplicationForms::PickCourseForm, type: :model 
       course_options_for_provider = described_class.new(form_data).course_options_for_provider(provider)
 
       expect(course_options_for_provider.length).to eq(2)
-      expect(course_options_for_provider.first.course_option_id).to eq(course_option_with_vacancies.id)
-      expect(course_options_for_provider.last.course_option_id).to eq(course_option_with_no_vacancies.id)
+      expect(course_options_for_provider.map(&:course_option_id).sort).to eq([course_option_with_vacancies.id, course_option_with_no_vacancies.id].sort)
     end
 
     it 'returns only course options from current cycle' do


### PR DESCRIPTION
## Context

This flakey spec relies on the order of results returned by `course_options_for_provider` which orders by course name.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

![image](https://user-images.githubusercontent.com/93511/174073226-fc598b28-101c-4ca6-ad86-687e2568a8a9.png)


Don't rely on ordering, just assert the results are correct.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
