### PR TITLE
Vendor api v1.2 - return new sex ethnicity disability HESA codes

### DIFF
--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -40,6 +40,7 @@ module VendorAPI
     '1.2pre' => [
       Changes::RejectByCodes,
       Changes::RejectionReasonCodes,
+      Changes::Add2023HesaToApplication,
     ],
   }.freeze
 end

--- a/app/lib/vendor_api/changes/add_2023_hesa_to_application.rb
+++ b/app/lib/vendor_api/changes/add_2023_hesa_to_application.rb
@@ -3,7 +3,7 @@ module VendorAPI
     class Add2023HesaToApplication < VersionChange
       description 'Include the 2023 HESA codes associated with the application'
 
-      resource ApplicationPresenter, [ApplicationPresenter::HesaData]
+      resource ApplicationPresenter, [ApplicationPresenter::EqualityAndDiversity]
     end
   end
 end

--- a/app/lib/vendor_api/changes/add_2023_hesa_to_application.rb
+++ b/app/lib/vendor_api/changes/add_2023_hesa_to_application.rb
@@ -1,0 +1,9 @@
+module VendorAPI
+  module Changes
+    class Add2023HesaToApplication < VersionChange
+      description 'Include the 2023 HESA codes associated with the application'
+
+      resource ApplicationPresenter, [ApplicationPresenter::HesaData]
+    end
+  end
+end

--- a/app/lib/vendor_api_specification.rb
+++ b/app/lib/vendor_api_specification.rb
@@ -18,6 +18,7 @@ class VendorAPISpecification
   end
 
   def spec
+    yaml_for_version = nil
     (0..minor_version_number(@version)).each_with_object({}) do |minor_version, versions|
       version_to_load = "#{major_version_number(@version)}.#{minor_version}"
 

--- a/app/presenters/vendor_api/application_presenter/equality_and_diversity.rb
+++ b/app/presenters/vendor_api/application_presenter/equality_and_diversity.rb
@@ -8,7 +8,7 @@ module VendorAPI::ApplicationPresenter::EqualityAndDiversity
   end
 
   def equality_and_diversity
-    return nil unless ApplicationStateChange::ACCEPTED_STATES.include?(application_choice.status.to_sym)
+    return nil unless ApplicationStateChange::ACCEPTED_STATES.include?(application_choice.status.to_sym) && application_choice.application_form.recruitment_cycle_year == RecruitmentCycle.current_year
 
     equality_and_diversity_data = application_form&.equality_and_diversity
 

--- a/app/presenters/vendor_api/application_presenter/equality_and_diversity.rb
+++ b/app/presenters/vendor_api/application_presenter/equality_and_diversity.rb
@@ -1,13 +1,13 @@
-module VendorAPI::ApplicationPresenter::HesaData
+module VendorAPI::ApplicationPresenter::EqualityAndDiversity
   def schema
     super.deep_merge!({
       attributes: {
-        hesa_data: hesa_data,
+        equality_and_diversity: equality_and_diversity,
       },
     })
   end
 
-  def hesa_data
+  def equality_and_diversity
     return nil unless ApplicationStateChange::ACCEPTED_STATES.include?(application_choice.status.to_sym)
 
     equality_and_diversity_data = application_form&.equality_and_diversity

--- a/app/presenters/vendor_api/application_presenter/hesa_data.rb
+++ b/app/presenters/vendor_api/application_presenter/hesa_data.rb
@@ -1,0 +1,23 @@
+module VendorAPI::ApplicationPresenter::HesaData
+  def schema
+    super.deep_merge!({
+      attributes: {
+        hesa_data: hesa_data,
+      },
+    })
+  end
+
+  def hesa_data
+    return nil unless ApplicationStateChange::ACCEPTED_STATES.include?(application_choice.status.to_sym)
+
+    equality_and_diversity_data = application_form&.equality_and_diversity
+
+    if equality_and_diversity_data
+      {
+        sex: equality_and_diversity_data['hesa_sex'],
+        disability: equality_and_diversity_data['hesa_disabilities'],
+        ethnicity: equality_and_diversity_data['hesa_ethnicity'],
+      }.merge(additional_hesa_itt_data(equality_and_diversity_data))
+    end
+  end
+end

