### PR TITLE
459 support site dont allow changing course from a fee paying to a salaried course

### DIFF
--- a/app/controllers/support_interface/application_forms/application_choices/change_offered_course_controller.rb
+++ b/app/controllers/support_interface/application_forms/application_choices/change_offered_course_controller.rb
@@ -57,10 +57,15 @@ module SupportInterface
         def update_offered_course_option
           @update_offered_course_option_form = UpdateOfferedCourseOptionForm.new(confirm_offered_course_option_params)
 
-          if @update_offered_course_option_form.save(@application_choice)
-            flash[:success] = 'Offered course choice updated successfully'
-            redirect_to support_interface_application_form_path(@application_form.id)
-          else
+          begin
+            if @update_offered_course_option_form.save(@application_choice)
+              flash[:success] = 'Offered course choice updated successfully'
+              redirect_to support_interface_application_form_path(@application_form.id)
+            else
+              render :confirm_offered_course_option
+            end
+          rescue FundingTypeError => e
+            flash[:warning] = e.message
             render :confirm_offered_course_option
           end
         end

--- a/app/controllers/support_interface/application_forms/courses_controller.rb
+++ b/app/controllers/support_interface/application_forms/courses_controller.rb
@@ -59,7 +59,7 @@ module SupportInterface
           else
             render :edit
           end
-        rescue CourseChoiceError, ProviderInterviewError => e
+        rescue CourseChoiceError, ProviderInterviewError, FundingTypeError => e
           flash[:warning] = e.message
           render :edit
         end

--- a/app/errors/funding_type_error.rb
+++ b/app/errors/funding_type_error.rb
@@ -1,0 +1,1 @@
+class FundingTypeError < StandardError; end

--- a/app/forms/support_interface/application_forms/update_offered_course_option_form.rb
+++ b/app/forms/support_interface/application_forms/update_offered_course_option_form.rb
@@ -13,11 +13,24 @@ module SupportInterface
 
         return false unless valid?
 
+        check_course_funding_type!(application_choice)
+
         application_choice.update_course_option_and_associated_fields!(course_option, audit_comment: audit_comment)
       end
 
       def course_option
         @_course_option ||= CourseOption.find(course_option_id)
+      end
+
+    private
+
+      def check_course_funding_type!(application_choice)
+        current_course = application_choice.course
+        new_course = course_option.course
+
+        return unless current_course.fee_paying? && new_course.salaried_or_apprenticeship?
+
+        raise FundingTypeError, I18n.t('errors.messages.funding_type_error', course: 'an offered course')
       end
     end
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -123,6 +123,14 @@ class Course < ApplicationRecord
     !exposed_in_find
   end
 
+  def fee_paying?
+    funding_type == 'fee'
+  end
+
+  def salaried_or_apprenticeship?
+    funding_type == 'salary' || funding_type == 'apprenticeship'
+  end
+
   def find_url
     url = if HostingEnvironment.sandbox_mode?
             I18n.t('find_postgraduate_teacher_training.sandbox_url')

--- a/app/services/support_interface/change_application_choice_course_option.rb
+++ b/app/services/support_interface/change_application_choice_course_option.rb
@@ -21,6 +21,7 @@ module SupportInterface
     def call
       check_application_state!
       check_interviewing_providers!
+      check_course_funding_type!
 
       application_choice.update_course_option_and_associated_fields!(course_option,
                                                                      other_fields: { course_option: course_option },
@@ -39,6 +40,15 @@ module SupportInterface
       return if !application_choice.interviewing? || (application_choice.interviewing? && application_choice.provider_ids.include?(provider_id))
 
       raise ProviderInterviewError, 'Changing a course choice when the provider is not on the interview is not allowed'
+    end
+
+    def check_course_funding_type!
+      current_course = application_choice.course
+      new_course = course_option.course
+
+      return unless current_course.fee_paying? && new_course.salaried_or_apprenticeship?
+
+      raise FundingTypeError, I18n.t('errors.messages.funding_type_error', course: 'a course choice')
     end
 
     def course_option

--- a/config/locales/candidate_interface/courses.yml
+++ b/config/locales/candidate_interface/courses.yml
@@ -43,3 +43,6 @@ en:
           attributes:
             add_another_course:
               blank: Select if you want to add another course
+  errors:
+    messages:
+      funding_type_error: Changing %{course} from fee paying to salaried or an apprenticeship is not allowed. Please raise a dev support ticket.

--- a/spec/forms/support_interface/application_forms/change_course_choice_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/change_course_choice_form_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe SupportInterface::ApplicationForms::ChangeCourseChoiceForm, type:
     context 'if the new course is already an existing choice' do
       it 'raises a CourseChoiceError error' do
         first_course_option = create(:course_option)
-        second_course_option = create(:course_option)
+        second_course_option = create(:course_option, course: create(:course, funding_type: 'fee'))
         application_form = create(:application_form)
         application_choice_to_change = create(:application_choice, :awaiting_provider_decision, course_option: first_course_option, application_form: application_form)
         create(:application_choice, :awaiting_provider_decision, course_option: second_course_option, application_form: application_form)

--- a/spec/services/support_interface/change_application_choice_course_option_spec.rb
+++ b/spec/services/support_interface/change_application_choice_course_option_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe SupportInterface::ChangeApplicationChoiceCourseOption do
                               study_mode: course_option.course.study_mode,
                               site_code: course_option.site.code,
                               audit_comment: audit_comment).call
