### PR TITLE
New references - Update the carry over interstitial to mention references

### DIFF
--- a/app/components/candidate_interface/carry_over_interstitial_component.html.erb
+++ b/app/components/candidate_interface/carry_over_interstitial_component.html.erb
@@ -13,6 +13,14 @@
       Continue your application to apply for courses starting in the <%= next_academic_cycle %> academic year instead.
     </p>
 
+    <p class="govuk-body">
+      You no longer need to request and receive references before submitting your application.
+    </p>
+
+    <p class="govuk-body">
+      Instead, you’ll need to give details of 2 people who can give references if you accept a place on a course.
+    </p>
+
     <%= govuk_button_to 'Continue', candidate_interface_carry_over_path, class: 'govuk-!-margin-bottom-5' %>
   </div>
 </div>

--- a/spec/components/candidate_interface/carry_over_interstitial_component_spec.rb
+++ b/spec/components/candidate_interface/carry_over_interstitial_component_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe CandidateInterface::CarryOverInterstitialComponent do
 
       expect(result.text).to include('You started an application for courses starting in the 2021 to 2022 academic year, which have now closed.')
       expect(result.text).to include('Continue your application to apply for courses starting in the 2022 to 2023 academic year instead.')
+      expect(result.text).to include('You no longer need to request and receive references before submitting your application.')
+      expect(result.text).to include('Instead, you’ll need to give details of 2 people who can give references if you accept a place on a course.')
     end
   end
 
@@ -37,6 +39,8 @@ RSpec.describe CandidateInterface::CarryOverInterstitialComponent do
 
       expect(result.text).to include('You started an application for courses starting in the 2021 to 2022 academic year, which have now closed.')
       expect(result.text).to include('Continue your application to apply for courses starting in the 2022 to 2023 academic year instead.')
+      expect(result.text).to include('You no longer need to request and receive references before submitting your application.')
+      expect(result.text).to include('Instead, you’ll need to give details of 2 people who can give references if you accept a place on a course.')
     end
   end
 end

--- a/spec/system/candidate_interface/course_selection/candidate_attempts_to_add_course_from_find_to_application_from_previous_cycle_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_attempts_to_add_course_from_find_to_application_from_previous_cycle_spec.rb
@@ -44,6 +44,8 @@ RSpec.feature 'Candidate attempts to add course via Find to application from pre
   def then_i_see_that_my_application_must_be_carried_over
     expect(page).to have_content('You started an application for courses starting in the 2020 to 2021 academic year, which have now closed.')
     expect(page).to have_content('Continue your application to apply for courses starting in the 2021 to 2022 academic year instead.')
+    expect(page).to have_content('You no longer need to request and receive references before submitting your application.')
+    expect(page).to have_content('Instead, you’ll need to give details of 2 people who can give references if you accept a place on a course.')
 
     # Normally we'd avoid a trip directly to the db in a system spec,
     # this is here to prove a particular bug has been solved.


### PR DESCRIPTION
## Context

If a candidate signs in and has an unsubmitted application from after the the apply deadline has passed, they see an interstitial to tell them that the deadline has passed, and that they can continue their application for the next year instead.

We want to add something here about the new references process.

## Changes proposed in this pull request

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/47917431/188204806-cd07baee-0106-4e5a-8bfc-2f229ec3b362.png)|![image](https://user-images.githubusercontent.com/47917431/188204831-a9b08527-213c-45ca-bc02-e390756dc0df.png)|

## Guidance to review

We need to think about what we'll do next year in terms of updating this content 🤔 

## Link to Trello card

https://trello.com/c/xmOtNESM/575-update-the-carry-over-interstitial-to-mention-the-new-references-process

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
