### PR TITLE
Improve utm content param for pages before auth

### DIFF
--- a/app/views/candidate_interface/shared/_support.html.erb
+++ b/app/views/candidate_interface/shared/_support.html.erb
@@ -2,7 +2,7 @@
   <h2 class="govuk-heading-s govuk-!-margin-bottom-2" id="support-title"><%= t('layout.support.title') %></h2>
 
   <ul class="govuk-list govuk-!-font-size-16">
-    <li>Call <%= t('get_into_teaching.tel') %> or <%= govuk_link_to_with_utm_params 'chat online', t('get_into_teaching.url_online_chat'), current_candidate&.current_application.present? ? current_application.phase : nil %></li>
+    <li>Call <%= t('get_into_teaching.tel') %> or <%= govuk_link_to_with_utm_params 'chat online', t('get_into_teaching.url_online_chat'), current_candidate&.current_application.present? ? current_application.phase : t('layout.support_links.not_logged_in') %></li>
     <li><%= t('get_into_teaching.opening_times') %></li>
     <li>Free of charge</li>
   </ul>

--- a/app/views/content/complaints.html.erb
+++ b/app/views/content/complaints.html.erb
@@ -14,7 +14,7 @@
 
     <h2 class="govuk-heading-m">If you need advice about your teacher training application</h2>
 
-    <p class="govuk-body"><%= govuk_link_to_with_utm_params 'Call us or chat online', t('get_into_teaching.url_online_chat'), utm_campaign(params), current_candidate&.current_application.present? ? current_application.phase : nil %> instead.</p>
+    <p class="govuk-body"><%= govuk_link_to_with_utm_params 'Call us or chat online', t('get_into_teaching.url_online_chat'), utm_campaign(params), current_candidate&.current_application.present? ? current_application.phase : t('layout.support_links.not_logged_in') %> instead.</p>
 
     <h2 class="govuk-heading-m">What to do if a teacher training provider has treated you unfairly</h2>
 

--- a/app/views/content/terms_candidate.html.erb
+++ b/app/views/content/terms_candidate.html.erb
@@ -38,7 +38,7 @@
 
     <p class="govuk-body">Each time you submit an application you can apply for up to 3 courses.</p>
 
-    <p class="govuk-body"><%= govuk_link_to_with_utm_params('Chat online for help applying again', t('get_into_teaching.url_online_chat'), utm_campaign(params), current_candidate&.current_application.present? ? current_application.phase : nil) %>.</p>
+    <p class="govuk-body"><%= govuk_link_to_with_utm_params('Chat online for help applying again', t('get_into_teaching.url_online_chat'), utm_campaign(params), current_candidate&.current_application.present? ? current_application.phase : t('layout.support_links.not_logged_in')) %>.</p>
 
     <h3 class="govuk-heading-m">Making changes to your application</h3>
 

--- a/app/views/layouts/_footer_meta_candidate.html.erb
+++ b/app/views/layouts/_footer_meta_candidate.html.erb
@@ -1,5 +1,5 @@
 <h2 class="govuk-heading-m"><%= t('layout.support.title') %></h2>
-<p class="govuk-body-s govuk-!-margin-bottom-1">Call <%= t('get_into_teaching.tel') %> or <%= govuk_link_to_with_utm_params 'chat online', t('get_into_teaching.url_online_chat'), utm_campaign(params), current_candidate&.current_application.present? ? current_application.phase : nil, class: 'govuk-footer__link' %></p>
+<p class="govuk-body-s govuk-!-margin-bottom-1">Call <%= t('get_into_teaching.tel') %> or <%= govuk_link_to_with_utm_params 'chat online', t('get_into_teaching.url_online_chat'), utm_campaign(params), current_candidate&.current_application.present? ? current_application.phase : t('layout.support_links.not_logged_in'), class: 'govuk-footer__link' %></p>
 <p class="govuk-body-s govuk-!-margin-bottom-1"><%= t('get_into_teaching.opening_times') %></p>
 <p class="govuk-body-s">Free of charge</p>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -341,6 +341,7 @@ en:
       privacy_policy: Privacy policy
       privacy: Privacy
       roadmap: Changes to this service
+      not_logged_in: candidate_not_logged_in
   activemodel:
     attributes:
       vendor_api/metadata:

--- a/spec/helpers/utm_link_helper_spec.rb
+++ b/spec/helpers/utm_link_helper_spec.rb
@@ -37,6 +37,18 @@ RSpec.describe UtmLinkHelper, type: :helper do
         expect(link).to include('class="govuk-link"')
       end
     end
+
+    context 'when GIT links are accessed before auth' do
+      let(:application_form) { nil }
+      let(:utm_campaign) { 'candidate_interface/sign_up-new' }
+      let(:utm_content) { 'candidate_not_logged_in' }
+
+      it 'returns a user-friendly message in utm_content' do
+        link = helper.govuk_link_to_with_utm_params(link_text, link_url, utm_campaign, utm_content)
+
+        expect(link).to eq('<a class="govuk-link" href="/some/link?utm_source=apply-for-teacher-training.service.gov.uk&amp;utm_medium=referral&amp;utm_campaign=candidate_interface%2Fsign_up-new&amp;utm_content=candidate_not_logged_in">Somewhere over the rainbow</a>')
+      end
+    end
   end
 
   describe '#email_link_with_utm_params' do


### PR DESCRIPTION
## Context
In GIT's google analytics the utm content is not set when a candidate clicks on a git link from a page in the footer before auth

## Changes proposed in this pull request
* Add a user friendly message

## Guidance to review


## Link to Trello card
N/A

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
