### PR TITLE
Use the 'summariser' matchers in component specs

### DIFF
--- a/spec/components/candidate_interface/english_foreign_language/ielts_review_component_spec.rb
+++ b/spec/components/candidate_interface/english_foreign_language/ielts_review_component_spec.rb
@@ -8,21 +8,51 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::IeltsReviewComponent,
       award_year: '2001',
       band_score: '8',
     )
-    result = render_inline(described_class.new(ielts_qualification))
+    render_inline(described_class.new(ielts_qualification))
 
-    [
-      { position: 0, title: 'Have you done an English as a foreign language assessment?', value: 'Yes', change: 'foo' },
-      { position: 1, title: 'Type of assessment', value: 'IELTS' },
-      { position: 2, title: 'Test report form (TRF) number', value: '111111' },
-      { position: 3, title: 'Year completed', value: '2001' },
-      { position: 4, title: 'Overall band score', value: '8' },
-    ].each do |row|
-      expect(result.css('.govuk-summary-list__key')[row[:position]].text).to include(row[:title])
-      expect(result.css('.govuk-summary-list__value')[row[:position]].text).to include(row[:value])
-    end
+    expect(rendered_content).to summarise(
+      key: 'Have you done an English as a foreign language assessment?',
+      value: 'Yes',
+      action: {
+        text: 'Change whether or not you have a qualification',
+        href: Rails.application.routes.url_helpers.candidate_interface_english_foreign_language_edit_start_path,
+      },
+    )
 
-    expect(result.css('.govuk-summary-list__actions a')[0][:href]).to eq(
-      Rails.application.routes.url_helpers.candidate_interface_english_foreign_language_edit_start_path,
+    expect(rendered_content).to summarise(
+      key: 'Type of assessment',
+      value: 'IELTS',
+      action: {
+        text: 'Change type of assessment',
+        href: Rails.application.routes.url_helpers.candidate_interface_english_foreign_language_type_path,
+      },
+    )
+
+    expect(rendered_content).to summarise(
+      key: 'Test report form (TRF) number',
+      value: '111111',
+      action: {
+        text: 'Change TRF number',
+        href: Rails.application.routes.url_helpers.candidate_interface_edit_ielts_path,
+      },
+    )
+
+    expect(rendered_content).to summarise(
+      key: 'Year completed',
+      value: '2001',
+      action: {
+        text: 'Change year completed',
+        href: Rails.application.routes.url_helpers.candidate_interface_edit_ielts_path,
+      },
+    )
+
+    expect(rendered_content).to summarise(
+      key: 'Overall band score',
+      value: '8',
+      action: {
+        text: 'Change overall band score',
+        href: Rails.application.routes.url_helpers.candidate_interface_edit_ielts_path,
+      },
     )
   end
 
@@ -35,8 +65,13 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::IeltsReviewComponent,
     )
     result = render_inline(described_class.new(ielts_qualification, return_to_application_review: true))
 
-    expect(result.css('.govuk-summary-list__actions a')[0][:href]).to eq(
-      Rails.application.routes.url_helpers.candidate_interface_english_foreign_language_edit_start_path('return-to' => 'application-review'),
+    expect(rendered_content).to summarise(
+      key: 'Test report form (TRF) number',
+      value: '111111',
+      action: {
+        text: 'Change TRF number',
+        href: Rails.application.routes.url_helpers.candidate_interface_edit_ielts_path('return-to' => 'application-review'),
+      },
     )
   end
 end

--- a/spec/components/candidate_interface/english_foreign_language/ielts_review_component_spec.rb
+++ b/spec/components/candidate_interface/english_foreign_language/ielts_review_component_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::IeltsReviewComponent,
       award_year: '2001',
       band_score: '8',
     )
