### PR TITLE
Resolve duplicate link text on timeline in Manage

### DIFF
--- a/app/components/provider_interface/application_timeline_component.html.erb
+++ b/app/components/provider_interface/application_timeline_component.html.erb
@@ -12,7 +12,7 @@
       <div class="app-timeline__event_link">
         <% if event.link_name && event.link_path %>
           <%= govuk_link_to event.link_path, no_visited_state: true do %>
-            <%= event.link_name %> <span class="govuk-visually-hidden"><%= event.date.to_fs(:govuk_date_and_time) %></span>
+            <%= event.link_name %> <span class="govuk-visually-hidden"><%= "#{event.title}:" %> <%= event.actor %> <%= event.date.to_fs(:govuk_date_and_time) %></span>
           <% end %>
         <% end %>
       </div>

--- a/spec/components/provider_interface/application_timeline_component_spec.rb
+++ b/spec/components/provider_interface/application_timeline_component_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       expect(rendered.text).to include 'Candidate'
       expect(rendered.text).to include 5.days.ago.to_fs(:govuk_date_and_time)
       expect(rendered.css('a').text).to include 'View application'
-      expect(rendered.css('.govuk-visually-hidden').text).to eq 5.days.ago.to_fs(:govuk_date_and_time)
+      expect(rendered.css('.govuk-visually-hidden').text).to eq "Application received: Candidate #{5.days.ago.to_fs(:govuk_date_and_time)}"
       expect(rendered.css('a').attr('href').value).to eq provider_interface_application_choice_path(application_choice)
     end
   end
@@ -75,7 +75,7 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       expect(rendered.text).to include 'Bob Roberts'
       expect(rendered.text).to include 3.days.ago.to_fs(:govuk_date_and_time)
       expect(rendered.css('a').text).to include 'View offer'
-      expect(rendered.css('.govuk-visually-hidden').text).to eq 3.days.ago.to_fs(:govuk_date_and_time)
+      expect(rendered.css('.govuk-visually-hidden').text).to eq "Offer made: Bob Roberts #{3.days.ago.to_fs(:govuk_date_and_time)}"
       expect(rendered.css('a').attr('href').value).to eq provider_interface_application_choice_offer_path(application_choice)
     end
   end
@@ -94,7 +94,7 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       expect(rendered.text).to include 'Bob Roberts'
       expect(rendered.text).to include Time.zone.now.to_fs(:govuk_date_and_time)
       expect(rendered.css('a').text).to include 'View note'
-      expect(rendered.css('.govuk-visually-hidden').text).to eq Time.zone.now.to_fs(:govuk_date_and_time)
+      expect(rendered.css('.govuk-visually-hidden').text).to eq "Note added: Bob Roberts #{Time.zone.now.to_fs(:govuk_date_and_time)}"
       expect(rendered.css('a').attr('href').value).to eq "/provider/applications/#{application_choice.id}/notes/#{note.id}"
     end
 
@@ -126,7 +126,7 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       expect(rendered.text).to include 'Feedback sent'
       expect(rendered.text).to include Time.zone.now.to_fs(:govuk_date_and_time)
       expect(rendered.css('a').text).to include 'View feedback'
-      expect(rendered.css('.govuk-visually-hidden').text).to eq Time.zone.now.to_fs(:govuk_date_and_time)
+      expect(rendered.css('.govuk-visually-hidden').text).to eq "Feedback sent: Apply support #{Time.zone.now.to_fs(:govuk_date_and_time)}"
       expect(rendered.css('a').attr('href').value).to eq "/provider/applications/#{application_choice.id}/feedback"
     end
   end
@@ -134,12 +134,12 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
   context 'for an application with a change offer event' do
     it 'renders the change offer event' do
       application_choice = create(:application_choice, :with_changed_offer)
-      create(:application_choice_audit, :with_changed_offer, application_choice: application_choice)
+      create(:application_choice_audit, :with_changed_offer, application_choice: application_choice, user: provider_user)
       rendered = render_inline(described_class.new(application_choice: application_choice))
       expect(rendered.text).to include 'Offer changed'
       expect(rendered.text).to include Time.zone.now.to_fs(:govuk_date_and_time)
       expect(rendered.css('a').text).to include 'View offer'
-      expect(rendered.css('.govuk-visually-hidden').text).to eq Time.zone.now.to_fs(:govuk_date_and_time)
+      expect(rendered.css('.govuk-visually-hidden').text).to eq "Offer changed: Bob Roberts #{Time.zone.now.to_fs(:govuk_date_and_time)}"
       expect(rendered.css('a').attr('href').value).to eq provider_interface_application_choice_offer_path(application_choice)
     end
   end
@@ -147,12 +147,12 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
   context 'for an application with a change course event' do
     it 'renders the change course event' do
       application_choice = create(:application_choice)
-      create(:application_choice_audit, :with_changed_course, application_choice: application_choice)
+      create(:application_choice_audit, :with_changed_course, application_choice: application_choice, user: provider_user)
       rendered = render_inline(described_class.new(application_choice: application_choice))
       expect(rendered.text).to include 'Course updated'
       expect(rendered.text).to include Time.zone.now.to_fs(:govuk_date_and_time)
       expect(rendered.css('a').text).to include 'View application'
