### PR TITLE
Error returned if no provider selected when generating token

### DIFF
--- a/app/controllers/support_interface/api_tokens_controller.rb
+++ b/app/controllers/support_interface/api_tokens_controller.rb
@@ -1,12 +1,27 @@
 module SupportInterface
   class APITokensController < SupportInterfaceController
+    rescue_from MissingProviderError do
+      redirect_to support_interface_api_tokens_path
+      flash[:warning] = 'Did not select a provider'
+    end
+
     def index
       @api_tokens = VendorAPIToken.order(created_at: :desc)
     end
 
     def create
+      raise_error_unless_provider(params)
+
       provider = Provider.find(params[:vendor_api_token][:provider_id])
       @unhashed_token = VendorAPIToken.create_with_random_token!(provider: provider)
+    end
+
+  private
+
+    def raise_error_unless_provider(params)
+      if params[:vendor_api_token][:provider_id].blank?
+        raise MissingProviderError
+      end
     end
   end
 end

--- a/app/errors/missing_provider_error.rb
+++ b/app/errors/missing_provider_error.rb
@@ -1,0 +1,1 @@
+class MissingProviderError < StandardError; end

--- a/spec/system/support_interface/api_tokens_spec.rb
+++ b/spec/system/support_interface/api_tokens_spec.rb
@@ -7,7 +7,11 @@ RSpec.feature 'Manage API tokens' do
     given_i_am_signed_in
     and_providers_exist
     when_i_visit_the_tokens_page
-    and_i_select_a_provider
+    and_i_click_on_create_a_token_without_entering_a_provider
+    then_i_am_redirected_to_the_support_page
+    and_a_warning_message_is_showing
+
+    when_i_select_a_provider
     and_i_click_on_create_a_token
     then_i_should_see_a_new_token
     and_i_am_able_to_connect_to_the_api_using_the_token
@@ -22,18 +26,27 @@ RSpec.feature 'Manage API tokens' do
     visit support_interface_api_tokens_path
   end
 
+  def then_i_am_redirected_to_the_support_page
+    expect(page).to have_current_path(support_interface_api_tokens_path)
+  end
+
+  def and_a_warning_message_is_showing
+    expect(page).to have_content 'Did not select a provider'
+  end
+
   def and_providers_exist
     create(:provider, name: 'Some Provider')
     create(:provider, name: 'Super Provider')
   end
 
-  def and_i_select_a_provider
+  def when_i_select_a_provider
     select 'Super Provider'
   end
 
   def and_i_click_on_create_a_token
     click_on 'Create new token'
   end
+  alias_method :and_i_click_on_create_a_token_without_entering_a_provider, :and_i_click_on_create_a_token
 
   def then_i_should_see_a_new_token
     expect(page).to have_content 'Your token is'


### PR DESCRIPTION
## Context

There is an 500 error when submitting page before the token is created as provider id is nil in params
There is now a message to support user letting them know they did not select a provider. Model validation not used as error occurs before active record connects to db

## Changes proposed in this pull request
* Added missing provider error
* Add to system spec
## Guidance to review

Try to generate vendor api token without selecting provider at `/support/tokens`

## Link to Trello card

https://trello.com/c/dUIwWqpx/314-500-error-returned-if-no-provider-is-selected-when-generating-a-token

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
