### PR TITLE
Cancel outstading requests when the application is rejected

### DIFF
--- a/app/services/cancel_outstanding_references.rb
+++ b/app/services/cancel_outstanding_references.rb
@@ -1,0 +1,17 @@
+class CancelOutstandingReferences
+  attr_reader :application_form
+
+  delegate :application_references, :show_new_reference_flow?, to: :application_form
+
+  def initialize(application_form:)
+    @application_form = application_form
+  end
+
+  def call!
+    return unless show_new_reference_flow?
+
+    application_references.feedback_requested.each do |reference|
+      CancelReferee.new.call(reference: reference)
+    end
+  end
+end

--- a/app/services/reject_application.rb
+++ b/app/services/reject_application.rb
@@ -34,6 +34,8 @@ class RejectApplication
 
       CancelUpcomingInterviews.new(actor: @auth.actor, application_choice: @application_choice, cancellation_reason: I18n.t('interview_cancellation.reason.application_rejected')).call!
 
+      CancelOutstandingReferences.new(application_form: @application_choice.application_form).call!
+
       SendCandidateRejectionEmail.new(application_choice: @application_choice).call
     end
 

--- a/spec/services/cancel_outstanding_references_spec.rb
+++ b/spec/services/cancel_outstanding_references_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe CancelOutstandingReferences, sidekiq: true do
+  let(:service) { described_class.new(application_form: application_form) }
+
+  context 'when an application has requested references in the new cycle' do
+    let(:application_form) { create(:application_form, :minimum_info, recruitment_cycle_year: 2023) }
+    let!(:requested_reference) { create(:reference, :feedback_requested, application_form: application_form) }
+    let!(:provided_reference) { create(:reference, :feedback_provided, application_form: application_form) }
+
+    before do
+      FeatureFlag.activate(:new_references_flow)
+    end
+
+    it 'cancel the requested references' do
+      service.call!
+
+      expect(requested_reference.reload.feedback_status).to eq('cancelled')
+      expect(provided_reference.reload.feedback_status).to eq('feedback_provided')
+    end
+
+    it 'deliver email to requested references' do
+      service.call!
+
+      expect(ActionMailer::Base.deliveries.map(&:to).flatten).to match_array([requested_reference.email_address])
+    end
+  end
+
+  context 'when the application is from the old cycle' do
+    let(:application_form) { create(:application_form, :minimum_info, recruitment_cycle_year: 2022) }
+
+    it 'does not cancel any reference' do
+      requested_reference = create(:reference, :feedback_requested, application_form: application_form)
+
+      service.call!
+
+      expect(requested_reference.reload.feedback_status).to eq('feedback_requested')
+    end
+  end
+end

--- a/spec/services/reject_application_spec.rb
+++ b/spec/services/reject_application_spec.rb
@@ -93,5 +93,15 @@ RSpec.describe RejectApplication do
       service.save
       expect(cancel_upcoming_interviews).to have_received(:call!)
     end
+
+    it 'calls the CancelOutstandingReferences service' do
+      cancel_outstanding_references = instance_double(CancelOutstandingReferences, call!: true)
+
+      allow(CancelOutstandingReferences)
+        .to receive(:new).with(application_form: application_choice.application_form)
+                         .and_return(cancel_outstanding_references)
+      service.save
+      expect(cancel_outstanding_references).to have_received(:call!)
+    end
   end
 end

--- a/spec/services/reject_application_spec.rb
+++ b/spec/services/reject_application_spec.rb
@@ -98,8 +98,10 @@ RSpec.describe RejectApplication do
       cancel_outstanding_references = instance_double(CancelOutstandingReferences, call!: true)
 
       allow(CancelOutstandingReferences)
-        .to receive(:new).with(application_form: application_choice.application_form)
-                         .and_return(cancel_outstanding_references)
+        .to receive(:new)
+        .with(application_form: application_choice.application_form)
+        .and_return(cancel_outstanding_references)
+
       service.save
       expect(cancel_outstanding_references).to have_received(:call!)
     end


### PR DESCRIPTION
## Context

After accepting an offer a candidate can still end up in an unsuccessful end state. Then we will cancel the references.

For now, this PR adds only for the rejected state.
