### PR TITLE
Improve the information shown on the support course picker

### DIFF
--- a/app/controllers/support_interface/application_forms/application_choices/change_offered_course_controller.rb
+++ b/app/controllers/support_interface/application_forms/application_choices/change_offered_course_controller.rb
@@ -30,6 +30,8 @@ module SupportInterface
             course_code: params[:course_code],
             application_form_id: @application_form.id,
           )
+
+          load_course_options
         end
 
         def choose_offered_course_option
@@ -46,6 +48,7 @@ module SupportInterface
               course_option_id:,
             )
           else
+            load_course_options
             render :offered_course_options
           end
         end
@@ -102,6 +105,14 @@ module SupportInterface
 
         def application_choice_pending_recruitment?
           @application_choice.pending_conditions? || @application_choice.unconditional_offer_pending_recruitment?
+        end
+
+        def load_course_options
+          @options_from_same_provider, @options_from_ratified_provider = @pick_course
+            .course_options_for_provider(@application_choice.current_provider)
+            .partition { |option| option.provider_code == @application_choice.current_provider.code }
+
+          @options_from_other_providers = @pick_course.course_options_for_other_providers(@application_choice.current_provider)
         end
       end
     end

--- a/app/views/support_interface/application_forms/application_choices/change_offered_course/offered_course_options.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/change_offered_course/offered_course_options.html.erb
@@ -1,23 +1,34 @@
-<% content_for :title, title_with_error_prefix("Choose a course to replace #{@application_choice.current_course_option.course.name_and_code}", @pick_course.errors.any?) %>
+<% content_for :title, title_with_error_prefix("Choose a course to replace #{@application_choice.current_course.name_and_code} at #{@application_choice.current_provider.name_and_code}", @pick_course.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(support_interface_application_form_application_choice_change_offered_course_search_path(course_code: @pick_course.course_code)) %>
 
 <% if @pick_course.course_options.present? %>
   <%= form_with model: @pick_course, url: support_interface_application_form_application_choice_choose_offered_course_option_path(course_code: @pick_course.course_code) do |f| %>
     <%= f.govuk_error_summary %>
     <%= f.govuk_radio_buttons_fieldset :course_option_id, legend: { text: 'Which course should be added to the application?', size: 'm' } do %>
-      <% if (same_provider = @pick_course.course_options_for_provider(@application_choice.provider)).any? %>
-        <h2 class="govuk-heading-s">Courses from the same provider (<%= @application_choice.provider.name_and_code %>)</h2>
+      <p class="govuk-hint">All courses shown are from the current recruitment cycle (<%= CycleTimetable.current_year %>).</p>
+
+      <% if @options_from_same_provider.present? %>
+        <h2 class="govuk-heading-s">Courses from the same provider (<%= @application_choice.current_provider.name_and_code %>)</h2>
         <div class="same-provider govuk-!-margin-bottom-6">
-          <% same_provider.each_with_index do |co, i| %>
+          <% @options_from_same_provider.each_with_index do |co, i| %>
             <%= f.govuk_radio_button :course_option_id, co.course_option_id, label: { text: "#{co.course_name} (#{co.course_code})" }, hint: { text: "#{co.site_name} – #{co.study_mode}" }, link_errors: i.zero? %>
           <% end %>
         </div>
       <% end %>
 
-      <% if (other_providers = @pick_course.course_options_for_other_providers(@application_choice.provider)).any? %>
+      <% if @options_from_ratified_provider.present? %>
+        <h2 class="govuk-heading-s">Courses ratified by the same provider (<%= @application_choice.current_provider.name_and_code %>)</h2>
+        <div class="same-provider govuk-!-margin-bottom-6">
+          <% @options_from_ratified_provider.each_with_index do |co, i| %>
+            <%= f.govuk_radio_button :course_option_id, co.course_option_id, label: { text: "#{co.provider_name} (#{co.provider_code}) – #{co.course_name} (#{co.course_code})" }, hint: { text: "#{co.site_name} – #{co.study_mode}" }, link_errors: i.zero? %>
+          <% end %>
+        </div>
+      <% end %>
+
+      <% if @options_from_other_providers.present? %>
         <h2 class="govuk-heading-s">Courses from other providers</h2>
         <div class="other-providers">
-          <% other_providers.each_with_index do |co, i| %>
+          <% @options_from_other_providers.each_with_index do |co, i| %>
             <%= f.govuk_radio_button :course_option_id, co.course_option_id, label: { text: "#{co.provider_name} (#{co.provider_code}) – #{co.course_name} (#{co.course_code})" }, hint: { text: "#{co.site_name} – #{co.study_mode}" }, link_errors: i.zero? %>
           <% end %>
         </div>


### PR DESCRIPTION
This is now clearer about which year is being selected from, which provider is being selected regardless of ratified provider, and what the current provider is even if they've already moved courses.

## Context

In specific cases, courses from ratified providers get mixed together.  It's also not clear what year we're pulling from.

## Changes proposed in this pull request

### Before
<img width="877" alt="Screenshot 2022-10-07 at 11 14 55" src="https://user-images.githubusercontent.com/109225/194531810-8c41b2ed-f217-400a-abae-486bac712e71.png">

### After
<img width="1090" alt="Screenshot 2022-10-07 at 11 12 00" src="https://user-images.githubusercontent.com/109225/194531828-209a6e8a-057a-439f-a0a7-4717a04cc0d8.png">

## Link to Trello card

https://trello.com/c/xTfPqBhZ/747-add-more-information-in-the-pick-course-page-in-the-support-app
