### PR TITLE
Fix bug when deleting a reference that doesn't exist anymore

### DIFF
--- a/app/controllers/candidate_interface/new_references/review_controller.rb
+++ b/app/controllers/candidate_interface/new_references/review_controller.rb
@@ -29,6 +29,8 @@ module CandidateInterface
       end
 
       def destroy
+        return redirect_to_review_page if @reference.blank?
+
         DeleteReference.new.call(reference: @reference)
 
         VerifyAndMarkReferencesIncomplete.new(current_application).call

--- a/spec/requests/candidate_interface/new_references_delete_reference_spec.rb
+++ b/spec/requests/candidate_interface/new_references_delete_reference_spec.rb
@@ -18,4 +18,15 @@ RSpec.describe 'Candidate Interface - Redirects acepted offer', type: :request d
       expect(response).to redirect_to(candidate_interface_new_references_review_path)
     end
   end
+
+  context 'when deleting a nil reference' do
+    it 'redirects to review page' do
+      application_form = create(:application_form, recruitment_cycle_year: 2023, candidate:)
+      reference = create(:reference, :feedback_requested, application_form:)
+      reference.destroy
+
+      delete candidate_interface_destroy_new_reference_path(reference)
+      expect(response).to redirect_to(candidate_interface_new_references_review_path)
+    end
+  end
 end


### PR DESCRIPTION
## Context

This can be for variety reasons. One possibility is that users are hiting the back button on browser and trying to delete something already deleted. So I decide to redirect if you try to delete a reference that doesn't exist anymore.

More info on:

https://sentry.io/organizations/dfe-teacher-services/issues/3587460220/?environment=production&project=1765973&query=is%3Aunresolved

https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1665496163326819

## Guidance to review

1. Does it redirect if you destroy a reference, hit the browser back button and tries to delete the reference again?

## Link to Trello card

https://trello.com/c/5gnBDveP/761-sentry-nil-reference-when-deleting-reference
