### PR TITLE
Fix back link when cancel a request in the offer dashboard

### DIFF
--- a/app/components/candidate_interface/new_reference_history_component.html.erb
+++ b/app/components/candidate_interface/new_reference_history_component.html.erb
@@ -3,7 +3,7 @@
     <%= formatted_title event %> on <%= event.time.to_fs(:govuk_date) %>
 
     <% if event.name == 'request_sent' %>
-      - <%= govuk_link_to(t('application_form.new_references.cancel_request.action'), candidate_interface_new_references_confirm_cancel_reference_path(reference)) %>
+      - <%= govuk_link_to(t('application_form.new_references.cancel_request.action'), candidate_interface_new_references_confirm_cancel_reference_path(reference, return_to: 'offer-dashboard')) %>
     <% end %>
   </p>
 <% end %>

--- a/app/controllers/candidate_interface/new_references/cancel_controller.rb
+++ b/app/controllers/candidate_interface/new_references/cancel_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   module NewReferences
     class CancelController < BaseController
+      before_action :set_backlink
       skip_before_action :redirect_to_dashboard_if_submitted
 
       def new
@@ -17,6 +18,16 @@ module CandidateInterface
         end
 
         redirect_to candidate_interface_application_offer_dashboard_path
+      end
+
+    private
+
+      def set_backlink
+        @back_link = return_to_path || candidate_interface_application_offer_dashboard_reference_path(@reference)
+      end
+
+      def return_to_path
+        candidate_interface_application_offer_dashboard_path if params[:return_to] == 'offer-dashboard'
       end
     end
   end

--- a/app/views/candidate_interface/new_references/cancel/new.html.erb
+++ b/app/views/candidate_interface/new_references/cancel/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.new_references_cancel_request') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_offer_dashboard_reference_path(@reference)) %>
+<% content_for :before_content, govuk_back_link_to(@back_link) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/system/candidate_interface/new-references/candidate_request_references_new_references_spec.rb
+++ b/spec/system/candidate_interface/new-references/candidate_request_references_new_references_spec.rb
@@ -57,6 +57,8 @@ RSpec.feature 'New References', with_audited: true do
     and_i_should_be_on_check_your_answers
     and_i_click_to_request_the_reference
     then_the_reference_should_be_requested
+    and_i_click_cancel_request_from_the_list_page
+    then_the_back_link_should_point_to_the_offer_dashboard_page
   end
 
   def given_i_am_signed_in
@@ -258,6 +260,10 @@ RSpec.feature 'New References', with_audited: true do
     rescue StandardError
       nil
     end
+  end
+
+  def and_i_click_cancel_request_from_the_list_page
+    click_on 'Cancel request'
   end
 
   def back_link


### PR DESCRIPTION
## Context

We can request reference from the list references and when rendering
one reference and the back link should behave accordingly
## Guidance to review

1. Does the back link renders correctly when click cancel from the list page?
2. Does the back link renders correctly when click cancel from the view reference page?

## Link to Trello card

https://trello.com/c/RoQUzAqC/512-references-fix-cancel-request-back-link
