### PR TITLE
Provider EoC emails no longer use hardcoded dates

### DIFF
--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -209,19 +209,22 @@ class ProviderMailer < ApplicationMailer
 
   def apply_service_is_now_open(provider_user)
     @provider_user = provider_user
+    @recruitment_cycle = CycleTimetable.cycle_year_range(RecruitmentCycle.current_year)
 
     provider_notify_email(
       to: @provider_user.email_address,
-      subject: I18n.t!('provider_mailer.apply_service_is_now_open.subject', time_period: CycleTimetable.cycle_year_range),
+      subject: I18n.t!('provider_mailer.apply_service_is_now_open.subject', time_period: @recruitment_cycle),
     )
   end
 
   def find_service_is_now_open(provider_user)
     @provider_user = provider_user
+    @recruitment_cycle = CycleTimetable.cycle_year_range(RecruitmentCycle.current_year)
+    @apply_opens = CycleTimetable.apply_opens.to_fs(:govuk_date)
 
     provider_notify_email(
       to: @provider_user.email_address,
-      subject: I18n.t!('provider_mailer.find_service_is_now_open.subject', time_period: CycleTimetable.cycle_year_range),
+      subject: I18n.t!('provider_mailer.find_service_is_now_open.subject', time_period: @recruitment_cycle),
     )
   end
 

--- a/app/views/provider_mailer/apply_service_is_now_open.text.erb
+++ b/app/views/provider_mailer/apply_service_is_now_open.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @provider_user.full_name %>
 
-The 2022 to 2023 recruitment cycle is open. Candidates can now apply to your courses.
+The <%= @recruitment_cycle %> recruitment cycle is open. Candidates can now apply to your courses.
 
 Manage applications:
 

--- a/app/views/provider_mailer/find_service_is_now_open.text.erb
+++ b/app/views/provider_mailer/find_service_is_now_open.text.erb
@@ -1,5 +1,5 @@
 Dear <%= @provider_user.full_name %>
 
-The 2022 to 2023 recruitment cycle is open. Candidates can now find your courses.
+The <%= @recruitment_cycle %> recruitment cycle is open. Candidates can now find your courses.
 
-They’ll be able to apply on 12 October 2021 at 9am.
+They’ll be able to apply on <%= @apply_opens %> at 9am.

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -539,73 +539,67 @@ RSpec.describe CandidateMailer, type: :mailer do
   end
 
   describe '.new_cycle_has_started' do
-    before do
-      allow(CycleTimetable).to receive(:apply_opens).and_return(Date.new(2021, 10, 13))
-      allow(CycleTimetable).to receive(:cycle_year_range).and_return('2022 to 2023')
-    end
+    Timecop.freeze(2021, 10, 12) do
+      context "when the candidate's application was unsubmitted" do
+        let(:application_form) { build_stubbed(:application_form, first_name: 'Fred', submitted_at: nil) }
+        let(:email) { mailer.new_cycle_has_started(application_form) }
 
-    context "when the candidate's application was unsubmitted" do
-      let(:application_form) { build_stubbed(:application_form, first_name: 'Fred', submitted_at: nil) }
-      let(:email) { mailer.new_cycle_has_started(application_form) }
+        it_behaves_like(
+          'a mail with subject and content',
+          'Teacher training applications are open - apply for the 2022 to 2023 academic year',
+          'greeting' => 'Dear Fred',
+          'academic_year' => '2022 to 2023',
+          'details' => 'Applications are now open',
+        )
+      end
 
-      it_behaves_like(
-        'a mail with subject and content',
-        'Teacher training applications are open - apply for the 2022 to 2023 academic year',
-        'greeting' => 'Dear Fred',
-        'academic_year' => '2022 to 2023',
-        'details' => 'Applications are now open',
-      )
-    end
+      context "when the candidate's application was unsuccessful" do
+        let(:application_choice) { build_stubbed(:application_choice, :with_rejection) }
+        let(:application_form) { build_stubbed(:application_form, first_name: 'Fred', application_choices: [application_choice]) }
+        let(:email) { mailer.new_cycle_has_started(application_form) }
 
