### PR TITLE
Deprecate `hesa_itt_data` vendor API field

### DIFF
--- a/app/presenters/concerns/hesa_itt_data_api_data.rb
+++ b/app/presenters/concerns/hesa_itt_data_api_data.rb
@@ -1,17 +1,12 @@
 module HesaIttDataAPIData
+  HESA_CODES_UPDATE_YEAR = 2023
   HESA_DISABILITY_OTHER = '96'.freeze
 
   def hesa_itt_data
     return nil unless ApplicationStateChange::ACCEPTED_STATES.include?(application_choice.status.to_sym)
 
-    equality_and_diversity_data = application_form&.equality_and_diversity
-
-    if equality_and_diversity_data
-      {
-        sex: equality_and_diversity_data['hesa_sex'],
-        disability: equality_and_diversity_data['hesa_disabilities'],
-        ethnicity: equality_and_diversity_data['hesa_ethnicity'],
-      }.merge(additional_hesa_itt_data(equality_and_diversity_data))
+    unless (data = application_form&.equality_and_diversity).nil?
+      hesa_codes(data).merge(additional_hesa_itt_data(data))
     end
   end
 
@@ -34,5 +29,21 @@ module HesaIttDataAPIData
     return if known_ethnic_backgrounds.include?(equality_and_diversity_data['ethnic_background'])
 
     equality_and_diversity_data['ethnic_background']
+  end
+
+  def hesa_codes(equality_and_diversity_data)
+    if application_form.recruitment_cycle_year >= HESA_CODES_UPDATE_YEAR
+      {
+        disability: [],
+        ethnicity: nil,
+        sex: nil,
+      }
+    else
+      {
+        disability: equality_and_diversity_data['hesa_disabilities'],
+        ethnicity: equality_and_diversity_data['hesa_ethnicity'],
+        sex: equality_and_diversity_data['hesa_sex'],
+      }
+    end
   end
 end

--- a/app/views/api_docs/vendor_api_docs/pages/release_notes.md
+++ b/app/views/api_docs/vendor_api_docs/pages/release_notes.md
@@ -1,3 +1,10 @@
+## 7th October 2022
+
+Documentation:
+
+Mark `hesa_itt_data` as deprecated. HESA code fields (sex/disability/ethnicity) within this object will contain `nil` or an empty array
+for applications in the 2023 recruitment cycle.
+
 ## 12th July 2022
 
 `/test-data/generate` now accepts an optional `previous_cycle` query param.

--- a/app/views/api_docs/vendor_api_docs/pages/release_notes.md
+++ b/app/views/api_docs/vendor_api_docs/pages/release_notes.md
@@ -3,7 +3,7 @@
 Documentation:
 
 Mark `hesa_itt_data` as deprecated. HESA code fields (sex/disability/ethnicity) within this object will contain `nil` or an empty array
-for applications in the 2023 recruitment cycle.
+for applications in the 2022 to 2023 recruitment cycle.
 
 ## 12th July 2022
 

--- a/config/vendor_api/v1.0.yml
+++ b/config/vendor_api/v1.0.yml
@@ -520,8 +520,13 @@ components:
           anyOf:
           - "$ref": "#/components/schemas/HESAITTData"
           nullable: true
-          description: Values to populate this candidate’s HESA Initial Teacher
+          deprecated: true
+          description: |
+            Values to populate this candidate’s HESA Initial Teacher
             Training data return.  Available once an offer has been accepted.
+
+            Deprecation warning: HESA code fields (sex/disability/ethnicity) within this object will contain `nil` or an empty array
+            for applications in the 2023 recruitment cycle.
         further_information:
           type: string
           maxLength: 10240
@@ -1131,6 +1136,9 @@ components:
       description: |
         Information required by HESA for the Initial Teacher Training data
         return.
+
+        Deprecation warning: HESA code fields (sex/disability/ethnicity) within this object will contain `nil` or an empty array
+        for applications in the 2023 recruitment cycle.
       required:
       - sex
       - disability

--- a/spec/presenters/concerns/hesa_itt_data_api_data_spec.rb
+++ b/spec/presenters/concerns/hesa_itt_data_api_data_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe HesaIttDataAPIData do
   describe '#hesa_itt_data' do
     let(:disabilities) { %w[Deaf] }
     let(:hesa_disabilities) { %w[57] }
+    let(:hesa_ethnicity) { '10' }
+    let(:hesa_sex) { '1' }
     let(:ethnic_group) { 'White' }
     let(:ethnic_background) { 'Irish' }
     let(:equality_and_diversity) do
@@ -30,10 +32,12 @@ RSpec.describe HesaIttDataAPIData do
         ethnic_background:,
         disabilities:,
         hesa_disabilities:,
-        hesa_sex: '1',
+        hesa_ethnicity:,
+        hesa_sex:,
       }
     end
-    let(:application_form) { create(:application_form, :minimum_info, equality_and_diversity:) }
+    let(:recruitment_cycle_year) { 2022 }
+    let(:application_form) { create(:application_form, :minimum_info, equality_and_diversity:, recruitment_cycle_year:) }
     let(:application_choice) { create(:application_choice, :with_accepted_offer, application_form:) }
 
     context 'when an application choice has had an accepted offer' do
