### PR TITLE
Remove branch check conditional, branch is merged

### DIFF
--- a/.github/workflows/pull_request_checks.yml
+++ b/.github/workflows/pull_request_checks.yml
@@ -10,7 +10,6 @@ jobs:
   warn-enums:
     name: Detect enum changes
     runs-on: ubuntu-latest
-    if: github.head_ref != '513-upgrade-to-ruby-31'
 
     services:
       postgres:


### PR DESCRIPTION
## Context

We added this PR branch name check to skip the enum change PR check when upgrading Ruby. We don't need it any more as we've merge the Ruby update branch.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Remove PR branch name conditional check.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/ZH6ETbd1/513-upgrade-to-ruby-31
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
