### PR TITLE
Make vendor plan thread count configurable

### DIFF
--- a/jmeter/plans/vendor.rb
+++ b/jmeter/plans/vendor.rb
@@ -4,6 +4,7 @@ BASEURL = ENV.fetch('JMETER_TARGET_BASEURL')
 WAIT_FACTOR = ENV.fetch('JMETER_WAIT_FACTOR', 1).to_f
 RAMPUP = ENV.fetch('JMETER_RAMPUP', 0).to_i
 API_VERSION = ENV.fetch('API_VERSION', 'v1.0')
+THREAD_COUNT = ENV.fetch('JMETER_THREAD_COUNT', 2).to_i
 
 def since
   # 90 days ago
@@ -38,7 +39,7 @@ test do
 
   vendor_api_keys.each do |api_key|
     # Sync applications (last 90 days) once every hour
-    threads count: 1, rampup: RAMPUP, continue_forever: true, duration: 3600 do
+    threads count: (THREAD_COUNT / 2), rampup: RAMPUP, continue_forever: true, duration: 3600 do
       request_headers(api_key)
 
       get(
@@ -49,7 +50,7 @@ test do
     end
 
     # Make offer
-    threads count: 1, rampup: RAMPUP, continue_forever: true, duration: 3600 do
+    threads count: (THREAD_COUNT / 2), rampup: RAMPUP, continue_forever: true, duration: 3600 do
       request_headers(api_key)
 
       get(

--- a/jmeter/workspace_variables/vendor.tfvars
+++ b/jmeter/workspace_variables/vendor.tfvars
@@ -2,10 +2,11 @@ cf_space = "bat-prod"
 app_name = "apply-vendor-jmeter"
 app_env_variables = {
   JMETER_TARGET_PLAN      = "vendor"
-  JMETER_THREAD_COUNT     = 200
+  JMETER_THREAD_COUNT     = 2
   JMETER_RAMPUP           = 120
   JMETER_WAIT_FACTOR      = 1
   JMETER_TARGET_BASEURL   = "https://apply-loadtest.london.cloudapps.digital"
   JMETER_TARGET_APP       = "apply-loadtest"
   JMETER_TARGET_APP_SPACE = "bat-prod"
+  API_VERSION             = "v1.1"
 }


### PR DESCRIPTION
## Context

The vendor load test plan was hardcoded to 1 thread per scenario. This means a code change to increase load.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Make thread count configurable by env var.
- Set the default to 2 threads on both scenarios x 50 Vendor API users/tokens. 100 threads in total.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/TSHzwTi0/352-run-load-tests-and-report-findings
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
