### PR TITLE
Fix faker error

### DIFF
--- a/config/locales/faker.yml
+++ b/config/locales/faker.yml
@@ -5,3 +5,5 @@ en:
         - "#{Name.last_name} #{University.suffix}"
         - "#{Name.name} #{University.suffix}"
         - "#{University.prefix} #{Name.last_name} #{University.suffix}"
+    address:
+      county: [Avon, Bedfordshire, Berkshire, Borders, Buckinghamshire, Cambridgeshire, Central, Cheshire, Cleveland, Clwyd, Cornwall, County Antrim, County Armagh, County Down, County Fermanagh, County Londonderry, County Tyrone, Cumbria, Derbyshire, Devon, Dorset, Dumfries and Galloway, Durham, Dyfed, East Sussex, Essex, Fife, Gloucestershire, Grampian, Greater Manchester, Gwent, Gwynedd County, Hampshire, Herefordshire, Hertfordshire, Highlands and Islands, Humberside, Isle of Wight, Kent, Lancashire, Leicestershire, Lincolnshire, Lothian, Merseyside, Mid Glamorgan, Norfolk, North Yorkshire, Northamptonshire, Northumberland, Nottinghamshire, Oxfordshire, Powys, Rutland, Shropshire, Somerset, South Glamorgan, South Yorkshire, Staffordshire, Strathclyde, Suffolk, Surrey, Tayside, Tyne and Wear, Warwickshire, West Glamorgan, West Midlands, West Sussex, West Yorkshire, Wiltshire, Worcestershire]


### PR DESCRIPTION
## Context
We're getting a `translation missing: en.faker.address.county` in prod at the moment
Error is caused when this line is evaluated https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/spec/factories/site.rb#L11 when clicking on various mailer previews

## Changes proposed in this pull request
* Add county data to faker.yml

## Guidance to review

## Link to Trello card

n/a

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
