### PR TITLE
Update our hesa questionnaire sex question

### DIFF
--- a/app/exports/common_columns/_common_columns.yml
+++ b/app/exports/common_columns/_common_columns.yml
@@ -142,7 +142,7 @@ candidates_sex:
   enum:
     - Male
     - Female
-    - Intersex
+    - Other
     - Prefer not to say
     - Not provided
 area:

--- a/app/models/publications/monthly_statistics/by_sex.rb
+++ b/app/models/publications/monthly_statistics/by_sex.rb
@@ -32,6 +32,7 @@ module Publications
           'female' => {},
           'male' => {},
           'intersex' => {},
+          'other' => {},
           I18n.t('equality_and_diversity.sex.opt_out.label') => {},
         }
 

--- a/app/services/support_interface/applications_by_demographic_domicile_and_degree_class_export.rb
+++ b/app/services/support_interface/applications_by_demographic_domicile_and_degree_class_export.rb
@@ -175,9 +175,10 @@ module SupportInterface
 
     def equality_and_diversity_sql
       "WHEN f.equality_and_diversity is NULL THEN 'Not provided'
-      WHEN f.equality_and_diversity->> 'sex' = 'intersex' then 'Intersex'
       WHEN f.equality_and_diversity->> 'sex' = 'male' then 'Male'
       WHEN f.equality_and_diversity->> 'sex' = 'female' then 'Female'
+      WHEN f.equality_and_diversity->> 'sex' = 'other' then 'Other'
+      WHEN f.equality_and_diversity->> 'sex' = 'intersex' then 'Other'
       WHEN f.equality_and_diversity->> 'sex' = 'Prefer not to say' then 'Prefer not to say'"
     end
 

--- a/app/views/candidate_interface/equality_and_diversity/edit_sex.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_sex.html.erb
@@ -6,15 +6,15 @@
     <%= form_with model: @sex, url: candidate_interface_edit_equality_and_diversity_sex_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class='govuk-caption-l'><%= t('equality_and_diversity.title')%></span>
-      
-      <h1 class='govuk-heading-l'><%= t('equality_and_diversity.sex.heading')%></h1>
+      <span class='govuk-caption-l'><%= t('equality_and_diversity.title') %></span>
+
+      <title class='govuk-heading-l'><%= t('equality_and_diversity.sex.title') %></title>
 
       <p class='govuk-body'>Training providers will not see your answers to this question when deciding whether to offer you a place.</p>
 
       <p class='govuk-body'>They will only see your answer if you accept an offer with them.</p>
 
-      <%= f.govuk_radio_buttons_fieldset :sex, legend: { text: t('equality_and_diversity.sex.title'), size: 'm' } do %>
+      <%= f.govuk_radio_buttons_fieldset :sex, legend: { text: t('equality_and_diversity.sex.question'), size: 'm' } do %>
         <%= f.govuk_radio_button :sex, :female, label: { text: t('equality_and_diversity.sex.female.label') }, link_errors: true %>
         <%= f.govuk_radio_button :sex, :male, label: { text: t('equality_and_diversity.sex.male.label') } %>
         <%= f.govuk_radio_button :sex, :other, label: { text: t('equality_and_diversity.sex.other.label') } %>

--- a/app/views/candidate_interface/equality_and_diversity/edit_sex.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_sex.html.erb
@@ -6,10 +6,18 @@
     <%= form_with model: @sex, url: candidate_interface_edit_equality_and_diversity_sex_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :sex, caption: { text: t('equality_and_diversity.title'), size: 'xl' }, legend: { text: t('equality_and_diversity.sex.title'), size: 'xl', tag: 'h1' } do %>
+      <span class='govuk-caption-l'><%= t('equality_and_diversity.title')%></span>
+      
+      <h1 class='govuk-heading-l'><%= t('equality_and_diversity.sex.heading')%></h1>
+
+      <p class='govuk-body'>Training providers will not see your answers to this question when deciding whether to offer you a place.</p>
+
+      <p class='govuk-body'>They will only see your answer if you accept an offer with them.</p>
+
+      <%= f.govuk_radio_buttons_fieldset :sex, legend: { text: t('equality_and_diversity.sex.title'), size: 'm' } do %>
         <%= f.govuk_radio_button :sex, :female, label: { text: t('equality_and_diversity.sex.female.label') }, link_errors: true %>
         <%= f.govuk_radio_button :sex, :male, label: { text: t('equality_and_diversity.sex.male.label') } %>
