### PR TITLE
Character validation referee relationship

### DIFF
--- a/app/forms/candidate_interface/reference/referee_relationship_form.rb
+++ b/app/forms/candidate_interface/reference/referee_relationship_form.rb
@@ -4,7 +4,7 @@ module CandidateInterface
 
     attr_accessor :relationship
 
-    validates :relationship, presence: true, word_count: { maximum: 50 }
+    validates :relationship, presence: true, length: { maximum: 500 }
 
     def self.build_from_reference(reference)
       new(relationship: reference.relationship)

--- a/config/locales/candidate_interface/new_references.yml
+++ b/config/locales/candidate_interface/new_references.yml
@@ -104,6 +104,7 @@ en:
           attributes:
             relationship:
               blank: Enter how you know this referee and for how long
+              too_long: Enter how you know this referee and for how long in 500 characters or fewer
         candidate_interface/reference/submit_referee_form:
           attributes:
             submit:

--- a/spec/forms/candidate_interface/reference/referee_relationship_form_spec.rb
+++ b/spec/forms/candidate_interface/reference/referee_relationship_form_spec.rb
@@ -3,12 +3,7 @@ require 'rails_helper'
 RSpec.describe CandidateInterface::Reference::RefereeRelationshipForm, type: :model do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:relationship) }
-
-    valid_word_count = Faker::Lorem.sentence(word_count: 50)
-    invalid_word_count = Faker::Lorem.sentence(word_count: 51)
-
-    it { is_expected.to allow_value(valid_word_count).for(:relationship) }
-    it { is_expected.not_to allow_value(invalid_word_count).for(:relationship) }
+    it { is_expected.to validate_length_of(:relationship).is_at_most(500) }
   end
 
   describe '.build_from_reference' do


### PR DESCRIPTION
## Context
In the reference bug party it was found that you could enter any number of characters for the referee relationship attribute 

## Changes proposed in this pull request
* Change validation to add character limit

## Guidance to review
Visit /candidate/application/new-references/relationship/{id}

## Link to Trello card

https://trello.com/c/qvO23Xe0/515-references-bug-party-validate-word-count-whilst-adding-a-reference

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
