### PR TITLE
References email changes

### DIFF
--- a/app/views/candidate_mailer/_new_flow_chase_reference_again.text.erb
+++ b/app/views/candidate_mailer/_new_flow_chase_reference_again.text.erb
@@ -7,7 +7,7 @@ You asked <%= @referee.name %> for a reference for your teacher training applica
 You can sign into your account to:
 
 - ask someome else for a reference
-- send them, an email to remind them that you’ve asked for a reference
+- send them an email to remind them that you’ve asked for a reference
 - cancel the request for a reference
 
 

--- a/app/views/candidate_mailer/_new_flow_new_referee_request.text.erb
+++ b/app/views/candidate_mailer/_new_flow_new_referee_request.text.erb
@@ -42,5 +42,4 @@ You can sign into your account to:
 <% end %>
 [Sign into your account](<%= candidate_magic_link(@candidate) %>).
 
-<%= @reference.application_form.application_choices.pending_conditions.first&.provider&.name %> must check your references before they can confirm your place on the course.
-Contact them if you need help getting references or choosing who to ask.
+<%= @reference.application_form.application_choices.pending_conditions.first&.provider&.name %> must check your references before they can confirm your place on the course. Contact them if you need help getting references or choosing who to ask.

--- a/app/views/candidate_mailer/conditions_met.text.erb
+++ b/app/views/candidate_mailer/conditions_met.text.erb
@@ -1,9 +1,21 @@
 Dear <%= @application_form.first_name %>
 <% if @application_form.show_new_reference_flow? %>
 
-  <%= @course.provider.name %> has confirmed that you’ve met your conditions and they’ve checked your references.
+  <%= @course.provider.name %> has confirmed that you’ve met the conditions of your offer.
 
-  If they have not already, <%= @course.provider.name %> should contact you with details about enrolling on the course. Contact them directly if you have any questions.
+  They’ll let you know if they need further information before you can start training. Contact them if you have any questions.
+
+  You can sign into your account if you need to check the progress of your reference requests.
+
+  [Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>).
+
+  #What to do if you’re unable to start training in <%= @start_date %>
+
+  Some providers allow you to defer your offer. This means that you could start your course a year later.
+
+  Every provider is different, so it may or may not be possible to do this. Find out by contacting <%= @provider_name %>.
+
+  Asking if it’s possible to defer will not affect your existing offer.
 
 <% else %>
 
@@ -14,6 +26,3 @@ Dear <%= @application_form.first_name %>
   Contact them directly if you have any questions about this process.
 
 <% end %>
-
-
-

--- a/app/views/candidate_mailer/conditions_met.text.erb
+++ b/app/views/candidate_mailer/conditions_met.text.erb
@@ -9,13 +9,11 @@ Dear <%= @application_form.first_name %>
 
   [Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>).
 
-  #What to do if you’re unable to start training in <%= @start_date %>
+  #If you’re unable to start training in <%= @start_date %>
 
   Some providers allow you to defer your offer. This means that you could start your course a year later.
 
-  Every provider is different, so it may or may not be possible to do this. Find out by contacting <%= @provider_name %>.
-
-  Asking if it’s possible to defer will not affect your existing offer.
+  Contact <%= @provider_name%> to find out if they’ll allow you to defer your offer. Asking if it’s possible will not affect your existing offer.
 
 <% else %>
 

--- a/app/views/candidate_mailer/offer_accepted.text.erb
+++ b/app/views/candidate_mailer/offer_accepted.text.erb
@@ -4,18 +4,19 @@ You’ve accepted <%= @provider_name %>’s offer to study <%= @course_name_and_
 
 <% if @application_form.show_new_reference_flow? %>
 Your place will be confirmed when:
+
+- <%= @provider_name %> has received and checked your references
 - you’ve met your offer conditions
-- safeguarding checks like DBS and references have been completed
 
-If you meet your conditions, you’ll start <%= @course_name_and_code %> <%= @provider_name %> in <%= @start_date %>.
+Sign into your account to check the progress of your reference requests and offer conditions.
 
