### PR TITLE
Update the Find has opened email to mention the new references process

### DIFF
--- a/app/views/candidate_mailer/find_has_opened.erb
+++ b/app/views/candidate_mailer/find_has_opened.erb
@@ -8,6 +8,8 @@ You can now find teacher training courses starting in the <%= @academic_year %> 
 
 Apply early to have the best chance of getting onto the course you want, as courses fill up throughout the year.
 
+You’ll need to give details of 2 people who can give you a reference. They’ll only be contacted if you accept an offer on a course.
+
 [Get your application ready](<%= candidate_magic_link(@application_form.candidate) %>).
 
 You can submit from 9am on <%= @apply_opens %>.


### PR DESCRIPTION
## Context

We want to use our email that is going out to 8,000 candidates, to tell them Find is open, to inform them of the new reference process.

## Changes proposed in this pull request

Adding an extra line:
`You’ll need to give details of 2 people who can give you a reference. They’ll only be contacted if you accept an offer on a course.`

|Before|After|
|---|---|
|<img width="619" alt="image" src="https://user-images.githubusercontent.com/47917431/193588677-2deed33c-0a30-4270-8de3-a7788bfa7578.png">|<img width="609" alt="image" src="https://user-images.githubusercontent.com/47917431/193588598-af13113c-dc2f-44b0-9d14-3e7254f54567.png">|

## Link to Trello card

https://trello.com/c/E7yVTN4q/722-update-our-find-opens-email-to-explain-the-new-reference-process
