### PR TITLE
560 update existing email content with mention of references

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -275,12 +275,12 @@ class CandidateMailer < ApplicationMailer
 
   def conditions_met(application_choice)
     @application_choice = application_choice
-    course = application_choice.current_course_option.course
-    course_name = "#{course.name_and_code} at #{course.provider.name}"
+    @course = application_choice.current_course_option.course
+    course_name = "#{@course.name_and_code} at #{@course.provider.name}"
 
     email_for_candidate(
       application_choice.application_form,
-      subject: I18n.t!('candidate_mailer.conditions_met.subject', course_name:),
+      subject: I18n.t!("candidate_mailer.conditions_met.#{application_choice.application_form.show_new_reference_flow? ? 'subject_2023' : 'subject_2022'}", course_name:),
     )
   end
 

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -351,6 +351,7 @@ class CandidateMailer < ApplicationMailer
   def reinstated_offer(application_choice)
     @application_choice = application_choice
     @course_option = @application_choice.current_course_option
+    @provider_name = @course_option.provider.name
     @conditions = @application_choice.offer.conditions_text
 
     email_for_candidate(

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -417,7 +417,6 @@ class CandidateMailer < ApplicationMailer
     kwargs = {
       course_name_and_code: @course_name_and_code,
       provider_name: @provider_name,
-      start_date: @start_date,
     }
 
     email_for_candidate(

--- a/app/views/candidate_mailer/_still_interested_content.text.erb
+++ b/app/views/candidate_mailer/_still_interested_content.text.erb
@@ -19,4 +19,9 @@ Your last application is saved. All you need to do is:
 
 <% end %>
 
-[Sign in to apply again](<%= @candidate_magic_link %>).
+<% if @application_form.show_new_reference_flow? %>
+  [Sign in](<%= @candidate_magic_link %>) to apply again.
+<% else %>
+  [Sign in to apply again](<%= @candidate_magic_link %>).
+<% end %>
+

--- a/app/views/candidate_mailer/conditions_met.text.erb
+++ b/app/views/candidate_mailer/conditions_met.text.erb
@@ -1,7 +1,19 @@
 Dear <%= @application_form.first_name %>
+<% if @application_form.show_new_reference_flow? %>
 
-Congratulations, <%= @application_choice.current_course_option.course.provider.name %> has confirmed that you’ve met your conditions for <%= @application_choice.current_course_option.course.name_and_code %>.
+  <%= @course.provider.name %> has confirmed that you’ve met your conditions and they’ve checked your references.
 
-If they have not already, <%= @application_choice.current_course_option.course.provider.name %> should be in contact about enrolling on the course.
+  If they have not already, <%= @course.provider.name %> should contact you with details about enrolling on the course. Contact them directly if you have any questions.
 
-Contact them directly if you have any questions about this process.
+<% else %>
+
+  Congratulations, <%= @application_choice.current_course_option.course.provider.name %> has confirmed that you’ve met your conditions for <%= @application_choice.current_course_option.course.name_and_code %>.
+
+  If they have not already, <%= @application_choice.current_course_option.course.provider.name %> should be in contact about enrolling on the course.
+
+  Contact them directly if you have any questions about this process.
+
+<% end %>
+
+
+

--- a/app/views/candidate_mailer/offer_accepted.text.erb
+++ b/app/views/candidate_mailer/offer_accepted.text.erb
@@ -3,10 +3,9 @@ Dear <%= @application_form.first_name %>
 You’ve accepted <%= @provider_name %>’s offer to study <%= @course_name_and_code %>.
 
 <% if @application_form.show_new_reference_flow? %>
-  
-  Your place will be confirmed when:
-  - you’ve met your offer conditions
-  - when safeguarding checks like DBS and references have been completed
+Your place will be confirmed when:
+- you’ve met your offer conditions
+- safeguarding checks like DBS and references have been completed
 
 If you meet your conditions, you’ll start <%= @course_name_and_code %> <%= @provider_name %> in <%= @start_date %>.
 

--- a/app/views/candidate_mailer/offer_accepted.text.erb
+++ b/app/views/candidate_mailer/offer_accepted.text.erb
@@ -2,6 +2,24 @@ Dear <%= @application_form.first_name %>
 
 You’ve accepted <%= @provider_name %>’s offer to study <%= @course_name_and_code %>.
 
+<% if @application_form.show_new_reference_flow? %>
+  
+  Your place will be confirmed when:
+  - you’ve met your offer conditions
+  - when safeguarding checks like DBS and references have been completed
+
+If you meet your conditions, you’ll start <%= @course_name_and_code %> <%= @provider_name %> in <%= @start_date %>.
+
+[Sign in](<%= candidate_magic_link(@application_form.candidate) %>) to check the progress of your reference requests and offer conditions.
+
+#If you’re unable to start training in <%= @start_date %>
+
+Some providers allow you to defer your offer. This means that you could start your course a year later.
+
+Contact <%= @provider_name%> to find out if they’ll allow you to defer your offer. Asking them will not affect your existing offer.
+
+<% else %>
+
 If you meet your conditions, you’ll start <%= @course_name_and_code %> <%= @provider_name %> on <%= @start_date %>.
 
 [Sign in to your account to check your offer conditions](<%= candidate_magic_link(@application_form.candidate) %>).
@@ -13,3 +31,6 @@ Some providers allow you to defer your offer. This means that you could start yo
 Every provider is different, so it may or may not be possible to do this. Find out by contacting <%= @provider_name %>.
 
 Asking if it’s possible to defer will not affect your existing offer.
+
+<% end %>
+

--- a/app/views/candidate_mailer/reinstated_offer.text.erb
+++ b/app/views/candidate_mailer/reinstated_offer.text.erb
@@ -1,9 +1,8 @@
 Dear <%= @application_form.first_name %>
 
-<%= @course_option.course.provider.name %> has confirmed your deferred offer to study <%= @course_option.course.name_and_code %>.
+<%= @provider_name %> has confirmed your deferred offer to study <%= @course_option.course.name_and_code %>.
 
 The course starts in <%= @course_option.course.start_date.to_fs(:month_and_year) %>.
-
 
 <% if @application_choice.offer.conditions.where(status: 'met').count.zero? %>
 
@@ -13,4 +12,12 @@ The course starts in <%= @course_option.course.start_date.to_fs(:month_and_year)
   They’ll let you know if they need further information before you start training.
 <% end %>
 
-[Sign in to your account to see your offer details](<%= candidate_magic_link(@application_choice.application_form.candidate) %>).
+<% if @application_form.show_new_reference_flow? %>
+
+  <%= @provider_name %> also needs to check your references and DBS.
+
+  [Sign in](<%= candidate_magic_link(@application_choice.application_form.candidate) %>) to check the progress of your reference requests and offer conditions.
+
+<% else %>
+  [Sign in to your account to see your offer details](<%= candidate_magic_link(@application_choice.application_form.candidate) %>).
+<% end %>

--- a/app/views/candidate_mailer/withdraw_last_application_choice.text.erb
+++ b/app/views/candidate_mailer/withdraw_last_application_choice.text.erb
@@ -7,7 +7,7 @@ You’ve withdrawn your <%= 'application'.pluralize(@withdrawn_course_names.size
 <% if @application_form.show_new_reference_flow? %>
 Since you withdrew your application, we’ve contacted these people to say they do not need to give a reference:
 
-<% @application_form.application_references.select(&:feedback_requested?).each do |reference| %>
+<% @application_form.application_references.feedback_requested.each do |reference| %>
   -<%= reference.name %>
 <% end %>
 

--- a/app/views/candidate_mailer/withdraw_last_application_choice.text.erb
+++ b/app/views/candidate_mailer/withdraw_last_application_choice.text.erb
@@ -3,3 +3,13 @@ Dear <%= @application_form.first_name %>
 You’ve withdrawn your <%= 'application'.pluralize(@withdrawn_course_names.size) %> for <%= @withdrawn_course_names.to_sentence %>.
 
 <%= render 'still_interested_content' %>
+
+<% if @application_form.show_new_reference_flow? %>
+Since you withdrew your application, we’ve contacted these people to say they do not need to give a reference:
+
+<% @application_form.application_references.select(&:feedback_requested?).each do |reference| %>
+  -<%= reference.name %>
+<% end %>
+
+You can send another request for a reference from them if you apply again.
+<% end %>

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -74,7 +74,8 @@ en:
     conditions_statuses_changed:
       subject: "%{provider_name} has updated the status of your conditions for %{course_name}"
     conditions_met:
-      subject: "You have met your conditions for %{course_name}: next steps"
+      subject_2022: "You have met your conditions for %{course_name}: next steps"
+      subject_2023: "You’ve met your conditions for %{course_name}"
     conditions_not_met:
       subject: "You have not met your conditions for %{course_name}: next steps"
     changed_offer:

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -67,8 +67,8 @@ en:
       subject: Update on your application - respond by %{date}
     application_withdrawn:
       subject:
-        one: "You’ve withdrawn your application: next steps"
-        other: "You’ve withdrawn your applications: next steps"
+        one: "You’ve withdrawn your application"
+        other: "You’ve withdrawn your applications"
     application_declined:
       subject: "You’ve declined an offer: next steps"
     conditions_statuses_changed:

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -5,9 +5,11 @@ RSpec.describe CandidateMailer, type: :mailer do
 
   subject(:mailer) { described_class }
 
+  let(:recruitment_cycle_year) { ApplicationForm::OLD_REFERENCE_FLOW_CYCLE_YEAR }
   let(:application_form) do
     build_stubbed(:application_form, first_name: 'Fred',
                                      candidate:,
+                                     recruitment_cycle_year:,
                                      application_choices:)
   end
   let(:candidate) { build_stubbed(:candidate) }
@@ -199,8 +201,10 @@ RSpec.describe CandidateMailer, type: :mailer do
   end
 
   describe '.withdraw_last_application_choice' do
+    let(:recruitment_cycle_year) { ApplicationForm::OLD_REFERENCE_FLOW_CYCLE_YEAR }
     let(:application_form_with_references) do
       create(:application_form, first_name: 'Fred',
+                                recruitment_cycle_year: recruitment_cycle_year,
                                 application_choices: application_choices,
                                 application_references: [referee1, referee2])
     end
@@ -220,11 +224,11 @@ RSpec.describe CandidateMailer, type: :mailer do
     end
 
     context 'when new reference flow is active' do
+      let(:recruitment_cycle_year) { ApplicationForm::OLD_REFERENCE_FLOW_CYCLE_YEAR + 1 }
       let(:application_choices) { [create(:application_choice, status: 'withdrawn')] }
 
       before do
         FeatureFlag.activate(:new_references_flow)
-        application_form_with_references.recruitment_cycle_year = 2023
       end
 
       it_behaves_like(
@@ -309,6 +313,7 @@ RSpec.describe CandidateMailer, type: :mailer do
   end
 
   describe '.offer_accepted' do
+    let(:recruitment_cycle_year) { ApplicationForm::OLD_REFERENCE_FLOW_CYCLE_YEAR + 1 }
     let(:email) { described_class.offer_accepted(application_form.application_choices.first) }
     let(:application_choices) do
       [build_stubbed(
@@ -330,12 +335,11 @@ RSpec.describe CandidateMailer, type: :mailer do
     context 'when new reference flow is active' do
       before do
         FeatureFlag.activate(:new_references_flow)
-        application_form.recruitment_cycle_year = 2023
       end
 
       it 'includes reference text' do
         expect(email.body).to include('you’ve met your offer conditions')
-        expect(email.body).to include('when safeguarding checks like DBS and references have been completed')
+        expect(email.body).to include('safeguarding checks like DBS and references have been completed')
       end
     end
   end
@@ -370,6 +374,7 @@ RSpec.describe CandidateMailer, type: :mailer do
   end
 
   describe '.reinstated_offer' do
+    let(:recruitment_cycle_year) { ApplicationForm::OLD_REFERENCE_FLOW_CYCLE_YEAR + 1 }
     let(:offer) do
       build_stubbed(:application_choice, :with_offer,
                     sent_to_provider_at: Time.zone.today,
@@ -394,7 +399,6 @@ RSpec.describe CandidateMailer, type: :mailer do
     context 'when new reference flow is active' do
       before do
         FeatureFlag.activate(:new_references_flow)
-        application_form.recruitment_cycle_year = 2023
       end
 
       it 'includes reference text' do

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -364,6 +364,17 @@ RSpec.describe CandidateMailer, type: :mailer do
       'pending condition text' => 'You still need to meet the following condition',
       'pending condition' => 'Be cool',
     )
+
+    context 'when new reference flow is active' do
+      before do
+        FeatureFlag.activate(:new_references_flow)
+        application_form.recruitment_cycle_year = 2023
+      end
+
+      it 'includes reference text' do
+        expect(email.body).to include('Arithmetic College also needs to check your references and DBS.')
+      end
+    end
   end
 
   describe '.unconditional_offer_accepted' do

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -300,6 +300,18 @@ RSpec.describe CandidateMailer, type: :mailer do
       'offer_details' => 'You’ve accepted Arithmetic College’s offer to study Mathematics (M101)',
       'course start' => 'September 2021',
     )
+
+    context 'when new reference flow is active' do
+      before do
+        FeatureFlag.activate(:new_references_flow)
+        application_form.recruitment_cycle_year = 2023
+      end
+
+      it 'includes reference text' do
+        expect(email.body).to include('you’ve met your offer conditions')
+        expect(email.body).to include('when safeguarding checks like DBS and references have been completed')
+      end
+    end
   end
 
   describe '.conditions_statuses_changed' do

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -869,7 +869,7 @@ private
 
   def new_references_content(application_form)
     FeatureFlag.activate(:new_references_flow)
-    application_form.recruitment_cycle_year = 2023
+    application_form.recruitment_cycle_year = ApplicationForm::OLD_REFERENCE_FLOW_CYCLE_YEAR + 1
   end
 
   def candidate

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -815,10 +815,11 @@ class CandidateMailerPreview < ActionMailer::Preview
       course_option:,
       offer_deferred_at: Time.zone.local(2019, 10, 14),
     )
+    new_references_content(application_choice.application_form)
     CandidateMailer.reinstated_offer(application_choice)
   end
 
-  def reinstated_offer_without_condidtions
+  def reinstated_offer_without_conditions
     application_choice = FactoryBot.build(
       :application_choice,
       :with_recruited,
@@ -827,6 +828,7 @@ class CandidateMailerPreview < ActionMailer::Preview
       offer: FactoryBot.build(:unconditional_offer),
       offer_deferred_at: Time.zone.local(2019, 10, 14),
     )
+    new_references_content(application_choice.application_form)
     CandidateMailer.reinstated_offer(application_choice)
   end
 

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -620,6 +620,7 @@ class CandidateMailerPreview < ActionMailer::Preview
 
   def offer_accepted
     application_choice = FactoryBot.build_stubbed(:application_choice)
+    new_references_content(application_choice.application_form)
     CandidateMailer.offer_accepted(application_choice)
   end
 

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -713,6 +713,7 @@ class CandidateMailerPreview < ActionMailer::Preview
   end
 
   def conditions_met
+    new_references_content(application_choice_with_offer.application_form)
     CandidateMailer.conditions_met(application_choice_with_offer)
   end
 
@@ -858,6 +859,10 @@ class CandidateMailerPreview < ActionMailer::Preview
   end
 
 private
+  def new_references_content(application_form)
+    FeatureFlag.activate(:new_references_flow)
+    application_form.recruitment_cycle_year = 2023
+  end
 
   def candidate
     candidate = FactoryBot.build_stubbed(:candidate)
@@ -908,6 +913,7 @@ private
   def application_choice_with_offer
     FactoryBot.build(:application_choice,
                      :with_offer,
+                     application_form:,
                      course_option:,
                      decline_by_default_at: Time.zone.now,
                      sent_to_provider_at: 1.day.ago)

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -700,9 +700,13 @@ class CandidateMailerPreview < ActionMailer::Preview
       application_choices: [
         FactoryBot.build_stubbed(:application_choice, status: 'withdrawn', course_option:),
       ],
+      application_references: [
+        reference_feedback_requested,
+        reference_feedback_requested,
+      ],
       candidate:,
     )
-
+    new_references_content(application_form)
     CandidateMailer.withdraw_last_application_choice(application_form)
   end
 
@@ -862,6 +866,7 @@ class CandidateMailerPreview < ActionMailer::Preview
   end
 
 private
+
   def new_references_content(application_form)
     FeatureFlag.activate(:new_references_flow)
     application_form.recruitment_cycle_year = 2023
@@ -885,6 +890,10 @@ private
 
   def reference
     FactoryBot.build_stubbed(:reference, application_form:)
+  end
+
+  def reference_feedback_requested
+    FactoryBot.build_stubbed(:reference, feedback_status: :feedback_requested)
   end
 
   def application_form_with_course_choices(course_choices)

--- a/spec/system/provider_interface/provider_marks_conditions_as_met_spec.rb
+++ b/spec/system/provider_interface/provider_marks_conditions_as_met_spec.rb
@@ -111,6 +111,11 @@ RSpec.feature 'Confirm conditions met' do
 
   def and_the_candidate_receives_an_email_notification
     open_email(@application_choice.application_form.candidate.email_address)
-    expect(current_email.subject).to have_content 'You have met your conditions for'
+
+    if @application_choice.application_form.show_new_reference_flow?
+      expect(current_email.subject).to have_content 'You’ve met your conditions for'
+    else
+      expect(current_email.subject).to have_content 'You have met your conditions for'
+    end
   end
 end


### PR DESCRIPTION
## Context
We have a number of existing emails that need to be updated to inform candidates that references form part of an offer condition.

## Changes proposed in this pull request
* Update copy in various emails but behind a feature flag as providers are still able to make offers to candidates in the old cycle for a couple of weeks

## Guidance to review

Commit by commit. Email previews at `/rails/mailers/candidate_mailer/`

## Link to Trello card
https://trello.com/c/EL6GilJG/560-update-existing-email-content-with-mention-of-references

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