-[Sign in](<%= candidate_magic_link(@application_form.candidate) %>) to check the progress of your reference requests and offer conditions.
+[Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>).
 
 #If you’re unable to start training in <%= @start_date %>
 
 Some providers allow you to defer your offer. This means that you could start your course a year later.
 
-Contact <%= @provider_name%> to find out if they’ll allow you to defer your offer. Asking them will not affect your existing offer.
+Contact <%= @provider_name%> to find out if they’ll allow you to defer your offer. Asking if it’s possible will not affect your existing offer.
 
 <% else %>
 

--- a/app/views/candidate_mailer/reinstated_offer.text.erb
+++ b/app/views/candidate_mailer/reinstated_offer.text.erb
@@ -8,16 +8,10 @@ The course starts in <%= @course_option.course.start_date.to_fs(:month_and_year)
 
   <%= render "candidate_mailer/offer_conditions" %>
 
+  Sign into your account to check the progress of your offer conditions.
+
+  [Sign into your account](<%= candidate_magic_link(@application_choice.application_form.candidate) %>).
+
 <% else %>
   They’ll let you know if they need further information before you start training.
-<% end %>
-
-<% if @application_form.show_new_reference_flow? %>
-
-  <%= @provider_name %> also needs to check your references and DBS.
-
-  [Sign in](<%= candidate_magic_link(@application_choice.application_form.candidate) %>) to check the progress of your reference requests and offer conditions.
-
-<% else %>
-  [Sign in to your account to see your offer details](<%= candidate_magic_link(@application_choice.application_form.candidate) %>).
 <% end %>

--- a/app/views/candidate_mailer/unconditional_offer_accepted.text.erb
+++ b/app/views/candidate_mailer/unconditional_offer_accepted.text.erb
@@ -2,14 +2,16 @@ Dear <%= @application_form.first_name %>
 
 You’ve accepted <%= @provider_name %>’s offer to study <%= @course_name_and_code %>.
 
-The course starts <%= @start_date %>.
+<%= @provider_name %> will check your references once they receive them.
 
-<%= @provider_name %> will let you know if they need further information before you can start training.
+They’ll let you know if they need further information before you can start training.
 
-#What to do if you’re unable to start training in <%= @start_date %>
+Sign into your account to check the progress of your reference requests.
+
+[Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>).
+
+#If you’re unable to start training in <%= @start_date %>
 
 Some providers allow you to defer your offer. This means that you could start your course a year later.
 
-Every provider is different, so it may or may not be possible to do this. Find out by contacting <%= @provider_name %>.
-
-Asking if it’s possible to defer will not affect your existing offer.
+Contact <%= @provider_name %> to find out if they’ll allow you to defer your offer. Asking if it’s possible will not affect your existing offer.

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -75,7 +75,7 @@ en:
       subject: "%{provider_name} has updated the status of your conditions for %{course_name}"
     conditions_met:
       subject_2022: "You have met your conditions for %{course_name}: next steps"
-      subject_2023: "You’ve met your conditions for %{course_name}"
+      subject_2023: "You’ve met your conditions to study %{course_name}"
     conditions_not_met:
       subject: "You did not meet the offer conditions for %{course_name}"
     changed_offer:
@@ -87,7 +87,7 @@ en:
     deferred_offer_reminder:
       subject: "Reminder of your deferred offer"
     reinstated_offer:
