### PR TITLE
Update the reference object description

### DIFF
--- a/config/vendor_api/v1.0.yml
+++ b/config/vendor_api/v1.0.yml
@@ -503,6 +503,7 @@ components:
           type: array
           items:
             "$ref": "#/components/schemas/Reference"
+          description: References will only be included once a candidate has accepted an offer and has received a reference. There is no limit to the number of references.
         offer:
           anyOf:
           - "$ref": "#/components/schemas/Offer"


### PR DESCRIPTION
## Context

With the new reference flow we're changing what we surface over the API with references.

We will now send an empty array initially and will only populate it with references once the candidate has accepted an offer and references have been provided.

Updating the API spec to mention this.

## Changes proposed in this pull request

<img width="989" alt="image" src="https://user-images.githubusercontent.com/47917431/192962414-192dd9ef-1923-41bc-87e9-1c918ba83e5f.png">

## Link to Trello card

https://trello.com/c/DqtK25Rj/435-references-update-api-spec
