### PR TITLE
Render the make decision features on the references tab

### DIFF
--- a/app/controllers/provider_interface/references_controller.rb
+++ b/app/controllers/provider_interface/references_controller.rb
@@ -4,6 +4,10 @@ module ProviderInterface
 
     def index
       @references = @application_choice.application_form.application_references
+
+      @provider_can_make_decisions =
+        current_provider_user.authorisation.can_make_decisions?(application_choice: @application_choice,
+                                                                course_option: @application_choice.current_course_option)
     end
   end
 end

--- a/app/views/provider_interface/references/index.html.erb
+++ b/app/views/provider_interface/references/index.html.erb
@@ -1,8 +1,6 @@
 <% content_for :browser_title, "#{@application_choice.application_form.full_name} – #{@application_choice.course.name_and_code} - References" %>
 
-<%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(
-  application_choice: @application_choice,
-) %>
+<%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(application_choice: @application_choice, provider_can_respond: @provider_can_make_decisions) %>
 <h1 class="govuk-heading-l">References</h1>
 
 <% if @application_choice.pre_offer? %>


### PR DESCRIPTION
## Context

The Make decision button is not rendering on the references tab in Manage, but appearing on all other tabs. It should be here as well!

## Changes proposed in this pull request

We need to pass in the `provider_can_make_decisisons` argument into the `ApplicationChoiceHeaderComponent`

|Before|After|
|---|---|
|<img width="627" alt="image" src="https://user-images.githubusercontent.com/47917431/189160821-f86bb810-41ed-4003-8147-869a37c4a7cb.png">|<img width="671" alt="image" src="https://user-images.githubusercontent.com/47917431/189160676-d8e335fc-9c4c-4539-836a-c04b75daf42c.png">|

## Link to Trello card

https://trello.com/c/soPcMIig/603-fix-our-references-tab-and-ability-to-make-an-interview-when-viewing-references

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
