### PR TITLE
672 add reinstate references service

### DIFF
--- a/app/services/reinstate_reference.rb
+++ b/app/services/reinstate_reference.rb
@@ -1,0 +1,18 @@
+class ReinstateReference
+  attr_reader :reference
+
+  def initialize(reference, audit_comment:)
+    @reference = reference
+    @audit_comment = audit_comment
+  end
+
+  def call
+    @reference.update!(
+      feedback_status: :not_requested_yet,
+      cancelled_at: nil,
+      audit_comment: @audit_comment,
+    )
+
+    RequestReference.new(reference:).send_request
+  end
+end

--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -282,6 +282,19 @@ users.each do |user|
 end
 ```
 
+### Reinstate a reference
+
+When an application endup in an unsuccessful state we change the outstanding
+references to "cancelled".
+
+If we need to reinstate a reference we have a service called
+ReinstateReference which will revert the reference from 'cancelled' to
+'feedback_request' and will send an email to the referee as well.
+
+```
+  ReinstateReference.new(reference, audit_comment: 'zen-desk ticket url').call
+```
+
 ### Disable notifications for an HEI's users and all users at SDs for which they are the sole accredited body
 
 ```ruby

--- a/spec/services/reinstate_reference_spec.rb
+++ b/spec/services/reinstate_reference_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe ReinstateReference, sidekiq: true do
+  describe '#call' do
+    it 'requests a reference' do
+      reference = create(:reference, :cancelled)
+      described_class.new(reference, audit_comment: 'somezendesk ticket').call
+
+      expect(reference.reload).to be_feedback_requested
+      expect(reference.cancelled_at).to be_nil
+      expect(ActionMailer::Base.deliveries.map(&:to).flatten).to match_array(reference.email_address)
+    end
+  end
+end


### PR DESCRIPTION
## Context

There were a couple of cards in support of providers accidentally marking applications as not met or candidates accidentally being withdrawn. At the moment, its easy to reverse but if we cancel the outstanding references when we call these services we would need to manually re-add the references.

We add the service, just in case anyone needs to reinstate any reference via support ticket.