### PR TITLE
Hide cancel request link on references that cant be cancelled

### DIFF
--- a/app/components/candidate_interface/new_reference_history_component.html.erb
+++ b/app/components/candidate_interface/new_reference_history_component.html.erb
@@ -1,8 +1,8 @@
 <% history.each do |event| %>
   <p class="govuk-body-s govuk-!-margin-top-2 govuk-!-margin-bottom-0">
-    <%= formatted_title event %> on <%= event.time.to_fs(:govuk_date) %>
+    <%= formatted_title(event) %> on <%= event.time.to_fs(:govuk_date) %>
 
-    <% if event.name == 'request_sent' %>
+    <% if can_be_cancelled?(event) %>
       - <%= govuk_link_to(t('application_form.new_references.cancel_request.action'), candidate_interface_new_references_confirm_cancel_reference_path(reference, return_to: 'offer-dashboard')) %>
     <% end %>
   </p>

--- a/app/components/candidate_interface/new_reference_history_component.rb
+++ b/app/components/candidate_interface/new_reference_history_component.rb
@@ -21,5 +21,9 @@ module CandidateInterface
         event.name.humanize
       end
     end
+
+    def can_be_cancelled?(event)
+      reference.feedback_status == 'feedback_requested' && event.name == 'request_sent'
+    end
   end
 end

--- a/spec/components/candidate_interface/new_reference_history_component_spec.rb
+++ b/spec/components/candidate_interface/new_reference_history_component_spec.rb
@@ -34,4 +34,34 @@ RSpec.describe CandidateInterface::NewReferenceHistoryComponent, type: :componen
     list_item = result.css('p').first
     expect(list_item.text).to include "Request sent on #{Time.zone.now.to_fs(:govuk_date)}"
   end
+
+  it 'renders cancel request link for reference feedback_status that is feedback_requested', with_audited: true do
+    reference = create(:reference, :not_requested_yet)
+    reference.feedback_requested!
+
+    render_inline(described_class.new(reference))
+
+    expect(rendered_component).to have_text 'Cancel request'
+  end
+
+  it 'hides cancel request link for reference feedback_status that is not feedback_requested', with_audited: true do
+    reference = create(:reference, :not_requested_yet)
+    reference.feedback_requested!
+    reference.feedback_provided!
+
+    render_inline(described_class.new(reference))
+
+    expect(rendered_component).not_to have_text 'Cancel request'
+  end
+
+  it 'renders cancel request link once despite many reminders', with_audited: true do
+    reference = create(:reference, :not_requested_yet)
+    reference.feedback_requested!
+    reference.update!(reminder_sent_at: 1.day.ago)
+    reference.update!(reminder_sent_at: Time.zone.now)
+
+    render_inline(described_class.new(reference))
+
+    expect(rendered_component).to have_content('Cancel request', count: 1)
+  end
 end


### PR DESCRIPTION
## Context
Cancel request links were showing when they shouldn’t. For example, if a candidate had cancelled the reference request, the cancel request link would still show.  However, we still need to retain the cancel request link for when candidate only requests feedback. 

## Changes proposed in this pull request
* Hides the cancel request link unless reference is in a feedback requested state

## Guidance to review
Enable new reference flow. Verify cancel request links for references are hidden correctly by having references in different states after offer has been accepted

## Link to Trello card
https://trello.com/c/4Ky9P1Sr/517-references-bug-party-hide-the-small-cancel-request-link-on-references-that-cant-be-cancelled

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