-    context "when the candidate's application was unsuccessful" do
-      let(:application_choice) { build_stubbed(:application_choice, :with_rejection) }
-      let(:application_form) { build_stubbed(:application_form, first_name: 'Fred', application_choices: [application_choice]) }
-      let(:email) { mailer.new_cycle_has_started(application_form) }
+        it_behaves_like(
+          'a mail with subject and content',
+          'Teacher training applications are open - apply for the 2022 to 2023 academic year',
+          'greeting' => 'Dear Fred',
+          'academic_year' => '2022 to 2023',
+          'details' => 'Applications are now open - apply for teacher training again.',
+        )
+      end
 
-      it_behaves_like(
-        'a mail with subject and content',
-        'Teacher training applications are open - apply for the 2022 to 2023 academic year',
-        'greeting' => 'Dear Fred',
-        'academic_year' => '2022 to 2023',
-        'details' => 'Applications are now open - apply for teacher training again.',
-      )
-    end
+      context 'when a candidate has not provided a first name' do
+        let(:email) { mailer.new_cycle_has_started(application_form) }
+        let(:application_form) { build_stubbed(:application_form, first_name: nil) }
 
-    context 'when a candidate has not provided a first name' do
-      let(:email) { mailer.new_cycle_has_started(application_form) }
-      let(:application_form) { build_stubbed(:application_form, first_name: nil) }
-
-      it 'does not include a `Dear` heading' do
-        expect(email.body).not_to include('Dear')
+        it 'does not include a `Dear` heading' do
+          expect(email.body).not_to include('Dear')
+        end
       end
     end
   end
 
   describe '.find_has_opened' do
-    before do
-      allow(CycleTimetable).to receive(:apply_opens).and_return(Date.new(2021, 10, 13))
-      allow(CycleTimetable).to receive(:cycle_year_range).and_return('2022 to 2023')
-    end
+    Timecop.freeze(2021, 10, 12) do
+      context "when the candidate's application was unsubmitted" do
+        let(:application_form) { build_stubbed(:application_form, first_name: 'Fred', submitted_at: nil) }
+        let(:email) { mailer.find_has_opened(application_form) }
 
-    context "when the candidate's application was unsubmitted" do
-      let(:application_form) { build_stubbed(:application_form, first_name: 'Fred', submitted_at: nil) }
-      let(:email) { mailer.find_has_opened(application_form) }
+        it_behaves_like(
+          'a mail with subject and content',
+          'Find your teacher training course now',
+          'greeting' => 'Dear Fred',
+          'academic_year' => '2022 to 2023',
+          'details' => 'Find your courses:',
+        )
+      end
 
-      it_behaves_like(
-        'a mail with subject and content',
-        'Find your teacher training course now',
-        'greeting' => 'Dear Fred',
-        'academic_year' => '2022 to 2023',
-        'details' => 'Find your courses:',
-      )
-    end
+      context 'when a candidate has not provided a first name' do
+        let(:email) { mailer.find_has_opened(application_form) }
+        let(:application_form) { build_stubbed(:application_form, first_name: nil) }
 
-    context 'when a candidate has not provided a first name' do
-      let(:email) { mailer.find_has_opened(application_form) }
-      let(:application_form) { build_stubbed(:application_form, first_name: nil) }
-
-      it 'does not include a `Dear` heading' do
-        expect(email.body).not_to include('Dear')
+        it 'does not include a `Dear` heading' do
+          expect(email.body).not_to include('Dear')
+        end
       end
     end
   end

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -429,40 +429,34 @@ RSpec.describe ProviderMailer, type: :mailer do
   end
 
   describe 'apply_service_is_now_open' do
