### PR TITLE
Make monthly statistics cycle aware

### DIFF
--- a/app/controllers/publications/monthly_statistics_controller.rb
+++ b/app/controllers/publications/monthly_statistics_controller.rb
@@ -34,8 +34,6 @@ module Publications
     def current_report
       if params[:month].present?
         MonthlyStatisticsTimetable.report_for(params[:month])
-      elsif FeatureFlag.active? :lock_external_report_to_january_2022
-        MonthlyStatisticsTimetable.report_for('2022-01')
       else
         MonthlyStatisticsTimetable.report_for_current_period
       end

--- a/app/controllers/publications/monthly_statistics_controller.rb
+++ b/app/controllers/publications/monthly_statistics_controller.rb
@@ -33,7 +33,7 @@ module Publications
 
     def current_report
       if params[:month].present?
-        MonthlyStatisticsTimetable.report_for(params[:month])
+        MonthlyStatisticsTimetable.current_report_at(Date.parse("#{params[:month]}-01"))
       else
         MonthlyStatisticsTimetable.report_for_current_period
       end

--- a/app/models/publications/monthly_statistics/monthly_statistics_report.rb
+++ b/app/models/publications/monthly_statistics/monthly_statistics_report.rb
@@ -3,6 +3,14 @@ module Publications
     class MonthlyStatisticsReport < ApplicationRecord
       MISSING_VALUE = 'n/a'.freeze
 
+      def self.new_report
+        new(
+          month: MonthlyStatisticsTimetable.current_generation_date.strftime('%Y-%m'),
+          generation_date: MonthlyStatisticsTimetable.current_generation_date,
+          publication_date: MonthlyStatisticsTimetable.current_publication_date,
+        )
+      end
+
       def write_statistic(key, value)
         self.statistics = (statistics || {}).merge(key.to_s => value)
       end

--- a/app/presenters/publications/monthly_statistics_presenter.rb
+++ b/app/presenters/publications/monthly_statistics_presenter.rb
@@ -37,12 +37,19 @@ module Publications
     end
 
     def current_reporting_period
-      start, finish = MonthlyStatisticsTimetable.reporting_period(report.month)
-      "#{start.to_fs(:govuk_date)} to #{finish.to_fs(:govuk_date)}"
+      finish_period = MonthlyStatisticsTimetable.third_monday_of_the_month(
+        Date.parse("#{report.month}-01"),
+      )
+
+      "#{CycleTimetable.apply_opens.to_fs(:govuk_date)} to #{finish_period.to_fs(:govuk_date)}"
     end
 
     def deferred_applications_count
       report.statistics['deferred_applications_count'] || 0
+    end
+
+    def reporting_date_field(date)
+      Date.parse("#{date}-01").to_fs(:govuk_date)
     end
   end
 end

--- a/app/presenters/publications/monthly_statistics_presenter.rb
+++ b/app/presenters/publications/monthly_statistics_presenter.rb
@@ -3,10 +3,10 @@ module Publications
     attr_accessor :report
 
     def initialize(report)
-      self.report = report
+      @report = report
     end
 
-    delegate :statistics, :deferred_application_count, :month, to: :report
+    delegate :publication_date, :statistics, :deferred_application_count, :month, to: :report
 
     def next_cycle_name
       RecruitmentCycle.cycle_name(CycleTimetable.next_year)
@@ -28,20 +28,12 @@ module Publications
       RecruitmentCycle.previous_year
     end
 
-    def publication_date
-      MonthlyStatisticsTimetable.publication_date(report)
-    end
-
     def next_publication_date
       MonthlyStatisticsTimetable.next_publication_date
     end
 
     def current_reporting_period
-      finish_period = MonthlyStatisticsTimetable.third_monday_of_the_month(
-        Date.parse("#{report.month}-01"),
-      )
-
-      "#{CycleTimetable.apply_opens.to_fs(:govuk_date)} to #{finish_period.to_fs(:govuk_date)}"
+      "#{CycleTimetable.apply_opens.to_fs(:govuk_date)} to #{report.generation_date.to_fs(:govuk_date)}"
     end
 
     def deferred_applications_count

--- a/app/presenters/publications/monthly_statistics_presenter.rb
+++ b/app/presenters/publications/monthly_statistics_presenter.rb
@@ -47,9 +47,5 @@ module Publications
     def deferred_applications_count
       report.statistics['deferred_applications_count'] || 0
     end
