### PR TITLE
433 new references tab on manage

### DIFF
--- a/app/components/provider_interface/application_choice_header_component.rb
+++ b/app/components/provider_interface/application_choice_header_component.rb
@@ -43,7 +43,6 @@ module ProviderInterface
       sub_navigation_items.push(feedback_navigation_item) if application_choice.display_provider_feedback?
       sub_navigation_items.push(emails_navigation_item) if HostingEnvironment.sandbox_mode?
 
-
       sub_navigation_items
     end
 

--- a/app/components/provider_interface/application_choice_header_component.rb
+++ b/app/components/provider_interface/application_choice_header_component.rb
@@ -36,11 +36,13 @@ module ProviderInterface
       sub_navigation_items = [application_navigation_item]
 
       sub_navigation_items.push(offer_navigation_item) if offer_present?
+      sub_navigation_items.push(references_navigation_item) if FeatureFlag.active?(:new_references_flow_providers)
       sub_navigation_items.push(interviews_navigation_item) if interviews_present?
       sub_navigation_items.push(notes_navigation_item)
       sub_navigation_items.push(timeline_navigation_item)
       sub_navigation_items.push(feedback_navigation_item) if application_choice.display_provider_feedback?
       sub_navigation_items.push(emails_navigation_item) if HostingEnvironment.sandbox_mode?
+
 
       sub_navigation_items
     end
@@ -96,6 +98,10 @@ module ProviderInterface
 
     def offer_navigation_item
       { name: 'Offer', url: provider_interface_application_choice_offer_path(application_choice) }
+    end
+
+    def references_navigation_item
+      { name: 'References', url: provider_interface_application_choice_references_path(application_choice) }
     end
 
     def notes_navigation_item

--- a/app/components/provider_interface/new_reference_with_feedback_component.html.erb
+++ b/app/components/provider_interface/new_reference_with_feedback_component.html.erb
@@ -1,0 +1,3 @@
+<div data-qa="reference">
+  <%= render SummaryListComponent.new(rows: rows) %>
+</div>

--- a/app/components/provider_interface/new_reference_with_feedback_component.rb
+++ b/app/components/provider_interface/new_reference_with_feedback_component.rb
@@ -63,7 +63,7 @@ module ProviderInterface
     end
 
     def relationship_confirmation_row
