### PR TITLE
Restore dfe analytics include

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,4 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+  include DfE::Analytics::Entities
 end


### PR DESCRIPTION
When we downgraded to 1.3.2 we didn't restore the (then-manual, now-automatic) code to send model events to BigQuery. Restore it.