-
-    def reporting_date_field(date)
-      Date.parse("#{date}-01").to_fs(:govuk_date)
-    end
   end
 end

--- a/app/services/monthly_statistics_timetable.rb
+++ b/app/services/monthly_statistics_timetable.rb
@@ -1,102 +1,38 @@
 module MonthlyStatisticsTimetable
-  # Currently, this uses the 3rd Monday of each month as agreed with Mike.
-  # It's not ideal, and may well change at a later date.
-  # It's also not cycle aware and will be needed to be updated yearly.
-
-  GENERATION_DATES = {
-    'October' => Date.new(RecruitmentCycle.previous_year, 10, 18),
-    'November' => Date.new(RecruitmentCycle.previous_year, 11, 22),
-    'December' => Date.new(RecruitmentCycle.previous_year, 12, 20),
-    'January' => Date.new(RecruitmentCycle.current_year, 1, 17),
-    'February' => Date.new(RecruitmentCycle.current_year, 2, 21),
-    'March' => Date.new(RecruitmentCycle.current_year, 3, 21),
-    'April' => Date.new(RecruitmentCycle.current_year, 4, 18),
-    'May' => Date.new(RecruitmentCycle.current_year, 5, 16),
-    'June' => Date.new(RecruitmentCycle.current_year, 6, 20),
-    'July' => Date.new(RecruitmentCycle.current_year, 7, 18),
-    'August' => Date.new(RecruitmentCycle.current_year, 8, 15),
-    'September' => Date.new(RecruitmentCycle.current_year, 9, 19),
-  }.freeze
-
-  # The date the report will be pubished a week after the generation date
-
-  PUBLISHING_DATES = {
-    'October' => Date.new(RecruitmentCycle.previous_year, 10, 25),
-    'November' => Date.new(RecruitmentCycle.previous_year, 11, 29),
-    'December' => Date.new(RecruitmentCycle.previous_year, 12, 27),
-    'January' => Date.new(RecruitmentCycle.current_year, 1, 24),
-    'February' => Date.new(RecruitmentCycle.current_year, 2, 28),
-    'March' => Date.new(RecruitmentCycle.current_year, 3, 28),
-    'April' => Date.new(RecruitmentCycle.current_year, 4, 25),
-    'May' => Date.new(RecruitmentCycle.current_year, 5, 23),
-    'June' => Date.new(RecruitmentCycle.current_year, 6, 27),
-    'July' => Date.new(RecruitmentCycle.current_year, 7, 25),
-    'August' => Date.new(RecruitmentCycle.current_year, 8, 22),
-    'September' => Date.new(RecruitmentCycle.current_year, 9, 26),
-  }.freeze
-
   def self.generate_monthly_statistics?
-    Time.zone.today == GENERATION_DATES[Date::MONTHNAMES[Time.zone.today.month]]
+    Time.zone.today == generation_date
   end
 
-  def self.month_to_generate_for
-    GENERATION_DATES[Date::MONTHNAMES[Time.zone.today.month]]
-  end
-
-  def self.reporting_period(month)
-    # @todo see comment above - this data model needs revisiting
-    month_key = Date.parse("#{month}-01").strftime('%B')
-
-    [CycleTimetable.apply_opens, GENERATION_DATES[month_key]]
-  end
-
-  def self.current_reports_generation_date
-    report_date_for_current_month = GENERATION_DATES[Date::MONTHNAMES[Time.zone.today.month]]
-
-    if report_date_for_current_month > Time.zone.today
-      last_months_generation_date
-    else
-      current_months_generation_date
-    end
+  def self.generation_date
+    third_monday_of_the_month(Date.current.beginning_of_month)
   end
 
   def self.last_months_generation_date
-    GENERATION_DATES[Date::MONTHNAMES[(Time.zone.today - 1.month).month]]
+    third_monday_of_the_month(Date.current.beginning_of_month - 1.month)
   end
 
-  def self.current_months_generation_date
-    GENERATION_DATES[Date::MONTHNAMES[Time.zone.today.month]]
+  def self.publish_date
+    generation_date + 1.week
   end
 