-      subject: "Your deferred offer has been confirmed"
+      subject: "Your deferred offer to study %{course_name} has been confirmed by %{provider_name}"
     course_unavailable_notification:
       subject:
         course_full: "There are no more places for %{course_name} at %{provider_name}: update your course choice now"

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -346,7 +346,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
     it_behaves_like(
       'a mail with subject and content',
-      'Your deferred offer has been confirmed',
+      'Your deferred offer to study %{course_name} has been confirmed by %{provider_name}',
       'heading' => 'Dear Bob',
       'provider name' => 'Falconholt Technical College has confirmed your deferred offer to study',
       'name and code for course' => 'Forensic Science (E0FO)',
@@ -357,7 +357,7 @@ RSpec.describe CandidateMailer, type: :mailer do
     describe 'with pending conditions' do
       it_behaves_like(
         'a mail with subject and content',
-        'Your deferred offer has been confirmed',
+        'Your deferred offer to study %{course_name} has been confirmed by %{provider_name}',
         'heading' => 'Dear Bob',
         'provider name' => 'Falconholt Technical College has confirmed your deferred offer to study',
         'name and code for course' => 'Forensic Science (E0FO)',

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -351,7 +351,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       it 'includes reference text' do
         expect(email.body).to include('you’ve met your offer conditions')
-        expect(email.body).to include('safeguarding checks like DBS and references have been completed')
+        expect(email.body).to include('check the progress of your reference requests')
       end
     end
   end
@@ -401,7 +401,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
     it_behaves_like(
       'a mail with subject and content',
-      'Your deferred offer has been confirmed',
+      'Your deferred offer to study %{course_name} has been confirmed by %{provider_name}',
       'greeting' => 'Dear Fred',
       'details' => 'Arithmetic College has confirmed your deferred offer to study',
       'pending condition text' => 'You still need to meet the following condition',
@@ -413,7 +413,7 @@ RSpec.describe CandidateMailer, type: :mailer do
         FeatureFlag.activate(:new_references_flow)
       end
 
-      it 'includes reference text' do
+      xit 'includes reference text' do
         expect(email.body).to include('Arithmetic College also needs to check your references and DBS.')
       end
     end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -407,16 +407,6 @@ RSpec.describe CandidateMailer, type: :mailer do
       'pending condition text' => 'You still need to meet the following condition',
       'pending condition' => 'Be cool',
     )
-
-    context 'when new reference flow is active' do
-      before do
-        FeatureFlag.activate(:new_references_flow)
-      end
-
-      xit 'includes reference text' do
-        expect(email.body).to include('Arithmetic College also needs to check your references and DBS.')
-      end
-    end
   end
 
   describe '.unconditional_offer_accepted' do

--- a/spec/system/provider_interface/provider_marks_conditions_as_met_spec.rb
+++ b/spec/system/provider_interface/provider_marks_conditions_as_met_spec.rb
@@ -113,7 +113,7 @@ RSpec.feature 'Confirm conditions met' do
     open_email(@application_choice.application_form.candidate.email_address)
 
     if @application_choice.application_form.show_new_reference_flow?
-      expect(current_email.subject).to have_content 'You’ve met your conditions for'
+      expect(current_email.subject).to have_content 'You’ve met your conditions to study'
     else
       expect(current_email.subject).to have_content 'You have met your conditions for'
     end


### PR DESCRIPTION
## Context

Some of the candidate emails about references were not the most recent versions. We need to update them before the new references journey is launched on 11 October.

## Changes proposed in this pull request

I've updated:

- conditions_met.text.erb
- offer_accepted.text.erb
- reinstated_offer.text.erb
- unconditional_offer_accepted.text.erb

I've fixed typos in:

- new_referee_request.text.erb
- chase_reference_again.text.erb

## Guidance to review

### Changed logic

These are all content changes, except that I removed logic from reinstated_offer.text.erb. 

Previously it distinguished between the old and new reference journey. This affected how the link to the service was shown. I moved the link so it only displays if the candidate has conditions.

I could have nested the old/new journey logic inside the conditions/no conditions logic. But that seemed unnecessary given that no users should see the old journey any more, and it also isn't a significant change.

### reinstated_offer in support

The current reinstated_offer email does not display correctly in support when there are no conditions. The lead in line for conditions is shown, but with no bullet list as there are no conditions. 

To me it looks like the logic is OK in the code (and I haven't changed it). Whoever reviews this should check whether we need to make a change either as a commit in this PR or as a separate PR.

![CleanShot 2022-10-10 at 09 22 48](https://user-images.githubusercontent.com/29047487/194824946-fe9537da-3e86-4552-9d7a-8439c8d57d53.png)

### Tests

I included commits to fix the tests broken by the subject line changes.

## Link to Trello card

[<!-- http://trello.com/123-example-card -->
](https://trello.com/c/5dMY5JDf/750-update-candidate-emails)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
