### PR TITLE
548 references bug do not allow to submit anything if the references are not complete

### DIFF
--- a/app/controllers/candidate_interface/decisions_controller.rb
+++ b/app/controllers/candidate_interface/decisions_controller.rb
@@ -46,6 +46,7 @@ module CandidateInterface
         flash[:success] = "You have accepted your offer for #{@application_choice.current_course.name_and_code} at #{@application_choice.provider.name}"
         redirect_to candidate_interface_application_complete_path
       else
+        track_validation_error(@accept_offer)
         render :accept_offer
       end
     end

--- a/app/controllers/candidate_interface/new_references/request_reference/review_controller.rb
+++ b/app/controllers/candidate_interface/new_references/request_reference/review_controller.rb
@@ -13,6 +13,7 @@ module CandidateInterface
 
           redirect_to candidate_interface_application_offer_dashboard_path
         else
+          track_validation_error(request_reference)
           render :new
         end
       end

--- a/app/controllers/candidate_interface/new_references/request_reference/review_controller.rb
+++ b/app/controllers/candidate_interface/new_references/request_reference/review_controller.rb
@@ -6,14 +6,14 @@ module CandidateInterface
       before_action :verify_reference_can_be_requested, only: %i[request_feedback]
 
       def request_feedback
-        request_reference = ::RequestReference.new(reference: @reference)
+        @request_reference = ::RequestReference.new(reference: @reference)
 
-        if request_reference.send_request
+        if @request_reference.send_request
           flash[:success] = "Reference request sent to #{@reference.name}"
 
           redirect_to candidate_interface_application_offer_dashboard_path
         else
-          track_validation_error(request_reference)
+          track_validation_error(@request_reference)
           render :new
         end
       end

--- a/app/controllers/candidate_interface/new_references/request_reference/review_controller.rb
+++ b/app/controllers/candidate_interface/new_references/request_reference/review_controller.rb
@@ -6,10 +6,15 @@ module CandidateInterface
       before_action :verify_reference_can_be_requested, only: %i[request_feedback]
 
       def request_feedback
-        ::RequestReference.new.call(@reference)
-        flash[:success] = "Reference request sent to #{@reference.name}"
+        request_reference = ::RequestReference.new(reference: @reference)
 
-        redirect_to candidate_interface_application_offer_dashboard_path
+        if request_reference.send_request
+          flash[:success] = "Reference request sent to #{@reference.name}"
+
+          redirect_to candidate_interface_application_offer_dashboard_path
+        else
+          render :new
+        end
       end
 
     private

--- a/app/controllers/candidate_interface/new_references/review_controller.rb
+++ b/app/controllers/candidate_interface/new_references/review_controller.rb
@@ -5,14 +5,16 @@ module CandidateInterface
       before_action :set_destroy_backlink, only: %i[confirm_destroy_reference]
 
       def show
