### PR TITLE
Don't create duplicate candidates in test applications

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -138,11 +138,9 @@ private
     Audited.audit_class.as_user(candidate) do
       traits = [%i[with_safeguarding_issues_disclosed
                    with_safeguarding_issues_never_asked
-                   minimum_info duplicate_candidates].sample]
+                   minimum_info].sample]
 
       traits << :with_equality_and_diversity_data
-
-      last_name_on_application_form = traits.include?(:duplicate_candidates) && ApplicationForm.last&.last_name ? ApplicationForm.last.last_name : last_name
 
       simulate_signin(candidate)
 
@@ -159,7 +157,7 @@ private
           submitted_at: nil,
           candidate:,
           first_name:,
-          last_name: last_name_on_application_form,
+          last_name:,
           created_at: time,
           updated_at: time,
           recruitment_cycle_year:,


### PR DESCRIPTION
Currently 1 in 4 test applications created within review apps are deliberately created as "duplicate candidates" which are then blocked from being able to apply.

Most of the time, we aren’t testing this feature, and it can get in the way of testing the apply again feature (you have to manually unblock the candidate first).

Can we turn this off, so that by default we don't generate duplicate candidates unable to submit?  If we do need to test this feature, we could temporarily switch it back on again, or manually create 2 accounts with matching details.