### PR TITLE
Remove content from reference request page

### DIFF
--- a/app/views/candidate_interface/new_references/request_reference/review/new.html.erb
+++ b/app/views/candidate_interface/new_references/request_reference/review/new.html.erb
@@ -12,10 +12,6 @@
 
       <%= render CandidateInterface::RequestReferenceReviewComponent.new(@reference) %>
 
-      <p class="govuk-body">Referees cannot see the content of your application.</p>
-
-      <p class="govuk-body">It's a good idea to contact referees before requesting a reference so that they know what to expect.</p>
-
       <% if @policy.can_request? %>
         <%= f.govuk_submit t('application_form.new_references.send_request.confirm') %>
       <% end %>


### PR DESCRIPTION
This removes 2 lines of content from the reference request page shown only when requesting additional references after an offer has been accepted.

We’ve decided to remove these lines as:

* we no longer use the term "referee" anywhere in the service
* we don’t think we need to explain that referees cannot see the content of applications, as this hasn't come up in research as a concern. This is also still explained in the privacy policy.
* we don’t think candidates need telling to contact their referees, as many will anyway, and if they do, they don’t necessarily need to do it before sending the request, but could do it straight away after

If the need for either of these pieces of content re-emerges, we can re-review, also adding this content in the other places where references are requested.

➡️ [Change made in prototype](https://github.com/DFE-Digital/apply-for-teacher-training-prototype/pull/723)
🗂️ [Trello card](https://trello.com/c/coSag5vY/724-remove-mention-of-referees-from-the-final-screen-of-adding-a-reference-journey)

## Content removed

<img width="369" alt="Screenshot 2022-10-05 at 15 44 26" src="https://user-images.githubusercontent.com/30665/194313020-17765e20-ca60-449a-bdac-da4e63f0633d.png">