-        <%= f.govuk_radio_button :sex, :intersex, label: { text: t('equality_and_diversity.sex.intersex.label') } %>
+        <%= f.govuk_radio_button :sex, :other, label: { text: t('equality_and_diversity.sex.other.label') } %>
         <%= f.govuk_radio_divider %>
         <%= f.govuk_radio_button :sex, t('equality_and_diversity.sex.opt_out.label'), label: { text: t('equality_and_diversity.sex.opt_out.label') } %>
       <% end %>

--- a/app/views/candidate_interface/equality_and_diversity/edit_sex.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_sex.html.erb
@@ -6,13 +6,13 @@
     <%= form_with model: @sex, url: candidate_interface_edit_equality_and_diversity_sex_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class='govuk-caption-l'><%= t('equality_and_diversity.title') %></span>
+      <span class="govuk-caption-l"><%= t('equality_and_diversity.title') %></span>
 
-      <title class='govuk-heading-l'><%= t('equality_and_diversity.sex.title') %></title>
+      <h1 class="govuk-heading-l"><%= t('equality_and_diversity.sex.title') %></h1>
 
-      <p class='govuk-body'>Training providers will not see your answers to this question when deciding whether to offer you a place.</p>
+      <p class="govuk-body">Training providers will not see your answers to this question when deciding whether to offer you a place.</p>
 
-      <p class='govuk-body'>They will only see your answer if you accept an offer with them.</p>
+      <p class="govuk-body">They will only see your answer if you accept an offer with them.</p>
 
       <%= f.govuk_radio_buttons_fieldset :sex, legend: { text: t('equality_and_diversity.sex.question'), size: 'm' } do %>
         <%= f.govuk_radio_button :sex, :female, label: { text: t('equality_and_diversity.sex.female.label') }, link_errors: true %>

--- a/config/locales/candidate_interface/equality_and_diversity.yml
+++ b/config/locales/candidate_interface/equality_and_diversity.yml
@@ -2,8 +2,8 @@ en:
   equality_and_diversity:
     title: Equality and diversity questions
     sex:
-      title: What is your sex?
-      heading: Sex
+      question: What is your sex?
+      title: Sex
       female:
         label: Female
       male:

--- a/config/locales/candidate_interface/equality_and_diversity.yml
+++ b/config/locales/candidate_interface/equality_and_diversity.yml
@@ -10,6 +10,8 @@ en:
         label: Male
       other:
         label: Other
+      intersex:
+        label: 'Intersex'
       opt_out:
         label: Prefer not to say
     disability_status:

--- a/config/locales/candidate_interface/equality_and_diversity.yml
+++ b/config/locales/candidate_interface/equality_and_diversity.yml
@@ -3,12 +3,13 @@ en:
     title: Equality and diversity questions
     sex:
       title: What is your sex?
+      heading: Sex
       female:
         label: Female
       male:
         label: Male
-      intersex:
-        label: Intersex
+      other:
+        label: Other
       opt_out:
         label: Prefer not to say
     disability_status:

--- a/config/register-api.yml
+++ b/config/register-api.yml
@@ -285,7 +285,7 @@ components:
           enum:
           - male
           - female
-          - intersex
+          - other
           - Prefer not to say
         disabilities:
           type: array

--- a/spec/components/provider_interface/diversity_information_component_spec.rb
+++ b/spec/components/provider_interface/diversity_information_component_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe ProviderInterface::DiversityInformationComponent do
 
           expect(result.text).not_to include('The candidate disclosed information in the optional equality and diversity questionnaire.')
           expect(result.text).not_to include('This relates to their sex, ethnicity and disability status. We collect this data to help reduce discrimination on these grounds. (This is not the same as the information we request relating to the candidate’s disability, access and other needs)')
