### PR TITLE
New references - remove the mention of referees from the reference journey

### DIFF
--- a/config/locales/candidate_interface/new_references.yml
+++ b/config/locales/candidate_interface/new_references.yml
@@ -15,7 +15,7 @@ en:
         hint_text: Do not give details of a family member, partner or friend.
       email_address:
         label: What is %{referee_name}’s email address?
-        hint_text: In most cases, this should be a work address.
+        hint_text: Give their work email address if they have one.
       relationship:
         label: How do you know %{referee_name} and how long have you known them?
         hint_text:
@@ -97,14 +97,14 @@ en:
         candidate_interface/reference/referee_email_address_form:
           attributes:
             email_address:
-              blank: Enter your referee’s email address
+              blank: Enter their email address
               duplicate: Please give a different email address for each referee
               own: Enter an email address that’s not your own
         candidate_interface/reference/referee_relationship_form:
           attributes:
             relationship:
-              blank: Enter how you know this referee and for how long
-              too_long: Enter how you know this referee and for how long in 500 characters or fewer
+              blank: Enter how you know them and for how long
+              too_long: How you know them and for how long in 500 characters or fewer
         candidate_interface/reference/submit_referee_form:
           attributes:
             submit:

--- a/config/locales/candidate_interface/new_references.yml
+++ b/config/locales/candidate_interface/new_references.yml
@@ -11,7 +11,7 @@ en:
         character:
           label: Character, such as a mentor or someone you know from volunteering
       name:
-        label: What is the referee’s name?
+        label: What’s the name of the person who can give a reference?
         hint_text: You must not use family members, partners or friends as referees.
       email_address:
         label: What is %{referee_name}’s email address?

--- a/config/locales/candidate_interface/new_references.yml
+++ b/config/locales/candidate_interface/new_references.yml
@@ -92,8 +92,8 @@ en:
         candidate_interface/reference/referee_name_form:
           attributes:
             name:
-              blank: Enter your referee’s name
-              too_short: Your referee’s name must be %{count} characters or more
+              blank: Enter the name of the person who can give a reference
+              too_short: Name of the person who can give a reference must be %{count} characters or more
         candidate_interface/reference/referee_email_address_form:
           attributes:
             email_address:

--- a/config/locales/candidate_interface/new_references.yml
+++ b/config/locales/candidate_interface/new_references.yml
@@ -12,7 +12,7 @@ en:
           label: Character, such as a mentor or someone you know from volunteering
       name:
         label: What’s the name of the person who can give a reference?
-        hint_text: You must not use family members, partners or friends as referees.
+        hint_text: Do not give details of a family member, partner or friend.
       email_address:
         label: What is %{referee_name}’s email address?
         hint_text: In most cases, this should be a work address.

--- a/config/locales/candidate_interface/references.yml
+++ b/config/locales/candidate_interface/references.yml
@@ -105,18 +105,18 @@ en:
         candidate_interface/reference/referee_name_form:
           attributes:
             name:
-              blank: Enter your referee’s name
+              blank: Enter the name of the person who can give a reference
               too_short: Your referee’s name must be %{count} characters or more
         candidate_interface/reference/referee_email_address_form:
           attributes:
             email_address:
-              blank: Enter your referee’s email address
+              blank: Enter their email address
               duplicate: Please give a different email address for each referee
               own: Enter an email address that’s not your own
         candidate_interface/reference/referee_relationship_form:
           attributes:
             relationship:
-              blank: Enter how you know this referee and for how long
+              blank: Enter how you know them and for how long
         candidate_interface/reference/submit_referee_form:
           attributes:
             submit:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -184,7 +184,7 @@ en:
     destroy_volunteering_role: Are you sure you want to delete this role?
     new_references: References to be requested if you accept an offer
     new_references_start: Choose a referee
-    new_references_name: What is the referee’s name?
+    new_references_name: What’s the name of the person who can give a reference?
     new_references_edit_name: Edit the name of the referee
     new_references_email_address: What is %{referee_name}’s email address?
     new_references_edit_email_address: Edit %{referee_name}’s email address

--- a/spec/system/candidate_interface/new-references/candidate_add_references_spec.rb
+++ b/spec/system/candidate_interface/new-references/candidate_add_references_spec.rb
@@ -188,7 +188,7 @@ RSpec.feature 'New References' do
   end
 
   def when_i_fill_in_my_second_references_name
-    fill_in 'What is the referee’s name?', with: 'John Doe'
+    fill_in 'What’s the name of the person who can give a reference?', with: 'John Doe'
   end
 
   def when_i_provide_a_second_valid_email_address
@@ -263,7 +263,7 @@ RSpec.feature 'New References' do
   end
 
   def and_i_input_a_new_name
-    fill_in 'What is the referee’s name?', with: 'Jessie Pinkman'
+    fill_in 'What’s the name of the person who can give a reference?', with: 'Jessie Pinkman'
   end
 
   def then_i_see_the_updated_name

--- a/spec/system/candidate_interface/new-references/candidate_add_references_spec.rb
+++ b/spec/system/candidate_interface/new-references/candidate_add_references_spec.rb
@@ -208,7 +208,7 @@ RSpec.feature 'New References' do
   end
 
   def then_i_should_be_told_to_provide_an_email_address
-    expect(page).to have_content 'Enter your referee’s email address'
+    expect(page).to have_content 'Enter their email address'
   end
 
   def and_a_validation_error_is_logged_for_blank_email_address
@@ -240,7 +240,7 @@ RSpec.feature 'New References' do
   end
 
   def then_i_should_be_told_to_provide_a_relationship
