### PR TITLE
Revert "Update the Find has opened email to mention the new references process"

### DIFF
--- a/app/views/candidate_mailer/find_has_opened.erb
+++ b/app/views/candidate_mailer/find_has_opened.erb
@@ -8,8 +8,6 @@ You can now find teacher training courses starting in the <%= @academic_year %> 
 
 Apply early to have the best chance of getting onto the course you want, as courses fill up throughout the year.
 
-You’ll need to give details of 2 people who can give you a reference. They’ll only be contacted if you accept an offer on a course.
-
 [Get your application ready](<%= candidate_magic_link(@application_form.candidate) %>).
 
 You can submit from 9am on <%= @apply_opens %>.


### PR DESCRIPTION
Reverts DFE-Digital/apply-for-teacher-training#7510

We no longer need this now we've sent our find has opened email for this cycle. We won't need this copy next cycle.