### PR TITLE
Handle API rejections in relevant components

### DIFF
--- a/app/components/provider_interface/application_rejection_feedback_component.html.erb
+++ b/app/components/provider_interface/application_rejection_feedback_component.html.erb
@@ -7,7 +7,7 @@
       The following feedback was sent to the candidate.
     <% end -%>
   </p>
-  <% if application_choice.rejection_reasons_type == 'rejection_reasons' %>
+  <% if application_choice.rejection_reasons_type =~ /rejection_reasons$/ %>
     <%= render RejectionsComponent.new(application_choice: application_choice) %>
   <% else %>
     <%= govuk_inset_text do %>

--- a/app/components/shared/rejections_component.rb
+++ b/app/components/shared/rejections_component.rb
@@ -13,7 +13,7 @@ class RejectionsComponent < ViewComponent::Base
 
   def component_for_rejection_reasons_type
     case @application_choice.rejection_reasons_type
-    when 'rejection_reasons'
+    when 'rejection_reasons', 'vendor_api_rejection_reasons'
       rejection_reasons_component.new(structured_rejection_reasons_attrs)
     when 'reasons_for_rejection'
       RejectionReasons::ReasonsForRejectionComponent.new(structured_rejection_reasons_attrs)

--- a/app/models/candidate_interface/rejection_reasons_history.rb
+++ b/app/models/candidate_interface/rejection_reasons_history.rb
@@ -3,6 +3,12 @@ module CandidateInterface
     class UnsupportedSectionError < StandardError; end
     HistoryItem = Struct.new(:provider_name, :section, :feedback, :feedback_type)
 
+    FEEDBACK_REJECTION_REASONS_TYPES = %w[
+      reasons_for_rejection
+      rejection_reasons
+      vendor_api_rejection_reasons
+    ].freeze
+
     def self.all_previous_applications(application_form, section)
       new(application_form, section).all_previous_applications
     end
@@ -65,7 +71,7 @@ module CandidateInterface
     end
 
     def feedback_for_choice(choice)
-      return unless %w[rejection_reasons reasons_for_rejection].include?(choice.rejection_reasons_type)
+      return unless FEEDBACK_REJECTION_REASONS_TYPES.include?(choice.rejection_reasons_type)
 
       send(:"feedback_for_#{choice.rejection_reasons_type}", choice)
     end
@@ -77,6 +83,13 @@ module CandidateInterface
 
     def feedback_for_rejection_reasons(choice)
       send(:"feedback_for_#{section}", ::RejectionReasons.new(choice.structured_rejection_reasons))
+    end
+
+    def feedback_for_vendor_api_rejection_reasons(choice)
+      if section == :becoming_a_teacher
+        reasons = ::RejectionReasons.new(choice.structured_rejection_reasons)
+        [reasons.find('personal_statement')].compact
+      end
     end
 
     def feedback_for_becoming_a_teacher(rejection_reasons)

--- a/spec/components/shared/rejections_component_spec.rb
+++ b/spec/components/shared/rejections_component_spec.rb
@@ -73,4 +73,30 @@ RSpec.describe RejectionsComponent do
       expect(result.css('.govuk-link')[0].text).to eq('Find postgraduate teacher training courses')
     end
   end
+
+  describe "when the rejection reason type is 'vendor_api_rejection_reasons'" do
+    let(:application_choice) { build_stubbed(:application_choice, :with_vendor_api_rejection_reasons) }
+
+    it 'renders using RejectionReasonsComponent' do
+      result = render_inline(described_class.new(application_choice: application_choice))
+      expect(result.text).to include('Qualifications')
+      expect(result.text).to include('We could find no record of your GCSEs.')
+      expect(result.text).to include('Personal statement')
+      expect(result.text).to include('We do not accept applications written in Old Norse.')
+      expect(result.text).to include('References')
+      expect(result.text).to include('We do not accept references from close family members, such as your mum.')
+    end
+
+    it 'renders a link to find when rejected on qualifications' do
+      provider = build_stubbed(:provider)
+      course = build_stubbed(:course)
+      allow(application_choice).to receive(:provider).and_return(provider)
+      allow(application_choice).to receive(:course).and_return(course)
+
+      result = render_inline(described_class.new(application_choice: application_choice, render_link_to_find_when_rejected_on_qualifications: true))
+      expect(result.text).to include('View the course requirements on')
+      expect(result.css('.govuk-link')[0][:href]).to eq("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{provider.code}/#{course.code}#section-entry")
+      expect(result.css('.govuk-link')[0].text).to eq('Find postgraduate teacher training courses')
+    end
+  end
 end

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -227,6 +227,48 @@ FactoryBot.define do
       end
     end
 
+    trait :with_vendor_api_rejection_reasons do
+      with_rejection_by_default
+      structured_rejection_reasons do
+        {
+          selected_reasons: [
+            {
+              id: 'qualifications',
+              label: 'Qualifications',
+              details: {
+                id: 'qualifications_details', text: 'We could find no record of your GCSEs.'
+              },
+            },
+            {
+              id: 'personal_statement',
+              label: 'Personal statement',
+              details: {
+                id: 'personal_statement_details', text: 'We do not accept applications written in Old Norse.'
+              },
+            },
+            {
+              id: 'references',
+              label: 'References',
+              details: {
+                id: 'references_details',
+                text: 'We do not accept references from close family members, such as your mum.',
+              },
+            },
+          ],
+        }
+      end
+      rejection_reasons_type { 'vendor_api_rejection_reasons' }
+      reject_by_default_feedback_sent_at { Time.zone.now }
+
+      after(:create) do |_choice, evaluator|
+        create(
+          :application_choice_audit,
+          :with_rejection_by_default,
+          application_choice: evaluator,
+        )
+      end
+    end
+
     trait :application_not_sent do
       status { 'application_not_sent' }
       rejected_at { Time.zone.now }


### PR DESCRIPTION
## Context

Rejections from the Vendor API use a similar data structure to the current Manage rejection reasons, so we should be able to reuse the relevant components.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

![image](https://user-images.githubusercontent.com/93511/182846041-76eea003-4d0c-414f-a8d1-19f56e26f4e7.png)

- Allows existing components to render rejection reasons provided via the Vendor API. 
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

https://trello.com/c/Eus4YNBf/470-update-presenters-to-handle-vendor-api-r4r
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
