### PR TITLE
Don't require rubocop via bundler

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 require:
   - rubocop-rails
+  - rubocop-rake
+  - rubocop-rspec
   - ./lib/rubocop/cop/application_api_controller.rb
   - ./lib/rubocop/cop/govuk/govuk_button_to.rb
   - ./lib/rubocop/cop/govuk/govuk_link_to.rb

--- a/Gemfile
+++ b/Gemfile
@@ -25,10 +25,10 @@ gem 'mail-notify'
 gem 'govuk_markdown'
 
 # Linting
-gem 'rubocop'
-gem 'rubocop-rspec'
-gem 'rubocop-rails'
-gem 'rubocop-rake'
+gem 'rubocop', require: false
+gem 'rubocop-rails', require: false
+gem 'rubocop-rake', require: false
+gem 'rubocop-rspec', require: false
 gem 'erb_lint', require: false
 
 gem 'devise'


### PR DESCRIPTION
Because of all the rule definitions, rubocop takes almost a full second just to `require` it, and it isn't needed anyway.

See https://github.com/rubocop/rubocop#installation

## Context

Just `requiring` our bundled gems adds 5-8 seconds to each test run.  This saves us a full second each time.
