### PR TITLE
Relax application states rules when changing courses

### DIFF
--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -175,7 +175,7 @@ module SupportInterface
     end
 
     def change_course_choice_link
-      return {} unless @application_choice.application_form.editable? && ApplicationStateChange::DECISION_PENDING_STATUSES.include?(application_choice.status.to_sym)
+      return {} unless @application_choice.application_form.editable? && ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER.include?(application_choice.status.to_sym)
 
       {
         action: {

--- a/app/controllers/support_interface/application_forms/courses_controller.rb
+++ b/app/controllers/support_interface/application_forms/courses_controller.rb
@@ -60,12 +60,13 @@ module SupportInterface
             @show_course_change_confirmation = checkbox_rendered?
             render :edit
           end
-        rescue CourseChoiceError, ProviderInterviewError, FundingTypeError => e
+        rescue CourseChoiceError, FundingTypeError => e
           flash[:warning] = e.message
           render :edit
-        rescue CourseFullError => e
+        rescue ApplicationStateError, CourseFullError, ProviderInterviewError => e
           flash[:warning] = e.message
           @show_course_change_confirmation = true
+          @course_change_condition = course_change_condition(e)
           render :edit
         end
       end
@@ -96,6 +97,12 @@ module SupportInterface
 
       def course_code
         params[:course_code]
+      end
+
+      def course_change_condition(error)
+        return 'with no vacancies' if error.is_a?(CourseFullError)
+        return 'when interviews are pending' if error.is_a?(ProviderInterviewError)
+        return 'when a decision has already been made on the application' if error.is_a?(ApplicationStateError)
       end
     end
   end

--- a/app/views/support_interface/application_forms/courses/edit.html.erb
+++ b/app/views/support_interface/application_forms/courses/edit.html.erb
@@ -50,7 +50,7 @@
       <% if @show_course_change_confirmation %>
         <%= f.hidden_field :checkbox_rendered, value: true %>
         <%= f.govuk_check_boxes_fieldset :confirm_course_change, legend: nil do %>
-          <%= f.govuk_check_box :confirm_course_change, true, multiple: false, label: { text: 'I confirm that I would like to move the candidate to a course with no vacancies' }, link_errors: true %>
+          <%= f.govuk_check_box :confirm_course_change, true, multiple: false, label: { text: "I confirm that I would like to move the candidate to a course #{@course_change_condition}" }, link_errors: true %>
         <% end %>
       <% end %>
 

--- a/spec/components/support_interface/application_choice_component_spec.rb
+++ b/spec/components/support_interface/application_choice_component_spec.rb
@@ -27,8 +27,7 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
 
       render_inline(described_class.new(declined_offer))
 
-      expect(page).not_to have_selector '.govuk-summary-list__actions a'
-      expect(page).not_to have_text 'Reinstate offer'
+      expect(page).not_to have_selector '.govuk-summary-list__actions a', text: 'Reinstate offer'
     end
 
     it 'Does not render a link to the reinstate offer page if the application choice is declined by default' do
@@ -38,8 +37,7 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
 
       render_inline(described_class.new(application_choice))
 
-      expect(page).not_to have_selector '.govuk-summary-list__actions a'
-      expect(page).not_to have_text 'Reinstate offer'
+      expect(page).not_to have_selector '.govuk-summary-list__actions a', text: 'Reinstate offer'
     end
   end
 
@@ -124,10 +122,9 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
       rejected_application_choice.update!(
         rejected_by_default: true,
       )
-      result = render_inline(described_class.new(rejected_application_choice))
+      render_inline(described_class.new(rejected_application_choice))
 
-      expect(result.css('.govuk-summary-list__actions a')).to be_empty
-      expect(result.css('.govuk-summary-list__actions').text.strip).not_to include('Revert rejection')
+      expect(page).not_to have_selector '.govuk-summary-list__actions a', text: 'Revert rejection'
     end
   end
 
@@ -153,10 +150,9 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
       create(:application_choice, :with_accepted_offer, application_form:)
       FeatureFlag.activate(:support_user_revert_withdrawn_offer)
 
-      result = render_inline(described_class.new(withdrawn_application))
+      render_inline(described_class.new(withdrawn_application))
 
-      expect(result.css('.govuk-summary-list__actions a')).to be_empty
-      expect(result.css('.govuk-summary-list__actions').text.strip).not_to include('Revert withdrawal')
+      expect(page).not_to have_selector '.govuk-summary-list__actions a', text: 'Revert withdrawal'
     end
   end
 
@@ -207,7 +203,7 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
       expect(result.css('.govuk-summary-list__actions').text.strip).to include('Change course choice')
     end
 
-    it 'Does not render a link when the application has an offer' do
+    it 'Renders a link when the application has an offer' do
       application_choice = create(
         :application_choice,
         :with_completed_application_form,
@@ -216,16 +212,14 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
         decline_by_default_at: nil,
       )
 
-      result = render_inline(described_class.new(application_choice))
+      render_inline(described_class.new(application_choice))
 
-      expect(result.css('.govuk-summary-list__actions').map { |element| element['href'] }).not_to include(
-        Rails.application.routes.url_helpers.support_interface_application_form_change_course_choice_path(
-          application_form_id: application_choice.application_form.id,
-          application_choice_id: application_choice.id,
-        ),
+      change_course_path = Rails.application.routes.url_helpers.support_interface_application_form_change_course_choice_path(
+        application_form_id: application_choice.application_form.id,
+        application_choice_id: application_choice.id,
       )
 
-      expect(result.css('.govuk-summary-list__actions').text.strip).not_to include('Change course choice')
+      expect(page).to have_selector(".govuk-summary-list__actions a[href='#{change_course_path}']", text: 'Change course choice')
     end
   end
 

--- a/spec/forms/support_interface/application_forms/change_course_choice_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/change_course_choice_form_spec.rb
@@ -96,16 +96,17 @@ RSpec.describe SupportInterface::ApplicationForms::ChangeCourseChoiceForm, type:
         original_course_option = create(:course_option)
         application_choice = create(:application_choice, :interviewing, course_option: original_course_option)
 
-        course_option = create(:course_option, study_mode: :full_time)
         other_provider = create(:provider)
+        other_course = create(:course, provider: other_provider)
+        other_course_option = create(:course_option, course: other_course, study_mode: :full_time)
         zendesk_ticket = 'https://becomingateacher.zendesk.com/agent/tickets/12345'
 
         form = described_class.new(
           application_choice_id: application_choice.id,
           provider_code: other_provider.code,
-          course_code: course_option.course.code,
-          study_mode: course_option.course.study_mode,
-          site_code: course_option.site.code,
+          course_code: other_course_option.course.code,
+          study_mode: other_course_option.course.study_mode,
+          site_code: other_course_option.site.code,
           audit_comment_ticket: zendesk_ticket,
           accept_guidance: true,
         )

--- a/spec/services/support_interface/change_application_choice_course_option_spec.rb
+++ b/spec/services/support_interface/change_application_choice_course_option_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe SupportInterface::ChangeApplicationChoiceCourseOption do
                               study_mode: :part_time,
                               site_code: course_option.site.code,
                               audit_comment:).call
-        }.to raise_error(RuntimeError, "Changing the course option of application choices in the #{application_choice.status} state is not allowed")
+        }.to raise_error(SupportInterface::ApplicationStateError, "Changing the course option of application choices in the #{application_choice.status} state is not allowed")
       end
     end
 
@@ -139,7 +139,7 @@ RSpec.describe SupportInterface::ChangeApplicationChoiceCourseOption do
                               study_mode: course_option.course.study_mode,
                               site_code: course_option.site.code,
                               audit_comment:).call
-        }.not_to raise_error(FundingTypeError, error_message)
+        }.not_to raise_error
       end
     end
 


### PR DESCRIPTION
## Context

We have a high volume of support requests where a provider and/or candidate needs their course to be changed.
We have provision in the Support UI to do this when the application is in a decision pending state but not later in the workflow.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Relax the state checking validation to allow an application in any state visible to the provider to have the course changed.
Where it's 'past' the decision pending phase we only update the `current_course_option`, otherwise leave the change course behaviour as it was before.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/m8XJ0o5I/415-change-course-link-in-support-should-appear-in-many-scenarios
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
