### PR TITLE
Gcse type controller bug

### DIFF
--- a/app/controllers/candidate_interface/gcse/type_controller.rb
+++ b/app/controllers/candidate_interface/gcse/type_controller.rb
@@ -37,6 +37,7 @@ module CandidateInterface
         redirect_to next_gcse_path_after_edit
       else
         track_validation_error(@type_form)
+        @return_to = return_to_after_edit(default: candidate_interface_gcse_review_path)
         render :edit
       end
     end

--- a/spec/system/candidate_interface/entering_details/change_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/change_gcse_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.feature 'Change GCSE' do
+  include CandidateHelper
+
+  scenario 'Candidate changes their GCSE qualification type' do
+    given_i_am_signed_in
+    when_i_have_a_completed_english_gcse
+    and_i_visit_the_application_review_page
+    then_i_click_to_change_the_english_qualification_type
+
+    when_i_choose_other_uk_qualification
+    and_click_save_and_continue
+    then_i_should_see_a_validation_error_for_my_qualification_type
+
+    when_i_fill_in_the_other_uk_qualification
+    and_click_save_and_continue
+    and_i_fill_in_the_qualification_grade
+    and_click_save_and_continue
+    and_i_fill_in_the_qualification_year
+    and_click_save_and_continue
+    then_i_see_the_review_page_with_correct_details
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def when_i_have_a_completed_english_gcse
+    application_form = current_candidate.current_application
+    application_form.application_qualifications << create(:gcse_qualification, subject: 'english')
+    application_form.update!(english_gcse_completed: true)
+  end
+
+  def and_i_visit_the_application_review_page
+    visit candidate_interface_application_review_path
+  end
+
+  def then_i_click_to_change_the_english_qualification_type
+    within all('.app-summary-card__body')[0] do
+      click_change_link('qualification for GCSE, english')
+    end
+  end
+
+  def when_i_choose_other_uk_qualification
+    choose 'Other UK qualification'
+  end
+
+  def and_click_save_and_continue
+    click_button t('save_and_continue')
+  end
+
+  def then_i_should_see_a_validation_error_for_my_qualification_type
+    expect(page).to have_content t('activemodel.errors.models.candidate_interface/gcse_qualification_type_form.attributes.other_uk_qualification_type.blank')
+  end
+
+  def when_i_fill_in_the_other_uk_qualification
+    fill_in 'Qualification name', with: 'Diploma', match: :first
+  end
+
+  def and_i_fill_in_the_qualification_grade
+    fill_in 'Grade', with: '94%'
+  end
+
+  def and_i_fill_in_the_qualification_year
+    fill_in 'Year', with: '2013'
+  end
+
+  def then_i_see_the_review_page_with_correct_details
+    expect(page).to have_content 'English GCSE or equivalent'
+    expect(page).to have_content 'GCSE'
+    expect(page).to have_content '94%'
+    expect(page).to have_content '2013'
+  end
+end


### PR DESCRIPTION
## Context

There was recurring bug where a user would:
1) Click to change qualification for their GCSE from the application review page
2) Choose other or non uk qualification. Accidentally submit without filling in details.
3) 500 error instead of validation due to the template having undefined instance variable

## Changes proposed in this pull request
* Set required variable in the update action for the template as edit action not evaluated by the render
* Add system spec to cover scenario and successful edit

## Guidance to review
Verify bug no longer occurs 

## Link to Trello card

https://trello.com/c/L6yKyWDJ/300-gcse-typecontroller-faulty-backlinks

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
