### PR TITLE
Remove Postgres timeout values

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,9 +1,6 @@
 default: &default
   adapter: postgresql
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  variables:
-    statement_timeout: 20000
-    idle_in_transaction_session_timeout: 10000
   username: <%= ENV['DB_USERNAME'] %>
   password: <%= ENV['DB_PASSWORD'] %>
   host: <%= ENV['DB_HOSTNAME'] %>


### PR DESCRIPTION

## Context

As requested in the TL channel,
removing Postgres database settings for statement_timeout and idle_in_transaction_session_timeout 
which will set them to the default which is 0 (no timeout)
It's believed these settings are no longer required and the current settings cause issues with debugging
This has already been completed in Publish.

statement_timeout (integer): Abort any statement that takes more than the specified number of milliseconds
idle_in_transaction_session_timeout (integer): Terminate any session with an open transaction that has been idle for longer than the specified duration in milliseconds.

## Changes proposed in this pull request

Update database.yml

## Guidance to review

Check no errors on build/deploy

## Link to Trello card

https://trello.com/c/0yWScsWZ/597-remove-postgres-statement-timeout

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
