### PR TITLE
Improved content for start of cycle candidate emails

### DIFF
--- a/app/views/candidate_mailer/new_cycle_has_started.erb
+++ b/app/views/candidate_mailer/new_cycle_has_started.erb
@@ -2,14 +2,18 @@
   Dear <%= @application_form.first_name %>
 <% end %>
 
-You can now apply for a teacher training course starting in the <%= @academic_year %> academic year.
+You can now apply for teacher training courses which will start in the <%= @academic_year %> academic year.
 
 <% unless @application_form.submitted? %>
-Sign into your account to [finish and submit your application](<%= candidate_magic_link(@application_form.candidate) %>).
+Sign into your account to finish and submit your application.
+
+[Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>).
 <% end %>
 
 <% if @application_form.ended_without_success? %>
-Sign into your account to [make changes to your previous application and apply again](<%= candidate_magic_link(@application_form.candidate) %>).
+Sign into your account to make changes to your previous application and apply again.
+
+[Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>).
 <% end %>
 
 # Get help

--- a/app/views/candidate_mailer/new_cycle_has_started.erb
+++ b/app/views/candidate_mailer/new_cycle_has_started.erb
@@ -2,21 +2,15 @@
   Dear <%= @application_form.first_name %>
 <% end %>
 
-<% unless @application_form.submitted? %>
-  Applications are now open.
+You can now apply for a teacher training course starting in the <%= @academic_year %> academic year.
 
-  Complete your application to get on a course starting in the <%= @academic_year %> academic year:
+<% unless @application_form.submitted? %>
+Sign into your account to [finish and submit your application](<%= candidate_magic_link(@application_form.candidate) %>).
 <% end %>
 
 <% if @application_form.ended_without_success? %>
-  Applications are now open - apply for teacher training again.
-
-  You could get on a course starting in the <%= @academic_year %> academic year.
-
-  Make any changes to your previous application and apply again:
+Sign into your account to [make changes to your previous application and apply again](<%= candidate_magic_link(@application_form.candidate) %>).
 <% end %>
-
-<%= candidate_magic_link(@application_form.candidate) %>
 
 # Get help
 

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -112,7 +112,7 @@ en:
     approaching_eoc_deadline:
       subject: Submit your teacher training application before courses fill up
     new_cycle_has_started:
-      subject: Teacher training applications are open - apply for the %{academic_year} academic year
+      subject: Apply for teacher training starting in the %{academic_year} academic year
     find_has_opened:
       subject: Find your teacher training course now
     duplicate_match:

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -626,7 +626,7 @@ RSpec.describe CandidateMailer, type: :mailer do
           'Teacher training applications are open - apply for the 2022 to 2023 academic year',
           'greeting' => 'Dear Fred',
           'academic_year' => '2022 to 2023',
-          'details' => 'Applications are now open',
+          'details' => 'Sign into your account to finish and submit your application.',
         )
       end
 
@@ -640,7 +640,7 @@ RSpec.describe CandidateMailer, type: :mailer do
           'Teacher training applications are open - apply for the 2022 to 2023 academic year',
           'greeting' => 'Dear Fred',
           'academic_year' => '2022 to 2023',
-          'details' => 'Applications are now open - apply for teacher training again.',
+          'details' => 'Sign into your account to make changes to your previous application and apply again.',
         )
       end
 

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -623,7 +623,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
         it_behaves_like(
           'a mail with subject and content',
-          'Teacher training applications are open - apply for the 2022 to 2023 academic year',
+          'Apply for teacher training starting in the 2022 to 2023 academic year',
           'greeting' => 'Dear Fred',
           'academic_year' => '2022 to 2023',
           'details' => 'Sign into your account to finish and submit your application.',
@@ -637,7 +637,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
         it_behaves_like(
           'a mail with subject and content',
-          'Teacher training applications are open - apply for the 2022 to 2023 academic year',
+          'Apply for teacher training starting in the 2022 to 2023 academic year',
           'greeting' => 'Dear Fred',
           'academic_year' => '2022 to 2023',
           'details' => 'Sign into your account to make changes to your previous application and apply again.',


### PR DESCRIPTION
This is part of tidying up the end of cycle content. I've made the language more consistent with other parts of the service.

Also we now link on text rather than showing URLs, as the URLs have tracking information and are much longer.

https://trello.com/c/TsHxZJyT/358-update-eoc-content