### PR TITLE
Don't try to render grade details for qualifications marked as missing

### DIFF
--- a/app/decorators/application_qualification_decorator.rb
+++ b/app/decorators/application_qualification_decorator.rb
@@ -12,6 +12,8 @@ class ApplicationQualificationDecorator < SimpleDelegator
   end
 
   def grade_details
+    return [] if qualification.missing_qualification?
+
     case qualification.subject
     when ApplicationQualification::SCIENCE_TRIPLE_AWARD
       [

--- a/spec/decorators/application_qualification_decorator_spec.rb
+++ b/spec/decorators/application_qualification_decorator_spec.rb
@@ -24,11 +24,16 @@ RSpec.describe ApplicationQualificationDecorator do
         }
       end
 
+      let(:qualification_type) { 'gcse' }
+
       let(:application_qualification) do
-        create(:gcse_qualification,
-               subject: 'science triple award',
-               constituent_grades: science_triple_awards,
-               award_year: 2006)
+        create(
+          :gcse_qualification,
+          award_year: 2006,
+          constituent_grades: science_triple_awards,
+          qualification_type:,
+          subject: 'science triple award',
+        )
       end
 
       it 'renders grades for multiple Science GCSEs' do
@@ -48,6 +53,16 @@ RSpec.describe ApplicationQualificationDecorator do
           expect(grade_details).to include('Grade information not available (biology)')
           expect(grade_details).to include('Grade information not available (chemistry)')
           expect(grade_details).to include('Grade information not available (physics)')
+        end
+      end
+
+      context 'when the qualification is marked as missing' do
+        let(:qualification_type) { 'missing' }
+
+        it 'renders nothing for the grade details' do
+          grade_details = described_class.new(application_qualification).grade_details
+
+          expect(grade_details).to eq([])
         end
       end
     end


### PR DESCRIPTION
Qualifications can be of a type "missing" where the candidate for one reason or another did not get a required qualification (e.g. a core GCSE).

In those cases we don't have any grades to show, so we should not attempt to render any.

This is a relatively rare issue as it only caused a problem rendering the science tripe award, which is why it only showed up now.

## Guidance to review

Check that application data exports work as expected.
