### PR TITLE
Flakey isocode test

### DIFF
--- a/spec/presenters/hesa_qualification_fields_presenter_spec.rb
+++ b/spec/presenters/hesa_qualification_fields_presenter_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe HesaQualificationFieldsPresenter do
       it 'returns the institution country code' do
         iso3166_code = COUNTRIES_AND_TERRITORIES.except(*described_class::HESA_DEGCTRY_MAPPING.keys).keys.sample
         presenter = described_class.new(build(:degree_qualification, institution_country: iso3166_code))
-        expect(presenter.to_hash[:hesa_degctry]).to eq(iso3166_code)
+        expect(presenter.to_hash[:hesa_degctry]).to eq(iso3166_code&.slice(0, 2))
       end
     end
 


### PR DESCRIPTION
## Context
Now that we're coercing to 2 chars, whenever isocode happens to be the >2 letters in the sample it'll throw an error as its asserting against the code before its sliced.

## Changes proposed in this pull request
* Slice in assertion

## Guidance to review


## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
