### PR TITLE
Add scenario to support playbook

### DIFF
--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -128,7 +128,21 @@ If the current application status is `offer` use ChangeOffer service.
 
 This is possible via the support UI.
 
-### Revert an application choice to pending_conditions
+## Reverting an application choice to pending_conditions from recruited
+
+```ruby
+ac = ApplicationChoice.find(id)
+ac.update!(status: 'pending_conditions', recruited_at: nil, accepted_at: nil, audit_comment: 'Support request...')
+```
+Conditions can be added by creating a new OfferCondition object and then pushing it into the conditions collection, for example:
+
+```ruby
+condition = OfferCondition.new(text: 'You need to pass an 8 week SKE in Mathematics')
+ac.offer.conditions << condition
+```
+The default state for an OfferCondition object is 'pending'.
+
+### Revert an application choice to pending_conditions from conditions_not_met
 
 This can be requested if a provider accidentally marks an application as conditions not met.
 


### PR DESCRIPTION
## Context
Reverting application choice to pending_conditions from recruited

## Changes proposed in this pull request
* Add solution to scenario where provider may have accidentally marked an application as recruited with conditions met and therefore the dev will need to revert to pending conditions and potentially add conditions if none existed before

## Guidance to review

## Link to Trello card


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
