### PR TITLE
Reinstate rule of when to surface add course tool

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -317,7 +317,11 @@ class ApplicationForm < ApplicationRecord
   end
 
   def support_cannot_add_course_choice?
-    application_choices.where.not(status: :withdrawn).count >= maximum_number_of_course_choices
+    number_of_unsuccessful_application_choices >= maximum_number_of_course_choices
+  end
+
+  def number_of_unsuccessful_application_choices
+    application_choices.where.not(status: ApplicationStateChange::UNSUCCESSFUL_END_STATES).count
   end
 
   def maximum_number_of_course_choices

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -839,4 +839,23 @@ RSpec.describe ApplicationForm do
       end
     end
   end
+
+  describe '#support_cannot_add_course_choice?' do
+    let(:application_form) { create(:application_form) }
+
+    context 'when an application form has three submitted choices' do
+      it 'returns true' do
+        create_list(:application_choice, 3, :awaiting_provider_decision, application_form: application_form)
+        expect(application_form.support_cannot_add_course_choice?).to be true
+      end
+    end
+
+    context 'when an application has two submitted choices and one unsuccessful one' do
+      it 'returns false' do
+        create_list(:application_choice, 2, :awaiting_provider_decision, application_form: application_form)
+        create(:application_choice, :with_rejection, application_form: application_form)
+        expect(application_form.support_cannot_add_course_choice?).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

We accidentally reverted the rules which calculate the ability to add a course to an application form. Look at all
end states and not only withdrawn application to allow adding a new course. 

paired with @carlosmartinez 

## Changes proposed in this pull request

Revert back to look at all end states for calculation of when to surface the tool in support to add a course.

## Guidance to review

Did I miss anything?

## Link to Trello card

https://trello.com/c/6tjuHIxk/1506-application-form-41596-course-swap

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
