### PR TITLE
Add edit page titles for references

### DIFF
--- a/app/views/candidate_interface/new_references/email_address/edit.html.erb
+++ b/app/views/candidate_interface/new_references/email_address/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, title_with_error_prefix(t('page_titles.new_references_email_address', referee_name: @reference.name), @reference_email_address_form.errors.any?) %>
+<% content_for :title, title_with_error_prefix(t('page_titles.new_references_edit_email_address', referee_name: @reference.name), @reference_email_address_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(@edit_backlink) %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/new_references/name/edit.html.erb
+++ b/app/views/candidate_interface/new_references/name/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, title_with_error_prefix(t('page_titles.new_references_name'), @reference_name_form.errors.any?) %>
+<% content_for :title, title_with_error_prefix(t('page_titles.new_references_edit_name'), @reference_name_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(@edit_backlink) %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/new_references/relationship/edit.html.erb
+++ b/app/views/candidate_interface/new_references/relationship/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, title_with_error_prefix(t('page_titles.new_references_relationship'), @references_relationship_form.errors.any?) %>
+<% content_for :title, title_with_error_prefix(t('page_titles.new_references_edit_relationship'), @references_relationship_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(@edit_backlink) %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/new_references/type/edit.html.erb
+++ b/app/views/candidate_interface/new_references/type/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, title_with_error_prefix(t('page_titles.new_references_type'), @reference_type_form.errors.any?) %>
+<% content_for :title, title_with_error_prefix(t('page_titles.new_references_edit_type'), @reference_type_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(@edit_backlink) %>
 
 <div class="govuk-grid-row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -185,9 +185,13 @@ en:
     new_references: References
     new_references_start: Choose a referee
     new_references_name: What is the referee’s name?
+    new_references_edit_name: Edit the name of the referee
     new_references_email_address: What is %{referee_name}’s email address?
+    new_references_edit_email_address: Edit %{referee_name}’s email address
     new_references_type: What type of reference do you want to add?
+    new_references_edit_type: Edit the type of reference
     new_references_relationship: How do you know this referee and how long have you known them?
+    new_references_edit_relationship: Edit how you know this referee and how long you have known them
     new_references_unsubmitted_review: Check your answers before sending your request
     new_references_candidate_name: What’s your name?
     new_references_send_request: Are you ready to send a reference request?


### PR DESCRIPTION
## Context
There were no edit page titles for adding references. This meant there were duplicate page titles. This is not good for screen reader users and would be picked up on an accessibility review.

## Changes proposed in this pull request
* Add edit page titles for reference flow on candidate side

## Guidance to review
Add references and then edit to verify unique page titles

## Link to Trello card

https://trello.com/c/jhwFOJEX/514-references-bug-party-unique-page-titles

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
