### PR TITLE
Give vendors ability to generate applications in the previous cycles for testing

### DIFF
--- a/app/controllers/vendor_api/test_data_controller.rb
+++ b/app/controllers/vendor_api/test_data_controller.rb
@@ -18,6 +18,7 @@ module VendorAPI
         provider: current_provider,
         courses_per_application: courses_per_application_param,
         count: count_param,
+        previous_cycle: previous_cycle_param,
         for_training_courses: for_training_courses_param,
         for_ratified_courses: for_ratified_courses_param,
         for_test_provider_courses: for_test_provider_courses_param,
@@ -66,6 +67,10 @@ module VendorAPI
 
     def for_test_provider_courses_param
       params[:for_test_provider_courses] == 'true'
+    end
+
+    def previous_cycle_param
+      params[:previous_cycle] == 'true'
     end
   end
 end

--- a/app/controllers/vendor_api/test_data_controller.rb
+++ b/app/controllers/vendor_api/test_data_controller.rb
@@ -18,7 +18,7 @@ module VendorAPI
         provider: current_provider,
         courses_per_application: courses_per_application_param,
         count: count_param,
-        previous_cycle: previous_cycle_param,
+        previous_cycle: previous_cycle?,
         for_training_courses: for_training_courses_param,
         for_ratified_courses: for_ratified_courses_param,
         for_test_provider_courses: for_test_provider_courses_param,
@@ -69,7 +69,7 @@ module VendorAPI
       params[:for_test_provider_courses] == 'true'
     end
 
-    def previous_cycle_param
+    def previous_cycle?
       params[:previous_cycle] == 'true'
     end
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -16,7 +16,7 @@ class Course < ApplicationRecord
   scope :current_cycle, -> { where(recruitment_cycle_year: RecruitmentCycle.current_year) }
   scope :previous_cycle, -> { where(recruitment_cycle_year: RecruitmentCycle.previous_year) }
   scope :in_cycle, ->(year) { where(recruitment_cycle_year: year) }
-
+  scope :with_course_options_run_by_provider, ->(provider) { joins(:course_options).distinct.where(provider: provider) }
   scope :with_course_options, -> { left_outer_joins(:course_options).where.not(course_options: { id: nil }) }
 
   after_update :touch_application_choices_and_forms, if: :in_current_recruitment_cycle?
@@ -147,27 +147,6 @@ class Course < ApplicationRecord
       .joins(application_choices: :course_option)
       .where(application_choices: { course_options: { course: self } })
       .distinct
-  end
-
-  def self.find_courses_in_previous_cycle(provider)
-    previous_cycle
-        .joins(:course_options)
-        .distinct
-        .where(provider: provider)
-        .includes(%i[provider accredited_provider])
-  end
-
-  def self.find_courses_in_current_cycle(provider)
-    current_cycle
-        .open_on_apply
-        .joins(:course_options)
-        .distinct
-        .where(provider: provider)
-        .includes(%i[provider accredited_provider])
-  end
-
-  def self.unique_ratified_courses(provider)
-    joins(:course_options).distinct.where.not(provider: provider)
   end
 
   def subject_codes

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -149,6 +149,27 @@ class Course < ApplicationRecord
       .distinct
   end
 
+  def self.find_courses_in_previous_cycle(provider)
+    previous_cycle
+        .joins(:course_options)
+        .distinct
+        .where(provider: provider)
+        .includes(%i[provider accredited_provider])
+  end
+
+  def self.find_courses_in_current_cycle(provider)
+    current_cycle
+        .open_on_apply
+        .joins(:course_options)
+        .distinct
+        .where(provider: provider)
+        .includes(%i[provider accredited_provider])
+  end
+
+  def self.unique_ratified_courses(provider)
+    joins(:course_options).distinct.where.not(provider: provider)
+  end
+
   def subject_codes
     @subject_codes ||= subjects.includes(:course_subjects).map(&:code)
   end

--- a/app/queries/get_courses_ratified_by_provider.rb
+++ b/app/queries/get_courses_ratified_by_provider.rb
@@ -1,14 +1,7 @@
 class GetCoursesRatifiedByProvider
   def self.call(provider:, previous_cycle:)
-    if previous_cycle
-      provider.accredited_courses
-      .previous_cycle
-      .unique_ratified_courses(provider)
-    else
-      provider.accredited_courses
-      .current_cycle
-      .open_on_apply
-      .unique_ratified_courses(provider)
-    end
+    courses_scope = provider.accredited_courses
+    course_cycle_scope = previous_cycle ? courses_scope.previous_cycle : courses_scope.current_cycle.open_on_apply
+    course_cycle_scope.joins(:course_options).distinct.where.not(provider: provider)
   end
 end

--- a/app/queries/get_courses_ratified_by_provider.rb
+++ b/app/queries/get_courses_ratified_by_provider.rb
@@ -1,10 +1,14 @@
 class GetCoursesRatifiedByProvider
