### PR TITLE
New References - Confirm apply again will handle references correctly

### DIFF
--- a/spec/system/candidate_interface/new-references/candidate_apply_again_new_references_flow_spec.rb
+++ b/spec/system/candidate_interface/new-references/candidate_apply_again_new_references_flow_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidates in the 2023 cycle, applying again with the new references flow' do
+  include CandidateHelper
+  include CycleTimetableHelper
+
+  around do |example|
+    Timecop.travel(CycleTimetable.apply_1_deadline(2023)) do
+      example.run
+    end
+  end
+
+  scenario 'Candidate applies again' do
+    given_the_new_reference_flow_feature_flag_is_on
+
+    given_i_am_signed_in
+    and_i_have_unsuccessful_application
+
+    when_i_visit_the_application_dashboard
+    and_i_click_on_apply_again
+    and_i_am_redirected_to_the_new_application_form
+    and_i_am_told_my_new_application_is_ready_to_review
+    then_i_should_see_the_new_references_section
+
+    when_i_click_on_the_references_section
+    then_i_see_the_new_states_of_my_references
+  end
+
+  def given_i_am_signed_in
+    @candidate = create(:candidate)
+    login_as(@candidate)
+  end
+
+  def given_the_new_reference_flow_feature_flag_is_on
+    FeatureFlag.activate(:new_references_flow)
+  end
+
+  def and_i_have_unsuccessful_application
+    @application_form = create(:application_form, submitted_at: 2.days.ago, candidate: @candidate, application_references: [])
+    create(:application_choice, status: :rejected, application_form: @application_form)
+
+    @pending_reference = create(:reference, :feedback_requested, application_form: @application_form)
+    @declined_reference = create(:reference, :feedback_refused, name: 'Mr declined', application_form: @application_form)
+    @cancelled_reference = create(:reference, :cancelled, name: 'Mr cancelled', application_form: @application_form)
+    @not_sent_reference = create(:reference, :not_requested_yet, application_form: @application_form)
+    @selected_reference = create(:selected_reference, application_form: @application_form)
+  end
+
+  def when_i_visit_the_application_dashboard
+    visit candidate_interface_application_complete_path
+  end
+
+  def and_i_click_on_apply_again
+    click_on 'Apply again'
+  end
+
+  def and_i_am_redirected_to_the_new_application_form
+    expect(page).to have_current_path candidate_interface_application_form_path
+  end
+
+  def and_i_am_told_my_new_application_is_ready_to_review
+    expect(page).to have_content('We’ve copied your application. Please review all sections.')
+  end
+
+  def then_i_should_see_the_new_references_section
+    expect(page).to have_content 'References Incomplete'
+  end
+
+  def when_i_click_on_the_references_section
+    click_on 'References'
+  end
+
+  def new_application_form
+    ApplicationForm.find_by(previous_application_form_id: @application_form.id)
+  end
+
+  def then_i_see_the_new_states_of_my_references
+    expect(new_application_form.application_references.map(&:name)).not_to include(%w[Mr cancelled Mr declined])
+    expect(new_application_form.application_references.count).to eq 3
+    expect(new_application_form.application_references.first.feedback_status).to eq 'not_requested_yet'
+    expect(new_application_form.application_references.second.feedback_status).to eq 'not_requested_yet'
+    expect(new_application_form.application_references.third.feedback_status).to eq 'feedback_provided'
+    expect(page).to have_current_path(candidate_interface_new_references_review_path)
+    expect(page.text).to include @pending_reference.name
+    expect(page.text).to include @not_sent_reference.name
+    expect(page.text).to include "#{@selected_reference.name} will not be asked to give you another reference"
+  end
+
+  def and_i_sign_in_again
+    logout
+
+    login_as(@candidate)
+  end
+end


### PR DESCRIPTION
## Context

On the new references flow we need to confirm that we handle references correctly, when a candidate applies again:

|Pre AA status|Post AA status|
|---|---|
|Declined|Deleted|
|Cancelled|Deleted|
|Awaiting response|Not sent|
|Received|Received|
|Selected|Not a state on our new flow – will be 'Received'|

## Changes proposed in this pull request

Written a spec for this scenario – it is passing so it appears as if our current implementation is ok.

## Guidance to review

This could be tested manually:

1. Activate the new references flow (feature flag on + 2023 cycle year)
2. Grab an unsuccessful candidate with a mix of reference states
3. Apply again
4. Check the state of references have been transitioned and/or removed where applicable

## Link to Trello card

https://trello.com/c/BVhpR5yb/426-references-handling-references-at-apply-again

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
