### PR TITLE
Update accessibility statements

### DIFF
--- a/app/views/content/accessibility.md
+++ b/app/views/content/accessibility.md
@@ -1,37 +1,47 @@
-Apply for teacher training run by the Department for Education.
+This statement applies to the Manage teacher training applications service.
 
-To make this service accessible, we:
+Manage teacher training applications is run by the Department for Education.  It is designed to be used by as many people as possible. The text should be clear and simple to understand. You should be able to:
 
-* designed it using GOV.UK accessible design principles
-* carried out an accessibility audit
-* tested the service with users who have access needs
+* change colours, contrast levels and fonts
+* zoom in up to 300% without problems
+* navigate the service using just a keyboard
+* navigate the service using speech recognition software
+* use the service using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
 
-## What to do if you cannot access parts of this website
+We’ve also made the text in the service as simple as possible to understand.
 
-If you need information on this website in a different format, such as accessible PDF, large print, easy read, audio recording or braille, email <%= bat_contact_mail_to %>.
+[AbilityNet](<%= t('ability_net.url') %>) has advice on making your device easier to use if you have a disability.
+
+## Feedback and contact information
+
+If you need to use the service in a different way, email <%= bat_contact_mail_to %>.
 
 We’ll respond within 5 working days.
 
-[AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device easier to use if you’re disabled.
-
 ## Reporting accessibility problems with this website
 
-If you have any problems accessing the service or want to give feedback, email <%= bat_contact_mail_to %>.
+We’re always looking to improve the accessibility of this service. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, email <%= bat_contact_mail_to %>.
 
 ## Enforcement procedure
 
-The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’).
+If you contact us with a complaint and you’re not happy with our response [contact the Equality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com/).
 
-If you’re not happy with how we respond to your complaint, you can contact the [Equality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com/).
+The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’).
 
 ## Technical information about this website’s accessibility
 
 The Department for Education is committed to making its website services accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
 
-This website is compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21) AA standard.
+### Compliance status
+
+This website is fully compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21) AA standard.
 
 ## What we’re doing to improve accessibility
 
 We’ll continue to test the accessibility of this service as it develops.
 
-This statement was prepared on 29 November 2019.
+## Preparation of this accessibility statement
+
+This statement was prepared on 12 October 2022.
+
+This service was last tested in May 2022. The test was carried out by the Digital Accessibility Centre.

--- a/app/views/content/accessibility.md
+++ b/app/views/content/accessibility.md
@@ -1,6 +1,6 @@
-This statement applies to the Manage teacher training applications service.
+This statement applies to the ‘Manage teacher training applications’ service.
 
-Manage teacher training applications is run by the Department for Education.  It is designed to be used by as many people as possible. The text should be clear and simple to understand. You should be able to:
+‘Manage teacher training applications’ is run by the Department for Education. It’s designed to be used by as many people as possible. You should be able to:
 
 * change colours, contrast levels and fonts
 * zoom in up to 300% without problems
@@ -18,23 +18,23 @@ If you need to use the service in a different way, email <%= bat_contact_mail_to
 
 We’ll respond within 5 working days.
 
-## Reporting accessibility problems with this website
+## Reporting accessibility problems with this service
 
 We’re always looking to improve the accessibility of this service. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, email <%= bat_contact_mail_to %>.
 
 ## Enforcement procedure
 
-If you contact us with a complaint and you’re not happy with our response [contact the Equality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com/).
+If you’re not happy with our response to a complaint, [contact the Equality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com/).
 
 The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’).
 
-## Technical information about this website’s accessibility
+## Technical information about this service’s accessibility
 
-The Department for Education is committed to making its website services accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+The Department for Education is committed to making its services accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
 
 ### Compliance status
 
-This website is fully compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21) AA standard.
+This service is fully compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21) AA standard.
 
 ## What we’re doing to improve accessibility
 
@@ -44,4 +44,4 @@ We’ll continue to test the accessibility of this service as it develops.
 
 This statement was prepared on 12 October 2022.
 
-This service was last tested in May 2022. The test was carried out by the Digital Accessibility Centre.
+The service was last tested in May 2022. The test was carried out by the Digital Accessibility Centre.

--- a/app/views/content/accessibility_candidate.html.erb
+++ b/app/views/content/accessibility_candidate.html.erb
@@ -2,9 +2,9 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t('page_titles.accessibility') %></h1>
 
-    <p class="govuk-body">This statement applies to the Apply for teacher training service.</p>
+    <p class="govuk-body">This statement applies to the ‘Apply for teacher training’ service.</p>
 
-    <h2 class="govuk-body">Apply for teacher training is run by the Department for Education.  It is designed to be used by as many people as possible. The text should be clear and simple to understand. You should be able to:</h2>
+    <h2 class="govuk-body">‘Apply for teacher training’ is run by the Department for Education.  It is designed to be used by as many people as possible. You should be able to:</h2>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>change colours, contrast levels and fonts</li>
@@ -20,30 +20,30 @@
 
     <h2 class="govuk-heading-m">Feedback and contact information</h2>
 
