### PR TITLE
Fix typo in 2019 recruitment cycle dates

### DIFF
--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -7,7 +7,7 @@ class CycleTimetable
       apply_opens: Time.zone.local(2018, 10, 13, 9),
       apply_1_deadline: Time.zone.local(2019, 8, 24, 18),
       apply_2_deadline: Time.zone.local(2019, 9, 18, 18),
-      reject_by_default: Time.zone.local(2021, 9, 29, 23, 59, 59),
+      reject_by_default: Time.zone.local(2019, 9, 29, 23, 59, 59),
       find_closes: Time.zone.local(2019, 10, 3, 23, 59, 59),
       holidays: {},
     },

--- a/spec/services/set_reject_by_default_spec.rb
+++ b/spec/services/set_reject_by_default_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SetRejectByDefault do
 
   describe 'RBD calculation' do
     submitted_vs_rbd_dates = [
-      ['2 Sept 2019 9:00:00 AM BST', '01 Oct 2019 0:00:00 AM BST', 'near the BST/GMT boundary'],
+      ['2 Sept 2019 9:00:00 AM BST', '28 Sep 2019 0:00:00 AM BST', 'near the BST/GMT boundary'],
       ['1 Jul 2019 9:00:00 AM BST',  '30 Jul 2019 0:00:00 AM BST', 'safely within BST'],
       ['4 Jan 2019 11:00:00 PM GMT', '2 Mar 2019 0:00:00 AM GMT',  'safely within GMT'],
       ['1 Jul 2020 11:00:00 PM BST', '30 Jul 2020 0:00:00 AM BST', 'during the 20-day summer period'],


### PR DESCRIPTION
Spotted this typo, as @alaric-dfe has copied these dates into a separate repo in this PR: https://github.com/DFE-Digital/dfe-reference-data/pull/63

Presumably we only added these dates after they'd already passed, so it didn't affect anything?