### PR TITLE
Add a condition to check if email has already been sent

### DIFF
--- a/app/services/send_eoc_deadline_reminder_email_to_candidate.rb
+++ b/app/services/send_eoc_deadline_reminder_email_to_candidate.rb
@@ -1,6 +1,17 @@
 class SendEocDeadlineReminderEmailToCandidate
   def self.call(application_form:)
+    return if already_sent_to?(application_form)
+
     CandidateMailer.eoc_deadline_reminder(application_form).deliver_later
     ChaserSent.create!(chased: application_form, chaser_type: :eoc_deadline_reminder)
+  end
+
+  def self.already_sent_to?(application_form)
+    application_form.chasers_sent.where(
+      chaser_type: :eoc_deadline_reminder,
+    ).where(
+      'created_at > ?',
+      CycleTimetable.find_opens,
+    ).present?
   end
 end


### PR DESCRIPTION
## Context

We won't send the reminder email if it's already been sent to the candidate

## Changes proposed in this pull request

Add a method to check if the email has already been sent.
