### PR TITLE
Temporarily redirect monthly statistics

### DIFF
--- a/app/controllers/publications/monthly_statistics_controller.rb
+++ b/app/controllers/publications/monthly_statistics_controller.rb
@@ -29,6 +29,8 @@ module Publications
       end.compact
     end
 
+    def temporarily_unavailable; end
+
   private
 
     def current_report

--- a/app/views/publications/monthly_statistics/temporarily_unavailable.html.erb
+++ b/app/views/publications/monthly_statistics/temporarily_unavailable.html.erb
@@ -1,19 +1,23 @@
 <%= content_for :title, 'Monthly Statistics - ITT2023' %>
 
-<p class="govuk-body">
-  The ITT2022 recruitment cycle has now finished. The new ITT recruitment cycle started on Tuesday 11 October when Apply for teacher training opened for applications.
-</p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">
+      The ITT2022 recruitment cycle has now finished. The new ITT recruitment cycle started on Tuesday 11 October when Apply for teacher training opened for applications.
+    </p>
 
-<p class="govuk-body">
-  The first publication of ITT statistics for the new cycle will be on Monday 28 November 2022.
-</p>
+    <p class="govuk-body">
+      The first publication of ITT statistics for the new cycle will be on Monday 28 November 2022.
+    </p>
 
-<p class="govuk-body">
-  You can access the monthly data extracts from the last cycle (from October 2021 until September 2022) here:
-  <%= govuk_link_to 'https://www.gov.uk/government/publications/monthly-statistics-on-initial-teacher-training-itt-recruitment',
-                    'https://www.gov.uk/government/publications/monthly-statistics-on-initial-teacher-training-itt-recruitment' %>
-</p>
+    <p class="govuk-body">
+      You can access the monthly data extracts from the last cycle (from October 2021 until September 2022) here:
+      <%= govuk_link_to 'https://www.gov.uk/government/publications/monthly-statistics-on-initial-teacher-training-itt-recruitment',
+                        'https://www.gov.uk/government/publications/monthly-statistics-on-initial-teacher-training-itt-recruitment' %>
+    </p>
 
-<p class="govuk-body">
-  If you have any feedback or queries about the ITT statistics reports, please get in touch at <%= govuk_mail_to 'becomingateacher@digital.education.gov.uk' %>
-</p>
+    <p class="govuk-body">
+      If you have any feedback or queries about the ITT statistics reports, please get in touch at <%= govuk_mail_to 'becomingateacher@digital.education.gov.uk' %>
+    </p>
+  </div>
+</div>

--- a/app/views/publications/monthly_statistics/temporarily_unavailable.html.erb
+++ b/app/views/publications/monthly_statistics/temporarily_unavailable.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">
-      The ITT2022 recruitment cycle has now finished. The new ITT recruitment cycle started on Tuesday 11 October when Apply for teacher training opened for applications.
+      The 2021 to 2022 teacher training recruitment cycle has now finished. The 2022 to 2023 recruitment cycle started on Tuesday 11 October when Apply for teacher training opened for applications.
     </p>
 
     <p class="govuk-body">
@@ -11,9 +11,8 @@
     </p>
 
     <p class="govuk-body">
-      You can access the monthly data extracts from the last cycle (from October 2021 until September 2022) here:
-      <%= govuk_link_to 'https://www.gov.uk/government/publications/monthly-statistics-on-initial-teacher-training-itt-recruitment',
-                        'https://www.gov.uk/government/publications/monthly-statistics-on-initial-teacher-training-itt-recruitment' %>
+      You can view <%= govuk_link_to 'monthly statistics on initial teacher training', 'https://www.gov.uk/government/publications/monthly-statistics-on-initial-teacher-training-itt-recruitment' %>
+      from the last cycle (from October 2021 until September 2022).
     </p>
 
     <p class="govuk-body">

--- a/app/views/publications/monthly_statistics/temporarily_unavailable.html.erb
+++ b/app/views/publications/monthly_statistics/temporarily_unavailable.html.erb
@@ -2,8 +2,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-  
-  <h1 class="govuk-heading-l">Monthly statistics</h1>
+    <h1 class="govuk-heading-l">Monthly statistics</h1>
+
     <p class="govuk-body">
       The 2021 to 2022 teacher training recruitment cycle has now finished. The 2022 to 2023 recruitment cycle started on Tuesday 11 October when Apply for teacher training opened for applications.
     </p>

