### PR TITLE
Send a reference request when an unconditional offer is accepted

### DIFF
--- a/app/services/accept_unconditional_offer.rb
+++ b/app/services/accept_unconditional_offer.rb
@@ -11,6 +11,12 @@ class AcceptUnconditionalOffer < AcceptOffer
       ProviderMailer.unconditional_offer_accepted(provider_user, @application_choice).deliver_later
     end
 
+    if application_choice.application_form.show_new_reference_flow?
+      application_choice.application_form.application_references.includes([:application_form]).not_requested_yet.each do |reference|
+        RequestReference.new.call(reference)
+      end
+    end
+
     CandidateMailer.unconditional_offer_accepted(@application_choice).deliver_later
   rescue Workflow::NoTransitionAllowed
     false

--- a/spec/services/accept_unconditional_offer_spec.rb
+++ b/spec/services/accept_unconditional_offer_spec.rb
@@ -75,5 +75,15 @@ RSpec.describe AcceptUnconditionalOffer do
       expect(ActionMailer::Base.deliveries.first.to).to eq [application_choice.application_form.candidate.email_address]
       expect(ActionMailer::Base.deliveries.first.subject).to match(/You’ve accepted/)
     end
+
+    it 'sends an email to the candidates referees' do
+      FeatureFlag.activate(:new_references_flow)
+      application_form = create(:application_form, application_references: [create(:reference, :not_requested_yet), create(:reference, :not_requested_yet)])
+      application_choice = create(:application_choice, status: :offer, application_form: application_form)
+
+      expect { described_class.new(application_choice:).save! }.to change { ActionMailer::Base.deliveries.count }.by(3)
+      expect(ActionMailer::Base.deliveries.first.to).to eq [application_choice.application_form.application_references.first.email_address]
+      expect(ActionMailer::Base.deliveries.first.subject).to match(/ Teacher training reference needed for /)
+    end
   end
 end


### PR DESCRIPTION
## Context

Bug in prod – if a candidate accepts an unconditional offer we return from the `accept_offer` service and call the `AcceptUnconditionalOffer` instead, which currently doesn't include the RequestReference service. So adding this in.