### PR TITLE
Add a benchmark task for GetActivityLogEvents

### DIFF
--- a/lib/tasks/performance.rake
+++ b/lib/tasks/performance.rake
@@ -1,0 +1,34 @@
+namespace :performance do
+  desc 'Benchmark the activity log query used on Application Timeline and Support UI'
+  task benchmark_activity_log_query: :environment do
+    # Get provider ids for applications with the highest number of audit associations.
+    provider_ids = ApplicationForm
+      .includes(:application_choices)
+      .where(
+        id: Audited::Audit
+              .where(associated_type: 'ApplicationForm')
+              .group(:associated_id)
+              .order(Arel.sql('COUNT(audits.associated_id) DESC'))
+              .limit(5)
+              .pluck(:associated_id)
+              .uniq,
+      ).pluck('application_choices.provider_ids').flatten.uniq
+
+    application_choices = GetApplicationChoicesForProviders.call(providers: Provider.where(id: provider_ids.take(5)))
+
+    benchmarks = []
+    12.times do
+      benchmarks << Benchmark.measure { GetActivityLogEvents.call(application_choices: application_choices) }.real
+    end
+
+    # Discard first and last benchmark.
+    benchmarks.shift
+    benchmarks.pop
+
+    average = benchmarks.sum(0.0) / benchmarks.size
+
+    Rails.logger.info "GetActivityLogEvents average execution time for #{application_choices.size} applications:"
+    Rails.logger.info "#{average} seconds."
+    Rails.logger.info '-----------------------------------------------------------------------------------------'
+  end
+end


### PR DESCRIPTION
## Changes proposed in this pull request

Adds a rake task which attempts to find applications with high numbers of associated audits, then passes the application choices to GetActivityLogEvents for benchmarking. 

Reports the average `real` time of 10 runs.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/hwn63AG7/586-audit-table-check-how-slow-are-our-at-queries
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
