### PR TITLE
Wrap URLs to hide utm params

### DIFF
--- a/app/views/candidate_mailer/application_withdrawn_on_request_all_applications_withdrawn.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_all_applications_withdrawn.text.erb
@@ -2,9 +2,7 @@ Dear <%= @application_form.first_name %>
 
 At your request, <%= @course.provider.name %> has withdrawn your application to study <%= @course.name_and_code %>.
 
-Get in touch if you did not ask them to do this:
-
-<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'application_withdrawn_on_request_all_applications_withdrawn', @application_form.phase %>
+[Get in touch if you did not ask them to do this](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'application_withdrawn_on_request_all_applications_withdrawn', @application_form.phase %>)
 
 # You can apply again
 

--- a/app/views/candidate_mailer/application_withdrawn_on_request_awaiting_decision_only.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_awaiting_decision_only.text.erb
@@ -2,9 +2,7 @@ Dear <%= @application_form.first_name %>
 
 At your request, <%= @course.provider.name %> has withdrawn your application to study <%= @course.name_and_code %>.
 
-Get in touch if you did not ask them to do this:
-
-<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'application_withdrawn_on_request_awaiting_decision_only', @application_form.phase %>
+[Get in touch if you did not ask them to do this](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'application_withdrawn_on_request_awaiting_decision_only', @application_form.phase %>)
 
 <% if @awaiting_decision.length == 1 %>
 

--- a/app/views/candidate_mailer/application_withdrawn_on_request_offers_only.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_offers_only.text.erb
@@ -2,9 +2,7 @@ Dear <%= @application_form.first_name %>
 
 At your request, <%= @course.provider.name %> has withdrawn your application to study <%= @course.name_and_code %>.
 
-Get in touch if you did not ask them to do this:
-
-<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'application_withdrawn_on_request_offers_only', @application_form.phase%>
+[Get in touch if you did not ask them to do this](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'application_withdrawn_on_request_offers_only', @application_form.phase %>)
 
 # Respond to your <%= 'offer'.pluralize(@offers.length) %> by <%= @respond_by_date %>
 
@@ -26,6 +24,4 @@ You’re not waiting for any other decisions.
 
 The <%= 'offer'.pluralize(@offers.length) %> will be automatically declined if you do not respond by <%= @respond_by_date %>.
 
-Sign in to your account to respond:
-
-<%= @candidate_magic_link %>
+[Sign in to your account to respond](<%= @candidate_magic_link %>)

--- a/app/views/candidate_mailer/application_withdrawn_on_request_one_offer_one_awaiting_decision.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request_one_offer_one_awaiting_decision.text.erb
@@ -2,9 +2,7 @@ Dear <%= @application_form.first_name %>
 
 At your request, <%= @course.provider.name %> has withdrawn your application to study <%= @course.name_and_code %>.
 
-Get in touch if you did not ask them to do this:
-
-<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'application_withdrawn_on_request_one_offer_one_awaiting_decision', @application_form.phase %>
+[Get in touch if you did not ask them to do this](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'application_withdrawn_on_request_one_offer_one_awaiting_decision', @application_form.phase %>)
 
 # Application status
 

--- a/app/views/candidate_mailer/eoc_deadline_reminder.erb
+++ b/app/views/candidate_mailer/eoc_deadline_reminder.erb
@@ -16,4 +16,4 @@ Courses fill up quickly at this time of year.
 
 A teacher training adviser can help you write a strong application:
 
-<%= email_link_with_utm_params I18n.t('get_into_teaching.url_get_an_adviser_start'), 'eoc_deadline_reminder', @application_form.phase %>
+[Get a teacher training adviser](<%= email_link_with_utm_params I18n.t('get_into_teaching.url_get_an_adviser_start'), 'eoc_deadline_reminder', @application_form.phase %>)

--- a/app/views/candidate_mailer/find_has_opened.erb
+++ b/app/views/candidate_mailer/find_has_opened.erb
@@ -16,8 +16,6 @@ You can submit from 9am on <%= @apply_opens %>.
 
 # Get help
 
