### PR TITLE
Update the hesa codes for 2023

### DIFF
--- a/app/forms/candidate_interface/equality_and_diversity/sex_form.rb
+++ b/app/forms/candidate_interface/equality_and_diversity/sex_form.rb
@@ -32,7 +32,7 @@ module CandidateInterface
   private
 
     def hesa_sex_code
-      Hesa::Sex.find(sex)&.hesa_code
+      Hesa::Sex.find(sex, RecruitmentCycle.current_year)&.hesa_code
     end
   end
 end

--- a/app/lib/hesa/sex.rb
+++ b/app/lib/hesa/sex.rb
@@ -2,16 +2,19 @@ module Hesa
   class Sex
     SexStruct = Struct.new(:hesa_code, :type)
 
-    def self.all
-      HESA_SEX.map { |sex| SexStruct.new(*sex) }
+    def self.all(cycle_year)
+      collection_name = "HESA_SEX_#{cycle_year - 1}_#{cycle_year}"
+      HesaSexCollections.const_get(collection_name).map { |sex| SexStruct.new(*sex) }
+    rescue NameError
+      raise ArgumentError, "Do not know Hesa Sex codes for #{cycle_year}"
     end
 
-    def self.find(sex)
+    def self.find(sex, cycle_year = RecruitmentCycle.current_year)
       if sex == 'intersex'
         sex = 'other'
       end
 
-      all.find { |hesa_sex| hesa_sex.type == sex }
+      all(cycle_year).find { |hesa_sex| hesa_sex.type == sex }
     end
   end
 end

--- a/app/lib/hesa/sex.rb
+++ b/app/lib/hesa/sex.rb
@@ -3,13 +3,13 @@ module Hesa
     SexStruct = Struct.new(:hesa_code, :type)
 
     def self.all(cycle_year)
-      collection_name = "HESA_SEX_#{cycle_year - 1}_#{cycle_year}"
-      HesaSexCollections.const_get(collection_name).map { |sex| SexStruct.new(*sex) }
-    rescue NameError
-      raise ArgumentError, "Do not know Hesa Sex codes for #{cycle_year}"
+      collection_name = "#{cycle_year - 1}_#{cycle_year}"
+      collection = HESA_SEX_COLLECTIONS[collection_name] || HESA_SEX_COLLECTIONS[HESA_SEX_COLLECTIONS.keys.max]
+
+      collection.map { |sex| SexStruct.new(*sex) }
     end
 
-    def self.find(sex, cycle_year = RecruitmentCycle.current_year)
+    def self.find(sex, cycle_year)
       if sex == 'intersex'
         sex = 'other'
       end

--- a/app/services/candidate_interface/hesa_code_backfill.rb
+++ b/app/services/candidate_interface/hesa_code_backfill.rb
@@ -62,7 +62,7 @@ module CandidateInterface
     def hesa_sex_code(application_form)
       sex = application_form.equality_and_diversity['sex']
 
-      Hesa::Sex.find(sex)&.hesa_code
+      Hesa::Sex.find(sex, RecruitmentCycle.current_year)&.hesa_code
     end
   end
 end

--- a/config/initializers/hesa_sex.rb
+++ b/config/initializers/hesa_sex.rb
@@ -1,5 +1,17 @@
-HESA_SEX = [
-  %w[1 male],
-  %w[2 female],
-  %w[3 other],
-].freeze
+module HesaSexCollections
+  HESA_SEX_2019_2020 = [
+    %w[1 male],
+    %w[2 female],
+    %w[3 other],
+  ].freeze
+
+  HESA_SEX_2020_2021 = HESA_SEX_2019_2020
+
+  HESA_SEX_2021_2022 = HESA_SEX_2020_2021
+
+  HESA_SEX_2022_2023 = [
+    %w[10 female],
+    %w[11 male],
+    %w[12 other],
+  ].freeze
+end

--- a/config/initializers/hesa_sex.rb
+++ b/config/initializers/hesa_sex.rb
@@ -1,17 +1,18 @@
-module HesaSexCollections
-  HESA_SEX_2019_2020 = [
-    %w[1 male],
-    %w[2 female],
-    %w[3 other],
-  ].freeze
+HESA_SEX_2019_2020 = [
+  %w[1 male],
+  %w[2 female],
+  %w[3 other],
+].freeze
 
-  HESA_SEX_2020_2021 = HESA_SEX_2019_2020
+HESA_SEX_2022_2023 = [
+  %w[10 female],
+  %w[11 male],
+  %w[12 other],
+].freeze
 
-  HESA_SEX_2021_2022 = HESA_SEX_2020_2021
-
-  HESA_SEX_2022_2023 = [
-    %w[10 female],
-    %w[11 male],
-    %w[12 other],
-  ].freeze
-end
+HESA_SEX_COLLECTIONS = {
+  '2019_2020' => HESA_SEX_2019_2020,
+  '2020_2021' => HESA_SEX_2019_2020,
+  '2021_2022' => HESA_SEX_2019_2020,
+  '2022_2023' => HESA_SEX_2022_2023,
+}.freeze

--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -62,7 +62,7 @@ FactoryBot.define do
         other_disability = 'Acquired brain injury'
         all_disabilities = DisabilityHelper::STANDARD_DISABILITIES.map(&:second) << other_disability
         disabilities = rand < 0.85 ? all_disabilities.sample([*0..3].sample) : ['Prefer not to say']
