### PR TITLE
Improve performance of PersonaExport

### DIFF
--- a/app/services/support_interface/persona_export.rb
+++ b/app/services/support_interface/persona_export.rb
@@ -41,10 +41,10 @@ module SupportInterface
         [
           :provider,
           :site,
-          { application_form: [ { application_choices: [:site] }, :application_qualifications] },
+          { application_form: [{ application_choices: [:site] }, :application_qualifications] },
           { course: [:accredited_provider] },
           { course_option: [:site, { course: [:provider] }] },
-        ]
+        ],
       )
       .joins(:candidate)
       .merge(Candidate.order(:id))

--- a/app/services/support_interface/persona_export.rb
+++ b/app/services/support_interface/persona_export.rb
@@ -64,7 +64,7 @@ module SupportInterface
 
     def latest_degree(application_form)
       degrees_with_award_year = application_form.application_qualifications.select do |application_qualification|
-        application_qualification.level == 'degree' && application_qualification.award_year.present?
+        application_qualification.degree? && application_qualification.award_year.present?
       end
 
       return nil if degrees_with_award_year.blank?

--- a/app/services/support_interface/persona_export.rb
+++ b/app/services/support_interface/persona_export.rb
@@ -37,7 +37,15 @@ module SupportInterface
 
     def application_choices
       ApplicationChoice
-      .includes(%i[application_form site provider course candidate])
+      .includes(
+        [
+          :provider,
+          :site,
+          { application_form: [ { application_choices: [:site] }, :application_qualifications] },
+          { course: [:accredited_provider] },
+          { course_option: [:site, { course: [:provider] }] },
+        ]
+      )
       .joins(:candidate)
       .merge(Candidate.order(:id))
     end
@@ -55,7 +63,9 @@ module SupportInterface
     end
 
     def latest_degree(application_form)
-      degrees_with_award_year = application_form.application_qualifications.degree.select { |degree| degree.award_year.present? }
+      degrees_with_award_year = application_form.application_qualifications.select do |application_qualification|
+        application_qualification.level == 'degree' && application_qualification.award_year.present?
+      end
 
       return nil if degrees_with_award_year.blank?
 


### PR DESCRIPTION
## Context

The persona export is taking too long. This PR tries to address it.

In my local machine with 1350 records.

Before:

```
  10.020571   0.426850  10.447421 ( 22.192208)
```

After this PR:

```
  2.207273   0.054880   2.262153 (  3.584286)
```

## Changes proposed in this pull request

Removed all N+1 queries

## Guidance to review

1. Is it faster?
2. Will timeout for QA & Production?

## Link to Trello card

https://trello.com/c/oYluhT85/322-persona-export-not-completing
