### PR TITLE
New references - Update the school based referee guidance

### DIFF
--- a/config/locales/candidate_interface/new_references.yml
+++ b/config/locales/candidate_interface/new_references.yml
@@ -7,7 +7,7 @@ en:
         professional:
           label: Professional, such as a manager
         school_based:
-          label: Someone you know through experience working in a school
+          label: School experience, such as from the headteacher of a school you’ve been working in
         character:
           label: Character, such as a mentor or someone you know from volunteering
       name:

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_new_reference_feature_enabled_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_new_reference_feature_enabled_spec.rb
@@ -222,7 +222,7 @@ RSpec.feature 'Candidate accepts an offer' do
     when_i_click_to_add_another_reference
     then_the_back_link_should_point_to_the_accept_offer_page
     and_i_should_be_on_the_add_type_page
-    choose 'Someone you know through experience working in a school'
+    choose 'School experience, such as from the headteacher of a school you’ve been working in'
     and_i_click_continue
     and_i_should_be_on_the_add_name_page
     and_the_back_link_should_point_to_the_add_type_page


### PR DESCRIPTION
## Context

When a candidate chooses the type of reference, we want to change the way we describe school experience. We'll make it fit better with the way we describe the other types of references, and help them choose the right person.

## Changes proposed in this pull request

Change: 

Someone you know through experience working in a school

To: 

School experience, such as from the headteacher of a school you’ve been working in

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/vCpE9Jal/571-change-reference-type-page

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
