### PR TITLE
Update `apply` and `vendor` load test plans

### DIFF
--- a/jmeter/jmeter-courses.csv
+++ b/jmeter/jmeter-courses.csv
@@ -1,3 +1,3 @@
 courseCode,providerCode
-3369,1V7
-2MFP,1R3
+R294,2KL
+J912,2KL

--- a/jmeter/plans/vendor.rb
+++ b/jmeter/plans/vendor.rb
@@ -18,6 +18,12 @@ def request_headers(api_key)
   ]
 end
 
+def request_params
+  request_params = { since: since }
+  request_params.merge!(per_page: 50, page: 1) unless API_VERSION == 'v1.0'
+  request_params
+end
+
 def vendor_api_keys
   filepath = 'plans/vendor_api_keys.txt'
   raise "No load test API keys found in #{filepath}. (#{Dir.pwd})" unless File.exist?(filepath)
@@ -38,7 +44,7 @@ test do
       get(
         name: 'API Sync applications',
         url: "#{BASEURL}/api/#{API_VERSION}/applications",
-        raw_body: { since: since }.to_json { with_xhr },
+        raw_body: request_params.to_json { with_xhr },
       )
     end
 
@@ -49,7 +55,7 @@ test do
       get(
         name: 'API Sync applications',
         url: "#{BASEURL}/api/#{API_VERSION}/applications",
-        raw_body: { since: since }.to_json do
+        raw_body: request_params.to_json do
           extract name: 'last_application_id', json: '$.data[-1].id'
           with_xhr
         end,


### PR DESCRIPTION
## Context

Some dependencies were broken for the `apply` load test plan.
The Vendor API now supports pagination so we should load test this.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Updates the course data for the `apply` plan with courses with multiple study modes and sites - important for the plan to run completely.
- Updates the `vendor` plan to include pagination params where the `API_VERSION` env var is not `v1.0`

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/tchws88V/296-review-load-test-plans
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
