### PR TITLE
Cancel references from last cycles

### DIFF
--- a/app/services/data_migrations/end_of_cycle_cancel_outstanding_references.rb
+++ b/app/services/data_migrations/end_of_cycle_cancel_outstanding_references.rb
@@ -13,12 +13,14 @@ module DataMigrations
       end
     end
 
+    # rubocop:disable Rails/Output
     def dry_run
       "The total of #{records.count} references will be cancelled"
 
       "Double-check all recruitment cycle are in #{RECRUITMENT_CYCLES.join(' or ')}:"
       puts records.all? { |record| record.application_form.recruitment_cycle_year.in?(RECRUITMENT_CYCLES) }
     end
+    # rubocop:enable Rails/Output
 
     def records
       ApplicationReference.joins(:application_form)

--- a/app/services/data_migrations/end_of_cycle_cancel_outstanding_references.rb
+++ b/app/services/data_migrations/end_of_cycle_cancel_outstanding_references.rb
@@ -2,7 +2,7 @@ module DataMigrations
   class EndOfCycleCancelOutstandingReferences
     TIMESTAMP = 20220913163416
     MANUAL_RUN = true
-    RECRUITMENT_CYCLES = [2021, 2022]
+    RECRUITMENT_CYCLES = [2021, 2022].freeze
 
     def change
       records.each do |record|
@@ -15,10 +15,12 @@ module DataMigrations
 
     # rubocop:disable Rails/Output
     def dry_run
-      "The total of #{records.count} references will be cancelled"
+      puts "The total of #{records.count} references will be cancelled"
 
-      "Double-check all recruitment cycle are in #{RECRUITMENT_CYCLES.join(' or ')}:"
-      puts records.all? { |record| record.application_form.recruitment_cycle_year.in?(RECRUITMENT_CYCLES) }
+      puts "Double-check all recruitment cycle are in #{RECRUITMENT_CYCLES.join(' or ')}:"
+      puts records.all? do |record|
+        record.application_form.recruitment_cycle_year.in?(RECRUITMENT_CYCLES)
+      end
     end
     # rubocop:enable Rails/Output
 

--- a/app/services/data_migrations/end_of_cycle_cancel_outstanding_references.rb
+++ b/app/services/data_migrations/end_of_cycle_cancel_outstanding_references.rb
@@ -2,21 +2,22 @@ module DataMigrations
   class EndOfCycleCancelOutstandingReferences
     TIMESTAMP = 20220913163416
     MANUAL_RUN = true
-    RECRUITMENT_CYCLE_YEAR = 2022
-    PHASE = 'apply_2'.freeze
+    RECRUITMENT_CYCLES = [2021, 2022]
 
     def change
       records.each do |record|
-        record.update!(
+        record.update_columns(
           feedback_status: :cancelled_at_end_of_cycle,
           cancelled_at: Time.zone.now,
         )
-        RefereeMailer.reference_cancelled_email(record).deliver_later
       end
     end
 
     def dry_run
       "The total of #{records.count} references will be cancelled"
+
+      "Double-check all recruitment cycle are in #{RECRUITMENT_CYCLES.join(' or ')}:"
+      puts records.all? { |record| record.application_form.recruitment_cycle_year.in?(RECRUITMENT_CYCLES) }
     end
 
     def records
@@ -24,13 +25,9 @@ module DataMigrations
         .feedback_requested
         .where(
           application_form: {
-            recruitment_cycle_year: RECRUITMENT_CYCLE_YEAR,
-            phase: PHASE,
+            recruitment_cycle_year: RECRUITMENT_CYCLES,
           },
         )
-        .where(application_form: { id: ApplicationChoice
-            .where(status: 'unsubmitted')
-            .select('application_form_id') })
     end
   end
 end

--- a/spec/services/data_migrations/end_of_cycle_cancel_outstanding_references_spec.rb
+++ b/spec/services/data_migrations/end_of_cycle_cancel_outstanding_references_spec.rb
@@ -1,47 +1,45 @@
 require 'rails_helper'
 
 RSpec.describe DataMigrations::EndOfCycleCancelOutstandingReferences, sidekiq: true do
-  around do |example|
-    Timecop.freeze(CycleTimetable.apply_opens(ApplicationForm::OLD_REFERENCE_FLOW_CYCLE_YEAR)) do
-      example.run
+  context 'when 2021' do
+    it 'cancels references' do
+      application_form = create(:application_form, :minimum_info, recruitment_cycle_year: 2021)
+      reference = create(:reference, :feedback_requested, application_form: application_form)
+      described_class.new.change
+      expect(reference.reload).to be_cancelled_at_end_of_cycle
     end
   end
 
-  context 'when apply 2' do
+  context 'when 2023' do
+    it 'does not change' do
+      application_form = create(:application_form, :minimum_info, recruitment_cycle_year: 2023)
+      reference = create(:reference, :feedback_requested, application_form: application_form)
+      described_class.new.change
+      expect(reference.reload).to be_feedback_requested
+    end
+  end
+
+  context 'when 2022' do
     let!(:application_form) do
-      create(:application_form, :minimum_info, phase: 'apply_2')
+      create(:application_form, :minimum_info, recruitment_cycle_year: 2022)
     end
 
     context 'when feedback requested' do
       let!(:reference) do
         create(:reference, :feedback_requested, application_form: application_form)
       end
-
-      context 'when unsubmitted' do
-        let!(:application_choice) do
-          create(:application_choice, :unsubmitted, application_form: application_form)
-        end
-
-        it 'cancels the reference' do
-          described_class.new.change
-          expect(reference.reload).to be_cancelled_at_end_of_cycle
-        end
-
-        it 'sends email to the referee' do
-          described_class.new.change
-          expect(ActionMailer::Base.deliveries.map(&:to).flatten).to include(reference.email_address)
-        end
+      let!(:application_choice) do
+        create(:application_choice, :unsubmitted, application_form: application_form)
       end
 
-      context 'when conditions pending' do
-        let!(:application_choice) do
-          create(:application_choice, :with_accepted_offer, application_form: application_form)
-        end
+      it 'cancels the reference' do
+        described_class.new.change
+        expect(reference.reload).to be_cancelled_at_end_of_cycle
+      end
 
-        it 'does not change' do
-          described_class.new.change
-          expect(reference.reload).to be_feedback_requested
-        end
+      it 'does not send email to referee' do
+        described_class.new.change
+        expect(ActionMailer::Base.deliveries.map(&:to).flatten).to eq([])
       end
     end
 


### PR DESCRIPTION
## Context

We have more than 1000 references in the requested state from past cycles (almost 350 from 2022 and the rest from 2021).

So we need to cancel them but without notifying anyone about it.

