### PR TITLE
Rectify spelling mistakes in the reference received email

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -246,6 +246,10 @@ class ApplicationForm < ApplicationRecord
     choices_left_to_make.positive?
   end
 
+  def recruited?
+    application_choices.recruited.any?
+  end
+
   def successful?
     application_choices.present? &&
       application_choices.map(&:status).map(&:to_sym).any? { |status| ApplicationStateChange::SUCCESSFUL_STATES.include?(status) }

--- a/app/views/candidate_mailer/_new_flow_reference_received.text.erb
+++ b/app/views/candidate_mailer/_new_flow_reference_received.text.erb
@@ -1,7 +1,13 @@
 Dear <%= @application_form.first_name %>
 
-<%= @reference.application_form.application_choices.pending_conditions.first.provider.name %> has received a refrence for you from <%= @reference.name%>.
+<% if @application_form.recruited? %>
+<%= @reference.application_form.application_choices.recruited.first.provider.name %> has received a reference for you from <%= @reference.name%>.
 
-You can sign into your account to check the progress of your references requests and offer conditions.
+You can sign into your account to check the progress of your reference requests.
+<% else %>
+<%= @reference.application_form.application_choices.pending_conditions.first.provider.name %> has received a reference for you from <%= @reference.name%>.
+
+You can sign into your account to check the progress of your reference requests and offer conditions.
+<% end %>
 
 [Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>).

--- a/spec/mailers/candidate_mailer_referee_mails_spec.rb
+++ b/spec/mailers/candidate_mailer_referee_mails_spec.rb
@@ -210,15 +210,27 @@ RSpec.describe CandidateMailer, type: :mailer do
     context 'when the new references flow is active' do
       let(:reference) { create(:reference, :feedback_provided, name: 'Scott Knowles') }
       let(:recruitment_cycle_year) { ApplicationForm::OLD_REFERENCE_FLOW_CYCLE_YEAR + 1 }
-      let(:application_choice) { create(:application_choice, :pending_conditions, course_option: course_option) }
 
       before do
         FeatureFlag.activate(:new_references_flow)
       end
 
-      it 'includes content relating to the new flow' do
-        expect(email.body).to include('Arithmetic College has received a refrence for you from Scott Knowles')
-        expect(email.body).to include('You can sign into your account to check the progress of your references requests and offer conditions.')
+      context 'when the candidate is pending conditions' do
+        let(:application_choice) { create(:application_choice, :pending_conditions, course_option: course_option) }
+
+        it 'includes content relating to the new flow' do
+          expect(email.body).to include('Arithmetic College has received a reference for you from Scott Knowles')
+          expect(email.body).to include('You can sign into your account to check the progress of your reference requests and offer conditions.')
+        end
+      end
+
+      context 'when the candidate is recruited' do
+        let(:application_choice) { create(:application_choice, :with_recruited, course_option: course_option) }
+
+        it 'includes content relating to the new flow' do
+          expect(email.body).to include('Arithmetic College has received a reference for you from Scott Knowles')
+          expect(email.body).to include('You can sign into your account to check the progress of your reference requests.')
+        end
       end
     end
   end

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -571,6 +571,12 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.reference_received(reference)
   end
 
+  def reference_received_after_recruitment
+    new_references_content(reference_at_offer.application_form)
+    reference_at_offer.application_form.application_choices.first.update!(status: :recruited)
+    CandidateMailer.reference_received(reference)
+  end
+
   def two_references_received
     application_form_with_provided_references = FactoryBot.build_stubbed(
       :application_form,

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -887,4 +887,24 @@ RSpec.describe ApplicationForm do
       end
     end
   end
+
+  describe '#recruited?' do
+    context 'when a candidate has been recruited' do
+      it 'returns true' do
+        recruited_application_choice = create(:application_choice, :with_recruited)
+        other_choice = create(:application_choice, :with_rejection)
+        application_form = create(:completed_application_form, application_choices: [recruited_application_choice, other_choice])
+        expect(application_form).to be_recruited
+      end
+    end
+
+    context 'when a candidate has not yet met conditions' do
+      it 'returns false' do
+        application_choice_with_accepted_offer = create(:application_choice, :with_accepted_offer)
+        other_choice = create(:application_choice, :with_rejection)
+        application_form = create(:completed_application_form, application_choices: [application_choice_with_accepted_offer, other_choice])
+        expect(application_form).not_to be_recruited
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

A couple of spelling mistakes snuck their way into the new references email – fixing these.

Also conditionally hiding mention of "offer conditions" in the email when it is sent to any candidate who receives a reference but is in the recruited status.

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="609" alt="image" src="https://user-images.githubusercontent.com/47917431/191042081-d19e7136-b974-49ca-9104-d40ca190d9e1.png">|<img width="607" alt="image" src="https://user-images.githubusercontent.com/47917431/191042165-b8a1db3e-5864-43ea-96db-d66c880bed92.png">|
