### PR TITLE
Don't scope course searches by provider for course change support page

### DIFF
--- a/app/views/support_interface/application_forms/application_choices/change_offered_course/offered_course_options.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/change_offered_course/offered_course_options.html.erb
@@ -5,10 +5,25 @@
   <%= form_with model: @pick_course, url: support_interface_application_form_application_choice_choose_offered_course_option_path(course_code: @pick_course.course_code) do |f| %>
     <%= f.govuk_error_summary %>
     <%= f.govuk_radio_buttons_fieldset :course_option_id, legend: { text: 'Which course should be added to the application?', size: 'm' } do %>
-      <% @pick_course.course_options.each_with_index do |co, i| %>
-        <%= f.govuk_radio_button :course_option_id, co.course_option_id, label: { text: "#{co.provider_name} (#{co.provider_code}) – #{co.course_name} (#{co.course_code})" }, hint: { text: "#{co.site_name} – #{co.study_mode}" }, link_errors: i.zero? %>
+      <% if (same_provider = @pick_course.course_options_for_provider(@application_choice.provider)).any? %>
+        <h2 class="govuk-heading-s">Courses from the same provider (<%= @application_choice.provider.name_and_code %>)</h2>
+        <div class="same-provider govuk-!-margin-bottom-6">
+          <% same_provider.each_with_index do |co, i| %>
+            <%= f.govuk_radio_button :course_option_id, co.course_option_id, label: { text: "#{co.course_name} (#{co.course_code})" }, hint: { text: "#{co.site_name} – #{co.study_mode}" }, link_errors: i.zero? %>
+          <% end %>
+        </div>
+      <% end %>
+
+      <% if (other_providers = @pick_course.course_options_for_other_providers(@application_choice.provider)).any? %>
+        <h2 class="govuk-heading-s">Courses from other providers</h2>
+        <div class="other-providers">
+          <% other_providers.each_with_index do |co, i| %>
+            <%= f.govuk_radio_button :course_option_id, co.course_option_id, label: { text: "#{co.provider_name} (#{co.provider_code}) – #{co.course_name} (#{co.course_code})" }, hint: { text: "#{co.site_name} – #{co.study_mode}" }, link_errors: i.zero? %>
+          <% end %>
+        </div>
       <% end %>
     <% end %>
+
     <%= f.govuk_submit 'Continue' %>
   <% end %>
 <% else %>

