### PR TITLE
Revert "Add step to automerge Dependabot PRs"

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -449,23 +449,6 @@ jobs:
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
           env_url: ${{ steps.deploy_review.outputs.deploy-url }}
 
-  merge-dependabot:
-    name: Merge dependabot
-    if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'dependencies') }}
-    needs: [lint, test, deploy-review-app]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Merge minor dependency updates
-        uses: fastify/github-action-merge-dependabot@v3.2.0
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          target: minor
-          exclude: 'govuk-components,govuk_design_system_formbuilder,govuk-frontend'
-          merge-method: merge
-
   deploy-before-production:
     name: Parallel deployment before production
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
Reverts DFE-Digital/apply-for-teacher-training#7150
The automerge step isn't triggering the delete review app action or the action to deploy to prod, reverting for now