### PR TITLE
Data migration to remove orphaned temp sites

### DIFF
--- a/app/services/data_migrations/destroy_orphaned_sites.rb
+++ b/app/services/data_migrations/destroy_orphaned_sites.rb
@@ -1,0 +1,11 @@
+module DataMigrations
+  class DestroyOrphanedSites
+    TIMESTAMP = 20220620110204
+    MANUAL_RUN = true
+
+    def change
+      orphaned_sites = TempSite.left_outer_joins(:course_options).where(course_options: { id: nil }).distinct
+      orphaned_sites.destroy_all
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::DestroyOrphanedSites',
   'DataMigrations::RemoveExportApplicationDataFeatureFlag',
   'DataMigrations::RemoveSummerRecruitmentBannerFeatureFlag',
   'DataMigrations::ChangeEnglishNationalityData',

--- a/spec/services/data_migrations/destroy_orphaned_sites_spec.rb
+++ b/spec/services/data_migrations/destroy_orphaned_sites_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::DestroyOrphanedSites do
+  context 'when the site has a course option' do
+    it 'is not destroyed' do
+      provider = create(:provider)
+      create(:course_option, site: create(:site, provider: provider), course: create(:course, provider: provider))
+
+      expect { described_class.new.change }.not_to(change { TempSite.count })
+    end
+  end
+
+  context 'when the site does not have a course option' do
+    it 'is destroyed' do
+      create(:site)
+
+      expect { described_class.new.change }.to change { TempSite.count }.by(-1)
+    end
+  end
+end


### PR DESCRIPTION
## Context

We've ended up with some sites that are not associated with a course option. We're purging these orphans 

## Changes proposed in this pull request

Data migration to find all sites without a course option and destroy them

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/yzG11Oym/183-site-uuids-transition-2-2-remove-the-old-site-model-spike

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
