### PR TITLE
Improve the updated interview email

### DIFF
--- a/app/controllers/provider_interface/courses_controller.rb
+++ b/app/controllers/provider_interface/courses_controller.rb
@@ -64,7 +64,8 @@ module ProviderInterface
     def update_interviews_provider_service
       UpdateInterviewsProvider.new(actor: current_provider_user,
                                    application_choice: @application_choice,
-                                   provider: @wizard.course_option.provider)
+                                   provider: @wizard.course_option.provider,
+                                   previous_course: @application_choice.course_option.course)
     end
   end
 end

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -60,15 +60,17 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
-  def interview_updated(application_choice, interview)
+  def interview_updated(application_choice, interview, previous_course = nil)
     @application_form = application_choice.application_form
     @interview = interview
     @provider_name = interview.provider.name
-    @course_name_and_code = application_choice.current_course_option.course.name_and_code
+    @current_course_name_and_code = application_choice.current_course_option.course.name_and_code
+    @previous_course_name_and_code = previous_course&.name_and_code
+    @updated_course_name_and_code =  @current_course_name_and_code if @previous_course_name_and_code.present?
 
     email_for_candidate(
       @application_form,
-      subject: I18n.t!('candidate_mailer.interview_updated.subject', course_name_and_code: @course_name_and_code),
+      subject: I18n.t!('candidate_mailer.interview_updated.subject', course_name_and_code: @previous_course_name_and_code || @updated_course_name_and_code),
     )
   end
 

--- a/app/services/update_interviews_provider.rb
+++ b/app/services/update_interviews_provider.rb
@@ -1,17 +1,19 @@
 class UpdateInterviewsProvider
   include ImpersonationAuditHelper
 
-  attr_reader :auth, :interviews, :provider, :application_choice
+  attr_reader :auth, :interviews, :provider, :application_choice, :previous_course
 
   def initialize(
     actor:,
     application_choice:,
-    provider:
+    provider:,
+    previous_course:
   )
     @auth = ProviderAuthorisation.new(actor: actor)
     @application_choice = application_choice
     @provider = provider
     @interviews = application_choice.interviews
+    @previous_course = previous_course
   end
 
   def save!
@@ -27,7 +29,7 @@ class UpdateInterviewsProvider
     return if interview_list.empty?
 
     interview_list.map do |interview|
-      CandidateMailer.interview_updated(interview.application_choice, interview).deliver_later
+      CandidateMailer.interview_updated(interview.application_choice, interview, previous_course).deliver_later
     end
   end
 

--- a/app/views/candidate_mailer/interview_updated.text.erb
+++ b/app/views/candidate_mailer/interview_updated.text.erb
@@ -1,14 +1,23 @@
 Dear <%= @application_form.first_name %>
 
-The details of your interview for <%= @course_name_and_code %> have been updated.
+The details of your interview for <%= @previous_course_name_and_code || @updated_course_name_and_code %> have been updated.
 
-The new details are:
+<% if @updated_course_name_and_code %>
+  The interview is with <%= @provider_name %>. It’s now for <%= @updated_course_name_and_code %>.
 
-^ Training provider: <%= @provider_name %>
-^ Course: <%= @course_name_and_code %>
-^ Date: <%= @interview.date %>
-^ Time: <%= @interview.time %>
-^ Address or online meeting details: <%= @interview.location %>
-^ Additional details: <%= @interview.additional_details %>
+  It’s at <%= @interview.time %> on <%= @interview.date %>.
+<% else %>
+  The interview is with <%= @provider_name %>. It’s at <%= @interview.time %> on <%= @interview.date %>. 
+<% end %>
+
+Address or online meeting details:
+
+^ <%= @interview.location %>
+
+<% if @interview.additional_details.present? %>
+  Additional details: 
+
+  ^ <%= @interview.additional_details %>
+<% end %>
 
 Contact <%= @provider_name %> if you have any questions. Let them know if you cannot attend the interview.

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -410,18 +410,41 @@ RSpec.describe CandidateMailer, type: :mailer do
     end
 
     describe '.interview_updated' do
