### PR TITLE
Send VendorAPIRequests to BigQuery

### DIFF
--- a/app/controllers/vendor_api/vendor_api_controller.rb
+++ b/app/controllers/vendor_api/vendor_api_controller.rb
@@ -36,6 +36,9 @@ module VendorAPI
       @current_provider ||= @current_vendor_api_token&.provider
     end
 
+    # for dfe-analytics
+    alias current_user current_provider
+
     def set_user_context
       Sentry.set_user(id: "api_token_#{@current_vendor_api_token&.id}")
     end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -450,3 +450,14 @@ shared:
     - updated_at
     - provider_id
     - last_used_at
+  vendor_api_requests:
+    - id
+    - request_path
+    - request_method
+    - status_code
+    - request_headers
+    - request_body
+    - response_body
+    - provider_id
+    - response_headers
+    - created_at

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -127,17 +127,6 @@
   - details
   :vendor_api_tokens:
   - hashed_token
-  :vendor_api_requests:
-  - id
-  - request_path
-  - status_code
-  - request_headers
-  - request_body
-  - response_body
-  - created_at
-  - provider_id
-  - request_method
-  - response_headers
   :interviews:
   - additional_details
   - cancellation_reason


### PR DESCRIPTION
## Context

We're now logging Vendor API requests as web requests. To support investigation of historical data, send the `VendorAPIRequest` model too. (We can backfill BQ once this change is in).

## Changes proposed in this pull request

Add that table to `analytics.yml`.

Also enhance the API `web_request` records with a `user_id` — in this case the ID of the requesting provider — to make Vendor API `web_requests` more useful. For example, with a couple of JOINs it'll now be possible to get operations-via-Manage vs operations-via-API for a given provider.

Note that this change does cause duplication, because we will double up on request records from the Vendor API — one `web_request`, one `create_entity` for the `VendorAPIRequest` — from now. However, the API `web_request` logging applies to all APIs, not just the Vendor one, and it makes things consistent and therefore easier to work with. So it's not necessarily bad.

## Link to Trello card

https://trello.com/c/iUUsdRrE/636-pull-provider-user-type-data-api-vs-manage-into-bq

## Things to check

- [X] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
