### PR TITLE
New references flow - Update offer confirmation page

### DIFF
--- a/app/components/candidate_interface/offer_conditions_review_component.html.erb
+++ b/app/components/candidate_interface/offer_conditions_review_component.html.erb
@@ -9,5 +9,5 @@
 </p>
 
 <p class="govuk-body">
-  You should also have received full terms and conditions from the provider.
+  They’ll confirm your place once you’ve met the conditions and they’ve received your references.
 </p>

--- a/app/components/provider_interface/deferred_offer_details_component.html.erb
+++ b/app/components/provider_interface/deferred_offer_details_component.html.erb
@@ -4,4 +4,6 @@
 
 <h2 class="govuk-heading-m">Conditions of offer</h2>
 
+<p class="govuk-body">Candidates are required to receive 2 references.</p>
+
 <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>

--- a/app/components/provider_interface/offer_summary_component.html.erb
+++ b/app/components/provider_interface/offer_summary_component.html.erb
@@ -4,6 +4,8 @@
 
   <h2 class="govuk-heading-m">Conditions of offer</h2>
 
+  <p class="govuk-body">Candidates are required to receive 2 references.</p>
+
   <% if editable %>
     <% if @application_choice.pending_conditions? %>
       <div class='govuk-body'>

--- a/app/views/provider_interface/offer/conditions/_form.html.erb
+++ b/app/views/provider_interface/offer/conditions/_form.html.erb
@@ -14,6 +14,15 @@
                                          :name,
                                          legend: { size: 'm' }) %>
 
+      <h2 class="govuk-heading-m">References</h2>
+      <p class="govuk-body">The candidate will confirm which references they want to request when they accept your offer.</p>
+      <p class="govuk-body">They’ll be told they need 2 references including:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>an academic tutor if they have graduated in the past 5 years or are still studying</li>
+        <li>the headteacher if they’ve been working in a school</li>
+      </ul>
+      <p class="govuk-body">Add a further condition if you have other requirements for references</p>
+
       <%= f.govuk_fieldset(
         legend: {
           id: 'further-conditions-heading',

--- a/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
+++ b/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe CandidateInterface::ApplicationDashboardCourseChoicesComponent, t
       render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
 
       expect(rendered_component).to summarise(key: 'Status', value: "Offer received What to do if you’re unable to start training in #{application_choice.course_option.course.start_date.to_fs(:month_and_year)} Some providers allow you to defer your offer. This means that you could start your course a year later. Every provider is different, so it may or may not be possible to do this. Find out by contacting #{application_choice.course_option.course.provider.name}. Asking if it’s possible to defer will not affect your existing offer. If your provider agrees to defer your offer, you’ll need to accept the offer on your account first.")
-      expect(rendered_component).to summarise(key: 'Conditions', value: 'DBS check Get a haircut Contact the provider to find out more about these conditions. You should also have received full terms and conditions from the provider.')
+      expect(rendered_component).to summarise(key: 'Conditions', value: 'DBS check Get a haircut Contact the provider to find out more about these conditions. They’ll confirm your place once you’ve met the conditions and they’ve received your references.')
     end
 
     it 'renders component with the respond to offer link and message about waiting for providers to respond' do

--- a/spec/system/provider_interface/make_offer_spec.rb
+++ b/spec/system/provider_interface/make_offer_spec.rb
@@ -34,6 +34,7 @@ RSpec.feature 'Provider makes an offer' do
     when_i_choose_to_make_an_offer
     then_the_conditions_page_is_loaded
     and_the_default_conditions_are_checked
+    and_the_reference_guidance_is_visible
 
     when_i_add_further_conditions
     and_i_add_and_remove_another_condition
@@ -120,6 +121,13 @@ RSpec.feature 'Provider makes an offer' do
   def and_the_default_conditions_are_checked
     expect(find("input[value='Fitness to train to teach check']")).to be_checked
     expect(find("input[value='Disclosure and Barring Service (DBS) check']")).to be_checked
+  end
+
+  def and_the_reference_guidance_is_visible
+    expect(page).to have_content('The candidate will confirm which references they want to request when they accept your offer.')
+    expect(page).to have_content('They’ll be told they need 2 references including:')
+    expect(page).to have_content('They’ll be told they need 2 references including:')
+    expect(page).to have_content('an academic tutor if they have graduated in the past 5 years or are still studying the headteacher if they’ve been working in a school')
   end
 
   def when_i_add_further_conditions


### PR DESCRIPTION
## Context

We need to add guidance in a number of places to inform both the candidate and the provider that references are required as a condition of offer.

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="595" alt="image" src="https://user-images.githubusercontent.com/47917431/187421196-d3a83b0b-adad-4ed0-9470-3222def5bdcf.png">|<img width="662" alt="image" src="https://user-images.githubusercontent.com/47917431/187420557-f962ca42-096d-42c3-91e9-caccf87cce5f.png">|
|<img width="673" alt="image" src="https://user-images.githubusercontent.com/47917431/187421097-7090a381-6ec2-4005-bf72-f899e0ca634a.png">|<img width="669" alt="image" src="https://user-images.githubusercontent.com/47917431/187420613-357fd7e9-e614-44c6-b7de-47feffc9b8d5.png">|
|<img width="537" alt="image" src="https://user-images.githubusercontent.com/47917431/187420948-c4b79819-44a2-4acf-959c-35481a08830e.png">|<img width="633" alt="image" src="https://user-images.githubusercontent.com/47917431/187420721-40bea046-9eae-4147-b05b-d2782e447ac8.png">|
|<img width="605" alt="image" src="https://user-images.githubusercontent.com/47917431/187422092-4d7e4080-2b4f-4a56-9b8f-9a2b17a0a297.png">|<img width="640" alt="image" src="https://user-images.githubusercontent.com/47917431/187434139-fdf615fa-5b35-474d-9098-d267033c6a18.png">|

## Guidance to review

https://github.com/DFE-Digital/manage-teacher-training-applications-prototype/pull/583

## Link to Trello card

https://trello.com/c/YEhUDw1A/434-references-update-offer-confirmation-page

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
