### PR TITLE
Remove chase_provider_decision_at from application_choices

### DIFF
--- a/db/migrate/20221006112628_remove_chase_provider_decision_at_from_application_choices.rb
+++ b/db/migrate/20221006112628_remove_chase_provider_decision_at_from_application_choices.rb
@@ -1,0 +1,5 @@
+class RemoveChaseProviderDecisionAtFromApplicationChoices < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured { remove_column :application_choices, :chase_provider_decision_at, :datetime, if_exists: true }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_22_124940) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_06_112628) do
   create_sequence "qualifications_public_id_seq", start: 120000
 
   # These are extensions that must be enabled in order to support this database


### PR DESCRIPTION
This field exists only on QA because of c23b88167ad. Remove it.

This unblocks a fix for our analytics data.
