### PR TITLE
Remove unneeded govuk-hint classes which added spacing

### DIFF
--- a/app/views/candidate_interface/unsubmitted_application_form/_task_list.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/_task_list.html.erb
@@ -81,7 +81,7 @@
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.personal_statement') %></h2>
 
   <ol class="app-task-list">
-    <li class="app-task-list__item govuk-hint">
+    <li class="app-task-list__item">
       <%= render(TaskListItemComponent.new(
         text: t('page_titles.becoming_a_teacher'),
         completed: application_form_presenter.becoming_a_teacher_completed?,
@@ -90,7 +90,7 @@
         custom_color: application_form_presenter.becoming_a_teacher_review_pending? ? 'pink' : nil,
       )) %>
     </li>
-    <li class="app-task-list__item govuk-hint">
+    <li class="app-task-list__item">
       <%= render(TaskListItemComponent.new(
         text: t('page_titles.subject_knowledge'),
         completed: application_form_presenter.subject_knowledge_completed?,
@@ -113,7 +113,7 @@
         path: application_form_presenter.training_with_a_disability_valid? ? candidate_interface_training_with_a_disability_show_path : candidate_interface_new_training_with_a_disability_path,
       )) %>
     </li>
-    <li class="app-task-list__item govuk-hint">
+    <li class="app-task-list__item">
       <%= render(TaskListItemComponent.new(
         text: t('page_titles.interview_preferences.heading'),
         completed: application_form_presenter.interview_preferences_completed?,


### PR DESCRIPTION
This fixes a longstanding bug which was causing extra spacing to appear at the top of the "Your suitability to teach a subject or age group" row in the application task list.

This was caused by a `govuk-hint` class which isn't needed.

## Screenshots

### Before

<img width="743" alt="Screenshot 2022-09-05 at 13 45 40" src="https://user-images.githubusercontent.com/30665/188452547-3218d076-6947-4791-b3a7-54514cea8a2f.png">

### After

<img width="698" alt="Screenshot 2022-09-05 at 13 45 57" src="https://user-images.githubusercontent.com/30665/188452600-341fc66c-66d9-4d19-9632-ebf9fbdd6fd2.png">
