### PR TITLE
New References - Feature flag

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -32,6 +32,7 @@ class FeatureFlag
     [:draft_vendor_api_specification, 'The specification for Draft Vendor API v1.1', 'Abeer Salameh'],
     [:new_degree_flow, 'Allows us to use the new degree flow', 'Jon Filar'],
     [:reference_nudges, 'Nudge emails for candidates that have incomplete references', 'Steve Hook'],
+    [:new_references_flow, 'Show the new references flow', 'James and Tomas'],
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day


### PR DESCRIPTION
## Context

We're developing a new references flow – we need to wrap this around a feature flag to allow us to build it in parallel the the existing references journey.

## Changes proposed in this pull request

Add the `new_references_flow` feature flag

## Link to Trello card

https://trello.com/c/r8VLtIc3/420-references-add-a-feature-flag

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
