### PR TITLE
Use current course to surface diversity information

### DIFF
--- a/app/components/provider_interface/diversity_information_component.rb
+++ b/app/components/provider_interface/diversity_information_component.rb
@@ -68,7 +68,7 @@ module ProviderInterface
 
     def current_user_has_permission_to_view_diversity_information?
       current_provider_user.authorisation
-        .can_view_diversity_information?(course: application_choice.course)
+        .can_view_diversity_information?(course: application_choice.current_course)
     end
 
     def equality_and_diversity


### PR DESCRIPTION
 ## Context

If an application moves between accredited bodies, users might not be able to view diversity information as we are calculating the permissions based on the course and not current course.

## Changes proposed in this pull request

Use current course as the source of truth instead to always be up to date.

## Guidance to review

Did I miss anything?

## Link to Trello card

https://becomingateacher.zendesk.com/agent/tickets/84461

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
