### PR TITLE
Change reference status labels and the text underneath

### DIFF
--- a/app/components/candidate_interface/new_reference_status_line_component.html.erb
+++ b/app/components/candidate_interface/new_reference_status_line_component.html.erb
@@ -1,0 +1,23 @@
+<% if reference.email_bounced? %>
+  <p class="govuk-body-s govuk-!-margin-top-2 govuk-!-margin-bottom-0">
+    Email could not be sent - check email address and send again
+  </p>
+<% elsif reference.feedback_requested? %>
+  <p class="govuk-body-s govuk-!-margin-top-2 govuk-!-margin-bottom-0">
+    <%= "Request sent on #{request_sent_at.time.to_fs(:govuk_date)}" %>
+
+    <% if can_send_reminder? %>
+      - <%= govuk_link_to(
+        t('application_form.new_references.reminder_link'),
+        candidate_interface_new_references_new_reminder_path(reference, return_to: 'offer-dashboard'),
+      ) %>
+    <% end %>
+
+    <% if can_be_cancelled %>
+      <%= can_send_reminder? ? 'or' : '-' %> <%= govuk_link_to(
+        t('application_form.new_references.cancel_link'),
+        candidate_interface_new_references_confirm_cancel_reference_path(reference, return_to: 'offer-dashboard'),
+      ) %>
+    <% end %>
+  </p>
+<% end %>

--- a/app/components/candidate_interface/new_reference_status_line_component.rb
+++ b/app/components/candidate_interface/new_reference_status_line_component.rb
@@ -1,0 +1,17 @@
+module CandidateInterface
+  class NewReferenceStatusLineComponent < NewReferenceHistoryComponent
+    attr_reader :reference
+
+    def request_sent_at
+      reference.requested_at
+    end
+
+    def can_be_cancelled
+      history.find { |event| event.name == 'request_sent' }
+    end
+
+    def can_send_reminder?
+      ReferenceActionsPolicy.new(reference).can_send_reminder?
+    end
+  end
+end

--- a/app/components/candidate_interface/references_component.html.erb
+++ b/app/components/candidate_interface/references_component.html.erb
@@ -2,11 +2,11 @@
   <% references.each do |reference| %>
     <li class="app-task-list__item">
       <div class="app-task-list__content">
+        <%= render CandidateInterface::NewReferenceStatusesComponent.new(reference: reference) %>
         <div class="app-task-list__task-name">
           <%= govuk_link_to reference.name, candidate_interface_application_offer_dashboard_reference_path(reference.id) %>
-          <%= render(CandidateInterface::NewReferenceHistoryComponent.new(reference)) %>
+          <%= render(CandidateInterface::NewReferenceStatusLineComponent.new(reference)) %>
         </div>
-        <%= render CandidateInterface::NewReferenceStatusesComponent.new(reference: reference) %>
       </div>
     </li>
   <% end %>

--- a/config/locales/candidate_interface/candidate_reference_status.yml
+++ b/config/locales/candidate_interface/candidate_reference_status.yml
@@ -1,12 +1,11 @@
 en:
   candidate_new_reference_status:
-    cancelled: Cancelled
-    cancelled_at_end_of_cycle: Cancelled
-    not_requested_yet: Not requested yet
+    cancelled: Request cancelled
+    cancelled_at_end_of_cycle: Request cancelled
+    not_requested_yet: Not sent
     feedback_requested: Requested
-    feedback_provided: Reference completed
-    selected: Reference received
-    feedback_refused: Unable to give a reference
+    feedback_provided: Received by training provider
+    feedback_refused: Cannot give reference
     email_bounced: Request failed
     feedback_overdue: Response overdue
   candidate_new_reference_colours:
@@ -15,9 +14,8 @@ en:
     not_requested_yet: blue
     feedback_requested: purple
     feedback_provided: green
-    selected: green
     feedback_refused: red
-    email_bounced: red
+    email_bounced: yellow
     feedback_overdue: yellow
   candidate_reference_status:
     cancelled: Request cancelled

--- a/config/locales/candidate_interface/new_references.yml
+++ b/config/locales/candidate_interface/new_references.yml
@@ -46,6 +46,8 @@ en:
         email_address:
           label: Referee’s email address
           hint_text: Use their professional email address if they have one.
+      reminder_link: send a reminder
+      cancel_link: cancel request
       send_reminder:
         post_offer_action: Send a reminder
         action: Send a reminder to this referee