-  def self.call(provider:)
-    provider.accredited_courses
-            .current_cycle
-            .open_on_apply
-            .joins(:course_options)
-            .distinct
-            .where.not(provider: provider)
+  def self.call(provider:, previous_cycle:)
+    if previous_cycle
+      provider.accredited_courses
+      .previous_cycle
+      .unique_ratified_courses(provider)
+    else
+      provider.accredited_courses
+      .current_cycle
+      .open_on_apply
+      .unique_ratified_courses(provider)
+    end
   end
 end

--- a/app/queries/get_courses_ratified_by_provider.rb
+++ b/app/queries/get_courses_ratified_by_provider.rb
@@ -1,5 +1,5 @@
 class GetCoursesRatifiedByProvider
-  def self.call(provider:, previous_cycle:)
+  def self.call(provider:, previous_cycle: false)
     courses_scope = provider.accredited_courses
     course_cycle_scope = previous_cycle ? courses_scope.previous_cycle : courses_scope.current_cycle.open_on_apply
     course_cycle_scope.joins(:course_options).distinct.where.not(provider: provider)

--- a/app/services/generate_test_applications_for_provider.rb
+++ b/app/services/generate_test_applications_for_provider.rb
@@ -60,9 +60,9 @@ private
 
   def courses_run_by_provider
     @_courses_run_by_provider ||= if previous_cycle
-                                    Course.find_courses_in_previous_cycle(provider)
+                                    Course.previous_cycle.with_course_options_run_by_provider(provider)
                                   else
-                                    Course.find_courses_in_current_cycle(provider)
+                                    Course.current_cycle.open_on_apply.with_course_options_run_by_provider(provider)
                                   end
   end
 

--- a/app/services/test_provider.rb
+++ b/app/services/test_provider.rb
@@ -23,12 +23,6 @@ class TestProvider
     existing_courses.reload
   end
 
-  def self.create_course_option_for(course)
-    FactoryBot.create(:course_option, course: course)
-  end
-
-  private_class_method :create_course_option_for
-
   def self.recruitment_cycle_year(previous_cycle)
     if previous_cycle
       RecruitmentCycle.previous_year
@@ -37,13 +31,14 @@ class TestProvider
     end
   end
 
-  private_class_method :recruitment_cycle_year
-
   def self.generate_courses(previous_cycle, test_provider)
-    if previous_cycle
-      FactoryBot.create_list(:course, 3, :previous_year, provider: test_provider)
-    else
-      FactoryBot.create_list(:course, 3, :open_on_apply, provider: test_provider)
-    end
+    trait = previous_cycle ? :previous_year : :open_on_apply
+    FactoryBot.create_list(:course, 3, trait, provider: test_provider)
   end
+
+  def self.create_course_option_for(course)
+    FactoryBot.create(:course_option, course: course)
+  end
+
+  private_class_method :create_course_option_for
 end

--- a/app/views/api_docs/vendor_api_docs/pages/release_notes.md
+++ b/app/views/api_docs/vendor_api_docs/pages/release_notes.md
@@ -1,3 +1,9 @@
+## 12th July 2022
+
+`/test-data/generate` now accepts an optional `previous_cycle` query param.
+
+Supplying `previous_cycle=true` will ensure that test applications are generated for courses in the previous recruitment cycle
+
 ## v1.1 — 9th May 2022
 
 Minor Version Upgrade:

--- a/app/workers/generate_test_applications_for_courses.rb
+++ b/app/workers/generate_test_applications_for_courses.rb
@@ -18,7 +18,7 @@ private
   end
 
   def recruitment_cycle_year(previous_cycle)
-    if previous_cycle.present?
+    if previous_cycle
       RecruitmentCycle.previous_year
     else
       RecruitmentCycle.current_year
@@ -26,7 +26,7 @@ private
   end
 
   def application_state(previous_cycle, courses_per_application)
-    if previous_cycle.present?
+    if previous_cycle
       states_for_previous_cycle(courses_per_application)
     else
       [:awaiting_provider_decision] * courses_per_application
@@ -34,18 +34,7 @@ private
   end
 
   def states_for_previous_cycle(courses_per_application)
-    count = 0
-    states = []
-    loop do
-      break if count == courses_per_application
-
-      states << if count < 1
-                  :pending_conditions
-                else
-                  :awaiting_provider_decision
-                end
-      count += 1
-    end
+    states = ([:awaiting_provider_decision] * (courses_per_application - 1)) << :pending_conditions
     states.shuffle
   end
 end

--- a/app/workers/generate_test_applications_for_courses.rb
+++ b/app/workers/generate_test_applications_for_courses.rb
@@ -8,21 +8,13 @@ class GenerateTestApplicationsForCourses
 private
 
   def generate_single(course_ids, courses_per_application, previous_cycle)
