### PR TITLE
Render post offer dashboard for recruited candidates

### DIFF
--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -41,8 +41,8 @@ module CandidateInterface
       redirect_to candidate_interface_application_complete_path if current_application.submitted?
     end
 
-    def redirect_to_post_offer_dashboard_if_accepted
-      redirect_to candidate_interface_application_offer_dashboard_path if any_accepted_offer? && current_application.show_new_reference_flow?
+    def redirect_to_post_offer_dashboard_if_accepted_or_recruited
+      redirect_to candidate_interface_application_offer_dashboard_path if (any_accepted_offer? || current_application.recruited?) && current_application.show_new_reference_flow?
     end
 
     def redirect_to_application_form_unless_submitted
@@ -136,11 +136,15 @@ module CandidateInterface
     end
 
     def redirect_to_completed_dashboard_if_not_accepted
-      redirect_to candidate_interface_application_complete_path if !any_accepted_offer? || FeatureFlag.inactive?(:new_references_flow)
+      redirect_to candidate_interface_application_complete_path if no_offers_accepted_and_not_recruited? || FeatureFlag.inactive?(:new_references_flow)
     end
 
     def any_accepted_offer?
       current_application.application_choices.map(&:status).include?('pending_conditions')
+    end
+
+    def no_offers_accepted_and_not_recruited?
+      !any_accepted_offer? && !current_application.recruited?
     end
   end
 end

--- a/app/controllers/candidate_interface/offer_dashboard_controller.rb
+++ b/app/controllers/candidate_interface/offer_dashboard_controller.rb
@@ -6,8 +6,9 @@ module CandidateInterface
 
     def show
       @application_form = current_application
-      @application_choice_with_offer = current_application.application_choices.pending_conditions.first
+      @application_choice_with_offer = current_application.application_choices.pending_conditions.first || current_application.application_choices.recruited.first
       @accepted_offer_provider_name = @application_choice_with_offer.provider.name
+      @accepted_offer_course_name_and_code = @application_choice_with_offer.course.name_and_code
     end
 
   private

--- a/app/controllers/candidate_interface/submitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/submitted_application_form_controller.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   class SubmittedApplicationFormController < CandidateInterfaceController
     before_action :redirect_to_application_form_unless_submitted, except: %i[start_carry_over carry_over]
-    before_action :redirect_to_post_offer_dashboard_if_accepted, only: %i[complete]
+    before_action :redirect_to_post_offer_dashboard_if_accepted_or_recruited, only: %i[complete]
 
     def review_submitted
       @application_form = current_application

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -177,6 +177,10 @@ class ApplicationChoice < ApplicationRecord
     offer&.unconditional?
   end
 
+  def all_conditions_met?
+    offer.conditions.all?(&:met?)
+  end
+
   def unconditional_offer_pending_recruitment?
     return false unless recruited?
 

--- a/app/views/candidate_interface/offer_dashboard/show.html.erb
+++ b/app/views/candidate_interface/offer_dashboard/show.html.erb
@@ -1,21 +1,27 @@
 <h1 class="govuk-heading-xl">Your teacher training course</h1>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">You’ve accepted an offer from <%= @accepted_offer_provider_name %>.</p>
-    <p class="govuk-body">Your place will be confirmed once they’ve:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>received your references</li>
-      <li>marked your offer conditions as met</li>
-    </ul>
+    <p class="govuk-body">You’ve accepted an offer from <%= @accepted_offer_provider_name %> to study <%= @accepted_offer_course_name_and_code %>.</p>
+    <% if @application_choice_with_offer.pending_conditions? %>
+      <p class="govuk-body">Your place will be confirmed once they’ve:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>received your references</li>
+        <li>marked your offer conditions as met</li>
+      </ul>
+    <% end %>
 
     <h2 class="govuk-heading-m">References</h2>
     <p class="govuk-body">Contact <%= @accepted_offer_provider_name %> if you need help getting references.</p>
     <%= render CandidateInterface::ReferencesComponent.new(application_form: @application_form) %>
     <%= govuk_button_link_to 'Request another reference', candidate_interface_request_reference_new_references_start_path, secondary: true %>
 
