### PR TITLE
Fix some email subjects/contents

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -280,8 +280,9 @@ class CandidateMailer < ApplicationMailer
   def conditions_met(application_choice)
     @application_choice = application_choice
     @course = application_choice.current_course_option.course
-    course_name = "#{@course.name_and_code} at #{@course.provider.name}"
+    @start_date = application_choice.current_course_option.course.start_date.to_fs(:month_and_year)
 
+    course_name = "#{@course.name_and_code} at #{@course.provider.name}"
     email_for_candidate(
       application_choice.application_form,
       subject: I18n.t!("candidate_mailer.conditions_met.#{application_choice.application_form.show_new_reference_flow? ? 'subject_2023' : 'subject_2022'}", course_name:),

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -357,11 +357,12 @@ class CandidateMailer < ApplicationMailer
     @application_choice = application_choice
     @course_option = @application_choice.current_course_option
     @provider_name = @course_option.provider.name
+    @course_name = @course_option.course.name_and_code
     @conditions = @application_choice.offer.conditions_text
 
     email_for_candidate(
       @application_choice.application_form,
-      subject: I18n.t!('candidate_mailer.reinstated_offer.subject'),
+      subject: I18n.t!('candidate_mailer.reinstated_offer.subject', provider_name: @provider_name, course_name: @course_name),
     )
   end
 

--- a/app/views/candidate_mailer/conditions_met.text.erb
+++ b/app/views/candidate_mailer/conditions_met.text.erb
@@ -13,7 +13,7 @@ Dear <%= @application_form.first_name %>
 
   Some providers allow you to defer your offer. This means that you could start your course a year later.
 
-  Contact <%= @provider_name%> to find out if they’ll allow you to defer your offer. Asking if it’s possible will not affect your existing offer.
+  Contact <%= @course.provider.name %> to find out if they’ll allow you to defer your offer. Asking if it’s possible will not affect your existing offer.
 
 <% else %>
 

--- a/app/views/candidate_mailer/reinstated_offer.text.erb
+++ b/app/views/candidate_mailer/reinstated_offer.text.erb
@@ -4,7 +4,7 @@ Dear <%= @application_form.first_name %>
 
 The course starts in <%= @course_option.course.start_date.to_fs(:month_and_year) %>.
 
-<% if @application_choice.offer.conditions.any? { |c| c.status != 'met' } %>
+<% if @application_choice.offer.conditions.all?(&:met?) %>
 
   <%= render "candidate_mailer/offer_conditions" %>
 

--- a/app/views/candidate_mailer/reinstated_offer.text.erb
+++ b/app/views/candidate_mailer/reinstated_offer.text.erb
@@ -4,7 +4,7 @@ Dear <%= @application_form.first_name %>
 
 The course starts in <%= @course_option.course.start_date.to_fs(:month_and_year) %>.
 
-<% if @application_choice.offer.conditions.where(status: 'met').count.zero? %>
+<% if @application_choice.offer.conditions.any? { |c| c.status != 'met' } %>
 
   <%= render "candidate_mailer/offer_conditions" %>
 

--- a/app/views/candidate_mailer/reinstated_offer.text.erb
+++ b/app/views/candidate_mailer/reinstated_offer.text.erb
@@ -5,13 +5,11 @@ Dear <%= @application_form.first_name %>
 The course starts in <%= @course_option.course.start_date.to_fs(:month_and_year) %>.
 
 <% if @application_choice.offer.conditions.all?(&:met?) %>
-
+  They’ll let you know if they need further information before you start training.
+<% else %>
   <%= render "candidate_mailer/offer_conditions" %>
 
   Sign into your account to check the progress of your offer conditions.
 
   [Sign into your account](<%= candidate_magic_link(@application_choice.application_form.candidate) %>).
-
-<% else %>
-  They’ll let you know if they need further information before you start training.
 <% end %>

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -389,12 +389,20 @@ RSpec.describe CandidateMailer, type: :mailer do
     let(:application_choice) { build_stubbed(:application_choice, :with_changed_offer, course_option:, current_course_option: other_option, decline_by_default_at: 10.business_days.from_now) }
     let(:application_choices) { [application_choice] }
 
-    xit(
+    before do
+      FeatureFlag.activate(:new_references_flow)
+      allow(application_choice.current_course_option.course).to receive(:start_date)
+        .and_return(Time.zone.local(2049, 6, 5))
+    end
+
+    it_behaves_like(
       'a mail with subject and content',
-      'You’ve met your conditions for Forensic Science (E0FO) at Falconholt Technical College',
+      'You’ve met your conditions to study Forensic Science (E0FO) at Falconholt Technical College',
       'heading' => 'Dear Bob',
-      'title' => 'you’ve met your conditions',
+      'title' => 'you’ve met the conditions of your offer',
       'provider name' => 'Falconholt Technical College',
+      'start date' => 'June 2049',
+      'contact info' => 'Contact Falconholt Technical College',
     )
   end
 

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -344,27 +344,62 @@ RSpec.describe CandidateMailer, type: :mailer do
       magic_link_stubbing(application_form.candidate)
     end
 
-    it_behaves_like(
-      'a mail with subject and content',
-      'Your deferred offer to study %{course_name} has been confirmed by %{provider_name}',
-      'heading' => 'Dear Bob',
-      'provider name' => 'Falconholt Technical College has confirmed your deferred offer to study',
-      'name and code for course' => 'Forensic Science (E0FO)',
-      'start date of new course' => 'June 2020',
-      'course starts text' => 'The course starts',
-    )
+    describe 'with an unconditional offer' do
+      before do
+        application_choice.offer.conditions = []
+      end
 
-    describe 'with pending conditions' do
       it_behaves_like(
         'a mail with subject and content',
-        'Your deferred offer to study %{course_name} has been confirmed by %{provider_name}',
+        'Your deferred offer to study Forensic Science (E0FO) has been confirmed by Falconholt Technical College',
         'heading' => 'Dear Bob',
         'provider name' => 'Falconholt Technical College has confirmed your deferred offer to study',
         'name and code for course' => 'Forensic Science (E0FO)',
         'start date of new course' => 'June 2020',
-        'conditions of offer' => 'Be cool',
         'course starts text' => 'The course starts',
       )
+
+      it 'does not refer to conditions' do
+        expect(email.body).not_to include('condition')
+      end
+    end
+
+    describe 'with pending conditions' do
+      before do
+        application_choice.offer.conditions = [build_stubbed(:offer_condition, status: :pending, text: 'GCSE Maths grade 4 (C) or above, or equivalent')]
+      end
+
+      it_behaves_like(
+        'a mail with subject and content',
+        'Your deferred offer to study Forensic Science (E0FO) has been confirmed by Falconholt Technical College',
+        'heading' => 'Dear Bob',
+        'provider name' => 'Falconholt Technical College has confirmed your deferred offer to study',
+        'name and code for course' => 'Forensic Science (E0FO)',
+        'start date of new course' => 'June 2020',
+        'conditions section' => 'You still need to meet the following condition',
+        'conditions of offer' => 'GCSE Maths grade 4 (C) or above, or equivalent',
+        'course starts text' => 'The course starts',
+      )
+    end
+
+    describe 'with met conditions' do
+      before do
+        application_choice.offer.conditions = [build_stubbed(:offer_condition, status: :met, text: 'GCSE Maths grade 4 (C) or above, or equivalent')]
+      end
+
+      it_behaves_like(
+        'a mail with subject and content',
+        'Your deferred offer to study Forensic Science (E0FO) has been confirmed by Falconholt Technical College',
+        'heading' => 'Dear Bob',
+        'provider name' => 'Falconholt Technical College has confirmed your deferred offer to study',
+        'name and code for course' => 'Forensic Science (E0FO)',
+        'start date of new course' => 'June 2020',
+        'course starts text' => 'The course starts',
+      )
+
+      it 'does not refer to conditions' do
+        expect(email.body).not_to include('condition')
+      end
     end
   end
 

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -401,7 +401,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
     it_behaves_like(
       'a mail with subject and content',
-      'Your deferred offer to study %{course_name} has been confirmed by %{provider_name}',
+      'Your deferred offer to study Mathematics (M101) has been confirmed by Arithmetic College',
       'greeting' => 'Dear Fred',
       'details' => 'Arithmetic College has confirmed your deferred offer to study',
       'pending condition text' => 'You still need to meet the following condition',


### PR DESCRIPTION
## Context

The conditions-met and reinstated-offer emails had some bugs with their subjects and/or contents.

## Guidance to review

Previews of emails can be seen at:
- `/rails/mailers/candidate_mailer/conditions_met`
- `/rails/mailers/candidate_mailer/reinstated_offer_without_conditions`
- `/rails/mailers/candidate_mailer/reinstated_offer_with_conditions`
