### PR TITLE
633 cancel outstanding references for withdrawal

### DIFF
--- a/app/services/decline_or_withdraw_application.rb
+++ b/app/services/decline_or_withdraw_application.rb
@@ -14,6 +14,7 @@ class DeclineOrWithdrawApplication
     elsif withdrawing?
       withdraw!
       cancel_upcoming_interviews!
+      cancel_outstanding_references!
     end
 
     ProviderInterface::SendCandidateWithdrawnOnRequestEmail.new(application_choice:).call
@@ -62,6 +63,10 @@ private
       application_choice:,
       cancellation_reason: I18n.t('interview_cancellation.reason.application_withdrawn'),
     ).call!
+  end
+
+  def cancel_outstanding_references!
+    CancelOutstandingReferences.new(application_form: application_choice.application_form).call!
   end
 
   def auth

--- a/app/services/decline_or_withdraw_application.rb
+++ b/app/services/decline_or_withdraw_application.rb
@@ -66,7 +66,9 @@ private
   end
 
   def cancel_outstanding_references!
-    CancelOutstandingReferences.new(application_form: application_choice.application_form).call!
+    if application_choice.application_form.ended_without_success?
+      CancelOutstandingReferences.new(application_form: application_choice.application_form).call!
+    end
   end
 
   def auth

--- a/app/services/withdraw_application.rb
+++ b/app/services/withdraw_application.rb
@@ -19,9 +19,8 @@ class WithdrawApplication
       cancellation_reason: I18n.t('interview_cancellation.reason.application_withdrawn'),
     ).call!
 
-    CancelOutstandingReferences.new(application_form: application_choice.application_form).call!
-
     if application_choice.application_form.ended_without_success?
+      CancelOutstandingReferences.new(application_form: application_choice.application_form).call!
       CandidateMailer.withdraw_last_application_choice(application_choice.application_form).deliver_later
     end
 

--- a/app/services/withdraw_application.rb
+++ b/app/services/withdraw_application.rb
@@ -19,6 +19,8 @@ class WithdrawApplication
       cancellation_reason: I18n.t('interview_cancellation.reason.application_withdrawn'),
     ).call!
 
+    CancelOutstandingReferences.new(application_form: application_choice.application_form).call!
+
     if application_choice.application_form.ended_without_success?
       CandidateMailer.withdraw_last_application_choice(application_choice.application_form).deliver_later
     end

--- a/spec/services/decline_or_withdraw_application_spec.rb
+++ b/spec/services/decline_or_withdraw_application_spec.rb
@@ -78,19 +78,36 @@ RSpec.describe DeclineOrWithdrawApplication do
         expect(cancel_service).to have_received(:call!)
       end
 
-      it 'the CancelOutstandingReferencesService is called' do
-        cancel_service = instance_double(CancelOutstandingReferences, call!: true)
+      context 'CancelOutstandingReferences service' do
+        let(:cancel_service) { instance_double(CancelOutstandingReferences, call!: true) }
+        let(:application_form) { application_choice.application_form }
 
-        allow(CancelOutstandingReferences)
-        .to receive(:new)
-        .with(
-          application_form: application_choice.application_form,
-        )
-        .and_return(cancel_service)
+        before do
+          allow(CancelOutstandingReferences)
+          .to receive(:new)
+          .with(
+            application_form:,
+          )
+          .and_return(cancel_service)
+        end
 
-        described_class.new(application_choice:, actor: user).save!
+        it 'is called when all applications have ended without success' do
+          unsuccessful_application_choices = [create(:application_choice, :with_rejection), create(:application_choice, :with_rejection), application_choice]
+          application_form.application_choices << unsuccessful_application_choices
 
-        expect(cancel_service).to have_received(:call!)
+          described_class.new(application_choice:, actor: user).save!
+
+          expect(cancel_service).to have_received(:call!)
+        end
+
+        it 'is not called when there are applications that have not ended without success' do
+          application_choices_with_accepted_offer = [create(:application_choice, status: 'pending_conditions'), create(:application_choice, status: 'withdrawn'), application_choice]
+          application_form.application_choices << application_choices_with_accepted_offer
+
+          described_class.new(application_choice:, actor: user).save!
+
+          expect(cancel_service).not_to have_received(:call!)
+        end
       end
     end
   end

