### PR TITLE
Make our privacy notice stronger with regards to references

### DIFF
--- a/app/views/content/service_privacy_notice.md
+++ b/app/views/content/service_privacy_notice.md
@@ -158,7 +158,7 @@ We share data with our data processors for the purposes of provision of this ser
 
 ### Your rights
 
-Under the DPA 2018 and the UK GDPR, you have the right to find out what data we have about you. References provided in applications are considered confidential.
+Under the DPA 2018 and the UK GDPR, you have the right to find out what data we have about you. References provided in applications are confidential.
 
 However, your rights are conditional on the lawful basis under which your data is being processed. Our lawful basis is public task, which grants you the following rights:
 

--- a/app/views/content/service_privacy_notice.md
+++ b/app/views/content/service_privacy_notice.md
@@ -158,7 +158,7 @@ We share data with our data processors for the purposes of provision of this ser
 
 ### Your rights
 
-Under the DPA 2018 and the UK GDPR, you have the right to find out what data we have about you.References provided in applications are considered confidential.
+Under the DPA 2018 and the UK GDPR, you have the right to find out what data we have about you. References provided in applications are considered confidential.
 
 However, your rights are conditional on the lawful basis under which your data is being processed. Our lawful basis is public task, which grants you the following rights:
 

--- a/app/views/content/service_privacy_notice.md
+++ b/app/views/content/service_privacy_notice.md
@@ -158,7 +158,9 @@ We share data with our data processors for the purposes of provision of this ser
 
 ### Your rights
 
-Under the DPA 2018 and the UK GDPR, you have the right to find out what data we have about you. However, your rights are conditional on the lawful basis under which your data is being processed. Our lawful basis is public task, which grants you the following rights:
+Under the DPA 2018 and the UK GDPR, you have the right to find out what data we have about you.References provided in applications are considered confidential.
+
+However, your rights are conditional on the lawful basis under which your data is being processed. Our lawful basis is public task, which grants you the following rights:
 
 - being informed about how your data is being used
 - accessing personal data


### PR DESCRIPTION
## Context

We have spoken with our data protection team around exemptions for references. Being more explicit about this will strengthen our case.

## Changes proposed in this pull request

Adding a line on references being provided in confidence.

## Guidance to review

Does this look fine?

## Link to Trello card

https://trello.com/c/jaHsOhbo/788-update-our-privacy-notice-to-give-further-clarity-on-the-privacy-exemption-for-references

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
