### PR TITLE
Update link in 'Find has opened' email

### DIFF
--- a/app/views/candidate_mailer/find_has_opened.erb
+++ b/app/views/candidate_mailer/find_has_opened.erb
@@ -4,9 +4,7 @@
 
 You can now find teacher training courses starting in the <%= @academic_year %> academic year.
 
-Find your courses:
-
-<%= I18n.t('find_postgraduate_teacher_training.production_url') %>
+[Find your courses](<%= I18n.t('find_postgraduate_teacher_training.production_url') %>).
 
 Apply early to have the best chance of getting onto the course you want, as courses fill up throughout the year.
 

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -666,7 +666,7 @@ RSpec.describe CandidateMailer, type: :mailer do
           'Find your teacher training course now',
           'greeting' => 'Dear Fred',
           'academic_year' => '2022 to 2023',
-          'details' => 'Find your courses:',
+          'details' => 'Find your courses',
         )
       end
 


### PR DESCRIPTION
Naming all the links instead of having a mixture of URLs and named links.

Changed as part of end of cycle content review: https://docs.google.com/document/d/1jTkxD3rWHQ9uUcOv6nM2vMAo67_zVX444666HgRIhFI/edit#

🗂️ [Trello card](https://trello.com/c/TsHxZJyT/358-update-eoc-content)