### PR TITLE
Accessibility resolve duplicate confirm conditions page titles 

### DIFF
--- a/app/views/provider_interface/condition_statuses/checks/edit.html.erb
+++ b/app/views/provider_interface/condition_statuses/checks/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, title_with_error_prefix('Confirm conditions', @form_object.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix(t('page_titles.condition_statuses.check'), @form_object.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(edit_provider_interface_condition_statuses_path(@application_choice)) %>
 
 <div class="govuk-grid-row">

--- a/app/views/provider_interface/condition_statuses/edit.html.erb
+++ b/app/views/provider_interface/condition_statuses/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, title_with_error_prefix('Confirm conditions', @form_object.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix(t('page_titles.condition_statuses.confirm'), @form_object.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_path(@application_choice)) %>
 
 <div class="govuk-grid-row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -117,6 +117,9 @@ en:
     work_history_break: Please tell us what you were doing over this period
     destroy_work_history_break: Are you sure you want to delete this entry?
     add_job: Add job
+    condition_statuses:
+      confirm: Confirm conditions
+      check: Check conditions
     degree: Degree
     degree_country: Which country was the degree from?
     degree_completion_status: Have you completed your degree?


### PR DESCRIPTION
## Context
There are duplicate page titles in the confirm conditions flow. This is not good for screen reader users and was picked up in DAC report

## Changes proposed in this pull request
Before 
<img width="226" alt="Screenshot 2022-07-12 at 16 47 06" src="https://user-images.githubusercontent.com/58793682/178533899-9d178f65-6251-4055-91fb-265bb3ee3ad4.png">

`/provider/applications/{id}/condition-statuses/edit`
and `provider/applications/{id}/condition-statuses/check/edit`

After
<img width="226" alt="Screenshot 2022-07-12 at 16 47 06" src="https://user-images.githubusercontent.com/58793682/178533899-9d178f65-6251-4055-91fb-265bb3ee3ad4.png">

`/provider/applications/{id}/condition-statuses/edit`

<img width="258" alt="Screenshot 2022-07-12 at 16 46 44" src="https://user-images.githubusercontent.com/58793682/178534074-cd3a9f55-22d9-4d04-bf87-890e96c4aacc.png">

`provider/applications/{id}/condition-statuses/check/edit`

Page titles also added to locales

## Guidance to review



## Link to Trello card

https://trello.com/c/PESr0bdH/201-dac-resolve-duplicate-confirm-conditions-page-title

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
