### PR TITLE
458 support site when changing courses display vacancy status

### DIFF
--- a/app/controllers/support_interface/application_forms/application_choices/change_offered_course_controller.rb
+++ b/app/controllers/support_interface/application_forms/application_choices/change_offered_course_controller.rb
@@ -62,10 +62,15 @@ module SupportInterface
               flash[:success] = 'Offered course choice updated successfully'
               redirect_to support_interface_application_form_path(@application_form.id)
             else
+              @show_course_change_confirmation = checkbox_rendered?
               render :confirm_offered_course_option
             end
-          rescue FundingTypeError, CourseFullError => e
+          rescue FundingTypeError => e
             flash[:warning] = e.message
+            render :confirm_offered_course_option
+          rescue CourseFullError => e
+            flash[:warning] = e.message
+            @show_course_change_confirmation = true
             render :confirm_offered_course_option
           end
         end
@@ -79,6 +84,10 @@ module SupportInterface
 
         def course_option_id
           params.dig(:support_interface_application_forms_pick_course_form, :course_option_id)
+        end
+
+        def checkbox_rendered?
+          params.dig(:support_interface_application_forms_update_offered_course_option_form, :checkbox_rendered)
         end
 
         def confirm_offered_course_option_params

--- a/app/controllers/support_interface/application_forms/application_choices/change_offered_course_controller.rb
+++ b/app/controllers/support_interface/application_forms/application_choices/change_offered_course_controller.rb
@@ -64,7 +64,7 @@ module SupportInterface
             else
               render :confirm_offered_course_option
             end
-          rescue FundingTypeError => e
+          rescue FundingTypeError, CourseFullError => e
             flash[:warning] = e.message
             render :confirm_offered_course_option
           end
@@ -82,7 +82,7 @@ module SupportInterface
         end
 
         def confirm_offered_course_option_params
-          params.require(:support_interface_application_forms_update_offered_course_option_form).permit(:course_option_id, :audit_comment, :accept_guidance)
+          params.require(:support_interface_application_forms_update_offered_course_option_form).permit(:course_option_id, :audit_comment, :accept_guidance, :confirm_course_change, :checkbox_rendered)
         end
 
         def redirect_to_application_form_unless_accepted

--- a/app/controllers/support_interface/application_forms/courses_controller.rb
+++ b/app/controllers/support_interface/application_forms/courses_controller.rb
@@ -57,10 +57,15 @@ module SupportInterface
             flash[:success] = 'Course successfully changed'
             redirect_to support_interface_application_form_path(application_form_id)
           else
+            @show_course_change_confirmation = checkbox_rendered?
             render :edit
           end
-        rescue CourseChoiceError, ProviderInterviewError, FundingTypeError, CourseFullError => e
+        rescue CourseChoiceError, ProviderInterviewError, FundingTypeError => e
           flash[:warning] = e.message
+          render :edit
+        rescue CourseFullError => e
+          flash[:warning] = e.message
+          @show_course_change_confirmation = true
           render :edit
         end
       end
@@ -69,6 +74,10 @@ module SupportInterface
 
       def course_option_id
         params.dig(:support_interface_application_forms_pick_course_form, :course_option_id)
+      end
+
+      def checkbox_rendered?
+        params.dig(:support_interface_application_forms_change_course_choice_form, :checkbox_rendered)
       end
 
       def course_search_params

--- a/app/controllers/support_interface/application_forms/courses_controller.rb
+++ b/app/controllers/support_interface/application_forms/courses_controller.rb
@@ -59,7 +59,7 @@ module SupportInterface
           else
             render :edit
           end
-        rescue CourseChoiceError, ProviderInterviewError, FundingTypeError => e
+        rescue CourseChoiceError, ProviderInterviewError, FundingTypeError, CourseFullError => e
           flash[:warning] = e.message
           render :edit
         end
@@ -78,7 +78,7 @@ module SupportInterface
 
       def change_course_choice_params
         params.require(:support_interface_application_forms_change_course_choice_form)
-              .permit(:application_choice_id, :provider_code, :course_code, :study_mode, :site_code, :audit_comment_ticket, :accept_guidance)
+              .permit(:application_choice_id, :provider_code, :course_code, :study_mode, :site_code, :audit_comment_ticket, :accept_guidance, :confirm_course_change, :checkbox_rendered)
       end
 
       def application_form_id

