### PR TITLE
Update error message if reference type isn't selected

### DIFF
--- a/config/locales/candidate_interface/references.yml
+++ b/config/locales/candidate_interface/references.yml
@@ -101,7 +101,7 @@ en:
         candidate_interface/reference/referee_type_form:
           attributes:
             referee_type:
-              blank: Choose a type of referee
+              blank: Choose a type of reference
         candidate_interface/reference/referee_name_form:
           attributes:
             name:

--- a/spec/system/candidate_interface/new-references/candidate_add_references_spec.rb
+++ b/spec/system/candidate_interface/new-references/candidate_add_references_spec.rb
@@ -147,7 +147,7 @@ RSpec.feature 'New References' do
   end
 
   def then_i_should_be_told_to_provide_a_type
-    expect(page).to have_content 'Choose a type of referee'
+    expect(page).to have_content 'Choose a type of reference'
   end
 
   def and_a_validation_error_is_logged_for_type

--- a/spec/system/candidate_interface/references/candidate_adds_a_new_reference_feature_flag_disabled_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_adds_a_new_reference_feature_flag_disabled_spec.rb
@@ -136,7 +136,7 @@ RSpec.feature 'References' do
   end
 
   def then_i_should_be_told_to_provide_a_type
-    expect(page).to have_content 'Choose a type of referee'
+    expect(page).to have_content 'Choose a type of reference'
   end
 
   def and_a_validation_error_is_logged_for_type


### PR DESCRIPTION
This is more consistent with the question ("What type of reference do you want to add?") and we are no longer using "referee" as it’s harder to understand, and more commonly associated with sport.

## Screenshots

### Before

<img width="722" alt="Screenshot 2022-09-05 at 14 57 17" src="https://user-images.githubusercontent.com/30665/188466092-8ae3893b-1e37-4ded-9e76-aa5012155894.png">


### After

<img width="734" alt="Screenshot 2022-09-05 at 14 56 54" src="https://user-images.githubusercontent.com/30665/188466013-843c75b0-6c41-41d7-9e70-34748b0edd1f.png">
