### PR TITLE
Update privacy policy for new references process

### DIFF
--- a/app/views/content/service_privacy_notice.md
+++ b/app/views/content/service_privacy_notice.md
@@ -23,7 +23,7 @@ Each data controller is responsible for complying with data protection legislati
 
 ### The personal data we collect and how we collect it
 
-The personal data we collect will depend on whether you’re a candidate or a referee.
+The personal data we collect will depend on whether you’re a candidate, work for a training provider or give a reference.
 
 #### The data we collect if you’re a candidate
 If you’re a candidate using Apply, we collect the information that you enter directly when you apply. This includes personal information, such as your:
@@ -57,14 +57,14 @@ If you process teacher training applications, we may need to collect information
 - where you work
 - what your role is
 
-#### The data we collect if you’re a referee
+#### The data we collect if you give a reference
 
-If you’re a referee, we collect your personal details from a candidate who selected you as a referee. They told us your:
+If a candidate says that you can give them a reference, they’ll tell us:
 
-- name
-- email address
-- relationship to the candidate
-- reference type (for example, academic or personal)
+- your name
+- your email address
+- how you know them and how long you’ve known them
+- the type of reference you can give (for example, academic or professional)</li>
 
 ### How we use your data
 
@@ -74,7 +74,7 @@ Processing applications includes:
 
 - sending applications and references to providers
 - managing communications between you and providers
-- managing communications between referees and providers
+- managing communications between providers and people who give references
 - working out any funding you are entitled to
 - getting in touch if there’s a security issue concerning your data
 - getting in touch with you to ask if you would like to participate in user research
@@ -107,14 +107,14 @@ Processing references includes:
 - sending applications and references to providers
 - getting in touch if there’s a security issue concerning your data
 - getting in touch with you to ask if you would like to participate in user research
-- getting in touch with you about your references
+- getting in touch with you about your reference
 - analysing reference and service usage data
 
 ### Building a better teacher training application process
 
 We use some user data to improve our services. For example, we’ll look at any feedback you give us about our services so we can improve them.
 
-#### If you’re a referee
+#### If you give a reference
 
 We ask if you’re willing to participate in user research when you submit a reference. If you have given us your consent we may contact you to participate in user research.
 If you want to withdraw your consent to participate in user research at any time, you can contact us at becomingateacher@digital.education.gov.uk.
@@ -142,11 +142,11 @@ We need to share personal data for the purpose of recruiting high quality teache
 
 #### Sharing data with providers
 
-We share teacher training candidate and referee data with the providers to which the candidate has applied.
+We share data about candidates and people who give references with the providers to which the candidate has applied.
 
 We have a data sharing agreement with providers so that they are clear about their responsibilities as data controllers in their own right. As data controllers they are required to comply with the UK GDPR and DPA2018 including to inform you through a privacy notice like this one, as to what they will be doing with your data and your information rights.
 
-#### Sharing candidate data with referees
+#### Sharing candidate data with people who give references
 
 We’ll share candidate names with referees so that each referee can identify the candidate and give a reference.
 

--- a/app/views/content/service_privacy_notice.md
+++ b/app/views/content/service_privacy_notice.md
@@ -182,4 +182,4 @@ Once a candidate has enrolled with a teacher training provider, we will not be a
 
 We’ll update this privacy notice when required. You should regularly review the notice.
 
-This version was last updated on 8 July 2022.
+This version was last updated on 15 September 2022.

--- a/app/views/content/service_privacy_notice.md
+++ b/app/views/content/service_privacy_notice.md
@@ -64,7 +64,7 @@ If a candidate says that you can give them a reference, they’ll tell us:
 - your name
 - your email address
 - how you know them and how long you’ve known them
-- the type of reference you can give (for example, academic or professional)</li>
+- the type of reference you can give (for example, academic or professional)
 
 ### How we use your data
 

--- a/app/views/content/service_privacy_notice_candidate.html.erb
+++ b/app/views/content/service_privacy_notice_candidate.html.erb
@@ -84,7 +84,6 @@
       <li>your name</li>
       <li>your email address</li>
       <li>how you know them and how long you’ve known them</li>
-      <li>where you work</li>
       <li>the type of reference you can give (for example, academic or professional)</li>
     </ul>
 

--- a/app/views/content/service_privacy_notice_candidate.html.erb
+++ b/app/views/content/service_privacy_notice_candidate.html.erb
@@ -35,7 +35,7 @@
 
     <h2 class="govuk-heading-m">The personal data we collect and how we collect it</h2>
 
-    <p class="govuk-body">The personal data we collect will depend on whether you’re a candidate or a referee.</p>
+    <p class="govuk-body">The personal data we collect will depend on whether you’re a candidate, work for a training provider or give a reference.</p>
 
     <h3 class="govuk-heading-s">The data we collect if you’re a candidate</h3>
 
@@ -76,17 +76,16 @@
       <li>what your role is</li>
     </ul>
 
-    <h3 class="govuk-heading-s">The data we collect if you’re a referee</h3>
+    <h3 class="govuk-heading-s">The data we collect if you give a reference</h3>
 
