### PR TITLE
Add course full details text field

### DIFF
--- a/app/components/candidate_interface/rejection_reasons/rejection_reasons_component.html.erb
+++ b/app/components/candidate_interface/rejection_reasons/rejection_reasons_component.html.erb
@@ -1,7 +1,7 @@
 <% reasons.selected_reasons.each do |reason| %>
   <div class="app-rejection">
     <h3 class="govuk-heading-s"><%= reason.label %></h3>
-    <% if reason.details %>
+    <% if reason.details&.text.present? %>
       <% paragraphs(reason.details.text).each do |paragraph| %>
         <p><%= paragraph %></p>
       <% end %>

--- a/app/components/shared/rejection_reasons/rejection_reasons_component.html.erb
+++ b/app/components/shared/rejection_reasons/rejection_reasons_component.html.erb
@@ -3,7 +3,7 @@
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key"><%= reason.label %></dt>
       <dd class="govuk-summary-list__value">
-        <% if reason.details %>
+        <% if reason.details&.text.present? %>
           <% paragraphs(reason.details.text).each do |paragraph| %>
             <p><%= paragraph %></p>
           <% end %>

--- a/app/models/rejection_reasons/details.rb
+++ b/app/models/rejection_reasons/details.rb
@@ -3,8 +3,8 @@ class RejectionReasons
     include ActiveModel::Model
     WORD_COUNT = 100
 
-    attr_accessor :id, :label, :text
-    validate :text_present, :word_count
+    attr_accessor :id, :label, :text, :optional
+    validate :text_present, :word_count, unless: -> { optional }
 
     def inflate(model)
       @text = model.send(id)

--- a/app/presenters/rejection_reasons/rejection_reasons_presenter.rb
+++ b/app/presenters/rejection_reasons/rejection_reasons_presenter.rb
@@ -8,7 +8,7 @@ class RejectionReasons
       return {} unless structured_rejection_reasons&.any?
 
       reasons.each_with_object({}) do |reason, hash|
-        hash[reason.label] = if reason.details
+        hash[reason.label] = if reason.details&.text.present?
                                [reason.details.text]
                              elsif reason.selected_reasons
                                nested_reasons(reason)

--- a/config/rejection_reasons.yml
+++ b/config/rejection_reasons.yml
@@ -112,6 +112,10 @@
     :label: Details
 - :id: course_full
   :label: Course full
+  :details:
+    :id: course_full_details
+    :label: Details (optional)
+    :optional: true
 - :id: other
   :label: Other
   :details:

--- a/spec/components/shared/rejection_reasons/rejection_reasons_component_spec.rb
+++ b/spec/components/shared/rejection_reasons/rejection_reasons_component_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe RejectionReasons::RejectionReasonsComponent do
               text: 'A close family member, suchas your mother, cannot give a reference.',
             },
           },
-          { id: 'course_full', label: 'Course full' },
+          { id: 'course_full', label: 'Course full', details: { id: 'course_full_details' } },
           {
             id: 'other',
             label: 'Other',

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -941,7 +941,7 @@ private
   def vendor_api_rejection_reasons
     {
       selected_reasons: [
-        { id: 'qualifications', label: 'Qualifications', details: { id: 'qualifications_details', text: '' } },
+        { id: 'qualifications', label: 'Qualifications', details: { id: 'qualifications_details', text: 'We could not find any record of your qualifications' } },
         {
           id: 'personal_statement', label: 'Personal statement',
           details: {

--- a/spec/models/rejection_reasons/details_spec.rb
+++ b/spec/models/rejection_reasons/details_spec.rb
@@ -26,6 +26,10 @@ RSpec.describe RejectionReasons::Details do
       expect(details.valid?).to be false
       expect(details.errors.attribute_names).to eq([:aaa])
     end
+
+    it 'omits validation if details are optional' do
+      expect(described_class.new(id: 'aaa', text: '', optional: true)).to be_valid
+    end
   end
 
   describe '#as_json' do

--- a/spec/presenters/rejection_reasons/rejection_reasons_presenter_spec.rb
+++ b/spec/presenters/rejection_reasons/rejection_reasons_presenter_spec.rb
@@ -68,15 +68,24 @@ RSpec.describe RejectionReasons::RejectionReasonsPresenter do
       end
     end
 
-    describe 'reasons with no details or nested reasons' do
+    describe 'reasons with optional details and no nested reasons' do
       let(:reasons) do
-        {
-          selected_reasons: [{ id: 'course_full', label: 'Course full' }],
-        }
+        { selected_reasons: [{ id: 'course_full', label: 'Course full', details: details }] }
       end
 
-      it 'returns i18n translation keyed with the top level reason label' do
+      let(:details) { { id: 'course_full_details', text: text, optional: true } }
+      let(:text) { '' }
+
+      it 'returns i18n translation keyed with the top level reason label when text is blank' do
         expect(rejected_application_choice.rejection_reasons).to eq({ 'Course full' => ['The course is full.'] })
+      end
+
+      context 'when optional details text is present' do
+        let(:text) { 'Try another course, we provide many!' }
+
+        it 'returns details text with the top level reason label when text is present' do
+          expect(rejected_application_choice.rejection_reasons).to eq({ 'Course full' => ['Try another course, we provide many!'] })
+        end
       end
     end
   end

--- a/spec/system/provider_interface/reject_an_application_spec.rb
+++ b/spec/system/provider_interface/reject_an_application_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe 'Reject an application' do
     fill_in 'rejection-reasons-personal-statement-other-details-field', with: 'This was wayyyyy too personal'
 
     check 'rejection-reasons-selected-reasons-course-full-field'
+    fill_in 'rejection-reasons-course-full-details-field', with: 'Other courses exist'
     check 'rejection-reasons-selected-reasons-other-field'
     fill_in 'rejection-reasons-other-details-field', with: 'There are so many other reasons why your application was rejected...'
   end
@@ -106,7 +107,7 @@ RSpec.describe 'Reject an application' do
 
     expect(rows[2].text.split("\n")).to eq([
       'Course full',
-      'The course is full.',
+      'Other courses exist',
       'Change',
     ])
 
@@ -154,7 +155,7 @@ RSpec.describe 'Reject an application' do
     expect(page).to have_content('This was wayyyyy too personal')
 
     expect(page).to have_content('Course full')
-    expect(page).to have_content('The course is full')
+    expect(page).to have_content('Other courses exist')
 
     expect(page).to have_content('Other')
     expect(page).to have_content('There are so many other reasons why your application was rejected...')


### PR DESCRIPTION
## Context

We'd like to allow providers to give additional information about a course being full.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Add a course full details field.

#### Additional textarea

![image](https://user-images.githubusercontent.com/93511/184113245-cb5a14fa-f5a6-441f-9582-2218a5fe6d70.png)

#### Rejected application

![image](https://user-images.githubusercontent.com/93511/183695708-8169965b-c603-4e4c-bec1-710d487aeb74.png)


<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/Vso1SYpt/486-add-freetext-box-under-course-full-sr4r
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
