### PR TITLE
Create candidates at specific point of RC

### DIFF
--- a/spec/support/shared_examples/a_candidate_api_endpoint.rb
+++ b/spec/support/shared_examples/a_candidate_api_endpoint.rb
@@ -55,7 +55,7 @@ RSpec.shared_examples 'a candidate API endpoint' do |path, _date_param, api_vers
   end
 
   it 'does not return candidates without application forms which signed up during the previous recruitment_cycle' do
-    create(:candidate, created_at: 1.year.ago)
+    create(:candidate, created_at: CycleTimetable.apply_1_deadline(RecruitmentCycle.previous_year))
 
     get_api_request "#{path}?updated_since=#{CGI.escape(2.years.ago.iso8601)}", token: candidate_api_token
 
@@ -64,7 +64,7 @@ RSpec.shared_examples 'a candidate API endpoint' do |path, _date_param, api_vers
   end
 
   it 'does not return candidates who only have application forms in the previous cycle' do
-    candidate = create(:candidate, created_at: 1.year.ago)
+    candidate = create(:candidate, created_at: CycleTimetable.apply_1_deadline(RecruitmentCycle.previous_year))
     create(:completed_application_form, recruitment_cycle_year: RecruitmentCycle.previous_year, candidate:)
 
     get_api_request "#{path}?updated_since=#{CGI.escape(2.years.ago.iso8601)}", token: candidate_api_token


### PR DESCRIPTION
## Context

The Candidate API v1.2 endpoint returns candidates with applications in the current cycle or those created after the Apply 1 deadline the previous year. The shared examples didn't respect this and when we passed the Apply 1 deadline specs failed.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Fix the creation date of candidates in spec setup to Apply 1 deadline the previous year.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

`main` build is failing on this
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
