### PR TITLE
Accessibility - add missing error message

### DIFF
--- a/app/views/candidate_interface/prefill_application_form/new.html.erb
+++ b/app/views/candidate_interface/prefill_application_form/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.start_new_application') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.start_new_application'), @prefill_application_or_not_form.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/prefill_application_form/new.html.erb
+++ b/app/views/candidate_interface/prefill_application_form/new.html.erb
@@ -2,9 +2,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      <%= t('page_titles.start_new_application') %>
-    </h1>
 
     <%= form_with(
       model: @prefill_application_or_not_form,
@@ -12,6 +9,10 @@
       method: :post,
     ) do |f| %>
       <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">
+        <%= t('page_titles.start_new_application') %>
+      </h1>
 
       <%= f.govuk_radio_buttons_fieldset :prefill, legend: { text: 'What do you want to do?' } do %>
         <%= f.govuk_radio_button :prefill, false, label: { text: 'Start with a blank application form' }, link_errors: true %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -339,6 +339,10 @@ en:
         course_option: The new course
     errors:
       models:
+        candidate_interface/prefill_application_or_not_form:
+          attributes:
+            prefill:
+              blank: Select how you want to start a new application
         provider_interface/pick_response_form:
           attributes:
             decision:


### PR DESCRIPTION
## Context
There is a missing error message on a page users can access in Sandbox.

## Changes proposed in this pull request
Add missing message 
move summary above h1
add error prefix on page title


## Guidance to review
on `/candidate/application/prefill`

before 
<img width="1026" alt="Screenshot 2022-07-18 at 14 29 06" src="https://user-images.githubusercontent.com/58793682/179522141-3afa2122-90fc-4fcb-9ef9-d9187703cb12.png">



after
<img width="1130" alt="Screenshot 2022-07-18 at 14 26 19" src="https://user-images.githubusercontent.com/58793682/179521930-be97a455-3934-49b1-af39-7e2a0bb0396e.png">



## Link to Trello card
https://trello.com/c/3X0iIZ7f/220-dac-fix-missing-custom-error-for-sandbox-prefill-feature
https://trello.com/c/K28skq4I/246-missing-error-prefix-on-sandbox-prefill-page

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