-Call <%= t('get_into_teaching.tel') %> or chat online:
-
-<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'find_has_opened', @application_form.phase  %>
+Call <%= t('get_into_teaching.tel') %> or (chat online)[<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'find_has_opened', @application_form.phase %>
 
 <%= t('get_into_teaching.opening_times') %>.

--- a/app/views/candidate_mailer/new_cycle_has_started.erb
+++ b/app/views/candidate_mailer/new_cycle_has_started.erb
@@ -20,4 +20,4 @@ Sign into your account to make changes to your previous application and apply ag
 
 A teacher training adviser can help you write a strong application:
 
-<%= email_link_with_utm_params I18n.t('get_into_teaching.url_get_an_adviser_start'), 'new_cycle_has_started', @application_form.phase  %>
+[Get a teacher training adviser](<%= email_link_with_utm_params I18n.t('get_into_teaching.url_get_an_adviser_start'), 'new_cycle_has_started', @application_form.phase %>)

--- a/app/views/candidate_mailer/nudge_unsubmitted.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted.text.erb
@@ -10,12 +10,8 @@ Do you have a teacher training adviser yet? They can help you ensure that your a
 
 As former teachers, they can also offer insight into teacher training and teaching as a career.
 
-Get a teacher training adviser:
+[Get a teacher training adviser](<%= email_link_with_utm_params t('get_into_teaching.url_get_an_adviser_start'), 'nudge_unsubmitted', @application_form.phase %>)
 
-<%= email_link_with_utm_params t('get_into_teaching.url_get_an_adviser_start'), 'nudge_unsubmitted', @application_form.phase  %>
-
-Alternatively, call 0800 389 2500 or chat online:
-
-<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted', @application_form.phase  %>
+Alternatively, call 0800 389 2500 or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted', @application_form.phase %>)
 
 Monday to Friday, 8:30am to 5:30pm (except public holidays).

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_courses.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_courses.text.erb
@@ -6,12 +6,8 @@ You’ve not added courses to your teacher training application yet.
 
 A teacher training adviser can help you choose a course. 
 
-Get a teacher training adviser:
+[Get a teacher training adviser](<%= email_link_with_utm_params t('get_into_teaching.url_get_an_adviser_start'), 'nudge_unsubmitted_with_incomplete_courses', @application_form.phase %>)
 
-<%= email_link_with_utm_params t('get_into_teaching.url_get_an_adviser_start'), 'nudge_unsubmitted_with_incomplete_courses', @application_form.phase %>
-
-Alternatively, call 0800 389 2500 or chat online:
-
-<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_with_incomplete_courses', @application_form.phase  %>
+Alternatively, call 0800 389 2500 or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_with_incomplete_courses', @application_form.phase %>)
 
 Monday to Friday, 8:30am to 5:30pm (except public holidays).

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_personal_statement.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_personal_statement.text.erb
@@ -6,12 +6,8 @@ You have not marked your personal statement as complete.
 
 A teacher training adviser can help you understand what to put in your personal statement.
 
-Get a teacher training adviser:
+[Get a teacher training adviser](<%= email_link_with_utm_params t('get_into_teaching.url_get_an_adviser_start'), 'nudge_unsubmitted_with_incomplete_personal_statement', @application_form.phase %>)
 
-<%= email_link_with_utm_params t('get_into_teaching.url_get_an_adviser_start'), 'nudge_unsubmitted_with_incomplete_personal_statement', @application_form.phase  %>
-
-Alternatively, call 0800 389 2500 or chat online:
-
-<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_with_incomplete_personal_statement', @application_form.phase  %>
+Alternatively, call 0800 389 2500 or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_with_incomplete_personal_statement', @application_form.phase %>)
 
 Monday to Friday, 8:30am to 5:30pm (except public holidays).

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
@@ -24,12 +24,8 @@ So choose referees who could comment on as many of these as possible.
 
 A teacher training adviser can give advice on references:
 
-Get a teacher training adviser:
+[Get a teacher training adviser](<%= email_link_with_utm_params t('get_into_teaching.url_get_an_adviser_start'), 'nudge_unsubmitted_no_references', @application_form.phase %>)
 
-<%= email_link_with_utm_params t('get_into_teaching.url_get_an_adviser_start'), 'nudge_unsubmitted_no_references', @application_form.phase %>
-
-Alternatively, call 0800 389 2500 or chat online:
-
-<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_no_references', @application_form.phase %>
+Alternatively, call 0800 389 2500 or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_no_references', @application_form.phase %>)
 
 Monday to Friday, 8:30am to 5:30pm (except public holidays).

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/one_received_reference.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/one_received_reference.text.erb
@@ -8,12 +8,8 @@ You’ve received a teacher training reference, but you’ll need one more befor
 
 A teacher training adviser can give advice on references:
 
-Get a teacher training adviser:
+[Get a teacher training adviser](<%= email_link_with_utm_params t('get_into_teaching.url_get_an_adviser_start'), 'nudge_unsubmitted_one_received_reference', @application_form.phase %>)
 
-<%= email_link_with_utm_params t('get_into_teaching.url_get_an_adviser_start'), 'nudge_unsubmitted_one_received_reference', @application_form.phase %>
-
-Alternatively, call 0800 389 2500 or chat online:
-
-<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_one_received_reference', @application_form.phase %>
+Alternatively, call 0800 389 2500 or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_one_received_reference', @application_form.phase %>)
 
 Monday to Friday, 8:30am to 5:30pm (except public holidays).

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/one_requested_reference.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/one_requested_reference.text.erb
@@ -10,12 +10,8 @@ Before you can submit your application, you need to receive 2 references.
 
 A teacher training adviser can give advice on references:
 
-Get a teacher training adviser:
+[Get a teacher training adviser](<%= email_link_with_utm_params t('get_into_teaching.url_get_an_adviser_start'), 'nudge_unsubmitted_one_requested_reference', @application_form.phase %>)
 
-<%= email_link_with_utm_params t('get_into_teaching.url_get_an_adviser_start'), 'nudge_unsubmitted_one_requested_reference', @application_form.phase %>
-
-Alternatively, call 0800 389 2500 or chat online:
-
-<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_one_requested_reference', @application_form.phase %>
+Alternatively, call 0800 389 2500 or (chat online)[<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_one_requested_reference', @application_form.phase %>]
 
 Monday to Friday, 8:30am to 5:30pm (except public holidays).

--- a/app/views/layouts/candidate_email_with_support_footer.text.erb
+++ b/app/views/layouts/candidate_email_with_support_footer.text.erb
@@ -2,8 +2,6 @@
 
 # Get help
 
-Call <%= t('get_into_teaching.tel') %> or chat online:
-
-<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'support_footer_on_all_emails', @application_form.phase %>
+Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'support_footer_on_all_emails', @application_form.phase %>)
 
 <%= t('get_into_teaching.opening_times') %>.


### PR DESCRIPTION
## Context
Emails links to GIT were not wrapped, and so when the UTM params were included the link was lengthy and this made emails harder to read

## Changes proposed in this pull request
* Wrap GIT links

## Guidance to review
Visit support/docs/mailers on review app

## Link to Trello card

https://trello.com/c/MiofPGqT/768-wrap-our-email-urls-to-git-into-text-to-obfuscate-the-utms

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
