### PR TITLE
Allow smoketest users to also bypass email confirmation outside of prod

### DIFF
--- a/app/controllers/candidate_interface/sign_up_controller.rb
+++ b/app/controllers/candidate_interface/sign_up_controller.rb
@@ -35,7 +35,7 @@ module CandidateInterface
   private
 
     def redirect_after_signup(candidate, magic_link_token)
-      if candidate.load_tester?
+      if non_prod? && candidate.test_user?
         redirect_to candidate_interface_authenticate_url(token: magic_link_token)
       else
         redirect_to candidate_interface_check_email_sign_up_path
@@ -57,5 +57,9 @@ module CandidateInterface
       @course = @provider.courses.current_cycle.find_by(code: params[:courseCode]) if @provider.present?
       @course.id if @course.present?
     end
+  end
+
+  def non_prod?
+    !HostingEnvironment.production?
   end
 end

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -67,8 +67,8 @@ class Candidate < ApplicationRecord
     application_forms.current_cycle.exists?(phase: 'apply_2')
   end
 
-  def load_tester?
-    email_address.ends_with?('@loadtest.example.com') && !HostingEnvironment.production?
+  def test_user?
+    email_address.match?(/@(?:load|smoke)test\.example\.com\z/)
   end
 
   def never_signed_in?

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -230,30 +230,32 @@ RSpec.describe Candidate, type: :model do
     end
   end
 
-  describe '#load_tester?' do
-    context 'environment is production' do
-      before { allow(HostingEnvironment).to receive(:production?).and_return true }
+  describe '#test_user?' do
+    subject(:candidate) { build(:candidate, email_address:) }
+    let(:email_address) { nil }
 
-      it 'returns false regardless of the email address pattern' do
-        candidate = build(:candidate, email_address: 'someone@loadtest.example.com')
-        expect(candidate).not_to be_load_tester
-        candidate.email_address = 'someone@example.com'
-        expect(candidate).not_to be_load_tester
-      end
+    context 'when the candidate is a smoke test user' do
+      let(:email_address) { "#{SecureRandom.uuid}@smoketest.example.com" }
+
+      it { is_expected.to be_test_user }
     end
 
-    context 'environment is not production' do
-      before { allow(HostingEnvironment).to receive(:production?).and_return false }
+    context 'when the candidate is a load test user' do
+      let(:email_address) { "#{SecureRandom.uuid}@loadtest.example.com" }
 
-      it 'returns true if email address is for load testing' do
-        candidate = build(:candidate, email_address: 'someone@loadtest.example.com')
-        expect(candidate).to be_load_tester
-      end
+      it { is_expected.to be_test_user }
+    end
 
-      it 'returns false if email is not for load testing' do
-        candidate = build(:candidate, email_address: 'someone@example.com')
-        expect(candidate).not_to be_load_tester
-      end
+    context 'when the candidate coincidentally has a test-like email address' do
+      let(:email_address) { 'some-user@othertest.example.com' }
+
+      it { is_expected.not_to be_test_user }
+    end
+
+    context 'when the candidate is not a test user' do
+      let(:email_address) { 'some-user@legit.example.com' }
+
+      it { is_expected.not_to be_test_user }
     end
   end
 end


### PR DESCRIPTION
Similarly to loadtesting, this is used for smoke testing against QA.

## Context

This is required to ship in advance of moving smoke tests from cypress to rspec.

## Link to Trello card

https://trello.com/c/SU6R3Nn0/628-replace-cypress-with-something-more-simple-less-flakey-and-ruby-based
