### PR TITLE
Guard against `nil` permissions in `EditProviderUserPermissions` service

### DIFF
--- a/app/services/provider_interface/edit_provider_user_permissions.rb
+++ b/app/services/provider_interface/edit_provider_user_permissions.rb
@@ -8,7 +8,7 @@ module ProviderInterface
       @actor = actor
       @provider = provider
       @provider_user = provider_user
-      @permissions = permissions.compact_blank
+      @permissions = permissions&.compact_blank || []
     end
 
     def save

--- a/spec/services/provider_interface/edit_provider_user_permissions_spec.rb
+++ b/spec/services/provider_interface/edit_provider_user_permissions_spec.rb
@@ -22,6 +22,14 @@ RSpec.describe ProviderInterface::EditProviderUserPermissions do
     provider_permissions.save!
   end
 
+  describe '#initialize' do
+    it 'guards against nil permissions' do
+      instance = described_class.new(actor: actor, provider: provider, provider_user: provider_user, permissions: nil)
+
+      expect(instance.permissions).to eq([])
+    end
+  end
+
   describe '#save' do
     context 'when the actor does not have the manage users permission' do
       it 'raises an access denied error' do


### PR DESCRIPTION

## Context

We've seen production errors like:
https://sentry.io/organizations/dfe-teacher-services/issues/3494556591/?project=1765973
There may be a way to call the `EditProviderUserPermissions` service with nil permissions.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Add a guard against `nil` permissions in the `EditProviderUserPermissions` service, the call will no-op in this case instead of raising an error.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://sentry.io/organizations/dfe-teacher-services/issues/3494556591/?project=1765973
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
