### PR TITLE
Automate updating out of date provider ids on application choices

### DIFF
--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -215,12 +215,6 @@ class ApplicationChoice < ApplicationRecord
     update!(attrs)
   end
 
-private
-
-  def set_initial_status
-    self.status ||= 'unsubmitted'
-  end
-
   def provider_ids_for_access
     [
       course_option.course.provider.id,
@@ -228,5 +222,11 @@ private
       current_course_option.course.provider.id,
       current_course_option.course.accredited_provider&.id,
     ].compact.uniq
+  end
+
+private
+
+  def set_initial_status
+    self.status ||= 'unsubmitted'
   end
 end

--- a/app/workers/update_out_of_date_provider_ids_on_application_choices.rb
+++ b/app/workers/update_out_of_date_provider_ids_on_application_choices.rb
@@ -1,0 +1,32 @@
+class UpdateOutOfDateProviderIdsOnApplicationChoices
+  include Sidekiq::Worker
+
+  def perform
+    return unless out_of_date_application_choices.any?
+
+    update_out_of_date_application_choices
+  end
+
+private
+
+  def out_of_date_application_choices
+    @_out_of_date_application_choices ||= FindApplicationChoicesWithOutOfDateProviderIds.call
+  end
+
+  def update_out_of_date_application_choices
+    out_of_date_application_choices.each do |application_choice|
+      update_out_of_date_provider_ids(application_choice)
+    end
+  end
+
+  def update_out_of_date_provider_ids(application_choice)
+    if application_choice.current_recruitment_cycle_year == RecruitmentCycle.current_year
+      application_choice.update!(
+        provider_ids: application_choice.provider_ids_for_access,
+        audit_comment: 'Update out of date providers on application choice due to provider change',
+      )
+    else
+      application_choice.update_column(:provider_ids, application_choice.provider_ids_for_access)
+    end
+  end
+end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -25,6 +25,7 @@ class Clock
   every(1.hour, 'DetectInvariantsHourlyCheck', at: '**:30') { DetectInvariantsHourlyCheck.perform_async }
   every(1.hour, 'SendChaseEmailToProviders', at: '**:35') { SendChaseEmailToProvidersWorker.perform_async }
   every(1.hour, 'SendChaseEmailToCandidates', at: '**:40') { SendChaseEmailToCandidatesWorker.perform_async }
+  every(1.hour, 'UpdateOutOfDateProviderIdsOnApplicationChoices', at: '**:20') { UpdateOutOfDateProviderIdsOnApplicationChoices.perform_async }
 
   # Daily jobs
   every(1.day, 'DetectInvariantsDailyCheck', at: '07:00') { DetectInvariantsDailyCheck.perform_async }
@@ -44,7 +45,9 @@ class Clock
 
   every(1.day, 'UpdateDuplicateMatchesWorker', at: '13:00') { UpdateDuplicateMatchesWorker.perform_async }
   every(1.day, 'TriggerFullSyncIfFindClosed', at: '00:05') { TeacherTrainingPublicAPI::TriggerFullSyncIfFindClosed.call }
+  every(1.day, 'NudgeCandidatesWorker', at: '10:00') { NudgeCandidatesWorker.perform_async }
 
+  # Weekly jobs
   every(7.days, 'FullSyncAllFromTeacherTrainingPublicAPI', at: 'Saturday 00:59') do
     TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(false)
   end
@@ -54,6 +57,4 @@ class Clock
   end
   every(7.days, 'ApplicationsBySubjectRouteAndDegreeGradeExport', at: 'Sunday 23:59') { SupportInterface::ApplicationsBySubjectRouteAndDegreeGradeExport.run_weekly }
   every(7.days, 'ApplicationsByDemographicDomicileAndDegreeClassExport', at: 'Sunday 23:59') { SupportInterface::ApplicationsByDemographicDomicileAndDegreeClassExport.run_weekly }
-
-  every(1.day, 'NudgeCandidatesWorker', at: '10:00') { NudgeCandidatesWorker.perform_async }
 end

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
         application_choice.current_recruitment_cycle_year = application_choice.current_course_option.course.recruitment_cycle_year
       end
 
-      application_choice.provider_ids = application_choice.send(:provider_ids_for_access)
+      application_choice.provider_ids = application_choice.provider_ids_for_access
     end
 
     status { ApplicationStateChange.valid_states.sample }

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -370,4 +370,47 @@ RSpec.describe ApplicationChoice, type: :model do
       end
     end
   end
