### PR TITLE
673 Re-design and content of references tab in manage

### DIFF
--- a/app/components/provider_interface/new_reference_with_feedback_component.html.erb
+++ b/app/components/provider_interface/new_reference_with_feedback_component.html.erb
@@ -1,3 +1,0 @@
-<div data-qa="reference">
-  <%= render SummaryListComponent.new(rows: rows) %>
-</div>

--- a/app/components/provider_interface/references_summary_message.html.erb
+++ b/app/components/provider_interface/references_summary_message.html.erb
@@ -1,0 +1,3 @@
+<p class="govuk-body">
+  <%= message %>
+</p>

--- a/app/components/provider_interface/references_summary_message.rb
+++ b/app/components/provider_interface/references_summary_message.rb
@@ -1,0 +1,27 @@
+module ProviderInterface
+  class ReferencesSummaryMessage < ViewComponent::Base
+    attr_reader :references
+
+    delegate :feedback_provided, :feedback_requested, to: :references
+
+    def initialize(references)
+      @references = references
+    end
+
+    def message
+      if feedback_provided.blank?
+        "The candidate #{I18n.t('provider_interface.references.requested_message', count: feedback_requested.count)}."
+      else
+        "The candidate #{I18n.t('provider_interface.references.received_message', count: feedback_provided.count)}#{other_requested_reference}."
+      end
+    end
+
+  private
+
+    def other_requested_reference
+      return if feedback_requested.blank?
+
+      " #{I18n.t('provider_interface.references.requested_other_message', count: feedback_requested.count)}"
+    end
+  end
+end

--- a/app/views/provider_interface/references/_references.html.erb
+++ b/app/views/provider_interface/references/_references.html.erb
@@ -1,7 +1,8 @@
 <% references.each_with_index do |reference, index| %>
-  <h3 class="govuk-heading-s govuk-!-margin-top-4 govuk-!-margin-bottom-2">
-    <%= reference.referee_type.humanize %> reference from <%= reference.name %>
-  </h3>
-
-  <%= render ProviderInterface::NewReferenceWithFeedbackComponent.new(reference: reference, index: index, application_choice: @application_choice) %>
+  <%= render(SummaryCardComponent.new(
+    rows: ProviderInterface::NewReferenceWithFeedbackComponent.new(reference:, index:, application_choice: @application_choice).rows,
+    editable: false,
+  )) do %>
+    <%= render SummaryCardHeaderComponent.new(title: "#{reference.referee_type.humanize} reference from #{reference.name}", heading_level: 3) %>
+  <% end %>
 <% end %>

--- a/app/views/provider_interface/references/index.html.erb
+++ b/app/views/provider_interface/references/index.html.erb
@@ -12,7 +12,7 @@
 
 <% else %>
   <%= render(
-    ProviderInterface::ReferencesSummaryMessage.new(@references)
+    ProviderInterface::ReferencesSummaryMessage.new(@references),
   ) %>
 
   <% if @references.feedback_provided.present? %>

--- a/app/views/provider_interface/references/index.html.erb
+++ b/app/views/provider_interface/references/index.html.erb
@@ -4,20 +4,24 @@
 <h1 class="govuk-heading-l">References</h1>
 
 <% if @application_choice.pre_offer? %>
-  <p class="govuk-body">The candidate has given details of <%= @references.size %> people who can give references.</p>
-  <%= govuk_warning_text(text: 'You must not contact these references until the candidate has accepted an offer on your course') %>
+  <p class="govuk-body">
+    References will be requested when the candidate accepts an offer. Do not contact these people before then without permission from the candidate.
+  </p>
 
   <%= render 'references', references: @references, application_choice: @application_choice %>
 
 <% else %>
+  <%= render(
+    ProviderInterface::ReferencesSummaryMessage.new(@references)
+  ) %>
 
-  <h2 class="govuk-heading-m">Received references</h2>
-  <% if @references.feedback_provided.empty? %>
-    <p class="govuk-body">The candidate has not received a reference yet.</p>
-  <% else %>
+  <% if @references.feedback_provided.present? %>
+    <h2 class="govuk-heading-m">Received references</h2>
     <%= render 'references', references: @references.feedback_provided, application_choice: @application_choice %>
   <% end %>
 
-  <h2 class="govuk-heading-m">Requested references</h2>
-  <%= render 'references', references: @references.not_feedback_provided, application_choice: @application_choice %>
+  <% if @references.feedback_requested.present? %>
+    <h2 class="govuk-heading-m">Requested references</h2>
+    <%= render 'references', references: @references.feedback_requested, application_choice: @application_choice %>
+  <% end %>
 <% end %>