-      return if no_offer_yet?
+      return if application_choice.pre_offer?
 
       {
         key: 'Relationship confirmed by referee?',
@@ -72,7 +72,7 @@ module ProviderInterface
     end
 
     def relationship_correction_row
-      return if relationship_correction.blank? || no_offer_yet?
+      return if relationship_correction.blank? || application_choice.pre_offer?
 
       {
         key: 'Relationship amended by referee',
@@ -81,7 +81,7 @@ module ProviderInterface
     end
 
     def safeguarding_row
-      return if no_offer_yet?
+      return if application_choice.pre_offer?
 
       {
         key: 'Does the referee know of any reason why this candidate should not work with children?',
@@ -90,7 +90,7 @@ module ProviderInterface
     end
 
     def safeguarding_concerns_row
-      return if no_offer_yet? || !reference.has_safeguarding_concerns_to_declare?
+      return if application_choice.pre_offer? || !reference.has_safeguarding_concerns_to_declare?
 
       {
         key: 'Reason(s) given by referee why this candidate should not work with children',
@@ -99,16 +99,12 @@ module ProviderInterface
     end
 
     def feedback_row
-      return if no_offer_yet? || feedback.nil?
+      return if application_choice.pre_offer? || feedback.nil?
 
       {
         key: 'Reference',
         value: feedback,
       }
-    end
-
-    def no_offer_yet?
-      ApplicationStateChange::OFFERED_STATES.exclude? application_choice.status.to_sym
     end
   end
 end

--- a/app/components/provider_interface/new_reference_with_feedback_component.rb
+++ b/app/components/provider_interface/new_reference_with_feedback_component.rb
@@ -1,0 +1,103 @@
+module ProviderInterface
+  class NewReferenceWithFeedbackComponent < ViewComponent::Base
+    attr_accessor :reference, :index
+    delegate :feedback,
+             :name,
+             :email_address,
+             :referee_type,
+             :relationship,
+             :relationship_confirmation,
+             :relationship_correction,
+             :safeguarding_concerns,
+             :safeguarding_concerns_status,
+             to: :reference
+
+    def initialize(reference:, index:)
+      @reference = reference
+      @index = index
+    end
+
+    def rows
+      [
+        name_row,
+        email_address_row,
+        reference_type_row,
+        relationship_row,
+        relationship_confirmation_row,
+        relationship_correction_row,
+        safeguarding_row,
+        safeguarding_concerns_row,
+        feedback_row,
+      ].compact
+    end
+
+  private
+
+    def name_row
+      {
+        key: 'Name',
+        value: name,
+      }
+    end
+
+    def email_address_row
+      {
+        key: 'Email address',
+        value: govuk_mail_to(email_address, email_address),
+      }
+    end
+
+    def reference_type_row
+      {
+        key: 'Type of reference',
+        value: referee_type ? referee_type.capitalize.dasherize : '',
+      }
+    end
+
+    def relationship_row
+      {
+        key: 'Relationship between candidate and referee',
+        value: relationship,
+      }
+    end
+
+    def relationship_confirmation_row
+      {
+        key: 'Relationship confirmed by referee?',
+        value: relationship_correction.present? ? 'No' : 'Yes',
+      }
+    end
+
+    def relationship_correction_row
+      return if relationship_correction.blank?
+
+      {
+        key: 'Relationship amended by referee',
+        value: relationship_correction,
+      }
+    end
+
+    def safeguarding_row
+      {
+        key: 'Does the referee know of any reason why this candidate should not work with children?',
+        value: reference.has_safeguarding_concerns_to_declare? ? 'Yes' : 'No',
+      }
+    end
+
+    def safeguarding_concerns_row
+      return nil unless reference.has_safeguarding_concerns_to_declare?
+
+      {
+        key: 'Reason(s) given by referee why this candidate should not work with children',
+        value: safeguarding_concerns,
+      }
+    end
+
+    def feedback_row
+      {
+        key: 'Reference',
+        value: feedback.nil? ? 'Not answered' : feedback,
+      }
+    end
+  end
+end

--- a/app/controllers/provider_interface/references_controller.rb
+++ b/app/controllers/provider_interface/references_controller.rb
@@ -1,0 +1,9 @@
+module ProviderInterface
+  class ReferencesController < ProviderInterfaceController
+    before_action :set_application_choice
+
+    def index
+      @references = @application_choice.application_form.application_references
+    end
+  end
+end

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -64,6 +64,10 @@ class ApplicationChoice < ApplicationRecord
     ApplicationStateChange::DECISION_PENDING_STATUSES.include? status.to_sym
   end
 
+  def pre_offer?
+    ApplicationStateChange::OFFERED_STATES.exclude? status.to_sym
+  end
+
   def different_offer?
     current_course_option_id && current_course_option_id != course_option_id
   end

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -69,7 +69,7 @@
 
 <%= render PersonalStatementComponent.new(application_form: @application_choice.application_form) %>
 
-<% if @application_choice.application_form.selected_references.any? %>
+<% if @application_choice.application_form.selected_references.any? && FeatureFlag.inactive?(:new_references_flow_providers) %>
   <%= render 'references', selected_references: @application_choice.application_form.selected_references %>
 <% end %>
 

--- a/app/views/provider_interface/references/_references.html.erb
+++ b/app/views/provider_interface/references/_references.html.erb
@@ -1,0 +1,7 @@
+<% references.each_with_index do |reference, index| %>
+  <h3 class="govuk-heading-s govuk-!-margin-top-4 govuk-!-margin-bottom-2">
+    <%= reference.referee_type.humanize %> reference from <%= reference.name %>
+  </h3>
+
+  <%= render ProviderInterface::NewReferenceWithFeedbackComponent.new(reference: reference, index: index, application_choice: @application_choice) %>
+<% end %>

--- a/app/views/provider_interface/references/index.html.erb
+++ b/app/views/provider_interface/references/index.html.erb
@@ -1,0 +1,1 @@
+<h1>Hello from References tab</h1>

--- a/app/views/provider_interface/references/index.html.erb
+++ b/app/views/provider_interface/references/index.html.erb
@@ -5,12 +5,21 @@
 ) %>
 <h1 class="govuk-heading-l">References</h1>
 
-<p class="govuk-body">The candidate has received <%= @references.size %> references.</p>
+<% if ApplicationStateChange::OFFERED_STATES.exclude? @application_choice.status.to_sym %>
+  <p class="govuk-body">The candidate has given details of <%= @references.size %> people who can give references.</p>
+  <%= govuk_warning_text(text: 'You must not contact these references until the candidate has accepted an offer on your course') %>
 
-<% @references.each_with_index do |reference, index| %>
-  <h2 class="govuk-heading-m govuk-!-margin-top-4 govuk-!-margin-bottom-2">
-    <%= reference.referee_type.humanize %> reference from <%= reference.name %>
-  </h2>
+  <%= render 'references', references: @references, application_choice: @application_choice %>
 
-  <%= render ProviderInterface::NewReferenceWithFeedbackComponent.new(reference: reference, index: index, application_choice: @application_choice) %>
+<% else %>
+
+  <h2 class="govuk-heading-m">Received references</h2>
+  <% if @references.feedback_provided.empty? %>
+    <p class="govuk-body">The candidate has not received a reference yet.</p>
+  <% else %>
+    <%= render 'references', references: @references.feedback_provided, application_choice: @application_choice %>
+  <% end %>
+
+  <h2 class="govuk-heading-m">Requested references</h2>
+  <%= render 'references', references: @references.not_feedback_provided, application_choice: @application_choice %>
 <% end %>

--- a/app/views/provider_interface/references/index.html.erb
+++ b/app/views/provider_interface/references/index.html.erb
@@ -5,7 +5,7 @@
 ) %>
 <h1 class="govuk-heading-l">References</h1>
 
-<% if ApplicationStateChange::OFFERED_STATES.exclude? @application_choice.status.to_sym %>
+<% if @application_choice.pre_offer? %>
   <p class="govuk-body">The candidate has given details of <%= @references.size %> people who can give references.</p>
   <%= govuk_warning_text(text: 'You must not contact these references until the candidate has accepted an offer on your course') %>
 

--- a/app/views/provider_interface/references/index.html.erb
+++ b/app/views/provider_interface/references/index.html.erb
@@ -12,5 +12,5 @@
     <%= reference.referee_type.humanize %> reference from <%= reference.name %>
   </h2>
 
-  <%= render ProviderInterface::NewReferenceWithFeedbackComponent.new(reference: reference, index: index) %>
+  <%= render ProviderInterface::NewReferenceWithFeedbackComponent.new(reference: reference, index: index, application_choice: @application_choice) %>
 <% end %>

--- a/app/views/provider_interface/references/index.html.erb
+++ b/app/views/provider_interface/references/index.html.erb
@@ -1,1 +1,1 @@
-<h1>Hello from References tab</h1>
+<%= render 'provider_interface/application_choices/references', selected_references: @references %>

--- a/app/views/provider_interface/references/index.html.erb
+++ b/app/views/provider_interface/references/index.html.erb
@@ -1,1 +1,16 @@
-<%= render 'provider_interface/application_choices/references', selected_references: @references %>
+<% content_for :browser_title, "#{@application_choice.application_form.full_name} – #{@application_choice.course.name_and_code} - References" %>
+
+<%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(
+  application_choice: @application_choice,
+) %>
+<h1 class="govuk-heading-l">References</h1>
+
+<p class="govuk-body">The candidate has received <%= @references.size %> references.</p>
+
+<% @references.each_with_index do |reference, index| %>
+  <h2 class="govuk-heading-m govuk-!-margin-top-4 govuk-!-margin-bottom-2">
+    <%= reference.referee_type.humanize %> reference from <%= reference.name %>
+  </h2>
+
+  <%= render ProviderInterface::NewReferenceWithFeedbackComponent.new(reference: reference, index: index) %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -870,6 +870,7 @@ Rails.application.routes.draw do
       get '/decline-or-withdraw' => 'decline_or_withdraw#edit', as: :decline_or_withdraw_edit
       put '/decline-or-withdraw' => 'decline_or_withdraw#update', as: :decline_or_withdraw_update
 
+      resources :references, only: %i[index], as: :application_choice_references
       resources :notes, only: %i[index show new create], as: :application_choice_notes
 
       resources :interviews, only: %i[new create update edit index destroy], as: :application_choice_interviews do

--- a/spec/components/provider_interface/new_reference_with_feedback_component_spec.rb
+++ b/spec/components/provider_interface/new_reference_with_feedback_component_spec.rb
@@ -1,11 +1,18 @@
 require 'rails_helper'
 
-RSpec.describe ProviderInterface::NewReferenceWithFeedbackComponent do
+RSpec.describe ProviderInterface::NewReferenceWithFeedbackComponent, type: :component do
   describe '#rows' do
     let(:feedback) { 'A valuable unit of work' }
     let(:reference) { build(:reference, feedback: feedback) }
+    let(:application_choice) { build(:application_choice, :with_completed_application_form, :with_offer) }
 
-    subject(:component) { described_class.new(reference: reference, index: 0) }
+    subject(:component) do
+      described_class.new(
+        reference: reference,
+        index: 0,
+        application_choice: application_choice,
+      )
+    end
 
     it 'contains a name row' do
       row = component.rows.first
@@ -16,7 +23,7 @@ RSpec.describe ProviderInterface::NewReferenceWithFeedbackComponent do
     it 'contains an email address row' do
       row = component.rows.second
       expect(row[:key]).to eq('Email address')
-      expect(row[:value]).to include(reference.email_address)
+      expect(row[:value]).to eq(reference.email_address)
     end
 
     it 'contains a type of reference row' do
@@ -99,11 +106,11 @@ RSpec.describe ProviderInterface::NewReferenceWithFeedbackComponent do
         expect(row[:value]).to eq(reference.feedback)
       end
 
-      it 'contains a feedback row with "Not answered" when feedback is nil' do
+      it 'does not contain a feedback row when feedback when there is not an offer' do
         reference.feedback = nil
-        row = component.rows.last
-        expect(row[:key]).to eq('Reference')
-        expect(row[:value]).to eq('Not answered')
+        application_choice.status = 'awaiting_provider_decision'
+        result = render_inline(component)
+        expect(result.text).not_to include('Reference')
       end
     end
   end

--- a/spec/components/provider_interface/new_reference_with_feedback_component_spec.rb
+++ b/spec/components/provider_interface/new_reference_with_feedback_component_spec.rb
@@ -1,0 +1,110 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::NewReferenceWithFeedbackComponent do
+  describe '#rows' do
+    let(:feedback) { 'A valuable unit of work' }
+    let(:reference) { build(:reference, feedback: feedback) }
+
+    subject(:component) { described_class.new(reference: reference, index: 0) }
+
+    it 'contains a name row' do
+      row = component.rows.first
+      expect(row[:key]).to eq('Name')
+      expect(row[:value]).to eq(reference.name)
+    end
+
+    it 'contains an email address row' do
+      row = component.rows.second
+      expect(row[:key]).to eq('Email address')
+      expect(row[:value]).to include(reference.email_address)
+    end
+
+    it 'contains a type of reference row' do
+      row = component.rows.third
+      expect(row[:key]).to eq('Type of reference')
+      expect(row[:value]).to include(reference.referee_type.capitalize.dasherize)
+    end
+
+    context 'referee_type is nil' do
+      let(:reference) { build(:reference, feedback: feedback, referee_type: nil) }
+
+      it 'renders without raisin an error' do
+        row = component.rows.third
+        expect(row[:key]).to eq('Type of reference')
+        expect(row[:value]).to eq('')
+      end
+    end
+
+    it 'contains a relationship row' do
+      row = component.rows.fourth
+      expect(row[:key]).to eq('Relationship between candidate and referee')
+      expect(row[:value]).to eq(reference.relationship)
+    end
+
+    context 'referee relationship confirmation' do
+      it 'contains a confirmation row' do
+        expect(component.rows.fifth[:key]).to eq('Relationship confirmed by referee?')
+      end
+
+      it 'affirms the referee relationship when uncorrected' do
+        expect(component.rows.fifth[:value]).to eq('Yes')
+      end
+
+      it 'contains a correction as the row value when corrected' do
+        reference.relationship_correction = 'This is not correct'
+
+        expect(component.rows.fifth[:value]).to eq('No')
+
+        correction_row = component.rows[5]
+
+        expect(correction_row[:key]).to eq('Relationship amended by referee')
+        expect(correction_row[:value]).to eq('This is not correct')
+      end
+    end
+
+    context 'safeguarding' do
+      let(:safeguarding_row) { component.rows[5] }
+      let(:safeguarding_concerns_row) { component.rows[6] }
+
+      it 'contains a safeguarding row' do
+        expect(safeguarding_row[:key]).to eq(
+          'Does the referee know of any reason why this candidate should not work with children?',
+        )
+      end
+
+      it 'affirms safeguarding when no safeguarding concerns are present' do
+        expect(safeguarding_row[:value]).to eq('No')
+      end
+
+      it 'contains safeguarding concerns where present' do
+        reference.safeguarding_concerns = 'Is a big bad wolf, has posed as elderly grandparent.'
+        reference.safeguarding_concerns_status = :has_safeguarding_concerns_to_declare
+        expect(safeguarding_row[:value]).to eq('Yes')
+
+        expect(safeguarding_concerns_row[:key]).to eq(
+          'Reason(s) given by referee why this candidate should not work with children',
+        )
+        expect(safeguarding_concerns_row[:value]).to eq(reference.safeguarding_concerns)
+      end
+
+      it 'does not contain safeguarding concerns when nil' do
+        expect(safeguarding_concerns_row[:key]).to eq('Reference')
+      end
+    end
+
+    context 'feedback' do
+      it 'contains a feedback row' do
+        row = component.rows.last
+        expect(row[:key]).to eq('Reference')
+        expect(row[:value]).to eq(reference.feedback)
+      end
+
+      it 'contains a feedback row with "Not answered" when feedback is nil' do
+        reference.feedback = nil
+        row = component.rows.last
+        expect(row[:key]).to eq('Reference')
+        expect(row[:value]).to eq('Not answered')
+      end
+    end
+  end
+end

--- a/spec/system/provider_interface/provider_views_the_references_tab_on_manage_spec.rb
+++ b/spec/system/provider_interface/provider_views_the_references_tab_on_manage_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+RSpec.feature 'Provider views an application in new cycle' do
+  include CandidateHelper
+  include CycleTimetableHelper
+  include CourseOptionHelpers
+  include DfESignInHelpers
+
+  around do |example|
+    Timecop.freeze(CycleTimetable.apply_opens(2023) + 1.day) do
+      example.run
+    end
+  end
+
+  scenario 'Provider views the new references tab' do
+    given_the_new_reference_flow_feature_flag_is_on
+
+    given_i_am_a_provider_user_authenticated_with_dfe_sign_in
+    and_my_organisation_has_applications
+    and_i_sign_in_to_the_provider_interface
+    then_i_should_see_the_applications_from_my_organisation
+
+    when_i_click_on_an_application
+    then_i_should_be_on_the_application_view_page
+
+    when_i_click_on_the_references_tab
+    then_i_see_the_candidates_references
+  end
+
+  def given_the_new_reference_flow_feature_flag_is_on
+    FeatureFlag.activate(:new_references_flow_providers)
+  end
+
+  def given_i_am_a_provider_user_authenticated_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+    provider_signs_in_using_dfe_sign_in
+
+    provider_user = provider_user_exists_in_apply_database
+    create(:provider, :with_signed_agreement, code: 'ABC', provider_users: [provider_user])
+  end
+
+  def and_my_organisation_has_applications
+    course_option = course_option_for_provider_code(provider_code: 'ABC')
+
+    @my_provider_choice  = create(:submitted_application_choice,
+                                   :with_completed_application_form,
+                                   status: 'awaiting_provider_decision',
+                                   course_option: course_option)
+
+    @my_provider_choice.application_form.application_references.update(feedback_status: 'feedback_requested')
+  end
+
+  def then_i_should_see_the_applications_from_my_organisation
+    expect(page).to have_title 'Applications (1)'
+    expect(page).to have_content 'Applications (1)'
+    expect(page).to have_content @my_provider_choice.application_form.full_name
+  end
+
+  def when_i_click_on_an_application
+    click_on @my_provider_choice.application_form.full_name
+  end
+
+  def then_i_should_be_on_the_application_view_page
+    expect(page).to have_content @my_provider_choice.id
+
+    expect(page).to have_content @my_provider_choice.application_form.full_name
+  end
+
+  def when_i_click_on_the_references_tab
+    click_on 'References'
+  end
+
+  def then_i_see_the_candidates_references
+    references = @my_provider_choice.application_form.application_references
+    link = page.find_link('References', class: 'app-tab-navigation__link')
+    expect(link['aria-current']).to eq('page')
+
+    expect(page).to have_content 'The candidate has received 2 references'
+    expect(page).to have_content "#{references.first.referee_type.humanize} reference from #{references.first.name}"
+    expect(page).to have_content "#{references.second.referee_type.humanize} reference from #{references.second.name}"
+  end
+end

--- a/spec/system/provider_interface/provider_views_the_references_tab_on_manage_spec.rb
+++ b/spec/system/provider_interface/provider_views_the_references_tab_on_manage_spec.rb
@@ -42,10 +42,10 @@ RSpec.feature 'Provider views an application in new cycle' do
   def and_my_organisation_has_applications
     course_option = course_option_for_provider_code(provider_code: 'ABC')
 
-    @my_provider_choice  = create(:submitted_application_choice,
-                                   :with_completed_application_form,
-                                   status: 'awaiting_provider_decision',
-                                   course_option: course_option)
+    @my_provider_choice = create(:submitted_application_choice,
+                                 :with_completed_application_form,
+                                 status: 'awaiting_provider_decision',
+                                 course_option: course_option)
 
     @my_provider_choice.application_form.application_references.update(feedback_status: 'feedback_requested')
   end

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
 
   scenario 'the application data is visible' do
     given_i_am_a_provider_user_with_dfe_sign_in
+    and_the_feature_flag_for_new_references_is_inactive
     and_my_organisation_has_received_an_application_without_restructured_work_history
     and_i_am_permitted_to_see_applications_for_my_provider
     and_i_sign_in_to_the_provider_interface
@@ -61,6 +62,10 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
 
   def given_i_am_a_provider_user_with_dfe_sign_in
     provider_exists_in_dfe_sign_in
+  end
+
+  def and_the_feature_flag_for_new_references_is_inactive
+    FeatureFlag.deactivate(:new_references_flow_providers)
   end
 
   def and_i_am_permitted_to_see_applications_for_my_provider


### PR DESCRIPTION
## Context

We're adding a dedicated references tab whilst viewing an application on Manage.

If the candidate is yet to receive a reference i.e. they've only submitted an application then we will show a restricted view of the reference information and provide a warning for the provider not to contact the reference off-service.

Once they've accepted the offer the section is split into two: one for received references and one for requested references. The received references section will be populated as references are provided

## Changes proposed in this pull request
**New references tab on Manage:**
|Pre offer state|After accepting an offer|
|---|---|
|<img width="815" alt="image" src="https://user-images.githubusercontent.com/47917431/186187296-6a6250cc-a2e3-41db-bd63-d7dab37edac4.png">|<img width="858" alt="image" src="https://user-images.githubusercontent.com/47917431/186187498-07e80a71-a709-430e-87da-be747bf912a7.png">|


## Link to Trello card

https://trello.com/c/tXlSACLV/433-references-update-the-reference-information-we-show-on-the-application-tab