### PR TITLE
HTML fix: drop legend tag, move caption out from h1

### DIFF
--- a/app/views/candidate_interface/equality_and_diversity/edit_disabilities.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_disabilities.html.erb
@@ -6,14 +6,12 @@
     <%= form_with model: @disabilities, url: candidate_interface_edit_equality_and_diversity_disabilities_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-        <h1 class="govuk-fieldset__heading">
-          <span class="govuk-caption-l">
-            <%= t('equality_and_diversity.title') %>
-          </span>
-          <%= t('equality_and_diversity.disabilities.title') %>
-        </h1>
-      </legend>
+      <span class="govuk-caption-l">
+        <%= t('equality_and_diversity.title') %>
+      </span>
+      <h1 class="govuk-heading-l">
+        <%= t('equality_and_diversity.disabilities.title') %>
+      </h1>
 
       <p class="govuk-body">
         Training providers will not see your answer to this question when deciding whether to offer you a place.

--- a/app/views/candidate_interface/equality_and_diversity/edit_ethnic_group.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_ethnic_group.html.erb
@@ -9,14 +9,12 @@
     <%= form_with model: @ethnic_group, url: candidate_interface_edit_equality_and_diversity_ethnic_group_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-        <h1 class="govuk-fieldset__heading">
-          <span class="govuk-caption-l">
-            <%= t('equality_and_diversity.title') %>
-          </span>
-          <%= t('equality_and_diversity.ethnic_group.title') %>
-        </h1>
-      </legend>
+      <span class="govuk-caption-l">
+        <%= t('equality_and_diversity.title') %>
+      </span>
+      <h1 class="govuk-heading-l">
+        <%= t('equality_and_diversity.ethnic_group.title') %>
+      </h1>
 
       <p class="govuk-body">Training providers will not see your answer to this question when deciding whether to offer you a place.</p>
       <p class="govuk-body">They will only see your answer if you accept an offer from them.</p>


### PR DESCRIPTION
These h1s should no longer be contained in a legend tag, as they are no longer within a fieldset, as there’s now a separate h1 from the legend.

This will visually appear exactly the same, but will improve accessibility.