### PR TITLE
Bugfix: remove referee type from support interface if not set

### DIFF
--- a/app/components/support_interface/reference_with_feedback_component.rb
+++ b/app/components/support_interface/reference_with_feedback_component.rb
@@ -50,6 +50,8 @@ module SupportInterface
     end
 
     def type_of_reference_row
+      return if referee_type.nil?
+
       {
         key: 'Type',
         value: I18n.t("application_form.references.referee_type.#{referee_type}.label"),

--- a/spec/components/support_interface/reference_with_feedback_component_spec.rb
+++ b/spec/components/support_interface/reference_with_feedback_component_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe SupportInterface::ReferenceWithFeedbackComponent, type: :componen
     end
   end
 
-  context 'when there is no refere_type saved (as it’s an old reference)' do
+  context 'when there is no referee_type saved (as it’s an old reference)' do
     let(:reference) {
       create(:reference, :not_requested_yet,
              referee_type: nil)

--- a/spec/components/support_interface/reference_with_feedback_component_spec.rb
+++ b/spec/components/support_interface/reference_with_feedback_component_spec.rb
@@ -83,6 +83,17 @@ RSpec.describe SupportInterface::ReferenceWithFeedbackComponent, type: :componen
     end
   end
 
+  context 'when there is no refere_type saved (as it’s an old reference)' do
+    let(:reference) {
+      create(:reference, :not_requested_yet,
+             referee_type: nil)
+    }
+
+    it 'does not include the Type row' do
+      expect(rendered_content).not_to have_content('Type')
+    end
+  end
+
   describe 'Undo refusal link' do
     let(:reference) { create(:reference, feedback_status: 'feedback_refused') }
 


### PR DESCRIPTION
The type of reference wasn't asked early on, so some references don't have this field set. This was throwing an error in the support interface.

This is fixed by removing the whole row if there is no reference type to display.

Fixes bug: https://sentry.io/organizations/dfe-teacher-services/issues/3717069711/?project=1765973