### PR TITLE
Honour incomplete references when caching applications

### DIFF
--- a/app/presenters/vendor_api/application_presenter.rb
+++ b/app/presenters/vendor_api/application_presenter.rb
@@ -21,18 +21,23 @@ module VendorAPI
     end
 
     def serialized_json
-      Rails.cache.fetch(cache_key(application_choice, active_version), expires_in: CACHE_EXPIRES_IN) do
+      Rails.cache.fetch(cache_key(application_choice, active_version, cache_key_suffixes), expires_in: CACHE_EXPIRES_IN) do
         schema.to_json
       end
     end
 
     def as_json
-      Rails.cache.fetch(cache_key(application_choice, active_version, 'as_json'), expires_in: CACHE_EXPIRES_IN) do
+      key = cache_key(application_choice, active_version, cache_key_suffixes.merge(method: :as_json))
+      Rails.cache.fetch(key, expires_in: CACHE_EXPIRES_IN) do
         schema
       end
     end
 
   private
+
+    def cache_key_suffixes
+      { incomplete_references: include_incomplete_references }
+    end
 
     def schema
       {

--- a/app/presenters/vendor_api/base.rb
+++ b/app/presenters/vendor_api/base.rb
@@ -52,8 +52,8 @@ module VendorAPI
       !prerelease_suffix?(version)
     end
 
-    def cache_key(model, api_version, method = '')
-      CacheKey.generate("#{api_version}_#{model.cache_key_with_version}#{method}")
+    def cache_key(model, api_version, suffixes = {})
+      CacheKey.generate("#{api_version}_#{model.cache_key_with_version}#{suffixes.hash}")
     end
   end
 end

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -9,13 +9,13 @@ module VendorAPI
     end
 
     def serialized_json
-      references = ApplicationPresenter.new(
+      serialized_application_json = ApplicationPresenter.new(
         active_version,
         application,
         include_incomplete_references: include_incomplete_references,
       ).serialized_json
 
-      %({"data":#{references}})
+      %({"data":#{serialized_application_json}})
     end
   end
 end


### PR DESCRIPTION
## Context

The Vendor API caches the serialized json as well as the presented hash for each application with different cache keys (because we use the cached Ruby hash in the Support Interface)
The populated cache values can differ depending on the `incomplete_references` request param which causes applications with incomplete references to appear when they were not expected and vice versa depending on which variation gets cached first.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

This commit reworks the cache key to include a hashed hash of key suffixes, ie. a predictable integer generated from the contents of a hash.
eg. `{ method: :as_json, incomplete_references: false }.hash` `->` `3410546498469832963` (always)
So end up with predictable cache key suffix depending on the method (`:as_json` or not) and the incomplete references param value.


<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Current bug:

- First generate some test applications with incomplete references.
- Call `/api/v1.0/applications?since=<timestamp>&incomplete_references=true`
- Call `/api/v1.0/applications?since=<timestamp>&incomplete_references=false`

You see the same response which includes incomplete references.
Restart server or clear cache and call the latter again, you get `references: []` in the response.

This should be resolved by this PR so that we cache the application conditionally on the `incomplete_references` request param.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/8OeMZQWr/519-ellucian-api-references-data-is-being-odd-investigate
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
