### PR TITLE
Specify study mode and simplify assignment of provider

### DIFF
--- a/spec/system/provider_interface/provider_exits_journey_when_changing_a_course_before_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_exits_journey_when_changing_a_course_before_an_offer_spec.rb
@@ -11,12 +11,13 @@ RSpec.feature 'Provider exits journey when changing a course' do
   let!(:application_choice) do
     create(:application_choice, :awaiting_provider_decision,
            application_form: application_form,
+           current_course_option: course_option,
            course_option: course_option)
   end
   let(:course) do
     build(:course, :full_time, provider: provider, accredited_provider: ratifying_provider)
   end
-  let(:course_option) { build(:course_option, course: course) }
+  let(:course_option) { build(:course_option, :full_time, course: course) }
 
   scenario 'Cancelling journey when changing a course choice before point of offer' do
     given_i_am_a_provider_user
@@ -49,7 +50,7 @@ RSpec.feature 'Provider exits journey when changing a course' do
   end
 
   def and_the_provider_has_multiple_courses
-    @selected_course = create(:course, :open_on_apply, study_mode: :full_time, provider: application_choice.provider, accredited_provider: ratifying_provider)
+    @selected_course = create(:course, :open_on_apply, study_mode: :full_time, provider: provider, accredited_provider: ratifying_provider)
 
     create(:course_option, :full_time, course: course)
     create(:course_option, :full_time, course: @selected_course)


### PR DESCRIPTION
## Context

`spec/system/provider_interface/provider_exits_journey_when_changing_a_course_before_an_offer_spec.rb` is a flakey spec
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Be specific around course option study mode and how we assign the training provider.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Could not make this fail locally so this commit is at least making the spec more specific.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/0YPl0dxS/254-flakey-spec-providerinterface-providerexitsjourneywhenchangingacoursebeforeanofferspec21
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
