### PR TITLE
Allow providers to download application references as a PDF

### DIFF
--- a/app/views/provider_interface/references/index.html.erb
+++ b/app/views/provider_interface/references/index.html.erb
@@ -3,6 +3,16 @@
 <%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(application_choice: @application_choice, provider_can_respond: @provider_can_make_decisions, provider_can_set_up_interviews: @provider_can_set_up_interviews) %>
 <h1 class="govuk-heading-l">References</h1>
 
+<% if FeatureFlag.active?(:new_references_flow_providers) %>
+  <p class="govuk-body govuk-!-display-none-print">
+    <%= govuk_link_to(
+      'Download references (PDF)',
+      provider_interface_application_choice_references_path(@application_choice.id, format: :pdf),
+      download: "#{@application_choice.application_form.support_reference}-references",
+    ) %>
+  </p>
+<% end %>
+
 <% if @application_choice.pre_offer? || @application_choice.offer? %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/spec/system/provider_interface/see_individual_application_as_pdf_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_as_pdf_spec.rb
@@ -5,14 +5,24 @@ RSpec.feature 'Provider sees an application as PDF' do
   include DfESignInHelpers
 
   scenario 'viewing application in PDF format' do
+    given_the_new_reference_flow_feature_flag_is_on
+
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_permitted_to_see_applications_for_my_provider
     and_i_sign_in_to_the_provider_interface
     and_an_application_exists
 
     when_i_visit_the_provider_application_page
-    and_i_click_the_pdf_link
+    and_i_click_the_applications_pdf_link
     then_i_should_see_the_application_choice_in_pdf_format
+
+    when_i_visit_the_provider_application_references_page
+    and_i_click_the_references_pdf_link
+    then_i_should_see_the_application_references_in_pdf_format
+  end
+
+  def given_the_new_reference_flow_feature_flag_is_on
+    FeatureFlag.activate(:new_references_flow_providers)
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -47,11 +57,25 @@ RSpec.feature 'Provider sees an application as PDF' do
     visit provider_interface_application_choice_path(@application_choice.id)
   end
 
-  def and_i_click_the_pdf_link
+  def and_i_click_the_applications_pdf_link
     click_on 'Download application (PDF)'
   end
 
   def then_i_should_see_the_application_choice_in_pdf_format
+    expect(page.driver.response.status).to eq(200)
+    expect(page.driver.response.content_type).to eq('application/pdf')
+    expect(page.driver.response.length).to be > 0
+  end
+
+  def when_i_visit_the_provider_application_references_page
+    visit provider_interface_application_choice_references_path(@application_choice.id)
+  end
+
+  def and_i_click_the_references_pdf_link
+    click_on 'Download references (PDF)'
+  end
+
+  def then_i_should_see_the_application_references_in_pdf_format
     expect(page.driver.response.status).to eq(200)
     expect(page.driver.response.content_type).to eq('application/pdf')
     expect(page.driver.response.length).to be > 0


### PR DESCRIPTION
## Context

Providers can download a PDF copy of an application. References once appeared in this, now they do not.

Adding a link to the references tab that will allow them to download a PDF copy.

## Changes proposed in this pull request

<img width="731" alt="image" src="https://user-images.githubusercontent.com/47917431/192759331-8d3924fc-6b33-45a8-a7fe-8cc8d530a7f8.png">

## Link to Trello card

https://trello.com/c/Clo1wzMu/687-add-references-to-the-application-pdf-download
