### PR TITLE
Don't generate interviews for test applications when between cycles

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -354,6 +354,8 @@ private
   end
 
   def schedule_interview(choice)
+    return if CycleTimetable.between_reject_by_default_and_find_reopens?
+
     as_provider_user(choice) do
       interview_date = [7.business_days.from_now, choice.reject_by_default_at].min
       fast_forward

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -110,6 +110,10 @@ class CycleTimetable
     Time.zone.now.between?(CycleTimetable.apply_1_deadline, CycleTimetable.find_closes)
   end
 
+  def self.between_reject_by_default_and_find_reopens?
+    Time.zone.now.between?(CycleTimetable.reject_by_default, CycleTimetable.find_reopens)
+  end
+
   def self.show_apply_2_deadline_banner?(application_form)
     Time.zone.now.between?(date(:show_deadline_banner), date(:apply_2_deadline)) &&
       (application_form.phase == 'apply_2' || (application_form.phase == 'apply_1' && application_form.ended_without_success?))

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -514,4 +514,22 @@ RSpec.describe CycleTimetable do
       end
     end
   end
+
+  describe '.between_reject_by_default_and_find_reopens?' do
+    context 'it is before reject by default date' do
+      it 'returns false' do
+        Timecop.travel(described_class.reject_by_default - 1.day) do
+          expect(described_class.between_reject_by_default_and_find_reopens?).to be(false)
+        end
+      end
+    end
+
+    context 'it is after reject by default date' do
+      it 'returns true' do
+        Timecop.travel(described_class.reject_by_default + 1.day) do
+          expect(described_class.between_reject_by_default_and_find_reopens?).to be(true)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
While the `TestApplications` class manages its own copy of a running timestamp, other parts of the application still use `Time.zone.now`, especially the `CycleTimetable`, so various parts of the test application creation is still tied to the real world time.  In this particular case, the scheduling of interviews.

A thorough revision of how we try to artificially manage time outside of the test suite is needed to fix this properly, for now we're just skipping the creation of interviews if we're between cycles.

This will start working normally again after Find reopens.

## Context

This is breaking builds and QA test application generation.

## Link to Trello card

https://trello.com/c/LdwoNnAA/693-fix-failing-spec-cannot-schedule-interview-in-the-past