-      let(:email) { mailer.interview_updated(application_choice_with_interview, interview) }
+      let(:previous_course) { create(:course, name: 'Geography', code: 'G100') }
 
-      it_behaves_like(
-        'a mail with subject and content',
-        'Interview details updated for Mathematics (M101)',
-        'greeting' => 'Dear Fred',
-        'details' => 'The details of your interview for Mathematics (M101) have been updated.',
-        'interview date' => '15 January 2021',
-        'interview time' => '9:30am',
-        'interview location' => 'Hogwarts Castle',
-        'additional interview details' => 'Bring your magic wand for the spells test',
-      )
+      let(:email) { mailer.interview_updated(application_choice_with_interview, interview, previous_course) }
+
+      context 'when the course has been updated' do
+        it_behaves_like(
+          'a mail with subject and content',
+          'Interview details updated for Geography (G100)',
+          'greeting' => 'Dear Fred',
+          'details' => 'The details of your interview for Geography (G100) have been updated.',
+          'interview with new course details' => 'The interview is with Hogwards.',
+          'new course' => 'It’s now for Mathematics (M101).',
+          'interview date' => '15 January 2021',
+          'interview time' => '9:30am',
+          'interview location' => 'Hogwarts Castle',
+          'additional interview details' => 'Bring your magic wand for the spells test',
+        )
+      end
+
+      context 'when course is not changed and previous course is nil' do
+        let(:previous_course) { nil }
+        let(:email) { mailer.interview_updated(application_choice_with_interview, interview, previous_course) }
+
+        it 'the email does not contain any new course details' do
+          expect(email.body).not_to include('It’s now for Mathematics (M101).')
+        end
+      end
+
+      context 'when additional details is nil' do
+        it 'the email does not contain any additional details' do
+          interview.additional_details = nil
+          expect(email.body).not_to include('Bring your magic wand for the spells test')
+          expect(email.body).not_to include('Additional details:')
+        end
+      end
     end
 
     describe '.interview_cancelled' do

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -71,9 +71,17 @@ class CandidateMailerPreview < ActionMailer::Preview
   end
 
   def interview_updated
-    application_choice = FactoryBot.build_stubbed(:application_choice, :with_scheduled_interview)
+    application_choice = FactoryBot.build_stubbed(:application_choice, :with_scheduled_interview, application_form: application_form)
     interview = FactoryBot.build_stubbed(:interview, provider: application_choice.current_course_option.course.provider)
-    CandidateMailer.interview_updated(application_choice, interview)
+    previous_course = application_choice.course_option.course
+    CandidateMailer.interview_updated(application_choice, interview, previous_course)
+  end
+
+  def interview_updated_course_changed
+    application_choice = FactoryBot.build_stubbed(:application_choice, :with_scheduled_interview, application_form: application_form)
+    interview = FactoryBot.build_stubbed(:interview, provider: application_choice.current_course_option.course.provider)
+    previous_course = FactoryBot.build_stubbed(:course)
+    CandidateMailer.interview_updated(application_choice, interview, previous_course)
   end
 
   def interview_cancelled

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -73,7 +73,7 @@ class CandidateMailerPreview < ActionMailer::Preview
   def interview_updated
     application_choice = FactoryBot.build_stubbed(:application_choice, :with_scheduled_interview, application_form: application_form)
     interview = FactoryBot.build_stubbed(:interview, provider: application_choice.current_course_option.course.provider)
-    previous_course = application_choice.course_option.course
+    previous_course = nil
     CandidateMailer.interview_updated(application_choice, interview, previous_course)
   end
 

--- a/spec/services/update_interviews_provider_spec.rb
+++ b/spec/services/update_interviews_provider_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe UpdateInterviewsProvider do
   let(:new_training_provider) { create(:provider) }
   let(:accredited_provider) { create(:provider) }
 
+  let(:previous_course) { create(:course) }
+
   let(:provider_user) { create(:provider_user, :with_set_up_interviews, providers: [old_training_provider, new_training_provider, accredited_provider]) }
 
   let(:old_provider_params) do
