### PR TITLE
756 dont allow candidates to apply to courses which arent open yet

### DIFF
--- a/app/forms/candidate_interface/pick_course_form.rb
+++ b/app/forms/candidate_interface/pick_course_form.rb
@@ -64,7 +64,7 @@ module CandidateInterface
     end
 
     def available_courses
-      @available_courses ||= courses_for_current_cycle.exposed_in_find.includes(:accredited_provider, :course_options).order(:name)
+      @available_courses ||= courses_for_current_cycle.exposed_in_find.open_for_applications.includes(:accredited_provider, :course_options).order(:name)
     end
 
     def courses_with_names

--- a/app/forms/candidate_interface/pick_provider_form.rb
+++ b/app/forms/candidate_interface/pick_provider_form.rb
@@ -9,7 +9,7 @@ module CandidateInterface
       @available_providers ||= Provider
       .joins(:courses)
       .where(courses: { recruitment_cycle_year: RecruitmentCycle.current_year, exposed_in_find: true })
-      .where('courses.opened_on_apply_at <= ?', Time.zone.now)
+      .where('courses.applications_open_from <= ?', Time.zone.today)
       .order(:name)
       .distinct
     end

--- a/spec/forms/candidate_interface/pick_course_form_spec.rb
+++ b/spec/forms/candidate_interface/pick_course_form_spec.rb
@@ -20,14 +20,42 @@ RSpec.describe CandidateInterface::PickCourseForm do
   describe '#dropdown_available_courses' do
     it 'displays the vacancy status' do
       provider = create(:provider)
-      course = create(:course, open_on_apply: true, exposed_in_find: true, name: 'Maths', code: '123', provider:)
-      create(:course, open_on_apply: true, exposed_in_find: true, name: 'English', code: '456', description: 'PGCE with QTS full time', provider:)
-      create(:course, open_on_apply: true, exposed_in_find: true, name: 'English', code: '789', description: 'PGCE full time', provider:)
+      course = create(
+        :course,
+        :open_on_apply,
+        name: 'Maths',
+        code: '123',
+        provider:,
+      )
+      create(
+        :course,
+        :open_on_apply,
+        name: 'English',
+        code: '456',
+        description: 'PGCE with QTS full time',
+        provider:,
+      )
+      create(
+        :course,
+        :open_on_apply,
+        name: 'English',
+        code: '789',
+        description: 'PGCE full time',
+        provider:,
+      )
       create(:course_option, course:)
 
       form = described_class.new(provider_id: provider.id)
 
-      expect(form.dropdown_available_courses.map(&:name)).to eql(['English (456) – PGCE with QTS full time – No vacancies', 'English (789) – PGCE full time – No vacancies', 'Maths (123)'])
+      expect(
+        form.dropdown_available_courses.map(&:name),
+      ).to eql(
+        [
+          'English (456) – PGCE with QTS full time – No vacancies',
+          'English (789) – PGCE full time – No vacancies',
+          'Maths (123)',
+        ],
+      )
     end
 
     it 'respects the current recruitment cycle' do

--- a/spec/forms/candidate_interface/pick_course_form_spec.rb
+++ b/spec/forms/candidate_interface/pick_course_form_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe CandidateInterface::PickCourseForm do
       provider = create(:provider, name: 'School with courses')
 
       create(:course, :open_on_apply, exposed_in_find: false, name: 'Course not shown in Find', provider:)
+      create(:course, exposed_in_find: true, open_on_apply: true, name: 'Course that is not accepting applications', applications_open_from: Time.zone.tomorrow, provider:)
       create(:course, :open_on_apply, name: 'Course you can apply to', provider:)
       create(:course, :open_on_apply, name: 'Course from another cycle', provider:, recruitment_cycle_year: 2016)
       create(:course, :open_on_apply, name: 'Course from other provider')
@@ -39,6 +40,18 @@ RSpec.describe CandidateInterface::PickCourseForm do
       form = described_class.new(provider_id: provider.id)
 
       expect(form.dropdown_available_courses.map(&:name)).to eql(['This cycle (A)'])
