### PR TITLE
Add with_disability_randomness transient to ApplicationForm factory

### DIFF
--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -57,6 +57,10 @@ FactoryBot.define do
     end
 
     trait :with_equality_and_diversity_data do
+      transient do
+        with_disability_randomness { true }
+      end
+
       equality_and_diversity do
         all_ethnicities = Class.new.extend(EthnicBackgroundHelper).all_combinations
         if RecruitmentCycle.current_year < HesaChanges::YEAR_2023
@@ -69,7 +73,13 @@ FactoryBot.define do
           # Not included in other years
           all_disabilities.delete(I18n.t('equality_and_diversity.disabilities.development_condition')[:label])
         end
-        disabilities = rand < 0.85 ? all_disabilities.sample([*0..3].sample) : ['Prefer not to say']
+
+        disabilities = if with_disability_randomness
+                         rand < 0.85 ? all_disabilities.sample([*0..3].sample) : ['Prefer not to say']
+                       else
+                         all_disabilities.first(2)
+                       end
+
         hesa_sex = sex == 'Prefer not to say' ? nil : Hesa::Sex.find(sex, RecruitmentCycle.current_year)['hesa_code']
         hesa_disabilities = disabilities == ['Prefer not to say'] ? %w[00] : disabilities.map { |disability| Hesa::Disability.find(disability)['hesa_code'] }
         hesa_ethnicity = Hesa::Ethnicity.find(ethnicity.last, RecruitmentCycle.current_year)['hesa_code']

--- a/spec/presenters/vendor_api/v1.2/application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.2/application_presenter_spec.rb
@@ -5,8 +5,17 @@ RSpec.describe VendorAPI::ApplicationPresenter do
 
   let(:version) { '1.2' }
   let(:attributes) { application_json[:attributes] }
-  let(:application_form) { create(:completed_application_form, :with_equality_and_diversity_data, recruitment_cycle_year:) }
-  let(:application_choice) { create(:application_choice, :with_recruited, application_form: application_form) }
+  let(:application_form) do
+    create(
+      :completed_application_form,
+      :with_equality_and_diversity_data,
+      recruitment_cycle_year:,
+      with_disability_randomness: false,
+    )
+  end
+  let(:application_choice) do
+    create(:application_choice, :with_recruited, application_form: application_form)
+  end
 
   describe 'Equality and diversity data' do
     context 'when it is a current cycle application' do


### PR DESCRIPTION
## Context

The randomness in the ApplicationForm factory when setting disability attributes is causing spec flakiness in
`vendor_api/v1.2/application_presenter_spec`.

## Changes proposed in this pull request

Add transient attribute in ApplicationForm factory that allows overriding randomness when setting disability attributes.

## Guidance to review

Has the flakiness gone away?

## Link to Trello card

https://trello.com/c/KFjxdgCY/873-wakey-wakey-specs-are-flakey

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
