### PR TITLE
Describe the different course option fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A service for candidates to [apply for teacher training](https://www.apply-for-t
 - [Docker for DevOps](/docs/docker-for-devops.md)
 - [Swapping App Service Slots](/docs/swap-slots-pipeline.md)
 - [Performance monitoring](/docs/performance-monitoring.md)
+- [Understanding the different course option fields](/docs/course-options.md)
 
 We keep track of the things we learn:
 

--- a/docs/course-options.md
+++ b/docs/course-options.md
@@ -1,0 +1,9 @@
+# Understanding the different course option fields
+
+The `ApplicationChoice` class has three fields relating to course option. It's important to understand what these do and what the rationale for having them is.
+
+| Field | Description | Answers what question |
+| --- | --- | --- |
+| `original_course_option` | This field is only written once (when the application is submitted), and does what it says on the tin: it stores the candidate's original choice of course option, so that we always have this available for reporting and auditing purposes. | What course option did the candidate originally select? |
+| `current_course_option` | This is generally the most relevant course option field and is considered the single source of truth for the application in its current state. It will always be updated when the provider makes a change to the course, whether before or after making an offer. | What is the course option for this application choice? |
+| `course_option` | This field reflects the course option attached to the application choice at the point of making an offer. Once an offer has been made, the `course_option` field no longer changes. | What course option was the candidate offered? |


### PR DESCRIPTION
## Context

The `ApplicationChoice` class has three different fields relating to course options. It is helpful for developers to know what they do.

## Changes proposed in this pull request

Brief description of the different course option fields: what they do, and why they do it.

## Guidance to review

Read the document and see if you feel more or less confused than before.

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
