### PR TITLE
Downgrade faker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   ignore:
+  - dependency-name: faker
+    versions:
+    - 2.23.0
   - dependency-name: activerecord
     versions:
     - 6.1.3.1

--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ gem 'sentry-rails'
 gem 'sentry-sidekiq'
 
 gem 'factory_bot_rails'
-gem 'faker'
+gem 'faker', '2.22.0'
 
 gem 'view_component'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,7 +217,7 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faker (2.23.0)
+    faker (2.22.0)
       i18n (>= 1.8.11, < 2)
     faraday (1.10.1)
       faraday-em_http (~> 1.0)
@@ -776,7 +776,7 @@ DEPENDENCIES
   dotenv-rails
   erb_lint
   factory_bot_rails
-  faker
+  faker (= 2.22.0)
   geocoder
   govuk-components (~> 3.0.6)
   govuk_design_system_formbuilder (~> 3.1.2)


### PR DESCRIPTION
## Context

The new version (2.23.0) is raising issues in locales, for more info check the sentry errors:

https://sentry.io/organizations/dfe-teacher-services/issues/3562208831/?referrer=slack
https://sentry.io/organizations/dfe-teacher-services/issues/3562642655/?project=1765973&referrer=slack

## Why we are downgrading?

Because the issue with the locales requires a proper investigation that could take a while to fix.

## Who is affecting

* The Apply team trying to generate test applications for provider references presentation
* Vendors trying to generate test applications

## The plan to solve this issue

1. Downgrade to solve the issue in short term and disable dependabot to merge automatically the faker version
2. Create a trello ticket and solve the issue 
3. Remove the dependabot ignore config after the issue is fixed

