### PR TITLE
Fix qualification decorator if constituent grades are unavailable

### DIFF
--- a/app/decorators/application_qualification_decorator.rb
+++ b/app/decorators/application_qualification_decorator.rb
@@ -14,17 +14,16 @@ class ApplicationQualificationDecorator < SimpleDelegator
   def grade_details
     case qualification.subject
     when ApplicationQualification::SCIENCE_TRIPLE_AWARD
-      grades = qualification.constituent_grades
       [
-        "#{grades['biology']['grade']} (biology)",
-        "#{grades['chemistry']['grade']} (chemistry)",
-        "#{grades['physics']['grade']} (physics)",
+        "#{constituent_grade_for('biology')} (biology)",
+        "#{constituent_grade_for('chemistry')} (chemistry)",
+        "#{constituent_grade_for('physics')} (physics)",
       ]
     when ApplicationQualification::SCIENCE_DOUBLE_AWARD
       ["#{qualification.grade} (double award)"]
     when ApplicationQualification::SCIENCE_SINGLE_AWARD
       ["#{qualification.grade} (single award)"]
-    when ->(_n) { qualification.constituent_grades }
+    when ->(_n) { constituent_grades.present? }
       present_constituent_grades
     else
       [qualification.grade]
@@ -34,11 +33,18 @@ class ApplicationQualificationDecorator < SimpleDelegator
 private
 
   def present_constituent_grades
-    grades = qualification.constituent_grades
-    grades.map do |award, details|
+    constituent_grades.map do |award, details|
       return "#{details['grade']} (#{ENGLISH_AWARDS[award]})" if ENGLISH_AWARDS.include?(award)
 
       "#{details['grade']} (#{award.humanize(capitalize: false).sub('english', 'English')})"
     end
+  end
+
+  def constituent_grades
+    @constituent_grades ||= qualification.constituent_grades || {}
+  end
+
+  def constituent_grade_for(subject)
+    constituent_grades.dig(subject, 'grade') || 'Grade information not available'
   end
 end

--- a/spec/decorators/application_qualification_decorator_spec.rb
+++ b/spec/decorators/application_qualification_decorator_spec.rb
@@ -9,18 +9,20 @@ RSpec.describe ApplicationQualificationDecorator do
       it 'renders grades for multiple English GCSEs' do
         grade_details = described_class.new(application_qualification).grade_details
 
-        expect(grade_details).to include 'E (English language)'
-        expect(grade_details).to include 'E (English literature)'
-        expect(grade_details).to include 'A* (cockney rhyming slang)'
+        expect(grade_details).to include('E (English language)')
+        expect(grade_details).to include('E (English literature)')
+        expect(grade_details).to include('A* (cockney rhyming slang)')
       end
     end
 
     describe 'rendering multiple Science GCSEs' do
-      science_triple_awards = {
-        biology: { grade: 'A' },
-        chemistry: { grade: 'B' },
-        physics: { grade: 'C' },
-      }
+      let(:science_triple_awards) do
+        {
+          biology: { grade: 'A' },
+          chemistry: { grade: 'B' },
+          physics: { grade: 'C' },
+        }
+      end
 
       let(:application_qualification) do
         create(:gcse_qualification,
@@ -29,12 +31,24 @@ RSpec.describe ApplicationQualificationDecorator do
                award_year: 2006)
       end
 
-      it 'renders grades for multiple English GCSEs' do
+      it 'renders grades for multiple Science GCSEs' do
         grade_details = described_class.new(application_qualification).grade_details
 
-        expect(grade_details).to include 'A (biology)'
-        expect(grade_details).to include 'B (chemistry)'
-        expect(grade_details).to include 'C (physics)'
+        expect(grade_details).to include('A (biology)')
+        expect(grade_details).to include('B (chemistry)')
+        expect(grade_details).to include('C (physics)')
+      end
+
+      context 'when the constituent grades are not present' do
+        let(:science_triple_awards) { nil }
+
+        it 'renders "grade information not available" for each subject' do
+          grade_details = described_class.new(application_qualification).grade_details
+
+          expect(grade_details).to include('Grade information not available (biology)')
+          expect(grade_details).to include('Grade information not available (chemistry)')
+          expect(grade_details).to include('Grade information not available (physics)')
+        end
       end
     end
   end


### PR DESCRIPTION
We're not sure why they're missing, but this is blocking certain exports.

## Context

One or more providers (notably Manchester Met) cannot download their application data export.

## Changes proposed in this pull request

This just fixes the bug preventing the download, there's some followup tickets for error visibility and bad data investigation.
