### PR TITLE
Amend Deferral Site logic

### DIFF
--- a/app/models/course_option.rb
+++ b/app/models/course_option.rb
@@ -43,11 +43,12 @@ class CourseOption < ApplicationRecord
 
   def in_previous_cycle
     equivalent_course = course.in_previous_cycle
+    equivalent_sites = equivalent_site_for_years([RecruitmentCycle.previous_year])
 
-    if equivalent_course
+    if equivalent_course && equivalent_sites.any?
       CourseOption.find_by(
         course: equivalent_course,
-        site: site,
+        site: equivalent_sites,
         study_mode: study_mode,
       )
     end
@@ -55,13 +56,19 @@ class CourseOption < ApplicationRecord
 
   def in_next_cycle
     equivalent_course = course.in_next_cycle
-
-    if equivalent_course
+    equivalent_sites = equivalent_site_for_years([RecruitmentCycle.next_year])
+    if equivalent_course && equivalent_sites.any?
       CourseOption.find_by(
         course: equivalent_course,
-        site: site,
+        site: equivalent_sites,
         study_mode: study_mode,
       )
     end
+  end
+
+private
+
+  def equivalent_site_for_years(years)
+    site.provider.sites.for_recruitment_cycle_years(years).where(code: site.code)
   end
 end

--- a/app/models/course_option.rb
+++ b/app/models/course_option.rb
@@ -42,8 +42,9 @@ class CourseOption < ApplicationRecord
   end
 
   def in_previous_cycle
+    year = course.recruitment_cycle_year - 1
     equivalent_course = course.in_previous_cycle
