### PR TITLE
Generate next cycle test applications

### DIFF
--- a/app/controllers/support_interface/tasks_controller.rb
+++ b/app/controllers/support_interface/tasks_controller.rb
@@ -8,6 +8,10 @@ module SupportInterface
         GenerateTestApplications.perform_async
         flash[:success] = 'Scheduled job to generate test applications - this might take a while!'
         redirect_to support_interface_tasks_path
+      when 'generate_next_cycle_test_applications'
+        GenerateTestApplications.perform_async(true)
+        flash[:success] = 'Scheduled job to generate next cycle test applications - this might take a while!'
+        redirect_to support_interface_tasks_path
       when 'recalculate_dates'
         RecalculateDates.perform_async
         flash[:success] = 'Scheduled job to recalculate dates'

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -14,8 +14,10 @@ class SubmitApplication
     end
 
     # Cancel any outstanding references
-    application_form.application_references.feedback_requested.each do |reference|
-      CancelReferee.new.call(reference:)
+    unless application_form.show_new_reference_flow?
+      application_form.application_references.feedback_requested.each do |reference|
+        CancelReferee.new.call(reference:)
+      end
     end
     CandidateMailer.application_submitted(application_form).deliver_later
   end

--- a/app/views/support_interface/tasks/index.html.erb
+++ b/app/views/support_interface/tasks/index.html.erb
@@ -65,6 +65,18 @@
     </div>
   </section>
 
+    <section class="app-section app-section--with-top-border">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-heading-m">Generate test applications for the <%= RecruitmentCycle.next_year %> recruitment cycle</h2>
+        <p class="govuk-body">This task generates mostly-random test applications for the <%= RecruitmentCycle.next_year %> recruitment cycle.</p>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <%= govuk_button_to "Generate #{RecruitmentCycle.next_year} recruitment cycle test applications", support_interface_run_task_path('generate_next_cycle_test_applications'), secondary: true %>
+      </div>
+    </div>
+  </section>
+
   <section class="app-section app-section--with-top-border">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/app/workers/generate_test_applications.rb
+++ b/app/workers/generate_test_applications.rb
@@ -1,48 +1,63 @@
 class GenerateTestApplications
   include Sidekiq::Worker
 
-  def perform
+  def perform(next_cycle_applications = false)
     raise 'You cannot generate test data in production' if HostingEnvironment.production?
 
     current_cycle = RecruitmentCycle.current_year
     previous_cycle = RecruitmentCycle.previous_year
+    next_cycle = RecruitmentCycle.next_year
 
-    create recruitment_cycle_year: previous_cycle, states: %i[rejected rejected]
-    create recruitment_cycle_year: previous_cycle, states: %i[offer_withdrawn]
-    create recruitment_cycle_year: previous_cycle, states: %i[offer_deferred]
-    create recruitment_cycle_year: previous_cycle, states: %i[offer_deferred]
-    create recruitment_cycle_year: previous_cycle, states: %i[declined]
-    create recruitment_cycle_year: previous_cycle, states: %i[accepted]
-    create recruitment_cycle_year: previous_cycle, states: %i[recruited]
-    create recruitment_cycle_year: previous_cycle, states: %i[conditions_not_met]
-    create recruitment_cycle_year: previous_cycle, states: %i[withdrawn]
-    create recruitment_cycle_year: previous_cycle, states: %i[application_not_sent]
+    if next_cycle_applications
+      create recruitment_cycle_year: next_cycle, states: %i[awaiting_provider_decision], incomplete_references: true
+      create recruitment_cycle_year: next_cycle, states: %i[awaiting_provider_decision], incomplete_references: false
+      create recruitment_cycle_year: next_cycle, states: %i[pending_conditions], incomplete_references: true
+      create recruitment_cycle_year: next_cycle, states: %i[pending_conditions], incomplete_references: false
+      create recruitment_cycle_year: next_cycle, states: %i[offer awaiting_provider_decision offer], incomplete_references: true
+      create recruitment_cycle_year: next_cycle, states: %i[offer], incomplete_references: true
+      create recruitment_cycle_year: next_cycle, states: %i[offer], incomplete_references: false
+      create recruitment_cycle_year: next_cycle, states: %i[recruited], incomplete_references: false
+      create recruitment_cycle_year: next_cycle, states: %i[rejected rejected], incomplete_references: false
+      create recruitment_cycle_year: next_cycle, states: %i[offer_withdrawn], incomplete_references: true
+      create recruitment_cycle_year: next_cycle, states: %i[offer_deferred], incomplete_references: false
+    else
+      create recruitment_cycle_year: previous_cycle, states: %i[rejected rejected]
+      create recruitment_cycle_year: previous_cycle, states: %i[offer_withdrawn]
+      create recruitment_cycle_year: previous_cycle, states: %i[offer_deferred]
+      create recruitment_cycle_year: previous_cycle, states: %i[offer_deferred]
+      create recruitment_cycle_year: previous_cycle, states: %i[declined]
+      create recruitment_cycle_year: previous_cycle, states: %i[accepted]
+      create recruitment_cycle_year: previous_cycle, states: %i[recruited]
+      create recruitment_cycle_year: previous_cycle, states: %i[conditions_not_met]
+      create recruitment_cycle_year: previous_cycle, states: %i[withdrawn]
+      create recruitment_cycle_year: previous_cycle, states: %i[application_not_sent]
 
