### PR TITLE
Pin Sidekiq to version 6.x for now

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,7 +92,7 @@ gem 'request_store-sidekiq'
 gem 'rails_semantic_logger', group: %w[production]
 
 # Background processing
-gem 'sidekiq'
+gem 'sidekiq', '< 7'
 gem 'clockwork'
 
 # Rate limiting

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -829,7 +829,7 @@ DEPENDENCIES
   sentry-rails
   sentry-sidekiq
   shoulda-matchers (~> 5.2)
-  sidekiq
+  sidekiq (< 7)
   simplecov
   simplecov-cobertura
   skylight


### PR DESCRIPTION
The 7.0 release is currently considered a 'beta', so we should probably wait a bit before adopting it.

See https://github.com/DFE-Digital/apply-for-teacher-training/pull/7625#issuecomment-1299912189