--- a/config/locales/provider_interface/references.yml
+++ b/config/locales/provider_interface/references.yml
@@ -1,0 +1,13 @@
+en:
+  provider_interface:
+    references:
+      confirmed_by: This was confirmed by %{name}.
+      requested_message:
+        one: has requested 1 reference
+        other: has requested %{count} references
+      requested_other_message:
+        one: and has requested 1 other reference
+        other: and has requested %{count} other references
+      received_message:
+        one: has received 1 reference
+        other: has received %{count} references

--- a/spec/components/provider_interface/new_reference_with_feedback_component_spec.rb
+++ b/spec/components/provider_interface/new_reference_with_feedback_component_spec.rb
@@ -15,87 +15,57 @@ RSpec.describe ProviderInterface::NewReferenceWithFeedbackComponent, type: :comp
     end
 
     it 'contains a name row' do
-      row = component.rows.first
-      expect(row[:key]).to eq('Name')
-      expect(row[:value]).to eq(reference.name)
+      expect(component.rows).to include(
+        { key: 'Name', value: reference.name },
+      )
     end
 
     it 'contains an email address row' do
-      row = component.rows.second
-      expect(row[:key]).to eq('Email address')
-      expect(row[:value]).to eq(reference.email_address)
-    end
-
-    it 'contains a type of reference row' do
-      row = component.rows.third
-      expect(row[:key]).to eq('Type of reference')
-      expect(row[:value]).to include(reference.referee_type.capitalize.dasherize)
-    end
-
-    context 'referee_type is nil' do
-      let(:reference) { build(:reference, feedback:, referee_type: nil, feedback_status: 'feedback_provided') }
-
-      it 'renders without raisin an error' do
-        row = component.rows.third
-        expect(row[:key]).to eq('Type of reference')
-        expect(row[:value]).to eq('')
-      end
+      expect(component.rows).to include(
+        { key: 'Email address', value: reference.email_address },
+      )
     end
 
     it 'contains a relationship row' do
-      row = component.rows.fourth
-      expect(row[:key]).to eq('Relationship between candidate and referee')
-      expect(row[:value]).to eq(reference.relationship)
+      expect(component.rows).to include(
+        {
+          key: 'How the candidate knows them and how long for',
+          value: "#{reference.relationship}\n\nThis was confirmed by #{reference.name}.",
+        },
+      )
     end
 
-    context 'referee relationship confirmation' do
-      it 'contains a confirmation row' do
-        expect(component.rows.fifth[:key]).to eq('Relationship confirmed by referee?')
-      end
+    it 'contains a correction as the row value when corrected' do
+      reference.relationship_correction = 'This is not correct'
 
-      it 'affirms the referee relationship when uncorrected' do
-        expect(component.rows.fifth[:value]).to eq('Yes')
-      end
-
-      it 'contains a correction as the row value when corrected' do
-        reference.relationship_correction = 'This is not correct'
-
-        expect(component.rows.fifth[:value]).to eq('No')
-
-        correction_row = component.rows[5]
-
-        expect(correction_row[:key]).to eq('Relationship amended by referee')
-        expect(correction_row[:value]).to eq('This is not correct')
-      end
+      expect(component.rows).to include(
+        {
+          key: 'How the candidate knows them and how long for',
+          value: "#{reference.relationship}\n\n#{reference.relationship_correction}",
+        },
+      )
     end
 
     context 'safeguarding' do