-    equivalent_sites = equivalent_site_for_years([RecruitmentCycle.previous_year])
+    equivalent_sites = equivalent_site_for_years([year])
 
     if equivalent_course && equivalent_sites.any?
       CourseOption.find_by(
@@ -55,8 +56,10 @@ class CourseOption < ApplicationRecord
   end
 
   def in_next_cycle
+    year = course.recruitment_cycle_year + 1
     equivalent_course = course.in_next_cycle
-    equivalent_sites = equivalent_site_for_years([RecruitmentCycle.next_year])
+    equivalent_sites = equivalent_site_for_years([year])
+
     if equivalent_course && equivalent_sites.any?
       CourseOption.find_by(
         course: equivalent_course,

--- a/spec/factories/course_option.rb
+++ b/spec/factories/course_option.rb
@@ -36,6 +36,18 @@ FactoryBot.define do
 
       after(:create) do |course_option|
         new_course = course_option.course.in_next_cycle
+        new_site = create(
+          :site,
+          provider: course_option.course.provider,
+          code: course_option.site.code,
+          address_line1: course_option.site.address_line1,
+          address_line2: course_option.site.address_line2,
+          address_line3: course_option.site.address_line3,
+          address_line4: course_option.site.address_line4,
+          region: course_option.site.region,
+          postcode: course_option.site.postcode,
+        )
+
         unless new_course
           new_course = course_option.course.dup
           new_course.recruitment_cycle_year = RecruitmentCycle.current_year
@@ -43,7 +55,7 @@ FactoryBot.define do
           new_course.save
         end
 
-        create(:course_option, course: new_course, site: course_option.site)
+        create(:course_option, course: new_course, site: new_site)
       end
     end
 
@@ -52,6 +64,18 @@ FactoryBot.define do
 
       after(:create) do |course_option|
         new_course = course_option.course.in_next_cycle
+        new_site = create(
+          :site,
+          provider: course_option.course.provider,
+          code: course_option.site.code,
+          address_line1: course_option.site.address_line1,
+          address_line2: course_option.site.address_line2,
+          address_line3: course_option.site.address_line3,
+          address_line4: course_option.site.address_line4,
+          region: course_option.site.region,
+          postcode: course_option.site.postcode,
+        )
+
         unless new_course
           new_course = course_option.course.dup
           new_course.recruitment_cycle_year = RecruitmentCycle.next_year
@@ -59,7 +83,7 @@ FactoryBot.define do
           new_course.save
         end
 
-        create(:course_option, course: new_course, site: course_option.site)
+        create(:course_option, course: new_course, site: new_site)
       end
     end
   end

--- a/spec/models/course_option_spec.rb
+++ b/spec/models/course_option_spec.rb
@@ -126,4 +126,72 @@ RSpec.describe CourseOption, type: :model do
       end
     end
   end
+
+  describe '#in_previous_cycle' do
+    let(:site_current_cycle) { create(:site) }
+    let(:course_current_cycle) { create(:course, provider: site_current_cycle.provider) }
+    let!(:course_option_current_cycle) { create(:course_option, site: site_current_cycle, course: course_current_cycle) }
+
+    it 'returns the correct course option in the previous cycle' do
+      site_next_cycle = create(:site, provider: site_current_cycle.provider, code: site_current_cycle.code)
+      course_next_cycle = create(:course, provider: site_current_cycle.provider, recruitment_cycle_year: RecruitmentCycle.previous_year, code: course_current_cycle.code)
+      course_option_next_cycle = create(:course_option, site: site_next_cycle, course: course_next_cycle)
+
+      expect(course_option_current_cycle.in_previous_cycle).to eq(course_option_next_cycle)
+    end
+
+    it 'returns no course option if it does not exist in the previous cycle' do
+      site_next_cycle = create(:site, provider: site_current_cycle.provider, code: 'AnotherCode')
+      course_next_cycle = create(:course, provider: site_current_cycle.provider, recruitment_cycle_year: RecruitmentCycle.previous_year, code: course_current_cycle.code)
+      create(:course_option, site: site_next_cycle, course: course_next_cycle)
+
+      expect(course_option_current_cycle.in_previous_cycle).to be_nil
+    end
+
+    it 'ignores duplicate site codes in the same cycle and returns correct course option' do
+      site_next_cycle = create(:site, provider: site_current_cycle.provider, code: site_current_cycle.code)
+      course_next_cycle = create(:course, provider: site_current_cycle.provider, recruitment_cycle_year: RecruitmentCycle.previous_year, code: course_current_cycle.code)
+      course_option_next_cycle = create(:course_option, site: site_next_cycle, course: course_next_cycle)
+
+      another_site_next_cycle = create(:site, provider: site_current_cycle.provider, code: site_current_cycle.code)
+      another_course_next_cycle = create(:course, provider: site_current_cycle.provider, recruitment_cycle_year: RecruitmentCycle.previous_year)
+      create(:course_option, site: another_site_next_cycle, course: another_course_next_cycle)
+
+      expect(course_option_current_cycle.in_previous_cycle).to eq(course_option_next_cycle)
+    end
+  end
+
+  describe '#in_next_cycle' do
+    let(:site_current_cycle) { create(:site) }
+    let(:course_current_cycle) { create(:course, provider: site_current_cycle.provider) }
+    let!(:course_option_current_cycle) { create(:course_option, site: site_current_cycle, course: course_current_cycle) }
+
+    it 'returns the correct course option in the next cycle' do
+      site_next_cycle = create(:site, provider: site_current_cycle.provider, code: site_current_cycle.code)
+      course_next_cycle = create(:course, provider: site_current_cycle.provider, recruitment_cycle_year: RecruitmentCycle.next_year, code: course_current_cycle.code)
+      course_option_next_cycle = create(:course_option, site: site_next_cycle, course: course_next_cycle)
+
+      expect(course_option_current_cycle.in_next_cycle).to eq(course_option_next_cycle)
+    end
+
+    it 'returns no course option if it does not exist in the next cycle' do
+      site_next_cycle = create(:site, provider: site_current_cycle.provider, code: 'AnotherCode')
+      course_next_cycle = create(:course, provider: site_current_cycle.provider, recruitment_cycle_year: RecruitmentCycle.next_year, code: course_current_cycle.code)
+      create(:course_option, site: site_next_cycle, course: course_next_cycle)
+
+      expect(course_option_current_cycle.in_next_cycle).to be_nil
+    end
+
+    it 'ignores duplicate site codes in the same cycle and returns correct course option' do
+      site_next_cycle = create(:site, provider: site_current_cycle.provider, code: site_current_cycle.code)
+      course_next_cycle = create(:course, provider: site_current_cycle.provider, recruitment_cycle_year: RecruitmentCycle.next_year, code: course_current_cycle.code)
+      course_option_next_cycle = create(:course_option, site: site_next_cycle, course: course_next_cycle)
+
+      another_site_next_cycle = create(:site, provider: site_current_cycle.provider, code: site_current_cycle.code)
+      another_course_next_cycle = create(:course, provider: site_current_cycle.provider, recruitment_cycle_year: RecruitmentCycle.next_year)
+      create(:course_option, site: another_site_next_cycle, course: another_course_next_cycle)
+
+      expect(course_option_current_cycle.in_next_cycle).to eq(course_option_next_cycle)
+    end
+  end
 end


### PR DESCRIPTION
## Context

We previously had a site span multiple cycles, which allowed us to look up similar course options using the same site.
This is no longer the case.

## Changes proposed in this pull request

- Amend lookup for previous and next year course options to the relevant different sites which are scoped to code, year and provider. Since we can have multiple pass in an array to the lookup
- Amend factory to generate the data correctly
- 
## Guidance to review

Did I miss anything?

## Link to Trello card

https://trello.com/c/MynghCCC/213-site-uuids-transition-1-2-swap-the-site-models

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
