### PR TITLE
Fix a flakey spec in `DetectInvariantsDailyCheck`

### DIFF
--- a/app/workers/detect_invariants_daily_check.rb
+++ b/app/workers/detect_invariants_daily_check.rb
@@ -132,7 +132,7 @@ class DetectInvariantsDailyCheck
 
   def detect_obsolete_feature_flags
     feature_names = FeatureFlag::FEATURES.map(&:first)
-    obsolete_features = Feature.where.not(name: feature_names)
+    obsolete_features = Feature.where.not(name: feature_names).order(:name)
 
     return if obsolete_features.none?
 

--- a/spec/workers/detect_invariants_daily_check_spec.rb
+++ b/spec/workers/detect_invariants_daily_check_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe DetectInvariantsDailyCheck do
       described_class.new.perform
 
       message = 'The following obsolete feature flags have yet to be deleted from the database: ' \
-                "#{obsolete_features.map(&:name).to_sentence}"
+                "#{obsolete_features.map(&:name).sort.to_sentence}"
 
       expect(Sentry).to have_received(:capture_exception)
                     .with(described_class::ObsoleteFeatureFlags.new(message))


### PR DESCRIPTION
When selecting records from an SQL database there's no guarantee of returned order if one is not specified.

If we were just checking two arrays in this test then we could use a matcher that ignores order, but since it's converted to a sentence that's not possible.

Ordering by name seems as good an option as any.

## Context

https://github.com/DFE-Digital/apply-for-teacher-training/pull/7475#issuecomment-1259533905
