### PR TITLE
Improve hint position accessibility

### DIFF
--- a/app/views/candidate_interface/restructured_work_history/job/_form.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/job/_form.html.erb
@@ -7,8 +7,9 @@
 <% end %>
 
 <div class="app-work-experience__start-date" data-qa="start-date">
-  <%= f.govuk_fieldset legend: { text: t('application_form.restructured_work_history.start_date.label'), size: 'm' } do %>
-    <%= f.govuk_date_field :start_date, omit_day: true, legend: nil, hint: { text: t('application_form.restructured_work_history.start_date.hint_text') } %>
+  <%= f.govuk_fieldset(legend: { text: t('application_form.restructured_work_history.start_date.label') }, size: 'm') do %>
+    <%= tag.p(t('application_form.restructured_work_history.start_date.hint_text'), class: 'govuk-hint') %>
+    <%= f.govuk_date_field :start_date, omit_day: true, legend: nil %>
     <div class="govuk-form-group">
       <%= f.hidden_field :start_date_unknown, value: false %>
       <%= f.govuk_check_box :start_date_unknown, true, multiple: false, label: { text: t('application_form.restructured_work_history.start_date_unknown_checkbox') } %>

--- a/app/views/candidate_interface/volunteering/role/_form.html.erb
+++ b/app/views/candidate_interface/volunteering/role/_form.html.erb
@@ -13,7 +13,8 @@
 
 <div class="app-work-experience__start-date" data-qa="start-date">
   <%= f.govuk_fieldset legend: { text: t('application_form.volunteering.start_date_restructured_work_history.label'), size: 'm' } do %>
-    <%= f.govuk_date_field :start_date, omit_day: true, legend: nil, hint: { text: t('application_form.volunteering.start_date_restructured_work_history.hint_text') } %>
+    <%= tag.p(t('application_form.volunteering.start_date_restructured_work_history.hint_text'), class: 'govuk-hint') %>
+    <%= f.govuk_date_field :start_date, omit_day: true, legend: nil %>
     <div class="govuk-form-group">
       <%= f.govuk_check_box :start_date_unknown, 'true', 'false', multiple: false, label: { text: t('application_form.volunteering.start_date_unknown_checkbox') } %>
     </div>


### PR DESCRIPTION
## Context
Related to this PR https://github.com/DFE-Digital/apply-for-teacher-training/pull/7056

We had a slight code smell where the hint was associated with the nested fieldset instead of the outer fieldset. This is not optimal for screenreader users.

Issue was raised to get some clarity here: https://github.com/DFE-Digital/govuk-formbuilder/issues/369

## Changes proposed in this pull request

* Move the hint to the outer fieldset instead of date field fieldset by manually adding hint

## Guidance to review

Visit unpaid experience and work history section on candidate side

## Link to Trello card

https://trello.com/c/5xg4TKud/344-improve-fieldset-accessibility-issue

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