-    create recruitment_cycle_year: current_cycle, states: %i[unsubmitted]
-    create recruitment_cycle_year: current_cycle, states: %i[unsubmitted], course_full: true
-    create recruitment_cycle_year: current_cycle, states: %i[unsubmitted_with_completed_references]
-    create recruitment_cycle_year: current_cycle, states: %i[awaiting_provider_decision awaiting_provider_decision awaiting_provider_decision]
-    create recruitment_cycle_year: current_cycle, states: %i[awaiting_provider_decision awaiting_provider_decision awaiting_provider_decision]
-    create recruitment_cycle_year: current_cycle, states: %i[awaiting_provider_decision awaiting_provider_decision awaiting_provider_decision]
-    create recruitment_cycle_year: current_cycle, states: %i[interviewing awaiting_provider_decision offer]
-    create recruitment_cycle_year: current_cycle, states: %i[interviewing interviewing]
-    create recruitment_cycle_year: current_cycle, states: %i[awaiting_provider_decision], apply_again: true
-    create recruitment_cycle_year: current_cycle, states: %i[awaiting_provider_decision], carry_over: true
-    create recruitment_cycle_year: current_cycle, states: %i[offer offer]
-    create recruitment_cycle_year: current_cycle, states: %i[offer_changed]
-    create recruitment_cycle_year: current_cycle, states: %i[offer rejected]
-    create recruitment_cycle_year: current_cycle, states: %i[offer rejected], carry_over: true
-    create recruitment_cycle_year: current_cycle, states: %i[offer], apply_again: true
-    create recruitment_cycle_year: current_cycle, states: %i[rejected rejected]
-    create recruitment_cycle_year: current_cycle, states: %i[offer_withdrawn]
-    create recruitment_cycle_year: current_cycle, states: %i[offer_deferred]
-    create recruitment_cycle_year: current_cycle, states: %i[offer_deferred]
-    create recruitment_cycle_year: current_cycle, states: %i[declined]
-    create recruitment_cycle_year: current_cycle, states: %i[accepted]
-    create recruitment_cycle_year: current_cycle, states: %i[accepted_no_conditions]
-    create recruitment_cycle_year: current_cycle, states: %i[recruited]
-    create recruitment_cycle_year: current_cycle, states: %i[conditions_not_met]
-    create recruitment_cycle_year: current_cycle, states: %i[withdrawn]
+      create recruitment_cycle_year: current_cycle, states: %i[unsubmitted]
+      create recruitment_cycle_year: current_cycle, states: %i[unsubmitted], course_full: true
+      create recruitment_cycle_year: current_cycle, states: %i[unsubmitted_with_completed_references]
+      create recruitment_cycle_year: current_cycle, states: %i[awaiting_provider_decision awaiting_provider_decision awaiting_provider_decision]
+      create recruitment_cycle_year: current_cycle, states: %i[awaiting_provider_decision awaiting_provider_decision awaiting_provider_decision]
+      create recruitment_cycle_year: current_cycle, states: %i[awaiting_provider_decision awaiting_provider_decision awaiting_provider_decision]
+      create recruitment_cycle_year: current_cycle, states: %i[interviewing awaiting_provider_decision offer]
+      create recruitment_cycle_year: current_cycle, states: %i[interviewing interviewing]
+      create recruitment_cycle_year: current_cycle, states: %i[awaiting_provider_decision], apply_again: true
+      create recruitment_cycle_year: current_cycle, states: %i[awaiting_provider_decision], carry_over: true
+      create recruitment_cycle_year: current_cycle, states: %i[offer offer]
+      create recruitment_cycle_year: current_cycle, states: %i[offer_changed]
+      create recruitment_cycle_year: current_cycle, states: %i[offer rejected]
+      create recruitment_cycle_year: current_cycle, states: %i[offer rejected], carry_over: true
+      create recruitment_cycle_year: current_cycle, states: %i[offer], apply_again: true
+      create recruitment_cycle_year: current_cycle, states: %i[rejected rejected]
+      create recruitment_cycle_year: current_cycle, states: %i[offer_withdrawn]
+      create recruitment_cycle_year: current_cycle, states: %i[offer_deferred]
+      create recruitment_cycle_year: current_cycle, states: %i[offer_deferred]
+      create recruitment_cycle_year: current_cycle, states: %i[declined]
+      create recruitment_cycle_year: current_cycle, states: %i[accepted]
+      create recruitment_cycle_year: current_cycle, states: %i[accepted_no_conditions]
+      create recruitment_cycle_year: current_cycle, states: %i[recruited]
+      create recruitment_cycle_year: current_cycle, states: %i[conditions_not_met]
+      create recruitment_cycle_year: current_cycle, states: %i[withdrawn]
+    end
 
     StateChangeNotifier.disable_notifications do
       RejectApplicationsByDefault.new.call