--- a/spec/components/candidate_interface/new_reference_status_line_component_spec.rb
+++ b/spec/components/candidate_interface/new_reference_status_line_component_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::NewReferenceStatusLineComponent, type: :component do
+  it 'renders a status line for request_bounced events', with_audited: true do
+    reference = create(:reference, :not_requested_yet, email_address: 'example@email.com')
+    reference.email_bounced!
+
+    result = render_inline(described_class.new(reference))
+
+    list_item = result.css('p').first
+    expect(list_item.text).to include 'Email could not be sent - check email address and send again'
+  end
+
+  it 'renders a status line for request_sent events', with_audited: true do
+    reference = create(:reference, :not_requested_yet, email_address: 'example@email.com')
+    reference.update!(feedback_status: :feedback_requested, requested_at: Time.zone.now)
+
+    result = render_inline(described_class.new(reference))
+
+    list_item = result.css('p').first
+    expect(list_item.text).to include "Request sent on #{Time.zone.now.to_fs(:govuk_date)}"
+  end
+
+  it 'renders cancel request link for reference feedback_feedback_status that is feedback_requested', with_audited: true do
+    reference = create(:reference, :not_requested_yet)
+    reference.update!(feedback_status: :feedback_requested, requested_at: Time.zone.now)
+
+    render_inline(described_class.new(reference))
+
+    expect(rendered_component).to have_text 'send a reminder'
+    expect(rendered_component).to have_text 'or cancel request'
+  end
+
+  it 'conditionally changes the cancel link when a reminder has been sent', with_audited: true do
+    reference = create(:reference, :not_requested_yet, reminder_sent_at: 1.day.ago)
+    reference.update!(feedback_status: :feedback_requested, requested_at: Time.zone.now)
+
+    render_inline(described_class.new(reference))
+
+    expect(rendered_component).to have_text '- cancel request'
+  end
+end

--- a/spec/components/candidate_interface/references_component_spec.rb
+++ b/spec/components/candidate_interface/references_component_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe CandidateInterface::ReferencesComponent, type: :component do
     end
 
     it 'renders the correct status' do
-      expect(result.css('.govuk-tag').text).to include 'Reference completed'
+      expect(result.css('.govuk-tag').text).to include 'Received by training provider'
     end
   end
 end

--- a/spec/system/candidate_interface/new-references/candidate_request_references_new_references_spec.rb
+++ b/spec/system/candidate_interface/new-references/candidate_request_references_new_references_spec.rb
@@ -263,7 +263,7 @@ RSpec.feature 'New References', with_audited: true do
   end
 
   def and_i_click_cancel_request_from_the_list_page
-    click_on 'Cancel request'
+    click_on 'cancel request'
   end
 
   def back_link

--- a/spec/system/candidate_interface/new-references/candidate_views_their_references_on_the_post_offer_dashboard_spec.rb
+++ b/spec/system/candidate_interface/new-references/candidate_views_their_references_on_the_post_offer_dashboard_spec.rb
@@ -25,9 +25,11 @@ RSpec.feature 'New References', with_audited: true do
     then_i_see_the_reminder_confirmation_page
 
     when_i_confirm_i_want_to_send_the_reminder
+    and_i_click_on_my_requested_reference
     then_i_see_the_updated_history
 
-    when_i_click_on_my_requested_reference
+    when_i_go_back_to_the_dashboard
+    and_i_click_on_my_requested_reference
     and_i_click_cancel_request
     then_i_see_the_cancellation_confirmation_page
 
@@ -72,6 +74,8 @@ RSpec.feature 'New References', with_audited: true do
     click_link @pending_reference.name
   end
 
+  alias_method :and_i_click_on_my_requested_reference, :when_i_click_on_my_requested_reference
+
   def then_i_see_my_referee_information
     expect(page).to have_content @pending_reference.name
     expect(page).to have_content @pending_reference.email_address
@@ -100,6 +104,10 @@ RSpec.feature 'New References', with_audited: true do
 
   def then_i_see_the_updated_history
     expect(page).to have_content "Reminder sent on #{Time.zone.now.to_fs(:govuk_date)}"
+  end
+
+  def when_i_go_back_to_the_dashboard
+    click_link 'Back'
   end
 
   def and_i_click_cancel_request


### PR DESCRIPTION
## Context

We need to update the wording of the status labels for references. There are changes to:

- the wording of the labels
- the colour of the labels
- the wording that appears with some labels

## Changes proposed in this pull request

Some labels have changed and only two labels will show additional text"

* Requested
Request sent on ((date)) - [send reminder] or [cancel request]

* Request failed
Email could not be sent - check email address and send again

|Before|After|
|---|---|
|<img width="666" alt="image" src="https://user-images.githubusercontent.com/47917431/191233994-bdcd6b67-3c3c-496c-92bd-132ec4297d8d.png">|<img width="661" alt="image" src="https://user-images.githubusercontent.com/47917431/191735933-e8ba78ea-645f-4932-bbe2-ae1f09e11a9d.png">|

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/5Y3V1EH8/578-change-reference-status-labels-and-the-text-underneath

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
