### PR TITLE
Make references summary boxes full-width

### DIFF
--- a/app/views/candidate_interface/new_references/review/show.html.erb
+++ b/app/views/candidate_interface/new_references/review/show.html.erb
@@ -1,31 +1,29 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.new_references'), @section_complete_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @section_complete_form, url: candidate_interface_new_references_complete_path, method: :patch do |f| %>
+<%= form_with model: @section_complete_form, url: candidate_interface_new_references_complete_path, method: :patch do |f| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <%= f.govuk_error_summary %>
-        <h1 class="govuk-heading-l">
-          <%= t('page_titles.new_references') %>
-        </h1>
+      <h1 class="govuk-heading-l">
+        <%= t('page_titles.new_references') %>
+      </h1>
 
-        <%= render CandidateInterface::AddNewReferenceComponent.new(current_application) %>
-
-          <div class="govuk-block">
-            <%= render(
-              CandidateInterface::NewReferencesReviewComponent.new(
-                application_form: current_application,
-                editable: true,
-                references: @references,
-                heading_level: 3,
-              ),
-            ) %>
-          </div>
-
-        <% if current_application.complete_references_information? %>
-          <%= render CandidateInterface::CompleteSectionComponent.new(form: f) %>
-          <%= f.govuk_submit t('continue') %>
-        <% end %>
-    <% end %>
+      <%= render CandidateInterface::AddNewReferenceComponent.new(current_application) %>
+    </div>
   </div>
-</div>
+
+  <%= render(
+    CandidateInterface::NewReferencesReviewComponent.new(
+      application_form: current_application,
+      editable: true,
+      references: @references,
+      heading_level: 3,
+    ),
+  ) %>
+
+  <% if current_application.complete_references_information? %>
+    <%= render CandidateInterface::CompleteSectionComponent.new(form: f) %>
+    <%= f.govuk_submit t('continue') %>
+  <% end %>
+<% end %>


### PR DESCRIPTION
This gives them more room (on desktop), avoiding the likelihood of awkward wrapping of the email address.

This is also more consistent with the other sections, which all use full-width summary boxes.

🗂️ [Trello card](https://trello.com/c/msVurLf5/565-make-summary-list-boxes-full-width-on-references-index-page)

## Screenshots

### Before

![references-before](https://user-images.githubusercontent.com/30665/187933236-189d12f7-4954-45ec-97c0-ad94b64047cc.png)

### After

![references-after](https://user-images.githubusercontent.com/30665/187933276-c10c8c27-6d10-49c7-8709-13abe15d4070.png)