+    end
+
+    it 'only shows courses which are open for applications' do
+      provider = create(:provider)
+      course = create(:course, :open_on_apply, name: 'Course is open for applications', code: 'A', provider:)
+      create(:course, :open_on_apply, name: 'Course is not open for applications', provider:, applications_open_from: Time.zone.tomorrow)
+
+      create(:course_option, course:)
+
+      form = described_class.new(provider_id: provider.id)
+
+      expect(form.dropdown_available_courses.map(&:name)).to eql(['Course is open for applications (A)'])
     end
 
     context 'with no ambiguous courses' do

--- a/spec/forms/candidate_interface/pick_provider_form_spec.rb
+++ b/spec/forms/candidate_interface/pick_provider_form_spec.rb
@@ -2,12 +2,12 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::PickProviderForm do
   describe '#available_providers' do
-    it 'returns providers with a course exposed in find in the current cycle which are open on apply' do
+    it 'returns providers with a course exposed in find in the current cycle which are open to applications' do
       create(:provider, name: 'School without courses')
-      create(:course, :open_on_apply, exposed_in_find: false, provider: create(:provider, name: 'School with disabled courses'))
-      create(:course, :open_on_apply, opened_on_apply_at: Time.zone.today, provider: create(:provider, name: 'School with courses'))
-      create(:course, :open_on_apply, opened_on_apply_at: Time.zone.tomorrow, provider: create(:provider, name: 'School with courses but not open for applications'))
-      create(:course, :open_on_apply, recruitment_cycle_year: RecruitmentCycle.previous_year)
+      create(:course, open_on_apply: true, exposed_in_find: false, provider: create(:provider, name: 'School with disabled courses'))
+      create(:course, open_on_apply: true, exposed_in_find: true, applications_open_from: Time.zone.today, provider: create(:provider, name: 'School with courses'))
+      create(:course, open_on_apply: true, exposed_in_find: true, applications_open_from: Time.zone.tomorrow, provider: create(:provider, name: 'School with courses but not open for applications'))
+      create(:course, open_on_apply: true, exposed_in_find: true, recruitment_cycle_year: RecruitmentCycle.previous_year)
 
       form = described_class.new({})
 

--- a/spec/system/provider_interface/see_applications_for_accrediting_provider_spec.rb
+++ b/spec/system/provider_interface/see_applications_for_accrediting_provider_spec.rb
@@ -43,12 +43,12 @@ RSpec.feature 'See applications for accredited provider' do
   end
 
   def then_i_should_see_the_applications_from_my_organisation
-    expect(page).to have_content 'Jim'
-    expect(page).to have_content 'Clancy'
-    expect(page).to have_content 'Harry'
+    expect(page).to have_link 'Jim'
+    expect(page).to have_link 'Clancy'
+    expect(page).to have_link 'Harry'
   end
 
   def but_not_the_applications_from_other_providers
-    expect(page).not_to have_content 'Bert'
+    expect(page).not_to have_link 'Bert'
   end
 end


### PR DESCRIPTION
## Context

Candidates shouldn't be able to apply to courses which aren't open yet (open from date is in the future).

In the period between Find opening and Apply opening, we made these courses visible so that candidates could start working on their applications before submitting. Now Apply has opened, it's a bug. 

We'll work separately on a longer-term solution that allows candidates to see courses that haven't opened yet but not submit their application.

## Changes proposed in this pull request

Hide courses that are not open for applications yet (reverting [this](https://github.com/DFE-Digital/apply-for-teacher-training/commit/ed6fd0ccf2e99e89d500fb5fd735e5fd55f08ce5) and [this](https://github.com/DFE-Digital/apply-for-teacher-training/commit/24578ab4bd91f0b72e21c081f31ab5b0c4733aa4)).

## Link to Trello card

https://trello.com/c/8Ph5Axc3/756-dont-allow-candidates-to-apply-to-courses-which-arent-open-yet

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
