### PR TITLE
Use current course (option) where applicable

### DIFF
--- a/app/components/candidate_interface/application_dashboard_course_choices_component.rb
+++ b/app/components/candidate_interface/application_dashboard_course_choices_component.rb
@@ -53,7 +53,7 @@ module CandidateInterface
     def course_change_path(application_choice)
       if multiple_courses?(application_choice)
         candidate_interface_course_choices_course_path(
-          application_choice.provider.id,
+          application_choice.current_course.provider.id,
           course_choice_id: application_choice.id,
         )
       end
@@ -63,7 +63,7 @@ module CandidateInterface
       if multiple_sites?(application_choice)
         candidate_interface_course_choices_site_path(
           application_choice.provider.id,
-          application_choice.course.id,
+          application_choice.current_course.id,
           application_choice.current_course_option.study_mode,
           course_choice_id: application_choice.id,
         )
@@ -186,7 +186,7 @@ module CandidateInterface
     end
 
     def multiple_sites?(application_choice)
-      CourseOption.where(course_id: application_choice.course.id, study_mode: application_choice.current_course_option.study_mode).many?
+      CourseOption.where(course_id: application_choice.current_course.id, study_mode: application_choice.current_course_option.study_mode).many?
     end
 
     def multiple_courses?(application_choice)

--- a/app/components/candidate_interface/application_dashboard_course_choices_component.rb
+++ b/app/components/candidate_interface/application_dashboard_course_choices_component.rb
@@ -59,17 +59,6 @@ module CandidateInterface
       end
     end
 
-    def site_change_path(application_choice)
-      if multiple_sites?(application_choice)
-        candidate_interface_course_choices_site_path(
-          application_choice.provider.id,
-          application_choice.current_course.id,
-          application_choice.current_course_option.study_mode,
-          course_choice_id: application_choice.id,
-        )
-      end
-    end
-
     def container_class(application_choice)
       return unless @editable
 
@@ -183,10 +172,6 @@ module CandidateInterface
           ),
         ),
       }
-    end
-
-    def multiple_sites?(application_choice)
-      CourseOption.where(course_id: application_choice.current_course.id, study_mode: application_choice.current_course_option.study_mode).many?
     end
 
     def multiple_courses?(application_choice)

--- a/app/components/candidate_interface/application_status_tag_component.html.erb
+++ b/app/components/candidate_interface/application_status_tag_component.html.erb
@@ -14,11 +14,11 @@
   </p>
 <% elsif  @application_choice.offer_deferred? %>
   <p class="govuk-body govuk-!-margin-top-2">
-    Your training will now start in <%= (@application_choice.course_option.course.start_date + 1.year).to_fs(:month_and_year) %>.
+    Your training will now start in <%= (@application_choice.current_course_option.course.start_date + 1.year).to_fs(:month_and_year) %>.
   </p>
 <% elsif @application_choice.pending_conditions? || @application_choice.recruited? || @application_choice.offer? %>
     <%= govuk_details(
-      summary_text: "What to do if you’re unable to start training in #{@application_choice.course_option.course.start_date.to_fs(:month_and_year)}",
+      summary_text: "What to do if you’re unable to start training in #{@application_choice.current_course_option.course.start_date.to_fs(:month_and_year)}",
       classes: 'govuk-!-margin-bottom-0 govuk-!-margin-top-2',
     ) do %>
       <p>
@@ -27,7 +27,7 @@
 
       <p>
         Every provider is different, so it may or may not be possible to do this.
-        Find out by contacting <%= @application_choice.course_option.course.provider.name %>.
+        Find out by contacting <%= @application_choice.current_course_option.course.provider.name %>.
       </p>
 
       <p>

--- a/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
+++ b/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
@@ -33,20 +33,6 @@ RSpec.describe CandidateInterface::ApplicationDashboardCourseChoicesComponent, t
     end
   end
 
-  context 'when there are multiple site options for course' do
-    let(:application_form) { create_application_form_with_course_choices(statuses: %w[unsubmitted]) }
-
-    before do
-      create(:course_option, course: application_form.application_choices.first.course)
-    end
-
-    it 'renders without a "Change" location links' do
-      result = render_inline(described_class.new(application_form: application_form, editable: false))
-
-      expect(result.css('.govuk-summary-list__actions').text).not_to include('Change')
-    end
-  end
-
   context 'When a course has both study modes available' do
     let(:application_form) { create_application_form_with_course_choices(statuses: %w[unsubmitted]) }
     let(:application_choice) { application_form.application_choices.first }

--- a/spec/components/candidate_interface/application_status_tag_component_spec.rb
+++ b/spec/components/candidate_interface/application_status_tag_component_spec.rb
@@ -59,11 +59,12 @@ RSpec.describe CandidateInterface::ApplicationStatusTagComponent do
     end
 
     context 'when the application choice is in the offer_deferred state' do
-      it 'tells the candidate when their course will start' do
-        application_choice = create(:application_choice, :offer_deferred, course: course)
+      it 'tells the candidate when their current course will start' do
+        current_course = create(:course, start_date: Date.parse('2022-09-01'))
+        application_choice = create(:application_choice, :offer_deferred, course: course, current_course: current_course)
         result = render_inline(described_class.new(application_choice: application_choice))
 
-        expect(result.text).to include("Your training will now start in #{(application_choice.course.start_date + 1.year).to_fs(:month_and_year)}.")
+        expect(result.text).to include('Your training will now start in September 2023.')
       end
 
       context 'when the application choice is in the pending_conditions state' do


### PR DESCRIPTION
## Context

https://trello.com/c/ENtS21wb/1596-wrong-deferral-date-on-application

This comes from support. Part of the Applications dashboard does not contain accurate date information about deferrals.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Use `current_course` and `current_course_option` ftw
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/uRmheeFs/454-show-the-right-course-info-when-candidates-have-a-different-offered-course-that-they-applied-for-in-deferral-offer-recruited-sta
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
