### PR TITLE
Remove obsolete feature flag `lock_external_report_to_december_2021`

### DIFF
--- a/app/services/data_migrations/remove_lock_external_report_feature_flag.rb
+++ b/app/services/data_migrations/remove_lock_external_report_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class RemoveLockExternalReportFeatureFlag
+    TIMESTAMP = 20220922143134
+    MANUAL_RUN = false
+
+    def change
+      Feature.where(name: 'lock_external_report_to_december_2021').destroy_all
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveLockExternalReportFeatureFlag',
   'DataMigrations::EndOfCycleCancelOutstandingReferences',
   'DataMigrations::ProviderInterviewDataFix',
   'DataMigrations::MonthlyReportsBackfill',

--- a/spec/services/data_migrations/remove_lock_external_report_feature_flag_spec.rb
+++ b/spec/services/data_migrations/remove_lock_external_report_feature_flag_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveLockExternalReportFeatureFlag do
+  context 'when the feature flags exist' do
+    before do
+      create(:feature, name: 'lock_external_report_to_december_2021')
+      create(:feature, name: 'some_other_feature_flag')
+    end
+
+    it 'removes the relevant feature flags' do
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: 'lock_external_report_to_december_2021')).to be_none
+      expect(Feature.where(name: 'some_other_feature_flag')).to be_any
+    end
+  end
+
+  context 'when the feature flags have already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end


### PR DESCRIPTION
```
DataMigrations::RemoveLockExternalReportFeatureFlag#20220922143134 data migration completed successfully
```

## Link to Trello card

https://trello.com/c/A7zpFytA/642-sentry-obsolete-feature-flags

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