-        }.to raise_error(FundingTypeError, 'Changing a course choice from fee paying to salaried is not allowed. Please raise a dev support ticket')
+        }.to raise_error(FundingTypeError, error_message)
       end
 
       it 'does not raise an error for other combinations of funding types for courses' do
@@ -139,7 +139,7 @@ RSpec.describe SupportInterface::ChangeApplicationChoiceCourseOption do
                               study_mode: course_option.course.study_mode,
                               site_code: course_option.site.code,
                               audit_comment: audit_comment).call
-        }.not_to raise_error(FundingTypeError, 'Changing a course choice from fee paying to salaried is not allowed. Please raise a dev support ticket')
+        }.not_to raise_error(FundingTypeError, error_message)
       end
     end
   end

--- a/spec/system/support_interface/change_course_choice_spec.rb
+++ b/spec/system/support_interface/change_course_choice_spec.rb
@@ -79,7 +79,7 @@ RSpec.feature 'Change course choice' do
   end
 
   def when_i_enter_the_new_course_choice_and_press_change
-    @course_option = create(:course_option, study_mode: :full_time)
+    @course_option = create(:course_option, study_mode: :full_time, course: create(:course, funding_type: 'fee'))
 
     fill_in 'Provider code', with: @course_option.course.provider.code
     fill_in 'Course code', with: @course_option.course.code

--- a/spec/system/support_interface/change_offered_course_for_a_submitted_application_spec.rb
+++ b/spec/system/support_interface/change_offered_course_for_a_submitted_application_spec.rb
@@ -100,7 +100,7 @@ RSpec.feature 'Add course to submitted application' do
   end
 
   def and_i_enter_a_course_code_for_a_course_that_has_the_same_ratifying_provider
-    @course_option = create(:course_option, course: create(:course, :open_on_apply, provider: @application_choice.provider))
+    @course_option = create(:course_option, course: create(:course, :open_on_apply, funding_type: 'fee', provider: @application_choice.provider))
     @course_code = @course_option.course.code
     fill_in('Course code', with: @course_code)
   end


### PR DESCRIPTION
## Context
There was a recent issue where a candidate on a fee paying course was mistakenly moved to a salaried course in support

## Changes proposed in this pull request
* Flash warning message is shown if support agent tries to move candidate to a salaried course from a fee paying course telling the agent to raise a dev support ticket. 
* This occurs if the support agent tries to move the candidate when they are 'awaiting_provider_decision' and also after they have an offer and are in 'pending_conditions'.

## Guidance to review
1) Change a course choice to a salaried course. The candidate must be awaiting provider decision on a fee paying course.
2) Change an offered course to a salaried course. They must be in a pending conditions state on a fee paying course.

You should see the below message:

<img width="1278" alt="Screenshot 2022-08-10 at 15 05 42" src="https://user-images.githubusercontent.com/58793682/183921781-4b9ec15c-0965-410f-9a59-15040b987d49.png">
<img width="1326" alt="Screenshot 2022-08-10 at 15 10 30" src="https://user-images.githubusercontent.com/58793682/183922862-e72aa897-ec35-4788-ba9b-8050975b3828.png">

## Link to Trello card
https://trello.com/c/zuBT7efU/459-support-site-dont-allow-changing-course-from-a-fee-paying-to-a-salaried-course

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