-          expect(result.text).to include('What is your sex?')
+          expect(result.text).to include('Sex')
           expect(result.text).to include('Male')
           expect(result.text).to include('Are you disabled?')
           expect(result.text).to include('Yes')

--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -53,7 +53,7 @@ FactoryBot.define do
     end
 
     transient do
-      sex { ['male', 'female', 'intersex', 'Prefer not to say'].sample }
+      sex { ['male', 'female', 'other', 'Prefer not to say'].sample }
     end
 
     trait :with_equality_and_diversity_data do

--- a/spec/models/publications/monthly_statistics/by_age_group_spec.rb
+++ b/spec/models/publications/monthly_statistics/by_age_group_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Publications::MonthlyStatistics::ByAgeGroup do
        ['24',           0, 0, 0, 1, 0, 0, 1],
        ['25 to 29',     0, 0, 0, 0, 1, 2, 3],
        ['30 to 34',     0, 0, 0, 0, 0, 1, 1],
-       ['35 to 39',     0, 0, 0, 0, 0, 1, 1],
+       ['35 to 39',     0, 1, 0, 0, 0, 1, 2],
        ['40 to 44',     2, 0, 0, 0, 0, 0, 2],
        ['45 to 49',     0, 0, 0, 0, 0, 0, 0],
        ['50 to 54',     0, 0, 0, 0, 0, 0, 0],
@@ -26,6 +26,6 @@ RSpec.describe Publications::MonthlyStatistics::ByAgeGroup do
        ['65 and over',  1, 0, 1, 0, 0, 2, 4]]
     end
 
-    expect_column_totals(4, 1, 1, 1, 1, 7, 15)
+    expect_column_totals(4, 2, 1, 1, 1, 7, 16)
   end
 end

--- a/spec/models/publications/monthly_statistics/by_area_spec.rb
+++ b/spec/models/publications/monthly_statistics/by_area_spec.rb
@@ -22,12 +22,12 @@ RSpec.describe Publications::MonthlyStatistics::ByArea do
        ['South East',               0, 0, 0, 0, 0, 0, 0],
        ['South West',               0, 0, 0, 0, 0, 1, 1],
        ['Wales',                    0, 0, 0, 0, 0, 0, 0],
-       ['West Midlands',            0, 0, 0, 0, 0, 2, 2],
+       ['West Midlands',            0, 1, 0, 0, 0, 2, 3],
        ['Yorkshire and the Humber', 0, 0, 0, 1, 0, 0, 1],
        ['European Economic Area',   0, 0, 0, 0, 0, 0, 0],
        ['Rest of the World',        0, 0, 0, 0, 0, 0, 0]]
     end
 
-    expect_column_totals(4, 1, 1, 1, 1, 7, 15)
+    expect_column_totals(4, 2, 1, 1, 1, 7, 16)
   end
 end

--- a/spec/models/publications/monthly_statistics/by_course_age_group_spec.rb
+++ b/spec/models/publications/monthly_statistics/by_course_age_group_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe Publications::MonthlyStatistics::ByCourseAgeGroup do
   it "returns table data for 'by course age group'" do
     expect_report_rows(column_headings: ['Course phase', 'Recruited', 'Conditions pending', 'Deferred', 'Received an offer', 'Awaiting provider decisions', 'Unsuccessful', 'Total']) do
       [['Primary',           1, 1, 0, 1, 4, 0, 7],
-       ['Secondary',         3, 0, 1, 0, 0, 14, 18],
+       ['Secondary',         3, 1, 1, 0, 0, 14, 19],
        ['Further education', 0, 0, 0, 0, 0, 1, 1]]
     end
 
-    expect_column_totals(4, 1, 1, 1, 4, 15, 26)
+    expect_column_totals(4, 2, 1, 1, 4, 15, 27)
   end
 end

--- a/spec/models/publications/monthly_statistics/by_course_type_spec.rb
+++ b/spec/models/publications/monthly_statistics/by_course_type_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe Publications::MonthlyStatistics::ByCourseType do
 
   it "returns table data for 'by course type'" do
     expect_report_rows(column_headings: ['Course type', 'Recruited', 'Conditions pending', 'Deferred', 'Received an offer', 'Awaiting provider decisions', 'Unsuccessful', 'Total']) do
