### PR TITLE
Only show preview email link when action mailer show preview is enabled

### DIFF
--- a/app/components/shared/end_of_cycle_emails_component.rb
+++ b/app/components/shared/end_of_cycle_emails_component.rb
@@ -1,4 +1,6 @@
 class EndOfCycleEmailsComponent < ViewComponent::Base
+  include PreviewEmailLinkHelper
+
   EndOfCycleEmail = Struct.new(:link, :date, :candidates_size, keyword_init: true)
 
   def end_of_cycle_emails
@@ -52,16 +54,5 @@ class EndOfCycleEmailsComponent < ViewComponent::Base
 
   def email_date(event)
     CycleTimetable.send(event).strftime('%e %B %Y')
-  end
-
-  def preview_email_link(title, path:)
-    if Rails.application.config.action_mailer.show_previews
-      govuk_link_to(
-        title,
-        url_for(controller: 'rails/mailers', action: 'preview', path: path),
-      )
-    else
-      title
-    end
   end
 end

--- a/app/components/shared/end_of_cycle_emails_component.rb
+++ b/app/components/shared/end_of_cycle_emails_component.rb
@@ -4,27 +4,28 @@ class EndOfCycleEmailsComponent < ViewComponent::Base
   def end_of_cycle_emails
     [
       {
-        link: govuk_link_to('Apply 1 deadline reminder', url_for(controller: 'rails/mailers', action: 'preview', path: 'candidate_mailer/eoc_deadline_reminder')),
+        link: preview_email_link('Apply 1 deadline reminder', path: 'candidate_mailer/eoc_deadline_reminder'),
+
         date: "#{email_date(:apply_1_deadline_first_reminder)} and #{email_date(:apply_1_deadline_second_reminder)}",
         candidates_size: apply_1_candidates,
       },
       {
-        link: govuk_link_to('Apply 2 deadline reminder', url_for(controller: 'rails/mailers', action: 'preview', path: 'candidate_mailer/eoc_deadline_reminder')),
+        link: preview_email_link('Apply 2 deadline reminder', path: 'candidate_mailer/eoc_deadline_reminder'),
         date: "#{email_date(:apply_2_deadline_first_reminder)} and #{email_date(:apply_2_deadline_second_reminder)}",
         candidates_size: apply_2_candidates,
       },
       {
-        link: govuk_link_to('Find has opened', url_for(controller: 'rails/mailers', action: 'preview', path: 'candidate_mailer/find_has_opened')),
+        link: preview_email_link('Find has opened', path: 'candidate_mailer/find_has_opened'),
         date: email_date(:find_reopens),
         candidates_size: candidates_to_notify_about_find_and_apply,
       },
       {
-        link: govuk_link_to('Apply has opened', url_for(controller: 'rails/mailers', action: 'preview', path: 'candidate_mailer/new_cycle_has_started_with_unsuccessful_application')),
+        link: preview_email_link('Apply has opened', path: 'candidate_mailer/new_cycle_has_started_with_unsuccessful_application'),
         date: email_date(:apply_reopens),
         candidates_size: candidates_to_notify_about_find_and_apply,
       },
       {
-        link: govuk_link_to('Find is now open (providers)', url_for(controller: 'rails/mailers', action: 'preview', path: 'provider_mailer/find_service_is_now_open')),
+        link: preview_email_link('Find is now open (providers)', path: 'provider_mailer/find_service_is_now_open'),
         date: email_date(:find_reopens),
         candidates_size: providers_to_notify_about_find_and_apply,
       },
@@ -51,5 +52,16 @@ class EndOfCycleEmailsComponent < ViewComponent::Base
 
   def email_date(event)
     CycleTimetable.send(event).strftime('%e %B %Y')
+  end
+
+  def preview_email_link(title, path:)
+    if Rails.application.config.action_mailer.show_previews
+      govuk_link_to(
+        title,
+        url_for(controller: 'rails/mailers', action: 'preview', path: path),
+      )
+    else
+      title
+    end
   end
 end

--- a/app/helpers/preview_email_link_helper.rb
+++ b/app/helpers/preview_email_link_helper.rb
@@ -1,0 +1,12 @@
+module PreviewEmailLinkHelper
+  def preview_email_link(title, path:)
+    if Rails.application.config.action_mailer.show_previews
+      govuk_link_to(
+        title,
+        url_for(controller: 'rails/mailers', action: 'preview', path: path),
+      )
+    else
+      title
+    end
+  end
+end

--- a/spec/components/shared/end_of_cycle_emails_component_spec.rb
+++ b/spec/components/shared/end_of_cycle_emails_component_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe EndOfCycleEmailsComponent do
+  context 'when preview email is enabled' do
+    it 'renders preview email links' do
+      result = render_inline(described_class.new)
+
+      expect(result.css('.govuk-table__body a').map(&:text)).to eq([
+        'Apply 1 deadline reminder',
+        'Apply 2 deadline reminder',
+        'Find has opened',
+        'Apply has opened',
+        'Find is now open (providers)',
+      ])
+    end
+  end
+
+  context 'when preview is disabled' do
+    it 'renders texts without preview links' do
+      allow(Rails.application.config.action_mailer).to receive(:show_previews).and_return(false)
+      result = render_inline(described_class.new)
+
+      expect(result.css('.govuk-table__body a').map(&:text)).to eq([])
+      expect(result.css('.govuk-table__body th').map(&:text)).to eq([
+        'Apply 1 deadline reminder',
+        'Apply 2 deadline reminder',
+        'Find has opened',
+        'Apply has opened',
+        'Find is now open (providers)',
+      ])
+    end
+  end
+end


### PR DESCRIPTION
## Context

The Cycle Timeline page that we created on #7196 is not working in production.

The reason is that show email previews are disabled in production.

So the solution is to show the title only in production.

## Link to Trello card

https://trello.com/c/83phEQaW/414-fix-the-eoc-timeline-page

