### PR TITLE
Use referee name as summary card title

### DIFF
--- a/app/components/candidate_interface/new_references_review_component.html.erb
+++ b/app/components/candidate_interface/new_references_review_component.html.erb
@@ -8,7 +8,7 @@
     editable: editable,
     ignore_editable: ignore_editable_for,
   )) do %>
-    <%= render(SummaryCardHeaderComponent.new(title: card_title(index), heading_level: @heading_level)) do %>
+    <%= render(SummaryCardHeaderComponent.new(title: reference.name, heading_level: @heading_level)) do %>
       <div class="app-summary-card__actions">
         <ul class="app-summary-card__actions-list">
           <% if editable %>

--- a/app/components/candidate_interface/new_references_review_component.rb
+++ b/app/components/candidate_interface/new_references_review_component.rb
@@ -1,7 +1,6 @@
 module CandidateInterface
   class NewReferencesReviewComponent < ViewComponent::Base
     include ReferencesPathHelper
-    include ViewHelper
     attr_reader :references, :editable
 
     def initialize(application_form:, references:, application_choice: nil, editable: true, heading_level: 2, return_to_application_review: false, missing_error: false)
@@ -44,10 +43,6 @@ module CandidateInterface
       }
     end
 
-    def card_title(index)
-      "#{reference_number(index)} reference"
-    end
-
     def reference_rows(reference)
       [
         reference_type_row(reference),
@@ -66,10 +61,6 @@ module CandidateInterface
 
     def formatted_reference_type(reference)
       reference.referee_type ? reference.referee_type.capitalize.dasherize : ''
-    end
-
-    def reference_number(index)
-      TextOrdinalizer.call((index + 1)).capitalize
     end
 
     def name_row(reference)


### PR DESCRIPTION
This switches the title in the summary card on the references review pages to use the name of the referee instead of "First reference", "Second reference" etc.

This is because:

* the names might be easier to scan
* the order isn't important at all, but using "first", "second" etc might falsly imply that it is
* ordinal numbers can be slow to read, particularly when getting up to higher numbers ("Eleventh", "Sixteenth") – although it's unlikely many candidates add more than 10
* Using "reference" might imply that the reference has been collected (or will be), but in the new flow, the person isn't contacted for a reference until later.

There should always be a name, as the reference isn't saved to the database until after a name has been added.

One possible downside is that the name is now shown twice, which may be confusing. However we already do this in the A levels, degree, and unpaid work experience sections.

## Screenshots

### Before

![before](https://user-images.githubusercontent.com/30665/188429465-0c49378e-077d-46fa-baad-f77951c9efb6.png)

### After

![after](https://user-images.githubusercontent.com/30665/188429490-84b57ded-3896-43e5-a78d-bdcd925583ce.png)
