### PR TITLE
Do not obfuscate application choice IDs in BigQuery

### DIFF
--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -2,19 +2,11 @@ shared:
   application_forms:
     - support_reference
     - candidate_id
-  application_choices:
-    - id
   candidates:
     - id
   support_users:
     - dfe_sign_in_uid
   provider_users:
     - dfe_sign_in_uid
-  interviews:
-    - application_choice_id
-  notes:
-    - application_choice_id
-  offers:
-    - application_choice_id
   validation_errors:
     - user_id


### PR DESCRIPTION
## Context

We decided that this wasn't PII, and unobfuscating supports linking data between Apply and Register. Register wasn't obfuscating them anyway.

https://ukgovernmentdfe.slack.com/archives/C01H0LBCBDW/p1648048028194019

## Changes proposed in this pull request

Remove from `analytics_pii.yml`. [Docs](https://github.com/DFE-Digital/dfe-analytics#1-configure-bigquery-connection-feature-flags-etc)

## Guidance to review

Does this cover them all?

## Link to Trello card

https://trello.com/c/5URRFAO6/654-un-obfuscate-apply-appchoiceids-in-bigquery

## Things to check

- [X] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
