### PR TITLE
Allow user to choose courses that are not open for application

### DIFF
--- a/app/forms/candidate_interface/pick_course_form.rb
+++ b/app/forms/candidate_interface/pick_course_form.rb
@@ -64,7 +64,7 @@ module CandidateInterface
     end
 
     def available_courses
-      @available_courses ||= courses_for_current_cycle.exposed_in_find.open_for_applications.includes(:accredited_provider, :course_options).order(:name)
+      @available_courses ||= courses_for_current_cycle.exposed_in_find.includes(:accredited_provider, :course_options).order(:name)
     end
 
     def courses_with_names

--- a/spec/forms/candidate_interface/pick_course_form_spec.rb
+++ b/spec/forms/candidate_interface/pick_course_form_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe CandidateInterface::PickCourseForm do
       provider = create(:provider, name: 'School with courses')
 
       create(:course, exposed_in_find: false, open_on_apply: true, name: 'Course not shown in Find', provider:)
-      create(:course, exposed_in_find: true, open_on_apply: true, name: 'Course that is not accepting applications', applications_open_from: Time.zone.tomorrow, provider:)
       create(:course, exposed_in_find: true, open_on_apply: true, name: 'Course you can apply to', provider:)
       create(:course, exposed_in_find: true, open_on_apply: true, name: 'Course from another cycle', provider:, recruitment_cycle_year: 2016)
       create(:course, exposed_in_find: true, open_on_apply: true, name: 'Course from other provider')
@@ -40,18 +39,6 @@ RSpec.describe CandidateInterface::PickCourseForm do
       form = described_class.new(provider_id: provider.id)
 
       expect(form.dropdown_available_courses.map(&:name)).to eql(['This cycle (A)'])
-    end
-
-    it 'only shows courses which are open for applications' do
-      provider = create(:provider)
-      course = create(:course, :open_on_apply, name: 'Course is open for applications', code: 'A', provider:)
-      create(:course, :open_on_apply, name: 'Course is not open for applications', provider:, applications_open_from: Time.zone.tomorrow)
-
-      create(:course_option, course:)
-
-      form = described_class.new(provider_id: provider.id)
-
-      expect(form.dropdown_available_courses.map(&:name)).to eql(['Course is open for applications (A)'])
     end
 
     context 'with no ambiguous courses' do


### PR DESCRIPTION
## Context

Live bug

## Changes proposed in this pull request

Allow user to choose courses that are not open for application, otherwise candidates will not be able to start choosing courses between find re-opening and apply opening.

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