-      [['Higher education',                                3, 0, 1, 0, 0, 15, 19],
+      [['Higher education',                                3, 1, 1, 0, 0, 15, 20],
        ['Postgraduate teaching apprenticeship',            0, 0, 0, 1, 1, 0, 2],
        ['School-centred initial teacher training (SCITT)', 0, 0, 0, 0, 3, 0, 3],
        ['School Direct (fee-paying)',                      1, 0, 0, 0, 0, 0, 1],
        ['School Direct (salaried)',                        0, 1, 0, 0, 0, 0, 1]]
     end
 
-    expect_column_totals(4, 1, 1, 1, 4, 15, 26)
+    expect_column_totals(4, 2, 1, 1, 4, 15, 27)
   end
 end

--- a/spec/models/publications/monthly_statistics/by_provider_area_spec.rb
+++ b/spec/models/publications/monthly_statistics/by_provider_area_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Publications::MonthlyStatistics::ByProviderArea do
       [['East of England',          1, 0, 0, 0, 0, 0, 1],
        ['East Midlands',            0, 1, 0, 0, 0, 3, 4],
        ['London',                   0, 0, 0, 1, 0, 0, 1],
-       ['North East',               0, 0, 0, 0, 1, 2, 3],
+       ['North East',               0, 1, 0, 0, 1, 2, 4],
        ['North West',               0, 0, 0, 0, 1, 1, 2],
        ['South East',               0, 0, 0, 0, 1, 1, 2],
        ['South West',               0, 0, 0, 0, 0, 1, 1],
@@ -20,6 +20,6 @@ RSpec.describe Publications::MonthlyStatistics::ByProviderArea do
        ['Yorkshire and The Humber', 1, 0, 0, 0, 1, 4, 6]]
     end
 
-    expect_column_totals(4, 1, 1, 1, 4, 15, 26)
+    expect_column_totals(4, 2, 1, 1, 4, 15, 27)
   end
 end

--- a/spec/models/publications/monthly_statistics/by_secondary_subject_spec.rb
+++ b/spec/models/publications/monthly_statistics/by_secondary_subject_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Publications::MonthlyStatistics::BySecondarySubject do
   it 'correctly generates table data' do
     expect_report_rows(column_headings: ['Subject', 'Recruited', 'Conditions pending', 'Deferred', 'Received an offer', 'Awaiting provider decisions', 'Unsuccessful', 'Total']) do
       [['Art and design',           0, 0, 0, 0, 0, 1, 1],
-       ['Biology',                  0, 0, 0, 0, 0, 2, 2],
+       ['Biology',                  0, 1, 0, 0, 0, 2, 3],
        ['Business studies',         1, 0, 0, 0, 0, 0, 1],
        ['Chemistry',                0, 0, 0, 0, 0, 1, 1],
        ['Drama',                    0, 0, 0, 0, 0, 2, 2],
@@ -22,6 +22,6 @@ RSpec.describe Publications::MonthlyStatistics::BySecondarySubject do
        ['Other',                    0, 0, 1, 0, 0, 1, 2]]
     end
 
-    expect_column_totals(3, 0, 1, 0, 0, 14, 18)
+    expect_column_totals(3, 1, 1, 0, 0, 14, 19)
   end
 end

--- a/spec/models/publications/monthly_statistics/by_sex_spec.rb
+++ b/spec/models/publications/monthly_statistics/by_sex_spec.rb
@@ -11,10 +11,11 @@ RSpec.describe Publications::MonthlyStatistics::BySex do
     expect_report_rows(column_headings: ['Sex', 'Recruited', 'Conditions pending', 'Deferred', 'Received an offer', 'Awaiting provider decisions', 'Unsuccessful', 'Total']) do
       [['Female',            3, 1, 1, 1, 0, 5, 11],
        ['Male',              1, 0, 0, 0, 0, 1, 2],
-       ['Intersex',          0, 0, 0, 0, 0, 1, 1],
+       ['Other', 0, 0, 0, 0, 0, 1, 1],
+       ['Intersex', 0, 1, 0, 0, 0, 0, 1],
        ['Prefer not to say', 0, 0, 0, 0, 1, 0, 1]]
     end
 
-    expect_column_totals(4, 1, 1, 1, 1, 7, 15)
+    expect_column_totals(4, 2, 1, 1, 1, 7, 16)
   end
 end

--- a/spec/models/publications/monthly_statistics/by_status_spec.rb
+++ b/spec/models/publications/monthly_statistics/by_status_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Publications::MonthlyStatistics::ByStatus do
     it "returns table data for 'applications by status'" do
       expect_report_rows(column_headings: ['Status', 'First application', 'Apply again', 'Total']) do
         [['Recruited',                           3, 1, 4],
-         ['Conditions pending',                  1, 0, 1],
+         ['Conditions pending',                  2, 0, 2],
          ['Deferred',                            1, 0, 1],
          ['Received an offer but not responded', 1, 0, 1],
          ['Awaiting provider decisions',         4, 0, 4],
@@ -20,7 +20,7 @@ RSpec.describe Publications::MonthlyStatistics::ByStatus do
          ['Application rejected',                7, 3, 10]]
       end
 
-      expect_column_totals(21, 5, 26)
+      expect_column_totals(22, 5, 27)
     end
   end
 
@@ -30,7 +30,7 @@ RSpec.describe Publications::MonthlyStatistics::ByStatus do
     it "returns table data for 'candidates by status'" do
       expect_report_rows(column_headings: ['Status', 'First application', 'Apply again', 'Total']) do
         [['Recruited',                           3, 1, 4],
-         ['Conditions pending',                  1, 0, 1],
+         ['Conditions pending',                  2, 0, 2],
          ['Deferred',                            1, 0, 1],
          ['Received an offer but not responded', 1, 0, 1],
          ['Awaiting provider decisions',         1, 0, 1],
@@ -39,7 +39,7 @@ RSpec.describe Publications::MonthlyStatistics::ByStatus do
          ['Application rejected',                3, 2, 5]]
       end
 
-      expect_column_totals(11, 4, 15)
+      expect_column_totals(12, 4, 16)
     end
   end
 end

--- a/spec/requests/data_api/applications_by_demographic_domicile_and_degree_class_export_spec.rb
+++ b/spec/requests/data_api/applications_by_demographic_domicile_and_degree_class_export_spec.rb
@@ -44,9 +44,8 @@ RSpec.describe 'GET /data-api/tad-data-exports/applications-by-demographic-domic
 
   %w[intersex other].each do |option|
     context 'when sending old and new sex values' do
-
       it 'returns the latest tad age and hesa export' do
-        first_application_form.equality_and_diversity.merge!({ "sex" => "#{option}"})
+        first_application_form.equality_and_diversity.merge!({ 'sex' => option.to_s })
         first_application_form.save
         create(:application_qualification, level: 'degree', grade: 'First-class honours', application_form: first_application_form)
         create(:application_choice, :with_recruited, application_form: first_application_form)

--- a/spec/requests/data_api/applications_by_demographic_domicile_and_degree_class_export_spec.rb
+++ b/spec/requests/data_api/applications_by_demographic_domicile_and_degree_class_export_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'GET /data-api/tad-data-exports/applications-by-demographic-domic
       :completed_application_form,
       equality_and_diversity: {
         'sex' => 'male',
-        'hesa_sex' => '1',
+        'hesa_sex' => '11',
         'disabilities' => ['Learning difficulty', 'Social or communication impairment', 'Blind'],
         'ethnic_group' => 'Another ethnic group',
         'hesa_ethnicity' => '50',
@@ -40,6 +40,26 @@ RSpec.describe 'GET /data-api/tad-data-exports/applications-by-demographic-domic
     expect(response).to have_http_status(:success)
     expect(response.body).to start_with('age_group,sex,ethnicity,disability,degree_class,domicile,pending_conditions,recruited,total')
     expect(first_row).to include('Upper second-class honours (2:1)')
+  end
+
+  %w[intersex other].each do |option|
+    context 'when sending old and new sex values' do
+
+      it 'returns the latest tad age and hesa export' do
+        first_application_form.equality_and_diversity.merge!({ "sex" => "#{option}"})
+        first_application_form.save
+        create(:application_qualification, level: 'degree', grade: 'First-class honours', application_form: first_application_form)
+        create(:application_choice, :with_recruited, application_form: first_application_form)
+
+        DataExporter.perform_async(SupportInterface::ApplicationsByDemographicDomicileAndDegreeClassExport.to_s, data_export.id)
+
+        get_api_request '/data-api/applications-by-demographic-domicile-and-degree-class/latest', token: tad_api_token
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to start_with('age_group,sex,ethnicity,disability,degree_class,domicile,pending_conditions,recruited,total')
+        expect(first_row).to include('Other')
+      end
+    end
   end
 
   context 'when sending the new formatted degree grade' do

--- a/spec/services/support_interface/ministerial_report_applications_export_spec.rb
+++ b/spec/services/support_interface/ministerial_report_applications_export_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe SupportInterface::MinisterialReportApplicationsExport do
         application_withdrawn
       ]) do
         [[:art_and_design,           1, 1, 0, 1, 0, 0],
-         [:biology,                  2, 0, 0, 0, 1, 1],
+         [:biology,                  3, 1, 1, 0, 1, 1],
          [:business_studies,         1, 1, 1, 0, 0, 0],
          [:chemistry,                1, 0, 0, 0, 1, 0],
          [:classics,                 0, 0, 0, 0, 0, 0],
@@ -39,11 +39,11 @@ RSpec.describe SupportInterface::MinisterialReportApplicationsExport do
          [:physical_education,       0, 0, 0, 0, 0, 0],
          [:physics,                  1, 0, 0, 0, 0, 1],
          [:religious_education,      0, 0, 0, 0, 0, 0],
-         [:stem,                     6, 0, 0, 0, 4, 2],
-         [:ebacc,                    12, 2, 2, 0, 5, 4],
+         [:stem,                     7, 1, 1, 0, 4, 2],
+         [:ebacc,                    13, 3, 3, 0, 5, 4],
          [:primary,                  7, 3, 2, 0, 0, 0],
-         [:secondary,                17, 5, 4, 1, 6, 4],
-         [:total,                    24, 8, 6, 1, 6, 4]]
+         [:secondary,                18, 6, 5, 1, 6, 4],
+         [:total,                    25, 9, 7, 1, 6, 4]]
       end
     end
   end

