### PR TITLE
Cancel unsubmitted apps worker

### DIFF
--- a/app/controllers/support_interface/tasks_controller.rb
+++ b/app/controllers/support_interface/tasks_controller.rb
@@ -25,8 +25,8 @@ module SupportInterface
         flash[:success] = 'Scheduled job to send emails to candidates with pending offers from the previous cycle'
         redirect_to support_interface_tasks_path
       when 'cancel_applications_at_end_of_cycle'
-        CancelUnsubmittedApplicationsWorker.perform_async
-        flash[:success] = 'Scheduled job to cancel unsubmitted applications that reached end-of-cycle'
+        CancelPreviousCycleUnsubmittedApplicationsWorker.perform_async
+        flash[:success] = 'Scheduled job to cancel unsubmitted applications, from the previous cycle, that reached end-of-cycle'
         redirect_to support_interface_tasks_path
       when 'open_all_courses_on_apply'
         OpenAllCoursesOnApplyWorker.perform_async

--- a/app/workers/cancel_previous_cycle_unsubmitted_applications_worker.rb
+++ b/app/workers/cancel_previous_cycle_unsubmitted_applications_worker.rb
@@ -1,0 +1,21 @@
+class CancelPreviousCycleUnsubmittedApplicationsWorker
+  include Sidekiq::Worker
+
+  def perform
+    unsubmitted_applications_from_earlier_cycle.each do |application_form|
+      CandidateInterface::CancelUnsubmittedApplicationAtEndOfCycle.new(application_form).call
+    end
+  end
+
+private
+
+  def unsubmitted_applications_from_earlier_cycle
+    ApplicationForm
+      .unsubmitted
+      .where(recruitment_cycle_year: RecruitmentCycle.previous_year)
+      .where.not(application_forms: { candidate_id: Candidate.where(hide_in_reporting: true).select(:id) })
+      .where(application_forms: { id: ApplicationChoice.unsubmitted.select(:application_form_id) })
+      .includes(:application_choices)
+      .distinct
+  end
+end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -46,6 +46,8 @@ class Clock
   every(1.day, 'TriggerFullSyncIfFindClosed', at: '00:05') { TeacherTrainingPublicAPI::TriggerFullSyncIfFindClosed.call }
   every(1.day, 'NudgeCandidatesWorker', at: '10:00') { NudgeCandidatesWorker.perform_async }
 
+  every(1.day, 'CancelUnsubmittedApplicationsWorker', at: '00:10') { CancelUnsubmittedApplicationsWorker.perform_async }
+
   # Weekly jobs
   every(7.days, 'FullSyncAllFromTeacherTrainingPublicAPI', at: 'Saturday 00:59') do
     TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(false)

--- a/spec/system/support_interface/cancel_previous_cycle_unsubmitted_at_eoc_task_spec.rb
+++ b/spec/system/support_interface/cancel_previous_cycle_unsubmitted_at_eoc_task_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Cancel unsubmitted applications support task', sidekiq: true do
+RSpec.feature 'Cancel previous cycle unsubmitted applications support task', sidekiq: true do
   include DfESignInHelpers
   include CycleTimetableHelper
 
@@ -8,7 +8,7 @@ RSpec.feature 'Cancel unsubmitted applications support task', sidekiq: true do
     Timecop.freeze(after_apply_2_deadline) { example.run }
   end
 
-  scenario 'Support user performs the cancel unsubmitted applications at EoC task' do
+  scenario 'Support user performs the cancel previous cycle unsubmitted applications at EoC task' do
     given_i_have_a_candidate_with_an_unsubmitted_application
 
     when_i_am_a_support_user
@@ -26,7 +26,7 @@ RSpec.feature 'Cancel unsubmitted applications support task', sidekiq: true do
   end
 
   def given_i_have_a_candidate_with_an_unsubmitted_application
-    @application_form = create :completed_application_form, submitted_at: nil
+    @application_form = create :completed_application_form, submitted_at: nil, recruitment_cycle_year: RecruitmentCycle.previous_year
     create :application_choice, application_form: @application_form, status: :unsubmitted
   end
 
@@ -43,7 +43,7 @@ RSpec.feature 'Cancel unsubmitted applications support task', sidekiq: true do
   end
 
   def then_i_see_that_the_job_has_been_scheduled
-    expect(page).to have_content 'Scheduled job to cancel unsubmitted applications that reached end-of-cycle'
+    expect(page).to have_content 'Scheduled job to cancel unsubmitted applications, from the previous cycle, that reached end-of-cycle'
   end
 
   def when_i_lookup_the_candidates_application