-  def self.publication_date(report)
-    current_month = Date.parse("#{report.month}-1")
-    PUBLISHING_DATES[Date::MONTHNAMES[current_month.month]]
-  end
-
-  def self.next_publication_date
-    next_month = Date.parse("#{report_for_current_period.month}-1") + 1.month
-    PUBLISHING_DATES[Date::MONTHNAMES[next_month.month]]
-  end
-
-  def self.in_qa_period?
-    generation_date_for_current_month = GENERATION_DATES[Date::MONTHNAMES[Time.zone.today.month]]
-    publish_date_for_current_month = PUBLISHING_DATES[Date::MONTHNAMES[Time.zone.today.month]]
-
-    Time.zone.today.between?(generation_date_for_current_month, publish_date_for_current_month)
+  def self.last_months_publish_date
+    last_months_generation_date + 1.week
   end
 
   def self.report_for_current_period
-    publish_date_for_current_month = PUBLISHING_DATES[Date::MONTHNAMES[Time.zone.today.month]]
-    publish_date_for_previous_month = PUBLISHING_DATES[Date::MONTHNAMES[(Time.zone.today - 1.month).month]]
-
-    if publish_date_for_current_month > Time.zone.today
-      report_for(publish_date_for_previous_month.strftime('%Y-%m'))
+    if publish_date > Time.zone.today
+      report_for(last_months_publish_date.strftime('%Y-%m'))
     else
-      report_for(publish_date_for_current_month.strftime('%Y-%m'))
+      report_for(publish_date.strftime('%Y-%m'))
     end
   end
 
   def self.report_for(month)
     Publications::MonthlyStatistics::MonthlyStatisticsReport.where(month: month).order(created_at: :desc).first!
+  end
+
+  def self.third_monday_of_the_month(start_date)
+    first_monday = start_date.upto(start_date.next_week).find(&:monday?)
+    first_monday + 2.weeks
   end
 end

--- a/app/services/monthly_statistics_timetable.rb
+++ b/app/services/monthly_statistics_timetable.rb
@@ -1,34 +1,50 @@
 module MonthlyStatisticsTimetable
   def self.generate_monthly_statistics?
-    Time.zone.today == generation_date
+    Time.zone.today == current_generation_date
   end
 
-  def self.generation_date
+  def self.current_generation_date
     third_monday_of_the_month(Date.current.beginning_of_month)
   end
 
-  def self.last_months_generation_date
+  def self.current_publication_date
+    current_generation_date + 1.week
+  end
+
+  def self.last_generation_date
     third_monday_of_the_month(Date.current.beginning_of_month - 1.month)
   end
 
-  def self.publish_date
-    generation_date + 1.week
+  def self.last_publication_date
+    return current_publication_date if current_publication_date < Time.zone.today
+
+    last_generation_date + 1.week
   end
 
-  def self.last_months_publish_date
-    last_months_generation_date + 1.week
+  def self.next_generation_date
+    third_monday_of_the_month(Date.current.beginning_of_month + 1.month)
+  end
+
+  def self.next_publication_date
+    return current_publication_date if current_publication_date > Time.zone.today
+
+    next_generation_date + 1.week
   end
 
   def self.report_for_current_period
-    if publish_date > Time.zone.today
-      report_for(last_months_publish_date.strftime('%Y-%m'))
+    if next_publication_date > Time.zone.today
+      current_report_at(last_publication_date)
     else
-      report_for(publish_date.strftime('%Y-%m'))
+      current_report_at(Time.zone.today)
     end
   end
 
-  def self.report_for(month)
-    Publications::MonthlyStatistics::MonthlyStatisticsReport.where(month: month).order(created_at: :desc).first!
+  def self.current_report_at(date)
+    month = date.strftime('%Y-%m')
+    Publications::MonthlyStatistics::MonthlyStatisticsReport
+      .where(month: month)
+      .order(created_at: :desc)
+      .first!
   end
 
   def self.third_monday_of_the_month(start_date)

--- a/app/workers/generate_monthly_statistics.rb
+++ b/app/workers/generate_monthly_statistics.rb
@@ -6,7 +6,7 @@ class GenerateMonthlyStatistics
   def perform
     return false unless MonthlyStatisticsTimetable.generate_monthly_statistics?
 
