### PR TITLE
Obfuscate reference details for applications pre offer acceptance

### DIFF
--- a/spec/presenters/vendor_api/v1.0/application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.0/application_presenter_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe VendorAPI::ApplicationPresenter do
   let(:attributes) { application_json[:attributes] }
   let(:application_form) { create(:application_form, :minimum_info) }
 
+  before do
+    FeatureFlag.deactivate(:new_references_flow_providers)
+  end
+
   describe 'compliance with models that change updated_at' do
     let(:non_uk_application_form) do
       create(:application_form,

--- a/spec/requests/vendor_api/v1.1/get_single_application_with_references_on_the_new_flow_spec.rb
+++ b/spec/requests/vendor_api/v1.1/get_single_application_with_references_on_the_new_flow_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe 'Vendor API - GET /api/v1.1/applications/:application_id', type: :request do
+  include VendorAPISpecHelpers
+
+  let(:pending_reference) { create(:reference, :feedback_requested) }
+  let(:application_form) do
+    create(
+      :completed_application_form,
+      application_references: [
+        pending_reference,
+        create(
+          :reference,
+          :feedback_provided,
+          safeguarding_concerns: 'Concerned',
+          safeguarding_concerns_status: 'has_safeguarding_concerns_to_declare',
+        ),
+      ],
+    )
+  end
+
+  before do
+    FeatureFlag.activate(:new_references_flow_providers)
+  end
+
+  context 'when the candidate has not accepted an offer' do
+    it 'returns an empty references object' do
+      attributes = { status: 'awaiting_provider_decision', application_form: application_form }
+      application_choice = create_application_choice_for_currently_authenticated_provider(attributes)
+
+      get_api_request "/api/v1.1/applications/#{application_choice.id}"
+
+      expect(response).to have_http_status(:ok)
+      references = parsed_response['data']['attributes']['references']
+      expect(references).to eq []
+    end
+  end
+
+  context 'when a candidate has accepted an offer' do
+    it 'surfaces any references with provided feedback' do
+      attributes = { status: 'pending_conditions', application_form: application_form }
+      application_choice = create_application_choice_for_currently_authenticated_provider(attributes)
+
+      get_api_request "/api/v1.1/applications/#{application_choice.id}"
+
+      expect(response).to have_http_status(:ok)
+      references = parsed_response['data']['attributes']['references']
+      expect(references.pluck('reference').join.empty?).to be false
+      expect(references.pluck('safeguarding_concerns').any?).to be true
+      expect(references.pluck('id')).not_to include pending_reference.id
+    end
+  end
+end

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -6,9 +6,14 @@ RSpec.feature 'Vendor receives the application' do
   include CandidateHelper
 
   scenario 'A completed application is submitted with references' do
+    given_the_new_reference_flow_provider_feature_flag_is_off
     given_a_candidate_has_submitted_their_application
     when_i_retrieve_the_application_over_the_api
     then_it_should_include_the_data_from_the_application_form
+  end
+
+  def given_the_new_reference_flow_provider_feature_flag_is_off
+    FeatureFlag.deactivate(:new_references_flow_providers)
   end
 
   def given_a_candidate_has_submitted_their_application


### PR DESCRIPTION
## Context

We have some candidates that have existing provided references on their application, we are carrying these over with their application but hiding the feedback information on Manage until an offer has been made. 

We need to match this behaviour over the API.

## Changes proposed in this pull request

On the `ApplicationPresenter` `references` will no longer worry about determining selected references once the new references feature flag is on.

And once it is turned on we are only going to surface references once the candidate has accepted an offer and the referene has been received.

## Guidance to review

Test with Postman. 
We should only populate the reference object once the candidate has accepted an offer and the reference has been received.
<img width="441" alt="image" src="https://user-images.githubusercontent.com/47917431/191743933-d54018fc-14d4-4521-a398-bb8d84962b3c.png">



## Link to Trello card

https://trello.com/c/vIj9CMNh/623-obfuscate-reference-feedback-on-the-api-for-carried-over-references

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
