### PR TITLE
Use a task list instead of a table for offer conditions

### DIFF
--- a/app/components/candidate_interface/conditions_component.html.erb
+++ b/app/components/candidate_interface/conditions_component.html.erb
@@ -1,26 +1,22 @@
-<table class="govuk-table app-table--no-bottom-border">
-  <tbody class="govuk-table__body">
-    <% if conditions.none? %>
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell">
-          No conditions have been set for this offer.
-        </td>
-      </tr>
-    <% else %>
-      <% conditions.each do |condition| %>
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell"><%= condition.text %></td>
-          <td class="govuk-table__cell govuk-table__cell--numeric">
-            <% if condition.met? %>
-              <%= govuk_tag(text: 'Met', colour: 'green') %>
-            <% elsif condition.unmet? %>
-              <%= govuk_tag(text: 'Not met', colour: 'red') %>
-            <% else %>
-              <%= govuk_tag(text: 'Pending', colour: 'grey') %>
-            <% end %>
-          </td>
-        </tr>
-      <% end %>
+<% if conditions.none? %>
+  No conditions have been set for this offer.
+<% else %>
+  <ol class="app-task-list govuk-!-margin-bottom-2">
+    <% conditions.each do |condition| %>
+      <li class="app-task-list__item">
+        <div class="app-task-list__content">
+          <div class="app-task-list__task-name">
+            <%= condition.text %>
+          </div>
+          <% if condition.met? %>
+            <%= govuk_tag(text: 'Met', colour: 'green') %>
+          <% elsif condition.unmet? %>
+            <%= govuk_tag(text: 'Not met', colour: 'red') %>
+          <% else %>
+            <%= govuk_tag(text: 'Pending', colour: 'grey') %>
+          <% end %>
+        </div>
+      </li>
     <% end %>
-  </tbody>
-</table>
+  </ol>
+<% end %>

--- a/app/components/candidate_interface/conditions_component.html.erb
+++ b/app/components/candidate_interface/conditions_component.html.erb
@@ -1,7 +1,7 @@
 <% if conditions.none? %>
   No conditions have been set for this offer.
 <% else %>
-  <ol class="app-task-list govuk-!-margin-bottom-2">
+  <ul class="app-task-list govuk-!-margin-bottom-2">
     <% conditions.each do |condition| %>
       <li class="app-task-list__item">
         <div class="app-task-list__content">
@@ -18,5 +18,5 @@
         </div>
       </li>
     <% end %>
-  </ol>
+  </ul>
 <% end %>

--- a/spec/system/candidate_interface/new-references/candidate_request_references_new_references_spec.rb
+++ b/spec/system/candidate_interface/new-references/candidate_request_references_new_references_spec.rb
@@ -91,7 +91,7 @@ RSpec.feature 'New References', with_audited: true do
     expect(page).to have_content "You’ve accepted the offer from #{@application_choice.offer.provider.name}."
     expect(page).to have_content 'References'
     expect(page).to have_content 'Offer conditions'
-    expect(page).to have_content "#{@application_choice.offer.conditions.first.text} Pending"
+    expect(page).to have_content("#{@application_choice.offer.conditions.first.text} Pending", normalize_ws: true)
   end
 
   def when_i_click_request_another_reference

--- a/spec/system/candidate_interface/new-references/candidate_views_their_references_on_the_post_offer_dashboard_spec.rb
+++ b/spec/system/candidate_interface/new-references/candidate_views_their_references_on_the_post_offer_dashboard_spec.rb
@@ -65,7 +65,7 @@ RSpec.feature 'New References', with_audited: true do
     expect(page).to have_content "You’ve accepted the offer from #{@application_choice.offer.provider.name}."
     expect(page).to have_content 'References'
     expect(page).to have_content 'Offer conditions'
-    expect(page).to have_content "#{@application_choice.offer.conditions.first.text} Pending"
+    expect(page).to have_content("#{@application_choice.offer.conditions.first.text} Pending", normalize_ws: true)
   end
 
   def when_i_click_on_my_requested_reference


### PR DESCRIPTION
This changes the offer conditions status view in Apply to use a task list (styled `<ul>`) instead of a table. The main visual difference is to add a border at the top and the bottom.

This also improves accessibility, as the offer conditions aren't really tabular data, and is consistent with the HTML for the references status list above.

### Screenshots

|Before | After|
|--|--|
| <img width="724" alt="Screenshot 2022-09-22 at 11 46 24" src="https://user-images.githubusercontent.com/30665/191748376-d7d27039-7937-475b-a4fe-7998be4a0b61.png"> |  <img width="731" alt="Screenshot 2022-09-22 at 11 46 42" src="https://user-images.githubusercontent.com/30665/191748431-00507306-6992-4f99-805a-46261360b64a.png">  | 