--- a/app/views/support_interface/application_forms/application_choices/change_offered_course/offered_course_options.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/change_offered_course/offered_course_options.html.erb
@@ -1,17 +1,17 @@
 <% content_for :title, title_with_error_prefix("Choose a course to replace #{@application_choice.current_course_option.course.name_and_code}", @pick_course.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(support_interface_application_form_application_choice_change_offered_course_search_path(course_code: @pick_course.course_code)) %>
 
-<% if @pick_course.course_options_for_provider(@application_choice.provider).present? %>
+<% if @pick_course.course_options.present? %>
   <%= form_with model: @pick_course, url: support_interface_application_form_application_choice_choose_offered_course_option_path(course_code: @pick_course.course_code) do |f| %>
     <%= f.govuk_error_summary %>
     <%= f.govuk_radio_buttons_fieldset :course_option_id, legend: { text: 'Which course should be added to the application?', size: 'm' } do %>
-      <% @pick_course.course_options_for_provider(@application_choice.provider).each_with_index do |co, i| %>
+      <% @pick_course.course_options.each_with_index do |co, i| %>
         <%= f.govuk_radio_button :course_option_id, co.course_option_id, label: { text: "#{co.provider_name} (#{co.provider_code}) – #{co.course_name} (#{co.course_code})" }, hint: { text: "#{co.site_name} – #{co.study_mode}" }, link_errors: i.zero? %>
       <% end %>
     <% end %>
     <%= f.govuk_submit 'Continue' %>
   <% end %>
 <% else %>
-  <p class="govuk-body">No courses for <%= @application_choice.provider.name_and_code %> found.</p>
+  <p class="govuk-body">No open courses found for current recruitment cycle.</p>
   <%= govuk_button_link_to('Search again', support_interface_application_form_application_choice_change_offered_course_search_path(course_code: @pick_course.course_code)) %>
 <% end %>

--- a/spec/system/support_interface/change_offered_course_for_a_submitted_application_spec.rb
+++ b/spec/system/support_interface/change_offered_course_for_a_submitted_application_spec.rb
@@ -65,6 +65,14 @@ RSpec.feature 'Add course to submitted application' do
     and_i_should_see_new_course_with_no_vacancies_has_been_offered
   end
 
+  scenario 'Support user changes offered course where the new course is also available at other providers' do
+    when_i_click_on_change_offered_course
+    and_i_enter_a_course_code_which_is_available_at_the_same_provider_and_at_other_providers
+    and_i_click_search
+    then_i_should_see_the_course_results_page_with_results_for_the_same_provider
+    and_i_should_see_the_course_results_page_with_results_for_other_providers
+  end
+
   def given_i_am_a_support_user
     sign_in_as_support_user
   end
@@ -156,7 +164,7 @@ RSpec.feature 'Add course to submitted application' do
   end
 
   def when_i_select_a_course
-    choose "#{@course_option.provider.name} (#{@course_option.provider.code}) – #{@course_option.course.name} (#{@course_code})"
+    choose "#{@course_option.course.name} (#{@course_code})"
   end
   alias_method :when_i_select_a_course_with_no_vacancies, :when_i_select_a_course
 
@@ -220,5 +228,32 @@ RSpec.feature 'Add course to submitted application' do
 
   def when_i_confirm_changing_the_course
     find('input[name="support_interface_application_forms_update_offered_course_option_form[confirm_course_change]"]').check
+  end
+
+  def and_i_enter_a_course_code_which_is_available_at_the_same_provider_and_at_other_providers
+    course_at_same_provider = create(:course, :open_on_apply, funding_type: 'fee', provider: @application_choice.provider)
+    @course_code = course_at_same_provider.code
+    course_at_different_provider = create(:course, :open_on_apply, funding_type: 'fee', provider: create(:provider), code: @course_code)
+
+    @course_option_same_provider = create(:course_option, course: course_at_same_provider)
+    @course_option_different_provider = create(:course_option, course: course_at_different_provider)
+
+    fill_in('Course code', with: @course_code)
+  end
+
+  def then_i_should_see_the_course_results_page_with_results_for_the_same_provider
+    expect(page).to have_content("Choose a course to replace #{@application_choice.course.name_and_code}")
+
+    expect(page).to have_content("Courses from the same provider (#{@application_choice.provider.name_and_code})")
+    within '.same-provider' do
+      expect(page).to have_content(@course_option_same_provider.course.name_and_code)
+    end
+  end
+
+  def and_i_should_see_the_course_results_page_with_results_for_other_providers
+    expect(page).to have_content('Courses from other providers')
+    within '.other-providers' do
+      expect(page).to have_content("#{@course_option_different_provider.course.provider.name_and_code} – #{@course_option_different_provider.course.name_and_code}")
+    end
   end
 end

--- a/spec/system/support_interface/change_offered_course_for_a_submitted_application_spec.rb
+++ b/spec/system/support_interface/change_offered_course_for_a_submitted_application_spec.rb
@@ -19,9 +19,9 @@ RSpec.feature 'Add course to submitted application' do
 
     when_i_fill_in_the_course_code_for_a_course_that_is_not_associated_with_the_ratifying_provider
     and_i_click_search
-    then_i_should_see_the_course_results_page_with_no_results
+    then_i_should_see_the_course_results_page_with_results
 
-    when_i_click_search_again
+    when_i_click_back
     and_i_enter_a_course_code_for_a_course_that_has_the_same_ratifying_provider
     and_i_click_search
     then_i_should_see_the_course_results_page_with_results
@@ -103,8 +103,8 @@ RSpec.feature 'Add course to submitted application' do
 
   def when_i_fill_in_the_course_code_for_a_course_that_is_not_associated_with_the_ratifying_provider
     @other_providers_course_option = create(:course_option, course: create(:course, :open_on_apply))
-    @unassociated_course_code = @other_providers_course_option.course.code
-    fill_in('Course code', with: @unassociated_course_code)
+    @course_code = @other_providers_course_option.course.code
+    fill_in('Course code', with: @course_code)
   end
 
   def and_i_click_search
@@ -123,6 +123,10 @@ RSpec.feature 'Add course to submitted application' do
 
   def when_i_click_search_again
     click_link 'Search again'
+  end
+
+  def when_i_click_back
+    click_link 'Back'
   end
 
   def and_i_enter_a_course_code_for_a_course_that_has_the_same_ratifying_provider


### PR DESCRIPTION
This allows support staff to move a candidate from one provider to another, e.g. when organisations merge etc.

## Context

We're doing this as a (probably) short term measure to allow the merging of several providers.

## Changes proposed in this pull request

### Before
<img width="829" alt="Screenshot 2022-09-28 at 12 40 16" src="https://user-images.githubusercontent.com/109225/192769924-d0f6dfa3-44d1-4b59-9b50-3831a0d08dd5.png">

### After
<img width="791" alt="Screenshot 2022-09-28 at 12 31 28" src="https://user-images.githubusercontent.com/109225/192769931-13a987b9-ae03-4381-9d80-6852cee542e8.png">

## Link to Trello card

https://trello.com/c/pZbvttyX/686-relax-provider-only-restriction-when-changing-courses
https://trello.com/c/GykXgxhQ/1715-transfer-applicants-to-different-organisation

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