--- a/app/views/publications/monthly_statistics/temporarily_unavailable.html.erb
+++ b/app/views/publications/monthly_statistics/temporarily_unavailable.html.erb
@@ -2,6 +2,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+  
+  <h1 class="govuk-heading-l">Monthly statistics</h1>
     <p class="govuk-body">
       The 2021 to 2022 teacher training recruitment cycle has now finished. The 2022 to 2023 recruitment cycle started on Tuesday 11 October when Apply for teacher training opened for applications.
     </p>

--- a/app/views/publications/monthly_statistics/temporarily_unavailable.html.erb
+++ b/app/views/publications/monthly_statistics/temporarily_unavailable.html.erb
@@ -1,0 +1,19 @@
+<%= content_for :title, 'Monthly Statistics - ITT2023' %>
+
+<p class="govuk-body">
+  The ITT2022 recruitment cycle has now finished. The new ITT recruitment cycle started on Tuesday 11 October when Apply for teacher training opened for applications.
+</p>
+
+<p class="govuk-body">
+  The first publication of ITT statistics for the new cycle will be on Monday 28 November 2022.
+</p>
+
+<p class="govuk-body">
+  You can access the monthly data extracts from the last cycle (from October 2021 until September 2022) here:
+  <%= govuk_link_to 'https://www.gov.uk/government/publications/monthly-statistics-on-initial-teacher-training-itt-recruitment',
+                    'https://www.gov.uk/government/publications/monthly-statistics-on-initial-teacher-training-itt-recruitment' %>
+</p>
+
+<p class="govuk-body">
+  If you have any feedback or queries about the ITT statistics reports, please get in touch at <%= govuk_mail_to 'becomingateacher@digital.education.gov.uk' %>
+</p>

--- a/app/workers/detect_invariants_daily_check.rb
+++ b/app/workers/detect_invariants_daily_check.rb
@@ -137,7 +137,7 @@ class DetectInvariantsDailyCheck
     return if obsolete_features.none?
 
     message = 'The following obsolete feature flags have yet to be deleted from the database: ' \
-              "#{obsolete_features.map(&:name).to_sentence}"
+              "#{obsolete_features.map(&:name).sort.to_sentence}"
     Sentry.capture_exception(ObsoleteFeatureFlags.new(message))
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1310,8 +1310,9 @@ Rails.application.routes.draw do
   get '/check/version', to: 'healthcheck#version'
 
   namespace :publications, path: '/publications' do
-    get '/monthly-statistics(/:month)' => 'monthly_statistics#show', as: :monthly_report
-    get '/monthly-statistics/:month/:export_type' => 'monthly_statistics#download', as: :monthly_report_download
+    get '/monthly-statistics/temporarily-unavailable', to: 'monthly_statistics#temporarily_unavailable', as: :monthly_statistics_temporarily_unavailable
+    get '/monthly-statistics(/:month)' => redirect('/publications/monthly-statistics/temporarily-unavailable'), as: :monthly_report
+    get '/monthly-statistics/:month/:export_type' => redirect('/publications/monthly-statistics/temporarily-unavailable'), as: :monthly_report_download
   end
 
   mount Yabeda::Prometheus::Exporter => '/metrics'

--- a/spec/requests/publications/monthly_statistics_spec.rb
+++ b/spec/requests/publications/monthly_statistics_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe 'Monthly Statistics', type: :request do
   include StatisticsTestHelper
   let(:current_date) { [2021, 11, 29] }
 
+  let(:temporarily_unavailable) { '/publications/monthly-statistics/temporarily-unavailable' }
+
   around do |example|
     Timecop.freeze(*current_date) do
       example.run
@@ -34,103 +36,82 @@ RSpec.describe 'Monthly Statistics', type: :request do
       report.save
     end
 
-    it 'returns the report for 2021-11' do
+    it 'redirects the report for 2021-11' do
       get '/publications/monthly-statistics/'
-      expect(response).to have_http_status(:ok)
-      expect(response.body).to include('to 22 November 2021')
+      expect(response).to redirect_to(temporarily_unavailable)
+      get temporarily_unavailable
+      expect(response.body).to include('The first publication of ITT statistics for the new cycle will be on Monday 28 November 2022.')
+      expect(response.body).to include('https://www.gov.uk/government/publications/monthly-statistics-on-initial-teacher-training-itt-recruitment')
+      expect(response.body).to include('becomingateacher@digital.education.gov.uk')
 
       get '/publications/monthly-statistics/2021-10'
