### PR TITLE
[4328] Add degree uuids to Register API

### DIFF
--- a/app/presenters/register_api/single_application_presenter.rb
+++ b/app/presenters/register_api/single_application_presenter.rb
@@ -78,6 +78,10 @@ module RegisterAPI
         institution_details: institution_details(qualification),
         equivalency_details: qualification.composite_equivalency_details,
         comparable_uk_degree: qualification.comparable_uk_degree,
+        degree_type_uuid: qualification.degree_type_uuid,
+        degree_institution_uuid: qualification.degree_institution_uuid,
+        degree_grade_uuid: qualification.degree_grade_uuid,
+        degree_subject_uuid: qualification.degree_subject_uuid,
       }.merge HesaQualificationFieldsPresenter.new(qualification).to_hash
     end
 

--- a/spec/factories/application_qualification.rb
+++ b/spec/factories/application_qualification.rb
@@ -125,6 +125,13 @@ FactoryBot.define do
         grade { %w[pass merit distinction].sample }
         institution_country { Faker::Address.country_code }
       end
+
+      trait :with_degree_uuids do
+        degree_type_uuid { SecureRandom.uuid }
+        degree_institution_uuid { SecureRandom.uuid }
+        degree_grade_uuid { SecureRandom.uuid }
+        degree_subject_uuid { SecureRandom.uuid }
+      end
     end
   end
 end

--- a/spec/presenters/register_api/single_application_presenter_spec.rb
+++ b/spec/presenters/register_api/single_application_presenter_spec.rb
@@ -452,6 +452,25 @@ RSpec.describe RegisterAPI::SingleApplicationPresenter do
       expect(qualification_hash[:id]).to eq qualification.public_id
     end
 
+    it 'uses the corresponding degree uuids of a qualification as the uuids' do
+      qualification = create(
+        :other_qualification,
+        :with_degree_uuids,
+        application_form: application_choice.application_form,
+      )
+
+      qualification_hash = presenter.as_json.dig(
+        :attributes,
+        :qualifications,
+        :other_qualifications,
+      ).first
+
+      expect(qualification_hash[:degree_type_uuid]).to eq qualification.degree_type_uuid
+      expect(qualification_hash[:degree_institution_uuid]).to eq qualification.degree_institution_uuid
+      expect(qualification_hash[:degree_grade_uuid]).to eq qualification.degree_grade_uuid
+      expect(qualification_hash[:degree_subject_uuid]).to eq qualification.degree_subject_uuid
+    end
+
     it 'contains HESA qualification fields' do
       create(
         :other_qualification,


### PR DESCRIPTION
## Context

We need to add `degree_type_uuid`, `degree_institution_uuid`, `degree_grade_uuid` and `degree_subject_uuid` to the Apply Register API. 

This is so we can be consistent across services and pull data using the same uuids from the same source of truth i.e. the DfE Reference Data gem. 

Trello: https://trello.com/c/MASA5CjG/4328-m-add-uuids-to-apply-register-api

## Changes proposed in this pull request

* Add above 4 types of uuid into `qualification_to_hash` method

## Guidance to review

* I haven't touched the API before - please check I haven't missed updating anything
* I noticed a method include_degree_uuids? but I don't think I need to touch that - but could be wrong. Could you check this too?
* Do I need to update any API docs?

## Link to Trello card

https://trello.com/c/MASA5CjG/4328-m-add-uuids-to-apply-register-api

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