--- a/spec/services/support_interface/ministerial_report_candidates_export_spec.rb
+++ b/spec/services/support_interface/ministerial_report_candidates_export_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe SupportInterface::MinisterialReportCandidatesExport do
         application_withdrawn
       ]) do
         [[:art_and_design,           1, 1, 0, 1, 0, 0],
-         [:biology,                  1, 0, 0, 0, 1, 0],
+         [:biology,                  2, 1, 1, 0, 1, 0],
          [:business_studies,         1, 1, 1, 0, 0, 0],
          [:chemistry,                1, 0, 0, 0, 1, 0],
          [:classics,                 0, 0, 0, 0, 0, 0],
@@ -41,12 +41,12 @@ RSpec.describe SupportInterface::MinisterialReportCandidatesExport do
          [:physical_education,       0, 0, 0, 0, 0, 0],
          [:physics,                  0, 0, 0, 0, 0, 0],
          [:religious_education,      0, 0, 0, 0, 0, 0],
-         [:stem,                     3, 0, 0, 0, 3, 0],
-         [:ebacc,                    5, 0, 0, 0, 4, 1],
+         [:stem,                     4, 1, 1, 0, 3, 0],
+         [:ebacc,                    6, 1, 1, 0, 4, 1],
          [:primary,                  4, 3, 2, 0, 0, 0],
-         [:secondary,                9, 3, 2, 1, 4, 1],
+         [:secondary,                10, 4, 3, 1, 4, 1],
          [:split,                    1, 1, 1, 0, 0, 0],
-         [:total,                    14, 7, 5, 1, 4, 1]]
+         [:total,                    15, 8, 6, 1, 4, 1]]
       end
     end
 

