### PR TITLE
Revert deferral scenario for support playbook

### DIFF
--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -150,7 +150,14 @@ This can be requested if a provider accidentally marks an application as conditi
 a = ApplicationForm.find_by!(support_reference:'$REF')
 a.application_choices.select(&:conditions_not_met?).first.update!(status: :pending_conditions, conditions_not_met_at: nil, audit_comment: 'Support request following provider accidentally marking them as conditions_not_met.')
 ```
+### Revert an application choice to pending_conditions from offer_deferred
 
+This normally occurs after a candidate changes their mind and wants to start the course in the current recruitment cycle
+
+```ruby
+ac = ApplicationChoice.find(id)
+ac.update!(status: 'pending_conditions', offer_deferred_at: nil, status_before_deferral: nil, audit_comment: 'Support request...')
+```
 ### Revert a rejection
 
 Providers may need to revert a rejection so that they can offer a different course or if it was done in error.


### PR DESCRIPTION
## Context
What support dev should do if the candidate changes their mind and wants to revert their deferral
## Changes proposed in this pull request

* Add revert deferral scenario to support playbook

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/UjgQJ1Ie/557-update-support-playbook-with-instructions-for-undoing-a-deferral

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
