### PR TITLE
Fix confirm environment bug

### DIFF
--- a/app/forms/support_interface/confirm_environment.rb
+++ b/app/forms/support_interface/confirm_environment.rb
@@ -7,7 +7,7 @@ module SupportInterface
 
     def correct_environment
       if environment != HostingEnvironment.environment_name
-        errors[:environment] << "That’s not ’#{HostingEnvironment.environment_name}’!"
+        errors.add(:environment, "That’s not ’#{HostingEnvironment.environment_name}’!")
       end
     end
   end

--- a/spec/forms/support_interface/confirm_environment_spec.rb
+++ b/spec/forms/support_interface/confirm_environment_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ConfirmEnvironment do
+  it 'checks the confirmed environment against the hosting environment' do
+    allow(HostingEnvironment).to receive(:environment_name).and_return('foo')
+    expect(described_class.new(environment: 'foo')).to be_valid
+    expect(described_class.new(environment: 'bar')).not_to be_valid
+  end
+end


### PR DESCRIPTION

## Context

This was using the older method of pushing errors onto the form, no longer supported in Rails.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Use `errors.add` to populate the form error. Add test.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/5aPwfeLq/547-the-confirm-environment-page-doesnt-actually-require-you-to-confirm-the-environment
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
