### PR TITLE
New references – Update candidate reference guidance

### DIFF
--- a/app/components/candidate_interface/add_new_reference_component.html.erb
+++ b/app/components/candidate_interface/add_new_reference_component.html.erb
@@ -1,10 +1,10 @@
-<p class="govuk-body">You need to add details of 2 people who could give a reference for you. They will only be contacted if you accept an offer on a course.</p>
+<p class="govuk-body">You need to give details of 2 people who can give a reference for you. They’ll only be contacted if you accept an offer on a course.</p>
 
-<p class="govuk-body">You should choose:</p>
+<p class="govuk-body">You should include:</p>
 
 <ul class="govuk-list govuk-list--bullet">
-  <li>an academic tutor if you have not yet graduated or graduated within the past 5 years</li>
-  <li>a headteacher if you have been working in a school</li>
+  <li>an academic tutor if you graduated in the past 5 years or are still studying</li>
+  <li>the headteacher if you’ve been working in a school</li>
 </ul>
 <p class="govuk-body">They’ll be asked if they know any reason why you should not work with children.</p>
 


### PR DESCRIPTION
## Context

We want to change the references task index page to:

- make it clearer that referees will not be contacted immediately
- make general improvements to the content

## Changes proposed in this pull request

Change the body content to:

You need to give details of 2 people who can give a reference for you. They’ll be only be contacted if you accept an offer.

You should include:

-an academic tutor if you graduated in the past 5 years or are still studying
-the headteacher if you’ve been working in a school

They’ll be asked if they know any reason why you should not work with children.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/EfxNh7pc/569-change-content-of-references-task-index-page

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
