### PR TITLE
Fix visually hidden text delete reference

### DIFF
--- a/app/components/candidate_interface/new_references_review_component.html.erb
+++ b/app/components/candidate_interface/new_references_review_component.html.erb
@@ -15,7 +15,7 @@
             <li class="app-summary-card__actions-list-item">
               <%= govuk_link_to confirm_destroy_path(reference) do %>
                 <%= t('application_form.new_references.delete_reference.action') %>
-                <span class="govuk-visually-hidden"> <%= reference.name %></span>
+                <span class="govuk-visually-hidden">reference from <%= reference.name %></span>
               <% end %>
             </li>
           <% end %>

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_new_reference_feature_enabled_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_new_reference_feature_enabled_spec.rb
@@ -192,7 +192,7 @@ RSpec.feature 'Candidate accepts an offer' do
   end
 
   def and_i_click_delete_the_first_reference
-    click_on "Delete #{@application_form.application_references.first.name}"
+    click_on "Delete reference from #{@application_form.application_references.first.name}"
   end
 
   def then_the_back_link_should_point_to_the_accept_offer_page


### PR DESCRIPTION
## Context
Bug for visually hidden text when deleting references
## Changes proposed in this pull request
* Add 'reference from' to improve experience for screen reader users

## Guidance to review
Before
Delete Fred

After
<img width="625" alt="Screenshot 2022-08-22 at 12 32 45" src="https://user-images.githubusercontent.com/58793682/185912606-0f0c8283-ab09-4905-ae48-1adb7cd1cb32.png">

## Link to Trello card

https://trello.com/c/Io1Z5fyt/516-references-bug-party-visually-hidden-text
## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
