### PR TITLE
Display the 'set up interview' button on references tab

### DIFF
--- a/app/controllers/provider_interface/references_controller.rb
+++ b/app/controllers/provider_interface/references_controller.rb
@@ -8,6 +8,11 @@ module ProviderInterface
       @provider_can_make_decisions =
         current_provider_user.authorisation.can_make_decisions?(application_choice: @application_choice,
                                                                 course_option: @application_choice.current_course_option)
+
+      @provider_can_set_up_interviews = current_provider_user.authorisation.can_set_up_interviews?(
+        application_choice: @application_choice,
+        course_option: @application_choice.current_course_option,
+      )
     end
   end
 end

--- a/app/views/provider_interface/references/index.html.erb
+++ b/app/views/provider_interface/references/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :browser_title, "#{@application_choice.application_form.full_name} – #{@application_choice.course.name_and_code} - References" %>
 
-<%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(application_choice: @application_choice, provider_can_respond: @provider_can_make_decisions) %>
+<%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(application_choice: @application_choice, provider_can_respond: @provider_can_make_decisions, provider_can_set_up_interviews: @provider_can_set_up_interviews) %>
 <h1 class="govuk-heading-l">References</h1>
 
 <% if @application_choice.pre_offer? %>


### PR DESCRIPTION
## Context

In the provider interface, the button and the header "Set up an interview" is not showing on the references tab

## Changes

On this PR, the header "Set up an interview" is showing on the references tab and the button "Set up interview" too.

