### PR TITLE
Add reference-data GET endpoint for rejection reason codes

### DIFF
--- a/app/controllers/vendor_api/reference_data_controller.rb
+++ b/app/controllers/vendor_api/reference_data_controller.rb
@@ -17,5 +17,9 @@ module VendorAPI
     def a_and_as_level_grades
       render json: { data: A_LEVEL_GRADES | AS_LEVEL_GRADES }
     end
+
+    def rejection_reason_codes
+      render json: { data: VendorAPI::RejectionReasons.reference_data }
+    end
   end
 end

--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -39,6 +39,7 @@ module VendorAPI
     ],
     '1.2pre' => [
       Changes::RejectByCodes,
+      Changes::RejectionReasonCodes,
     ],
   }.freeze
 end

--- a/app/lib/vendor_api/changes/rejection_reason_codes.rb
+++ b/app/lib/vendor_api/changes/rejection_reason_codes.rb
@@ -1,0 +1,9 @@
+module VendorAPI
+  module Changes
+    class RejectionReasonCodes < VersionChange
+      description 'An array of objects denoting possible rejection reason codes, their corresponding rejection category and default details text.'
+
+      action ReferenceDataController, :rejection_reason_codes
+    end
+  end
+end

--- a/app/models/vendor_api/rejection_reasons.rb
+++ b/app/models/vendor_api/rejection_reasons.rb
@@ -17,6 +17,10 @@ module VendorAPI
         reason
       end
     end
+
+    def self.reference_data
+      CODES.map { |code, hash| { code: code, label: hash[:label], default_details: hash.dig(:details, :text) } }
+    end
   end
 
   class RejectionReasonCodeNotFound < StandardError; end

--- a/config/rejection_reason_codes.yml
+++ b/config/rejection_reason_codes.yml
@@ -13,7 +13,7 @@ R02:
   :details:
     :id: personal_statement_details
     :label: Details
-    :text: You personal statement did not meet our standards.
+    :text: Your personal statement did not meet our standards.
 R03:
   :id: teaching_knowledge
   :label: Teaching knowledge and ability

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -690,6 +690,7 @@ Rails.application.routes.draw do
     get '/reference-data/gcse-grades' => 'reference_data#gcse_grades'
     get '/reference-data/a-and-as-level-subjects' => 'reference_data#a_and_as_level_subjects'
     get '/reference-data/a-and-as-level-grades' => 'reference_data#a_and_as_level_grades'
+    get '/reference-data/rejection-reason-codes' => 'reference_data#rejection_reason_codes'
 
     post '/experimental/test-data/generate' => 'test_data#experimental_endpoint_moved'
     post '/experimental/test-data/clear' => 'test_data#experimental_endpoint_moved'

--- a/spec/models/vendor_api/rejection_reasons_spec.rb
+++ b/spec/models/vendor_api/rejection_reasons_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe VendorAPI::RejectionReasons do
     end
   end
 
-  describe 'new' do
+  describe 'initialize' do
     it 'populates selected reasons from codes' do
       instance = described_class.new([
         { code: 'R01', details: 'No relevant qualifications' },
@@ -36,6 +36,16 @@ RSpec.describe VendorAPI::RejectionReasons do
       expect(instance.selected_reasons.last).to be_a(::RejectionReasons::Reason)
       expect(instance.selected_reasons.last.label).to eq('Other')
       expect(instance.selected_reasons.last.details.text).to eq('Some other stuff')
+    end
+  end
+
+  describe '.reference_data' do
+    it 'returns an array of reference-data hashes for rejection reasons' do
+      expect(described_class.reference_data.map { |d| d[:code] }).to eq(described_class::CODES.keys)
+      expect(described_class.reference_data.map { |d| d[:label] }).to eq(described_class::CODES.values.map { |h| h[:label] })
+      expect(described_class.reference_data.map { |d| d[:default_details] }).to eq(
+        described_class::CODES.values.map { |h| h.dig(:details, :text) },
+      )
     end
   end
 end

--- a/spec/requests/vendor_api/v1.2/get_rejection_reason_codes_reference_data_spec.rb
+++ b/spec/requests/vendor_api/v1.2/get_rejection_reason_codes_reference_data_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe 'Vendor API - GET /api/v1.2/reference-data/rejection-reason-codes', type: :request do
+  include VendorAPISpecHelpers
+
+  before do
+    get_api_request '/api/v1.2/reference-data/rejection-reason-codes'
+  end
+
+  it 'returns a response that is valid according to the OpenAPI schema' do
+    expect(parsed_response).to be_valid_against_draft_openapi_schema('ObjectListResponse')
+  end
+
+  it 'lists all rejection reason codes' do
+    expect(parsed_response['data'].map { |hash| hash['code'] }).to eq(VendorAPI::RejectionReasons::CODES.keys)
+  end
+
+  it 'lists all rejection reason labels' do
+    expect(parsed_response['data'].map { |hash| hash['label'] }).to eq(VendorAPI::RejectionReasons::CODES.values.map { |v| v[:label] })
+  end
+
+  it 'lists all rejection reason default details text' do
+    expect(parsed_response['data'].map { |hash| hash['default_details'] }).to eq(
+      VendorAPI::RejectionReasons::CODES.values.map { |v| v.dig(:details, :text) },
+    )
+  end
+end


### PR DESCRIPTION
## Context

Vendors should have reference data detailing rejection reason codes and categories.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds the endpoint `GET /api/v1.2/reference-data/rejection-reason-codes`

![image](https://user-images.githubusercontent.com/93511/182829169-4a92916e-cebe-4b2b-a112-5ee85c8b1527.png)


<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/RUnVmwHj/468-add-reference-data-get-endpoint-for-r4r-codes
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
