### PR TITLE
Accessibility - error message work history

### DIFF
--- a/app/views/candidate_interface/restructured_work_history/start/choice.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/start/choice.html.erb
@@ -7,7 +7,7 @@
       <%= f.govuk_error_summary %>
 
       <div class="govuk-!-margin-top-6">
-        <%= f.govuk_radio_buttons_fieldset :work_history_status, legend: { text: t('page_titles.restructured_work_history_choice'), size: 'xl' } do %>
+        <%= f.govuk_radio_buttons_fieldset :choice, legend: { text: t('page_titles.restructured_work_history_choice'), size: 'xl' } do %>
           <%= f.govuk_radio_button :choice, :can_complete, label: { text: t('application_form.restructured_work_history.can_complete.label') }, link_errors: true %>
           <%= f.govuk_radio_button :choice, :full_time_education, label: { text: t('application_form.restructured_work_history.full_time_education.label') } %>
           <%= f.govuk_radio_button :choice, :can_not_complete, label: { text: t('application_form.restructured_work_history.can_not_complete.label') } do %>


### PR DESCRIPTION
## Context
An error message was not being rendered within the radio buttons. This was because the attribute in the fieldset did not match the attributes in the radio buttons.

## Changes proposed in this pull request
* Change radio button fieldset attribute

## Guidance to review
Before 
<img width="1091" alt="Screenshot 2022-07-18 at 16 15 29" src="https://user-images.githubusercontent.com/58793682/179544132-c81e1f6e-f404-46d4-80bc-c379484cc93a.png">

After
<img width="998" alt="Screenshot 2022-07-18 at 16 14 54" src="https://user-images.githubusercontent.com/58793682/179544148-2885eb8d-0ae5-4704-b805-8dbf8fd5dc42.png">


## Link to Trello card
https://trello.com/c/ujMATkdd/244-bug-error-is-not-repeated-within-radios-for-work-history-question
## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
