### PR TITLE
Drop ethnic background heading size from XL to L

### DIFF
--- a/app/views/candidate_interface/equality_and_diversity/edit_ethnic_background.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_ethnic_background.html.erb
@@ -6,7 +6,7 @@
     <%= form_with model: @ethnic_background, url: candidate_interface_edit_equality_and_diversity_ethnic_background_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :ethnic_background, caption: { text: t('equality_and_diversity.title'), size: 'xl' }, legend: { text: ethnic_background_title(@ethnic_group), size: 'xl' } do %>
+      <%= f.govuk_radio_buttons_fieldset :ethnic_background, caption: { text: t('equality_and_diversity.title'), size: 'l' }, legend: { text: ethnic_background_title(@ethnic_group), size: 'l' } do %>
         <% ethnic_backgrounds(@ethnic_group).each_with_index do |background, i| %>
           <% if background.textfield_label.nil? %>
             <%= f.govuk_radio_button :ethnic_background, background.label, label: { text: background.label }, link_errors: i.zero? %>


### PR DESCRIPTION
Missed this before when reviewing, but we’re dropping the maximum heading size down from XL to L. It's especially relevant here, as this can be quite a long heading (eg "Which of the following best describes your Black, African, Black British or Caribbean background?")