-        hesa_sex = sex == 'Prefer not to say' ? nil : Hesa::Sex.find(sex)['hesa_code']
+        hesa_sex = sex == 'Prefer not to say' ? nil : Hesa::Sex.find(sex, RecruitmentCycle.current_year)['hesa_code']
         hesa_disabilities = disabilities == ['Prefer not to say'] ? %w[00] : disabilities.map { |disability| Hesa::Disability.find(disability)['hesa_code'] }
         hesa_ethnicity = Hesa::Ethnicity.find(ethnicity.last, 2021)['hesa_code']
 

--- a/spec/lib/hesa/sex_spec.rb
+++ b/spec/lib/hesa/sex_spec.rb
@@ -27,13 +27,25 @@ RSpec.describe Hesa::Sex do
         expect(female.type).to eq 'female'
       end
     end
+
+    context 'when a year without data' do
+      it 'returns last one' do
+        sex_types = described_class.all(2090)
+
+        expect(sex_types.size).to eq 3
+
+        female = sex_types.find { |s| s.hesa_code == '10' }
+
+        expect(female.hesa_code).to eq '10'
+        expect(female.type).to eq 'female'
+      end
+    end
   end
 
   describe '.find' do
     context 'given a valid type' do
       it 'returns the matching struct' do
-        allow(RecruitmentCycle).to receive(:current_year).and_return(2022)
-        result = described_class.find('female')
+        result = described_class.find('female', 2022)
 
         expect(result.type).to eq 'female'
         expect(result.hesa_code).to eq '2'
@@ -42,8 +54,7 @@ RSpec.describe Hesa::Sex do
 
     context 'when 2023' do
       it 'returns a list of HESA sex structs' do
-        allow(RecruitmentCycle).to receive(:current_year).and_return(2023)
-        result = described_class.find('female')
+        result = described_class.find('female', 2023)
 
         expect(result.type).to eq 'female'
         expect(result.hesa_code).to eq '10'
@@ -52,7 +63,7 @@ RSpec.describe Hesa::Sex do
 
     context 'given an unrecognised type' do
       it 'returns nil' do
-        result = described_class.find('An unrecognised type')
+        result = described_class.find('An unrecognised type', 2022)
 
         expect(result).to be_nil
       end

--- a/spec/lib/hesa/sex_spec.rb
+++ b/spec/lib/hesa/sex_spec.rb
@@ -2,25 +2,51 @@ require 'rails_helper'
 
 RSpec.describe Hesa::Sex do
   describe '.all' do
-    it 'returns a list of HESA sex structs' do
-      sex_types = described_class.all
+    context 'when 2022' do
+      it 'returns a list of HESA sex structs' do
+        sex_types = described_class.all(2022)
 
-      expect(sex_types.size).to eq 3
+        expect(sex_types.size).to eq 3
 
-      female = sex_types.find { |s| s.hesa_code == '2' }
+        female = sex_types.find { |s| s.hesa_code == '2' }
 
-      expect(female.hesa_code).to eq '2'
-      expect(female.type).to eq 'female'
+        expect(female.hesa_code).to eq '2'
+        expect(female.type).to eq 'female'
+      end
+    end
+
+    context 'when 2023' do
+      it 'returns a list of HESA sex structs' do
+        sex_types = described_class.all(2023)
+
+        expect(sex_types.size).to eq 3
+
+        female = sex_types.find { |s| s.hesa_code == '10' }
+
+        expect(female.hesa_code).to eq '10'
+        expect(female.type).to eq 'female'
+      end
     end
   end
 
   describe '.find' do
     context 'given a valid type' do
       it 'returns the matching struct' do
+        allow(RecruitmentCycle).to receive(:current_year).and_return(2022)
         result = described_class.find('female')
 
         expect(result.type).to eq 'female'
         expect(result.hesa_code).to eq '2'
+      end
+    end
+
+    context 'when 2023' do
+      it 'returns a list of HESA sex structs' do
+        allow(RecruitmentCycle).to receive(:current_year).and_return(2023)
+        result = described_class.find('female')
+
+        expect(result.type).to eq 'female'
+        expect(result.hesa_code).to eq '10'
       end
     end
 

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -251,7 +251,7 @@ RSpec.describe TestApplications do
         expect(equality_and_diversity['hesa_sex']).to be_nil
       else
         expect(equality_and_diversity['hesa_sex']).to eq(
-          Hesa::Sex.find(equality_and_diversity['sex'], RecruitmentCycle.current_year)['hesa_code']
+          Hesa::Sex.find(equality_and_diversity['sex'], RecruitmentCycle.current_year)['hesa_code'],
         )
       end
     end

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -250,7 +250,9 @@ RSpec.describe TestApplications do
       if equality_and_diversity['sex'] == 'Prefer not to say'
         expect(equality_and_diversity['hesa_sex']).to be_nil
       else
-        expect(equality_and_diversity['hesa_sex']).to eq(Hesa::Sex.find(equality_and_diversity['sex'])['hesa_code'])
+        expect(equality_and_diversity['hesa_sex']).to eq(
+          Hesa::Sex.find(equality_and_diversity['sex'], RecruitmentCycle.current_year)['hesa_code']
+        )
       end
     end
 


### PR DESCRIPTION
## Context

We have the HESA new codes for 2023 cycle 

<img width="791" alt="hesa" src="https://user-images.githubusercontent.com/27509/192214992-c684a63a-17dc-4114-95eb-137f870e0c76.png">

This PR adds the HESA data for 2023 (and keeps old data for old cycles)

## Guidance to review

1. Are the codes correct?
2. Does it work posting the diversity questionnaire and see in the HESA export on provider interface?