--- a/app/errors/course_full_error.rb
+++ b/app/errors/course_full_error.rb
@@ -1,0 +1,1 @@
+class CourseFullError < StandardError; end

--- a/app/forms/support_interface/application_forms/change_course_choice_form.rb
+++ b/app/forms/support_interface/application_forms/change_course_choice_form.rb
@@ -3,9 +3,10 @@ module SupportInterface
     class ChangeCourseChoiceForm
       include ActiveModel::Model
 
-      attr_accessor :application_choice_id, :provider_code, :course_code, :study_mode, :site_code, :accept_guidance, :audit_comment_ticket
+      attr_accessor :application_choice_id, :provider_code, :course_code, :study_mode, :site_code, :accept_guidance, :audit_comment_ticket, :confirm_course_change, :checkbox_rendered
 
       validates :provider_code, :course_code, :study_mode, :site_code, :accept_guidance, :audit_comment_ticket, presence: true
+      validates :confirm_course_change, presence: true, if: :checkbox_rendered?
       validates_with ZendeskUrlValidator
 
       def save(application_choice)
@@ -20,6 +21,7 @@ module SupportInterface
           study_mode: study_mode,
           site_code: site_code,
           audit_comment: audit_comment_ticket,
+          confirm_course_change: confirm_course_change,
         ).call
       rescue ActiveRecord::RecordNotFound
         raise CourseChoiceError, 'This is not a valid course option'
@@ -33,6 +35,10 @@ module SupportInterface
         raise CourseChoiceError, 'This is not a valid provider code' if provider.nil?
 
         provider.id
+      end
+
+      def checkbox_rendered?
+        checkbox_rendered == 'true'
       end
     end
   end

--- a/app/forms/support_interface/application_forms/update_offered_course_option_form.rb
+++ b/app/forms/support_interface/application_forms/update_offered_course_option_form.rb
@@ -32,14 +32,14 @@ module SupportInterface
 
         return unless current_course.fee_paying? && new_course.salaried_or_apprenticeship?
 
-        raise FundingTypeError, I18n.t('errors.messages.funding_type_error', course: 'an offered course')
+        raise FundingTypeError, I18n.t('support_interface.errors.messages.funding_type_error', course: 'an offered course')
       end
 
       def check_course_full!
         return if confirm_course_change.present?
         return if course_option.vacancy_status == 'vacancies'
 
-        raise CourseFullError, 'Are you sure you want to move the candidate to a course with no vacancies? Please select the checkbox'
+        raise CourseFullError, I18n.t('support_interface.errors.messages.course_full_error')
       end
 
       def checkbox_rendered?

--- a/app/services/support_interface/change_application_choice_course_option.rb
+++ b/app/services/support_interface/change_application_choice_course_option.rb
@@ -52,14 +52,14 @@ module SupportInterface
 
       return unless current_course.fee_paying? && new_course.salaried_or_apprenticeship?
 
-      raise FundingTypeError, I18n.t('errors.messages.funding_type_error', course: 'a course choice')
+      raise FundingTypeError, I18n.t('support_interface.errors.messages.funding_type_error', course: 'a course choice')
     end
 
     def check_course_full!
       return if confirm_course_change.present?
       return if course_option.vacancy_status == 'vacancies'
 
-      raise CourseFullError, 'Are you sure you want to move the candidate to a course with no vacancies? Please select the checkbox'
+      raise CourseFullError, I18n.t('support_interface.errors.messages.course_full_error')
     end
 
     def course_option

--- a/app/services/support_interface/change_application_choice_course_option.rb
+++ b/app/services/support_interface/change_application_choice_course_option.rb
@@ -3,25 +3,29 @@ module SupportInterface
     VALID_STATES = ApplicationStateChange::DECISION_PENDING_STATUSES
 
     attr_reader :application_choice, :provider_id, :course_code, :study_mode, :site_code, :audit_comment
+    attr_accessor :confirm_course_change
 
     def initialize(application_choice_id:,
                    provider_id:,
                    course_code:,
                    study_mode:,
                    site_code:,
-                   audit_comment:)
+                   audit_comment:,
+                   confirm_course_change: false)
       @application_choice = ApplicationChoice.find(application_choice_id)
       @provider_id = provider_id
       @course_code = course_code
       @site_code = site_code
       @study_mode = study_mode
       @audit_comment = audit_comment
