### PR TITLE
Downgrade faker so generating applications return to work in sandbox

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,9 @@ gem 'sentry-rails'
 gem 'sentry-sidekiq'
 
 gem 'factory_bot_rails'
-gem 'faker', '3.0.0'
+
+# Leave 2.22.0 otherwise it could fail generating applications in sandbox
+gem 'faker', '2.22.0'
 
 gem 'view_component'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,7 +213,7 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faker (3.0.0)
+    faker (2.22.0)
       i18n (>= 1.8.11, < 2)
     faraday (1.10.2)
       faraday-em_http (~> 1.0)
@@ -776,7 +776,7 @@ DEPENDENCIES
   dotenv-rails
   erb_lint
   factory_bot_rails
-  faker (= 3.0.0)
+  faker (= 2.22.0)
   geocoder
   govuk-components (~> 3.2.1)
   govuk_design_system_formbuilder (~> 3.1.2)


### PR DESCRIPTION
Downgrade faker so generating applications return to work in sandbox

Sentry error: https://sentry.io/organizations/dfe-teacher-services/issues/3716414335/?project=1765973&query=is%3Aunresolved&referrer=issue-stream