### PR TITLE
Add `POST /api/v1.2/reject-by-codes` endpoint

### DIFF
--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -49,9 +49,8 @@ module VendorAPI
       decision = RejectApplication.new(
         actor: audit_user,
         application_choice: application_choice,
-        structured_rejection_reasons: VendorAPI::RejectionReasons.new(params[:data]),
+        structured_rejection_reasons: rejection_reasons,
       )
-
       respond_to_decision(decision)
     end
 
@@ -64,6 +63,12 @@ module VendorAPI
     end
 
   private
+
+    def rejection_reasons
+      VendorAPI::RejectionReasons.new(params[:data])
+    rescue RejectionReasonCodeNotFound
+      raise ValidationException, ['Please provide valid rejection codes.']
+    end
 
     def respond_to_decision(decision)
       if [MakeOffer, ChangeOffer].include?(decision.class)

--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -45,6 +45,16 @@ module VendorAPI
       respond_to_decision(decision)
     end
 
+    def reject_by_codes
+      decision = RejectApplication.new(
+        actor: audit_user,
+        application_choice: application_choice,
+        structured_rejection_reasons: VendorAPI::RejectionReasons.new(params[:data]),
+      )
+
+      respond_to_decision(decision)
+    end
+
     # This method is a no-op since we removed enrolment from the app
     def confirm_enrolment
       render_application

--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -37,5 +37,8 @@ module VendorAPI
       Changes::Pagination,
       Changes::AddMetaToApplication,
     ],
+    '1.2pre' => [
+      Changes::RejectByCodes,
+    ],
   }.freeze
 end

--- a/app/lib/vendor_api/changes/reject_by_codes.rb
+++ b/app/lib/vendor_api/changes/reject_by_codes.rb
@@ -1,0 +1,9 @@
+module VendorAPI
+  module Changes
+    class RejectByCodes < VersionChange
+      description 'Reject application with reasons codes via the API.'
+
+      action DecisionsController, :reject_by_codes
+    end
+  end
+end

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -55,6 +55,7 @@ class ApplicationChoice < ApplicationRecord
     rejection_reason: 'rejection_reason',           # Single text field reason predating Structured Reasons For Rejection and still writeable via API.
     reasons_for_rejection: 'reasons_for_rejection', # Initial iteration of Structured Reasons For Rejection model.
     rejection_reasons: 'rejection_reasons',         # Current iteration of Structured Reasons For Rejection.
+    vendor_api_rejection_reasons: 'vendor_api_rejection_reasons', # Rejection reasons via the Vendor API.
   }, _prefix: :rejection_reasons_type
 
   scope :decision_pending, -> { where(status: ApplicationStateChange::DECISION_PENDING_STATUSES) }

--- a/app/models/vendor_api/rejection_reasons.rb
+++ b/app/models/vendor_api/rejection_reasons.rb
@@ -13,7 +13,7 @@ module VendorAPI
     def initialize(reasons_attrs = [])
       @selected_reasons = reasons_attrs.map do |reason_attrs|
         reason = ::RejectionReasons::Reason.new(find(reason_attrs[:code]))
-        reason.details.text = reason_attrs[:details]
+        reason.details.text = reason_attrs[:details] if reason_attrs[:details]
         reason
       end
     end

--- a/app/presenters/rejected_application_choice_presenter.rb
+++ b/app/presenters/rejected_application_choice_presenter.rb
@@ -9,7 +9,7 @@ private
 
   def presenter_class
     case rejection_reasons_type
-    when 'rejection_reasons'
+    when 'rejection_reasons', 'vendor_api_rejection_reasons'
       RejectionReasons::RejectionReasonsPresenter
     when 'reasons_for_rejection'
       RejectionReasons::ReasonsForRejectionPresenter

--- a/app/services/reject_application.rb
+++ b/app/services/reject_application.rb
@@ -26,7 +26,7 @@ class RejectApplication
         @application_choice.update!(
           rejection_reason: @rejection_reason,
           structured_rejection_reasons: @structured_rejection_reasons,
-          rejection_reasons_type: structured_rejection_reasons.blank? ? :rejection_reason : structured_rejection_reasons.class.name.underscore,
+          rejection_reasons_type: rejection_reasons_type,
           rejected_at: Time.zone.now,
         )
         SetDeclineByDefault.new(application_form: @application_choice.application_form).call
@@ -47,6 +47,12 @@ class RejectApplication
   end
 
 private
+
+  def rejection_reasons_type
+    return :rejection_reason if @structured_rejection_reasons.blank?
+
+    structured_rejection_reasons.class.name.underscore.gsub('/', '_')
+  end
 
   def at_least_one_rejection_reason_format
     if rejection_reason.blank? && structured_rejection_reasons.blank?

--- a/config/rejection_reason_codes.yml
+++ b/config/rejection_reason_codes.yml
@@ -5,51 +5,63 @@ R01:
   :details:
     :id: qualifications_details
     :label: Details
+    :text: |
+      You did not have the required or relevant qualifications, or we could not find record of your qualifications.
 R02:
   :id: personal_statement
   :label: Personal statement
   :details:
     :id: personal_statement_details
     :label: Details