-      let(:safeguarding_row) { component.rows[5] }
-      let(:safeguarding_concerns_row) { component.rows[6] }
-
-      it 'contains a safeguarding row' do
-        expect(safeguarding_row[:key]).to eq(
-          'Does the referee know of any reason why this candidate should not work with children?',
+      it 'contains no concern on safeguarding' do
+        expect(component.rows).to include(
+          {
+            key: 'Concerns about the candidate working with children',
+            value: 'No concerns.',
+          },
         )
-      end
-
-      it 'affirms safeguarding when no safeguarding concerns are present' do
-        expect(safeguarding_row[:value]).to eq('No')
       end
 
       it 'contains safeguarding concerns where present' do
         reference.safeguarding_concerns = 'Is a big bad wolf, has posed as elderly grandparent.'
         reference.safeguarding_concerns_status = :has_safeguarding_concerns_to_declare
-        expect(safeguarding_row[:value]).to eq('Yes')
 
-        expect(safeguarding_concerns_row[:key]).to eq(
-          'Reason(s) given by referee why this candidate should not work with children',
+        expect(component.rows).to include(
+          {
+            key: 'Concerns about the candidate working with children',
+            value: reference.safeguarding_concerns,
+          },
         )
-        expect(safeguarding_concerns_row[:value]).to eq(reference.safeguarding_concerns)
-      end
-
-      it 'does not contain safeguarding concerns when nil' do
-        expect(safeguarding_concerns_row[:key]).to eq('Reference')
       end
     end
 
@@ -106,11 +76,18 @@ RSpec.describe ProviderInterface::NewReferenceWithFeedbackComponent, type: :comp
         expect(row[:value]).to eq(reference.feedback)
       end
 
+      it 'changes field name when carried over reference' do
+        reference.duplicate = true
+
+        row = component.rows.last
+        expect(row[:key]).to eq('Does the candidate have the potential to teach?')
+        expect(row[:value]).to eq(reference.feedback)
+      end
+
       it 'does not contain a feedback row when feedback when there is not an offer' do
         reference.feedback = nil
-        application_choice.status = 'awaiting_provider_decision'
-        result = render_inline(component)
-        expect(result.text).not_to include('Reference')
+        row = component.rows.last
+        expect(row[:key]).not_to eq('Reference')
       end
     end
   end

--- a/spec/components/provider_interface/references_summary_message_spec.rb
+++ b/spec/components/provider_interface/references_summary_message_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ReferencesSummaryMessage do
+  let(:application_form) { create(:application_form) }
+
+  subject(:result) do
+    render_inline(described_class.new(application_form.application_references))
+  end
+
+  context 'when no feedback provided' do
+    before do
+      create_list(:reference, 2, feedback_status: :feedback_requested, application_form:)
+    end
+
+    it 'renders number of references requested' do
+      expect(result.text).to include('The candidate has requested 2 references.')
+    end
+  end
+
+  context 'when all feedback provided' do
+    before do
+      create_list(:reference, 2, feedback_status: :feedback_provided, application_form:)
+    end
+
+    it 'renders number of references provided' do
+      expect(result.text).to include('The candidate has received 2 references.')
+    end
+  end
+
+  context 'when one feedback provided and one requested' do
+    before do
+      create(:reference, :feedback_requested, application_form:)
+      create(:reference, :feedback_provided, application_form:)
+    end
+
+    it 'renders number of references' do
+      expect(result.text).to include('The candidate has received 1 reference and has requested 1 other reference.')
+    end
+  end
+
+  context 'when some feedback provided and some requested' do
+    before do
+      create_list(:reference, 2, feedback_status: :feedback_requested, application_form:)
+      create_list(:reference, 2, feedback_status: :feedback_provided, application_form:)
+    end
+
+    it 'renders number of references' do
+      expect(result.text).to include('The candidate has received 2 references and has requested 2 other references.')
+    end
+  end
+end

--- a/spec/system/provider_interface/provider_views_the_references_tab_on_manage_spec.rb
+++ b/spec/system/provider_interface/provider_views_the_references_tab_on_manage_spec.rb
@@ -83,8 +83,8 @@ RSpec.feature 'Provider views an application in new cycle' do
     link = page.find_link('References', class: 'app-tab-navigation__link')
     expect(link['aria-current']).to eq('page')
 
-    expect(page).to have_content 'The candidate has given details of 2 people who can give references.'
-    expect(page).to have_content '!WarningYou must not contact these references until the candidate has accepted an offer on your course'
+    expect(page).to have_content pre_offer_message
+
     expect(page).to have_content "#{references.first.referee_type.humanize} reference from #{references.first.name}"
     expect(page).to have_content "#{references.second.referee_type.humanize} reference from #{references.second.name}"
   end
@@ -102,14 +102,17 @@ RSpec.feature 'Provider views an application in new cycle' do
   end
 
   def then_i_see_the_reference_received_section
-    expect(page).not_to have_content '!WarningYou must not contact these references until the candidate has accepted an offer on your course'
-    expect(page).to have_content 'Received references'
-    expect(page).to have_content 'The candidate has not received a reference yet'
-    expect(page).to have_content @my_provider_choice.application_form.application_references.first.feedback
+    expect(page).not_to have_content pre_offer_message
     expect(page).to have_content 'Requested references'
+    expect(page).to have_content 'The candidate has requested 2 references.'
+    expect(page).to have_content @my_provider_choice.application_form.application_references.first.feedback
   end
 
   def then_i_see_the_reference_feedback
     expect(page).to have_content @my_provider_choice.application_form.application_references.first.feedback
+  end
+
+  def pre_offer_message
+    'References will be requested when the candidate accepts an offer. Do not contact these people before then without permission from the candidate.'
   end
 end


### PR DESCRIPTION
## Context

We are redesigning the references tab on Manage.

Changes included in the PR:

Moves the references into "summary cards", which gives them a border and a title
'Type' row removed, as this is now in the card title
"How the candidate knows them and how long for" row combines both what the candidate said and what the referee says (if they say it's not correct) or just says it's confirmed.
"Concerns about the candidate working with children" label updated slightly, and shows either "No concerns" or the concerns given by the referee
"Reference" contains the actual reference. For carried over references from the past cycle this would say "Does the candidate have the potential to teach?"
Where the candidate hasn't accepted an offer yet, adds a line of guidance
Where a candidate has accepted an offer, adds a line summarising how many references in each state. Additional headings separate the different reference states.

