### PR TITLE
Add data migration to backfill monthly reports

### DIFF
--- a/app/services/data_migrations/monthly_reports_backfill.rb
+++ b/app/services/data_migrations/monthly_reports_backfill.rb
@@ -1,0 +1,40 @@
+module DataMigrations
+  class MonthlyReportsBackfill
+    TIMESTAMP = 20220711115142
+    MANUAL_RUN = false
+
+    GENERATION_DATES = {
+      '2021-10' => Date.new(RecruitmentCycle.previous_year, 10, 18),
+      '2021-11' => Date.new(RecruitmentCycle.previous_year, 11, 22),
+      '2021-12' => Date.new(RecruitmentCycle.previous_year, 12, 20),
+      '2022-01' => Date.new(RecruitmentCycle.current_year, 1, 17),
+      '2022-02' => Date.new(RecruitmentCycle.current_year, 2, 21),
+      '2022-03' => Date.new(RecruitmentCycle.current_year, 3, 21),
+      '2022-04' => Date.new(RecruitmentCycle.current_year, 4, 18),
+      '2022-05' => Date.new(RecruitmentCycle.current_year, 5, 16),
+      '2022-06' => Date.new(RecruitmentCycle.current_year, 6, 20),
+    }.freeze
+
+    # The date the report will be pubished a week after the generation date
+    PUBLISHING_DATES = {
+      '2021-10' => Date.new(RecruitmentCycle.previous_year, 10, 25),
+      '2021-11' => Date.new(RecruitmentCycle.previous_year, 11, 29),
+      '2021-12' => Date.new(RecruitmentCycle.previous_year, 12, 27),
+      '2022-01' => Date.new(RecruitmentCycle.current_year, 1, 24),
+      '2022-02' => Date.new(RecruitmentCycle.current_year, 2, 28),
+      '2022-03' => Date.new(RecruitmentCycle.current_year, 3, 28),
+      '2022-04' => Date.new(RecruitmentCycle.current_year, 4, 25),
+      '2022-05' => Date.new(RecruitmentCycle.current_year, 5, 23),
+      '2022-06' => Date.new(RecruitmentCycle.current_year, 6, 27),
+    }.freeze
+
+    def change
+      GENERATION_DATES.each do |month, generation_date|
+        Publications::MonthlyStatistics::MonthlyStatisticsReport.where(month: month).update_all(
+          generation_date: generation_date,
+          publication_date: PUBLISHING_DATES[month],
+        )
+      end
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::MonthlyReportsBackfill',
   'DataMigrations::RemoveDataExportsFeatureFlag',
   'DataMigrations::BackfillSitesFromTempSites',
   'DataMigrations::DestroyOrphanedSites',

--- a/spec/services/data_migrations/monthly_reports_backfill_spec.rb
+++ b/spec/services/data_migrations/monthly_reports_backfill_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::MonthlyReportsBackfill do
+  it 'backfill adding the generation date' do
+    stats = { my_table: { rows: [{ bucket_1: 10, bucket_2: 11, bucket: 3 }] } }
+
+    described_class::GENERATION_DATES.each do |month, _expected_date|
+      Publications::MonthlyStatistics::MonthlyStatisticsReport.create(
+        statistics: stats,
+        month: month,
+      )
+    end
+
+    described_class.new.change
+
+    described_class::GENERATION_DATES.each do |month, expected_date|
+      report = Publications::MonthlyStatistics::MonthlyStatisticsReport.find_by(month: month)
+
+      expect(report.generation_date).to eq(expected_date)
+    end
+  end
+
+  it 'backfill adding the publication date' do
+    stats = { my_table: { rows: [{ bucket_1: 10, bucket_2: 11, bucket: 3 }] } }
+
+    described_class::GENERATION_DATES.each do |month, _expected_date|
+      Publications::MonthlyStatistics::MonthlyStatisticsReport.create(
+        statistics: stats,
+        month: month,
+      )
+    end
+
+    described_class.new.change
+
+    described_class::PUBLISHING_DATES.each do |month, expected_date|
+      report = Publications::MonthlyStatistics::MonthlyStatisticsReport.find_by(month: month)
+
+      expect(I18n.l(report.publication_date)).to eq(I18n.l(expected_date))
+    end
+  end
+end


### PR DESCRIPTION
## Context

The monthly reports were hardcoding the generation and publication dates
The ones generated should be updated in those respective fields.

## Guidance to review

1. Are the columns updated correctly?

## Link to Trello card

https://trello.com/c/gXj3tWE6/359-eoc-make-the-monthlystatistictimetable-cycle-aware
