### PR TITLE
StatisticsTestHelper: make date_of_birth relative to current cycle

### DIFF
--- a/spec/support/statistics_test_helper.rb
+++ b/spec/support/statistics_test_helper.rb
@@ -254,6 +254,6 @@ module StatisticsTestHelper
   end
 
   def date_of_birth(years_ago:)
-    years_ago.years.ago
+    Date.new(RecruitmentCycle.current_year - years_ago, 1, 1)
   end
 end


### PR DESCRIPTION
Ages are grouped relative to recruitment cycle year. The test applications should be created accordingly.

Fixes failing test in by_age_group_spec.rb:

```
Publications::MonthlyStatistics::ByAgeGroup returns rows for 'by age group'
```

This started failing on 01 August 2022, perhaps unsurprisingly given the query in `MonthlyStatistics::Base` defines age groups as being between 1 August and 31 July.

## Guidance to review

Do the tests pass?

## Link to Trello card

https://trello.com/c/tdzY1qy2/463-publicationsmonthlystatisticsbyagegroup-stopped-working

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