+    :text: You personal statement did not meet our standards.
 R03:
   :id: teaching_knowledge
   :label: Teaching knowledge and ability
   :details:
     :id: teaching_knowledge_details
     :label: Details
+    :text: |
+      Your teaching knowledge was insufficient. This may relate to subject knowledge, safeguarding knowledge, teaching method knowledge or teaching demonstration.
 R04:
   :id: communication_and_scheduling
   :label: Communication, interview attendance and scheduling
   :details:
     :id: communication_and_scheduling_details
     :label: Details
+    :text: |
+      You did not reply to messages or failed to attend an interview or we could not successfully arrange and interview with you.
 R05:
   :id: references
   :label: References
   :details:
     :id: references_details
     :label: Details
+    :text: Your references were either missing or not satisfactory.
 R06:
   :id: safeguarding
   :label: Safeguarding
   :details:
     :id: safeguarding_details
     :label: Details
+    :text: We are unable to accept your application due to safeguarding concerns.
 R07:
   :id: visa_sponsorship
   :label: Visa sponsorship
   :details:
     :id: visa_sponsorship_details
     :label: Details
+    :text: We are unable to accept your application due to visa sponsorship issues.
 R08:
   :id: course_full
   :label: Course full
   :details:
     :id: course_full_details
     :label: Details
+    :text: We are unable to offer you a place on the chosen course because it is fully subscribed.
 R09:
   :id: other
   :label: Other
   :details:
     :id: other_details
     :label: Details
+    :text: We were unable to offer you a place on the chosen course. Please contact us for details.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -634,6 +634,7 @@ Rails.application.routes.draw do
       post '/confirm-conditions-met' => 'decisions#confirm_conditions_met'
       post '/conditions-not-met' => 'decisions#conditions_not_met'
       post '/reject' => 'decisions#reject'
+      post '/reject-by-codes' => 'decisions#reject_by_codes'
       post '/confirm-enrolment' => 'decisions#confirm_enrolment'
       post '/notes/create' => 'notes#create'
       post '/withdraw' => 'withdraw_or_decline_offer#create'

--- a/spec/models/vendor_api/rejection_reasons_spec.rb
+++ b/spec/models/vendor_api/rejection_reasons_spec.rb
@@ -10,7 +10,15 @@ RSpec.describe VendorAPI::RejectionReasons do
 
     it 'returns the hash entry for code' do
       expect(described_class.new.find('R01')).to eq(
-        { id: 'qualifications', label: 'Qualifications', details: { id: 'qualifications_details', label: 'Details' } },
+        {
+          id: 'qualifications',
+          label: 'Qualifications',
+          details: {
+            id: 'qualifications_details',
+            label: 'Details',
+            text: "You did not have the required or relevant qualifications, or we could not find record of your qualifications.\n",
+          },
+        },
       )
     end
   end

--- a/spec/requests/vendor_api/v1.2/post_reject_by_codes_spec.rb
+++ b/spec/requests/vendor_api/v1.2/post_reject_by_codes_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe 'Vendor API - POST /applications/:application_id/reject-by-codes', type: :request do
+  include VendorAPISpecHelpers
+  include CourseOptionHelpers
+
+  it_behaves_like 'an endpoint that requires metadata', '/reject-by-codes', '1.2'
+
+  describe 'with valid codes and details' do
+    let(:application_choice) do
+      create_application_choice_for_currently_authenticated_provider(
+        status: 'awaiting_provider_decision',
+      )
+    end
+
+    it 'responds with a rejected application' do
+      request_body = {
+        data: [
+          {
+            code: 'R01',
+            details: 'Does not meet minimum GCSE requirements.',
+          },
+          {
+            code: 'R09',
+            details: 'Wearing clown shoes to the interview was odd.',
+          },
+        ],
+      }
+
+      post_api_request "/api/v1.2/applications/#{application_choice.id}/reject-by-codes", params: request_body
+
+      expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse', '1.2')
+      expect(parsed_response['data']['attributes']['status']).to eq 'rejected'
+      expect(parsed_response['data']['attributes']['rejection']).to match a_hash_including(
+        'reason' => "Qualifications:\nDoes not meet minimum GCSE requirements.\n\nOther:\nWearing clown shoes to the interview was odd.",
+      )
+      expect(application_choice.reload.structured_rejection_reasons).to eq(
+        'selected_reasons' => [
+          {
+            'id' => 'qualifications',
+            'label' => 'Qualifications',
+            'details' => {
+              'id' => 'qualifications_details',
+              'text' => 'Does not meet minimum GCSE requirements.',
+            },
+          },
+          {
+            'id' => 'other',
+            'label' => 'Other',
+            'details' => {
+              'id' => 'other_details',
+              'text' => 'Wearing clown shoes to the interview was odd.',
+            },
+          },
+        ],
+      )
+      expect(application_choice.reload.rejected_at).to be_present
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
## Context

We are defining a new endpoint to allow vendors to reject applications with predefined reasons which can be specified in the request payload by code.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Adds the endpoint `POST /api/v1.2/applications/{application_id}/reject-by-codes`
- Translates codes from the request payload into rejection reasons.
- Allows vendors to provide more detailed explanations along with the reasons codes.
- Provides default explanations where no further details are provided with the reasons codes.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/X1Y1EYF5/464-create-v12-endpoint-for-r4r-over-api
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
