### PR TITLE
Define rejection codes for Vendor API

### DIFF
--- a/app/models/vendor_api/rejection_reasons.rb
+++ b/app/models/vendor_api/rejection_reasons.rb
@@ -1,0 +1,23 @@
+module VendorAPI
+  class RejectionReasons
+    CODES = YAML.load_file(Rails.root.join('config/rejection_reason_codes.yml'))
+
+    def find(code)
+      CODES.fetch(code)
+    rescue KeyError
+      raise RejectionReasonCodeNotFound
+    end
+
+    attr_accessor :selected_reasons
+
+    def initialize(reasons_attrs = [])
+      @selected_reasons = reasons_attrs.map do |reason_attrs|
+        reason = ::RejectionReasons::Reason.new(find(reason_attrs[:code]))
+        reason.details.text = reason_attrs[:details]
+        reason
+      end
+    end
+  end
+
+  class RejectionReasonCodeNotFound < StandardError; end
+end

--- a/config/rejection_reason_codes.yml
+++ b/config/rejection_reason_codes.yml
@@ -1,0 +1,55 @@
+---
+R01:
+  :id: qualifications
+  :label: Qualifications
+  :details:
+    :id: qualifications_details
+    :label: Details
+R02:
+  :id: personal_statement
+  :label: Personal statement
+  :details:
+    :id: personal_statement_details
+    :label: Details
+R03:
+  :id: teaching_knowledge
+  :label: Teaching knowledge and ability
+  :details:
+    :id: teaching_knowledge_details
+    :label: Details
+R04:
+  :id: communication_and_scheduling
+  :label: Communication, interview attendance and scheduling
+  :details:
+    :id: communication_and_scheduling_details
+    :label: Details
+R05:
+  :id: references
+  :label: References
+  :details:
+    :id: references_details
+    :label: Details
+R06:
+  :id: safeguarding
+  :label: Safeguarding
+  :details:
+    :id: safeguarding_details
+    :label: Details
+R07:
+  :id: visa_sponsorship
+  :label: Visa sponsorship
+  :details:
+    :id: visa_sponsorship_details
+    :label: Details
+R08:
+  :id: course_full
+  :label: Course full
+  :details:
+    :id: course_full_details
+    :label: Details
+R09:
+  :id: other
+  :label: Other
+  :details:
+    :id: other_details
+    :label: Details

--- a/spec/models/vendor_api/rejection_reasons_spec.rb
+++ b/spec/models/vendor_api/rejection_reasons_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe VendorAPI::RejectionReasons do
+  describe '#find' do
+    it 'raises on invalid code' do
+      expect {
+        described_class.new.find('hohoho')
+      }.to raise_error(VendorAPI::RejectionReasonCodeNotFound)
+    end
+
+    it 'returns the hash entry for code' do
+      expect(described_class.new.find('R01')).to eq(
+        { id: 'qualifications', label: 'Qualifications', details: { id: 'qualifications_details', label: 'Details' } },
+      )
+    end
+  end
+
+  describe 'new' do
+    it 'populates selected reasons from codes' do
+      instance = described_class.new([
+        { code: 'R01', details: 'No relevant qualifications' },
+        { code: 'R09', details: 'Some other stuff' },
+      ])
+
+      expect(instance.selected_reasons.first).to be_a(::RejectionReasons::Reason)
+      expect(instance.selected_reasons.first.label).to eq('Qualifications')
+      expect(instance.selected_reasons.first.details.text).to eq('No relevant qualifications')
+      expect(instance.selected_reasons.last).to be_a(::RejectionReasons::Reason)
+      expect(instance.selected_reasons.last.label).to eq('Other')
+      expect(instance.selected_reasons.last.details.text).to eq('Some other stuff')
+    end
+  end
+end


### PR DESCRIPTION
## Context

We'd like to enable vendors to reject applications based on a finite number of reasons over the Vendor API.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Defines codes and related reasons categories for rejecting applications over the Vendor API.
This PR also provides a way to turn the configured codes into valid `RejectionReasons::Reason` instances.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/nS1JQAwA/465-define-vendor-api-r4r-codes-and-data-format
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