-      expect(response).to have_http_status(:ok)
-      expect(response.body).to include('to 18 October 2021')
+      expect(response).to redirect_to(temporarily_unavailable)
 
       get '/publications/monthly-statistics/2021-11'
-      expect(response).to have_http_status(:ok)
-      expect(response.body).to include('to 22 November 2021')
+      expect(response).to redirect_to(temporarily_unavailable)
 
       get '/publications/monthly-statistics/2021-12'
-      expect(response).to have_http_status(:not_found)
+      expect(response).to redirect_to(temporarily_unavailable)
     end
 
-    it 'returns application by status csv for 2021-10' do
+    it 'redirects application by status csv for 2021-10' do
       get '/publications/monthly-statistics/2021-10/applications_by_status.csv'
-      expect(response).to have_http_status(:ok)
+      expect(response).to redirect_to(temporarily_unavailable)
     end
   end
 
-  it 'returns application by status csv' do
+  it 'redirects application by status csv' do
     get '/publications/monthly-statistics/2021-11/applications_by_status.csv'
-    expect(response).to have_http_status(:ok)
-    expect(response.body).to start_with 'Status,First application,Apply again,Total'
-    expect(response.header['Content-Type']).to include 'text/csv'
+    expect(response).to redirect_to(temporarily_unavailable)
   end
 
-  it 'returns candidates by status csv' do
+  it 'redirects candidates by status csv' do
     get '/publications/monthly-statistics/2021-11/candidates_by_status'
-    expect(response).to have_http_status(:ok)
-    expect(response.body).to start_with 'Status,First application,Apply again,Total'
-    expect(response.header['Content-Type']).to include 'text/csv'
+    expect(response).to redirect_to(temporarily_unavailable)
   end
 
-  it 'returns candidates by age group csv' do
+  it 'redirects candidates by age group csv' do
     get '/publications/monthly-statistics/2021-11/by_age_group'
-    expect(response).to have_http_status(:ok)
-    expect(response.body).to start_with 'Age group,Recruited,Conditions pending'
-    expect(response.header['Content-Type']).to include 'text/csv'
+    expect(response).to redirect_to(temporarily_unavailable)
   end
 
-  it 'returns applications by course age group csv' do
+  it 'redirects applications by course age group csv' do
     get '/publications/monthly-statistics/2021-11/by_course_age_group'
-    expect(response).to have_http_status(:ok)
-    expect(response.body).to start_with 'Course phase,Recruited,Conditions pending'
-    expect(response.header['Content-Type']).to include 'text/csv'
+    expect(response).to redirect_to(temporarily_unavailable)
   end
 
-  it 'returns candidates by area csv' do
+  it 'redirects candidates by area csv' do
     get '/publications/monthly-statistics/2021-11/by_area'
-    expect(response).to have_http_status(:ok)
-    expect(response.body).to start_with 'Area,Recruited,Conditions pending'
-    expect(response.header['Content-Type']).to include 'text/csv'
+    expect(response).to redirect_to(temporarily_unavailable)
   end
 
-  it 'returns candidates by sex csv' do
+  it 'redirects candidates by sex csv' do
     get '/publications/monthly-statistics/2021-11/by_sex'
-    expect(response).to have_http_status(:ok)
-    expect(response.body).to start_with 'Sex,Recruited,Conditions pending'
-    expect(response.header['Content-Type']).to include 'text/csv'
+    expect(response).to redirect_to(temporarily_unavailable)
   end
 
-  it 'returns applications by course type csv' do
+  it 'redirects applications by course type csv' do
     get '/publications/monthly-statistics/2021-11/by_course_type'
-    expect(response).to have_http_status(:ok)
-    expect(response.body).to start_with 'Course type,Recruited,Conditions pending'
-    expect(response.header['Content-Type']).to include 'text/csv'
+    expect(response).to redirect_to(temporarily_unavailable)
   end
 
-  it 'returns applications by primary specialist subject csv' do
+  it 'redirects applications by primary specialist subject csv' do
     get '/publications/monthly-statistics/2021-11/by_primary_specialist_subject'
