### PR TITLE
Make rack-mini-profiler opt-in

### DIFF
--- a/config/initializers/rack_profiler.rb
+++ b/config/initializers/rack_profiler.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-if HostingEnvironment.test_environment? && HostingEnvironment.environment_name != 'test'
+if HostingEnvironment.test_environment? && HostingEnvironment.environment_name != 'test' && ENV.fetch('RACK_MINI_PROFILER', nil) == 'true'
   require 'rack-mini-profiler'
 
   # initialization is skipped so trigger it


### PR DESCRIPTION
This gem has a small but sometimes noticeable effect on load times and local resources when providing profiling information, so it makes sense to only invoke it when we're going to make use of that information.

Set the env var RACK_MINI_PROFILER to `true` when you want to see profiling information (or if you want to put it back to how it was).

### Before

<img width="860" alt="Screenshot 2022-09-30 at 10 43 48" src="https://user-images.githubusercontent.com/109225/193244357-1358714d-f951-4f76-a0b7-7c0071e2e414.png">

### After

<img width="870" alt="Screenshot 2022-09-30 at 10 44 44" src="https://user-images.githubusercontent.com/109225/193244390-1b3b52ba-32ed-4c14-b72b-2c69859ce936.png">

## Link to Trello card

https://trello.com/c/0M84STpQ/695-speed-up-app-development
