### PR TITLE
Update the reference section title for candidates

### DIFF
--- a/app/views/candidate_interface/unsubmitted_application_form/_task_list.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/_task_list.html.erb
@@ -130,7 +130,7 @@
     <% if current_application.show_new_reference_flow? %>
       <li class="app-task-list__item">
         <%= render(TaskListItemComponent.new(
-          text: 'References',
+          text: 'References to be requested if you accept an offer',
           completed: application_form_presenter.references_completed?,
           path: candidate_interface_new_references_review_path,
         )) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -182,7 +182,7 @@ en:
     add_volunteering_role: Add role
     edit_volunteering_role: Edit role
     destroy_volunteering_role: Are you sure you want to delete this role?
-    new_references: References
+    new_references: References to be requested if you accept an offer
     new_references_start: Choose a referee
     new_references_name: What is the referee’s name?
     new_references_edit_name: Edit the name of the referee

--- a/spec/system/candidate_interface/new-references/candidate_add_references_spec.rb
+++ b/spec/system/candidate_interface/new-references/candidate_add_references_spec.rb
@@ -356,7 +356,7 @@ RSpec.feature 'New References' do
   end
 
   def and_the_references_section_is_marked_as_completed
-    expect(safeguarding_section.text.downcase).to include('references completed')
+    expect(safeguarding_section.text.downcase).to include('references to be requested if you accept an offer completed')
   end
 
   def then_i_should_be_redirected_to_my_application
@@ -379,7 +379,7 @@ RSpec.feature 'New References' do
   def then_my_application_references_should_be_incomplete
     expect(@application.reload.references_completed).to be false
     click_link 'Back to application'
-    expect(safeguarding_section.text.downcase).to include('references incomplete')
+    expect(safeguarding_section.text.downcase).to include('references to be requested if you accept an offer incomplete')
   end
 
   def safeguarding_section

--- a/spec/system/candidate_interface/new-references/candidate_apply_again_new_references_flow_spec.rb
+++ b/spec/system/candidate_interface/new-references/candidate_apply_again_new_references_flow_spec.rb
@@ -63,11 +63,11 @@ RSpec.feature 'Candidates in the 2023 cycle, applying again with the new referen
   end
 
   def then_i_should_see_the_new_references_section
-    expect(page).to have_content 'References Incomplete'
+    expect(page).to have_content 'References to be requested if you accept an offer Incomplete'
   end
 
   def when_i_click_on_the_references_section
-    click_on 'References'
+    click_on 'References to be requested if you accept an offer'
   end
 
   def new_application_form

--- a/spec/system/candidate_interface/new-references/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/new-references/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
@@ -76,11 +76,11 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   def when_i_click_on_the_new_references_section
-    click_link 'References'
+    click_link 'References to be requested if you accept an offer'
   end
 
   def then_i_see_the_new_references_section
-    expect(links_under_safeguarding).to include('References')
+    expect(links_under_safeguarding).to include('References to be requested if you accept an offer')
   end
 
   def then_i_see_the_new_states_of_my_references

--- a/spec/system/candidate_interface/references/candidate_carries_over_unsubmitted_application_to_new_reference_flow_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_carries_over_unsubmitted_application_to_new_reference_flow_spec.rb
@@ -77,7 +77,7 @@ RSpec.feature 'New references flow' do
   end
 
   def then_i_see_the_new_references_section
-    expect(links_under_safeguarding).to include('References')
+    expect(links_under_safeguarding).to include('References to be requested if you accept an offer')
   end
 
   def links_under_safeguarding
@@ -85,7 +85,7 @@ RSpec.feature 'New references flow' do
   end
 
   def when_i_click_on_the_new_references_section
-    click_link 'References'
+    click_link 'References to be requested if you accept an offer'
   end
 
   def and_i_visit_the_application_dashboard
@@ -93,7 +93,7 @@ RSpec.feature 'New references flow' do
   end
 
   def and_references_is_marked_as_incomplete
-    expect(safeguarding_section.text.downcase).to include('references incomplete')
+    expect(safeguarding_section.text.downcase).to include('references to be requested if you accept an offer incomplete')
   end
 
   def new_application_form


### PR DESCRIPTION
## Context

We want to make it clearer that referees will not be contacted immediately.

## Changes proposed in this pull request

Change the name of the task from 'References' to 'References to be requested if you accept an offer'.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/w6EkO4bg/568-change-name-of-references-task

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
