### PR TITLE
Stop hardcoding years in the performance dashboard

### DIFF
--- a/app/controllers/support_interface/performance_controller.rb
+++ b/app/controllers/support_interface/performance_controller.rb
@@ -15,7 +15,7 @@ module SupportInterface
     def courses_dashboard; end
 
     def service_performance_dashboard
-      year = params[:year] if %w[2020 2021 2022].include?(params[:year])
+      year = params[:year] if RecruitmentCycle.years_visible_in_support.include?(params[:year].to_i)
 
       @statistics = PerformanceStatistics.new(year)
     end


### PR DESCRIPTION
## Context

People are still using the service performance dashboard but the values are currently hardcoded and often get forgotten about.

## Changes proposed in this pull request

Use the `RecruitmentCycle.years_visible_in_support` method so we no longer need to worry about populating the years.