### PR TITLE
Fix a mime-type issue with CSV downloads

### DIFF
--- a/app/controllers/concerns/streamable_data_export.rb
+++ b/app/controllers/concerns/streamable_data_export.rb
@@ -13,7 +13,7 @@ private
     block ||= ->(row) { row }
 
     set_stream_headers
-    send_stream(filename:) do |stream|
+    send_stream(filename:, type: 'text/csv') do |stream|
       stream.write SafeCSV.generate_line(block.call(data.first).keys)
 
       data.find_each(batch_size:) do |row|


### PR DESCRIPTION
Due to an issue with `ActionController::Live` not always sending a string for the mime type, it's safer for us to specify one here.

This will fix an issue with an interaction with a DfE analytics gem.

## Context

https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1666382932798649

## Guidance to review

Check one of the CSV exports to make sure it still works, and ideally that it sends the correct mime-type.
