### PR TITLE
Accessibility resolve duplicate interview needs page titles

### DIFF
--- a/app/views/candidate_interface/interview_needs/_form.html.erb
+++ b/app/views/candidate_interface/interview_needs/_form.html.erb
@@ -1,6 +1,6 @@
 <%= f.govuk_error_summary %>
 
-<h1 class="govuk-heading-xl"><%= t('page_titles.interview_preferences') %></h1>
+<h1 class="govuk-heading-xl"><%= t('page_titles.interview_preferences.heading') %></h1>
 
 <p class="govuk-body">
   Providers do not usually have much flexibility when setting a date

--- a/app/views/candidate_interface/interview_needs/edit.html.erb
+++ b/app/views/candidate_interface/interview_needs/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, title_with_error_prefix(t('page_titles.interview_preferences'), @interview_preferences_form.errors.any?) %>
+<% content_for :title, title_with_error_prefix(t('page_titles.interview_preferences.edit'), @interview_preferences_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/interview_needs/new.html.erb
+++ b/app/views/candidate_interface/interview_needs/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, title_with_error_prefix(t('page_titles.interview_preferences'), @interview_preferences_form.errors.any?) %>
+<% content_for :title, title_with_error_prefix(t('page_titles.interview_preferences.heading'), @interview_preferences_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/interview_needs/show.html.erb
+++ b/app/views/candidate_interface/interview_needs/show.html.erb
@@ -1,11 +1,11 @@
-<% content_for :title, t('page_titles.interview_preferences') %>
+<% content_for :title, t('page_titles.interview_preferences.review') %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_interview_preferences_complete_path, method: :patch do |f| %>
   <%= f.govuk_error_summary %>
 
   <h1 class="govuk-heading-xl">
-    <%= t('page_titles.interview_preferences') %>
+    <%= t('page_titles.interview_preferences.heading') %>
   </h1>
 
   <%= render CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: @application_form) %>

--- a/app/views/candidate_interface/unsubmitted_application_form/_task_list.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/_task_list.html.erb
@@ -113,7 +113,7 @@
     </li>
     <li class="app-task-list__item govuk-hint">
       <%= render(TaskListItemComponent.new(
-        text: t('page_titles.interview_preferences'),
+        text: t('page_titles.interview_preferences.heading'),
         completed: application_form_presenter.interview_preferences_completed?,
         path: application_form_presenter.interview_preferences_valid? ? candidate_interface_interview_preferences_show_path : candidate_interface_new_interview_preferences_path,
       )) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -159,7 +159,10 @@ en:
     destroy_other_qualification: Are you sure you want to delete this qualification?
     becoming_a_teacher: Why you want to teach
     subject_knowledge: Your suitability to teach a subject or age group
-    interview_preferences: Interview needs
+    interview_preferences: 
+      heading: Interview needs
+      edit: Edit your interview needs
+      review: Check your interview needs
     training_with_a_disability: Ask for support if you’re disabled
     suitability_to_work_with_children: Declare any safeguarding issues
     thank_you: Thank you for your feedback

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -85,7 +85,7 @@ module CandidateHelper
     click_link 'Your suitability to teach a subject or age group'
     candidate_fills_in_subject_knowledge
 
-    click_link t('page_titles.interview_preferences')
+    click_link t('page_titles.interview_preferences.heading')
     candidate_fills_in_interview_preferences
 
     if international

--- a/spec/system/candidate_interface/entering_details/candidate_entering_interview_preferences_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_interview_preferences_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature 'Entering interview preferences' do
   end
 
   def when_i_click_on_interview_preferences
-    click_link t('page_titles.interview_preferences')
+    click_link t('page_titles.interview_preferences.heading')
   end
 
   def and_i_submit_the_form
@@ -60,7 +60,7 @@ RSpec.feature 'Entering interview preferences' do
   end
 
   def then_i_can_check_my_answers
-    expect(page).to have_content t('page_titles.interview_preferences')
+    expect(page).to have_content t('page_titles.interview_preferences.heading')
     expect(page).to have_content 'Hello world'
   end
 
@@ -73,7 +73,7 @@ RSpec.feature 'Entering interview preferences' do
   end
 
   def then_i_can_check_my_revised_answers
-    expect(page).to have_content t('page_titles.interview_preferences')
+    expect(page).to have_content t('page_titles.interview_preferences.heading')
     expect(page).to have_content t('application_form.personal_statement.interview_preferences.no_value')
   end
 
@@ -94,7 +94,7 @@ RSpec.feature 'Entering interview preferences' do
   end
 
   def then_i_should_see_the_form
-    expect(page).to have_content(t('page_titles.interview_preferences'))
+    expect(page).to have_content(t('page_titles.interview_preferences.heading'))
   end
 
   def and_that_the_section_is_completed

--- a/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
@@ -103,7 +103,7 @@ RSpec.feature 'International candidate submits the application' do
     click_link 'Your suitability to teach a subject or age group'
     candidate_fills_in_subject_knowledge
 
-    click_link t('page_titles.interview_preferences')
+    click_link t('page_titles.interview_preferences.heading')
     candidate_fills_in_interview_preferences
 
     candidate_provides_two_referees


### PR DESCRIPTION
## Context
Interview needs section uses one page title for the whole section
## Changes proposed in this pull request
* Make unique page titles for the interview needs journey so that screen reader users can more easily differentiate between the pages.
## Guidance to review

Visit interview needs section for a candidate and verify unique page titles as per DAC recommendation

## Link to Trello card
https://trello.com/c/wtduPAqG/200-dac-resolve-duplicate-interview-needs-page-title

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
