### PR TITLE
Update copy on making changes to 'rest of' your application when unable to submit at this point in time

### DIFF
--- a/app/components/candidate_interface/review_application_component.html.erb
+++ b/app/components/candidate_interface/review_application_component.html.erb
@@ -1,7 +1,7 @@
 <section>
   <% if CycleTimetable.between_cycles?(application_form.phase) %>
     <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.review') %></h2>
-    <p class="govuk-body">You cannot submit your application until 9am on <%= reopen_date %>. You can keep making changes to the rest of your application until then.</p>
+    <p class="govuk-body">You cannot submit your application until 9am on <%= reopen_date %>. You can keep making changes to your application until then.</p>
     <%= govuk_button_link_to 'Review your application', candidate_interface_application_review_path %>
   <% else %>
     <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.check_and_submit') %></h2>

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -14,7 +14,7 @@
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.courses') %></h2>
   <% if !@application_form.submitted? && !CycleTimetable.can_add_course_choice?(@application_form) %>
     <p class="govuk-body govuk-!-width-two-thirds">
-      You can find courses from 9am on <%= CycleTimetable.find_reopens.to_fs(:govuk_date) %>. You can keep making changes to the rest of your application until then.
+      You can find courses from 9am on <%= CycleTimetable.find_reopens.to_fs(:govuk_date) %>. You can keep making changes to your application until then.
     </p>
   <% else %>
     <%= render(

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -41,7 +41,7 @@
       <section class="govuk-!-margin-bottom-8">
         <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.courses') %></h2>
           <p class="govuk-body">
-            You can find courses from 9am on <%= CycleTimetable.find_reopens.to_fs(:govuk_date) %>. You can keep making changes to the rest of your application until then.
+            You can find courses from 9am on <%= CycleTimetable.find_reopens.to_fs(:govuk_date) %>. You can keep making changes to your application until then.
           </p>
       </section>
     <% else %>

--- a/spec/components/candidate_interface/review_application_component_spec.rb
+++ b/spec/components/candidate_interface/review_application_component_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe CandidateInterface::ReviewApplicationComponent do
       application_form = create(:application_form)
       result = render_inline(described_class.new(application_form:))
 
-      expect(result.text).to include("You cannot submit your application until 9am on #{CycleTimetable.apply_reopens.to_fs(:govuk_date)}. You can keep making changes to the rest of your application until then.")
+      expect(result.text).to include("You cannot submit your application until 9am on #{CycleTimetable.apply_reopens.to_fs(:govuk_date)}. You can keep making changes to your application until then.")
     end
   end
 
@@ -42,7 +42,7 @@ RSpec.describe CandidateInterface::ReviewApplicationComponent do
       application_form = create(:application_form)
       result = render_inline(described_class.new(application_form:))
 
-      expect(result.text).to include("You cannot submit your application until 9am on #{CycleTimetable.apply_opens.to_fs(:govuk_date)}. You can keep making changes to the rest of your application until then.")
+      expect(result.text).to include("You cannot submit your application until 9am on #{CycleTimetable.apply_opens.to_fs(:govuk_date)}. You can keep making changes to your application until then.")
     end
   end
 end

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_and_needs_to_select_course_feature_flag_disabled_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_and_needs_to_select_course_feature_flag_disabled_spec.rb
@@ -113,7 +113,7 @@ RSpec.feature 'Carry over' do
   end
 
   def then_i_can_see_that_i_need_to_select_courses_when_apply_reopens
-    expect(page).to have_content "You can find courses from 9am on #{CycleTimetable.find_reopens.to_fs(:govuk_date)}. You can keep making changes to the rest of your application until then."
+    expect(page).to have_content "You can find courses from 9am on #{CycleTimetable.find_reopens.to_fs(:govuk_date)}. You can keep making changes to your application until then."
     expect(page).not_to have_link 'Choose your courses'
   end
 end

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   def and_i_can_see_that_no_courses_are_selected_and_i_cannot_add_any_yet
-    expect(page).to have_content "You can find courses from 9am on #{CycleTimetable.find_reopens.to_fs(:govuk_date)}. You can keep making changes to the rest of your application until then."
+    expect(page).to have_content "You can find courses from 9am on #{CycleTimetable.find_reopens.to_fs(:govuk_date)}. You can keep making changes to your application until then."
     expect(page).not_to have_link 'Course choice'
   end
 

--- a/spec/system/candidate_interface/course_selection/candidate_cannot_add_new_course_once_the_cycle_has_closed_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_cannot_add_new_course_once_the_cycle_has_closed_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'Candidate vists their application form after the cycle has ended
   end
 
   def then_i_see_that_i_can_add_new_course_choices_in_october
-    expect(page).to have_content "You can find courses from 9am on #{CycleTimetable.find_reopens.to_fs(:govuk_date)}. You can keep making changes to the rest of your application until then."
+    expect(page).to have_content "You can find courses from 9am on #{CycleTimetable.find_reopens.to_fs(:govuk_date)}. You can keep making changes to your application until then."
   end
 
   def and_there_is_not_a_link_to_the_course_choices_section


### PR DESCRIPTION
## Context

This is a quick change proposed by @johndoates as part of the end of cycle content review.

## Changes proposed in this pull request

Changing 'rest of your application' to 'your application'.

## Guidance to review

Does this need to be amended in all cases?

## Link to Trello card

N/A

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
