### PR TITLE
Hide certain rows if the reference has not been provided

### DIFF
--- a/app/components/provider_interface/new_reference_with_feedback_component.rb
+++ b/app/components/provider_interface/new_reference_with_feedback_component.rb
@@ -63,7 +63,7 @@ module ProviderInterface
     end
 
     def relationship_confirmation_row
-      return if application_choice.pre_offer?
+      return if application_choice.pre_offer? || reference_not_provided?
 
       {
         key: 'Relationship confirmed by referee?',
@@ -81,7 +81,7 @@ module ProviderInterface
     end
 
     def safeguarding_row
-      return if application_choice.pre_offer?
+      return if application_choice.pre_offer? || reference_not_provided?
 
       {
         key: 'Does the referee know of any reason why this candidate should not work with children?',
@@ -105,6 +105,10 @@ module ProviderInterface
         key: 'Reference',
         value: feedback,
       }
+    end
+
+    def reference_not_provided?
+      !reference.feedback_provided?
     end
   end
 end

--- a/spec/components/provider_interface/new_reference_with_feedback_component_spec.rb
+++ b/spec/components/provider_interface/new_reference_with_feedback_component_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ProviderInterface::NewReferenceWithFeedbackComponent, type: :component do
   describe '#rows' do
     let(:feedback) { 'A valuable unit of work' }
-    let(:reference) { build(:reference, feedback: feedback) }
+    let(:reference) { build(:reference, feedback: feedback, feedback_status: 'feedback_provided') }
     let(:application_choice) { build(:application_choice, :with_completed_application_form, :with_offer) }
 
     subject(:component) do
@@ -33,7 +33,7 @@ RSpec.describe ProviderInterface::NewReferenceWithFeedbackComponent, type: :comp
     end
 
     context 'referee_type is nil' do
-      let(:reference) { build(:reference, feedback: feedback, referee_type: nil) }
+      let(:reference) { build(:reference, feedback: feedback, referee_type: nil, feedback_status: 'feedback_provided') }
 
       it 'renders without raisin an error' do
         row = component.rows.third


### PR DESCRIPTION
## Context

There are certain rows on a reference that we don't want to show until the reference has been received.

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="1010" alt="image" src="https://user-images.githubusercontent.com/47917431/188464013-80a075d9-1a53-4074-a37a-c3685699b075.png">|<img width="1007" alt="image" src="https://user-images.githubusercontent.com/47917431/188464082-58db859a-92f9-4aea-b996-95a5b9139774.png">|

## Guidance to review

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