-    <h2 class="govuk-heading-m">Offer conditions</h2>
-    <p class="govuk-body"><%= @accepted_offer_provider_name %> will mark these conditions as met once you’ve completed them.</p>
-    <%= render CandidateInterface::ConditionsComponent.new(application_choice: @application_choice_with_offer) %>
+    <% unless @application_choice_with_offer.unconditional_offer? %>
+      <h2 class="govuk-heading-m">Offer conditions</h2>
+      <% unless @application_choice_with_offer.recruited? && @application_choice_with_offer.all_conditions_met? %>
+        <p class="govuk-body"><%= @accepted_offer_provider_name %> will mark these conditions as met once you’ve completed them.</p>
+      <% end %>
+      <%= render CandidateInterface::ConditionsComponent.new(application_choice: @application_choice_with_offer) %>
+    <% end %>
   </div>
 
   <div class="govuk-grid-column-third">

--- a/spec/system/candidate_interface/new-references/candidate_request_references_new_references_spec.rb
+++ b/spec/system/candidate_interface/new-references/candidate_request_references_new_references_spec.rb
@@ -88,7 +88,7 @@ RSpec.feature 'New References', with_audited: true do
 
   def then_i_should_see_the_post_offer_dashboard
     expect(page).to have_content 'Your teacher training course'
-    expect(page).to have_content "You’ve accepted an offer from #{@application_choice.offer.provider.name}."
+    expect(page).to have_content "You’ve accepted an offer from #{@application_choice.course_option.course.provider.name} to study #{@application_choice.course.name_and_code}."
     expect(page).to have_content 'References'
     expect(page).to have_content 'Offer conditions'
     expect(page).to have_content("#{@application_choice.offer.conditions.first.text} Pending", normalize_ws: true)

--- a/spec/system/candidate_interface/new-references/candidate_views_their_references_on_the_post_offer_dashboard_spec.rb
+++ b/spec/system/candidate_interface/new-references/candidate_views_their_references_on_the_post_offer_dashboard_spec.rb
@@ -64,7 +64,7 @@ RSpec.feature 'New References', with_audited: true do
 
   def then_i_should_see_the_post_offer_dashboard
     expect(page).to have_content 'Your teacher training course'
-    expect(page).to have_content "You’ve accepted an offer from #{@application_choice.offer.provider.name}."
+    expect(page).to have_content "You’ve accepted an offer from #{@application_choice.course_option.course.provider.name} to study #{@application_choice.course.name_and_code}."
     expect(page).to have_content 'References'
     expect(page).to have_content 'Offer conditions'
     expect(page).to have_content("#{@application_choice.offer.conditions.first.text} Pending", normalize_ws: true)

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_new_reference_feature_enabled_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_new_reference_feature_enabled_spec.rb
@@ -102,6 +102,10 @@ RSpec.feature 'Candidate accepts an offer' do
 
     when_i_visit_the_decline_page_of_the_accepted_offer
     then_i_see_the_page_not_found
+
+    when_the_provider_marks_my_application_as_recruited
+    and_i_view_my_application
+    then_i_see_the_new_dashboard_content
   end
 
   def given_i_am_signed_in
@@ -467,5 +471,17 @@ RSpec.feature 'Candidate accepts an offer' do
 
   def back_link
     find('a', text: 'Back')[:href]
+  end
+
+  def when_the_provider_marks_my_application_as_recruited
+    @application_choice.recruited!
+  end
+
+  def and_i_view_my_application
+    visit candidate_interface_application_complete_path
+  end
+
+  def then_i_see_the_new_dashboard_content
+    expect(page).to have_content "You’ve accepted an offer from #{@course_option.course.provider.name} to study #{@course_option.course.name_and_code}."
   end
 end


### PR DESCRIPTION
## Context

As we're allowing candidates to continue requesting references once they are recruited, we want to render the post offer dashboard for them, currently they'll land on a different page after being marked as recruited.

We will also hide the conditions component if they're given an unconditional offer

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="717" alt="image" src="https://user-images.githubusercontent.com/47917431/193076211-48022efb-f886-4e91-8d14-18f1c2b2f6d2.png">|<img width="779" alt="image" src="https://user-images.githubusercontent.com/47917431/193076157-05e5a3e7-b19b-4d93-b25a-8092e8b720c1.png">|

|Unconditional offer|
|---|
|<img width="753" alt="image" src="https://user-images.githubusercontent.com/47917431/193076575-29b71386-8258-40c8-b62e-5d3ad6ba31e1.png">|

## Guidance to review

https://apply-beta-prototype.herokuapp.com/dashboard/45678/recruited-conditions-met

## Link to Trello card

https://trello.com/c/PZWu4ZB4/694-references-render-the-post-offer-dashboard-for-recruited-candidates

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
