### PR TITLE
Update the deadline reminder email subject

### DIFF
--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -109,7 +109,7 @@ en:
     interview_cancelled:
       subject: Interview cancelled - %{provider_name}
     approaching_eoc_deadline:
-      subject: Submit your application before courses fill up
+      subject: Submit your teacher training application before courses fill up
     new_cycle_has_started:
       subject: Teacher training applications are open - apply for the %{academic_year} academic year
     find_has_opened:

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -508,7 +508,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       it_behaves_like(
         'a mail with subject and content',
-        'Submit your application before courses fill up',
+        'Submit your teacher training application before courses fill up',
         'heading' => 'Dear Fred',
         'cycle_details' => "as soon as you can to get on a course starting in the #{RecruitmentCycle.current_year} to #{RecruitmentCycle.next_year} academic year.",
         'details' => "The deadline to submit your application is 6pm on #{CycleTimetable.apply_1_deadline.to_fs(:govuk_date)}",
@@ -521,7 +521,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       it_behaves_like(
         'a mail with subject and content',
-        'Submit your application before courses fill up',
+        'Submit your teacher training application before courses fill up',
         'heading' => 'Dear Fred',
         'cycle_details' => "as soon as you can to get on a course starting in the #{RecruitmentCycle.current_year} to #{RecruitmentCycle.next_year} academic year.",
         'details' => "The deadline to submit your application is 6pm on #{CycleTimetable.apply_2_deadline.to_fs(:govuk_date)}",


### PR DESCRIPTION
## Context

We're about to send out our deadline reminder emails... we've reviewed the content and it needs an update!

## Changes proposed in this pull request

Subject line is now `Submit your teacher training application before courses fill up`

## Guidance to review

Per John Oates

## Link to Trello card

https://trello.com/c/4mm4ZRjC/346-eoc-review-content-of-banners-emails-and-interstitials

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
