### PR TITLE
Make interview date respect RBD for test applications

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -337,12 +337,13 @@ private
 
   def schedule_interview(choice)
     as_provider_user(choice) do
+      interview_date = [7.business_days.from_now, choice.reject_by_default_at].min
       fast_forward
       CreateInterview.new(
         actor:,
         application_choice: choice,
         provider: choice.course_option.provider,
-        date_and_time: 7.business_days.from_now,
+        date_and_time: interview_date,
         location: Faker::Address.full_address,
         additional_details: [nil, nil, 'Use staff entrance', 'Ask for John at the reception'].sample,
       ).save!


### PR DESCRIPTION
## Changes proposed in this pull request

Preserve the rule that test applications have interviews 7 days from creation unless the application choice RBD is before this, we use the RBD date in this case.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

PR test suite should pass...
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
