### PR TITLE
Show the current report the exact day that it should be published

### DIFF
--- a/app/services/monthly_statistics_timetable.rb
+++ b/app/services/monthly_statistics_timetable.rb
@@ -16,7 +16,7 @@ module MonthlyStatisticsTimetable
   end
 
   def self.last_publication_date
-    return current_publication_date if current_publication_date < Time.zone.today
+    return current_publication_date if current_publication_date <= Time.zone.today
 
     last_generation_date + 1.week
   end

--- a/spec/services/monthly_statistics_timetable_spec.rb
+++ b/spec/services/monthly_statistics_timetable_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe MonthlyStatisticsTimetable do
       end
     end
 
-    context 'when today is after the publishing date in the current month' do
+    context 'when today is on or after the publishing date in the current month' do
       it 'returns the previous report' do
         Timecop.freeze(Time.zone.local(2021, 12, 27, 0, 0, 1)) do
           expect(described_class.report_for_current_period).to eq(current_report)

--- a/spec/services/monthly_statistics_timetable_spec.rb
+++ b/spec/services/monthly_statistics_timetable_spec.rb
@@ -20,8 +20,12 @@ RSpec.describe MonthlyStatisticsTimetable do
   end
 
   describe '#report_for_current_period' do
-    let!(:current_report) { Publications::MonthlyStatistics::MonthlyStatisticsReport.create(month: '2021-12') }
-    let!(:previous_report) { Publications::MonthlyStatistics::MonthlyStatisticsReport.create(month: '2021-11') }
+    let!(:current_report) do
+      Publications::MonthlyStatistics::MonthlyStatisticsReport.create(month: '2021-12')
+    end
+    let!(:previous_report) do
+      Publications::MonthlyStatistics::MonthlyStatisticsReport.create(month: '2021-11')
+    end
 
     context 'when today is before the publishing date in the current month' do
       it 'returns the previous report' do
@@ -33,7 +37,7 @@ RSpec.describe MonthlyStatisticsTimetable do
 
     context 'when today is after the publishing date in the current month' do
       it 'returns the previous report' do
-        Timecop.freeze(Date.new(2021, 12, 28)) do
+        Timecop.freeze(Time.zone.local(2021, 12, 27, 0, 0, 1)) do
           expect(described_class.report_for_current_period).to eq(current_report)
         end
       end


### PR DESCRIPTION
## Context

Paired with @d-a-v-e. 

The user raised a bug that the monthly statistics report didn't seem to have published the August breakdown and is suggesting there won't be another until September. But the code generated the report but it wasn't showing in the interface. 

For more info see the commit message.

## Link to Trello card

https://trello.com/c/22sh8PIT/549-issue-with-the-monthly-stats-report