-    expect(response).to have_http_status(:ok)
-    expect(response.body).to start_with 'Subject,Recruited,Conditions pending'
-    expect(response.header['Content-Type']).to include 'text/csv'
+    expect(response).to redirect_to(temporarily_unavailable)
   end
 
-  it 'returns applications by secondary subject csv' do
+  it 'redirects applications by secondary subject csv' do
     get '/publications/monthly-statistics/2021-11/by_secondary_subject'
-    expect(response).to have_http_status(:ok)
-    expect(response.body).to start_with 'Subject,Recruited,Conditions pending'
-    expect(response.header['Content-Type']).to include 'text/csv'
+    expect(response).to redirect_to(temporarily_unavailable)
   end
 
-  it 'returns applications by provider area csv' do
+  it 'redirects applications by provider area csv' do
     get '/publications/monthly-statistics/2021-11/by_provider_area'
-    expect(response).to have_http_status(:ok)
-    expect(response.body).to start_with 'Area,Recruited,Conditions pending'
-    expect(response.header['Content-Type']).to include 'text/csv'
+    expect(response).to redirect_to(temporarily_unavailable)
   end
 
-  it 'returns a 404 when an invalid date is in the URL' do
+  it 'redirects a 404 when an invalid date is in the URL' do
     get '/publications/monthly-statistics/foo-2021-11/by_provider_area'
-    expect(response).to have_http_status(:not_found)
-    expect(response.body).to include 'Page not found'
-    expect(response.header['Content-Type']).not_to include 'text/csv'
+    expect(response).to redirect_to(temporarily_unavailable)
   end
 end

--- a/spec/system/monthly_statistics/monthly_statistics_page_spec.rb
+++ b/spec/system/monthly_statistics/monthly_statistics_page_spec.rb
@@ -17,9 +17,7 @@ RSpec.feature 'Monthly statistics page', mid_cycle: false do
 
   scenario 'User can download a CSV from the monthly statistics page' do
     given_i_visit_the_monthly_statistics_page
-    and_i_see_the_monthly_statistics
-    when_i_click_a_link
-    then_a_csv_downloads
+    then_i_should_be_redirected_to_the_temporarily_unavailable_page
   end
 
   def create_monthly_stats_report
@@ -30,15 +28,7 @@ RSpec.feature 'Monthly statistics page', mid_cycle: false do
     visit '/publications/monthly-statistics'
   end
 
-  def and_i_see_the_monthly_statistics
-    expect(page).to have_content "Initial teacher training applications for courses starting in the #{RecruitmentCycle.cycle_name(CycleTimetable.next_year)} academic year"
-  end
-
-  def when_i_click_a_link
-    click_link 'Applications by status (CSV)'
-  end
-
-  def then_a_csv_downloads
-    expect(page).to(have_text('Status,First application,Apply again,Total'))
+  def then_i_should_be_redirected_to_the_temporarily_unavailable_page
+    expect(page).to have_current_path('/publications/monthly-statistics/temporarily-unavailable')
   end
 end

--- a/spec/workers/detect_invariants_daily_check_spec.rb
+++ b/spec/workers/detect_invariants_daily_check_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe DetectInvariantsDailyCheck do
       allow(Sentry).to receive(:capture_exception).with(an_instance_of(described_class::ObsoleteFeatureFlags))
 
       obsolete_features = create_list(:feature, 5)
-      FeatureFlag::FEATURES.map { |feature| Feature.find_or_create_by(name: feature.first) }
+      FeatureFlag::FEATURES.each { |feature| Feature.find_or_create_by(name: feature.first) }
 
       described_class.new.perform
 


### PR DESCRIPTION
I've left a bunch of now-unused and inaccessible code here because it's being reverted soon.

## Context

The underlying stats code apparently needs changing.

## Changes proposed in this pull request

### Before

<img width="776" alt="Screenshot 2022-10-11 at 15 39 11" src="https://user-images.githubusercontent.com/109225/195121698-68c90138-ad59-43e2-b468-3fd2430456b7.png">

### After

<img width="994" alt="Screenshot 2022-10-11 at 15 26 00" src="https://user-images.githubusercontent.com/109225/195121733-b4367e4d-6049-4e9e-b287-e45f615cfe3b.png">