### PR TITLE
Limit candidate edits audits check to past 7 days

### DIFF
--- a/app/workers/detect_invariants_hourly_check.rb
+++ b/app/workers/detect_invariants_hourly_check.rb
@@ -36,6 +36,7 @@ class DetectInvariantsHourlyCheck
     unauthorised_changes = Audited::Audit
       .joins("INNER JOIN application_forms ON audits.associated_type = 'ApplicationForm' AND application_forms.id = audits.associated_id")
       .joins('INNER JOIN candidates ON candidates.id = application_forms.candidate_id')
+      .where('audits.created_at > ?', 7.days.ago)
       .where(user_type: 'Candidate', associated_type: 'ApplicationForm')
       .where('candidates.id != audits.user_id')
       .pluck('application_forms.id').uniq


### PR DESCRIPTION
## Context

https://sentry.io/organizations/dfe-teacher-services/issues/2527648396/events/?project=1765973&statsPeriod=14d
The timeout consistently occurs on the `DetectInvariantsHourlyCheck#detect_unauthorised_application_form_edits` method.
We run this check hourly, so there's no need to scan the entire audits table for bogus edits.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Limit the audits records in the query to those created in the past 7 days.

This takes the query from around 40 seconds in production to
under 1 second.

#### Before

```
irb(main):007:0> puts Benchmark.measure { Audited::Audit.joins("INNER JOIN application_forms ON audits.associated_type = 'ApplicationForm' AND application_forms.id = audits.associated_id").joins('INNER JOIN candidates ON candidates.id = application_forms.candidate_id').where(user_type: 'Candidate', associated_type: 'ApplicationForm').where('candidates.id != audits.user_id').p
luck('application_forms.id').uniq.sort }
  0.001131   0.000103   0.001234 ( 41.799048)
```

#### After

```
irb(main):008:0> puts Benchmark.measure { Audited::Audit.joins("INNER JOIN application_forms ON audits.associated_type = 'ApplicationForm' AND application_forms.id = audits.associated_id").
joins('INNER JOIN candidates ON candidates.id = application_forms.candidate_id').where('audits.created_at > ?', 7.days.ago).where(user_type: 'Candidate', associated_type: 'ApplicationForm').where('candidates.id != audits.user_id').pluck('application_forms.id').uniq.sort }
  0.001547   0.000000   0.001547 (  0.107618)
```

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

I've made the assumption that because this is an hourly check we do not need to consider older audits records - is this right?
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/cVfB32Wx/393-detectinvariantshourlycheck-is-routinely-timing-out
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
