### PR TITLE
Add 'Development condition' to Ethnicity and disabilities questionnaire

### DIFF
--- a/app/helpers/disability_helper.rb
+++ b/app/helpers/disability_helper.rb
@@ -1,5 +1,5 @@
 module DisabilityHelper
-  STANDARD_DISABILITIES = %w[blind deaf learning long_standing mental physical social].map do |disability|
+  STANDARD_DISABILITIES = %w[blind deaf development learning long_standing mental physical social].map do |disability|
     [disability, I18n.t("equality_and_diversity.disabilities.#{disability}.label")]
   end.freeze
 end

--- a/app/lib/hesa/disability.rb
+++ b/app/lib/hesa/disability.rb
@@ -23,6 +23,7 @@ module Hesa
         'Long-standing illness' => HesaDisabilityValues::LONGSTANDING_ILLNESS,
         'Mental health condition' => HesaDisabilityValues::MENTAL_HEALTH_CONDITION,
         'Physical disability or mobility issue' => HesaDisabilityValues::PHYSICAL_OR_MOBILITY,
+        'Development condition' => HesaDisabilityValues::DEVELOPMENT_CONDITION,
         'Deaf' => HesaDisabilityValues::DEAF,
         'Blind' => HesaDisabilityValues::BLIND,
         'Other' => HesaDisabilityValues::OTHER,

--- a/config/locales/candidate_interface/equality_and_diversity.yml
+++ b/config/locales/candidate_interface/equality_and_diversity.yml
@@ -27,6 +27,9 @@ en:
       deaf:
         label: Deaf
         hint_text: Or a serious hearing impairment
+      development:
+        label: Development condition
+        hint_text: A condition had since childhood which affects motor, cognitive, social and emotional skills, and speech and language
       learning:
         label: Learning difficulty
         hint_text: For example, dyslexia, dyspraxia or ADHD

--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -63,7 +63,7 @@ FactoryBot.define do
         all_disabilities = DisabilityHelper::STANDARD_DISABILITIES.map(&:second) << other_disability
         disabilities = rand < 0.85 ? all_disabilities.sample([*0..3].sample) : ['Prefer not to say']
         hesa_sex = sex == 'Prefer not to say' ? nil : Hesa::Sex.find(sex)['hesa_code']
-        hesa_disabilities = disabilities == ['Prefer not to say'] ? %w[00] : disabilities.map { |disability| Hesa::Disability.find(disability)['hesa_code'] }
+        hesa_disabilities = disabilities == ['Prefer not to say'] ? %w[00] : disabilities.map { |disability| Hesa::Disability.find(disability, 2023)['hesa_code'] }
         hesa_ethnicity = Hesa::Ethnicity.find(ethnicity.last, 2021)['hesa_code']
 
         {


### PR DESCRIPTION
## Context

We would like the Ethnicities and disabilities questionnaire to be consistent with Register and other services. These contain the latest HESA value for _Development condition_
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Add _Development condition_ to list of standard disabilities

![image](https://user-images.githubusercontent.com/93511/187712089-2c9883d9-a9d8-4e26-acef-a3b65b335071.png)

`...`

![image](https://user-images.githubusercontent.com/93511/187711935-4b76be74-dac2-48e4-b1cc-e37133bf02cf.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/E8spUc8F/537-add-development-condition-to-our-ed-questions-to-mirror-register
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
