### PR TITLE
Support playbook: add instructions for reverting a rejection

### DIFF
--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -167,6 +167,15 @@ Providers may need to revert a rejection so that they can offer a different cour
 If less than five working days have passed since the application has been submitted, then the rejection can be reverted via the
 Support UI when viewing the application choice.
 
+If more than five working days have passed, the rejection can be reverted as follows:
+
+```ruby
+application_choice = ApplicationChoice.find(id)
+zendesk_ticket = 'https://becomingateacher.zendesk.com/agent/tickets/...'
+SupportInterface::RevertRejection.new(application_choice:, zendesk_ticket:).save!
+
+```
+
 If a candidate has had a course rejected in error but wishes to replace their course option with another offered by a _different_ provider,
 then following reverting the rejection via the Support UI, you will need to [withdraw the course option via the console](#change-providercourse),
 before adding a new course choice via the Support UI.


### PR DESCRIPTION
When it can no longer be done in the Support UI

## Context

I was on support and needed to revert a rejection

## Changes proposed in this pull request

Add instructions to the support playbook for reverting a rejection in a Rails console

## Guidance to review

Does it make sense?

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