-    <p class="govuk-body">If you’re a referee, we collect your personal details from a candidate who selected you as a
-      referee. They told us your:</p>
+    <p class="govuk-body">If a candidate says that you can give them a reference, they’ll tell us:</p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>name</li>
-      <li>email address</li>
-      <li>relationship to the candidate</li>
+      <li>your name</li>
+      <li>your email address</li>
+      <li>how you know them and how long you’ve known them</li>
       <li>where you work</li>
-      <li>reference type (for example, academic or personal)</li>
+      <li>the type of reference you can give (for example, academic or professional)</li>
     </ul>
 
     <h2 class="govuk-heading-m">How we use your data</h2>
@@ -98,7 +97,7 @@
     <ul class="govuk-list govuk-list--bullet">
       <li>sending applications and references to providers</li>
       <li>managing communications between you and providers</li>
-      <li>managing communications between referees and providers</li>
+      <li>managing communications between providers and people who give references</li>
       <li>working out any funding you are entitled to</li>
       <li>getting in touch if there’s a security issue concerning your data</li>
       <li>getting in touch with you to ask if you would like to participate in user research</li>
@@ -144,7 +143,7 @@
       <li>sending applications and references to providers</li>
       <li>getting in touch if there’s a security issue concerning your data</li>
       <li>getting in touch with you to ask if you would like to participate in user research</li>
-      <li>getting in touch with you about your references</li>
+      <li>getting in touch with you about your reference</li>
       <li>analysing reference and service usage data</li>
     </ul>
 
@@ -153,7 +152,7 @@
     <p class="govuk-body">We use some user data to improve our services. For example, we’ll look at any feedback you
       give us about our services so we can improve them.</p>
 
-    <h3 class="govuk-heading-s">If you’re a referee</h3>
+    <h3 class="govuk-heading-s">If you give a reference</h3>
 
     <p class="govuk-body">We ask if you’re willing to participate in user research when you submit a reference. If you have given us your consent we may contact you to
       participate in user research.
@@ -228,7 +227,7 @@
 
     <h3 class="govuk-heading-s">Sharing data with providers</h3>
 
-    <p class="govuk-body">We share teacher training candidate and referee data with the providers to which the
+    <p class="govuk-body">We share data about candidates and people who give references with the providers to which the
       candidate has applied.</p>
 
     <p class="govuk-body">We have a data sharing agreement with providers so that they are clear about their
@@ -236,13 +235,19 @@
       UK GDPR and DPA2018 including to inform you through a privacy notice like this one, as to what they will be doing
       with your data and your information rights.</p>
 
-    <h3 class="govuk-heading-s">Sharing candidate data with referees</h3>
+    <h3 class="govuk-heading-s">Sharing candidate data with people who give references</h3>
 
-    <p class="govuk-body">We’ll share candidate names with referees so that each referee can identify the candidate and
-      give a reference.</p>
-
-    <p class="govuk-body">We’ll share additional information to help the referee identify the candidate, such as how
-      the candidate knows the referee.</p>
+    <p class="govuk-body">We share candidate data with people who give references, to help them identify candidates and understand how references will be used.</p>
+    
+    <p class="govuk-body">The data we share includes:</p> 
+      
+    <ul class="govuk-list govuk-list--bullet">
+  
+      <li>the candidate’s name</li>
+      <li>the name of the training provider which the candidate has accepted an offer from</li>
+      <li>how the candidate said they know the person giving a reference and how long they’ve known them</li>
+      
+    </ul>
 
     <h3 class="govuk-heading-s">External organisations who process data</h3>
 

--- a/app/views/content/service_privacy_notice_candidate.html.erb
+++ b/app/views/content/service_privacy_notice_candidate.html.erb
@@ -237,15 +237,13 @@
     <h3 class="govuk-heading-s">Sharing candidate data with people who give references</h3>
 
     <p class="govuk-body">We share candidate data with people who give references, to help them identify candidates and understand how references will be used.</p>
-    
-    <p class="govuk-body">The data we share includes:</p> 
-      
+
+    <p class="govuk-body">The data we share includes:</p>
+
     <ul class="govuk-list govuk-list--bullet">
-  
       <li>the candidate’s name</li>
       <li>the name of the training provider which the candidate has accepted an offer from</li>
       <li>how the candidate said they know the person giving a reference and how long they’ve known them</li>
-      
     </ul>
 
     <h3 class="govuk-heading-s">External organisations who process data</h3>

--- a/app/views/content/service_privacy_notice_candidate.html.erb
+++ b/app/views/content/service_privacy_notice_candidate.html.erb
@@ -288,6 +288,6 @@
 
     <p class="govuk-body">We’ll update this privacy notice when required. You should regularly review the notice.</p>
 
-    <p class="govuk-body">This version was last updated on 8 July 2022.</p>
+    <p class="govuk-body">This version was last updated on 15 September 2022.</p>
   </div>
 </div>


### PR DESCRIPTION
We no longer use the term 'referee' in the service so I've changed it to 'person giving a reference'.

I've also made changes to correctly reflect the data we gather and show. In particular, we will show the name of the training provider to the person giving a reference. 

I've tried to keep changes to a minimum as there are a lot of ways in which this content could be improved.

https://trello.com/c/RtzmSKFP/526-update-privacy-policy-content-about-references