+      @confirm_course_change = confirm_course_change
     end
 
     def call
       check_application_state!
       check_interviewing_providers!
       check_course_funding_type!
+      check_course_full!
 
       application_choice.update_course_option_and_associated_fields!(course_option,
                                                                      other_fields: { course_option: course_option },
@@ -49,6 +53,13 @@ module SupportInterface
       return unless current_course.fee_paying? && new_course.salaried_or_apprenticeship?
 
       raise FundingTypeError, I18n.t('errors.messages.funding_type_error', course: 'a course choice')
+    end
+
+    def check_course_full!
+      return if confirm_course_change.present?
+      return if course_option.vacancy_status == 'vacancies'
+
+      raise CourseFullError, 'Are you sure you want to move the candidate to a course with no vacancies? Please select the checkbox'
     end
 
     def course_option

--- a/app/views/support_interface/application_forms/application_choices/change_offered_course/confirm_offered_course_option.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/change_offered_course/confirm_offered_course_option.html.erb
@@ -39,7 +39,7 @@
         <%= f.govuk_check_box :accept_guidance, true, multiple: false, label: { text: 'I have read the guidance' }, link_errors: true %>
       <% end %>
 
-      <% if flash["warning"] == I18n.t('support_interface.errors.messages.course_full_error') %>
+      <% if @show_course_change_confirmation %>
         <%= f.hidden_field :checkbox_rendered, value: true %>
         <%= f.govuk_check_boxes_fieldset :confirm_course_change, legend: nil do %>
           <%= f.govuk_check_box :confirm_course_change, true, multiple: false, label: { text: 'I confirm that I would like to move the candidate to a course with no vacancies' }, link_errors: true %>

--- a/app/views/support_interface/application_forms/application_choices/change_offered_course/confirm_offered_course_option.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/change_offered_course/confirm_offered_course_option.html.erb
@@ -39,6 +39,13 @@
         <%= f.govuk_check_box :accept_guidance, true, multiple: false, label: { text: 'I have read the guidance' }, link_errors: true %>
       <% end %>
 
+      <% if flash["warning"] == "Are you sure you want to move the candidate to a course with no vacancies? Please select the checkbox" %>
+        <%= f.hidden_field :checkbox_rendered, value: true %>
+        <%= f.govuk_check_boxes_fieldset :confirm_course_change, legend: nil do %>
+          <%= f.govuk_check_box :confirm_course_change, true, multiple: false, label: { text: 'I confirm that I would like to move the candidate to a course with no vacancies' }, link_errors: true %>
+        <% end %>
+      <% end %>
+
       <%= f.govuk_submit t('continue') %>
     <% end %>
   </div>

--- a/app/views/support_interface/application_forms/application_choices/change_offered_course/confirm_offered_course_option.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/change_offered_course/confirm_offered_course_option.html.erb
@@ -39,7 +39,7 @@
         <%= f.govuk_check_box :accept_guidance, true, multiple: false, label: { text: 'I have read the guidance' }, link_errors: true %>
       <% end %>
 
-      <% if flash["warning"] == "Are you sure you want to move the candidate to a course with no vacancies? Please select the checkbox" %>
+      <% if flash["warning"] == I18n.t('support_interface.errors.messages.course_full_error') %>
         <%= f.hidden_field :checkbox_rendered, value: true %>
         <%= f.govuk_check_boxes_fieldset :confirm_course_change, legend: nil do %>
           <%= f.govuk_check_box :confirm_course_change, true, multiple: false, label: { text: 'I confirm that I would like to move the candidate to a course with no vacancies' }, link_errors: true %>

--- a/app/views/support_interface/application_forms/courses/edit.html.erb
+++ b/app/views/support_interface/application_forms/courses/edit.html.erb
@@ -47,7 +47,7 @@
         <%= f.govuk_check_box :accept_guidance, true, multiple: false, label: { text: 'I have read the guidance' }, link_errors: true %>
       <% end %>
 
-      <% if flash["warning"] == I18n.t('support_interface.errors.messages.course_full_error') %>
+      <% if @show_course_change_confirmation %>
         <%= f.hidden_field :checkbox_rendered, value: true %>
         <%= f.govuk_check_boxes_fieldset :confirm_course_change, legend: nil do %>
           <%= f.govuk_check_box :confirm_course_change, true, multiple: false, label: { text: 'I confirm that I would like to move the candidate to a course with no vacancies' }, link_errors: true %>

--- a/app/views/support_interface/application_forms/courses/edit.html.erb
+++ b/app/views/support_interface/application_forms/courses/edit.html.erb
@@ -47,7 +47,7 @@
         <%= f.govuk_check_box :accept_guidance, true, multiple: false, label: { text: 'I have read the guidance' }, link_errors: true %>
       <% end %>
 
-      <% if flash["warning"] == "Are you sure you want to move the candidate to a course with no vacancies? Please select the checkbox" %>
+      <% if flash["warning"] == I18n.t('support_interface.errors.messages.course_full_error') %>
         <%= f.hidden_field :checkbox_rendered, value: true %>
         <%= f.govuk_check_boxes_fieldset :confirm_course_change, legend: nil do %>
           <%= f.govuk_check_box :confirm_course_change, true, multiple: false, label: { text: 'I confirm that I would like to move the candidate to a course with no vacancies' }, link_errors: true %>

--- a/app/views/support_interface/application_forms/courses/edit.html.erb
+++ b/app/views/support_interface/application_forms/courses/edit.html.erb
@@ -47,6 +47,13 @@
         <%= f.govuk_check_box :accept_guidance, true, multiple: false, label: { text: 'I have read the guidance' }, link_errors: true %>
       <% end %>
 
+      <% if flash["warning"] == "Are you sure you want to move the candidate to a course with no vacancies? Please select the checkbox" %>
+        <%= f.hidden_field :checkbox_rendered, value: true %>
+        <%= f.govuk_check_boxes_fieldset :confirm_course_change, legend: nil do %>
+          <%= f.govuk_check_box :confirm_course_change, true, multiple: false, label: { text: 'I confirm that I would like to move the candidate to a course with no vacancies' }, link_errors: true %>
+        <% end %>
+      <% end %>
+
       <%= f.govuk_submit 'Change' %>
     <% end %>
   </div>

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -43,6 +43,10 @@ en:
     audit_comment_ticket:
       label: 'Zendesk ticket URL'
       hint: 'For example https://becomingateacher.zendesk.com/agent/tickets/12345'
+    errors:
+      messages:
+       funding_type_error: Changing %{course} from fee paying to salaried or an apprenticeship is not allowed. Please raise a dev support ticket.
+       course_full_error: 'Are you sure you want to move the candidate to a course with no vacancies? Please check the box'
   activemodel:
     errors:
       models:
@@ -261,3 +265,5 @@ en:
           attributes:
             accept_guidance:
               blank: Confirm that you have read the guidance
+        
+

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -241,6 +241,8 @@ en:
             audit_comment:
               blank: Enter a Zendesk ticket URL
               invalid: Enter a valid Zendesk ticket URL
+            confirm_course_change:
+              blank: Select that you would like to move the candidate to a course with no vacancies
         support_interface/application_forms/revert_rejection_form:
           attributes:
             accept_guidance:

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -69,6 +69,8 @@ en:
             audit_comment_ticket:
               blank: Enter a Zendesk ticket URL
               invalid: Enter a valid Zendesk ticket URL
+            confirm_course_change:
+              blank: Select that you would like to move the candidate to a course with no vacancies
         support_interface/application_comment_form:
           attributes:
             comment:

--- a/spec/forms/support_interface/application_forms/update_offered_course_option_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/update_offered_course_option_form_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe SupportInterface::ApplicationForms::UpdateOfferedCourseOptionForm
       let(:salaried_course) { create(:course, funding_type: 'salary') }
       let(:application_choice) { create(:application_choice, status: :offer, course_option: create(:course_option, course: fee_paying_course)) }
       let(:course_option) { create(:course_option, course: salaried_course) }
-      let!(:error_message) { I18n.t('errors.messages.funding_type_error', course: 'an offered course') }
+      let!(:error_message) { I18n.t('support_interface.errors.messages.funding_type_error', course: 'an offered course') }
 
       it 'raises a FundingTypeError if current course is fee paying and the new course is salaried' do
         expect {
@@ -66,7 +66,7 @@ RSpec.describe SupportInterface::ApplicationForms::UpdateOfferedCourseOptionForm
         course_option = create(:course_option, :no_vacancies, course: fee_paying_course)
         application_choice = create(:application_choice, status: :offer)
 
-        error_message = 'Are you sure you want to move the candidate to a course with no vacancies? Please select the checkbox'
+        error_message = I18n.t('support_interface.errors.messages.course_full_error')
 
         expect {
           described_class.new(course_option_id: course_option.id, audit_comment: zendesk_ticket, accept_guidance: 'true').save(application_choice)
@@ -75,7 +75,7 @@ RSpec.describe SupportInterface::ApplicationForms::UpdateOfferedCourseOptionForm
 
       it 'does not raise a CourseFullError if confirm_course_change is true' do
         course_option =  create(:course_option, :no_vacancies, course: fee_paying_course)
-        error_message = 'Are you sure you want to move the candidate to a course with no vacancies? Please select the checkbox'
+        error_message = I18n.t('support_interface.errors.messages.course_full_error')
 
         expect {
           described_class.new(course_option_id: course_option.id, audit_comment: zendesk_ticket, accept_guidance: 'true', confirm_course_change: 'true').save(application_choice)

--- a/spec/forms/support_interface/application_forms/update_offered_course_option_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/update_offered_course_option_form_spec.rb
@@ -60,5 +60,27 @@ RSpec.describe SupportInterface::ApplicationForms::UpdateOfferedCourseOptionForm
         }.not_to raise_error(FundingTypeError, error_message)
       end
     end
+
+    context 'course full check' do
+      it 'raises a CourseFullError if the new course has no vacancies' do
+        course_option = create(:course_option, :no_vacancies, course: fee_paying_course)
+        application_choice = create(:application_choice, status: :offer)
+
+        error_message = 'Are you sure you want to move the candidate to a course with no vacancies? Please select the checkbox'
+
+        expect {
+          described_class.new(course_option_id: course_option.id, audit_comment: zendesk_ticket, accept_guidance: 'true').save(application_choice)
+        }.to raise_error(CourseFullError, error_message)
+      end
+
+      it 'does not raise a CourseFullError if confirm_course_change is true' do
+        course_option =  create(:course_option, :no_vacancies, course: fee_paying_course)
+        error_message = 'Are you sure you want to move the candidate to a course with no vacancies? Please select the checkbox'
+
+        expect {
+          described_class.new(course_option_id: course_option.id, audit_comment: zendesk_ticket, accept_guidance: 'true', confirm_course_change: 'true').save(application_choice)
+        }.not_to raise_error(CourseFullError, error_message)
+      end
+    end
   end
 end

--- a/spec/services/support_interface/change_application_choice_course_option_spec.rb
+++ b/spec/services/support_interface/change_application_choice_course_option_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe SupportInterface::ChangeApplicationChoiceCourseOption do
       let(:salaried_course) { create(:course, funding_type: 'salary') }
       let(:application_choice) { create(:application_choice, :awaiting_provider_decision, course_option: create(:course_option, course: fee_paying_course)) }
       let(:course_option) { create(:course_option, course: salaried_course) }
-      let!(:error_message) { I18n.t('errors.messages.funding_type_error', course: 'a course choice') }
+      let!(:error_message) { I18n.t('support_interface.errors.messages.funding_type_error', course: 'a course choice') }
 
       it 'raises a FundingTypeError if current course is fee paying and the new course is salaried' do
         expect {
@@ -146,7 +146,7 @@ RSpec.describe SupportInterface::ChangeApplicationChoiceCourseOption do
     context 'course full check' do
       it 'raises a CourseFullError if the new course has no vacancies' do
         course_option = create(:course_option, :no_vacancies, course: fee_paying_course)
-        error_message = 'Are you sure you want to move the candidate to a course with no vacancies? Please select the checkbox'
+        error_message = I18n.t('support_interface.errors.messages.course_full_error')
 
         expect {
           described_class.new(application_choice_id: application_choice.id,
@@ -160,7 +160,7 @@ RSpec.describe SupportInterface::ChangeApplicationChoiceCourseOption do
 
       it 'does not raise a CourseFullError if confirm_course_change is true' do
         course_option =  create(:course_option, :no_vacancies, course: fee_paying_course)
-        error_message = 'Are you sure you want to move the candidate to a course with no vacancies? Please select the checkbox'
+        error_message = I18n.t('support_interface.errors.messages.course_full_error')
 
         expect {
           described_class.new(application_choice_id: application_choice.id,

--- a/spec/system/support_interface/change_course_choice_spec.rb
+++ b/spec/system/support_interface/change_course_choice_spec.rb
@@ -109,7 +109,7 @@ RSpec.feature 'Change course choice' do
   end
 
   def then_i_see_a_warning_message
-    expect(page).to have_content('Are you sure you want to move the candidate to a course with no vacancies? Please select the checkbox')
+    expect(page).to have_content(I18n.t('support_interface.errors.messages.course_full_error'))
   end
 
   def when_i_select_the_confirm_checkbox_and_press_change

--- a/spec/system/support_interface/change_course_choice_spec.rb
+++ b/spec/system/support_interface/change_course_choice_spec.rb
@@ -16,6 +16,14 @@ RSpec.feature 'Change course choice' do
     when_i_click_continue
     then_i_see_a_validation_error
 
+    when_i_enter_the_new_course_choice_for_a_course_with_no_vacancies_and_press_change
+    then_i_see_a_warning_message
+    when_i_select_the_confirm_checkbox_and_press_change
+    then_i_see_the_application_page
+    and_the_new_course_choice
+
+    when_i_click_change_course_choice
+    then_i_see_a_confirmation_page_prompting_for_course_details
     when_i_enter_the_new_course_choice_and_press_change
     then_i_see_the_application_page
     and_the_new_course_choice
@@ -81,12 +89,31 @@ RSpec.feature 'Change course choice' do
   def when_i_enter_the_new_course_choice_and_press_change
     @course_option = create(:course_option, study_mode: :full_time, course: create(:course, funding_type: 'fee'))
 
+    fill_in_course_details
+  end
+
+  def when_i_enter_the_new_course_choice_for_a_course_with_no_vacancies_and_press_change
+    @course_option = create(:course_option, :no_vacancies, study_mode: :full_time, course: create(:course, funding_type: 'fee'))
+
+    fill_in_course_details
+  end
+
+  def fill_in_course_details
     fill_in 'Provider code', with: @course_option.course.provider.code
     fill_in 'Course code', with: @course_option.course.code
     choose 'Full time'
     fill_in 'Site code', with: @course_option.site.code
     fill_in 'Zendesk ticket URL', with: 'https://becomingateacher.zendesk.com/agent/tickets/123'
     check 'I have read the guidance'
+    click_on 'Change'
+  end
+
+  def then_i_see_a_warning_message
+    expect(page).to have_content('Are you sure you want to move the candidate to a course with no vacancies? Please select the checkbox')
+  end
+
+  def when_i_select_the_confirm_checkbox_and_press_change
+    check 'I confirm that I would like to move the candidate to a course with no vacancies'
     click_on 'Change'
   end
 

--- a/spec/system/support_interface/change_offered_course_for_a_submitted_application_spec.rb
+++ b/spec/system/support_interface/change_offered_course_for_a_submitted_application_spec.rb
@@ -207,7 +207,7 @@ RSpec.feature 'Add course to submitted application' do
   alias_method :and_i_should_see_new_course_with_no_vacancies_has_been_offered, :and_i_should_see_new_course_has_been_offered
 
   def then_i_see_a_warning_message
-    expect(page).to have_content('Are you sure you want to move the candidate to a course with no vacancies? Please select the checkbox')
+    expect(page).to have_content(I18n.t('support_interface.errors.messages.course_full_error'))
   end
 
   def and_a_confirm_course_change_checkbox

--- a/spec/system/support_interface/change_offered_course_for_a_submitted_application_spec.rb
+++ b/spec/system/support_interface/change_offered_course_for_a_submitted_application_spec.rb
@@ -3,13 +3,15 @@ require 'rails_helper'
 RSpec.feature 'Add course to submitted application' do
   include DfESignInHelpers
 
-  scenario 'Support user adds course to submitted application' do
+  before do
     given_i_am_a_support_user
     and_there_is_a_submitted_application_in_the_system_with_an_accepted_offer
     and_i_visit_the_support_page
-
     when_i_click_on_an_application
-    and_i_click_on_change_offered_course
+  end
+
+  scenario 'Support user adds course to submitted application' do
+    when_i_click_on_change_offered_course
     then_i_should_see_the_change_offered_course_search_page
 
     when_i_click_search
@@ -39,6 +41,30 @@ RSpec.feature 'Add course to submitted application' do
     and_i_should_see_new_course_has_been_offered
   end
 
+  scenario 'Support user changes offered course for a submitted application to a course with no vacancies' do
+    when_i_click_on_change_offered_course
+    then_i_should_see_the_change_offered_course_search_page
+    and_i_enter_a_course_code_for_a_course_that_has_no_vacancies
+    and_i_click_search
+    then_i_should_see_the_course_results_page_with_results
+
+    when_i_select_a_course_with_no_vacancies
+    and_i_click_to_change_the_offered_course
+    then_i_see_the_confirm_offered_course_page
+    and_i_see_the_guidance_on_changing_an_offered_course
+
+    when_i_provide_a_valid_zendesk_ticket
+    and_i_confirm_changing_the_offer
+    and_i_click_continue
+    then_i_see_a_warning_message
+    and_a_confirm_course_change_checkbox
+
+    when_i_confirm_changing_the_course
+    and_i_click_continue
+    then_i_am_redirected_to_the_application_form_page
+    and_i_should_see_new_course_with_no_vacancies_has_been_offered
+  end
+
   def given_i_am_a_support_user
     sign_in_as_support_user
   end
@@ -56,7 +82,7 @@ RSpec.feature 'Add course to submitted application' do
     click_on 'Alice Wunder'
   end
 
-  def and_i_click_on_change_offered_course
+  def when_i_click_on_change_offered_course
     click_on 'Change offered course'
   end
 
@@ -105,6 +131,12 @@ RSpec.feature 'Add course to submitted application' do
     fill_in('Course code', with: @course_code)
   end
 
+  def and_i_enter_a_course_code_for_a_course_that_has_no_vacancies
+    @course_option = create(:course_option, :no_vacancies, course: create(:course, :open_on_apply, funding_type: 'fee', provider: @application_choice.provider))
+    @course_code = @course_option.course.code
+    fill_in('Course code', with: @course_code)
+  end
+
   def then_i_should_see_the_course_results_page_with_results
     expect(page).to have_current_path support_interface_application_form_application_choice_choose_offered_course_option_path(
       application_form_id: @application_form.id,
@@ -122,6 +154,7 @@ RSpec.feature 'Add course to submitted application' do
   def when_i_select_a_course
     choose "#{@course_option.provider.name} (#{@course_option.provider.code}) – #{@course_option.course.name} (#{@course_code})"
   end
+  alias_method :when_i_select_a_course_with_no_vacancies, :when_i_select_a_course
 
   def when_i_click_to_change_the_offered_course
     click_button 'Continue'
@@ -170,5 +203,18 @@ RSpec.feature 'Add course to submitted application' do
   def and_i_should_see_new_course_has_been_offered
     expect(page).to have_current_path support_interface_application_form_path(application_form_id: @application_form.id)
     expect(page).to have_content("#{RecruitmentCycle.current_year}: #{@course_option.course.name} (#{@course_option.course.code})")
+  end
+  alias_method :and_i_should_see_new_course_with_no_vacancies_has_been_offered, :and_i_should_see_new_course_has_been_offered
+
+  def then_i_see_a_warning_message
+    expect(page).to have_content('Are you sure you want to move the candidate to a course with no vacancies? Please select the checkbox')
+  end
+
+  def and_a_confirm_course_change_checkbox
+    expect(page).to have_content 'I confirm that I would like to move the candidate to a course with no vacancies'
+  end
+
+  def when_i_confirm_changing_the_course
+    find('input[name="support_interface_application_forms_update_offered_course_option_form[confirm_course_change]"]').check
   end
 end


### PR DESCRIPTION
## Context
The support agent should be aware when they are moving a candidate to a course with no vacancies. It requires consent from all parties.

## Changes proposed in this pull request
* A warning message is presented to support agent. With a checkbox for the agent to check that they understand they are moving the candidate to a course with no vacancies
* For both changing a course choice when the candidate is 'awaiting_provider_decision' and for an offered course when they are 'pending_conditions'

## Guidance to review
Try to move a candidate to a course with no vacancies in support interface in both states

## Link to Trello card
https://trello.com/c/1UccAwjM/458-support-site-when-changing-courses-display-vacancy-status

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
