### PR TITLE
Log API requests to BigQuery

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,9 @@
+require:
+  - ./lib/rubocop/cop/application_api_controller.rb
+  - ./lib/rubocop/cop/govuk/govuk_button_to.rb
+  - ./lib/rubocop/cop/govuk/govuk_link_to.rb
+  - ./lib/rubocop/cop/govuk/govuk_submit.rb
+
 inherit_from:
   - .rubocop_todo.yml
   - ./config/rubocop/config/rspec.yml
@@ -8,11 +14,6 @@ inherit_from:
   - ./config/rubocop/config/lint.yml
   - ./config/rubocop/config/metrics.yml
   - ./config/rubocop/config/naming.yml
-
-require:
-  - ./lib/rubocop/cop/govuk/govuk_button_to.rb
-  - ./lib/rubocop/cop/govuk/govuk_link_to.rb
-  - ./lib/rubocop/cop/govuk/govuk_submit.rb
 
 AllCops:
   NewCops: enable

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 require:
+  - rubocop-rails
   - ./lib/rubocop/cop/application_api_controller.rb
   - ./lib/rubocop/cop/govuk/govuk_button_to.rb
   - ./lib/rubocop/cop/govuk/govuk_link_to.rb

--- a/app/controllers/application_api_controller.rb
+++ b/app/controllers/application_api_controller.rb
@@ -1,0 +1,2 @@
+class ApplicationAPIController < ActionController::API
+end

--- a/app/controllers/application_api_controller.rb
+++ b/app/controllers/application_api_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationAPIController < ActionController::API
+  include DfE::Analytics::Requests
 end

--- a/app/controllers/candidate_api/candidates_controller.rb
+++ b/app/controllers/candidate_api/candidates_controller.rb
@@ -1,5 +1,5 @@
 module CandidateAPI
-  class CandidatesController < ActionController::API
+  class CandidatesController < ApplicationAPIController
     include ServiceAPIUserAuthentication
     include RemoveBrowserOnlyHeaders
     include Pagy::Backend

--- a/app/controllers/data_api/tad_data_exports_controller.rb
+++ b/app/controllers/data_api/tad_data_exports_controller.rb
@@ -1,5 +1,5 @@
 module DataAPI
-  class TADDataExportsController < ActionController::API
+  class TADDataExportsController < ApplicationAPIController
     include ServiceAPIUserAuthentication
     include RemoveBrowserOnlyHeaders
 

--- a/app/controllers/integrations/integrations_controller.rb
+++ b/app/controllers/integrations/integrations_controller.rb
@@ -1,5 +1,5 @@
 module Integrations
-  class IntegrationsController < ActionController::API
+  class IntegrationsController < ApplicationAPIController
   protected
 
     def render_error(name:, message:, status:)

--- a/app/controllers/register_api/applications_controller.rb
+++ b/app/controllers/register_api/applications_controller.rb
@@ -1,5 +1,5 @@
 module RegisterAPI
-  class ApplicationsController < ActionController::API
+  class ApplicationsController < ApplicationAPIController
     include ServiceAPIUserAuthentication
     include RemoveBrowserOnlyHeaders
     include Pagy::Backend

--- a/app/controllers/vendor_api/vendor_api_controller.rb
+++ b/app/controllers/vendor_api/vendor_api_controller.rb
@@ -1,5 +1,5 @@
 module VendorAPI
-  class VendorAPIController < ActionController::API
+  class VendorAPIController < ApplicationAPIController
     include ActionController::HttpAuthentication::Token::ControllerMethods
     include RequestQueryParams
     include RemoveBrowserOnlyHeaders

--- a/config/rubocop/config/rails.yml
+++ b/config/rubocop/config/rails.yml
@@ -1,5 +1,3 @@
-require: rubocop-rails
-
 Rails/BulkChangeTable:
   Enabled: false
 

--- a/lib/rubocop/cop/application_api_controller.rb
+++ b/lib/rubocop/cop/application_api_controller.rb
@@ -1,0 +1,13 @@
+module RuboCop
+  module Cop
+    class ApplicationAPIController < Base
+      extend AutoCorrector
+
+      MSG = 'API controllers should subclass `ApplicationAPIController`.'.freeze
+      SUPERCLASS = 'ApplicationAPIController'.freeze
+      BASE_PATTERN = '(const (const nil? :ActionController) :API)'.freeze
+
+      include RuboCop::Cop::EnforceSuperclass
+    end
+  end
+end

--- a/spec/requests/vendor_api/v1.0/get_multiple_applications_spec.rb
+++ b/spec/requests/vendor_api/v1.0/get_multiple_applications_spec.rb
@@ -137,4 +137,12 @@ RSpec.describe 'Vendor API - GET /api/v1.0/applications', type: :request do
     expect(response_data.second['id']).to eq(application_choices.second.id.to_s)
     expect(response_data.last['id']).to eq(application_choices.last.id.to_s)
   end
+
+  it 'sends a web_request to BigQuery' do
+    FeatureFlag.activate(:send_request_data_to_bigquery)
+
+    expect {
+      get_api_request "/api/v1.0/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
+    }.to have_sent_analytics_event_types(:web_request)
+  end
 end


### PR DESCRIPTION
## Context

First attempt: https://github.com/DFE-Digital/apply-for-teacher-training/pull/6450

Reverted: https://github.com/DFE-Digital/apply-for-teacher-training/pull/6468

It was reverted because API controllers didn't define `current_user` — this is no longer required in the latest `dfe-analytics`

## Changes proposed in this pull request

Make all API controllers inherit from an `ApplicationAPIController` where we can add `DfE::Analytics` mixins

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
