### PR TITLE
Remove mention of offer once an offer has been accepted

### DIFF
--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -159,7 +159,7 @@
 <section class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.safeguarding') %></h2>
   <% if @application_form.show_new_reference_flow? %>
-    <h3 class="govuk-heading-m"><%= t('page_titles.new_references') %></h3>
+    <h3 class="govuk-heading-m"><%= @application_form.any_offer_accepted? ? 'Reference requests' : t('page_titles.new_references') %></h3>
     <%= render(CandidateInterface::NewReferencesReviewComponent.new(application_form: current_application, editable: editable, references: @application_form.application_references, heading_level: 3, return_to_application_review: true, missing_error: missing_error)) %>
     <h3 class="govuk-heading-m"><%= t('page_titles.suitability_to_work_with_children') %></h3>
   <% end %>


### PR DESCRIPTION
## Context

Tiny content bug – if a candidate views their application after accepting an offer we still say `References to be requested if you accept an offer`. This doesn't make sense.

## Changes proposed in this pull request

Conditionally change the title depending on application status.

|Before|After|
|---|---|
|<img width="1017" alt="image" src="https://user-images.githubusercontent.com/47917431/192527427-4541932c-bc5e-442d-a83c-81ef440ac0dc.png">|<img width="1022" alt="image" src="https://user-images.githubusercontent.com/47917431/192527352-c4aabdfc-f4e4-42fb-a49f-6f90b9126405.png">|
