### PR TITLE
Improve content of email when creating an account

### DIFF
--- a/app/views/authentication_mailer/sign_up_email.text.erb
+++ b/app/views/authentication_mailer/sign_up_email.text.erb
@@ -1,6 +1,5 @@
-
-Confirm your email address to apply for teacher training:
+Confirm that you want to use this email address to apply for teacher training:
 
 <%= @magic_link %>
 
-You can then save and return to your application.
+You’ll be able to sign in with this email address to return to your application.

--- a/app/views/authentication_mailer/sign_up_email.text.erb
+++ b/app/views/authentication_mailer/sign_up_email.text.erb
@@ -1,5 +1,3 @@
-Confirm that you want to use this email address to apply for teacher training:
+Confirm that you want to create an account to apply for teacher training:
 
 <%= @magic_link %>
-
-You’ll be able to sign in with this email address to return to your application.

--- a/config/locales/candidate_interface/authentication.yml
+++ b/config/locales/candidate_interface/authentication.yml
@@ -6,7 +6,7 @@ en:
         label: Email address
         hint_label: Do not use a work or university email address you might lose access to.
       email:
-        subject: Please confirm your email address
+        subject: Confirm your email address to apply for teacher training
     check_your_email: Check your email
     sign_in:
       heading: Sign In

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -21,7 +21,7 @@ const SECONDS_BETWEEN_NOTIFY_ATTEMPTS = 1;
 
 const hasCorrectSubject = notifyEmail =>
   notifyEmail["subject"].includes("Sign in to apply for teacher training") ||
-  notifyEmail["subject"].includes("Please confirm your email address");
+  notifyEmail["subject"].includes("Confirm your email address to apply for teacher training");
 
 const wasCreatedInTheLastHour = notifyEmail =>
   new Date() - new Date(notifyEmail["created_at"]) < ONE_HOUR;

--- a/spec/mailers/authentication_mailer_spec.rb
+++ b/spec/mailers/authentication_mailer_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe AuthenticationMailer, type: :mailer do
     it_behaves_like(
       'a mail with subject and content',
       I18n.t('authentication.sign_up.email.subject'),
-      'body' => 'Confirm your email address to apply for teacher training',
+      'body' => 'Confirm that you want to use this email address to apply for teacher training:',
       'magic_link' => 'http://localhost:3000/candidate/sign-in/confirm?token=blub',
     )
 

--- a/spec/mailers/authentication_mailer_spec.rb
+++ b/spec/mailers/authentication_mailer_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe AuthenticationMailer, type: :mailer do
     it_behaves_like(
       'a mail with subject and content',
       I18n.t('authentication.sign_up.email.subject'),
-      'body' => 'Confirm that you want to use this email address to apply for teacher training:',
+      'body' => 'Confirm that you want to create an account to apply for teacher training:',
       'magic_link' => 'http://localhost:3000/candidate/sign-in/confirm?token=blub',
     )
 


### PR DESCRIPTION
We’ve tweaked this slightly to include the phrase "an account" to try and remind candidates that that’s what they're doing (to make it easer it to sign in next time, when we ask if they’ve got an account or not).

https://trello.com/c/TuBJSfJq/502-review-the-content-of-the-confirm-email-and-create-account-email


## Screenshots

### Before

<img width="579" alt="Screenshot 2022-08-11 at 09 19 27" src="https://user-images.githubusercontent.com/30665/184096319-e3946d8f-48ae-4f8a-b636-0ca9d8354447.png">

### After

<img width="584" alt="Screenshot 2022-08-15 at 14 46 18" src="https://user-images.githubusercontent.com/30665/184647327-52825c98-eba1-4275-b3e9-4a7a8d5b5f16.png">