-    dashboard = Publications::MonthlyStatistics::MonthlyStatisticsReport.new(month: MonthlyStatisticsTimetable.month_to_generate_for.strftime('%Y-%m'))
+    dashboard = Publications::MonthlyStatistics::MonthlyStatisticsReport.new(month: MonthlyStatisticsTimetable.generation_date.strftime('%Y-%m'))
     dashboard.load_table_data
     dashboard.save!
   end

--- a/app/workers/generate_monthly_statistics.rb
+++ b/app/workers/generate_monthly_statistics.rb
@@ -6,7 +6,7 @@ class GenerateMonthlyStatistics
   def perform
     return false unless MonthlyStatisticsTimetable.generate_monthly_statistics?
 
-    dashboard = Publications::MonthlyStatistics::MonthlyStatisticsReport.new(month: MonthlyStatisticsTimetable.generation_date.strftime('%Y-%m'))
+    dashboard = Publications::MonthlyStatistics::MonthlyStatisticsReport.new_report
     dashboard.load_table_data
     dashboard.save!
   end

--- a/lib/tasks/monthly_report.rake
+++ b/lib/tasks/monthly_report.rake
@@ -1,6 +1,6 @@
 desc 'Generate a new MonthlyStatisticsReport as of right now'
 task run_monthly_report: :environment do
-  report = Publications::MonthlyStatistics::MonthlyStatisticsReport.new(month: MonthlyStatisticsTimetable.month_to_generate_for.strftime('%Y-%m'))
+  report = Publications::MonthlyStatistics::MonthlyStatisticsReport.new(month: MonthlyStatisticsTimetable.generation_date.strftime('%Y-%m'))
   report.load_table_data
   report.save!
 end
@@ -12,6 +12,6 @@ end
 
 desc 'Import a MonthlyStatisticsReport created by the :export_monthly_report task'
 task import_monthly_report: :environment do
-  month = MonthlyStatisticsTimetable.month_to_generate_for.strftime('%Y-%m')
+  month = MonthlyStatisticsTimetable.generation_date.strftime('%Y-%m')
   Publications::MonthlyStatistics::JSONExport.new('monthly_report.json').import!(month)
 end

--- a/lib/tasks/monthly_report.rake
+++ b/lib/tasks/monthly_report.rake
@@ -1,6 +1,6 @@
 desc 'Generate a new MonthlyStatisticsReport as of right now'
 task run_monthly_report: :environment do
-  report = Publications::MonthlyStatistics::MonthlyStatisticsReport.new(month: MonthlyStatisticsTimetable.generation_date.strftime('%Y-%m'))
+  report = Publications::MonthlyStatistics::MonthlyStatisticsReport.new_report
   report.load_table_data
   report.save!
 end
@@ -12,6 +12,6 @@ end
 
 desc 'Import a MonthlyStatisticsReport created by the :export_monthly_report task'
 task import_monthly_report: :environment do
-  month = MonthlyStatisticsTimetable.generation_date.strftime('%Y-%m')
+  month = MonthlyStatisticsTimetable.current_generation_date.strftime('%Y-%m')
   Publications::MonthlyStatistics::JSONExport.new('monthly_report.json').import!(month)
 end

--- a/spec/presenters/publications/monthly_statistics_presenter_spec.rb
+++ b/spec/presenters/publications/monthly_statistics_presenter_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe Publications::MonthlyStatisticsPresenter do
       statistics: statistics,
       created_at: Date.new(2021, 11, 23),
       month: '2021-11',
+      generation_date: Date.new(2021, 11, 22),
+      publication_date: Date.new(2021, 11, 29),
     )
   end
 
@@ -65,7 +67,7 @@ RSpec.describe Publications::MonthlyStatisticsPresenter do
 
   describe '#current_reporting_period' do
     it 'returns the correct dates per the Timetable' do
-      expect(presenter.current_reporting_period).to eq '12 October 2021 to 15 November 2021'
+      expect(presenter.current_reporting_period).to eq '12 October 2021 to 22 November 2021'
     end
   end
 end

--- a/spec/presenters/publications/monthly_statistics_presenter_spec.rb
+++ b/spec/presenters/publications/monthly_statistics_presenter_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Publications::MonthlyStatisticsPresenter do
 
   describe '#current_reporting_period' do
     it 'returns the correct dates per the Timetable' do
