### PR TITLE
Permit make decisions for all load test vendor api users

### DIFF
--- a/lib/tasks/load_test.rake
+++ b/lib/tasks/load_test.rake
@@ -16,6 +16,11 @@ namespace :load_test do
     Rails.logger.info 'Finished'
   end
 
+  desc 'Generate more load test applications'
+  task generate_test_applications: :environment do
+    10.times { GenerateTestApplications.new.perform }
+  end
+
   desc 'Set up provider and course data from the Teacher training public API'
   task setup_provider_and_course_data: :environment do
     check_environment!

--- a/lib/tasks/load_test.rake
+++ b/lib/tasks/load_test.rake
@@ -39,6 +39,8 @@ namespace :load_test do
         provider_from_api: provider_from_api, recruitment_cycle_year: RecruitmentCycle.current_year,
       ).call(run_in_background: false)
 
+      ProviderRelationshipPermissions.update_all(training_provider_can_make_decisions: true)
+
     rescue JsonApiClient::Errors::NotFound
       Rails.logger.warn "Could not find Provider for code #{code}. Skipping."
     end
@@ -58,6 +60,8 @@ namespace :load_test do
         last_name: Faker::Name.last_name,
       }, [code])
     end
+
+    ProviderPermissions.update_all(make_decisions: true)
   end
 
   desc 'Set up signed provider agreements'


### PR DESCRIPTION
## Context

When setting up or resetting the `apply-loadtest` application all provider users and organisations should be permitted to make decisions. Necessary for the vendor plan to run the _make offer_ scenario.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Permit all provider users and orgs to make decisions.
- Add a task to generate more test applications
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
