### PR TITLE
Add step to automerge Dependabot PRs

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -449,6 +449,23 @@ jobs:
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
           env_url: ${{ steps.deploy_review.outputs.deploy-url }}
 
+  merge-dependabot:
+    name: Merge dependabot
+    if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'dependencies') }}
+    needs: [lint, test, deploy-review-app]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Merge minor dependency updates
+        uses: fastify/github-action-merge-dependabot@v3.2.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          target: minor
+          exclude: 'govuk-components,govuk_design_system_formbuilder,govuk-frontend'
+          merge-method: merge
+
   deploy-before-production:
     name: Parallel deployment before production
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Context
We have enabled Dependabot to raise PRs to update our dependencies in the apply repo daily. The ops team also helped us with deploying those changes to a review app whilst in PR. 

Currently merging those PRs is manual. We would like to automate this process.

## Changes proposed in this pull request

If a dependency upgrade is done by Dependabot, and passes all test, linting and deployment to review app steps merge
it automatically to main using https://github.com/fastify/github-action-merge-dependabot

We are skipping govuk frontend dependencies to ensure they are done manually as sometimes they have recommendations we should address before merging, although they might not fail the build (recommended by @frankieroberto).

## Guidance to review

Did I miss anything?

We will be testing this before merging on other Dependabot PRs currently not merged

## Link to Trello card

https://trello.com/c/ZGoDCOpq/328-automate-dependabot-pr-merges

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
