### PR TITLE
Update referee emails

### DIFF
--- a/app/views/referee_mailer/reference_cancelled_email.text.erb
+++ b/app/views/referee_mailer/reference_cancelled_email.text.erb
@@ -1,9 +1,5 @@
 Dear <%= @name %>
 
-<%= @candidate_name %> had previously asked for a reference from you for their teacher training application.
+You were asked to give a reference for <%= @candidate_name %>’s teacher training application.
 
-It looks like they do not need a reference anymore.
-
-You do not need to do anything.
-
-If you’re in touch with the candidate they may be able to explain why they no longer need a reference.
+They no longer need this reference. You do not need to do anything.

--- a/app/views/referee_mailer/reference_confirmation_email.text.erb
+++ b/app/views/referee_mailer/reference_confirmation_email.text.erb
@@ -1,7 +1,3 @@
 Dear <%= @name %>
 
-Thank you for your reference for <%= @candidate_name %>.
-
-Find out how the Department for Education processes your reference:
-
-<%= candidate_interface_privacy_policy_url %>
+You’ve submitted a reference for  <%= @candidate_name %>.

--- a/config/locales/referee_interface/referee_interface.yml
+++ b/config/locales/referee_interface/referee_interface.yml
@@ -48,9 +48,9 @@ en:
         label: Please let us know when you’re available and give a phone number
       submit: Finish
   reference_confirmation_email:
-    subject: Reference submitted for %{candidate_name}
+    subject: Teacher training reference submitted for %{candidate_name}
   reference_cancelled_email:
-    subject: "%{candidate_name} no longer needs a reference"
+    subject: "Teacher training reference no longer needed for %{candidate_name}"
 
   activemodel:
     errors:

--- a/spec/system/candidate_interface/references/candidate_reviews_references_feature_flag_disabled_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_reviews_references_feature_flag_disabled_spec.rb
@@ -168,8 +168,8 @@ RSpec.feature 'Review references' do
   def and_referee_receives_email_about_reference_cancellation
     open_email(@requested_reference.email_address)
 
-    expect(current_email.subject).to include 'no longer needs a reference'
-    expect(current_email.text).to include 'It looks like they do not need a reference anymore.'
+    expect(current_email.subject).to include 'reference no longer needed'
+    expect(current_email.text).to include 'They no longer need this reference.'
   end
 
   def and_i_can_return_to_the_application_page


### PR DESCRIPTION
Updates the referee emails when a reference is cancelled, and when the reference is submitted.

(The main referee email requesting a reference is being updated in #7489)