-        @section_complete_form = SectionCompleteForm.new(
+        @section_complete_form = ReferenceSectionCompleteForm.new(
           completed: current_application.references_completed,
         )
       end
 
       def complete
         @application_form = current_application
-        @section_complete_form = SectionCompleteForm.new(application_form_params)
+        @section_complete_form = ReferenceSectionCompleteForm.new(
+          application_form_params.merge(application_form: @application_form)
+        )
 
         if @application_form.complete_references_information? && @section_complete_form.save(current_application, :references_completed)
           redirect_to candidate_interface_application_form_path
@@ -54,7 +56,7 @@ module CandidateInterface
       end
 
       def application_form_params
-        strip_whitespace params.fetch(:candidate_interface_section_complete_form, {}).permit(:completed)
+        strip_whitespace params.fetch(:candidate_interface_reference_section_complete_form, {}).permit(:completed)
       end
     end
   end

--- a/app/forms/candidate_interface/reference_section_complete_form.rb
+++ b/app/forms/candidate_interface/reference_section_complete_form.rb
@@ -2,6 +2,6 @@ module CandidateInterface
   class ReferenceSectionCompleteForm < SectionCompleteForm
     attr_accessor :application_form
 
-    validates :application_form, application_form_with_complete_references: true
+    validates :application_form, application_form_with_complete_references: true, if: :completed?
   end
 end

--- a/app/forms/candidate_interface/reference_section_complete_form.rb
+++ b/app/forms/candidate_interface/reference_section_complete_form.rb
@@ -1,0 +1,7 @@
+module CandidateInterface
+  class ReferenceSectionCompleteForm < SectionCompleteForm
+    attr_accessor :application_form
+
+    validates :application_form, application_form_with_complete_references: true
+  end
+end

--- a/app/services/accept_offer.rb
+++ b/app/services/accept_offer.rb
@@ -3,6 +3,7 @@ class AcceptOffer
   attr_accessor :application_choice
 
   validate :references_completed, if: :new_reference_flow?
+  validates :application_choice, application_form_with_complete_references: true, if: :new_reference_flow?
 
   def save!
     return unless valid?

--- a/app/validators/application_form_with_complete_references_validator.rb
+++ b/app/validators/application_form_with_complete_references_validator.rb
@@ -1,25 +1,16 @@
 class ApplicationFormWithCompleteReferencesValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    return unless record.completed?
-
-    application_form = value
+    application_form = value.is_a?(ApplicationForm) ? value : value.application_form
 
     record.errors.add(attribute, :incomplete_references) if invalid_references?(application_form)
   end
 
   def invalid_references?(application_form)
-    !application_form.complete_references_information? ||
-      application_form.application_references.any? do |application_reference|
-        referee_email_address_form = CandidateInterface::Reference::RefereeEmailAddressForm.new(
-          email_address: application_reference.email_address,
-          reference_id: application_reference.id,
-        )
-
-        referee_relationship_form = CandidateInterface::Reference::RefereeRelationshipForm.new(
-          relationship: application_reference.relationship,
-        )
-
-        referee_email_address_form.invalid? || referee_relationship_form.invalid?
-      end
+    application_form.application_references.any? do |application_reference|
+      !CandidateInterface::Reference::SubmitRefereeForm.new(
+        submit: 'yes',
+        reference_id: application_reference.id,
+      ).valid?
+    end
   end
 end

--- a/app/validators/application_form_with_complete_references_validator.rb
+++ b/app/validators/application_form_with_complete_references_validator.rb
@@ -1,0 +1,25 @@
+class ApplicationFormWithCompleteReferencesValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return unless record.completed?
+
+    application_form = value
+
+    record.errors.add(attribute, :incomplete_references) if invalid_references?(application_form)
+  end
+
+  def invalid_references?(application_form)
+    !application_form.complete_references_information? ||
+      application_form.application_references.any? do |application_reference|
+        referee_email_address_form = CandidateInterface::Reference::RefereeEmailAddressForm.new(
+          email_address: application_reference.email_address,
+          reference_id: application_reference.id,
+        )
+
+        referee_relationship_form = CandidateInterface::Reference::RefereeRelationshipForm.new(
+          relationship: application_reference.relationship,
+        )
+
+        referee_email_address_form.invalid? || referee_relationship_form.invalid?
+      end
+  end
+end

--- a/app/views/candidate_interface/new_references/request_reference/review/new.html.erb
+++ b/app/views/candidate_interface/new_references/request_reference/review/new.html.erb
@@ -3,11 +3,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">
-      <%= I18n.t('page_titles.new_references_request_reference_review') %>
-    </h1>
+    <%= form_with model: @request_reference, url: candidate_interface_new_references_request_reference_request_feedback_path(@reference), method: :post do |f| %>
+      <%= f.govuk_error_summary %>
 
-    <%= form_with model: @reference, url: candidate_interface_new_references_request_reference_request_feedback_path(@reference), method: :post do |f| %>
+      <h1 class="govuk-heading-l">
+        <%= I18n.t('page_titles.new_references_request_reference_review') %>
+      </h1>
+
       <%= render CandidateInterface::RequestReferenceReviewComponent.new(@reference) %>
 
       <p class="govuk-body">Referees cannot see the content of your application.</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -530,6 +530,7 @@ en:
       before: Enter %{article} %{attribute} that is before the %{compared_attribute}
       dob_future: Enter a %{attribute} that is in the past, for example 31 3 1980
       dob_below_min_age: Enter a date of birth before %{date} – you must be over %{min_age} years old to Apply for teacher training
+      incomplete_references: Enter all required fields for each reference added
     application_choices:
       course_not_available: You cannot apply to ‘%{descriptor}’ because it is not running
       course_full: You cannot apply to ‘%{descriptor}’ because it has no vacancies

--- a/spec/forms/candidate_interface/reference_section_complete_form_spec.rb
+++ b/spec/forms/candidate_interface/reference_section_complete_form_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::ReferenceSectionCompleteForm do
+  context 'when two or more references' do
+    context 'when mark as incomplete' do
+      it 'is valid' do
+        application_form = create(:application_form, :with_completed_references)
+        create(:reference, email_address: nil, relationship: nil, application_form: application_form)
+        form = described_class.new(application_form: application_form, completed: 'false')
+        expect(form).to be_valid
+      end
+    end
+
+    context 'when one of the references has incomplete email' do
+      it 'is invalid' do
+        application_form = create(:application_form, :with_completed_references)
+        create(:reference, application_form: application_form)
+        create(:reference, email_address: nil, application_form: application_form)
+        form = described_class.new(application_form: application_form, completed: 'true')
+        expect(form).to be_invalid
+        expect(form.errors[:application_form]).to include(
+          I18n.t('errors.messages.incomplete_references')
+        )
+      end
+    end
+
+    context 'when one of the references has incomplete relationship' do
+      it 'is invalid' do
+        application_form = create(:application_form, :with_completed_references)
+        create(:reference, application_form: application_form)
+        create(:reference, relationship: nil, application_form: application_form)
+        form = described_class.new(application_form: application_form, completed: 'true')
+        expect(form).to be_invalid
+      end
+    end
+
+    context 'when one of the references has wrong data' do
+      it 'is invalid' do
+        application_form = create(:application_form, :with_completed_references)
+        create(:reference, email_address: 'aaa', relationship: nil, application_form: application_form)
+        form = described_class.new(application_form: application_form, completed: 'true')
+        expect(form).to be_invalid
+      end
+    end
+
+    context 'when references has complete data' do
+      it 'is valid' do
+        application_form = create(:application_form)
+        create_list(:reference, 2, application_form: application_form)
+        form = described_class.new(application_form: application_form, completed: 'true')
+        expect(form).to be_valid
+      end
+    end
+  end
+
+  context 'when less than two references' do
+    it 'is invalid' do
+      application_form = create(:application_form)
+      form = described_class.new(application_form: application_form, completed: 'true')
+      expect(form).to be_invalid
+    end
+  end
+end

--- a/spec/forms/candidate_interface/reference_section_complete_form_spec.rb
+++ b/spec/forms/candidate_interface/reference_section_complete_form_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe CandidateInterface::ReferenceSectionCompleteForm do
         form = described_class.new(application_form: application_form, completed: 'true')
         expect(form).to be_invalid
         expect(form.errors[:application_form]).to include(
-          I18n.t('errors.messages.incomplete_references')
+          I18n.t('errors.messages.incomplete_references'),
         )
       end
     end
@@ -50,14 +50,6 @@ RSpec.describe CandidateInterface::ReferenceSectionCompleteForm do
         form = described_class.new(application_form: application_form, completed: 'true')
         expect(form).to be_valid
       end
-    end
-  end
-
-  context 'when less than two references' do
-    it 'is invalid' do
-      application_form = create(:application_form)
-      form = described_class.new(application_form: application_form, completed: 'true')
-      expect(form).to be_invalid
     end
   end
 end

--- a/spec/services/accept_offer_spec.rb
+++ b/spec/services/accept_offer_spec.rb
@@ -28,6 +28,20 @@ RSpec.describe AcceptOffer do
         end
       end
 
+      context 'when one of the references has incomplete email' do
+        it 'is invalid' do
+          application_form = create(:application_form, :minimum_info, recruitment_cycle_year: 2023)
+          application_choice = create(:application_choice, :with_offer, application_form: application_form)
+          create(:reference, application_form: application_form)
+          create(:reference, email_address: nil, application_form: application_form)
+          form = described_class.new(application_choice: application_choice)
+          expect(form).to be_invalid
+          expect(form.errors[:application_choice]).to include(
+            I18n.t('errors.messages.incomplete_references'),
+          )
+        end
+      end
+
       context 'when the reference is pending', sidekiq: true do
         it 'send the reference request' do
           application_form = create(:completed_application_form, :with_completed_references, recruitment_cycle_year: 2023)

--- a/spec/services/request_reference_spec.rb
+++ b/spec/services/request_reference_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe RequestReference do
+  let(:application_form) { create(:application_form, recruitment_cycle_year: 2023) }
+
+  describe '#send_request' do
+    context 'when new references feature flag is active' do
+      before do
+        FeatureFlag.activate(:new_references_flow)
+      end
+
+      context 'when one of the references has incomplete email' do
+        it 'is invalid' do
+          reference = create(:reference, email_address: nil, application_form: application_form)
+          request_reference = described_class.new(reference: reference)
+          expect(request_reference.send_request).to be_falsey
+          expect(request_reference.errors[:reference]).to include(
+            I18n.t('errors.messages.incomplete_references'),
+          )
+        end
+      end
+
+      context 'when one of the references has incomplete relationship' do
+        it 'is invalid' do
+          reference = create(:reference, relationship: nil, application_form: application_form)
+          request_reference = described_class.new(reference: reference)
+          expect(request_reference.send_request).to be_falsey
+          expect(request_reference.errors[:reference]).to include(
+            I18n.t('errors.messages.incomplete_references'),
+          )
+        end
+      end
+    end
+
+    context 'when new references feature flag is inactive' do
+      before do
+        FeatureFlag.deactivate(:new_references_flow)
+      end
+
+      it 'is valid' do
+        reference = create(:reference, email_address: nil, application_form: application_form)
+        request_reference = described_class.new(reference: reference)
+        expect(request_reference).to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

There is the scenario where the candidate creates a reference without an email and/or relationship so we need to prevent for progressing until those fields are complete.

## Trello card 

https://trello.com/c/Vebfn0da/548-references-bug-do-not-allow-to-submit-anything-if-the-references-are-not-complete