### PR TITLE
Stop using set-output in check_sp workflow

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -33,15 +33,15 @@ runs:
 
         if [ -n "${{ inputs.pr-number }}" ]; then
           echo "DEPLOY_ENV=review-${{ inputs.pr-number }}" >> $GITHUB_ENV
-          echo "::set-output name=deploy_url::https://apply-review-${{ inputs.pr-number }}.london.cloudapps.digital"
+          echo "deploy_url=https://apply-review-${{ inputs.pr-number }}.london.cloudapps.digital" >> $GITHUB_OUTPUT
         else
           echo "DEPLOY_ENV=${{ inputs.environment }}" >> $GITHUB_ENV
 
           hostname=$(jq -r '.service_gov_uk_host_names[0]' ${tf_vars_file})
           if [[ $hostname != null ]]; then
-            echo "::set-output name=deploy_url::https://${hostname}.apply-for-teacher-training.service.gov.uk"
+            echo "deploy_url=https://${hostname}.apply-for-teacher-training.service.gov.uk" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=deploy_url::https://apply-${{ inputs.environment }}.london.cloudapps.digital"
+            echo "deploy_url=https://apply-${{ inputs.environment }}.london.cloudapps.digital" >> $GITHUB_OUTPUT
           fi
         fi;
         echo "DOCKER_IMAGE=$DOCKER_IMAGE" >> $GITHUB_ENV
@@ -54,7 +54,7 @@ runs:
         DOCKER_IMAGE: ${{ format('ghcr.io/dfe-digital/apply-teacher-training:{0}', inputs.sha) }}
 
     - name: Use Terraform v1.2.3
-      uses: hashicorp/setup-terraform@v1
+      uses: hashicorp/setup-terraform@v2
       with:
         terraform_version: 1.2.3
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -255,12 +255,13 @@ jobs:
           file_text=$(cat /app/tmp/rspec-retry-flakey-specs.log)
           if [ ! -z "$file_text" ]
           then
-            file_text="${file_text//'%'/'%25'}"
-            file_text="${file_text//$'\n'/'%0A'}"
-            file_text="${file_text//$'\r'/'%0D'}"
-            file_text="${file_text//'\u003c'/'&lt;'}"
-            file_text="${file_text//'\u003e'/'&gt;'}"
-            echo "::set-output name=flakey_tests::$file_text"
+            echo "Flakey specs found"
+            echo "file_text: $file_text"
+
+            # Use GitHub SHA as uuidgen is not available
+            echo "flakey_tests<<$GITHUB_SHA" >> $GITHUB_OUTPUT
+            cat /app/tmp/rspec-retry-flakey-specs.log >> $GITHUB_OUTPUT
+            echo "$GITHUB_SHA" >> $GITHUB_OUTPUT
           else
             echo "No flakey tests logged"
           fi
@@ -364,8 +365,12 @@ jobs:
           file_text=$(cat "$FILE")
           if [ ! -z "$file_text" ]
           then
-            file_text="${file_text//$'\n'/%0A}"
-            echo "::set-output name=base_coverage_data::$file_text"
+            echo "Base coverage available for comparison."
+
+            DELIMITER=$(uuidgen)
+            echo "base_coverage_data<<$DELIMITER" >> $GITHUB_OUTPUT
+            cat base-coverage/.last_run.json >> $GITHUB_OUTPUT
+            echo "$DELIMITER" >> $GITHUB_OUTPUT
           fi
 
       - name: Output PR coverage results
@@ -382,8 +387,12 @@ jobs:
           file_text=$(cat "$FILE")
           if [ ! -z "$file_text" ]
           then
-            file_text="${file_text//$'\n'/%0A}"
-            echo "::set-output name=pr_coverage_data::$file_text"
+            echo "PR coverage available for comparison."
+
+            DELIMITER=$(uuidgen)
+            echo "pr_coverage_data<<$DELIMITER" >> $GITHUB_OUTPUT
+            cat coverage/.last_run.json >> $GITHUB_OUTPUT
+            echo "$DELIMITER" >> $GITHUB_OUTPUT
           fi
 
       - name: Compare coverage results

--- a/.github/workflows/pull_request_checks.yml
+++ b/.github/workflows/pull_request_checks.yml
@@ -2,9 +2,9 @@ name: Pull request checks
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths:
-    - 'app/models/**'
+      - "app/models/**"
 
 jobs:
   warn-enums:
@@ -88,7 +88,10 @@ jobs:
           MULTILINE="${MULTILINE//$'\n'/'%0A'}"
           MULTILINE="${MULTILINE//$'\r'/'%0D'}"
           echo $MULTILINE
-          echo "::set-output name=data::$MULTILINE"
+
+          echo "data<<$GITHUB_SHA" >> $GITHUB_OUTPUT
+          cat changed_enums.log >> $GITHUB_OUTPUT
+          echo "$GITHUB_SHA" >> $GITHUB_OUTPUT
         shell: bash
 
       # Comment on the PR if enums have changed

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 # Ignore SQL backups
 *.sql
 *.tar.gz
+*.sql.gz
 
 # Ignore all logfiles and tempfiles.
 /log/*


### PR DESCRIPTION
## Context

The set-output command is being deprecated soon.

## Changes proposed in this pull request

Resolution is to use $GITHUB_OUTPUT as per the workflow commands docs.

## Guidance to review

Confirm updated workflows tested where possible:

- [x] Deploy
- [x] Build and deploy ([base coverage, pr coverage](https://github.com/DFE-Digital/apply-for-teacher-training/actions/runs/3600808359/jobs/6066229182))
- [x] Flakey specs test checks ([set-output](https://github.com/DFE-Digital/apply-for-teacher-training/actions/runs/3591753162/jobs/6046742141), [GITHUB_OUTPUT](https://github.com/DFE-Digital/apply-for-teacher-training/actions/runs/3592360332))
- [x] PR checks ([set-output](https://github.com/DFE-Digital/apply-for-teacher-training/actions/runs/3591753169/jobs/6046742618), [GITHUB_OUTPUT](https://github.com/DFE-Digital/apply-for-teacher-training/actions/runs/3592360330/jobs/6047978531))

## Link to Trello card

https://trello.com/c/3s3iC7UV