-      expect(presenter.current_reporting_period).to eq '12 October 2021 to 22 November 2021'
+      expect(presenter.current_reporting_period).to eq '12 October 2021 to 15 November 2021'
     end
   end
 end

--- a/spec/requests/publications/monthly_statistics_spec.rb
+++ b/spec/requests/publications/monthly_statistics_spec.rb
@@ -2,9 +2,10 @@ require 'rails_helper'
 
 RSpec.describe 'Monthly Statistics', type: :request do
   include StatisticsTestHelper
+  let(:current_date) { [2021, 11, 29] }
 
   around do |example|
-    Timecop.freeze(2021, 11, 29) do
+    Timecop.freeze(*current_date) do
       example.run
     end
   end
@@ -28,7 +29,7 @@ RSpec.describe 'Monthly Statistics', type: :request do
     it 'returns the report for 2021-11' do
       get '/publications/monthly-statistics/'
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include('to 22 November 2021')
+      expect(response.body).to include('to 15 November 2021')
 
       get '/publications/monthly-statistics/2021-10'
       expect(response).to have_http_status(:ok)
@@ -36,7 +37,7 @@ RSpec.describe 'Monthly Statistics', type: :request do
 
       get '/publications/monthly-statistics/2021-11'
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include('to 22 November 2021')
+      expect(response.body).to include('to 15 November 2021')
 
       get '/publications/monthly-statistics/2021-12'
       expect(response).to have_http_status(:not_found)
@@ -45,23 +46,6 @@ RSpec.describe 'Monthly Statistics', type: :request do
     it 'returns application by status csv for 2021-10' do
       get '/publications/monthly-statistics/2021-10/applications_by_status.csv'
       expect(response).to have_http_status(:ok)
-    end
-
-    context 'when the "lock external report to January 2022" feature flag is on' do
-      before do
-        report = Publications::MonthlyStatistics::MonthlyStatisticsReport.new(month: '2022-01')
-        report.load_table_data
-        report.save
-
-        FeatureFlag.activate('lock_external_report_to_january_2022')
-      end
-
-      it 'displays that month’s report' do
-        get '/publications/monthly-statistics/'
-
-        expect(response.body).to include('to 17 January 2022')
-        expect(response).to have_http_status(:ok)
-      end
     end
   end
 

--- a/spec/requests/publications/monthly_statistics_spec.rb
+++ b/spec/requests/publications/monthly_statistics_spec.rb
@@ -13,7 +13,11 @@ RSpec.describe 'Monthly Statistics', type: :request do
   before do
     generate_statistics_test_data
 
-    report = Publications::MonthlyStatistics::MonthlyStatisticsReport.new(month: '2021-11')
+    report = Publications::MonthlyStatistics::MonthlyStatisticsReport.new(
+      month: '2021-11',
+      generation_date: Date.new(2021, 11, 22),
+      publication_date: Date.new(2021, 11, 29),
+    )
     report.load_table_data
     report.save
   end
@@ -21,7 +25,11 @@ RSpec.describe 'Monthly Statistics', type: :request do
   describe 'getting reports for different dates' do
     before do
       # assign the current numbers to the 2021-10 report so we can test retrieving that report
-      report = Publications::MonthlyStatistics::MonthlyStatisticsReport.new(month: '2021-10')
+      report = Publications::MonthlyStatistics::MonthlyStatisticsReport.new(
+        month: '2021-10',
+        generation_date: Date.new(2021, 10, 18),
+        publication_date: Date.new(2021, 10, 25),
+      )
       report.load_table_data
       report.save
     end
@@ -29,7 +37,7 @@ RSpec.describe 'Monthly Statistics', type: :request do
     it 'returns the report for 2021-11' do
       get '/publications/monthly-statistics/'
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include('to 15 November 2021')
+      expect(response.body).to include('to 22 November 2021')
 
       get '/publications/monthly-statistics/2021-10'
       expect(response).to have_http_status(:ok)
@@ -37,7 +45,7 @@ RSpec.describe 'Monthly Statistics', type: :request do
 
       get '/publications/monthly-statistics/2021-11'
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include('to 15 November 2021')
+      expect(response.body).to include('to 22 November 2021')
 
       get '/publications/monthly-statistics/2021-12'
       expect(response).to have_http_status(:not_found)

