### PR TITLE
Improve sign in email

### DIFF
--- a/app/mailers/authentication_mailer.rb
+++ b/app/mailers/authentication_mailer.rb
@@ -11,6 +11,7 @@ class AuthenticationMailer < ApplicationMailer
 
   def sign_in_email(candidate:, token:)
     @magic_link = candidate_interface_authenticate_url(magic_link_params(token))
+    @application_form = candidate.application_forms.order(:created_at).last
 
     notify_email(
       to: candidate.email_address,

--- a/app/mailers/authentication_mailer.rb
+++ b/app/mailers/authentication_mailer.rb
@@ -11,7 +11,7 @@ class AuthenticationMailer < ApplicationMailer
 
   def sign_in_email(candidate:, token:)
     @magic_link = candidate_interface_authenticate_url(magic_link_params(token))
-    @application_form = candidate.application_forms.order(:created_at).last
+    @application_form = candidate.current_application
 
     notify_email(
       to: candidate.email_address,

--- a/app/views/authentication_mailer/sign_in_email.text.erb
+++ b/app/views/authentication_mailer/sign_in_email.text.erb
@@ -1,4 +1,4 @@
-<% if @application_form.first_name.present? %>
+<% if @application_form&.first_name.present? %>
   Dear <%= @application_form.first_name %>
 <% end %>
 

--- a/app/views/authentication_mailer/sign_in_email.text.erb
+++ b/app/views/authentication_mailer/sign_in_email.text.erb
@@ -1,3 +1,7 @@
-Sign in to apply for teacher training:
+<% if @application_form.first_name.present? %>
+  Dear <%= @application_form.first_name %>
+<% end %>
+
+Sign in to continue your application for teacher training:
 
 <%= @magic_link %>

--- a/config/locales/candidate_interface/authentication.yml
+++ b/config/locales/candidate_interface/authentication.yml
@@ -11,7 +11,7 @@ en:
     sign_in:
       heading: Sign In
       email:
-        subject: Sign in to apply for teacher training
+        subject: Sign in to continue your application for teacher training
       email_address:
         label: Email address
     sign_in_without_account:

--- a/spec/mailers/authentication_mailer_spec.rb
+++ b/spec/mailers/authentication_mailer_spec.rb
@@ -33,9 +33,14 @@ RSpec.describe AuthenticationMailer, type: :mailer do
     let(:token) { 'blub' }
     let(:email) { mailer.sign_in_email(candidate: candidate, token: token) }
 
+    before do
+      create(:application_form, candidate: candidate, first_name: 'John')
+    end
+
     it_behaves_like(
       'a mail with subject and content',
       I18n.t('authentication.sign_in.email.subject'),
+      'intro' => 'Dear John',
       'heading' => I18n.t('authentication.sign_in.email.subject'),
       'magic link' => 'http://localhost:3000/candidate/sign-in/confirm?token=blub',
     )

--- a/spec/mailers/previews/authentication_mailer_preview.rb
+++ b/spec/mailers/previews/authentication_mailer_preview.rb
@@ -8,6 +8,6 @@ class AuthenticationMailerPreview < ActionMailer::Preview
   end
 
   def sign_in_email
-    AuthenticationMailer.sign_in_email(candidate: FactoryBot.build_stubbed(:candidate), token: SecureRandom.hex)
+    AuthenticationMailer.sign_in_email(candidate: FactoryBot.create(:candidate), token: SecureRandom.hex)
   end
 end


### PR DESCRIPTION
A small tweak to:

* add the candidate’s name (when they've entered it, which should be most of the time)
* change the lead-in line to make it more applicable to continuing an application

https://trello.com/c/V8d1h4jZ/504-review-the-content-of-the-sign-in-email


## Screenshots

### Before

<img width="583" alt="Screenshot 2022-08-11 at 09 29 39" src="https://user-images.githubusercontent.com/30665/184094447-18f1d375-aba5-424f-816e-c9d6c1a52d48.png">

### After

<img width="583" alt="Screenshot 2022-08-11 at 09 29 22" src="https://user-images.githubusercontent.com/30665/184094467-67d6fcf4-f9c8-4eff-9e20-b118a05b7d77.png">

