### PR TITLE
Fix provider dropdown query

### DIFF
--- a/app/forms/candidate_interface/pick_provider_form.rb
+++ b/app/forms/candidate_interface/pick_provider_form.rb
@@ -9,7 +9,7 @@ module CandidateInterface
       @available_providers ||= Provider
       .joins(:courses)
       .where(courses: { recruitment_cycle_year: RecruitmentCycle.current_year, exposed_in_find: true })
-      .where('courses.applications_open_from <= ?', Time.zone.today)
+      .where('courses.opened_on_apply_at <= ?', Time.zone.now)
       .order(:name)
       .distinct
     end

--- a/spec/forms/candidate_interface/pick_provider_form_spec.rb
+++ b/spec/forms/candidate_interface/pick_provider_form_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::PickProviderForm do
   describe '#available_providers' do
-    it 'returns providers with a course exposed in find in the current cycle which are open to applications' do
+    it 'returns providers with a course exposed in find in the current cycle which are open on apply' do
       create(:provider, name: 'School without courses')
       create(:course, open_on_apply: true, exposed_in_find: false, provider: create(:provider, name: 'School with disabled courses'))
-      create(:course, open_on_apply: true, exposed_in_find: true, applications_open_from: Time.zone.today, provider: create(:provider, name: 'School with courses'))
-      create(:course, open_on_apply: true, exposed_in_find: true, applications_open_from: Time.zone.tomorrow, provider: create(:provider, name: 'School with courses but not open for applications'))
+      create(:course, open_on_apply: true, exposed_in_find: true, opened_on_apply_at: Time.zone.today, provider: create(:provider, name: 'School with courses'))
+      create(:course, open_on_apply: true, exposed_in_find: true, opened_on_apply_at: Time.zone.tomorrow, provider: create(:provider, name: 'School with courses but not open for applications'))
       create(:course, open_on_apply: true, exposed_in_find: true, recruitment_cycle_year: RecruitmentCycle.previous_year)
 
       form = described_class.new({})


### PR DESCRIPTION
Populate providers dropdown on the basis of `opened_on_apply_at` rather than `applications_open_from`, as candidates should be able to choose courses now, although they can't submit them for another week.

## Context

Live bug

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