--- a/spec/workers/cancel_previous_cycle_unsubmitted_applications_worker_spec.rb
+++ b/spec/workers/cancel_previous_cycle_unsubmitted_applications_worker_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe CancelPreviousCycleUnsubmittedApplicationsWorker do
+  include CycleTimetableHelper
+
+  describe '#perform' do
+    it 'cancels any unsubmitted applications from the last cycle' do
+      unsubmitted_application_from_last_year = create(
+        :application_form,
+        submitted_at: nil,
+        recruitment_cycle_year: RecruitmentCycle.previous_year,
+      )
+      create(
+        :application_choice,
+        status: :unsubmitted,
+        application_form: unsubmitted_application_from_last_year,
+        course_option: create(:course_option, course: create(:course, recruitment_cycle_year: RecruitmentCycle.previous_year)),
+      )
+
+      hidden_application_from_this_year = create(
+        :application_form,
+        submitted_at: nil,
+        candidate: create(:candidate, hide_in_reporting: true),
+        recruitment_cycle_year: RecruitmentCycle.current_year,
+      )
+      create(
+        :application_choice,
+        status: :unsubmitted,
+        application_form: hidden_application_from_this_year,
+        course_option: create(:course_option, course: create(:course, recruitment_cycle_year: RecruitmentCycle.current_year)),
+      )
+
+      unsubmitted_application_from_this_year = create(
+        :application_form,
+        submitted_at: nil,
+        recruitment_cycle_year: RecruitmentCycle.current_year,
+      )
+      create(
+        :application_choice,
+        status: :unsubmitted,
+        application_form: unsubmitted_application_from_this_year,
+        course_option: create(:course_option, course: create(:course, recruitment_cycle_year: RecruitmentCycle.current_year)),
+      )
+
+      rejected_application_from_this_year = create(
+        :application_form,
+        recruitment_cycle_year: RecruitmentCycle.current_year,
+      )
+      create(
+        :application_choice,
+        status: :rejected,
+        application_form: rejected_application_from_this_year,
+        course_option: create(:course_option, course: create(:course, recruitment_cycle_year: RecruitmentCycle.current_year)),
+      )
+
+      unsubmitted_cancelled_application_from_this_year = create(
+        :application_form,
+        submitted_at: nil,
+        recruitment_cycle_year: RecruitmentCycle.current_year,
+      )
+      create(
+        :application_choice,
+        status: :application_not_sent,
+        application_form: unsubmitted_cancelled_application_from_this_year,
+        course_option: create(:course_option, course: create(:course, recruitment_cycle_year: RecruitmentCycle.current_year)),
+      )
+
+      described_class.new.perform
+
+      expect(unsubmitted_application_from_this_year.reload.application_choices.first).not_to be_application_not_sent
+      expect(unsubmitted_application_from_last_year.reload.application_choices.first).to be_application_not_sent
+      expect(rejected_application_from_this_year.reload.application_choices.first).not_to be_application_not_sent
+      expect(hidden_application_from_this_year.reload.application_choices.first).not_to be_application_not_sent
+      expect(unsubmitted_cancelled_application_from_this_year.reload.application_choices.first).to be_application_not_sent
+    end
+  end
+end

--- a/spec/workers/cancel_unsubmitted_applications_worker_spec.rb
+++ b/spec/workers/cancel_unsubmitted_applications_worker_spec.rb
@@ -4,78 +4,85 @@ RSpec.describe CancelUnsubmittedApplicationsWorker do
   include CycleTimetableHelper
 
   describe '#perform' do
-    around do |example|
-      Timecop.freeze(after_apply_2_deadline) { example.run }
+    let(:unsubmitted_application_from_this_year) do
+      create(:application_form,
+             submitted_at: nil,
+             recruitment_cycle_year: RecruitmentCycle.current_year,
+             application_choices: [create_an_application_choice(:unsubmitted, current_year_course_option)])
+    end
+
+    let(:unsubmitted_application_from_last_year) do
+      create(:application_form,
+             submitted_at: nil,
+             recruitment_cycle_year: RecruitmentCycle.previous_year,
+             application_choices: [create_an_application_choice(:unsubmitted, previous_year_course_option)])
+    end
+
+    let(:previous_year_course_option) do
+      create(:course_option,
+             course: create(:course,
+                            recruitment_cycle_year: RecruitmentCycle.previous_year))
+    end
+
+    let(:current_year_course_option) do
+      create(:course_option,
+             course: create(:course,
+                            recruitment_cycle_year: RecruitmentCycle.current_year))
     end
 
     it 'cancels any unsubmitted applications from the last cycle' do
-      unsubmitted_application_from_last_year = create(
-        :application_form,
-        submitted_at: nil,
-        recruitment_cycle_year: RecruitmentCycle.previous_year,
-      )
-      create(
-        :application_choice,
-        status: :unsubmitted,
-        application_form: unsubmitted_application_from_last_year,
-        course_option: create(:course_option, course: create(:course, recruitment_cycle_year: RecruitmentCycle.previous_year)),
-      )
+      Timecop.freeze(after_apply_2_deadline) do
+        unsubmitted_application_from_this_year
+        unsubmitted_application_from_last_year
 