-    courses_to_apply_to = Course.where(id: course_ids, recruitment_cycle_year: recruitment_cycle_year(previous_cycle))
+    courses_to_apply_to = Course.where(id: course_ids, recruitment_cycle_year: TestProvider.recruitment_cycle_year(previous_cycle))
 
     TestApplications.new.create_application(
-      recruitment_cycle_year: recruitment_cycle_year(previous_cycle),
+      recruitment_cycle_year: TestProvider.recruitment_cycle_year(previous_cycle),
       states: application_state(previous_cycle, courses_per_application),
       courses_to_apply_to: courses_to_apply_to,
     )
-  end
-
-  def recruitment_cycle_year(previous_cycle)
-    if previous_cycle
-      RecruitmentCycle.previous_year
-    else
-      RecruitmentCycle.current_year
-    end
   end
 
   def application_state(previous_cycle, courses_per_application)

--- a/config/vendor_api/experimental-v1.0.yml
+++ b/config/vendor_api/experimental-v1.0.yml
@@ -40,6 +40,14 @@ paths:
         in: query
         schema:
           type: string
+      - name: previous_cycle
+        description: Generate applications for courses in the previous recruitment cycle. Please specify 'true', for example previous_cycle=true.
+                     The application will have a ‘pending_conditions’ state and also ‘withdrawn’ if there is more than one
+                     course choice per application.
+        in: query
+        schema:
+          type: string
+          default: false
       responses:
         '200':
           "$ref": "#/components/responses/OK"

--- a/config/vendor_api/experimental-v1.0.yml
+++ b/config/vendor_api/experimental-v1.0.yml
@@ -43,7 +43,7 @@ paths:
       - name: previous_cycle
         description: Generate applications for courses in the previous recruitment cycle. Please specify 'true', for example previous_cycle=true.
                      The application will have a ‘pending_conditions’ state and also ‘withdrawn’ if there is more than one
-                     course choice per application.
+                     course choice per application form.
         in: query
         schema:
           type: string

--- a/spec/queries/get_courses_ratified_by_provider_spec.rb
+++ b/spec/queries/get_courses_ratified_by_provider_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe GetCoursesRatifiedByProvider do
   let(:provider) { create(:provider) }
+  let(:previous_cycle) { false }
 
   it 'returns courses in the current year' do
     course_current_year = create(:course, :open_on_apply, accredited_provider: provider)
@@ -9,14 +10,14 @@ RSpec.describe GetCoursesRatifiedByProvider do
 
     create(:course_option, course: create(:course, :open_on_apply, :previous_year, accredited_provider: provider))
 
-    result = described_class.call(provider: provider)
+    result = described_class.call(provider: provider, previous_cycle: previous_cycle)
     expect(result).to contain_exactly(course_current_year)
   end
 
   it 'only returns courses with a course option' do
     create(:course, :open_on_apply, accredited_provider: provider)
 
-    result = described_class.call(provider: provider)
+    result = described_class.call(provider: provider, previous_cycle: previous_cycle)
     expect(result).to be_empty
   end
 
@@ -24,14 +25,25 @@ RSpec.describe GetCoursesRatifiedByProvider do
     create(:course, :open_on_apply, provider: provider, accredited_provider: provider)
     create(:course, :open_on_apply, provider: provider)
 
-    result = described_class.call(provider: provider)
+    result = described_class.call(provider: provider, previous_cycle: previous_cycle)
     expect(result).to be_empty
   end
 
   it 'only returns courses that are open on apply' do
     create(:course, accredited_provider: provider)
 
-    result = described_class.call(provider: provider)
+    result = described_class.call(provider: provider, previous_cycle: previous_cycle)
     expect(result).to be_empty
+  end
+
+  it 'returns courses in the previous year' do
+    previous_cycle = true
+    course_previous_year = create(:course, :previous_year, accredited_provider: provider)
+    create_list(:course_option, 3, course: course_previous_year)
+
+    create(:course_option, course: create(:course, :open_on_apply, accredited_provider: provider))
+
+    result = described_class.call(provider: provider, previous_cycle: previous_cycle)
+    expect(result).to contain_exactly(course_previous_year)
   end
 end


### PR DESCRIPTION
## Context
Since vendors are now implementing deferred applications. They need test data from the previous cycle in to ensure they can defer and then confirm deferred applications

## Changes proposed in this pull request
* New param - previous_cycle - to /generate-data endpoint. Enables providers to generate applications in the pending_conditions state on sandbox

## Guidance to review
Use Postman to test locally - /api/v1/test-data/generate
Make sure to pass in previous_cycle = 'true' in body or params
Check status of applications and that they can be deferred

## Link to Trello card

https://trello.com/c/zFd5WstY/330-give-vendors-ability-to-generate-applications-in-the-previous-cycles-for-testing

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