@@ -51,7 +66,7 @@ class GenerateTestApplications
 
 private
 
-  def create(recruitment_cycle_year:, states:, apply_again: false, carry_over: false, course_full: false)
+  def create(recruitment_cycle_year:, states:, apply_again: false, carry_over: false, course_full: false, incomplete_references: false)
     TestApplications.new.create_application(
       states:,
       recruitment_cycle_year:,
@@ -59,11 +74,12 @@ private
       apply_again:,
       carry_over:,
       course_full:,
+      incomplete_references:,
     )
   end
 
   def courses_to_apply_to(year)
-    courses = Course.open_on_apply.in_cycle(year)
+    courses = Course.open_on_apply.in_cycle([RecruitmentCycle.current_year, year].min)
 
     if dev_support_user
       courses = courses.where(provider: dev_support_user.providers)

--- a/spec/workers/generate_test_applications_spec.rb
+++ b/spec/workers/generate_test_applications_spec.rb
@@ -43,4 +43,36 @@ RSpec.describe GenerateTestApplications, mid_cycle: true do
     # there is at least one successful apply again application
     expect(ApplicationForm.joins(:application_choices).where('application_choices.status': 'offer', phase: 'apply_2').where.not(previous_application_form_id: nil)).not_to be_empty
   end
+
+  it 'generates test applications for the next cycle', sidekiq: true do
+    FeatureFlag.activate(:new_references_flow)
+    current_cycle = RecruitmentCycle.current_year
+    next_cycle = RecruitmentCycle.next_year
+    provider = create(:provider)
+
+    create(:course_option, course: create(:course, :open_on_apply, recruitment_cycle_year: current_cycle, provider: provider))
+    create(:course_option, course: create(:course, :open_on_apply, recruitment_cycle_year: current_cycle, provider: provider))
+    create(:course_option, course: create(:course, :open_on_apply, recruitment_cycle_year: current_cycle, provider: provider))
+
+    ClimateControl.modify(STATE_CHANGE_SLACK_URL: 'https://example.com') do
+      described_class.new.perform(true)
+    end
+
+    pending_references = ApplicationChoice.where(status: :pending_conditions).first.application_form.application_references.flat_map(&:feedback_status)
+    processed_references = ApplicationChoice.where(status: :pending_conditions).last.application_form.application_references.flat_map(&:feedback_status)
+
+    expect(ApplicationChoice.pluck(:status)).to include(
+      'awaiting_provider_decision',
+      'pending_conditions',
+      'offer',
+      'rejected',
+      'offer_withdrawn',
+      'offer_deferred',
+      'recruited',
+    )
+
+    expect(ApplicationForm.last.recruitment_cycle_year).to eq next_cycle
+    expect(pending_references).to eq %w[feedback_requested feedback_requested feedback_requested feedback_requested feedback_requested]
+    expect(processed_references).to eq %w[feedback_refused cancelled feedback_provided feedback_provided feedback_provided]
+  end
 end


### PR DESCRIPTION
## Context

We're launching the new references flow in the next cycle. This feature will only be shown to candidates who have a `recruitment_cycle_year` value of next cycle. This requires the user to manually update the recruitment cycle value on the application form. This task will generate next cycle applications in various states.

## Changes proposed in this pull request

New task in the support UI:
<img width="1151" alt="image" src="https://user-images.githubusercontent.com/47917431/192226789-0944619e-dc47-437d-accc-29b8d77863da.png">


## Guidance to review

Maybe we don't care about the course itself for the purpose of out testing but i'm not a fan of:

```
courses = if year == RecruitmentCycle.next_year
                Course.open_on_apply.in_cycle(RecruitmentCycle.current_year)
              else
                Course.open_on_apply.in_cycle(year)
              end
```

Also need to consider the `POST /test-data/generate` endpoint, but perhaps for a follow up PR.

