### PR TITLE
New references - Update the candidate reference chaser and reference received emails

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -214,6 +214,7 @@ class CandidateMailer < ApplicationMailer
     @reference = reference
     @selected_references = reference.application_form.application_references.select(&:selected)
     @provided_references = reference.application_form.application_references.select(&:feedback_provided?)
+
     email_for_candidate(
       reference.application_form,
       subject: I18n.t!('candidate_mailer.reference_received.subject', referee_name: @reference.name),

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -22,6 +22,7 @@ class CandidateMailer < ApplicationMailer
 
   def chase_reference(reference)
     @reference = reference
+    @application_form = @reference.application_form
 
     email_for_candidate(
       reference.application_form,

--- a/app/views/candidate_mailer/_new_flow_chase_reference.text.erb
+++ b/app/views/candidate_mailer/_new_flow_chase_reference.text.erb
@@ -1,0 +1,14 @@
+Dear <%= @application_form.first_name %>
+
+You asked <%= @reference.name %> for a reference for your teacher training application. They have not replied yet.
+
+You can sign into your account to:
+
+- send them an email to remind them that you’ve asked for a reference
+- cancel the request for a reference
+- ask someone else for a reference
+
+
+[Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>).
+
+<%= @application_form.application_choices.pending_conditions.first.provider.name %> must check your references before they can confirm your place on the course. Contact them if you need help getting references or choosing who to ask.

--- a/app/views/candidate_mailer/_new_flow_chase_reference_again.text.erb
+++ b/app/views/candidate_mailer/_new_flow_chase_reference_again.text.erb
@@ -1,0 +1,16 @@
+Dear <%= @application_form.first_name %>
+
+You asked <%= @referee.name %> for a reference for your teacher training applicaiton. They have not replied yet.
+
+<%= @referee.application_form.application_choices.pending_conditions.first.provider.name %> needs to check your references before they can confirm your place on the course.
+
+You can sign into your account to:
+
+- ask someome else for a reference
+- send them, an email to remind them that you’ve asked for a reference
+- cancel the request for a reference
+
+
+[Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>).
+
+Contact <%= @referee.application_form.application_choices.pending_conditions.first.provider.name %> if you need help getting references or choosing who to ask.

--- a/app/views/candidate_mailer/_new_flow_new_referee_request.text.erb
+++ b/app/views/candidate_mailer/_new_flow_new_referee_request.text.erb
@@ -1,0 +1,46 @@
+Dear <%= @application_form.first_name %>
+
+<% if @reason == :email_bounced %>
+
+You asked <%= @reference.name %> for a reference for your teacher training application.
+
+Your request did not reach <%= @reference.name %>. This could be because:
+
+- there’s a problem with their email service
+- you entered the wrong email address
+
+
+It’s important that <%= @reference.application_form.application_choices.pending_conditions.first.provider.name %> receives your references as soon as possible.
+
+You can sign into your account to:
+
+- request the reference again - check the email address before you do this
+- ask someone else for a reference
+
+
+<% elsif @reason == :refused %>
+
+<%= @reference.name %> has said that they’re unable to give you a reference.
+
+It’s important that <%= @reference.application_form.application_choices.pending_conditions.first.provider.name %> receives your references as soon as possible.
+
+You can sign into your account to request a reference from someone else.
+
+<% else %>
+
+You asked <%= @reference.name %> for a reference for your teacher training application. They have not replied yet.
+
+It’s important that <%= @reference.application_form.application_choices.pending_conditions.first.provider.name %> receives your references as soon as possible.
+
+You can sign into your account to:
+
+- send them an email to remind them that you’ve asked for a reference
+- cancel the request for a reference
+- ask someone else for a reference
+
+
+<% end %>
+[Sign into your account](<%= candidate_magic_link(@candidate) %>).
+
+<%= @reference.application_form.application_choices.pending_conditions.first.provider.name %> must check your references before they can confirm your place on the course.
+Contact them if you need help getting references or choosing who to ask.

--- a/app/views/candidate_mailer/_new_flow_reference_received.text.erb
+++ b/app/views/candidate_mailer/_new_flow_reference_received.text.erb
@@ -1,0 +1,7 @@
+Dear <%= @application_form.first_name %>
+
+<%= @reference.application_form.application_choices.pending_conditions.first.provider.name %> has received a refrence for you from <%= @reference.name%>.
+
+You can sign into your account to check the progress of your references requests and offer conditions.
+
+[Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>).

--- a/app/views/candidate_mailer/_old_flow_chase_reference.text.erb
+++ b/app/views/candidate_mailer/_old_flow_chase_reference.text.erb
@@ -1,0 +1,9 @@
+<%= @reference.name %> has not responded yet.
+
+You can add as many referees as you like to increase the chances of getting 2 references quickly.
+
+You can also send one reminder to each referee from your account.
+
+[Manage your references](<%= candidate_magic_link(@application_form.candidate) %>).
+
+You cannot submit your application without 2 references. Courses can become full anytime - get your references as soon as possible.

--- a/app/views/candidate_mailer/_old_flow_chase_reference_again.text.erb
+++ b/app/views/candidate_mailer/_old_flow_chase_reference_again.text.erb
@@ -1,0 +1,9 @@
+<%= @referee.name %> has not responded yet.
+
+You can add as many referees as you like to increase the chances of getting 2 references quickly.
+
+You can also send one reminder to each referee from your account.
+
+[Manage your references](<%= candidate_magic_link(@application_form.candidate) %>).
+
+You cannot submit your application without 2 references. Courses can become full anytime - get your references as soon as possible.

--- a/app/views/candidate_mailer/_old_flow_new_referee_request.text.erb
+++ b/app/views/candidate_mailer/_old_flow_new_referee_request.text.erb
@@ -1,0 +1,17 @@
+<% if @reason == :email_bounced %>
+Your referee request did not reach <%= @reference.name %>.
+
+Check you gave the correct email address and request the reference again.
+<% elsif @reason == :refused %>
+<%= @reference.name %> has declined your reference request.
+<% else %>
+<%= @reference.name %> has not responded yet.
+<% end %>
+
+You can add as many referees as you like to increase the chances of getting 2 references quickly.
+
+You can also send one reminder to each referee from your account.
+
+[Manage your references](<%= candidate_magic_link(@candidate) %>).
+
+You cannot submit your application without 2 references. Courses can become full anytime - get your references as soon as possible.

--- a/app/views/candidate_mailer/_old_flow_reference_received.text.erb
+++ b/app/views/candidate_mailer/_old_flow_reference_received.text.erb
@@ -1,0 +1,21 @@
+You have a reference from <%= @reference.name %>.
+
+<% if @selected_references.count >= ApplicationForm::REQUIRED_REFERENCE_SELECTIONS %>
+You’ve selected 2 references to submit with your application already, but you can change your selection if you want.
+
+[Sign in to complete your application](<%= candidate_magic_link(@application_form.candidate) %>).
+<% elsif @provided_references.count > ApplicationForm::REQUIRED_REFERENCE_SELECTIONS %>
+You have more than enough references to send your application to training providers.
+
+[Sign in to select 2 references to include in your application](<%= candidate_magic_link(@application_form.candidate) %>).
+<% elsif @provided_references.count == ApplicationForm::REQUIRED_REFERENCE_SELECTIONS %>
+You have enough references to send your application to training providers.
+
+[Sign in to select 2 references to include in your application.](<%= candidate_magic_link(@application_form.candidate) %>)
+<% else %>
+You need another reference before you can send your application to training providers.
+
+You can request as many references as you like to increase the chances of getting 2 quickly.
+
+[Sign in to manage your reference requests](<%= candidate_magic_link(@application_form.candidate) %>).
+<% end %>

--- a/app/views/candidate_mailer/chase_reference.text.erb
+++ b/app/views/candidate_mailer/chase_reference.text.erb
@@ -1,27 +1,9 @@
 <% if @application_form.show_new_reference_flow? %>
-  Dear <%= @application_form.first_name %>
 
-  You asked <%= @reference.name %> for a reference for your teacher training application. They have not replied yet.
-
-  You can sign into your account to:
-
-  - send them an email to remind them that you’ve asked for a reference
-  - cancel the request for a reference
-  - ask someone else for a reference
-
-
- [Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>).
-
- <%= @application_form.application_choices.pending_conditions.first.provider.name %> must check your references before they can confirm your place on the course. Contact them if you need help getting references or choosing who to ask.
+<%= render 'new_flow_chase_reference' %>
 
 <% else %>
-  <%= @reference.name %> has not responded yet.
 
-  You can add as many referees as you like to increase the chances of getting 2 references quickly.
+<%= render 'old_flow_chase_reference' %>
 
-  You can also send one reminder to each referee from your account.
-
-  [Manage your references](<%= candidate_magic_link(@application_form.candidate) %>).
-
-  You cannot submit your application without 2 references. Courses can become full anytime - get your references as soon as possible.
 <% end %>

--- a/app/views/candidate_mailer/chase_reference.text.erb
+++ b/app/views/candidate_mailer/chase_reference.text.erb
@@ -1,9 +1,27 @@
-<%= @reference.name %> has not responded yet.
+<% if @application_form.show_new_reference_flow? %>
+  Dear <%= @application_form.first_name %>
 
-You can add as many referees as you like to increase the chances of getting 2 references quickly.
+  You asked <%= @reference.name %> for a reference for your teacher training application. They have not replied yet.
 
-You can also send one reminder to each referee from your account.
+  You can sign into your account to:
 
-[Manage your references](<%= candidate_magic_link(@application_form.candidate) %>).
+  - send them an email to remind them that you’ve asked for a reference
+  - cancel the request for a reference
+  - ask someone else for a reference
 
-You cannot submit your application without 2 references. Courses can become full anytime - get your references as soon as possible.
+
+ [Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>).
+
+ <%= @application_form.application_choices.pending_conditions.first.provider.name %> must check your references before they can confirm your place on the course. Contact them if you need help getting references or choosing who to ask.
+
+<% else %>
+  <%= @reference.name %> has not responded yet.
+
+  You can add as many referees as you like to increase the chances of getting 2 references quickly.
+
+  You can also send one reminder to each referee from your account.
+
+  [Manage your references](<%= candidate_magic_link(@application_form.candidate) %>).
+
+  You cannot submit your application without 2 references. Courses can become full anytime - get your references as soon as possible.
+<% end %>

--- a/app/views/candidate_mailer/chase_reference_again.text.erb
+++ b/app/views/candidate_mailer/chase_reference_again.text.erb
@@ -1,28 +1,9 @@
 <% if @application_form.show_new_reference_flow? %>
-  Dear <%= @application_form.first_name %>
 
-  You asked <%= @referee.name %> for a reference for your teacher training applicaiton. They have not replied yet.
+<%= render 'new_flow_chase_reference_again' %>
 
-  <%= @referee.application_form.application_choices.pending_conditions.first.provider.name %> needs to check your references before they can confirm your place on the course.
-
-  You can sign into your account to:
-
-  - ask someome else for a reference
-  - send them, an email to remind them that you’ve asked for a reference
-  - cancel the request for a reference
-
-
-  [Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>).
-
-  Contact <%= @referee.application_form.application_choices.pending_conditions.first.provider.name %> if you need help getting references or choosing who to ask.
 <% else %>
-  <%= @referee.name %> has not responded yet.
 
-  You can add as many referees as you like to increase the chances of getting 2 references quickly.
+<%= render 'old_flow_chase_reference_again' %>
 
-  You can also send one reminder to each referee from your account.
-
-  [Manage your references](<%= candidate_magic_link(@application_form.candidate) %>).
-
-  You cannot submit your application without 2 references. Courses can become full anytime - get your references as soon as possible.
 <% end %>

--- a/app/views/candidate_mailer/chase_reference_again.text.erb
+++ b/app/views/candidate_mailer/chase_reference_again.text.erb
@@ -1,9 +1,28 @@
-<%= @referee.name %> has not responded yet.
+<% if @application_form.show_new_reference_flow? %>
+  Dear <%= @application_form.first_name %>
 
-You can add as many referees as you like to increase the chances of getting 2 references quickly.
+  You asked <%= @referee.name %> for a reference for your teacher training applicaiton. They have not replied yet.
 
-You can also send one reminder to each referee from your account.
+  <%= @referee.application_form.application_choices.pending_conditions.first.provider.name %> needs to check your references before they can confirm your place on the course.
 
-[Manage your references](<%= candidate_magic_link(@application_form.candidate) %>).
+  You can sign into your account to:
 
-You cannot submit your application without 2 references. Courses can become full anytime - get your references as soon as possible.
+  - ask someome else for a reference
+  - send them, an email to remind them that you’ve asked for a reference
+  - cancel the request for a reference
+
+
+  [Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>).
+
+  Contact <%= @referee.application_form.application_choices.pending_conditions.first.provider.name %> if you need help getting references or choosing who to ask.
+<% else %>
+  <%= @referee.name %> has not responded yet.
+
+  You can add as many referees as you like to increase the chances of getting 2 references quickly.
+
+  You can also send one reminder to each referee from your account.
+
+  [Manage your references](<%= candidate_magic_link(@application_form.candidate) %>).
+
+  You cannot submit your application without 2 references. Courses can become full anytime - get your references as soon as possible.
+<% end %>

--- a/app/views/candidate_mailer/new_referee_request.text.erb
+++ b/app/views/candidate_mailer/new_referee_request.text.erb
@@ -1,17 +1,66 @@
-<% if @reason == :email_bounced %>
-Your referee request did not reach <%= @reference.name %>.
+<% if @application_form.show_new_reference_flow? %>
+  Dear <%= @application_form.first_name %>
 
-Check you gave the correct email address and request the reference again.
-<% elsif @reason == :refused %>
-<%= @reference.name %> has declined your reference request.
+  <% if @reason == :email_bounced %>
+
+  You asked <%= @reference.name %> for a reference for your teacher training application.
+
+  Your request did not reach <%= @reference.name %>. This could be because:
+
+  - there’s a problem with their email service
+  - you entered the wrong email address
+
+
+  It’s important that receives your references as soon as possible.
+
+  You can sign into your account to:
+
+  - request the reference again - check the email address before you do this
+  - ask someone else for a reference
+
+
+  <% elsif @reason == :refused %>
+
+  <%= @reference.name %> has said that they’re unable to give you a reference.
+
+  It’s important that <%= @reference.application_form.application_choices.pending_conditions.first.provider.name %> receives your references as soon as possible.
+
+  You can sign into your account to request a reference from someone else.
+
+  <% else %>
+
+  You asked <%= @reference.name %> for a reference for your teacher training application. They have not replied yet.
+
+  It’s important that <%= @reference.application_form.application_choices.pending_conditions.first.provider.name %> receives your references as soon as possible.
+
+  You can sign into your account to:
+
+  - send them an email to remind them that you’ve asked for a reference
+  - cancel the request for a reference
+  - ask someone else for a reference
+
+
+  <% end %>
+  [Sign into your account](<%= candidate_magic_link(@candidate) %>).
+
+  <%= @reference.application_form.application_choices.pending_conditions.first.provider.name %> must check your references before they can confirm your place on the course.
+  Contact them if you need help getting references or choosing who to ask.
 <% else %>
-<%= @reference.name %> has not responded yet.
+  <% if @reason == :email_bounced %>
+  Your referee request did not reach <%= @reference.name %>.
+
+  Check you gave the correct email address and request the reference again.
+  <% elsif @reason == :refused %>
+  <%= @reference.name %> has declined your reference request.
+  <% else %>
+  <%= @reference.name %> has not responded yet.
+  <% end %>
+
+  You can add as many referees as you like to increase the chances of getting 2 references quickly.
+
+  You can also send one reminder to each referee from your account.
+
+  [Manage your references](<%= candidate_magic_link(@candidate) %>).
+
+  You cannot submit your application without 2 references. Courses can become full anytime - get your references as soon as possible.
 <% end %>
-
-You can add as many referees as you like to increase the chances of getting 2 references quickly.
-
-You can also send one reminder to each referee from your account.
-
-[Manage your references](<%= candidate_magic_link(@candidate) %>).
-
-You cannot submit your application without 2 references. Courses can become full anytime - get your references as soon as possible.

--- a/app/views/candidate_mailer/new_referee_request.text.erb
+++ b/app/views/candidate_mailer/new_referee_request.text.erb
@@ -1,66 +1,9 @@
 <% if @application_form.show_new_reference_flow? %>
-  Dear <%= @application_form.first_name %>
 
-  <% if @reason == :email_bounced %>
+<%= render 'new_flow_new_referee_request' %>
 
-  You asked <%= @reference.name %> for a reference for your teacher training application.
-
-  Your request did not reach <%= @reference.name %>. This could be because:
-
-  - there’s a problem with their email service
-  - you entered the wrong email address
-
-
-  It’s important that receives your references as soon as possible.
-
-  You can sign into your account to:
-
-  - request the reference again - check the email address before you do this
-  - ask someone else for a reference
-
-
-  <% elsif @reason == :refused %>
-
-  <%= @reference.name %> has said that they’re unable to give you a reference.
-
-  It’s important that <%= @reference.application_form.application_choices.pending_conditions.first.provider.name %> receives your references as soon as possible.
-
-  You can sign into your account to request a reference from someone else.
-
-  <% else %>
-
-  You asked <%= @reference.name %> for a reference for your teacher training application. They have not replied yet.
-
-  It’s important that <%= @reference.application_form.application_choices.pending_conditions.first.provider.name %> receives your references as soon as possible.
-
-  You can sign into your account to:
-
-  - send them an email to remind them that you’ve asked for a reference
-  - cancel the request for a reference
-  - ask someone else for a reference
-
-
-  <% end %>
-  [Sign into your account](<%= candidate_magic_link(@candidate) %>).
-
-  <%= @reference.application_form.application_choices.pending_conditions.first.provider.name %> must check your references before they can confirm your place on the course.
-  Contact them if you need help getting references or choosing who to ask.
 <% else %>
-  <% if @reason == :email_bounced %>
-  Your referee request did not reach <%= @reference.name %>.
 
-  Check you gave the correct email address and request the reference again.
-  <% elsif @reason == :refused %>
-  <%= @reference.name %> has declined your reference request.
-  <% else %>
-  <%= @reference.name %> has not responded yet.
-  <% end %>
+<%= render 'old_flow_new_referee_request' %>
 
-  You can add as many referees as you like to increase the chances of getting 2 references quickly.
-
-  You can also send one reminder to each referee from your account.
-
-  [Manage your references](<%= candidate_magic_link(@candidate) %>).
-
-  You cannot submit your application without 2 references. Courses can become full anytime - get your references as soon as possible.
 <% end %>

--- a/app/views/candidate_mailer/reference_received.text.erb
+++ b/app/views/candidate_mailer/reference_received.text.erb
@@ -1,22 +1,31 @@
-You have a reference from <%= @reference.name %>.
+<% if @application_form.show_new_reference_flow? %>
+  Dear <%= @application_form.first_name %>
 
-<% if @selected_references.count >= ApplicationForm::REQUIRED_REFERENCE_SELECTIONS %>
-You’ve selected 2 references to submit with your application already, but you can change your selection if you want.
+  <%= @reference.application_form.application_choices.pending_conditions.first.provider.name %> has received a refrence for you from <%= @reference.name%>.
 
-[Sign in to complete your application](<%= candidate_magic_link(@application_form.candidate) %>).
-<% elsif @provided_references.count > ApplicationForm::REQUIRED_REFERENCE_SELECTIONS %>
-You have more than enough references to send your application to training providers.
+  You can sign into your account to check the progress of your references requests and offer conditions.
 
-[Sign in to select 2 references to include in your application](<%= candidate_magic_link(@application_form.candidate) %>).
-<% elsif @provided_references.count == ApplicationForm::REQUIRED_REFERENCE_SELECTIONS %>
-You have enough references to send your application to training providers.
-
-[Sign in to select 2 references to include in your application.](<%= candidate_magic_link(@application_form.candidate) %>)
+  [Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>).
 <% else %>
-You need another reference before you can send your application to training providers.
+  You have a reference from <%= @reference.name %>.
 
-You can request as many references as you like to increase the chances of getting 2 quickly.
+  <% if @selected_references.count >= ApplicationForm::REQUIRED_REFERENCE_SELECTIONS %>
+  You’ve selected 2 references to submit with your application already, but you can change your selection if you want.
 
-[Sign in to manage your reference requests](<%= candidate_magic_link(@application_form.candidate) %>).
+  [Sign in to complete your application](<%= candidate_magic_link(@application_form.candidate) %>).
+  <% elsif @provided_references.count > ApplicationForm::REQUIRED_REFERENCE_SELECTIONS %>
+  You have more than enough references to send your application to training providers.
+
+  [Sign in to select 2 references to include in your application](<%= candidate_magic_link(@application_form.candidate) %>).
+  <% elsif @provided_references.count == ApplicationForm::REQUIRED_REFERENCE_SELECTIONS %>
+  You have enough references to send your application to training providers.
+
+  [Sign in to select 2 references to include in your application.](<%= candidate_magic_link(@application_form.candidate) %>)
+  <% else %>
+  You need another reference before you can send your application to training providers.
+
+  You can request as many references as you like to increase the chances of getting 2 quickly.
+
+  [Sign in to manage your reference requests](<%= candidate_magic_link(@application_form.candidate) %>).
+  <% end %>
 <% end %>
-

--- a/app/views/candidate_mailer/reference_received.text.erb
+++ b/app/views/candidate_mailer/reference_received.text.erb
@@ -1,31 +1,9 @@
 <% if @application_form.show_new_reference_flow? %>
-  Dear <%= @application_form.first_name %>
 
-  <%= @reference.application_form.application_choices.pending_conditions.first.provider.name %> has received a refrence for you from <%= @reference.name%>.
+<%= render 'new_flow_reference_received' %>
 
-  You can sign into your account to check the progress of your references requests and offer conditions.
-
-  [Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>).
 <% else %>
-  You have a reference from <%= @reference.name %>.
 
-  <% if @selected_references.count >= ApplicationForm::REQUIRED_REFERENCE_SELECTIONS %>
-  You’ve selected 2 references to submit with your application already, but you can change your selection if you want.
+<%= render 'old_flow_reference_received' %>
 
-  [Sign in to complete your application](<%= candidate_magic_link(@application_form.candidate) %>).
-  <% elsif @provided_references.count > ApplicationForm::REQUIRED_REFERENCE_SELECTIONS %>
-  You have more than enough references to send your application to training providers.
-
-  [Sign in to select 2 references to include in your application](<%= candidate_magic_link(@application_form.candidate) %>).
-  <% elsif @provided_references.count == ApplicationForm::REQUIRED_REFERENCE_SELECTIONS %>
-  You have enough references to send your application to training providers.
-
-  [Sign in to select 2 references to include in your application.](<%= candidate_magic_link(@application_form.candidate) %>)
-  <% else %>
-  You need another reference before you can send your application to training providers.
-
-  You can request as many references as you like to increase the chances of getting 2 quickly.
-
-  [Sign in to manage your reference requests](<%= candidate_magic_link(@application_form.candidate) %>).
-  <% end %>
 <% end %>

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -17,7 +17,7 @@ en:
     chase_reference:
       subject: "%{referee_name} has not replied to your request for a reference"
     chase_reference_again:
-      subject: "%{referee_name} has not responded yet"
+      subject: "%{referee_name} has not replied to your request for a reference"
     offer_withdrawn:
       subject: "Offer withdrawn by %{provider_name}"
     offer_accepted:

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -1,7 +1,7 @@
 en:
   candidate_mailer:
     reference_received:
-      subject: "You have a reference from %{referee_name}"
+      subject: "%{referee_name} has given you a reference"
     application_submitted:
       subject: "You’ve submitted your teacher training application"
     candidate_offer:

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -26,15 +26,15 @@ en:
       subject: "You’ve accepted %{provider_name}’s offer to study %{course_name_and_code}"
     new_referee_request:
       not_responded:
-        subject: "%{referee_name} has not responded yet"
+        subject: "%{referee_name} has not replied to your request for a reference"
         explanation: |-
           We have not had a reference from %{referee_name}.
       refused:
-        subject: "%{referee_name} has declined your reference request"
+        subject: "%{referee_name} is unable to give you a reference"
         explanation: |-
           %{referee_name} said they will not give a reference.
       email_bounced:
-        subject: "Referee request did not reach %{referee_name}"
+        subject: "%{referee_name} has not received your request for a reference"
         explanation: |-
           Our email requesting a reference did not reach %{referee_name}.
 

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -15,7 +15,7 @@ en:
       subject_singular: Make a decision on your teacher training application
       subject_plural: Make a decision on your teacher training applications
     chase_reference:
-      subject: "%{referee_name} has not responded yet"
+      subject: "%{referee_name} has not replied to your request for a reference"
     chase_reference_again:
       subject: "%{referee_name} has not responded yet"
     offer_withdrawn:

--- a/spec/mailers/candidate_mailer_referee_mails_spec.rb
+++ b/spec/mailers/candidate_mailer_referee_mails_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       it_behaves_like(
         'a mail with subject and content',
-        'You have a reference from Scott Knowles',
+        'Scott Knowles has given you a reference',
         'request other' => 'You need another reference',
       )
     end
@@ -163,7 +163,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       it_behaves_like(
         'a mail with subject and content',
-        'You have a reference from Scott Knowles',
+        'Scott Knowles has given you a reference',
         'request other' => 'You have enough references to send your application to training providers.',
       )
     end
@@ -182,7 +182,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       it_behaves_like(
         'a mail with subject and content',
-        'You have a reference from Scott Knowles',
+        'Scott Knowles has given you a reference',
         'request other' => 'You have more than enough references to send your application to training providers.',
       )
     end
@@ -202,7 +202,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       it_behaves_like(
         'a mail with subject and content',
-        'You have a reference from Scott Knowles',
+        'Scott Knowles has given you a reference',
         'request other' => 'You’ve selected 2 references to submit with your application already',
       )
     end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
     it_behaves_like(
       'a mail with subject and content',
-      'Jolyne Doe has not responded yet',
+      'Jolyne Doe has not replied to your request for a reference',
       'magic_link' => '/candidate/sign-in/confirm?token=raw_token',
     )
 

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -12,18 +12,18 @@ RSpec.describe CandidateMailer, type: :mailer do
                                      recruitment_cycle_year:,
                                      application_choices:)
   end
-  let(:candidate) { build_stubbed(:candidate) }
+  let(:candidate) { create(:candidate) }
   let(:application_choices) { [build_stubbed(:application_choice)] }
   let(:dbd_application) { build_stubbed(:application_choice, :dbd) }
   let(:course_option) do
-    build_stubbed(
+    create(
       :course_option,
-      course: build_stubbed(
+      course: create(
         :course,
         name: 'Mathematics',
         code: 'M101',
         start_date: Time.zone.local(2021, 9, 6),
-        provider: build_stubbed(
+        provider: create(
           :provider,
           name: 'Arithmetic College',
         ),
@@ -266,15 +266,27 @@ RSpec.describe CandidateMailer, type: :mailer do
   end
 
   describe '.chase_reference_again' do
+    let(:recruitment_cycle_year) { ApplicationForm::OLD_REFERENCE_FLOW_CYCLE_YEAR + 1 }
     let(:email) { described_class.chase_reference_again(referee) }
-    let(:referee) { build_stubbed(:reference, name: 'Jolyne Doe', application_form:) }
-    let(:application_choices) { [] }
+    let(:application_choices) { [create(:application_choice, :pending_conditions, course_option: course_option)] }
+    let(:application_form) { create(:application_form, recruitment_cycle_year: recruitment_cycle_year, application_choices: application_choices, candidate: candidate) }
+    let(:referee) { create(:reference, name: 'Jolyne Doe', application_form: application_form) }
 
     it_behaves_like(
       'a mail with subject and content',
       'Jolyne Doe has not responded yet',
       'magic_link' => '/candidate/sign-in/confirm?token=raw_token',
     )
+
+    context 'when the new references flow is active' do
+      before do
+        FeatureFlag.activate(:new_references_flow)
+      end
+
+      it 'includes content relating to the new flow' do
+        expect(email.body).to include('Arithmetic College needs to check your references before they can confirm your place on the course.')
+      end
+    end
   end
 
   describe '.offer_withdrawn' do

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -45,22 +45,27 @@ class CandidateMailerPreview < ActionMailer::Preview
   end
 
   def chase_reference
-    CandidateMailer.chase_reference(reference)
+    new_references_content(reference_at_offer.application_form)
+    CandidateMailer.chase_reference(reference_at_offer)
   end
 
   def chase_reference_again
+    new_references_content(reference_at_offer.application_form)
     CandidateMailer.chase_reference_again(reference)
   end
 
   def new_referee_request
+    new_references_content(reference_at_offer.application_form)
     CandidateMailer.new_referee_request(reference, reason: :not_responded)
   end
 
   def new_referee_request_with_refused
+    new_references_content(reference_at_offer.application_form)
     CandidateMailer.new_referee_request(reference, reason: :refused)
   end
 
   def new_referee_request_with_email_bounced
+    new_references_content(reference_at_offer.application_form)
     CandidateMailer.new_referee_request(reference, reason: :email_bounced)
   end
 
@@ -562,6 +567,7 @@ class CandidateMailerPreview < ActionMailer::Preview
   end
 
   def reference_received
+    new_references_content(reference_at_offer.application_form)
     CandidateMailer.reference_received(reference)
   end
 
@@ -892,6 +898,11 @@ private
     FactoryBot.build_stubbed(:reference, application_form:)
   end
 
+  def reference_at_offer
+    @application_form = FactoryBot.create(:application_form, :minimum_info, recruitment_cycle_year: 2023, application_choices: [application_choice_pending_conditions])
+    FactoryBot.create(:reference, application_form: @application_form)
+  end
+
   def reference_feedback_requested
     FactoryBot.build_stubbed(:reference, feedback_status: :feedback_requested)
   end
@@ -920,6 +931,19 @@ private
 
   def course_option
     FactoryBot.build_stubbed(:course_option, course:, site:)
+  end
+
+  def application_choice_pending_conditions
+    provider = FactoryBot.build(:provider, name: 'Brighthurst Technical College')
+    course = FactoryBot.build(:course, name: 'Applied Science (Psychology)', code: '3TT5', provider: provider)
+    course_option = FactoryBot.build(:course_option, course: course)
+
+    FactoryBot.build(:application_choice,
+                     :pending_conditions,
+                     application_form:,
+                     course_option: course_option,
+                     decline_by_default_at: Time.zone.now,
+                     sent_to_provider_at: 1.day.ago)
   end
 
   def application_choice_with_offer

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
@@ -270,7 +270,7 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
   def and_the_candidate_receives_a_notification
     open_email(current_candidate.email_address)
 
-    expect(current_email.subject).to end_with('You have a reference from Terri Tudor')
+    expect(current_email.subject).to end_with('Terri Tudor has given you a reference')
     expect(current_email.body).to have_content('You need another reference')
   end
 

--- a/spec/system/referee_interface/referee_does_not_respond_spec.rb
+++ b/spec/system/referee_interface/referee_does_not_respond_spec.rb
@@ -28,8 +28,8 @@ RSpec.feature 'Referee does not respond in time' do
   end
 
   def given_there_is_an_application_with_a_reference
-    @reference = create(:reference, :feedback_requested, email_address: 'anne@other.com', name: 'Anne Other')
-    @application = create(:application_form, first_name: 'F', last_name: 'B', application_references: [@reference])
+    @application = create(:application_form, first_name: 'F', last_name: 'B')
+    @reference = create(:reference, :feedback_requested, email_address: 'anne@other.com', name: 'Anne Other', application_form: @application)
   end
 
   def and_the_referee_does_not_respond_within_7_days
@@ -73,7 +73,7 @@ RSpec.feature 'Referee does not respond in time' do
 
     expect(current_emails.size).to be(1)
 
-    expect(current_email.subject).to end_with('Anne Other has not responded yet')
+    expect(current_email.subject).to end_with('Anne Other has not replied to your request for a reference')
   end
 
   def when_the_candidate_does_not_respond_within_16_days
@@ -88,7 +88,7 @@ RSpec.feature 'Referee does not respond in time' do
 
     expect(current_emails.size).to be(2)
 
-    expect(current_email.subject).to have_content('Anne Other has not responded yet')
+    expect(current_email.subject).to have_content('Anne Other has not replied to your request for a reference')
   end
 
   def when_the_referee_does_not_respond_within_28_days
@@ -121,7 +121,7 @@ RSpec.feature 'Referee does not respond in time' do
     open_email(@application.candidate.email_address)
     expect(current_emails.size).to be(3)
 
-    expect(current_email.subject).to have_content('Anne Other has not responded yet')
+    expect(current_email.subject).to have_content('Anne Other has not replied to your request for a reference')
   end
 
   def and_the_referee_is_sent_a_final_chase_email

--- a/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
+++ b/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
@@ -60,7 +60,7 @@ RSpec.feature 'Refusing to give a reference' do
   def then_an_email_is_sent_to_the_candidate
     open_email(@application.candidate.email_address)
 
-    expect(current_email.subject).to have_content('Terri Tudor has declined your reference request')
+    expect(current_email.subject).to have_content('Terri Tudor is unable to give you a reference')
   end
 
   def then_i_should_see_the_thank_you_page


### PR DESCRIPTION
## Context

Candidates who are on the new references flow will need to see the new content in their emails. This is because selecting a reference is no longer relevant and we're also referring to the fact that references are part of an offer condition.

## Changes proposed in this pull request

Four emails have been updated:

- chase_reference.text.erb

- chase_reference_again.text.erb

- new_referee_request.text.erb

- reference_receive.text.erb

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/TV25JimW/606-references-update-candidate-reference-chaser-and-received-emails

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
