### PR TITLE
Drop 'other' from 'other offer conditions'

### DIFF
--- a/app/views/candidate_interface/offer_dashboard/show.html.erb
+++ b/app/views/candidate_interface/offer_dashboard/show.html.erb
@@ -5,7 +5,7 @@
     <p class="govuk-body">Your place will be confirmed once they have:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>received your references</li>
-      <li>marked your other offer conditions as met</li>
+      <li>marked your offer conditions as met</li>
     </ul>
 
     <h2 class="govuk-heading-m">References</h2>


### PR DESCRIPTION
We decided to drop "other" from "marked your other offer conditions as met" as we're not describing references as an offer condition to candidates (just something they need to do).