### PR TITLE
Protect against RangeError parsing user input for DOB

### DIFF
--- a/app/forms/candidate_interface/personal_details_form.rb
+++ b/app/forms/candidate_interface/personal_details_form.rb
@@ -36,7 +36,7 @@ module CandidateInterface
 
       begin
         Date.new(*date_args)
-      rescue ArgumentError
+      rescue ArgumentError, RangeError
         Struct.new(:day, :month, :year).new(day, month, year)
       end
     end

--- a/spec/forms/candidate_interface/personal_details_form_spec.rb
+++ b/spec/forms/candidate_interface/personal_details_form_spec.rb
@@ -65,6 +65,14 @@ RSpec.describe CandidateInterface::PersonalDetailsForm, type: :model do
       let(:model) { described_class.new(day: day, month: month, year: year) }
 
       include_examples 'date_of_birth validations', verify_presence: true
+
+      it 'is invalid on RangeError and does not raise' do
+        expect {
+          model = described_class.new(day: '9301305922083', month: '01', year: '2022')
+
+          expect(model).to be_invalid
+        }.not_to raise_error(RangeError)
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

`RangeError` encountered in production:
https://sentry.io/organizations/dfe-teacher-services/issues/3493611756/?project=1765973

We should catch this in validations and not raise.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

`rescue RangeError`  and allow validations to handle the error.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1660167734527309
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
