### PR TITLE
Update link to training to teach if you're disabled

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,7 +34,7 @@ en:
     url_get_an_adviser: https://adviser-getintoteaching.education.gov.uk
     url_get_an_adviser_start: https://getintoteaching.education.gov.uk/teacher-training-advisers
     url_international_candidates: https://getintoteaching.education.gov.uk/non-uk-teachers
-    url_support_if_you_are_disabled: https://getintoteaching.education.gov.uk/get-support-training-to-teach-if-you-are-disabled
+    url_support_if_you_are_disabled: https://getintoteaching.education.gov.uk/funding-and-support/if-youre-disabled
     url_online_chat: https://getintoteaching.education.gov.uk/#talk-to-us
     url_get_school_experience: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/get-school-experience
     url_ways_to_train: https://getintoteaching.education.gov.uk/train-to-be-a-teacher


### PR DESCRIPTION
## Context

Get into teaching have updated their page for this topic, so we're changing our config file to point to the new link,

## Changes proposed in this pull request

FROM:            https://getintoteaching.education.gov.uk/get-support-training-to-teach-if-you-are-disabled
 
TO:                  https://getintoteaching.education.gov.uk/funding-and-support/if-youre-disabled

## Guidance to review

This appears to be the only place we link to this page (as a standard config file).

## Link to Trello card

N/A - adhoc request.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
