### PR TITLE
Update content on initial Equality and diversity questions page

### DIFF
--- a/app/views/candidate_interface/equality_and_diversity/start.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/start.html.erb
@@ -6,15 +6,10 @@
 
     <h1 class="govuk-heading-l"><%= t('equality_and_diversity.title') %></h1>
 
-    <p class="govuk-body">Your answers will not be shown to training providers as they assess your application. We will share your answers if you accept a place on their course.</p>
+    <p class="govuk-body">Before you submit your application, you’ll be asked questions to help prevent discrimination in teacher recruitment.</p>
 
-    <p class="govuk-body">You can select 'Prefer not to say' for any question.</p>
-
-    <p class="govuk-body">We use the information you give us to help prevent discrimination in teacher recruitment.</p>
-
-    <p class="govuk-body govuk-!-margin-bottom-8"><%= govuk_link_to 'Find out how we use and look after your data', candidate_interface_privacy_policy_path %></p>
+    <p class="govuk-body">You can answer ‘Prefer not to say’ to any question.</p>
 
     <%= govuk_link_to 'Continue', candidate_interface_edit_equality_and_diversity_sex_path, class: 'govuk-button' %>
-
   </div>
 </div>


### PR DESCRIPTION
## Context
These changes aim to more clearly introduce the section and let candidates know that they haven't submitted their application yet.

The content around who sees the answers to each question will be moved to the question pages instead.

## Changes proposed in this pull request

* copy change 

## Guidance to review
Before 
<img width="1082" alt="Screenshot 2022-10-04 at 12 43 37" src="https://user-images.githubusercontent.com/58793682/193811221-be52712d-8359-46ed-9938-07828ffb51eb.png">

After
<img width="895" alt="Screenshot 2022-10-04 at 12 43 22" src="https://user-images.githubusercontent.com/58793682/193811238-e956bc84-4921-4f8f-aadb-27a463a5e403.png">


## Link to Trello card

https://trello.com/c/yEslpCVs/733-needs-to-be-done-by-11-oct-update-the-start-page-for-our-equality-and-diversity-questionnaire

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