+
+  describe '#provider_ids_for_access' do
+    let(:course) { create(:course) }
+    let(:course_option) { create(:course_option, course: course) }
+    let(:application_choice) { create(:application_choice, course_option: course_option) }
+
+    context 'associated to course with training provider only' do
+      it 'returns training provider id' do
+        expect(application_choice.provider_ids_for_access).to contain_exactly(course.provider.id)
+      end
+    end
+
+    context 'associated to course with training and accredited provider' do
+      let(:course) { create(:course, :with_accredited_provider) }
+
+      it 'returns training and accredited provider id' do
+        expect(application_choice.provider_ids_for_access)
+          .to contain_exactly(
+            course.provider.id,
+            course.accredited_provider.id,
+          )
+      end
+    end
+
+    context 'associated to multiple courses with training and accredited providers' do
+      let(:course) { create(:course, :with_accredited_provider) }
+      let(:another_course) { create(:course, :with_accredited_provider) }
+      let(:another_course_option) { create(:course_option, course: another_course) }
+      let(:application_choice) do
+        create(:application_choice, course_option: course_option, current_course_option: another_course_option)
+      end
+
+      it 'returns training and accredited provider ids for all courses' do
+        expect(application_choice.provider_ids_for_access)
+          .to contain_exactly(
+            course.provider.id,
+            course.accredited_provider.id,
+            another_course.provider.id,
+            another_course.accredited_provider.id,
+          )
+      end
+    end
+  end
 end

--- a/spec/workers/update_out_of_date_provider_ids_on_application_choices_spec.rb
+++ b/spec/workers/update_out_of_date_provider_ids_on_application_choices_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe UpdateOutOfDateProviderIdsOnApplicationChoices, sidekiq: true, with_audited: true do
+  describe '#perform' do
+    let(:wrong_provider) { create(:provider) }
+    let(:accredited_course) { create(:course, :with_accredited_provider) }
+    let(:accredited_course_option) { create(:course_option, course: accredited_course) }
+    let!(:application_choice) do
+      create(:application_choice, course_option: accredited_course_option)
+    end
+
+    context 'when application choice provider ids are up to date' do
+      it 'does nothing if no application choices provider ids are out of date' do
+        expect { described_class.new.perform }.not_to change(application_choice, :provider_ids)
+      end
+    end
+
+    context 'when application choice in current cycle provider ids are out of date' do
+      before { application_choice.update!(provider_ids: [wrong_provider.id]) }
+
+      it 'updates application provider ids' do
+        expect { described_class.new.perform }
+          .to change { application_choice.reload.provider_ids }
+          .from([wrong_provider.id])
+          .to([accredited_course.provider.id, accredited_course.accredited_provider.id])
+      end
+
+      it 'amends updated_at timestamp on the application' do
+        updated_at_time = 1.day.from_now.change(usec: 0)
+
+        Timecop.freeze(updated_at_time) do
+          expect { described_class.new.perform }.to change { application_choice.reload.updated_at }.to(updated_at_time)
+        end
+      end
+
+      it 'adds an audit comment to application choice' do
+        described_class.new.perform
+        audit = application_choice.audits.last
+
+        expect(audit.comment)
+          .to eq('Update out of date providers on application choice due to provider change')
+      end
+    end
+
+    context 'when application choice in previous cycle provider ids are out of date' do
+      let(:accredited_course) { create(:course, :with_accredited_provider, :previous_year) }
+
+      before { application_choice.update!(provider_ids: [wrong_provider.id]) }
+
+      it 'updates application provider ids' do
+        expect { described_class.new.perform }
+          .to change { application_choice.reload.provider_ids }
+          .from([wrong_provider.id])
+          .to([accredited_course.provider.id, accredited_course.accredited_provider.id])
+      end
+
+      it 'does not amend updated_at timestamp on the application' do
+        updated_at_time = 1.day.before
+        application_choice.update!(updated_at: updated_at_time)
+
+        described_class.new.perform
+
+        expect(application_choice.reload.updated_at).to be_within(1.second).of(updated_at_time)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

We currently store denormalised course data on application choices. One of those fields holds all provider ids that the course option and current course option relate to (provider and accredited provider).

This field is key to show the application to the relevant providers.
We currently pull course data from publish, which is updating accredited providers regularly. When we sync with the publish API we are updating the course accredited provider, but not application choices. This means that application choices will have stale provider ids

## Changes proposed in this pull request

- Add worker to update stale provider ids on application choices
- Run this job every hour

## Guidance to review
Did I miss anything?
Needed to do some test rejigging to appease Rubocop overlord

## Link to Trello card

https://trello.com/c/Q5ovlGxk/327-automate-accredited-provider-updates-to-courses

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
