### PR TITLE
Increase rejections text fields to 200 words

### DIFF
--- a/app/models/rejection_reasons/details.rb
+++ b/app/models/rejection_reasons/details.rb
@@ -1,7 +1,7 @@
 class RejectionReasons
   class Details
     include ActiveModel::Model
-    WORD_COUNT = 100
+    MAX_WORDS = 200
 
     attr_accessor :id, :label, :text, :optional
     validate :text_present, :word_count, unless: -> { optional }
@@ -20,7 +20,7 @@ class RejectionReasons
     end
 
     def word_count
-      if text.present? && text.scan(/\S+/).size > WORD_COUNT
+      if text.present? && text.scan(/\S+/).size > MAX_WORDS
         errors.add(id, RejectionReasons.translated_error(id, :size))
       end
     end

--- a/app/views/provider_interface/rejections/new.html.erb
+++ b/app/views/provider_interface/rejections/new.html.erb
@@ -27,7 +27,7 @@
           <%= f.govuk_check_box :selected_reasons, reason.id, label: { text: reason.label }, link_errors: true do %>
             <% if reason.details.present? %>
               <%= f.govuk_text_area reason.details.id.to_sym,
-                  label: { text: reason.details.label, class: 'govuk-label govuk-label--s' }, max_words: 100 %>
+                  label: { text: reason.details.label, class: 'govuk-label govuk-label--s' }, max_words: RejectionReasons::Details::MAX_WORDS %>
             <% elsif reason.reasons&.any? %>
               <%= f.govuk_check_boxes_fieldset reason.selected_reasons_attr_name, legend: { text: 'Reasons', size: 's' } do %>
                 <% reason.reasons.each do |nested_reason| %>
@@ -37,7 +37,11 @@
                     link_errors: true do %>
                     <% if nested_reason.details.present? %>
                       <%= f.govuk_text_area nested_reason.details.id.to_sym,
-                          label: { text: nested_reason.details.label, class: 'govuk-label govuk-label--s' }, max_words: 100 %>
+                        label: {
+                          text: nested_reason.details.label,
+                          class: 'govuk-label govuk-label--s',
+                        },
+                        max_words: RejectionReasons::Details::MAX_WORDS %>
                     <% end %>
                   <% end %>
                 <% end %>

--- a/spec/models/rejection_reasons/details_spec.rb
+++ b/spec/models/rejection_reasons/details_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RejectionReasons::Details do
 
     it 'validates word count of text' do
       words = 'All work and no play makes Jack a dull boy. '
-      11.times { words += words }
+      21.times { words += words }
 
       details = described_class.new(id: 'aaa', text: words)
 


### PR DESCRIPTION
## Context

Some Providers want more space to provide rejection feedback. 

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Increase rejections details text field max word count from 100 to 200.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/cTIQYZIO/485-r4r-increase-length-of-free-text-box
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
