### PR TITLE
Adding script to cancel references for 2022 apply again

### DIFF
--- a/app/services/data_migrations/end_of_cycle_cancel_outstanding_references.rb
+++ b/app/services/data_migrations/end_of_cycle_cancel_outstanding_references.rb
@@ -3,7 +3,7 @@ module DataMigrations
     TIMESTAMP = 20220913163416
     MANUAL_RUN = true
     RECRUITMENT_CYCLE_YEAR = 2022
-    PHASE = 'apply_1'.freeze
+    PHASE = 'apply_2'.freeze
 
     def change
       records.each do |record|

--- a/spec/services/data_migrations/end_of_cycle_cancel_outstanding_references_spec.rb
+++ b/spec/services/data_migrations/end_of_cycle_cancel_outstanding_references_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe DataMigrations::EndOfCycleCancelOutstandingReferences, sidekiq: true do
-  context 'when apply 1' do
+  context 'when apply 2' do
     let!(:application_form) do
-      create(:application_form, :minimum_info, phase: 'apply_1')
+      create(:application_form, :minimum_info, phase: 'apply_2')
     end
 
     context 'when feedback requested' do


### PR DESCRIPTION
## Context

Apply again deadline is today so after it finishes we need to run this migration to cancel references from applications on 2022 / apply again.