--- a/spec/services/decline_or_withdraw_application_spec.rb
+++ b/spec/services/decline_or_withdraw_application_spec.rb
@@ -77,6 +77,21 @@ RSpec.describe DeclineOrWithdrawApplication do
 
         expect(cancel_service).to have_received(:call!)
       end
+
+      it 'the CancelOutstandingReferencesService is called' do
+        cancel_service = instance_double(CancelOutstandingReferences, call!: true)
+
+        allow(CancelOutstandingReferences)
+        .to receive(:new)
+        .with(
+          application_form: application_choice.application_form,
+        )
+        .and_return(cancel_service)
+
+        described_class.new(application_choice:, actor: user).save!
+
+        expect(cancel_service).to have_received(:call!)
+      end
     end
   end
 end

--- a/spec/services/withdraw_application_spec.rb
+++ b/spec/services/withdraw_application_spec.rb
@@ -40,18 +40,35 @@ RSpec.describe WithdrawApplication do
       expect(cancel_service).to have_received(:call!)
     end
 
-    it 'the CancelOutstandingReferences service is called' do
-      cancel_service = instance_double(CancelOutstandingReferences, call!: true)
-      application_choice = create(:application_choice, status: :awaiting_provider_decision)
+    context 'CancelOutstandingReferences service' do
+      let(:withdrawing_application) { create(:application_choice, status: :awaiting_provider_decision) }
+      let(:cancel_service) { instance_double(CancelOutstandingReferences, call!: true) }
+      let(:application_form) { withdrawing_application.application_form }
 
-      allow(CancelOutstandingReferences)
-      .to receive(:new)
-      .with(application_form: application_choice.application_form)
-      .and_return(cancel_service)
+      before do
+        allow(CancelOutstandingReferences)
+        .to receive(:new)
+        .with(application_form: withdrawing_application.application_form)
+        .and_return(cancel_service)
+      end
 
-      described_class.new(application_choice:).save!
+      it 'is called when all applications have ended without success' do
+        unsuccessful_application_choices = [create(:application_choice, :with_rejection), create(:application_choice, :with_rejection), withdrawing_application]
+        application_form.application_choices << unsuccessful_application_choices
 
-      expect(cancel_service).to have_received(:call!)
+        described_class.new(application_choice: withdrawing_application).save!
+
+        expect(cancel_service).to have_received(:call!)
+      end
+
+      it 'is not called when there are applications that have not ended without success' do
+        application_choices_with_accepted_offer = [create(:application_choice, status: 'pending_conditions'), create(:application_choice, status: 'withdrawn'), withdrawing_application]
+        application_form.application_choices << application_choices_with_accepted_offer
+
+        described_class.new(application_choice: withdrawing_application).save!
+
+        expect(cancel_service).not_to have_received(:call!)
+      end
     end
 
     it 'sends a notification email to the training provider and ratifying provider', sidekiq: true do

--- a/spec/services/withdraw_application_spec.rb
+++ b/spec/services/withdraw_application_spec.rb
@@ -40,6 +40,20 @@ RSpec.describe WithdrawApplication do
       expect(cancel_service).to have_received(:call!)
     end
 
+    it 'the CancelOutstandingReferences service is called' do
+      cancel_service = instance_double(CancelOutstandingReferences, call!: true)
+      application_choice = create(:application_choice, status: :awaiting_provider_decision)
+
+      allow(CancelOutstandingReferences)
+      .to receive(:new)
+      .with(application_form: application_choice.application_form)
+      .and_return(cancel_service)
+
+      described_class.new(application_choice:).save!
+
+      expect(cancel_service).to have_received(:call!)
+    end
+
     it 'sends a notification email to the training provider and ratifying provider', sidekiq: true do
       training_provider = create(:provider)
       training_provider_user = create(:provider_user, :with_notifications_enabled, providers: [training_provider])


### PR DESCRIPTION
## Context
When candidate withdraws or providers withdraws candidate, outstanding references need to be cancelled and referees informed

## Changes proposed in this pull request

* Calls CancelOutstandingReferences service in withdraw application service for candidate and decline_or_withdraw service for provider
* Only cancels references for application forms with application choices that are without success
## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/xlbc5ksI/633-cancel-outstanding-references-for-candidate-withdrawing-application-or-a-provider-withdrawing-it-on-their-behalf

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