--- a/spec/services/monthly_statistics_timetable_spec.rb
+++ b/spec/services/monthly_statistics_timetable_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe MonthlyStatisticsTimetable do
-  describe '#generate_monthly_statistics' do
+  describe '#generate_monthly_statistics?' do
     it 'returns true if the monthly report is scheduled to run on the current date' do
       1.upto(12).each do |month|
         Timecop.travel(described_class.third_monday_of_the_month(Date.new(RecruitmentCycle.current_year, month, 1))) do
@@ -36,16 +36,6 @@ RSpec.describe MonthlyStatisticsTimetable do
         Timecop.freeze(Date.new(2021, 12, 28)) do
           expect(described_class.report_for_current_period).to eq(current_report)
         end
-      end
-    end
-  end
-
-  describe '.publication_date' do
-    let!(:current_report) { Publications::MonthlyStatistics::MonthlyStatisticsReport.create(month: '2021-12') }
-
-    it 'returns the publication date of that report irrespective of the current date' do
-      Timecop.freeze(Date.new(2022, 6, 21)) do
-        expect(described_class.publication_date(current_report)).to eq(Date.new(2021, 12, 27))
       end
     end
   end

--- a/spec/services/monthly_statistics_timetable_spec.rb
+++ b/spec/services/monthly_statistics_timetable_spec.rb
@@ -3,63 +3,17 @@ require 'rails_helper'
 RSpec.describe MonthlyStatisticsTimetable do
   describe '#generate_monthly_statistics' do
     it 'returns true if the monthly report is scheduled to run on the current date' do
-      MonthlyStatisticsTimetable::GENERATION_DATES.each_value do |date|
-        Timecop.travel(date) do
+      1.upto(12).each do |month|
+        Timecop.travel(described_class.third_monday_of_the_month(Date.new(RecruitmentCycle.current_year, month, 1))) do
           expect(described_class.generate_monthly_statistics?).to be true
         end
       end
     end
 
     it 'returns false if the monthly report is not scheduled to run on the current date' do
-      MonthlyStatisticsTimetable::GENERATION_DATES.each_value do |date|
-        date = [date - 1.day, date + 1.day].sample
-
-        Timecop.travel(date) do
+      1.upto(12).each do |month|
+        Timecop.travel(RecruitmentCycle.current_year, month, 1) do
           expect(described_class.generate_monthly_statistics?).to be false
-        end
-      end
-    end
-  end
-
-  describe '#current_reports_generation_date' do
-    context 'when the most recent generation date is within the same month' do
-      it 'returns the correct value' do
-        Timecop.travel(described_class::GENERATION_DATES.values.first + 1.day) do
-          expect(described_class.current_reports_generation_date).to eq described_class::GENERATION_DATES.values.first
-        end
-      end
-    end
-
-    context 'when the most recent generation date was last month' do
-      it 'returns the correct value' do
-        Timecop.travel(described_class::GENERATION_DATES.values.second - 1.day) do
-          expect(described_class.current_reports_generation_date).to eq described_class::GENERATION_DATES.values.first
-        end
-      end
-    end
-  end
-
-  describe '#in_qa_period?' do
-    context 'when it is before the generation date for the current month' do
-      it 'returns false' do
-        Timecop.travel(described_class::GENERATION_DATES.values.third - 1.day) do
-          expect(described_class.in_qa_period?).to be false
-        end
-      end
-    end
-
-    context 'when it is after the publish date for the current month' do
-      it 'returns false' do
-        Timecop.travel(described_class::PUBLISHING_DATES.values.third + 1.day) do
-          expect(described_class.in_qa_period?).to be false
-        end
-      end
-    end
-
-    context 'when it is between the generation and publish dates for the current month' do
-      it 'returns true' do
-        Timecop.travel(described_class::GENERATION_DATES.values.third + 1.day) do
-          expect(described_class.in_qa_period?).to be true
         end
       end
     end


### PR DESCRIPTION
## Context

Currently, monthly statistics it is not cycle aware and the dates that the monthly report needs to be generated and published/manually entered. So the timetabled class should be cycle aware and automatically produce the correct date.

## Guidance to review

1. Does it work independently of the cycle?

## Link to Trello card

https://trello.com/c/gXj3tWE6/359-eoc-make-the-monthlystatistictimetable-cycle-aware
