### PR TITLE
Add Roma to White ethnicity group

### DIFF
--- a/config/initializers/ethnicities.rb
+++ b/config/initializers/ethnicities.rb
@@ -14,7 +14,7 @@ ETHNIC_BACKGROUNDS = {
   EthnicGroup::ASIAN => %w[Bangladeshi Chinese Indian Pakistani],
   EthnicGroup::BLACK => %w[African Caribbean],
   EthnicGroup::MIXED => ['Asian and White', 'Black African and White', 'Black Caribbean and White'],
-  EthnicGroup::WHITE => ['British, English, Northern Irish, Scottish, or Welsh', 'Irish', 'Irish Traveller or Gypsy'],
+  EthnicGroup::WHITE => ['British, English, Northern Irish, Scottish, or Welsh', 'Irish', 'Irish Traveller or Gypsy', 'Roma'],
   EthnicGroup::OTHER => %w[Arab],
 }.freeze
 


### PR DESCRIPTION
## Context

2022/23 HESA data adds the Ethnicity `White - Roma`. We should allow candidates to select this value.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds `Roma` to White ethnicity group.

![image](https://user-images.githubusercontent.com/93511/187637443-2ff4f530-2e9b-4c8d-8087-ed897bbb53f7.png)

`->`

![image](https://user-images.githubusercontent.com/93511/187637596-7fa91274-7517-40c3-96cd-1b715dc61632.png)


<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/fv8YVsWd/536-add-roma-to-our-ed-question-under-white
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
