### PR TITLE
Reduce the date range of the audit query

### DIFF
--- a/app/queries/get_activity_log_events.rb
+++ b/app/queries/get_activity_log_events.rb
@@ -24,7 +24,7 @@ class GetActivityLogEvents
   IGNORE_STATUS = %i[interviewing].freeze
 
   def self.call(application_choices:, since: nil)
-    since ||= Time.zone.local(2018, 1, 1) # before the pilot began, i.e. all records
+    since ||= application_choices.includes(:application_form).minimum('application_forms.created_at')
 
     application_choices_join_sql = <<~COMBINE_AUDITS_WITH_APPLICATION_CHOICES_SCOPE_AND_FILTER.squish
       INNER JOIN (#{application_choices.to_sql}) ac

--- a/spec/queries/get_activity_log_events_spec.rb
+++ b/spec/queries/get_activity_log_events_spec.rb
@@ -63,6 +63,23 @@ RSpec.describe GetActivityLogEvents, with_audited: true do
 
       expect(result.first).to eq(expected)
     end
+
+    it 'defaults the query date range to the earliest scoped application form creation' do
+      query_instance = instance_double(ActiveRecord::QueryMethods)
+      allow(Audited::Audit).to receive(:includes).and_return(query_instance)
+      %i[joins where order].each { |meth| allow(query_instance).to receive(meth).and_return(query_instance) }
+
+      choice = create_application_choice_for_course course_provider_a
+      another_choice = create_application_choice_for_course course_provider_a
+      create_audit_for_application_choice choice
+      create_audit_for_application_choice another_choice
+
+      another_choice.application_form.update(created_at: 1.day.ago)
+
+      described_class.call(application_choices: application_choices_for_provider_user)
+
+      expect(query_instance).to have_received(:where).with('audits.created_at >= ?', another_choice.application_form.created_at)
+    end
   end
 
   context 'includes all and only relevant audits' do


### PR DESCRIPTION
## Context

We have the scope of the application choices when we are querying audits and these records contain an associated `application_forms.created_at` timestamp.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Reduce the scope of the `GetActivityLogEvents` query to the creation date the of the earliest application form.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Adds one additional query to the timeline page/tab for an application:

```
SELECT MIN("application_forms"."created_at") FROM "application_choices" LEFT OUTER JOIN "application_forms" ON "application_forms"."id" = "application_choices"."application_form_id" WHERE "application_choices"."id" = $1;
```
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/hwn63AG7/586-audit-table-check-12m-counting
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
