### PR TITLE
Improve Cypress specs and outputs

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -126,6 +126,7 @@ runs:
       if: inputs.environment != 'rollover'
       id: run_cypress
       uses: cypress-io/github-action@v2.3.10
+      continue-on-error: true
       with:
         browser: chrome
         spec: cypress/integration/candidate.spec.js

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -127,6 +127,7 @@ runs:
       id: run_cypress
       uses: cypress-io/github-action@v2.3.10
       with:
+        browser: chrome
         spec: cypress/integration/candidate.spec.js
       env:
         CYPRESS_ENVIRONMENT: ${{ inputs.environment }}

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -143,7 +143,7 @@ runs:
         path: |
           cypress/videos
           cypress/screenshots
-        if-no-files-found: ignore
+        if-no-files-found: warn
         retention-days: 7
 
     - name: Notify Slack channel on job failure

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -137,14 +137,14 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
 
     - name: Upload Cypress screenshot and videos
-      if: steps.run_cypress.outcome == 'success' || steps.run_cypress.outcome == 'failure' || steps.run_cypress.outcome == 'cancelled'
+      if: always()
       uses: actions/upload-artifact@v2.2.4
       with:
         name: smoke-test-${{ inputs.environment }}
         path: |
           cypress/videos
           cypress/screenshots
-        if-no-files-found: warn
+        if-no-files-found: ignore
         retention-days: 7
 
     - name: Notify Slack channel on job failure

--- a/cypress/integration/candidate.spec.js
+++ b/cypress/integration/candidate.spec.js
@@ -40,7 +40,8 @@ const andIClickContinue = () => {
 };
 
 const andIClickSignIn = () => {
-  cy.get("button").contains("Sign in").click();
+  cy.get("button").contains("Accept analytics cookies").click();
+  cy.get("button").contains(/Sign in|Create an account/).click();
 };
 
 const thenICanCreateAnAccount = () => {

--- a/cypress/integration/candidate.spec.js
+++ b/cypress/integration/candidate.spec.js
@@ -1,5 +1,7 @@
 const ENVIRONMENT = Cypress.env("ENVIRONMENT") || "Unknown";
 const CANDIDATE_EMAIL = Cypress.env("CANDIDATE_TEST_EMAIL");
+// Used in generating a randomish email address like apply-test+ebwbfyuwb@digital.blah.com
+const SEED = Math.random().toString(36).substring(2, 15);
 
 describe(`[${ENVIRONMENT}] Candidate`, () => {
   it("can sign up successfully", () => {
@@ -41,7 +43,7 @@ const andIClickContinue = () => {
 
 const andIClickSignIn = () => {
   cy.get("button").contains("Accept analytics cookies").click();
-  cy.get("button").contains(/Sign in|Create an account/).click();
+  cy.get("button").contains(/Sign in|Create account/).click();
 };
 
 const thenICanCreateAnAccount = () => {
@@ -50,7 +52,7 @@ const thenICanCreateAnAccount = () => {
 
 const whenITypeInMyEmail = () => {
   cy.get("#candidate-interface-sign-up-form-email-address-field").type(
-    CANDIDATE_EMAIL
+    candidateEmailAddress()
   );
 };
 
@@ -59,7 +61,7 @@ const thenIAmToldToCheckMyEmail = () => {
 };
 
 const whenIClickTheLinkInMyEmail = () => {
-  cy.task("getSignInLinkFor", { emailAddress: CANDIDATE_EMAIL }).then(
+  cy.task("getSignInLinkFor", { emailAddress: candidateEmailAddress() }).then(
     signInLink => {
       cy.visit(signInLink);
     }
@@ -83,3 +85,8 @@ const thenIShouldBeToldThatApplicationsAreClosed = () => {
 };
 
 const isSandbox = () => ENVIRONMENT.toUpperCase() === "SANDBOX";
+
+const candidateEmailAddress = () => {
+  const [name, domain] = CANDIDATE_EMAIL.split('@');
+  return `${name}+${SEED}@${domain}`;
+}


### PR DESCRIPTION
## Context

Cypress specs are failing for a bunch of reasons:

- CA Cert issue with default Electron browser
- Indeterminate candidate sign up journey opens us up to the _Shrodinger's Button_ paradox
- Cross domain issues with multiple review apps (and Sandbox) using the same email address

We also abuse the Notify guidance on Smoke and Integration testing, and the test result artifacts don't get uploaded to the end of the GitHub Workflow run.
Broken.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Make the default Cypress browser Chrome
- Match on either 'Create account' or 'Sign in' button
- Use a random(ish) email address for test runs so we don't have a race condition between multiple workflow runs
- Always upload artifacts after the Girhub workflow run.
- Continue on error, the tests still fail intermittently but at least we can merge on what is a flakey integration spec run.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
