### PR TITLE
Add next_cycle param to the generate test data endpoint

### DIFF
--- a/app/controllers/vendor_api/test_data_controller.rb
+++ b/app/controllers/vendor_api/test_data_controller.rb
@@ -23,6 +23,7 @@ module VendorAPI
         for_ratified_courses: for_ratified_courses_param,
         for_test_provider_courses: for_test_provider_courses_param,
         incomplete_references: with_incomplete_references_param,
+        next_cycle: next_cycle_param,
       ).call
 
       render json: { data: { message: 'Request submitted. Applications will appear once they have been generated' } }
@@ -75,7 +76,13 @@ module VendorAPI
     end
 
     def previous_cycle?
+      return false if next_cycle_param
+
       params[:previous_cycle] == 'true'
+    end
+
+    def next_cycle_param
+      params[:next_cycle] == 'true'
     end
   end
 end

--- a/app/services/generate_test_applications_for_provider.rb
+++ b/app/services/generate_test_applications_for_provider.rb
@@ -7,7 +7,8 @@ class GenerateTestApplicationsForProvider
     for_ratified_courses: false,
     for_test_provider_courses: false,
     previous_cycle: false,
-    incomplete_references: false
+    incomplete_references: false,
+    next_cycle: false
   )
     @provider = provider
     @courses_per_application = courses_per_application
@@ -21,6 +22,7 @@ class GenerateTestApplicationsForProvider
     @for_test_provider_courses = for_test_provider_courses
     @previous_cycle = previous_cycle
     @incomplete_references = incomplete_references
+    @next_cycle = next_cycle
   end
 
   def call
@@ -33,7 +35,7 @@ class GenerateTestApplicationsForProvider
       raise ParameterInvalid, 'Parameter is invalid (cannot be greater than number of available courses): courses_per_application' if course_ids.count < courses_per_application
 
       GenerateTestApplicationsForCourses.perform_async(
-        course_ids, courses_per_application, previous_cycle, incomplete_references
+        course_ids, courses_per_application, previous_cycle, incomplete_references, next_cycle
       )
     end
   end
@@ -41,7 +43,8 @@ class GenerateTestApplicationsForProvider
 private
 
   attr_reader :provider, :courses_per_application, :application_count, :for_training_courses,
-              :for_ratified_courses, :for_test_provider_courses, :previous_cycle, :incomplete_references
+              :for_ratified_courses, :for_test_provider_courses, :previous_cycle, :incomplete_references,
+              :next_cycle
 
   def random_course_ids_to_apply_for
     even_split = even_split_for_number_of_course_types


### PR DESCRIPTION
## Context

We have an [endpoint](https://www.apply-for-teacher-training.service.gov.uk/api-docs/v1.1/reference#post-test-data-generate) that providers use to generate test data over the API.

For them to test the new references flow they need applications in the next recruitment cycle (as it's not yet launched).

## Changes proposed in this pull request

Add `next_cycle` param. This will generate applications in the 2023 recruitment cycle year. It randomly alternates between setting the application status to conditions pending and awaiting provider decision.

## Guidance to review

Postman:

`localhost:3000/api/v1.1/test-data/generate?next_cycle=true&count=5&incomplete_references=true`
or
`localhost:3000/api/v1.1/test-data/generate?next_cycle=true&count=5`

passing in:
`localhost:3000/api/v1.1/test-data/generate?next_cycle=true&previous_cycle=false&count=5`
should keep `previous_cycle` as false

## Link to Trello card

https://trello.com/c/3VwATjRt/682-add-next-cycle-parameter-to-post-test-data-generate

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
