### PR TITLE
Remove request_body from VendorAPIRequest analytics events

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -456,7 +456,6 @@ shared:
     - request_method
     - status_code
     - request_headers
-    - request_body
     - response_body
     - provider_id
     - response_headers

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -127,6 +127,8 @@
   - details
   :vendor_api_tokens:
   - hashed_token
+  :vendor_api_requests:
+  - request_body
   :interviews:
   - additional_details
   - cancellation_reason


### PR DESCRIPTION
This can contain PII in the form of name and email of the initiating provider user

Accidentally included with #7209 