@@ -80,6 +84,7 @@ RSpec.describe HesaIttDataAPIData do
     context 'when the application choice has other freetext ethnicity' do
       let(:ethnic_group) { 'White' }
       let(:ethnic_background) { 'Custom ethnic background' }
+      let(:hesa_ethnicity) { '10' }
 
       it 'returns the other ethnicity in the other_ethnicity_details field' do
         expect(presenter.hesa_itt_data).to eq({
@@ -95,6 +100,7 @@ RSpec.describe HesaIttDataAPIData do
     context 'when the application choice has other non-freetext ethnicity' do
       let(:ethnic_group) { 'Another ethnic group' }
       let(:ethnic_background) { 'Another ethnic background' }
+      let(:hesa_ethnicity) { '80' }
 
       it 'does not return the other ethnicity in the other_ethnicity_details field' do
         expect(presenter.hesa_itt_data).to eq({
@@ -110,6 +116,7 @@ RSpec.describe HesaIttDataAPIData do
     context 'when the application choice has set prefer not to say as the ethnic background' do
       let(:ethnic_group) { 'Another ethnic group' }
       let(:ethnic_background) { 'Prefer not to say' }
+      let(:hesa_ethnicity) { '98' }
 
       it 'does not return the other ethnicity in the other_ethnicity_details field' do
         expect(presenter.hesa_itt_data).to eq({
@@ -128,6 +135,38 @@ RSpec.describe HesaIttDataAPIData do
 
       it 'the hesa_itt_data attribute of an application is nil' do
         expect(presenter.hesa_itt_data).to be_nil
+      end
+    end
+
+    context 'when the application is from the 2022 recruitment cycle' do
+      let(:recruitment_cycle_year) { 2022 }
+
+      let(:hesa_disabilities) { %w[57] } # Deafness
+      let(:hesa_ethnicity) { '10' } # White
+      let(:hesa_sex) { '1' } # Male
+
+      it 'returns the 2022 HESA codes' do
+        expect(presenter.hesa_itt_data).to include(
+          disability: %w[57],
+          sex: '1',
+          ethnicity: '10',
+        )
+      end
+    end
+
+    context 'when the application is from the 2023 recruitment cycle' do
+      let(:recruitment_cycle_year) { 2023 }
+
+      let(:hesa_disabilities) { %w[57] } # Deafness
+      let(:hesa_ethnicity) { '166' } # White/Irish
+      let(:hesa_sex) { '11' } # Male
+
+      it 'returns nil instead of the HESA codes' do
+        expect(presenter.hesa_itt_data).to include(
+          disability: [],
+          sex: nil,
+          ethnicity: nil,
+        )
       end
     end
   end


### PR DESCRIPTION
The HESA code fields (sex/disability/ethnicity) will return `nil` or `[]` for applications in the 2023 cycle.

Note: This **does not** change the API used by Register.

## Context

These fields are being replaced to account for longer HESA codes.

## Changes proposed in this pull request

### Documentation
#### Before
<img width="926" alt="Screenshot 2022-10-07 at 15 42 24" src="https://user-images.githubusercontent.com/109225/194580822-c93a0208-9b72-429e-952f-ee3a965ab6a4.png">
<img width="1101" alt="Screenshot 2022-10-07 at 15 42 11" src="https://user-images.githubusercontent.com/109225/194580855-3f62527a-bd7d-43f6-983b-5934fa764d4b.png">

#### After
<img width="961" alt="Screenshot 2022-10-07 at 15 41 45" src="https://user-images.githubusercontent.com/109225/194580958-f88e8250-4c9f-447f-a10f-3e187b1fc832.png">
<img width="1068" alt="Screenshot 2022-10-07 at 15 41 32" src="https://user-images.githubusercontent.com/109225/194580974-0751f37e-8cfb-4b5e-a4a5-aaa30a839d9a.png">

### Actual API response
#### 2022
##### Before
```
            "hesa_itt_data": {
                "sex": "10",
                "disability": [
                    "96"
                ],
                "ethnicity": "31",
                "other_disability_details": "Acquired brain injury",
                "other_ethnicity_details": null
            },
```
##### After
```
            "hesa_itt_data": {
                "disability": [
                    "96"
                ],
                "ethnicity": "31",
                "sex": "10",
                "other_disability_details": "Acquired brain injury",
                "other_ethnicity_details": null
            },
```
#### 2023
##### Before
```
            "hesa_itt_data": {
                "sex": "12",
                "disability": [
                    "51"
                ],
                "ethnicity": "50",
                "other_disability_details": null,
                "other_ethnicity_details": null
            },
```
##### After
```
            "hesa_itt_data": {
                "disability": [],
                "ethnicity": null,
                "sex": null,
                "other_disability_details": null,
                "other_ethnicity_details": null
            },
```

## Link to Trello card

https://trello.com/c/tvrmz5D4/748-vendor-api-null-out-sex-ethnicity-disability-hesa-codes-for-the-new-cycle

## Things to check

- [x] API release notes have been updated if necessary
