### PR TITLE
Fix qualification docs page

### DIFF
--- a/app/views/support_interface/docs/qualifications.html.erb
+++ b/app/views/support_interface/docs/qualifications.html.erb
@@ -11,7 +11,7 @@
   </div>
 
   <div class="govuk-grid-column-three-quarters">
-    <%= govuk_accordion(id: 'qualifications') do |accordion| %>
+    <%= govuk_accordion(html_attributes: { id: 'qualifications' }) do |accordion| %>
       <% accordion.section(heading_text: 'GCSE subjects') do %>
         <%= render SupportInterface::QualificationDocumentationComponent.new(list: GCSE_SUBJECTS) %>
       <% end %>

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -16,6 +16,9 @@ RSpec.feature 'Docs' do
 
     when_i_click_on_the_end_of_cycle_documentation
     then_i_can_see_the_apply_reopens_date
+
+    when_i_click_on_qualifications_documentation
+    then_i_can_see_all_qualifications_data
   end
 
   def given_i_am_a_support_user
@@ -87,9 +90,19 @@ RSpec.feature 'Docs' do
     click_on 'Cycle timeline'
   end
 
+  def when_i_click_on_qualifications_documentation
+    click_on 'Qualifications'
+  end
+
   def then_i_can_see_the_apply_reopens_date
     expect(page).to have_content 'Cycle timeline'
     expect(page).to have_content 'Apply reopens'
     expect(page).to have_content CycleTimetable.apply_reopens.to_fs(:govuk_date_and_time)
+  end
+
+  def then_i_can_see_all_qualifications_data
+    expect(page).to have_content('These lists are a reference for the values used throughout the service.')
+    expect(page).to have_content('Degree grades (with HESA codes)')
+    expect(page).to have_content('Degree types')
   end
 end


### PR DESCRIPTION
## Context

The qualification docs were raising a 500 eror page, because the new govuk components gem requires the key html attributes, adding it, solves the issue.

## Guidance to review

1. Does the qualification docs renders correctly on support UI?

## Link to Trello card

https://trello.com/c/fGvM4ran/451-support-docs-qualifications-page-returns-500
