### PR TITLE
Updated nudge email for new reference usage

### DIFF
--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
@@ -13,7 +13,7 @@ A referee could be someone like a manager, a university tutor or a client.
 In their reference, your referee will be asked to:
 
   - confirm how they know you and how long they’ve known you for
-  - state whether you have any concerns about them working with children
+  - state whether they have any concerns about you working with children
   - give information which can be used to check your application
 
 # Get help

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
@@ -10,7 +10,7 @@ You’ll need to give details of 2 people who can give you a reference. They’l
 
 A referee could be someone like a manager, a university tutor or a client.
 
-In their reference, your referee will be asked to:
+In their reference, they will be asked to:
 
   - confirm how they know you and how long they’ve known you for
   - say if they know any reason why you should not work with children

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
@@ -8,7 +8,7 @@ You need to give details of 2 people who can give you a reference. They’ll onl
 
 # Who to choose to give you a reference
 
-A referee could be someone like a manager, a university tutor or a client.
+You could choose someone like a manager, a university tutor or a client.
 
 In their reference, they will be asked to:
 

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
@@ -4,7 +4,7 @@ You have not yet completed the references section of your teacher training appli
 
 You need to give details of 2 people who can give you a reference. They’ll only be contacted if you accept an offer on a course.
 
-[Sign in to your account to start requesting references](<%= candidate_magic_link(@application_form.candidate) %>).
+[Sign into your account to complete the references section.](<%= candidate_magic_link(@application_form.candidate) %>).
 
 # Who to choose to give you a reference
 

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
@@ -2,7 +2,7 @@ Dear <%= @application_form.first_name %>
 
 You have not yet completed the references section of your teacher training application.
 
-You’ll need to give details of 2 people who can give you a reference. They’ll only be contacted if you accept an offer on a course.
+You need to give details of 2 people who can give you a reference. They’ll only be contacted if you accept an offer on a course.
 
 [Sign in to your account to start requesting references](<%= candidate_magic_link(@application_form.candidate) %>).
 

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
@@ -13,7 +13,7 @@ A referee could be someone like a manager, a university tutor or a client.
 In their reference, your referee will be asked to:
 
   - confirm how they know you and how long they’ve known you for
-  - state whether they have any concerns about you working with children
+  - say if they know any reason why you should not work with children
   - give information which can be used to check your application
 
 # Get help

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
@@ -2,7 +2,7 @@ Dear <%= @application_form.first_name %>
 
 You have not added your teacher training references yet.
 
-You'll need to give details of 2 people who can give you a reference. They'll only be contacted if you accept an offer on a course.
+You’ll need to give details of 2 people who can give you a reference. They’ll only be contacted if you accept an offer on a course.
 
 [Sign in to your account to start requesting references](<%= candidate_magic_link(@application_form.candidate) %>).
 

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @application_form.first_name %>
 
-You have not added your teacher training references yet.
+You have not yet completed the references section of your teacher training application.
 
 You’ll need to give details of 2 people who can give you a reference. They’ll only be contacted if you accept an offer on a course.
 

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
@@ -1,8 +1,8 @@
 Dear <%= @application_form.first_name %>
 
-You have not requested your teacher training references yet. 
+You have not added your teacher training references yet.
 
-Before you can submit your application, you need to receive 2 references.
+You'll need to give details of 2 people who can give you a reference. They'll only be contacted if you accept an offer on a course.
 
 [Sign in to your account to start requesting references](<%= candidate_magic_link(@application_form.candidate) %>).
 
@@ -10,15 +10,11 @@ Before you can submit your application, you need to receive 2 references.
 
 A referee could be someone like a manager, a university tutor or a client.
 
-In their reference, your referee will be asked to talk about your:
+In their reference, your referee will be asked to:
 
-  - communication skills
-  - reliability and professionalism
-  - transferable skills
-  - ability to work with children
-  - academic skills
-
-So choose referees who could comment on as many of these as possible.
+  - confirm how they know you and how long they’ve known you for
+  - state whether you have any concerns about them working with children
+  - give information which can be used to check your application
 
 # Get help
 

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
@@ -6,7 +6,7 @@ You’ll need to give details of 2 people who can give you a reference. They’l
 
 [Sign in to your account to start requesting references](<%= candidate_magic_link(@application_form.candidate) %>).
 
-# Who to choose as a referee
+# Who to choose to give you a reference
 
 A referee could be someone like a manager, a university tutor or a client.
 

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
@@ -14,7 +14,7 @@ In their reference, they will be asked to:
 
   - confirm how they know you and how long they’ve known you for
   - say if they know any reason why you should not work with children
-  - give information which can be used to check your application
+  - give factual information which can be used to check your application
 
 # Get help
 

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -121,7 +121,7 @@ en:
       subject: Get last-minute advice about your teacher training application
     nudge_unsubmitted_with_incomplete_references:
       no_references:
-        subject: Get 2 references to submit your teacher training application
+        subject: Give details of 2 people who can give references
       one_requested_reference:
         subject: Request another reference for your teacher training application
       one_received_reference:

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -729,7 +729,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       it_behaves_like(
         'a mail with subject and content',
-        'Get 2 references to submit your teacher training application',
+        'Give details of 2 people who can give references',
         'greeting' => 'Dear Fred',
         'content' => 'You have not requested your teacher training references yet.',
       )

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -731,7 +731,7 @@ RSpec.describe CandidateMailer, type: :mailer do
         'a mail with subject and content',
         'Give details of 2 people who can give references',
         'greeting' => 'Dear Fred',
-        'content' => 'You have not requested your teacher training references yet.',
+        'content' => 'You have not added your teacher training references yet.',
       )
     end
 

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -731,7 +731,7 @@ RSpec.describe CandidateMailer, type: :mailer do
         'a mail with subject and content',
         'Give details of 2 people who can give references',
         'greeting' => 'Dear Fred',
-        'content' => 'You have not added your teacher training references yet.',
+        'content' => 'You have not yet completed the references section',
       )
     end
 


### PR DESCRIPTION
## Context

We have a nudge that is sent when a candidate is stuck on references (has completed all other sections) and has been inactive for 7 days. At the moment, this copy references the old world of references. This draft attempts to bring it back to the new way of reference collection, drawing on copy used in the [referee flow PR](https://github.com/DFE-Digital/apply-for-teacher-training/pull/7489/files).

## Changes proposed in this pull request

Update copy to reflect the new reference process.

## Guidance to review

- Does the copy make sense
- Do we ned to remove the term 'referee'? I think we have done elsewhere.

## Link to Trello card

https://trello.com/c/XdGHvt5E/712-amend-copy-and-re-enable-our-unsubmitted-application-with-just-references-left-to-complete-nudge

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
