### PR TITLE
455 bug on other qualification end date

### DIFF
--- a/app/forms/candidate_interface/other_qualification_details_form.rb
+++ b/app/forms/candidate_interface/other_qualification_details_form.rb
@@ -13,8 +13,7 @@ module CandidateInterface
 
     validates :qualification_type, presence: true
 
-    validates :award_year, presence: true, numericality: { only_integer: true }
-    validate :award_year_is_within_acceptable_range, if: -> { award_year }
+    validates :award_year, presence: true, numericality: { only_integer: true, in: 100.years.ago.year..RecruitmentCycle.next_year }
     validates :subject, :grade, presence: true, if: -> { should_validate_grade? }
     validates :subject, :grade, length: { maximum: 255 }
     validates :other_uk_qualification_type, length: { maximum: 100 }
@@ -196,12 +195,6 @@ module CandidateInterface
       qualification_type.in? [OtherQualificationTypeForm::A_LEVEL_TYPE,
                               OtherQualificationTypeForm::AS_LEVEL_TYPE,
                               OtherQualificationTypeForm::GCSE_TYPE]
-    end
-
-    def award_year_is_within_acceptable_range
-      return if award_year.to_i.zero? && award_year != '0'
-
-      errors.add(:award_year, :future) unless (100.years.ago.year..RecruitmentCycle.next_year).cover?(award_year.to_i)
     end
   end
 end

--- a/app/forms/candidate_interface/other_qualification_details_form.rb
+++ b/app/forms/candidate_interface/other_qualification_details_form.rb
@@ -199,6 +199,8 @@ module CandidateInterface
     end
 
     def award_year_is_within_acceptable_range
+      return if award_year.to_i.zero? && award_year != '0'
+
       errors.add(:award_year, :future) unless (100.years.ago.year..RecruitmentCycle.next_year).cover?(award_year.to_i)
     end
   end

--- a/app/forms/candidate_interface/other_qualification_details_form.rb
+++ b/app/forms/candidate_interface/other_qualification_details_form.rb
@@ -13,7 +13,7 @@ module CandidateInterface
 
     validates :qualification_type, presence: true
 
-    validates :award_year, presence: true
+    validates :award_year, presence: true, numericality: { only_integer: true }
     validate :award_year_is_within_acceptable_range, if: -> { award_year }
     validates :subject, :grade, presence: true, if: -> { should_validate_grade? }
     validates :subject, :grade, length: { maximum: 255 }

--- a/app/views/candidate_interface/other_qualifications/details/_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/_form.html.erb
@@ -2,7 +2,7 @@
     <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.optional_label'), size: 'm' } %>
     <%= f.govuk_collection_select :institution_country, select_country_options, :id, :name, label: { text: t('application_form.other_qualification.institution_country.label'), size: 'm' } %>
     <%= f.govuk_text_field :grade, label: { text: t('application_form.other_qualification.grade.optional_label'), size: 'm' }, width: 10 %>
-    <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint: { text: t('application_form.other_qualification.award_year.hint_text') }, type: :number, width: 4 %>
+    <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint: { text: t('application_form.other_qualification.award_year.hint_text') }, inputmode: 'numeric', width: 4 %>
   <% elsif @form.btec? %>
     <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label'), size: 'm' } %>
     <%= tag.div(id: 'subject-autosuggest-data', data: { source: subjects }) if subjects %>
@@ -20,5 +20,5 @@
                            width: ['A level', 'AS level', 'GCSE'].include?(@form.qualification_type) ? 4 : 10,
                            hint: @form.grade_hint %>
     <%= tag.div(id: 'grade-autosuggest-data', data: { source: grades }) if grades %>
-    <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint: { text: t('application_form.other_qualification.award_year.hint_text') }, type: :number, width: 4 %>
+    <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint: { text: t('application_form.other_qualification.award_year.hint_text') }, inputmode: 'numeric', width: 4 %>
   <% end %>

--- a/config/locales/candidate_interface/other_qualification.yml
+++ b/config/locales/candidate_interface/other_qualification.yml
@@ -75,5 +75,7 @@ en:
             award_year:
               blank: Enter the year the qualification was awarded
               future: Year qualification awarded must be this year, next year or a previous year
+              not_an_integer: Year qualification awarded must be a real year
+              not_a_number: Year qualification awarded must be a real year
             choice:
               blank: Do you want to add another qualification?

--- a/config/locales/candidate_interface/other_qualification.yml
+++ b/config/locales/candidate_interface/other_qualification.yml
@@ -74,7 +74,7 @@ en:
               too_long: The grade must be %{count} characters or fewer
             award_year:
               blank: Enter the year the qualification was awarded
-              future: Year qualification awarded must be this year, next year or a previous year
+              in: Year qualification awarded must be this year, next year or a previous year
               not_an_integer: Year qualification awarded must be a real year
               not_a_number: Year qualification awarded must be a real year
             choice:

--- a/spec/forms/candidate_interface/other_qualification_details_form_spec.rb
+++ b/spec/forms/candidate_interface/other_qualification_details_form_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
 
           invalid_award_year.valid?(:details)
 
-          expect(invalid_award_year.errors.full_messages_for(:award_year)).to eq(['Award year Year qualification awarded must be a real year', 'Award year Year qualification awarded must be this year, next year or a previous year'])
+          expect(invalid_award_year.errors.full_messages_for(:award_year)).to eq(['Award year Year qualification awarded must be a real year'])
         end
       end
     end

--- a/spec/forms/candidate_interface/other_qualification_details_form_spec.rb
+++ b/spec/forms/candidate_interface/other_qualification_details_form_spec.rb
@@ -123,6 +123,22 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
 
           expect(invalid_award_year.errors.full_messages_for(:award_year)).not_to be_empty
         end
+
+        it 'is not valid if non integer is used' do
+          invalid_award_year = described_class.new(nil, nil, qualification_type: 'Other', award_year: '2022.9')
+
+          invalid_award_year.valid?(:details)
+
+          expect(invalid_award_year.errors.full_messages_for(:award_year)).to eq(['Award year Year qualification awarded must be a real year'])
+        end
+
+        it 'is not valid if letters are used' do
+          invalid_award_year = described_class.new(nil, nil, qualification_type: 'Other', award_year: 'abcde')
+
+          invalid_award_year.valid?(:details)
+
+          expect(invalid_award_year.errors.full_messages_for(:award_year)).to eq(['Award year Year qualification awarded must be a real year', 'Award year Year qualification awarded must be this year, next year or a previous year'])
+        end
       end
     end
   end


### PR DESCRIPTION
## Context

A user was able to add '2022.9' as their award year on a qualification. This should be picked up by a validation as not only is it incorrect, but it's a problem for vendor SITS. 

## Changes proposed in this pull request
* Add numerical check to validation. This will make sure only integers can pass.
* `type: :number` removed as it allows edge case where an '.' and/or 'e' input would actually send no value in the params causing it trigger the blank validation and not retain the value.

## Guidance to review
Visit `/candidate/application/other-qualifications/details` and test award year field

## Link to Trello card
https://trello.com/c/ZJCEBZo8/455-bug-on-other-qualification-end-date

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
