### PR TITLE
New references - Change the candidate wording for referee relationship

### DIFF
--- a/app/components/candidate_interface/new_references_review_component.rb
+++ b/app/components/candidate_interface/new_references_review_component.rb
@@ -90,7 +90,7 @@ module CandidateInterface
                end
 
       {
-        key: 'Name',
+        key: t('review_application.new_references.name.label'),
         value: reference.name,
       }.merge(action)
     end
@@ -115,12 +115,12 @@ module CandidateInterface
 
       if reference.email_address?
         {
-          key: 'Email',
+          key: t('review_application.new_references.email.label'),
           value: reference.email_address,
         }.merge(action)
       else
         {
-          key: 'Email',
+          key: t('review_application.new_references.email.label'),
           value: govuk_link_to('Enter email address', edit_email_path),
         }
       end
@@ -146,12 +146,12 @@ module CandidateInterface
 
       if reference.relationship?
         {
-          key: 'How you know them and for how long',
+          key: t('review_application.new_references.relationship.label'),
           value: reference.relationship,
         }.merge(action)
       else
         {
-          key: 'How you know them and for how long',
+          key: t('review_application.new_references.relationship.label'),
           value: govuk_link_to('Enter relationship to referee', edit_relationship_path),
         }
       end
@@ -175,7 +175,7 @@ module CandidateInterface
                end
 
       {
-        key: 'Type',
+        key: t('review_application.new_references.type.label'),
         value: formatted_reference_type(reference),
       }.merge(action)
     end
@@ -186,7 +186,7 @@ module CandidateInterface
       double_break = tag.br + tag.br
 
       {
-        key: 'Status',
+        key: t('review_application.new_references.status.label'),
         value: feedback_status_label(reference) + double_break + t('application_form.new_references.status.first_line', name: reference.name) + double_break + t('application_form.new_references.status.second_line'),
       }
     end

--- a/app/components/candidate_interface/new_references_review_component.rb
+++ b/app/components/candidate_interface/new_references_review_component.rb
@@ -146,12 +146,12 @@ module CandidateInterface
 
       if reference.relationship?
         {
-          key: 'Relationship to you',
+          key: 'How you know them and for how long',
           value: reference.relationship,
         }.merge(action)
       else
         {
-          key: 'Relationship to you',
+          key: 'How you know them and for how long',
           value: govuk_link_to('Enter relationship to referee', edit_relationship_path),
         }
       end

--- a/app/views/candidate_interface/offer_dashboard/view_reference.html.erb
+++ b/app/views/candidate_interface/offer_dashboard/view_reference.html.erb
@@ -7,27 +7,27 @@
   <table class="govuk-table">
     <tbody class="govuk-table__body">
       <tr class="govuk-table__row">
-        <th scope="row" class="govuk-table__header">Name</th>
+        <th scope="row" class="govuk-table__header"><%= t('review_application.new_references.name.label') %></th>
         <td class="govuk-table__cell"><%= @reference.name %></td>
       </tr>
 
       <tr class="govuk-table__row">
-        <th scope="row" class="govuk-table__header">Email</th>
+        <th scope="row" class="govuk-table__header"><%= t('review_application.new_references.email.label') %></th>
         <td class="govuk-table__cell"><%= @reference.email_address %></td>
       </tr>
 
       <tr class="govuk-table__row">
-        <th scope="row" class="govuk-table__header">Type</th>
+        <th scope="row" class="govuk-table__header"><%= t('review_application.new_references.type.label') %></th>
         <td class="govuk-table__cell"><%= @reference.referee_type.humanize %></td>
       </tr>
 
       <tr class="govuk-table__row">
-        <th scope="row" class="govuk-table__header">How you know them and for how long</th>
+        <th scope="row" class="govuk-table__header"><%= t('review_application.new_references.relationship.label') %></th>
         <td class="govuk-table__cell"><%= @reference.relationship %></td>
       </tr>
 
       <tr class="govuk-table__row">
-        <th scope="row" class="govuk-table__header">Status</th>
+        <th scope="row" class="govuk-table__header"><%= t('review_application.new_references.status.label') %></th>
         <td class="govuk-table__cell">
           <%= render CandidateInterface::NewReferenceStatusesComponent.new(reference: @reference) %>
         </td>

--- a/app/views/candidate_interface/offer_dashboard/view_reference.html.erb
+++ b/app/views/candidate_interface/offer_dashboard/view_reference.html.erb
@@ -22,7 +22,7 @@
       </tr>
 
       <tr class="govuk-table__row">
-        <th scope="row" class="govuk-table__header">Relationship to you</th>
+        <th scope="row" class="govuk-table__header">How you know them and for how long</th>
         <td class="govuk-table__cell"><%= @reference.relationship %></td>
       </tr>
 

--- a/config/locales/candidate_interface/review_application.yml
+++ b/config/locales/candidate_interface/review_application.yml
@@ -76,6 +76,16 @@ en:
       add_more_references: Add another reference
       not_entered: References not entered
       enter_references: Add references
+      name:
+        label: Name
+      email:
+        label: Email
+      relationship:
+        label: How you know them and for how long
+      type:
+        label: Type
+      status:
+        label: Status
     references_provided:
       incomplete: You need %{minimum_references} references before you can submit your application
       complete_section: Manage your references

--- a/spec/components/candidate_interface/new_references_review_component_spec.rb
+++ b/spec/components/candidate_interface/new_references_review_component_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe CandidateInterface::NewReferencesReviewComponent, type: :componen
       result = render_inline(described_class.new(references: [reference], application_form: application_form))
 
       relationship_row = result.css('.govuk-summary-list__row')[3].text
-      expect(relationship_row).to include 'Relationship to you'
+      expect(relationship_row).to include 'How you know them and for how long'
       expect(relationship_row).to include reference.relationship
     end
 


### PR DESCRIPTION
## Context

When a candidate adds a reference, we display a summary of what they added. 

Currently we use the term 'Relationship to you' in the summary but it is not a good description of what the candidate was asked to enter.

## Changes proposed in this pull request

Change 'Relationship to you' to 'How you know them and for how long'.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/PHcHST7i/570-change-summary-on-references-index-page

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