-    <p class="govuk-body">If you need to apply for teacher training in a different way, such as using a large print form, audio recording or Braille, email <%= bat_contact_mail_to %></p>
+    <p class="govuk-body">If you need to apply for teacher training in a different way, such as using a large print form, audio recording or Braille, email <%= bat_contact_mail_to %>.</p>
 
     <p class="govuk-body">We’ll respond within 5 working days.</p>
 
-    <h2 class="govuk-heading-m">Reporting accessibility problems with this website</h2>
+    <h2 class="govuk-heading-m">Reporting accessibility problems with this service</h2>
 
     <p class="govuk-body">We’re always looking to improve the accessibility of this service. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, email <%= bat_contact_mail_to %>.</p>
 
     <h2 class="govuk-heading-m">Enforcement procedure</h2>
 
-    <p class="govuk-body">If you contact us with a complaint and you’re not happy with our response
+    <p class="govuk-body">If you’re not happy with our response to a complaint, 
       <%= govuk_link_to('contact the Equality Advisory and Support Service (EASS)', t('equality_advisory_service.url')) %>.</p>
 
     <p class="govuk-body">The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’).</p>
 
-    <h2 class="govuk-heading-m">Technical information about this website’s accessibility</h2>
+    <h2 class="govuk-heading-m">Technical information about this service’s accessibility</h2>
 
-    <p class="govuk-body">The Department for Education is committed to making its website services accessible,
+    <p class="govuk-body">The Department for Education is committed to making its services accessible,
       in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations
       2018.</p>
 
     <h3 class="govuk-heading-s">Compliance status</h3>
 
-    <p class="govuk-body">This website is fully compliant with the
+    <p class="govuk-body">This service is fully compliant with the
       <%= govuk_link_to('Web Content Accessibility Guidelines version 2.1', t('web_content_accessibility_guidelines.url')) %> AA standard.</p>
 
     <h2 class="govuk-heading-m">What we’re doing to improve accessibility</h2>
@@ -54,6 +54,6 @@
 
     <p class="govuk-body">This statement was prepared on 12 October 2022.</p>
 
-    <p class="govuk-body">This service was last tested in May 2022. The test was carried out by the Digital Accessibility Centre.</p>
+    <p class="govuk-body">The service was last tested in May 2022. The test was carried out by the Digital Accessibility Centre.</p>
   </div>
 </div>

--- a/app/views/content/accessibility_candidate.html.erb
+++ b/app/views/content/accessibility_candidate.html.erb
@@ -2,39 +2,38 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t('page_titles.accessibility') %></h1>
 
-    <h2 class="govuk-body">Apply for teacher training run by the Department for Education.</h2>
+    <p class="govuk-body">This statement applies to the Apply for teacher training service.</p>
 
-    <h2 class="govuk-body">To make this service accessible, we:</h2>
+    <h2 class="govuk-body">Apply for teacher training is run by the Department for Education.  It is designed to be used by as many people as possible. The text should be clear and simple to understand. You should be able to:</h2>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>designed it using GOV.UK accessible design principles</li>
-      <li>carried out an accessibility audit</li>
-      <li>tested the service with users who have access needs</li>
+      <li>change colours, contrast levels and fonts</li>
+      <li>zoom in up to 300% without problems</li>
+      <li>navigate the service using just a keyboard</li>
+      <li>navigate the service using speech recognition software</li>
+      <li>use the service using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)</li>
     </ul>
 
-    <h2 class="govuk-heading-m">What to do if you cannot access parts of this website</h2>
+    <p class="govuk-body">We’ve also made the text in the service as simple as possible to understand.</p>
 
-    <p class="govuk-body">If you need information on this website in a different format, such as accessible PDF,
-      large print, easy read, audio recording or braille, email <%= bat_contact_mail_to %></p>
+    <p class="govuk-body"><%= govuk_link_to('AbilityNet', t('ability_net.url')) %> has advice on making your device easier to use if you have a disability.</p>
+
+    <h2 class="govuk-heading-m">Feedback and contact information</h2>
+
+    <p class="govuk-body">If you need to apply for teacher training in a different way, such as using a large print form, audio recording or Braille,  email <%= bat_contact_mail_to %></p>
 
     <p class="govuk-body">We’ll respond within 5 working days.</p>
 
-    <p class="govuk-body"><%= govuk_link_to('AbilityNet', t('ability_net.url')) %> has advice on making your device
-      easier to use if you’re disabled.</p>
-
     <h2 class="govuk-heading-m">Reporting accessibility problems with this website</h2>
 
-    <p class="govuk-body">If you have any problems accessing the service or want to give feedback, email
-      <%= bat_contact_mail_to %></p>
+    <p class="govuk-body">We’re always looking to improve the accessibility of this service. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, email <%= bat_contact_mail_to %>.</p>
 
     <h2 class="govuk-heading-m">Enforcement procedure</h2>
 
-    <p class="govuk-body">The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public
-      Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018
-      (the ‘accessibility regulations’).</p>
+    <p class="govuk-body">If you contact us with a complaint and you’re not happy with our response
+      <%= govuk_link_to('contact the Equality Advisory and Support Service (EASS)', t('equality_advisory_service.url')) %>.</p>
 