--- a/config/initializers/hesa_sex.rb
+++ b/config/initializers/hesa_sex.rb
@@ -8,6 +8,8 @@ HESA_SEX_2022_2023 = [
   %w[10 female],
   %w[11 male],
   %w[12 other],
+  ['96', 'information refused'],
+  ['99', 'not available'],
 ].freeze
 
 HESA_SEX_COLLECTIONS = {

--- a/config/vendor_api/draft.yml
+++ b/config/vendor_api/draft.yml
@@ -73,6 +73,7 @@ components:
       properties:
         hesa_data:
           "$ref": "#/components/schemas/HESAData"
+          nullable: true
     ObjectListResponse:
       type: object
       required:
@@ -113,7 +114,6 @@ components:
       description: |
         Values to populate this candidate’s HESA Initial Teacher
         Training data return.  Available once an offer has been accepted.
-      nullable: true
       required:
         - sex
         - disability

--- a/config/vendor_api/draft.yml
+++ b/config/vendor_api/draft.yml
@@ -12,9 +12,9 @@ info:
     Experimental endpoints prefixed with `/test-data` may change or be removed.
 servers:
 - description: Sandbox (test environment for vendors)
-  url: https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.1
+  url: https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.2
 - description: Production
-  url: https://www.apply-for-teacher-training.service.gov.uk/api/v1.1
+  url: https://www.apply-for-teacher-training.service.gov.uk/api/v1.2
 paths:
   "/applications/{application_id}/reject-by-codes":
     post:
@@ -68,6 +68,11 @@ paths:
                 "$ref": "#/components/schemas/ObjectListResponse"
 components:
   schemas:
+    ApplicationAttributes:
+      type: object
+      properties:
+        hesa_data:
+          "$ref": "#/components/schemas/HESAData"
     ObjectListResponse:
       type: object
       required:
@@ -103,3 +108,85 @@ components:
           description: Optional details about why the application was rejected for the given reason.
           example: You did not attend any of the arranged interviews.
           maxLength: 65535
+    HESAData:
+      type: object
+      description: |
+        Values to populate this candidate’s HESA Initial Teacher
+        Training data return.  Available once an offer has been accepted.
+      nullable: true
+      required:
+        - sex
+        - disability
+        - ethnicity
+      properties:
+        sex:
+          type: string
+          nullable: true
+          description: The candidate’s sex as a [2-digit HESA code for Sex](https://www.hesa.ac.uk/collection/c22053/e/sexid)
+          example: "10"
+          enum:
+          - "10"
+          - "11"
+          - "12"
+        disability:
+          nullable: true
+          type: array
+          items:
+            type: string
+          description: The candidate’s disabilities as an array of [2-digit HESA codes for Disability](https://www.hesa.ac.uk/collection/c22053/e/disable)
+          example:
+            - "95"
+          enum:
+          - "95"
+          - "58"
+          - "57"
+          - "59"
+          - "51"
+          - "54"
+          - "55"
+          - "56"
+          - "53"
+          - "96"
+          - "98"
+          - "99"
+        ethnicity:
+          type: string
+          nullable: true
+          description: The candidate’s ethnicity as [a 3-digit HESA code for Ethnicity](https://www.hesa.ac.uk/collection/c22053/e/ethnic)
+          example: "180"
+          enum:
+            - "180"
+            - "100"
+            - "101"
+            - "103"
+            - "104"
+            - "119"
+            - "120"
+            - "121"
+            - "139"
+            - "140"
+            - "141"
+            - "142"
+            - "159"
+            - "160"
+            - "163"
+            - "166"
+            - "168"
+            - "179"
+            - "899"
+            - "997"
+            - "998"
+            - "999"
+        other_disability_details:
+          type: string
+          nullable: true
+          description: The candidate’s description of their disability, if they selected “Other” and entered a value. This corresponds to HESA disability code `96`.
+          maxLength: 10240
+          example: "My disability is..."
+        other_ethnicity_details:
+          type: string
+          nullable: true
+          description: The candidate’s description of their ethnicity, if they selected “Other” and entered a value.
+          maxLength: 10240
+          example: "My ethnicity is..."
+ 

--- a/config/vendor_api/draft.yml
+++ b/config/vendor_api/draft.yml
@@ -71,8 +71,9 @@ components:
     ApplicationAttributes:
       type: object
       properties:
-        hesa_data:
-          "$ref": "#/components/schemas/HESAData"
+        equality_and_diversity:
+          anyOf:
+           -  "$ref": "#/components/schemas/EqualityAndDiversity"
           nullable: true
     ObjectListResponse:
       type: object
@@ -109,7 +110,7 @@ components:
           description: Optional details about why the application was rejected for the given reason.
           example: You did not attend any of the arranged interviews.
           maxLength: 65535
-    HESAData:
+    EqualityAndDiversity:
       type: object
       description: |
         Values to populate this candidate’s HESA Initial Teacher
@@ -133,7 +134,7 @@ components:
           type: array
           items:
             type: string
-          description: The candidate’s disabilities as an array of [2-digit HESA codes for Disability](https://www.hesa.ac.uk/collection/c22053/e/disable)
+          description: The candidate’s self-declared disabilities or health conditions as an array of [2-digit HESA codes for Disability](https://www.hesa.ac.uk/collection/c22053/e/disable)
           example:
             - "95"
           enum:
@@ -180,13 +181,13 @@ components:
         other_disability_details:
           type: string
           nullable: true
-          description: The candidate’s description of their disability, if they selected “Other” and entered a value. This corresponds to HESA disability code `96`.
+          description: The candidate’s description of their disability, if they selected “An impairment, health condition or learning difference not listed above” (96) and entered a description. 
           maxLength: 10240
           example: "My disability is..."
         other_ethnicity_details:
           type: string
           nullable: true
-          description: The candidate’s description of their ethnicity, if they selected “Other” and entered a value.
+          description: The candidate’s description of their ethnicity, if they selected an option such as “Any other ethnic background” or ”Any other White background” and then entered another ethnicity.
           maxLength: 10240
           example: "My ethnicity is..."
  

--- a/spec/lib/hesa/sex_spec.rb
+++ b/spec/lib/hesa/sex_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Hesa::Sex do
       it 'returns a list of HESA sex structs' do
         sex_types = described_class.all(2023)
 
-        expect(sex_types.size).to eq 3
+        expect(sex_types.size).to eq 5
 
         female = sex_types.find { |s| s.hesa_code == '10' }
 
@@ -32,7 +32,7 @@ RSpec.describe Hesa::Sex do
       it 'returns last one' do
         sex_types = described_class.all(2090)
 
-        expect(sex_types.size).to eq 3
+        expect(sex_types.size).to eq 5
 
         female = sex_types.find { |s| s.hesa_code == '10' }
 

--- a/spec/presenters/vendor_api/v1.2/application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.2/application_presenter_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe VendorAPI::ApplicationPresenter do
       equality_and_diversity_data = application_form[:equality_and_diversity]
       expect(attributes).to include(
         {
-          hesa_data: {
+          equality_and_diversity: {
             sex: equality_and_diversity_data['hesa_sex'],
             disability: equality_and_diversity_data['hesa_disabilities'],
             ethnicity: equality_and_diversity_data['hesa_ethnicity'],

--- a/spec/presenters/vendor_api/v1.2/application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.2/application_presenter_spec.rb
@@ -5,23 +5,37 @@ RSpec.describe VendorAPI::ApplicationPresenter do
 
   let(:version) { '1.2' }
   let(:attributes) { application_json[:attributes] }
-  let(:application_form) { create(:completed_application_form, :with_equality_and_diversity_data) }
+  let(:application_form) { create(:completed_application_form, :with_equality_and_diversity_data, recruitment_cycle_year:) }
   let(:application_choice) { create(:application_choice, :with_recruited, application_form: application_form) }
 
-  describe 'HESA data' do
-    it 'returns the HESA codes associated with that application' do
-      equality_and_diversity_data = application_form[:equality_and_diversity]
-      expect(attributes).to include(
-        {
-          equality_and_diversity: {
-            sex: equality_and_diversity_data['hesa_sex'],
-            disability: equality_and_diversity_data['hesa_disabilities'],
-            ethnicity: equality_and_diversity_data['hesa_ethnicity'],
-            other_disability_details: equality_and_diversity_data['other_disability_details'],
-            other_ethnicity_details: equality_and_diversity_data['other_ethnicity_details'],
+  describe 'Equality and diversity data' do
+    context 'when it is a current cycle application' do
+      let(:recruitment_cycle_year) { RecruitmentCycle.current_year }
+
+      it 'returns the 2023 HESA codes associated with that application' do
+        equality_and_diversity_data = application_form[:equality_and_diversity]
+        expect(attributes).to include(
+          {
+            equality_and_diversity: {
+              sex: equality_and_diversity_data['hesa_sex'],
+              disability: equality_and_diversity_data['hesa_disabilities'],
+              ethnicity: equality_and_diversity_data['hesa_ethnicity'],
+              other_disability_details: equality_and_diversity_data['other_disability_details'],
+              other_ethnicity_details: equality_and_diversity_data['other_ethnicity_details'],
+            },
           },
-        },
-      )
+        )
+      end
+    end
+
+    context 'when it is a previous cycle application' do
+      let(:recruitment_cycle_year) { 2022 }
+
+      it 'does not return the 2023 HESA codes associated with that applications' do
+        expect(attributes).to include({
+          equality_and_diversity: nil,
+        })
+      end
     end
   end
 end

--- a/spec/presenters/vendor_api/v1.2/application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.2/application_presenter_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe VendorAPI::ApplicationPresenter do
+  subject(:application_json) { described_class.new(version, application_choice).as_json }
+
+  let(:version) { '1.2' }
+  let(:attributes) { application_json[:attributes] }
+  let(:application_form) { create(:completed_application_form, :with_equality_and_diversity_data) }
+  let(:application_choice) { create(:application_choice, :with_recruited, application_form: application_form) }
+
+  describe 'HESA data' do
+    it 'returns the HESA codes associated with that application' do
+      equality_and_diversity_data = application_form[:equality_and_diversity]
+      expect(attributes).to include(
+        {
+          hesa_data: {
+            sex: equality_and_diversity_data['hesa_sex'],
+            disability: equality_and_diversity_data['hesa_disabilities'],
+            ethnicity: equality_and_diversity_data['hesa_ethnicity'],
+            other_disability_details: equality_and_diversity_data['other_disability_details'],
+            other_ethnicity_details: equality_and_diversity_data['other_ethnicity_details'],
+          },
+        },
+      )
+    end
+  end
+end

--- a/spec/requests/vendor_api/v1.2/post_reject_by_codes_spec.rb
+++ b/spec/requests/vendor_api/v1.2/post_reject_by_codes_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject-by-codes'
 
       post_api_request "/api/v1.2/applications/#{application_choice.id}/reject-by-codes", params: request_body
 
-      expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse', '1.2')
+      expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse', '1.2', draft: true)
       expect(parsed_response['data']['attributes']['status']).to eq 'rejected'
       expect(parsed_response['data']['attributes']['rejection']).to match a_hash_including(
         'reason' => "Qualifications:\nDoes not meet minimum GCSE requirements.\n\nOther:\nWearing clown shoes to the interview was odd.",
@@ -69,7 +69,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject-by-codes'
 
       post_api_request "/api/v1.2/applications/#{application_choice.id}/reject-by-codes", params: request_body
 
-      expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse', '1.2')
+      expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse', '1.2', draft: true)
       expect(parsed_response['data']['attributes']['status']).to eq 'rejected'
       expect(parsed_response['data']['attributes']['rejection']).to match a_hash_including(
         'reason' => "Qualifications:\nYou did not have the required or relevant qualifications, or we could not find record of your qualifications.\n",


### PR DESCRIPTION
## Context

Due to changes in the way that HESA is collecting data around ethnicity, sex and disabilities for ITT trainees, the codes that the Manage API will send for these questions will change from 11 October 2022 for the 2022-2023 recruitment cycle.

As before, the data for these fields will only be included in the API for candidates whose application status is recruited or pending_conditions.

## Changes proposed in this pull request

Add a new `hesa_data` object to the vendor API as part of `v1.2`

## Guidance to review

Check postman for:
- `hesa_data` not appearing in `v1.0`-`v1.1`
- `hesa_data` not appearing in `v1.2` for a candidate who has not been recruited
- `hesa_data` appearing for a recruited candidate in `v1.2`

Refer to 
[Ethnicity codes](https://www.hesa.ac.uk/collection/c22053/e/ethnic)
[Disability codes](https://www.hesa.ac.uk/collection/c22053/e/disable)
[Gender codes](https://www.hesa.ac.uk/collection/c22053/e/sexid)

## Link to Trello card

https://trello.com/c/ejYCaBG2/749-vendor-api-v12-return-new-sex-ethnicity-disability-hesa-codes

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
