### PR TITLE
Add data migration to fix wrong column data

### DIFF
--- a/app/services/data_migrations/provider_interview_data_fix.rb
+++ b/app/services/data_migrations/provider_interview_data_fix.rb
@@ -1,7 +1,7 @@
 module DataMigrations
   class ProviderInterviewDataFix
     TIMESTAMP = 20220720155903
-    MANUAL_RUN = false
+    MANUAL_RUN = true
 
     def change
       interviews.each do |interview|

--- a/app/services/data_migrations/provider_interview_data_fix.rb
+++ b/app/services/data_migrations/provider_interview_data_fix.rb
@@ -1,0 +1,29 @@
+module DataMigrations
+  class ProviderInterviewDataFix
+    TIMESTAMP = 20220720155903
+    MANUAL_RUN = false
+
+    def change
+      provider = Provider.find_by(name: 'The Manchester Metropolitan University')
+
+      Interview
+        .where(provider_id: provider.id)
+        .where("location LIKE 'An email%'").each do |interview|
+        interview.update_columns(
+          location: '',
+          additional_details: additional_details_for(interview),
+        )
+      end
+    end
+
+  private
+
+    def additional_details_for(interview)
+      if interview.additional_details.blank?
+        interview.location
+      else
+        "#{interview.additional_details} #{interview.location}"
+      end
+    end
+  end
+end

--- a/app/services/data_migrations/provider_interview_data_fix.rb
+++ b/app/services/data_migrations/provider_interview_data_fix.rb
@@ -4,11 +4,7 @@ module DataMigrations
     MANUAL_RUN = false
 
     def change
-      provider = Provider.find_by(name: 'The Manchester Metropolitan University')
-
-      Interview
-        .where(provider_id: provider.id)
-        .where("location LIKE 'An email%'").each do |interview|
+      interviews.each do |interview|
         interview.update_columns(
           location: '',
           additional_details: additional_details_for(interview),
@@ -16,13 +12,45 @@ module DataMigrations
       end
     end
 
+    # rubocop:disable Rails/Output
+    def dry_run
+      interviews.each do |interview|
+        puts '-' * 80
+        puts "Application number #{interview.application_choice.id}"
+        puts '-' * 80
+        puts
+
+        if interview.additional_details.present?
+          puts
+          puts 'Move location value below AMENDING/ADDING to the additional details column:'
+          puts
+          puts "'#{additional_details_for(interview)}'"
+        else
+          puts 'Moving location value below to additional details column:'
+          puts
+          puts "'#{interview.location}'"
+        end
+
+        puts
+      end
+    end
+  # rubocop:enable Rails/Output
+
   private
+
+    def provider
+      Provider.find_by(name: 'The Manchester Metropolitan University')
+    end
+
+    def interviews
+      Interview.includes(:application_choice).where(provider_id: provider.id).where("location LIKE 'An email%'")
+    end
 
     def additional_details_for(interview)
       if interview.additional_details.blank?
         interview.location
       else
-        "#{interview.additional_details} #{interview.location}"
+        "#{interview.additional_details}\n\n#{interview.location}"
       end
     end
   end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::ProviderInterviewDataFix',
   'DataMigrations::MonthlyReportsBackfill',
   'DataMigrations::RemoveDataExportsFeatureFlag',
   'DataMigrations::BackfillSitesFromTempSites',

--- a/spec/services/data_migrations/provider_interview_data_fix_spec.rb
+++ b/spec/services/data_migrations/provider_interview_data_fix_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe DataMigrations::ProviderInterviewDataFix do
       interview.reload
       expect(interview.location).to eq('')
       expect(interview.additional_details).to eq(
-        "This is also our last scheduled interview session.\nAn email will be sent to you with all the details.",
+        "This is also our last scheduled interview session.\n\nAn email will be sent to you with all the details.",
       )
     end
   end

--- a/spec/services/data_migrations/provider_interview_data_fix_spec.rb
+++ b/spec/services/data_migrations/provider_interview_data_fix_spec.rb
@@ -33,7 +33,9 @@ RSpec.describe DataMigrations::ProviderInterviewDataFix do
 
       interview.reload
       expect(interview.location).to eq('')
-      expect(interview.additional_details).to eq('This is also our last scheduled interview session. An email will be sent to you with all the details.')
+      expect(interview.additional_details).to eq(
+        "This is also our last scheduled interview session.\nAn email will be sent to you with all the details.",
+      )
     end
   end
 end

--- a/spec/services/data_migrations/provider_interview_data_fix_spec.rb
+++ b/spec/services/data_migrations/provider_interview_data_fix_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::ProviderInterviewDataFix do
+  let(:provider) { create(:provider, name: 'The Manchester Metropolitan University') }
+
+  context 'when additional details are empty' do
+    it 'transfer location to additional details' do
+      interview = create(
+        :interview,
+        provider: provider,
+        location: 'An email will be sent to you with all the details.',
+        additional_details: '',
+      )
+
+      described_class.new.change
+
+      interview.reload
+      expect(interview.location).to eq('')
+      expect(interview.additional_details).to eq('An email will be sent to you with all the details.')
+    end
+  end
+
+  context 'when additional details are present' do
+    it 'amend additional details with location' do
+      interview = create(
+        :interview,
+        provider: provider,
+        location: 'An email will be sent to you with all the details.',
+        additional_details: 'This is also our last scheduled interview session.',
+      )
+
+      described_class.new.change
+
+      interview.reload
+      expect(interview.location).to eq('')
+      expect(interview.additional_details).to eq('This is also our last scheduled interview session. An email will be sent to you with all the details.')
+    end
+  end
+end


### PR DESCRIPTION
Refer to trello for more details

## Context

It looks like one provider have entered the "additional_details" data into the "Location" field on 1288 interviews.

## Changes proposed in this pull request

Migrate those from location into additional_details. 

## Guidance to review

1. Does it work with a snapshot database?

## Link to Trello card

[<!-- http://trello.com/123-example-card -->](https://trello.com/c/mYcJwMU9/407-fix-mmu-interview-data-from-thesis)

