### PR TITLE
Restore course CSV test and fix a bug

### DIFF
--- a/app/controllers/concerns/streamable_data_export.rb
+++ b/app/controllers/concerns/streamable_data_export.rb
@@ -16,8 +16,11 @@ private
     send_stream(filename:, type: 'text/csv') do |stream|
       stream.write SafeCSV.generate_line(block.call(data.first).keys)
 
-      data.find_each(batch_size:) do |row|
-        stream.write SafeCSV.generate_line(block.call(row).values)
+      row_block = ->(row) { stream.write SafeCSV.generate_line(block.call(row).values) }
+      if data.respond_to?(:find_each)
+        data.find_each(batch_size:, &row_block)
+      else
+        data.each(&row_block)
       end
     end
   end

--- a/spec/system/support_interface/providers_and_courses_spec.rb
+++ b/spec/system/support_interface/providers_and_courses_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.feature 'Providers and courses' do
+  include DfESignInHelpers
+  include TeacherTrainingPublicAPIHelper
+
+  scenario 'User fetches course CSV info' do
+    given_i_am_a_support_user
+    and_providers_are_configured
+    and_i_visit_a_providers_page
+    and_i_click_on_courses
+    and_i_click_on_the_csv_button
+    then_i_should_get_a_csv_with_all_the_courses
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_i_visit_the_tasks_page
+    visit support_interface_tasks_path
+  end
+
+  def and_providers_are_configured
+    provider = create(:provider, :with_signed_agreement, code: 'ABC', name: 'Royal Academy of Dance')
+    create(:provider_user, email_address: 'harry@example.com', providers: [provider])
+
+    course_option = create(:course_option, course: create(:course, provider: provider))
+    create(:application_choice, application_form: create(:application_form, support_reference: 'XYZ123'), course_option: course_option)
+
+    create(:provider, :with_signed_agreement, code: 'DEF', name: 'Gorse SCITT')
+    create(:provider, :with_signed_agreement, code: 'DOF', name: 'An Unsynced Provider')
+    @somerset_scitt = create(:provider, :with_signed_agreement, code: 'GHI', name: 'Somerset SCITT Consortium')
+
+    course_option_with_accredited_provider = create(:course_option, course: create(:course, accredited_provider: provider))
+    create(:application_choice, application_form: create(:application_form, support_reference: 'TUV123'), course_option: course_option_with_accredited_provider)
+
+    create(:course_option, course: create(:course, exposed_in_find: true, accredited_provider: @somerset_scitt))
+    create(:course_option, course: create(:course, exposed_in_find: true, provider: @somerset_scitt))
+  end
+
+  def and_i_visit_a_providers_page
+    visit support_interface_provider_path(@somerset_scitt)
+  end
+
+  def and_i_click_on_courses
+    click_link 'Courses'
+  end
+
+  def and_i_click_on_the_csv_button
+    click_link 'courses as CSV'
+  end
+
+  def then_i_should_get_a_csv_with_all_the_courses
+    rows = CSV.parse(page.html, headers: :first_row).map(&:to_h)
+    expect(rows).to be_present
+    rows.each do |r|
+      bodies = [r['accredited_provider_code'], r['provider_code']]
+      expect(bodies).to include('GHI')
+    end
+  end
+end


### PR DESCRIPTION
## Context

https://sentry.io/organizations/dfe-teacher-services/issues/3713185516/?project=1765973&referrer=slack

## Guidance to review

Confirm that the "Download CSV" button works properly in the support UI (providers -> some provider -> courses).