### PR TITLE
API test data: incomplete_references param sets all references as not_requested_yet

### DIFF
--- a/app/controllers/concerns/vendor_api/application_data_concerns.rb
+++ b/app/controllers/concerns/vendor_api/application_data_concerns.rb
@@ -6,6 +6,10 @@ module VendorAPI
       params.permit(:application_id)[:application_id]
     end
 
+    def include_incomplete_references?
+      params[:incomplete_references] == 'true'
+    end
+
     def application_choice
       @application_choice ||= application_choices_visible_to_provider.find(application_choice_id)
     end

--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -12,13 +12,23 @@ module VendorAPI
     end
 
     def show
-      render json: SingleApplicationPresenter.new(version_number, application_choice).serialized_json
+      render json: SingleApplicationPresenter.new(
+        version_number,
+        application_choice,
+        include_incomplete_references: include_incomplete_references?,
+      ).serialized_json
     end
 
   private
 
     def serialized_application_choices_data
-      MultipleApplicationsPresenter.new(version_number, get_application_choices_for_provider_since(since: since_param), request, pagination_params).serialized_applications_data
+      MultipleApplicationsPresenter.new(
+        version_number,
+        get_application_choices_for_provider_since(since: since_param),
+        request,
+        pagination_params,
+        include_incomplete_references: include_incomplete_references?,
+      ).serialized_applications_data
     end
 
     def get_application_choices_for_provider_since(since:)

--- a/app/controllers/vendor_api/test_data_controller.rb
+++ b/app/controllers/vendor_api/test_data_controller.rb
@@ -22,6 +22,7 @@ module VendorAPI
         for_training_courses: for_training_courses_param,
         for_ratified_courses: for_ratified_courses_param,
         for_test_provider_courses: for_test_provider_courses_param,
+        incomplete_references: with_incomplete_references_param,
       ).call
 
       render json: { data: { message: 'Request submitted. Applications will appear once they have been generated' } }
@@ -67,6 +68,10 @@ module VendorAPI
 
     def for_test_provider_courses_param
       params[:for_test_provider_courses] == 'true'
+    end
+
+    def with_incomplete_references_param
+      params[:incomplete_references] == 'true'
     end
 
     def previous_cycle?

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -219,7 +219,10 @@ private
       fast_forward
 
       if incomplete_references
-        @application_form.application_references.update_all(feedback_status: 'not_requested_yet')
+        @application_form.application_references.update_all(
+          feedback_status: 'not_requested_yet',
+          selected: true,
+        )
       else
         # The first reference is declined by the referee
         @application_form.application_references.feedback_requested.first.update!(feedback_status: 'feedback_refused')

--- a/app/presenters/vendor_api/multiple_applications_presenter.rb
+++ b/app/presenters/vendor_api/multiple_applications_presenter.rb
@@ -1,12 +1,13 @@
 module VendorAPI
   class MultipleApplicationsPresenter < Base
-    attr_reader :applications, :options, :request
+    attr_reader :applications, :options, :request, :include_incomplete_references
 
-    def initialize(version, applications, request = {}, options = {})
+    def initialize(version, applications, request = {}, options = {}, include_incomplete_references: false)
       super(version)
       @applications = applications
       @request = request
       @options = options
+      @include_incomplete_references = include_incomplete_references
     end
 
     def serialized_applications_data
@@ -15,7 +16,11 @@ module VendorAPI
 
     def serialized_applications
       applications_scope.map do |application|
-        ApplicationPresenter.new(active_version, application).serialized_json
+        ApplicationPresenter.new(
+          active_version,
+          application,
+          include_incomplete_references: include_incomplete_references,
+        ).serialized_json
       end
     end
 

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -1,14 +1,21 @@
 module VendorAPI
   class SingleApplicationPresenter < Base
-    attr_reader :application
+    attr_reader :application, :include_incomplete_references
 
-    def initialize(version, application)
+    def initialize(version, application, include_incomplete_references: false)
       super(version)
       @application = application
+      @include_incomplete_references = include_incomplete_references
     end
 
     def serialized_json