--- a/spec/support/statistics_test_helper.rb
+++ b/spec/support/statistics_test_helper.rb
@@ -56,7 +56,7 @@ module StatisticsTestHelper
            course_option: course_option_with(level: 'secondary', program_type: 'higher_education_programme', region: 'north_east', subjects: [secondary_subject('Biology')]),
            application_form: withdrawn_form)
 
-    pending_conditions_form = create(:application_form, :minimum_info, :with_equality_and_diversity_data, sex: 'intersex', date_of_birth: date_of_birth(years_ago: 35), phase: 'apply_1')
+    pending_conditions_form = create(:application_form, :minimum_info, :with_equality_and_diversity_data, sex: 'intersex', region_code: :west_midlands, date_of_birth: date_of_birth(years_ago: 35), phase: 'apply_1')
     create(:application_choice,
            :pending_conditions,
            course_option: course_option_with(level: 'secondary', program_type: 'higher_education_programme', region: 'north_east', subjects: [secondary_subject('Biology')]),

--- a/spec/support/statistics_test_helper.rb
+++ b/spec/support/statistics_test_helper.rb
@@ -56,8 +56,15 @@ module StatisticsTestHelper
            course_option: course_option_with(level: 'secondary', program_type: 'higher_education_programme', region: 'north_east', subjects: [secondary_subject('Biology')]),
            application_form: withdrawn_form)
 
