### PR TITLE
Respond with 422 when reject-by-codes payload data is blank/empty

### DIFF
--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -65,6 +65,8 @@ module VendorAPI
   private
 
     def rejection_reasons
+      raise ValidationException, ['Please provide one or more valid rejection codes.'] if params[:data].blank?
+
       VendorAPI::RejectionReasons.new(params[:data])
     rescue RejectionReasonCodeNotFound
       raise ValidationException, ['Please provide valid rejection codes.']

--- a/spec/requests/vendor_api/v1.2/post_reject_by_codes_spec.rb
+++ b/spec/requests/vendor_api/v1.2/post_reject_by_codes_spec.rb
@@ -109,6 +109,24 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject-by-codes'
     end
   end
 
+  describe 'with no codes in payload data' do
+    let(:application_choice) do
+      create_application_choice_for_currently_authenticated_provider(
+        status: 'awaiting_provider_decision',
+      )
+    end
+
+    it 'responds with 422' do
+      request_body = { data: [] }
+
+      post_api_request "/api/v1.2/applications/#{application_choice.id}/reject-by-codes", params: request_body
+
+      expect(response).to have_http_status(:unprocessable_entity)
+
+      expect(parsed_response).to contain_schema_with_error('UnprocessableEntityResponse', 'Please provide one or more valid rejection codes.')
+    end
+  end
+
   it 'returns an error when trying to transition to an invalid state' do
     application_choice = create_application_choice_for_currently_authenticated_provider(status: 'rejected')
     request_body = { data: [{ code: 'R01' }] }


### PR DESCRIPTION
## Context

@JonF1 kindly tested the v1.2 rejection codes API endpoint and this additional error scenario came out of the discussion.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Respond with 422 when reject-by-codes payload data is blank or an empty array.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