-    <p class="govuk-body">If you’re not happy with how we respond to your complaint, you can contact the
-      <%= govuk_link_to('Equality Advisory and Support Service (EASS)', t('equality_advisory_service.url')) %></p>
+    <p class="govuk-body">The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’).</p>
 
     <h2 class="govuk-heading-m">Technical information about this website’s accessibility</h2>
 
@@ -42,13 +41,19 @@
       in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations
       2018.</p>
 
-    <p class="govuk-body">This website is compliant with the
+    <h3 class="govuk-heading-s">Compliance status</h3>
+
+    <p class="govuk-body">This website is fully compliant with the
       <%= govuk_link_to('Web Content Accessibility Guidelines version 2.1', t('web_content_accessibility_guidelines.url')) %> AA standard.</p>
 
     <h2 class="govuk-heading-m">What we’re doing to improve accessibility</h2>
 
     <p class="govuk-body">We’ll continue to test the accessibility of this service as it develops.</p>
 
-    <p class="govuk-body">This statement was prepared on 29 November 2019.</p>
+    <h2 class="govuk-heading-m">Preparation of this accessibility statement</h2>
+
+    <p class="govuk-body">This statement was prepared on 12 October 2022.</p>
+
+    <p class="govuk-body">This service was last tested in May 2022. The test was carried out by the Digital Accessibility Centre.</p>
   </div>
 </div>

--- a/app/views/content/accessibility_candidate.html.erb
+++ b/app/views/content/accessibility_candidate.html.erb
@@ -4,7 +4,7 @@
 
     <p class="govuk-body">This statement applies to the ‘Apply for teacher training’ service.</p>
 
-    <h2 class="govuk-body">‘Apply for teacher training’ is run by the Department for Education.  It is designed to be used by as many people as possible. You should be able to:</h2>
+    <h2 class="govuk-body">‘Apply for teacher training’ is run by the Department for Education.  It’s designed to be used by as many people as possible. You should be able to:</h2>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>change colours, contrast levels and fonts</li>

--- a/app/views/content/accessibility_candidate.html.erb
+++ b/app/views/content/accessibility_candidate.html.erb
@@ -20,7 +20,7 @@
 
     <h2 class="govuk-heading-m">Feedback and contact information</h2>
 
-    <p class="govuk-body">If you need to apply for teacher training in a different way, such as using a large print form, audio recording or Braille,  email <%= bat_contact_mail_to %></p>
+    <p class="govuk-body">If you need to apply for teacher training in a different way, such as using a large print form, audio recording or Braille, email <%= bat_contact_mail_to %></p>
 
     <p class="govuk-body">We’ll respond within 5 working days.</p>
 

--- a/app/views/content/accessibility_candidate.html.erb
+++ b/app/views/content/accessibility_candidate.html.erb
@@ -20,7 +20,8 @@
 
     <h2 class="govuk-heading-m">Feedback and contact information</h2>
 
-    <p class="govuk-body">If you need to apply for teacher training in a different way, such as using a large print form, audio recording or Braille, email <%= bat_contact_mail_to %>.</p>
+    <p class="govuk-body">If you need to apply for teacher training in a different way, such as using a large print form, audio recording or Braille, email <%= bat_contact_mail_to %>.
+    </p>
 
     <p class="govuk-body">We’ll respond within 5 working days.</p>
 
@@ -30,8 +31,9 @@
 
     <h2 class="govuk-heading-m">Enforcement procedure</h2>
 
-    <p class="govuk-body">If you’re not happy with our response to a complaint, 
-      <%= govuk_link_to('contact the Equality Advisory and Support Service (EASS)', t('equality_advisory_service.url')) %>.</p>
+    <p class="govuk-body">If you’re not happy with our response to a complaint,
+      <%= govuk_link_to('contact the Equality Advisory and Support Service (EASS)', t('equality_advisory_service.url')) %>.
+    </p>
 
     <p class="govuk-body">The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’).</p>
 
@@ -44,7 +46,8 @@
     <h3 class="govuk-heading-s">Compliance status</h3>
 
     <p class="govuk-body">This service is fully compliant with the
-      <%= govuk_link_to('Web Content Accessibility Guidelines version 2.1', t('web_content_accessibility_guidelines.url')) %> AA standard.</p>
+      <%= govuk_link_to('Web Content Accessibility Guidelines version 2.1', t('web_content_accessibility_guidelines.url')) %> AA standard.
+    </p>
 
     <h2 class="govuk-heading-m">What we’re doing to improve accessibility</h2>
 


### PR DESCRIPTION
This updates both the provider-facing and candidate-facing accessibility statements to:

* mention that that the service was last tested in May 2022 by the Digital Accessibility Centre.
* more closely follow the format of the [sample accessibility statement](https://www.gov.uk/government/publications/sample-accessibility-statement/sample-accessibility-statement-for-a-fictional-public-sector-website)
* make the 2 versions more specific to the Manage vs Apply services.

🗂️ [Trello card](https://trello.com/c/eFxOaEfB/383-update-our-dac-page-with-the-latest-report)