### PR TITLE
Redirect to the review page after deleting a reference

### DIFF
--- a/app/controllers/candidate_interface/new_references/review_controller.rb
+++ b/app/controllers/candidate_interface/new_references/review_controller.rb
@@ -31,7 +31,7 @@ module CandidateInterface
 
         VerifyAndMarkReferencesIncomplete.new(current_application).call
 
-        next_step
+        redirect_to_review_page
       end
 
       def destroy_reference_path

--- a/spec/requests/candidate_interface/new_references_delete_reference_spec.rb
+++ b/spec/requests/candidate_interface/new_references_delete_reference_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidate Interface - Redirects acepted offer', type: :request do
+  include Devise::Test::IntegrationHelpers
+  let(:candidate) { create(:candidate) }
+
+  before do
+    sign_in candidate
+    FeatureFlag.activate(:new_references_flow)
+  end
+
+  context 'when deleting a reference from references review' do
+    it 'destroys the reference and redirect to references review' do
+      application_form = create(:application_form, recruitment_cycle_year: 2023, candidate: candidate)
+      reference = create(:reference, :feedback_requested, application_form: application_form)
+
+      delete candidate_interface_destroy_new_reference_path(reference)
+      expect(response).to redirect_to(candidate_interface_new_references_review_path)
+    end
+  end
+end


### PR DESCRIPTION
## Context

When deleting a reference it is redirecting to the application review (which is wrong). It should always redirects to the review page

## Guidance to review

1. When you delete a reference before submit does it redirect to the reference review page?
2.When you delete a reference before accepting the offer does it redirect to the right offer page? 

## Link to Trello card

https://trello.com/c/Jzyym5Cj/511-references-redirect-to-the-references-review-after-deleting