-      expect(rendered.css('.govuk-visually-hidden').text).to eq Time.zone.now.to_fs(:govuk_date_and_time)
+      expect(rendered.css('.govuk-visually-hidden').text).to eq "Course updated: Bob Roberts #{Time.zone.now.to_fs(:govuk_date_and_time)}"
       expect(rendered.css('a').attr('href').value).to eq "/provider/applications/#{application_choice.id}"
     end
   end
@@ -162,17 +162,16 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       application_choice = build_stubbed(:application_choice, status: 'interviewing')
       interview = build_stubbed(:interview)
       application_choice_audit = build_stubbed(:application_choice_audit, application_choice: application_choice, audited_changes: { status: %w[awaiting_provider_decision interviewing] })
-      interview_audit = build_stubbed(:interview_audit, interview: interview, application_choice: application_choice, audited_changes: {})
+      interview_audit = build_stubbed(:interview_audit, interview: interview, application_choice: application_choice, audited_changes: {}, user: provider_user)
       allow(application_choice_audit).to receive(:auditable).and_return(application_choice)
       allow(interview_audit).to receive(:auditable).and_return(interview)
       allow(GetActivityLogEvents).to receive(:call)
         .and_return([interview_audit, application_choice_audit])
-
       rendered = render_inline(described_class.new(application_choice: application_choice))
       expect(rendered.text).to include 'Interview set up'
       expect(rendered.text).to include Time.zone.now.to_fs(:govuk_date_and_time)
       expect(rendered.css('a').text).to include 'View interview'
-      expect(rendered.css('.govuk-visually-hidden').text).to eq Time.zone.now.to_fs(:govuk_date_and_time)
+      expect(rendered.css('.govuk-visually-hidden').text).to eq "Interview set up: Bob Roberts #{Time.zone.now.to_fs(:govuk_date_and_time)}"
       expect(rendered.css('a').attr('href').value).to eq "/provider/applications/#{application_choice.id}/interviews#interview-#{interview.id}"
     end
 
@@ -180,7 +179,7 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       application_choice = build_stubbed(:application_choice, status: 'interviewing')
       interview = build_stubbed(:interview)
       application_choice_audit = build_stubbed(:application_choice_audit, application_choice: application_choice, audited_changes: { status: %w[awaiting_provider_decision interviewing] })
-      interview_audit = build_stubbed(:interview_audit, action: 'update', interview: interview, application_choice: application_choice, audited_changes: {})
+      interview_audit = build_stubbed(:interview_audit, action: 'update', interview: interview, application_choice: application_choice, audited_changes: {}, user: provider_user)
       allow(application_choice_audit).to receive(:auditable).and_return(application_choice)
       allow(interview_audit).to receive(:auditable).and_return(interview)
       allow(GetActivityLogEvents).to receive(:call)
@@ -190,7 +189,7 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       expect(rendered.text).to include 'Interview updated'
       expect(rendered.text).to include Time.zone.now.to_fs(:govuk_date_and_time)
       expect(rendered.css('a').text).to include 'View interview'
-      expect(rendered.css('.govuk-visually-hidden').text).to eq Time.zone.now.to_fs(:govuk_date_and_time)
+      expect(rendered.css('.govuk-visually-hidden').text).to eq "Interview updated: Bob Roberts #{Time.zone.now.to_fs(:govuk_date_and_time)}"
       expect(rendered.css('a').attr('href').value).to eq "/provider/applications/#{application_choice.id}/interviews#interview-#{interview.id}"
     end
 
@@ -198,7 +197,7 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       application_choice = build_stubbed(:application_choice, status: 'interviewing')
       interview = build_stubbed(:interview)
       application_choice_audit = build_stubbed(:application_choice_audit, application_choice: application_choice, audited_changes: { status: %w[awaiting_provider_decision interviewing] })
-      interview_audit = build_stubbed(:interview_audit, action: 'update', interview: interview, application_choice: application_choice, audited_changes: { cancelled_at: [nil, Time.zone.now] })
+      interview_audit = build_stubbed(:interview_audit, action: 'update', interview: interview, application_choice: application_choice, audited_changes: { cancelled_at: [nil, Time.zone.now] }, user: provider_user)
       allow(application_choice_audit).to receive(:auditable).and_return(application_choice)
       allow(interview_audit).to receive(:auditable).and_return(interview)
       allow(GetActivityLogEvents).to receive(:call)
@@ -208,7 +207,7 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       expect(rendered.text).to include 'Interview cancelled'
       expect(rendered.text).to include Time.zone.now.to_fs(:govuk_date_and_time)
       expect(rendered.css('a').text).to include 'View interview'
-      expect(rendered.css('.govuk-visually-hidden').text).to eq Time.zone.now.to_fs(:govuk_date_and_time)
+      expect(rendered.css('.govuk-visually-hidden').text).to eq "Interview cancelled: Bob Roberts #{Time.zone.now.to_fs(:govuk_date_and_time)}"
       expect(rendered.css('a').attr('href').value).to eq "/provider/applications/#{application_choice.id}/interviews#interview-#{interview.id}"
     end
   end


### PR DESCRIPTION
## Context
Add more context to visually hidden text
On the timeline component, only the date and time is rendered in the visually hidden text for each link

## Changes proposed in this pull request
* Adds title of action and name of actor to hidden text as per DAC recommendation

## Guidance to review

Visit /provider/applications/#{id}/timeline and inspect the DOM

## Link to Trello card
https://trello.com/c/xpOKFY8W/206-dac-resolve-duplicate-link-text-on-timeline-in-manage

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