-      %({"data":#{ApplicationPresenter.new(active_version, application).serialized_json}})
+      references = ApplicationPresenter.new(
+        active_version,
+        application,
+        include_incomplete_references: include_incomplete_references,
+      ).serialized_json
+
+      %({"data":#{references}})
     end
   end
 end

--- a/app/presenters/vendor_api/single_application_presenter/meta.rb
+++ b/app/presenters/vendor_api/single_application_presenter/meta.rb
@@ -1,5 +1,13 @@
 module VendorAPI::SingleApplicationPresenter::Meta
   def serialized_json
-    %({"data":#{VendorAPI::ApplicationPresenter.new(active_version, application).serialized_json}, "meta": #{VendorAPI::MetaPresenter.new(active_version).as_json}})
+    references = VendorAPI::ApplicationPresenter.new(
+      active_version,
+      application,
+      include_incomplete_references: include_incomplete_references,
+    ).serialized_json
+
+    meta = VendorAPI::MetaPresenter.new(active_version).as_json
+
+    %({"data":#{references}, "meta": #{meta}})
   end
 end

--- a/app/services/generate_test_applications_for_provider.rb
+++ b/app/services/generate_test_applications_for_provider.rb
@@ -1,5 +1,14 @@
 class GenerateTestApplicationsForProvider
-  def initialize(provider:, courses_per_application:, count:, for_training_courses: false, for_ratified_courses: false, for_test_provider_courses: false, previous_cycle: false)
+  def initialize(
+    provider:,
+    courses_per_application:,
+    count:,
+    for_training_courses: false,
+    for_ratified_courses: false,
+    for_test_provider_courses: false,
+    previous_cycle: false,
+    incomplete_references: false
+  )
     @provider = provider
     @courses_per_application = courses_per_application
     @application_count = count
@@ -11,6 +20,7 @@ class GenerateTestApplicationsForProvider
     @for_ratified_courses = for_ratified_courses
     @for_test_provider_courses = for_test_provider_courses
     @previous_cycle = previous_cycle
+    @incomplete_references = incomplete_references
   end
 
   def call
@@ -22,13 +32,16 @@ class GenerateTestApplicationsForProvider
 
       raise ParameterInvalid, 'Parameter is invalid (cannot be greater than number of available courses): courses_per_application' if course_ids.count < courses_per_application
 
-      GenerateTestApplicationsForCourses.perform_async(course_ids, courses_per_application, previous_cycle)
+      GenerateTestApplicationsForCourses.perform_async(
+        course_ids, courses_per_application, previous_cycle, incomplete_references
+      )
     end
   end
 
 private
 
-  attr_reader :provider, :courses_per_application, :application_count, :for_training_courses, :for_ratified_courses, :for_test_provider_courses, :previous_cycle
+  attr_reader :provider, :courses_per_application, :application_count, :for_training_courses,
+              :for_ratified_courses, :for_test_provider_courses, :previous_cycle, :incomplete_references
 
   def random_course_ids_to_apply_for
     even_split = even_split_for_number_of_course_types

--- a/app/workers/generate_test_applications_for_courses.rb
+++ b/app/workers/generate_test_applications_for_courses.rb
@@ -1,19 +1,20 @@
 class GenerateTestApplicationsForCourses
   include Sidekiq::Worker
 
-  def perform(course_ids, courses_per_application, previous_cycle)
-    generate_single(course_ids, courses_per_application, previous_cycle)
+  def perform(course_ids, courses_per_application, previous_cycle, incomplete_references = false)
+    generate_single(course_ids, courses_per_application, previous_cycle, incomplete_references)
   end
 
 private
 
-  def generate_single(course_ids, courses_per_application, previous_cycle)
+  def generate_single(course_ids, courses_per_application, previous_cycle, incomplete_references)
     courses_to_apply_to = Course.where(id: course_ids, recruitment_cycle_year: TestProvider.recruitment_cycle_year(previous_cycle))
 
     TestApplications.new.create_application(
       recruitment_cycle_year: TestProvider.recruitment_cycle_year(previous_cycle),
       states: application_state(previous_cycle, courses_per_application),
       courses_to_apply_to: courses_to_apply_to,
+      incomplete_references: incomplete_references,
     )
   end
 

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -177,6 +177,12 @@ RSpec.describe TestApplications do
       end
 
       it { is_expected.to match_array(expected) }
+
+      describe 'all references marked as selected' do
+        subject { references.pluck(:selected).uniq }
+
+        it { is_expected.to eq [true] }
+      end
     end
   end
 


### PR DESCRIPTION
## Context

We are changing references such that the vendor API will include incomplete references (in `not_requested_yet` status, with referee info but not reference detail). We want to trial this structure in the test data to allow vendors to test on Sandbox.

## Changes proposed in this pull request

Add new param `incomplete_references` to `POST /test-data/generate` endpoint. When `true`, set all references in the generated applications to `not_requested_yet` and mark them as `selected`.

Also add param `incomplete_references` to `GET /applications` and `GET /applications/:id` endpoints so that they can optionally include references for which feedback has not been provided.

## Guidance to review

Run `/api/v1/test-data/generate` locally or on the review app, with `not_requested_yet` param set to true. Does it generate applications in the expected state?

## Link to Trello card

https://trello.com/c/2XfUgQbb/412-create-test-data-for-vendors-to-check-that-references-changes-will-not-cause-issues

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