-    result = render_inline(described_class.new(ielts_qualification, return_to_application_review: true))
+    render_inline(described_class.new(ielts_qualification, return_to_application_review: true))
 
     expect(rendered_content).to summarise(
       key: 'Test report form (TRF) number',

--- a/spec/components/candidate_interface/volunteering_review_component_spec.rb
+++ b/spec/components/candidate_interface/volunteering_review_component_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe CandidateInterface::VolunteeringReviewComponent do
+RSpec.describe CandidateInterface::VolunteeringReviewComponent, type: :component do
   context 'when they have no experience in volunteering' do
     it 'confirms that they have no volunteering experience' do
       application_form = build_stubbed(:application_form)
@@ -63,67 +63,67 @@ RSpec.describe CandidateInterface::VolunteeringReviewComponent do
     end
 
     it 'renders component with correct values for role' do
-      result = render_inline(described_class.new(application_form:))
+      render_inline(described_class.new(application_form:))
 
-      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.volunteering.role.review_label'))
-      expect(result.css('.govuk-summary-list__value').to_html).to include('School Experience Intern')
-      expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include(
-        Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(volunteering_role),
-      )
-      expect(result.css('.govuk-summary-list__actions').text).to include(
-        "Change #{t('application_form.volunteering.role.change_action')} for School Experience Intern, A Noice School",
+      expect(rendered_content).to summarise(
+        key: 'Role',
+        value: 'School Experience Intern',
+        action: {
+          text: 'Change role for School Experience Intern, A Noice School',
+          href: Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(volunteering_role),
+        },
       )
     end
 
     it 'renders component with correct values for organisation' do
-      result = render_inline(described_class.new(application_form:))
+      render_inline(described_class.new(application_form:))
 
-      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.volunteering.organisation.review_label'))
-      expect(result.css('.govuk-summary-list__value').to_html).to include('A Noice School')
-      expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include(
-        Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(volunteering_role),
-      )
-      expect(result.css('.govuk-summary-list__actions').text).to include(
-        "Change #{t('application_form.volunteering.organisation.change_action')} for School Experience Intern, A Noice School",
+      expect(rendered_content).to summarise(
+        key: 'Organisation',
+        value: 'A Noice School',
+        action: {
+          text: 'Change organisation for School Experience Intern, A Noice School',
+          href: Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(volunteering_role),
+        },
       )
     end
 
     it 'renders component with correct values for working with children' do
-      result = render_inline(described_class.new(application_form:))
+      render_inline(described_class.new(application_form:))
 
-      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.volunteering.working_with_children.review_label'))
-      expect(result.css('.govuk-summary-list__value').to_html).to include('Yes')
-      expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include(
-        Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(volunteering_role),
-      )
-      expect(result.css('.govuk-summary-list__actions').text).to include(
-        "Change #{t('application_form.volunteering.working_with_children.change_action')} for School Experience Intern, A Noice School",
+      expect(rendered_content).to summarise(
+        key: 'Did this role involve working in a school or with children?',
+        value: 'Yes',
+        action: {
+          text: 'Change if this role involved working in a school or with children for School Experience Intern, A Noice School',
+          href: Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(volunteering_role),
+        },
       )
     end
 
     it 'renders component with correct values for length' do
-      result = render_inline(described_class.new(application_form:))
+      render_inline(described_class.new(application_form:))
 
-      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.volunteering.length.review_label'))
-      expect(result.css('.govuk-summary-list__value').to_html).to include('August 2019 - Present')
-      expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include(
-        Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(volunteering_role),
-      )
-      expect(result.css('.govuk-summary-list__actions').text).to include(
-        "Change #{t('application_form.volunteering.length.change_action')} for School Experience Intern, A Noice School",
+      expect(rendered_content).to summarise(
+        key: 'Dates',
+        value: 'August 2019 - Present',
+        action: {
+          text: 'Change dates for School Experience Intern, A Noice School',
+          href: Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(volunteering_role),
+        },
       )
     end
 
     it 'renders component with correct values for details of experience' do
-      result = render_inline(described_class.new(application_form:))
+      render_inline(described_class.new(application_form:))
 
-      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.volunteering.details.review_label'))
-      expect(result.css('.govuk-summary-list__value').to_html).to include('<p class="govuk-body">I interned.</p>')
-      expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include(
-        Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(volunteering_role),
-      )
-      expect(result.css('.govuk-summary-list__actions').text).to include(
-        "Change #{t('application_form.volunteering.details.change_action')} for School Experience Intern, A Noice School",
+      expect(rendered_content).to summarise(
+        key: 'Time commitment and responsibilities',
+        value: 'I interned.',
+        action: {
+          text: 'Change time commitment and responsibilities for School Experience Intern, A Noice School',
+          href: Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(volunteering_role),
+        },
       )
     end
 

--- a/spec/support/summarise_matcher.rb
+++ b/spec/support/summarise_matcher.rb
@@ -12,7 +12,7 @@ RSpec::Matchers.define :summarise do |expected|
       "Could not find the key ‘#{expected[:key]}’ within\n\n #{actual}"
     elsif !value_html
       "Could not find a <dd class=\"govuk-summary-list__value\"> element within HTML: \n#{row_html.native.to_html}"
-    elsif value_text != expected[:text]
+    elsif value_text != expected[:value]
       "Expected ‘#{expected[:key]}’ value to be ‘#{expected[:value]}’ but was ‘#{value_text}’"
     elsif !action_link
       "Could not find the link ‘#{expected[:action][:text]}’ within HTML: \n#{row_html.native.to_html}"


### PR DESCRIPTION
About a year ago I worked with a developer to add a [custom rspec matcher for summary list components](https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/spec/support/summarise_matcher.rb). This aims to avoid having to make a bunch of assertions based on long CSS class names, which makes the specs easier to read.

It also also be used to check any 'actions' (usually 'Change' links) and can use the full text including the visually-hidden text, which helps make sure that the links remain unique and accessible.

Unfortunately we didn't do a great job of telling people about this custom matcher, so it hasn't been widely used! 🤦‍♂️ 

This PR switches a couple of existing specs (picked at random) to use it, as a quick demonstrator.

It'd be great to get feedback on:

* is this custom matcher useful?
* could it be improved in any way?
* are there any other custom matchers we should consider?