-      hidden_application_from_this_year = create(
-        :application_form,
-        submitted_at: nil,
-        candidate: create(:candidate, hide_in_reporting: true),
-        recruitment_cycle_year: RecruitmentCycle.current_year,
-      )
-      create(
-        :application_choice,
-        status: :unsubmitted,
-        application_form: hidden_application_from_this_year,
-        course_option: create(:course_option, course: create(:course, recruitment_cycle_year: RecruitmentCycle.current_year)),
-      )
+        hidden_application_from_this_year = create(
+          :application_form,
+          submitted_at: nil,
+          candidate: create(:candidate, hide_in_reporting: true),
+          recruitment_cycle_year: RecruitmentCycle.current_year,
+          application_choices: [create_an_application_choice(:unsubmitted, current_year_course_option)],
+        )
 
-      unsubmitted_application_from_this_year = create(
-        :application_form,
-        submitted_at: nil,
-        recruitment_cycle_year: RecruitmentCycle.current_year,
-      )
-      create(
-        :application_choice,
-        status: :unsubmitted,
-        application_form: unsubmitted_application_from_this_year,
-        course_option: create(:course_option, course: create(:course, recruitment_cycle_year: RecruitmentCycle.current_year)),
-      )
+        rejected_application_from_this_year = create(
+          :application_form,
+          recruitment_cycle_year: RecruitmentCycle.current_year,
+          application_choices: [create_an_application_choice(:rejected, current_year_course_option)],
+        )
 
-      rejected_application_from_this_year = create(
-        :application_form,
-        recruitment_cycle_year: RecruitmentCycle.current_year,
-      )
-      create(
-        :application_choice,
-        status: :rejected,
-        application_form: rejected_application_from_this_year,
-        course_option: create(:course_option, course: create(:course, recruitment_cycle_year: RecruitmentCycle.current_year)),
-      )
+        unsubmitted_cancelled_application_from_this_year = create(
+          :application_form,
+          submitted_at: nil,
+          recruitment_cycle_year: RecruitmentCycle.current_year,
+          application_choices: [create_an_application_choice(:application_not_sent, current_year_course_option)],
+        )
 
-      unsubmitted_cancelled_application_from_this_year = create(
-        :application_form,
-        submitted_at: nil,
-        recruitment_cycle_year: RecruitmentCycle.current_year,
-      )
-      create(
-        :application_choice,
-        status: :application_not_sent,
-        application_form: unsubmitted_cancelled_application_from_this_year,
-        course_option: create(:course_option, course: create(:course, recruitment_cycle_year: RecruitmentCycle.current_year)),
-      )
+        described_class.new.perform
 
-      described_class.new.perform
-
-      expect(unsubmitted_application_from_this_year.reload.application_choices.first).to be_application_not_sent
-      expect(unsubmitted_application_from_last_year.reload.application_choices.first).not_to be_application_not_sent
-      expect(rejected_application_from_this_year.reload.application_choices.first).not_to be_application_not_sent
-      expect(hidden_application_from_this_year.reload.application_choices.first).not_to be_application_not_sent
-      expect(unsubmitted_cancelled_application_from_this_year.reload.application_choices.first).to be_application_not_sent
+        expect(unsubmitted_application_from_this_year.reload.application_choices.first).to be_application_not_sent
+        expect(unsubmitted_application_from_last_year.reload.application_choices.first).not_to be_application_not_sent
+        expect(rejected_application_from_this_year.reload.application_choices.first).not_to be_application_not_sent
+        expect(hidden_application_from_this_year.reload.application_choices.first).not_to be_application_not_sent
+        expect(unsubmitted_cancelled_application_from_this_year.reload.application_choices.first).to be_application_not_sent
+      end
     end
+
+    it 'does not run once in the new cycle' do
+      Timecop.freeze(CycleTimetable.apply_opens) do
+        unsubmitted_application_from_this_year
+        unsubmitted_application_from_last_year
+
+        task = described_class.new.perform
+
+        expect(task).to eq []
+      end
+    end
+  end
+
+  def create_an_application_choice(status, course_option)
+    create(
+      :application_choice,
+      status: status,
+      course_option: course_option,
+    )
   end
 end


### PR DESCRIPTION
## Context

we have a task in the support UI, running it at the end of the cycle changes the status of unsubmitted applications to `application_not_sent`. 

It was missed this year, so we need to change the manual task to only cancel applications in the previous cycle. It also makes sense to add this as a clock job so it's not missed in future cycles.

## Changes proposed in this pull request

- Make a copy of the existing worker but set the task to only cancel unsubmitted applications in the previous cycle
- We've updated the existing (current cycle) one to run as a job on clock

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/bcEmjwWB/760-update-the-cancelunsubmittedapplicationsworker

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
