### PR TITLE
Cancel outstanding requests from 2022 apply 1

### DIFF
--- a/app/services/data_migrations/end_of_cycle_cancel_outstanding_references.rb
+++ b/app/services/data_migrations/end_of_cycle_cancel_outstanding_references.rb
@@ -1,0 +1,35 @@
+module DataMigrations
+  class EndOfCycleCancelOutstandingReferences
+    TIMESTAMP = 20220913163416
+    MANUAL_RUN = true
+    RECRUITMENT_CYCLE_YEAR = 2022
+    PHASE = 'apply_1'.freeze
+
+    def change
+      records.each do |record|
+        record.update!(
+          feedback_status: :cancelled_at_end_of_cycle,
+          cancelled_at: Time.zone.now,
+        )
+      end
+    end
+
+    def dry_run
+      "The total of #{records.count} references will be cancelled"
+    end
+
+    def records
+      ApplicationReference.joins(:application_form)
+        .feedback_requested
+        .where(
+          application_form: {
+            recruitment_cycle_year: RECRUITMENT_CYCLE_YEAR,
+            phase: PHASE,
+          },
+        )
+        .where(application_form: { id: ApplicationChoice
+            .where(status: 'unsubmitted')
+            .select('application_form_id') })
+    end
+  end
+end

--- a/app/services/data_migrations/end_of_cycle_cancel_outstanding_references.rb
+++ b/app/services/data_migrations/end_of_cycle_cancel_outstanding_references.rb
@@ -11,6 +11,7 @@ module DataMigrations
           feedback_status: :cancelled_at_end_of_cycle,
           cancelled_at: Time.zone.now,
         )
+        RefereeMailer.reference_cancelled_email(record).deliver_later
       end
     end
 

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::EndOfCycleCancelOutstandingReferences',
   'DataMigrations::ProviderInterviewDataFix',
   'DataMigrations::MonthlyReportsBackfill',
   'DataMigrations::RemoveDataExportsFeatureFlag',

--- a/spec/services/data_migrations/end_of_cycle_cancel_outstanding_references_spec.rb
+++ b/spec/services/data_migrations/end_of_cycle_cancel_outstanding_references_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::EndOfCycleCancelOutstandingReferences do
+  context 'when apply 1' do
+    let!(:application_form) do
+      create(:application_form, :minimum_info, phase: 'apply_1')
+    end
+
+    context 'when feedback requested' do
+      let!(:reference) do
+        create(:reference, :feedback_requested, application_form: application_form)
+      end
+
+      context 'when unsubmitted' do
+        let!(:application_choice) do
+          create(:application_choice, :unsubmitted, application_form: application_form)
+        end
+
+        it 'cancels the reference' do
+          described_class.new.change
+          expect(reference.reload).to be_cancelled_at_end_of_cycle
+        end
+      end
+
+      context 'when conditions pending' do
+        let!(:application_choice) do
+          create(:application_choice, :with_accepted_offer, application_form: application_form)
+        end
+
+        it 'does not change' do
+          described_class.new.change
+          expect(reference.reload).to be_feedback_requested
+        end
+      end
+    end
+
+    context 'when feedback provided' do
+      let!(:reference) do
+        create(:reference, :feedback_provided, application_form: application_form)
+      end
+      let!(:application_choice) do
+        create(:application_choice, :unsubmitted, application_form: application_form)
+      end
+
+      it 'does not change' do
+        described_class.new.change
+        expect(reference.reload).to be_feedback_provided
+      end
+    end
+  end
+end

--- a/spec/services/data_migrations/end_of_cycle_cancel_outstanding_references_spec.rb
+++ b/spec/services/data_migrations/end_of_cycle_cancel_outstanding_references_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe DataMigrations::EndOfCycleCancelOutstandingReferences do
+RSpec.describe DataMigrations::EndOfCycleCancelOutstandingReferences, sidekiq: true do
   context 'when apply 1' do
     let!(:application_form) do
       create(:application_form, :minimum_info, phase: 'apply_1')
@@ -19,6 +19,11 @@ RSpec.describe DataMigrations::EndOfCycleCancelOutstandingReferences do
         it 'cancels the reference' do
           described_class.new.change
           expect(reference.reload).to be_cancelled_at_end_of_cycle
+        end
+
+        it 'sends email to the referee' do
+          described_class.new.change
+          expect(ActionMailer::Base.deliveries.map(&:to).flatten).to include(reference.email_address)
         end
       end
 


### PR DESCRIPTION
## Context

This PR adds a data migration where we cancel outstanding references (considered as "feedback_requested") from unsubmitted applications on apply 1.

## Guidance to review

1. Does the criteria of records correctly?
2. Does it cancel outstanding references from 2022 that are on apply 1 and unsubmitted?
