### PR TITLE
Don't accidentally hide exceptions during mailer previews

### DIFF
--- a/config/initializers/mailer_previews.rb
+++ b/config/initializers/mailer_previews.rb
@@ -7,10 +7,13 @@ ActiveSupport.on_load(:action_controller, run_once: true) do
   private
 
     def rollback_changes
+      exception_during_preview = nil
       ActiveRecord::Base.transaction do
         yield
+      rescue => e # rubocop:disable Style/RescueStandardError
+        exception_during_preview = e
       ensure
-        raise ActiveRecord::Rollback
+        raise exception_during_preview || ActiveRecord::Rollback
       end
     end
   end


### PR DESCRIPTION
Otherwise we just get a blank page.

## Context

https://ukgovernmentdfe.slack.com/archives/CAHBLU6ET/p1667490456092129
