### PR TITLE
Update email content when trying to sign in without an account

### DIFF
--- a/app/views/authentication_mailer/sign_in_without_account_email.text.erb
+++ b/app/views/authentication_mailer/sign_in_without_account_email.text.erb
@@ -1,5 +1,9 @@
-You tried to sign in to apply for teacher training. It looks like you do not have an account yet.
+You tried to sign in to apply for teacher training but you do not have an account with this email address.
 
-Create an account:
+If you started applying for teacher training using a different email address, sign in using that instead:
+
+<%= candidate_interface_create_account_or_sign_in_url %>
+
+If you have not previously started your application, get started by creating an account:
 
 <%= candidate_interface_sign_up_url %>

--- a/app/views/authentication_mailer/sign_in_without_account_email.text.erb
+++ b/app/views/authentication_mailer/sign_in_without_account_email.text.erb
@@ -1,9 +1,9 @@
-You tried to sign in to apply for teacher training but you do not have an account with this email address.
+You tried to sign in to apply for teacher training but there is no account with this email address.
 
-If you started applying for teacher training using a different email address, sign in using that instead:
+If you’ve started an application using a different email address, sign in using that address instead:
 
 <%= candidate_interface_create_account_or_sign_in_url %>
 
-If you have not previously started your application, get started by creating an account:
+If you have not started an application, you need to create an account:
 
 <%= candidate_interface_sign_up_url %>

--- a/config/locales/candidate_interface/authentication.yml
+++ b/config/locales/candidate_interface/authentication.yml
@@ -16,7 +16,7 @@ en:
         label: Email address
     sign_in_without_account:
       email:
-        subject: Sign up to apply for teacher training
+        subject: Check the email address you’re using to apply for teacher training
     expired_token:
       heading: The link you clicked has expired
       button: Email me a new link

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_without_account_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_without_account_spec.rb
@@ -8,8 +8,11 @@ RSpec.feature 'Candidate tries to sign in without an account' do
     and_i_submit_my_email_address
     then_i_receive_an_email_inviting_me_to_sign_up
 
-    when_i_click_on_the_link_in_my_email
-    then_i_am_taken_to_the_sign_up_page
+    when_i_click_on_the_first_link_in_my_email
+    then_i_am_taken_to_the_create_account_or_sign_in_page
+
+    when_i_click_on_the_second_link_in_my_email
+    then_i_am_taken_to_the_create_an_account_page
   end
 
   def given_i_am_a_candidate_without_an_account
@@ -30,11 +33,19 @@ RSpec.feature 'Candidate tries to sign in without an account' do
     expect(current_email.subject).to have_content t('authentication.sign_in_without_account.email.subject')
   end
 
-  def when_i_click_on_the_link_in_my_email
+  def when_i_click_on_the_first_link_in_my_email
     current_email.find_css('a').first.click
   end
 
-  def then_i_am_taken_to_the_sign_up_page
-    expect(page).to have_current_path(candidate_interface_sign_up_path)
+  def when_i_click_on_the_second_link_in_my_email
+    current_email.find_css('a').second.click
+  end
+
+  def then_i_am_taken_to_the_create_account_or_sign_in_page
+    expect(page).to have_selector('h1', text: 'Create an account or sign in')
+  end
+
+  def then_i_am_taken_to_the_create_an_account_page
+    expect(page).to have_selector('h1', text: 'Create an account')
   end
 end


### PR DESCRIPTION
We suspect that some users are accidentally creating a duplicate account by trying to sign in with a different email address from the one they used previously. This may lead to both their accounts becoming temporarily blocked when our code detects the duplicate accounts.

This change to the email content tries to help resolve this by prompting users to sign in with their other email address if they believe they've already started their application.

If they hadn't yet started an application (but perhaps thought they already had "a government account") then they are prompted to create an account instead.

Ideally we’d track these link clicks to see whether a significant number of users use the first link or not. (If not, then we could revert back to something similar to our current email content).

https://trello.com/c/9Q2n28wW/500-update-the-content-of-the-email-when-someone-tries-to-sign-in-with-an-email-that-doesnt-have-an-account

## Screenshots

### Before

> Subject line: Sign up to apply for teacher training

<img width="591" alt="Screenshot 2022-08-11 at 09 07 38" src="https://user-images.githubusercontent.com/30665/184090624-5209d443-90ac-4f4e-bc2a-0880f9c0dac4.png">

### After

> Subject line: Check the email address you’re using to apply for teacher training

<img width="576" alt="Screenshot 2022-08-11 at 09 07 29" src="https://user-images.githubusercontent.com/30665/184090643-302e6964-68b3-4886-8507-7eccdcaf1718.png">


