### PR TITLE
New References - feature flag for Manage

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -33,6 +33,7 @@ class FeatureFlag
     [:new_degree_flow, 'Allows us to use the new degree flow', 'Jon Filar'],
     [:reference_nudges, 'Nudge emails for candidates that have incomplete references', 'Steve Hook'],
     [:new_references_flow, 'Show the new references flow', 'James and Tomas'],
+    [:new_references_flow_providers, 'Show the new references features on Manage', 'James and Tomas'],
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day


### PR DESCRIPTION
## Context

We need to have a separate feature flag for the provider side of the references work. This is because we will be turning on the first (and current) one in September but we will still want to hide the new references work on Manage until the new cycle.

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
