### PR TITLE
Ensure hesa_degctry is limited to 2 characters

### DIFF
--- a/app/presenters/hesa_qualification_fields_presenter.rb
+++ b/app/presenters/hesa_qualification_fields_presenter.rb
@@ -43,7 +43,7 @@ class HesaQualificationFieldsPresenter
     iso_code = HESA_DEGCTRY_MAPPING.fetch(
       @qualification.institution_country, @qualification.institution_country
     )
-    alpha2 = iso_code[0, 2]
+    alpha2 = iso_code&.slice(0, 2)
     { hesa_degctry: alpha2 }
   end
 end

--- a/app/presenters/hesa_qualification_fields_presenter.rb
+++ b/app/presenters/hesa_qualification_fields_presenter.rb
@@ -40,6 +40,10 @@ class HesaQualificationFieldsPresenter
   end
 
   def hesa_degctry
-    { hesa_degctry: HESA_DEGCTRY_MAPPING.fetch(@qualification.institution_country, @qualification.institution_country) }
+    iso_code = HESA_DEGCTRY_MAPPING.fetch(
+      @qualification.institution_country, @qualification.institution_country
+    )
+    alpha2 = iso_code[0, 2]
+    { hesa_degctry: alpha2 }
   end
 end

--- a/spec/presenters/hesa_qualification_fields_presenter_spec.rb
+++ b/spec/presenters/hesa_qualification_fields_presenter_spec.rb
@@ -38,6 +38,16 @@ RSpec.describe HesaQualificationFieldsPresenter do
       end
     end
 
+    context 'when iso3166 institution country code is for a specific territory' do
+      it 'returns the alpha-2 two-character version' do
+        iso3166_code = 'AE-DU'
+        presenter = described_class.new(
+          build(:degree_qualification, institution_country: iso3166_code),
+        )
+        expect(presenter.to_hash[:hesa_degctry]).to eq('AE')
+      end
+    end
+
     context 'when the start and award years are missing' do
       let(:qualification) { create(:degree_qualification, start_year: nil, award_year: nil) }
 


### PR DESCRIPTION
We [specify](https://www.apply-for-teacher-training.service.gov.uk/api-docs/v1.1/reference#qualification-object) that a `Qualification` object's `hesa_degctry` is limited to 2 characters. However, the institution country field contains an ISO3166 code which sometimes includes country and territory, eg `"UE-DU"` for Dubai.

To make our implementation consistent with the docs, trim the country code so it always returns the Alpha-2 substring.

## Context

A vendor has imported an application with a degree code of Dubai, which is breaking their integration.

## Changes proposed in this pull request

To make our implementation consistent with the docs, trim the country code so it always returns the Alpha-2 substring.

## Guidance to review

Running locally, update an application like so:

```
app.application_qualifications.degree.first.update(institution_country: 'AE-DU')
```

Then fetch that application via the API and ensure that the `hesa_degctry` is `AE`.

## Link to Trello card

https://trello.com/c/Y3Hz7dHF/685-hesa-country-field-is-not-always-2-characters

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
