### PR TITLE
Use same content from label in the review screen

### DIFF
--- a/app/components/candidate_interface/new_references_review_component.rb
+++ b/app/components/candidate_interface/new_references_review_component.rb
@@ -60,7 +60,7 @@ module CandidateInterface
   private
 
     def formatted_reference_type(reference)
-      reference.referee_type ? reference.referee_type.capitalize.dasherize : ''
+      t("application_form.new_references.referee_type.#{reference.referee_type}.label")
     end
 
     def name_row(reference)

--- a/spec/components/candidate_interface/new_references_review_component_spec.rb
+++ b/spec/components/candidate_interface/new_references_review_component_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe CandidateInterface::NewReferencesReviewComponent, type: :componen
 
       type_row = result.css('.govuk-summary-list__row')[0].text
       expect(type_row).to include 'Type'
-      expect(type_row).to include 'School-based'
+      expect(type_row).to include 'School experience, such as from the headteacher of a school you’ve been working in'
     end
 
     it 'renders the relationship' do


### PR DESCRIPTION
This updates the references summary page to use the same labels for "Type" as are shown as labels when answering the question. This makes them longer, but helps improve consistency and avoid any ambiguity over "School-based", which some users have previously interpreted as being from when they were at school as a child...

## Screenshots

| Before | After |
|---|---
| <img width="1007" alt="Screenshot 2022-10-03 at 12 59 25" src="https://user-images.githubusercontent.com/30665/193572035-b2b7830b-4cad-46a2-a7df-7b0929c24759.png"> | <img width="996" alt="Screenshot 2022-10-03 at 12 59 12" src="https://user-images.githubusercontent.com/30665/193572079-3030ffb4-e4ab-4d98-bfec-129bfcc772c6.png"> |
