### PR TITLE
Change scope to be application form

### DIFF
--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -95,7 +95,7 @@ class ApplicationReference < ApplicationRecord
   def order_in_application_references
     return if failed?
 
-    candidate
+    application_form
       .application_references
       .feedback_provided
       .order(id: :asc)

--- a/spec/models/application_reference_spec.rb
+++ b/spec/models/application_reference_spec.rb
@@ -115,7 +115,10 @@ RSpec.describe ApplicationReference do
   end
 
   describe '#order_in_application_references' do
-    let(:application_form) { create(:application_form) }
+    let(:last_cycle_application_form) { create(:completed_application_form, recruitment_cycle_year: RecruitmentCycle.previous_year) }
+    let(:previous_cycle_reference) { create(:reference, :feedback_provided, :cancelled_at_end_of_cycle, application_form: last_cycle_application_form) }
+    let(:application_form) { create(:application_form, previous_application_form: last_cycle_application_form) }
+
     let!(:reference_1) { create(:reference, :feedback_provided, application_form: application_form) }
     let!(:reference_failed) { create(:reference, :feedback_refused, application_form: application_form) }
     let!(:reference_2) { create(:reference, :feedback_provided, application_form: application_form) }
@@ -126,6 +129,7 @@ RSpec.describe ApplicationReference do
       expect(reference_2.order_in_application_references).to eq 2
       expect(reference_3.order_in_application_references).to eq 3
       expect(reference_failed.order_in_application_references).to be_nil
+      expect(previous_cycle_reference.order_in_application_references).to be_nil
     end
   end
 


### PR DESCRIPTION
## Context

A support ticket has raised a concern that the reference provided email is incorrectly counting the number of references provider. This is because we're been scoping the count on a `candidate` object rather than an `application_form`. This means it will also include the number of references provided on any previous applications.

## Changes proposed in this pull request

Change `candidate` to `application_form`

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