-    before do
-      allow(CycleTimetable).to receive(:apply_opens).and_return(Date.new(2021, 10, 12))
-      allow(CycleTimetable).to receive(:cycle_year_range).and_return('2022 to 2023')
+    Timecop.freeze(2021, 10, 12) do
+      let(:provider_user) { build_stubbed(:provider_user, first_name: 'Johny', last_name: 'English') }
+      let(:email) { described_class.apply_service_is_now_open(provider_user) }
+
+      it_behaves_like(
+        'a mail with subject and content',
+        'Candidates can now apply - manage teacher training applications',
+        'salutation' => 'Dear Johny English',
+        'main paragraph' => 'The 2022 to 2023 recruitment cycle is open. Candidates can now apply to your courses.',
+        'link to applications' => 'http://localhost:3000/provider/applications',
+        'footer' => 'Get help, report a problem or give feedback',
+      )
     end
-
-    let(:provider_user) { build_stubbed(:provider_user, first_name: 'Johny', last_name: 'English') }
-    let(:email) { described_class.apply_service_is_now_open(provider_user) }
-
-    it_behaves_like(
-      'a mail with subject and content',
-      'Candidates can now apply - manage teacher training applications',
-      'salutation' => 'Dear Johny English',
-      'main paragraph' => 'The 2022 to 2023 recruitment cycle is open. Candidates can now apply to your courses.',
-      'link to applications' => 'http://localhost:3000/provider/applications',
-      'footer' => 'Get help, report a problem or give feedback',
-    )
   end
 
   describe 'find_service_is_now_open' do
-    before do
-      allow(CycleTimetable).to receive(:apply_opens).and_return(Date.new(2021, 10, 12))
-      allow(CycleTimetable).to receive(:cycle_year_range).and_return('2022 to 2023')
+    Timecop.freeze(2021, 10, 12) do
+      let(:provider_user) { build_stubbed(:provider_user, first_name: 'Johny', last_name: 'English') }
+      let(:email) { described_class.find_service_is_now_open(provider_user) }
+
+      it_behaves_like(
+        'a mail with subject and content',
+        'Candidates can now find courses - manage teacher training applications',
+        'salutation' => 'Dear Johny English',
+        'main paragraph' => 'The 2022 to 2023 recruitment cycle is open. Candidates can now find your courses.',
+        'Opening date paragraph' => 'They’ll be able to apply on 12 October 2021 at 9am.',
+      )
     end
-
-    let(:provider_user) { build_stubbed(:provider_user, first_name: 'Johny', last_name: 'English') }
-    let(:email) { described_class.find_service_is_now_open(provider_user) }
-
-    it_behaves_like(
-      'a mail with subject and content',
-      'Candidates can now find courses - manage teacher training applications',
-      'salutation' => 'Dear Johny English',
-      'main paragraph' => 'The 2022 to 2023 recruitment cycle is open. Candidates can now find your courses.',
-      'Opening date paragraph' => 'They’ll be able to apply on 12 October 2021 at 9am.',
-    )
   end
 
   describe 'set_up_organisation_permissions for single provider with one relationship' do

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -429,6 +429,11 @@ RSpec.describe ProviderMailer, type: :mailer do
   end
 
   describe 'apply_service_is_now_open' do
+    before do
+      allow(CycleTimetable).to receive(:apply_opens).and_return(Date.new(2021, 10, 12))
+      allow(CycleTimetable).to receive(:cycle_year_range).and_return('2022 to 2023')
+    end
+
     let(:provider_user) { build_stubbed(:provider_user, first_name: 'Johny', last_name: 'English') }
     let(:email) { described_class.apply_service_is_now_open(provider_user) }
 
@@ -443,6 +448,11 @@ RSpec.describe ProviderMailer, type: :mailer do
   end
 
   describe 'find_service_is_now_open' do
+    before do
+      allow(CycleTimetable).to receive(:apply_opens).and_return(Date.new(2021, 10, 12))
+      allow(CycleTimetable).to receive(:cycle_year_range).and_return('2022 to 2023')
+    end
+
     let(:provider_user) { build_stubbed(:provider_user, first_name: 'Johny', last_name: 'English') }
     let(:email) { described_class.find_service_is_now_open(provider_user) }
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

EoC work – provider emails are currently using hardcoded dates. We should be using the `CycleTimetable` class to dynamically provide these dates. The candidate mailer currently does this.

## Guidance to review

Emails available to review in support.