@@ -20,6 +22,7 @@ RSpec.describe UpdateInterviewsProvider do
       actor: provider_user,
       provider: old_training_provider,
       application_choice: application_choice,
+      previous_course: previous_course,
     }
   end
 
@@ -28,6 +31,7 @@ RSpec.describe UpdateInterviewsProvider do
       actor: provider_user,
       provider: new_training_provider,
       application_choice: application_choice,
+      previous_course: previous_course,
     }
   end
 
@@ -53,7 +57,7 @@ RSpec.describe UpdateInterviewsProvider do
       it 'sends an email' do
         described_class.new(new_provider_params).notify
 
-        expect(CandidateMailer).to have_received(:interview_updated).with(application_choice, interview)
+        expect(CandidateMailer).to have_received(:interview_updated).with(application_choice, interview, previous_course)
       end
     end
 
@@ -73,7 +77,7 @@ RSpec.describe UpdateInterviewsProvider do
       it 'does not send an email' do
         described_class.new(old_provider_params).notify
 
-        expect(CandidateMailer).not_to have_received(:interview_updated).with(application_choice, interview)
+        expect(CandidateMailer).not_to have_received(:interview_updated).with(application_choice, interview, previous_course)
       end
     end
 
@@ -95,7 +99,7 @@ RSpec.describe UpdateInterviewsProvider do
       it 'does not send an email' do
         described_class.new(new_provider_params).notify
 
-        expect(CandidateMailer).not_to have_received(:interview_updated).with(application_choice, interview)
+        expect(CandidateMailer).not_to have_received(:interview_updated).with(application_choice, interview, previous_course)
       end
     end
 
@@ -106,6 +110,7 @@ RSpec.describe UpdateInterviewsProvider do
           actor: provider_user,
           provider: accredited_provider,
           application_choice: application_choice,
+          previous_course: previous_course,
         }
       end
 
@@ -124,7 +129,7 @@ RSpec.describe UpdateInterviewsProvider do
       it 'sends an email' do
         described_class.new(service_params).notify
 
-        expect(CandidateMailer).to have_received(:interview_updated).with(application_choice, interview)
+        expect(CandidateMailer).to have_received(:interview_updated).with(application_choice, interview, previous_course)
       end
     end
 
@@ -134,6 +139,7 @@ RSpec.describe UpdateInterviewsProvider do
           actor: provider_user,
           provider: new_training_provider,
           application_choice: application_choice_with_multiple_interviews,
+          previous_course: previous_course,
         }
       end
 
@@ -164,7 +170,7 @@ RSpec.describe UpdateInterviewsProvider do
       it 'does not send an email' do
         described_class.new(old_provider_params).notify
 
-        expect(CandidateMailer).not_to have_received(:interview_updated).with(application_choice, interview)
+        expect(CandidateMailer).not_to have_received(:interview_updated).with(application_choice, interview, previous_course)
       end
     end
 
@@ -186,7 +192,7 @@ RSpec.describe UpdateInterviewsProvider do
       it 'does not send an email' do
         described_class.new(old_provider_params).notify
 
-        expect(CandidateMailer).not_to have_received(:interview_updated).with(application_choice, interview)
+        expect(CandidateMailer).not_to have_received(:interview_updated).with(application_choice, interview, previous_course)
       end
     end
 
@@ -205,6 +211,7 @@ RSpec.describe UpdateInterviewsProvider do
           actor: provider_user,
           provider: different_provider,
           application_choice: application_choice,
+          previous_course: previous_course,
         }
       end
 


### PR DESCRIPTION
## Context
The content of the updated interview email needed to be improved. The update interview email is sent in two places:
1) When the course is changed by provider
2) When interview details are changed by the provider e.g organisation carrying out interview

## Changes proposed in this pull request
* If the course is changed by provider the email will show both the old and new course with extra text
* If there are additional details extra text will be shown
* Update candidate mailer preview
* Method on candidate mailer takes extra previous course argument when called in `update_interview_provider` service

## Guidance to review

## Link to Trello card

https://trello.com/c/AqhZGOOP/476-improve-the-updated-interview-email

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
