### PR TITLE
Makes current years courses visible to support

### DIFF
--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -28,7 +28,7 @@ module RecruitmentCycle
   end
 
   def self.years_visible_in_support
-    [2022, 2021, 2020, 2019]
+    current_year.downto(CycleTimetable::CYCLE_DATES.keys.min)
   end
 
   def self.cycle_name(year = current_year)

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe RecruitmentCycle do
     end
   end
 
+  describe '.years_visible_in_support' do
+    it 'returns correct array of years' do
+      allow(CycleTimetable).to receive(:current_year).and_return(2023)
+
+      expect(described_class.years_visible_in_support).to contain_exactly(2023, 2022, 2021, 2020, 2019)
+    end
+  end
+
   describe '.current_year' do
     it 'delegates to CycleTimetable' do
       allow(CycleTimetable).to receive(:current_year)


### PR DESCRIPTION
## Context
At the moment the current recruitment cycle's courses are not visible in support interface, this is because the array of years was hardcoded.

## Changes proposed in this pull request
* Replace hardcoded years with more dynamic method

## Guidance to review

After

<img width="1235" alt="Screenshot 2022-10-19 at 13 15 05" src="https://user-images.githubusercontent.com/58793682/196688042-1bc27ac8-3b56-4e13-a6fd-6bf10860a70e.png">


## Link to Trello card

https://trello.com/c/mRD5naFJ/811-fix-the-support-console-so-it-shows-the-current-years-courses

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
