### PR TITLE
Accessibility resolve duplicate personal information page title

### DIFF
--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -4,7 +4,7 @@
 
 <section class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.personal_details') %></h2>
-  <h3 class="govuk-heading-m" id="personal_details"><%= t('page_titles.personal_information') %></h3>
+  <h3 class="govuk-heading-m" id="personal_details"><%= t('page_titles.personal_information.heading') %></h3>
   <%= render(CandidateInterface::PersonalDetailsReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, return_to_application_review: true)) %>
   <h3 class="govuk-heading-m" id="contact_details"><%= t('page_titles.contact_information') %></h3>
   <%= render(CandidateInterface::ContactDetailsReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submitting_application: true, return_to_application_review: true)) %>

--- a/app/views/candidate_interface/personal_details/name_and_dob/_shared_form.html.erb
+++ b/app/views/candidate_interface/personal_details/name_and_dob/_shared_form.html.erb
@@ -1,7 +1,7 @@
   <%= f.govuk_error_summary %>
 
   <h1 class="govuk-heading-xl">
-    <%= t('page_titles.personal_information') %>
+    <%= t('page_titles.personal_information.heading') %>
   </h1>
 
   <%= f.govuk_text_field :first_name, label: { text: t('application_form.personal_details.first_name.label'), size: 'm' }, hint: { text: t('application_form.personal_details.first_name.hint_text') }, autocomplete: 'given-name' %>

--- a/app/views/candidate_interface/personal_details/name_and_dob/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/name_and_dob/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, title_with_error_prefix(t('page_titles.personal_information'), @personal_details_form.errors.any?) %>
+<% content_for :title, title_with_error_prefix(t('page_titles.personal_information.edit'), @personal_details_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/personal_details/name_and_dob/new.html.erb
+++ b/app/views/candidate_interface/personal_details/name_and_dob/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, title_with_error_prefix(t('page_titles.personal_information'), @personal_details_form.errors.any?) %>
+<% content_for :title, title_with_error_prefix(t('page_titles.personal_information.heading'), @personal_details_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/personal_details/review/show.html.erb
+++ b/app/views/candidate_interface/personal_details/review/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, title_with_error_prefix(t('page_titles.personal_information'),
+<% content_for :title, title_with_error_prefix(t('page_titles.personal_information.review'),
                                                 @personal_details_form.errors.any? ||
                                                  @nationalities_form.errors.any? ||
                                                   @section_complete_form.errors.any?) %>
@@ -9,7 +9,7 @@
   <%= f.govuk_error_summary %>
 
   <h1 class="govuk-heading-xl">
-    <%= t('page_titles.personal_information') %>
+    <%= t('page_titles.personal_information.heading') %>
   </h1>
 
   <%= render SummaryCardComponent.new(rows: @personal_details_review.rows) %>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -22,7 +22,7 @@
             (!@application_form_presenter.english_main_language.nil? || @application_form_presenter.right_to_work_or_study_present?)
           ) %>
           <%= render(TaskListItemComponent.new(
-            text: t('page_titles.personal_information'),
+            text: t('page_titles.personal_information.heading'),
             completed: @application_form_presenter.personal_details_completed?,
             path: all_sections_completed ? candidate_interface_personal_details_show_path : candidate_interface_name_and_dob_path,
           )) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,7 +89,10 @@ en:
     internal_server_error: Sorry, there’s a problem with the service
     unprocessable_entity: Sorry, there’s a problem with the service
     personal_details: Personal details
-    personal_information: Personal information
+    personal_information: 
+      heading: Personal information
+      edit: Edit your personal information
+      review: Check your personal information
     nationalities: What is your nationality?
     languages: Is English your main language?
     immigration_right_to_work: Right to work or study in the UK

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -35,7 +35,7 @@ module CandidateHelper
 
     candidate_fills_in_apply_again_course_choice
 
-    click_link t('page_titles.personal_information')
+    click_link t('page_titles.personal_information.heading')
     candidate_fills_in_personal_details(international: international)
 
     click_link t('page_titles.contact_information')

--- a/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_spec.rb
@@ -49,7 +49,7 @@ RSpec.feature 'Entering their personal details' do
   end
 
   def when_i_click_on_personal_information
-    click_link t('page_titles.personal_information')
+    click_link t('page_titles.personal_information.heading')
   end
 
   def and_i_fill_in_some_details_but_omit_some_required_details
@@ -139,7 +139,7 @@ RSpec.feature 'Entering their personal details' do
   end
 
   def then_i_should_see_the_form
-    expect(page).to have_content(t('page_titles.personal_information'))
+    expect(page).to have_content(t('page_titles.personal_information.heading'))
   end
 
   def and_that_the_section_is_completed

--- a/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_when_requiring_visa_2022_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_when_requiring_visa_2022_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Entering personal details' do
   end
 
   def and_i_can_complete_personal_information_stating_that_i_need_a_visa_sponsorship
-    click_link t('page_titles.personal_information')
+    click_link t('page_titles.personal_information.heading')
 
     # Basic details
     scope = 'application_form.personal_details'

--- a/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_when_requiring_visa_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_when_requiring_visa_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature 'Entering personal details' do
   end
 
   def and_i_can_complete_personal_information_with_non_british_or_irish_nationality
-    click_link t('page_titles.personal_information')
+    click_link t('page_titles.personal_information.heading')
 
     # Basic details
     scope = 'application_form.personal_details'

--- a/spec/system/candidate_interface/entering_details/international_candidate_enters_their_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/international_candidate_enters_their_other_qualification_spec.rb
@@ -86,7 +86,7 @@ RSpec.feature 'Non-uk Other qualifications', mid_cycle: false do
   end
 
   def and_i_am_an_international_candidate
-    click_link t('page_titles.personal_information')
+    click_link t('page_titles.personal_information.heading')
     candidate_fills_in_personal_details(international: true)
   end
 

--- a/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature 'International candidate submits the application' do
     candidate_fills_in_apply_again_course_choice
 
     # Basic personal details
-    click_link t('page_titles.personal_information')
+    click_link t('page_titles.personal_information.heading')
     scope = 'application_form.personal_details'
     fill_in t('first_name.label', scope: scope), with: 'Lando'
     fill_in t('last_name.label', scope: scope), with: 'Calrissian'


### PR DESCRIPTION
## Context
Personal information section uses one page title for the whole section
## Changes proposed in this pull request
* Make unique page titles for the personal information journey so that screen reader users can more easily differentiate between the pages.
## Guidance to review

Visit personal information section for a candidate and verify unique page titles as per DAC recommendation

## Link to Trello card

https://trello.com/c/7hMOF1Ke/203-dac-resolve-duplicate-personal-information-page-title

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