+    pending_conditions_form = create(:application_form, :minimum_info, :with_equality_and_diversity_data, sex: 'intersex', date_of_birth: date_of_birth(years_ago: 35), phase: 'apply_1')
+    create(:application_choice,
+           :pending_conditions,
+           course_option: course_option_with(level: 'secondary', program_type: 'higher_education_programme', region: 'north_east', subjects: [secondary_subject('Biology')]),
+           application_form: pending_conditions_form)
+
     # keep the country code nil so that this application falls into the "No region" bucket in the MonthlyStatisticsReport
     form = create(:application_form, :minimum_info, :with_equality_and_diversity_data, country: nil, sex: 'other', date_of_birth: date_of_birth(years_ago: 35), phase: 'apply_1')
+
     create(:application_choice,
            :withdrawn,
            course_option: course_option_with(level: 'secondary', program_type: 'higher_education_programme', region: 'south_east', subjects: [secondary_subject('English')]),

--- a/spec/support/statistics_test_helper.rb
+++ b/spec/support/statistics_test_helper.rb
@@ -57,7 +57,7 @@ module StatisticsTestHelper
            application_form: withdrawn_form)
 
     # keep the country code nil so that this application falls into the "No region" bucket in the MonthlyStatisticsReport
-    form = create(:application_form, :minimum_info, :with_equality_and_diversity_data, country: nil, sex: 'intersex', date_of_birth: date_of_birth(years_ago: 35), phase: 'apply_1')
+    form = create(:application_form, :minimum_info, :with_equality_and_diversity_data, country: nil, sex: 'other', date_of_birth: date_of_birth(years_ago: 35), phase: 'apply_1')
     create(:application_choice,
            :withdrawn,
            course_option: course_option_with(level: 'secondary', program_type: 'higher_education_programme', region: 'south_east', subjects: [secondary_subject('English')]),


### PR DESCRIPTION
## Context
In our equality and diversity flow we are bringing the options for our sex/gender question in line with HESA. We are replacing intersex with other.

Register will need to update their mapping

## Changes proposed in this pull request
* copy change to view
* change radio button
* update spec/exports

## Guidance to review
Before
<img width="1119" alt="Screenshot 2022-10-05 at 14 32 39" src="https://user-images.githubusercontent.com/58793682/194073124-68d5f98d-994f-49e9-917e-e914654b9835.png">
After
<img width="1052" alt="Screenshot 2022-10-05 at 14 32 17" src="https://user-images.githubusercontent.com/58793682/194073132-ac0d4b43-3583-45f1-9f5c-5517dfe6b46d.png">


## Link to Trello card
https://trello.com/c/m0NkalzQ/727-needs-to-be-done-by-11-oct-update-our-hesa-questionnaire-questions-sex-question

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
