### PR TITLE
New references - Update the content for references the candidate has already received

### DIFF
--- a/app/components/candidate_interface/new_references_review_component.rb
+++ b/app/components/candidate_interface/new_references_review_component.rb
@@ -183,11 +183,13 @@ module CandidateInterface
     def status_row(reference)
       return nil unless reference.feedback_provided?
 
-      double_break = tag.br + tag.br
-
       {
-        key: t('review_application.new_references.status.label'),
-        value: feedback_status_label(reference) + double_break + t('application_form.new_references.status.first_line', name: reference.name) + double_break + t('application_form.new_references.status.second_line'),
+        key: '',
+        value: [
+          t('application_form.new_references.status.first_line', name: reference.name),
+          '',
+          t('application_form.new_references.status.second_line'),
+        ],
       }
     end
 

--- a/config/locales/candidate_interface/new_references.yml
+++ b/config/locales/candidate_interface/new_references.yml
@@ -75,8 +75,8 @@ en:
         one: Add another reference
         other: Add another reference
       status:
-        first_line: '%{name} will not be asked to give you another reference.'
-        second_line: If you accept an offer, your previous reference will be shown to the provider.
+        first_line: '%{name} has already given a reference.'
+        second_line: If you accept an offer, the training provider will see the reference.
 
   activemodel:
     errors:

--- a/spec/components/candidate_interface/new_references_review_component_spec.rb
+++ b/spec/components/candidate_interface/new_references_review_component_spec.rb
@@ -116,9 +116,8 @@ RSpec.describe CandidateInterface::NewReferencesReviewComponent, type: :componen
           result = render_inline(described_class.new(references: [reference], application_form: application_form))
 
           status_row = result.css('.govuk-summary-list__row')[4].text
-          expect(status_row).to include 'Status'
-          expect(status_row).to include 'Reference completed'
-          expect(status_row).to include "#{reference.name} will not be asked to give you another reference."
+          expect(status_row).to include "#{reference.name} has already given a reference."
+          expect(status_row).to include 'If you accept an offer, the training provider will see the reference.'
         end
       end
 

--- a/spec/system/candidate_interface/new-references/candidate_apply_again_new_references_flow_spec.rb
+++ b/spec/system/candidate_interface/new-references/candidate_apply_again_new_references_flow_spec.rb
@@ -83,7 +83,8 @@ RSpec.feature 'Candidates in the 2023 cycle, applying again with the new referen
     expect(page).to have_current_path(candidate_interface_new_references_review_path)
     expect(page.text).to include @pending_reference.name
     expect(page.text).to include @not_sent_reference.name
-    expect(page.text).to include "#{@selected_reference.name} will not be asked to give you another reference"
+    expect(page.text).to include "#{@selected_reference.name} has already given a reference."
+    expect(page.text).to include 'If you accept an offer, the training provider will see the reference.'
   end
 
   def and_i_sign_in_again


### PR DESCRIPTION
## Context

Where an application has been copied over from the previous cycle (or in the new cycle if withdrawing after accepting an offer), references may already have been collected.

We need to let candidates know that:

* these people won't be contacted again, the previous reference will be shown
* it'll only be shown to providers if they accept an offer from them
* they can delete the reference if they no longer want to use it

## Changes proposed in this pull request

We have updated the content by:

* removing the "status" label
* removing the "reference completed" tag
* rewriting the 2 sentences slightly, for improved clarity

<img width="1026" alt="image" src="https://user-images.githubusercontent.com/47917431/188219044-d76dfbd0-856f-48f2-ab08-3039d824a241.png">

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/eyRQaO0N/576-review-content-for-references-where-the-reference-has-already-been-given

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
