### PR TITLE
Bugfix: add character limit javascript with threshold on relationship page in new references flow

### DIFF
--- a/app/views/candidate_interface/new_references/relationship/_shared_form.html.erb
+++ b/app/views/candidate_interface/new_references/relationship/_shared_form.html.erb
@@ -2,6 +2,7 @@
 
 <%= f.govuk_text_area :relationship,
                       label: { text: t('application_form.new_references.relationship.label', referee_name: @reference.name), size: 'l', tag: 'h1' },
-                      hint: { text: t("application_form.new_references.relationship.hint_text.#{@reference.referee_type.downcase}"), max_words: 50 } %>
+                      hint: { text: t("application_form.new_references.relationship.hint_text.#{@reference.referee_type.downcase}") },
+                      max_chars: 500, threshold: 95 %>
 
 <%= f.govuk_submit t('save_and_continue') %>


### PR DESCRIPTION
The javascript which tells the user when they are approaching (or over) the character limit wasn't appearing.

This adds the javascript, and sets the threshold as 95% (so the message is only shown when at or above 95% of the limit).

🗂️ [Trello card](https://trello.com/c/3DVH6RMx/566-word-count-on-relationship-details-page)

## Screenshots

### Before

![relationship-before](https://user-images.githubusercontent.com/30665/187938456-017028d6-3d4f-415e-974e-b60b5ab782ec.png)

### After (approaching limit)

![relationship-after](https://user-images.githubusercontent.com/30665/187938504-1255b10a-ad0e-4976-91d2-ac9ef23f9c36.png)

### After (over the limit)

![relationship-after-error](https://user-images.githubusercontent.com/30665/187938561-86cb0c8f-6ef9-4e04-936c-399a8114132e.png)
