### PR TITLE
Remove new degree flow feature flag from db

### DIFF
--- a/app/services/data_migrations/remove_new_degree_flow_feature_flag.rb
+++ b/app/services/data_migrations/remove_new_degree_flow_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class RemoveNewDegreeFlowFeatureFlag
+    TIMESTAMP = 20221019111412
+    MANUAL_RUN = false
+
+    def change
+      Feature.find_by(name: 'new_degree_flow')&.destroy
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveNewDegreeFlowFeatureFlag',
   'DataMigrations::RemoveLockExternalReportFeatureFlag',
   'DataMigrations::EndOfCycleCancelOutstandingReferences',
   'DataMigrations::ProviderInterviewDataFix',

--- a/spec/services/data_migrations/remove_new_degree_flow_feature_flag_spec.rb
+++ b/spec/services/data_migrations/remove_new_degree_flow_feature_flag_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveNewDegreeFlowFeatureFlag do
+  context 'when the feature flag exists' do
+    it 'removes the feature flag' do
+      create(:feature, name: 'new_degree_flow')
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: 'new_degree_flow')).to be_none
+    end
+  end
+
+  context 'when the feature flag has already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end


### PR DESCRIPTION
## Context
Our feature flags are stored in the feature table in the database. This PR remove the new degree flow record in all envs as no longer in use.

## Changes proposed in this pull request
* Data migration to remove unneeded feature flag

## Guidance to review


## Link to Trello card

N/A

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