-    expect(page).to have_content 'Enter how you know this referee and for how long'
+    expect(page).to have_content 'Enter how you know them and for how long'
   end
 
   def and_a_validation_error_is_logged_for_relationship

--- a/spec/system/candidate_interface/new-references/candidate_add_references_spec.rb
+++ b/spec/system/candidate_interface/new-references/candidate_add_references_spec.rb
@@ -175,7 +175,7 @@ RSpec.feature 'New References' do
   end
 
   def then_i_should_be_told_to_provide_a_name
-    expect(page).to have_content 'Enter your referee’s name'
+    expect(page).to have_content 'Enter the name of the person who can give a reference'
   end
 
   def and_a_validation_error_is_logged_for_name

--- a/spec/system/candidate_interface/new-references/candidate_request_references_new_references_spec.rb
+++ b/spec/system/candidate_interface/new-references/candidate_request_references_new_references_spec.rb
@@ -133,7 +133,7 @@ RSpec.feature 'New References', with_audited: true do
   end
 
   def and_i_fill_in_the_reference_name
-    fill_in 'What is the referee’s name?', with: 'Aragorn'
+    fill_in 'What’s the name of the person who can give a reference?', with: 'Aragorn'
   end
 
   def and_i_should_be_on_add_email_address_page
@@ -226,7 +226,7 @@ RSpec.feature 'New References', with_audited: true do
   end
 
   def and_when_i_change_the_reference_name
-    fill_in 'What is the referee’s name?', with: 'Aragorn the Middle earth king'
+    fill_in 'What’s the name of the person who can give a reference?', with: 'Aragorn the Middle earth king'
     and_i_click_save_and_continue
   end
 

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_new_reference_feature_enabled_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_new_reference_feature_enabled_spec.rb
@@ -226,7 +226,7 @@ RSpec.feature 'Candidate accepts an offer' do
     and_i_click_continue
     and_i_should_be_on_the_add_name_page
     and_the_back_link_should_point_to_the_add_type_page
-    fill_in 'What is the referee’s name?', with: 'Gimli'
+    fill_in 'What’s the name of the person who can give a reference?', with: 'Gimli'
     and_i_click_save_and_continue
     and_i_should_be_on_add_email_address_page
     and_the_back_link_should_point_to_the_add_name_page
@@ -290,7 +290,7 @@ RSpec.feature 'Candidate accepts an offer' do
   end
 
   def and_i_add_a_reference_name
-    fill_in 'What is the referee’s name?', with: 'Aragorn'
+    fill_in 'What’s the name of the person who can give a reference?', with: 'Aragorn'
     and_i_click_save_and_continue
   end
 
@@ -361,7 +361,7 @@ RSpec.feature 'Candidate accepts an offer' do
   end
 
   def when_i_change_the_reference_name
-    fill_in 'What is the referee’s name?', with: 'Legolas'
+    fill_in 'What’s the name of the person who can give a reference?', with: 'Legolas'
     and_i_click_save_and_continue
   end
 

--- a/spec/system/candidate_interface/references/candidate_adds_a_new_reference_feature_flag_disabled_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_adds_a_new_reference_feature_flag_disabled_spec.rb
@@ -164,7 +164,7 @@ RSpec.feature 'References' do
   end
 
   def then_i_should_be_told_to_provide_a_name
-    expect(page).to have_content 'Enter your referee’s name'
+    expect(page).to have_content 'Enter the name of the person who can give a reference'
   end
 
   def and_a_validation_error_is_logged_for_name
@@ -185,7 +185,7 @@ RSpec.feature 'References' do
   end
 
   def then_i_should_be_told_to_provide_an_email_address
-    expect(page).to have_content 'Enter your referee’s email address'
+    expect(page).to have_content 'Enter their email address'
   end
 
   def and_a_validation_error_is_logged_for_blank_email_address
@@ -217,7 +217,7 @@ RSpec.feature 'References' do
   end
 
   def then_i_should_be_told_to_provide_a_relationship
-    expect(page).to have_content 'Enter how you know this referee and for how long'
+    expect(page).to have_content 'Enter how you know them and for how long'
   end
 
   def and_a_validation_error_is_logged_for_relationship

--- a/spec/system/candidate_interface/references/candidate_requests_a_reference_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_requests_a_reference_spec.rb
@@ -241,7 +241,7 @@ RSpec.feature 'Candidate requests a reference' do
   end
 
   def then_i_see_email_address_validation_errors
-    expect(page).to have_content('Enter your referee’s email address')
+    expect(page).to have_content('Enter their email address')
   end
 
   def when_i_change_the_email_address


### PR DESCRIPTION
## Context

We do not want to use the word 'referee'. It's jargon and more commonly associated with sport. Instead we can say things like "the person who can give you a reference".

## Changes proposed in this pull request
### Name page
<img width="710" alt="image" src="https://user-images.githubusercontent.com/47917431/188197846-5b5d9d09-bc23-4457-98ea-529bd3e61879.png">

### Email address page
<img width="688" alt="image" src="https://user-images.githubusercontent.com/47917431/188197884-7e184c42-3c9a-4bdd-9abc-df74e8d6b608.png">

### Relationship page
<img width="718" alt="image" src="https://user-images.githubusercontent.com/47917431/188197924-c9557da8-799a-4890-8873-2a045dc6e76a.png">

## Guidance to review

Without quite a bit of modification to our forms, we're unable to get the referee name in on the `blank` error messages for email address and relationship. So these will also appear on the old flow. This approach has been 👍  by @frankieroberto and @johndoates 

## Link to Trello card

https://trello.com/c/CrH8B3kV/573-remove-the-mention-of-referees-from-the-reference-journey

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
