### PR TITLE
Link to teacher training events and update Find courses page

### DIFF
--- a/app/views/candidate_interface/course_choices/course_decision/go_to_find.html.erb
+++ b/app/views/candidate_interface/course_choices/course_decision/go_to_find.html.erb
@@ -3,24 +3,22 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
+    <h1 class="govuk-heading-l">
       <%= t('page_titles.find_a_course') %>
     </h1>
 
-    <p class="govuk-body-l">Search for courses near you on Find postgraduate teacher&nbsp;training.</p>
+    <p class="govuk-body">You can find information about training providers and courses, including:</p>
 
-    <%= govuk_start_button(
-      text: t('application_form.begin_button'),
-      href: find_url,
-      classes: 'govuk-!-margin-bottom-2',
-      html_attributes: {
-        target: '_blank',
-        rel: 'noopener',
-        'aria-describedby': 'find-new-window',
-      },
-    ) %>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>entry requirements</li>
+      <li>school placements</li>
+      <li>whether bursaries or salaries are available</li>
+      <li>contact details</li>
+    </ul>
 
-    <p class="govuk-body-s govuk-!-margin-bottom-6" id="find-new-window" aria-hidden="true">Opens in a new window</p>
-    <p class="govuk-body"><%= govuk_link_to 'Return to your application', candidate_interface_application_form_path %></p>
+    <%= govuk_button_link_to t('continue'), find_url %>
+
+    <p class="govuk-body">You can also speak to training providers at <%= govuk_link_to_with_utm_params 'teacher training events', t('get_into_teaching.url_events'), 'apply_find_a_course' %>.</p>
+
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,7 @@ en:
     url_applying: https://getintoteaching.education.gov.uk/steps-to-become-a-teacher#step-5
     url_get_an_adviser: https://adviser-getintoteaching.education.gov.uk
     url_get_an_adviser_start: https://getintoteaching.education.gov.uk/teacher-training-advisers
+    url_events: https://getintoteaching.education.gov.uk/events
     url_international_candidates: https://getintoteaching.education.gov.uk/non-uk-teachers
     url_support_if_you_are_disabled: https://getintoteaching.education.gov.uk/funding-and-support/if-youre-disabled
     url_online_chat: https://getintoteaching.education.gov.uk/#talk-to-us

--- a/spec/system/candidate_interface/course_selection/candidate_does_not_know_where_they_want_to_apply_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_does_not_know_where_they_want_to_apply_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'Selecting a course' do
     and_i_choose_that_i_do_not_know_where_i_want_to_apply
     then_i_should_be_on_the_find_a_course_page
 
-    when_i_click_start_now
+    when_i_click_continue
     then_i_am_sent_to_find
   end
 
@@ -28,16 +28,19 @@ RSpec.feature 'Selecting a course' do
   end
 
   def and_i_choose_that_i_do_not_know_where_i_want_to_apply
-    choose 'No, I need to find a course'
-    click_button t('continue')
+    within_fieldset 'Do you know which course you want to apply to?' do
+      choose 'No, I need to find a course'
+    end
+    click_button 'Continue'
   end
 
   def then_i_should_be_on_the_find_a_course_page
+    expect(page).to have_selector('h1', text: 'Find a course')
     expect(page).to have_current_path(candidate_interface_go_to_find_path)
   end
 
-  def when_i_click_start_now
-    click_link 'Start now'
+  def when_i_click_continue
+    click_link 'Continue'
   end
 
   def then_i_am_sent_to_find


### PR DESCRIPTION
This gives candidates a link to the get into teaching events, if they're not yet sure where to apply to. Also updates the content of this page to use a regular button instead of a "Start now" button, and to not open it in a new tab.

## Screenshots

### Before

![before](https://user-images.githubusercontent.com/30665/195646283-da8b0ab4-9cdf-4722-a77c-bd22aa7e0860.png)

### After

![after](https://user-images.githubusercontent.com/30665/195646338-5c3e692b-d849-4aa7-95ba-6e66d2ed4f21.png)

