### PR TITLE
Don't automatically confirm in subject (etc) dropdown on blur

### DIFF
--- a/app/frontend/packs/autosuggests/init-autosuggest.js
+++ b/app/frontend/packs/autosuggests/init-autosuggest.js
@@ -1,7 +1,7 @@
 import { accessibleAutosuggestFromSource } from './helpers'
 import dfeAutocomplete from 'dfe-autocomplete'
 
-dfeAutocomplete({ rawAttribute: true })
+dfeAutocomplete({ rawAttribute: true, confirmOnBlur: false })
 
 export const initAutosuggest = ({ inputIds, containerId, templates = {}, styles = () => {}, stripWhitespace = true }) => {
   try {

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -8,7 +8,7 @@ end
 Capybara.register_driver :chrome_headless do |app|
   options = ::Selenium::WebDriver::Chrome::Options.new
 
-  options.add_argument('--headless')
+  options.add_argument('--headless') unless ENV['HEADLESS'] == 'false'
   options.add_argument('--no-sandbox')
   options.add_argument('--disable-dev-shm-usage')
   options.add_argument('--disable-gpu')

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_adding_unknown_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_adding_unknown_degrees_spec.rb
@@ -67,6 +67,41 @@ RSpec.feature 'Adding an unknown degree', js: true do
     then_i_can_check_my_answers
   end
 
+  # https://trello.com/c/MaFJIstY/871-custom-degree-subjects-sometimes-cannot-be-entered-by-candidates
+  scenario 'Candidate enters a custom degree subject that has an incorrect auto-suggestion' do
+    given_i_am_at_the_degree_subject_page
+    when_i_fill_in_the_subject_with_a_custom_subject_that_has_an_incorrect_auto_suggestion
+    then_the_custom_subject_should_have_remained_filled_in
+  end
+
+  def given_i_am_at_the_degree_subject_page
+    given_i_am_signed_in
+    when_i_view_the_degree_section
+
+    # Add degree
+    and_i_click_add_degree
+
+    # Add country
+    then_i_can_see_the_country_page
+    when_i_choose_united_kingdom
+    and_i_click_on_save_and_continue
+
+    # Add degree level
+    then_i_can_see_the_level_page
+    when_i_choose_the_level
+    and_i_click_on_save_and_continue
+  end
+
+  def when_i_fill_in_the_subject_with_a_custom_subject_that_has_an_incorrect_auto_suggestion
+    @input = find('input[name="candidate_interface_degree_wizard[subject_raw]"]')
+    @input.native.send_keys('History of Art and History')
+    find_by_id('main-content').click
+  end
+
+  def then_the_custom_subject_should_have_remained_filled_in
+    expect(@input.value).to eq('History of Art and History')
+  end
+
   def given_i_am_signed_in
     create_and_sign_in_candidate
   end

--- a/yarn.lock
+++ b/yarn.lock
@@ -3107,7 +3107,7 @@ detect-newline@^3.0.0:
 
 "dfe-autocomplete@github:DFE-Digital/dfe-autocomplete":
   version "0.0.1"
-  resolved "https://codeload.github.com/DFE-Digital/dfe-autocomplete/tar.gz/24c2552c2f2f51ed9b804725d620f2da71c85246"
+  resolved "https://codeload.github.com/DFE-Digital/dfe-autocomplete/tar.gz/36d80e6b5bba67c92cd9ec6982a4e536d1889aed"
   dependencies:
     accessible-autocomplete "^2.0.4"
 


### PR DESCRIPTION
We want people to be able to type their own subjects even if the autosuggest has a possible option.
