### PR TITLE
Improve reference email error messaging

### DIFF
--- a/app/controllers/candidate_interface/references/email_address_controller.rb
+++ b/app/controllers/candidate_interface/references/email_address_controller.rb
@@ -3,6 +3,7 @@ module CandidateInterface
     class EmailAddressController < BaseController
       before_action :redirect_to_review_page_unless_reference_is_editable, :verify_email_is_editable
       before_action :set_edit_backlink, only: %i[edit update]
+      before_action :set_email_address_form, only: %i[create update]
 
       def new
         @reference_email_address_form = Reference::RefereeEmailAddressForm.build_from_reference(@reference)
@@ -13,8 +14,6 @@ module CandidateInterface
       end
 
       def create
-        @reference_email_address_form = Reference::RefereeEmailAddressForm.new(referee_email_address_param)
-
         if @reference_email_address_form.save(@reference)
           redirect_to next_path
         else
@@ -24,8 +23,6 @@ module CandidateInterface
       end
 
       def update
-        @reference_email_address_form = Reference::RefereeEmailAddressForm.new(referee_email_address_param)
-
         if @reference_email_address_form.save(@reference)
           next_step
         else
@@ -38,6 +35,10 @@ module CandidateInterface
 
       def next_path
         candidate_interface_references_relationship_path(@reference.id)
+      end
+
+      def set_email_address_form
+        @reference_email_address_form = Reference::RefereeEmailAddressForm.new(referee_email_address_param)
       end
 
       def referee_email_address_param

--- a/app/controllers/candidate_interface/references/request_reference/email_address_controller.rb
+++ b/app/controllers/candidate_interface/references/request_reference/email_address_controller.rb
@@ -8,6 +8,10 @@ module CandidateInterface
           @reference.id,
         )
       end
+
+      def set_email_address_form
+        @reference_email_address_form = Reference::RequestRefereeEmailAddressForm.new(referee_email_address_param)
+      end
     end
   end
 end

--- a/app/forms/candidate_interface/reference/request_referee_email_address_form.rb
+++ b/app/forms/candidate_interface/reference/request_referee_email_address_form.rb
@@ -1,10 +1,10 @@
 module CandidateInterface
   class Reference::RequestRefereeEmailAddressForm < Reference::RefereeEmailAddressForm
     def email_address_unique
-      other_references.each do |other_reference|
-        next if other_reference.cancelled? || other_reference.cancelled_at_end_of_cycle?
-
-        errors.add(:email_address, :"duplicate.#{other_reference.feedback_status}") if other_reference.email_address.downcase == email_address.downcase
+      other_references
+        .reject { |reference| reference.cancelled? || reference.cancelled_at_end_of_cycle? }
+        .select { |reference| reference.email_address.downcase == email_address.downcase }.each do |other_reference|
+        errors.add(:email_address, :"duplicate.#{other_reference.feedback_status}")
       end
     end
 

--- a/app/forms/candidate_interface/reference/request_referee_email_address_form.rb
+++ b/app/forms/candidate_interface/reference/request_referee_email_address_form.rb
@@ -1,0 +1,16 @@
+module CandidateInterface
+  class Reference::RequestRefereeEmailAddressForm < Reference::RefereeEmailAddressForm
+    def email_address_unique
+      other_references.each do |other_reference|
+        next if other_reference.cancelled? || other_reference.cancelled_at_end_of_cycle?
+
+        errors.add(:email_address, :"duplicate.#{other_reference.feedback_status}") if other_reference.email_address.downcase == email_address.downcase
+      end
+    end
+
+    def other_references
+      reference = ApplicationReference.find(reference_id)
+      reference.application_form.application_references.where.not(id: reference_id)
+    end
+  end
+end

--- a/app/forms/candidate_interface/reference/request_referee_email_address_form.rb
+++ b/app/forms/candidate_interface/reference/request_referee_email_address_form.rb
@@ -1,9 +1,11 @@
 module CandidateInterface
   class Reference::RequestRefereeEmailAddressForm < Reference::RefereeEmailAddressForm
     def email_address_unique
+      return true if email_address.blank?
+
       other_references
         .reject { |reference| reference.cancelled? || reference.cancelled_at_end_of_cycle? }
-        .select { |reference| reference.email_address.downcase == email_address.downcase }.each do |other_reference|
+        .select { |reference| reference.email_address.to_s.downcase == email_address.downcase }.each do |other_reference|
         errors.add(:email_address, :"duplicate.#{other_reference.feedback_status}")
       end
     end

--- a/config/locales/candidate_interface/request_referee_email_address.yml
+++ b/config/locales/candidate_interface/request_referee_email_address.yml
@@ -1,0 +1,13 @@
+en:
+  activemodel:
+    errors:
+      models:
+        candidate_interface/reference/request_referee_email_address_form:
+          attributes:
+            email_address:
+              duplicate:
+                not_requested_yet: A reference request has already been started for this email address
+                feedback_requested: A reference request has already been sent to this email address
+                feedback_provided: A reference has already been received from this email address
+                feedback_refused: The person using this email address said that they cannot give a reference
+                email_bounced: A reference request already failed to reach this email address

--- a/spec/forms/candidate_interface/reference/request_referee_email_address_form_spec.rb
+++ b/spec/forms/candidate_interface/reference/request_referee_email_address_form_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::Reference::RequestRefereeEmailAddressForm, type: :model do
+  describe 'validations' do
+    let(:form) { subject }
+
+    context 'when a duplicate email is given' do
+      let!(:application_form) { create(:application_form) }
+      let!(:application_reference) { create(:reference, email_address: nil, application_form:) }
+
+      context 'when duplicate reference is not sent' do
+        it 'returns custom error message' do
+          create(:reference, :not_requested_yet, email_address: 'iamtheone@whoknocks.com', application_form:)
+          form = described_class.new(email_address: 'iAMtheone@whoknocks.com', reference_id: application_reference.id)
+
+          form.save(application_reference)
+          expect(form.errors[:email_address]).to include('A reference request has already been started for this email address')
+        end
+      end
+
+      context 'when duplicate reference is requested' do
+        it 'returns custom error message' do
+          create(:reference, :feedback_requested, email_address: 'iamtheone@whoknocks.com', application_form:)
+          form = described_class.new(email_address: 'iAMtheone@whoknocks.com', reference_id: application_reference.id)
+
+          form.save(application_reference)
+          expect(form.errors[:email_address]).to include('A reference request has already been sent to this email address')
+        end
+      end
+
+      context 'when duplicate reference is received' do
+        it 'returns custom error message' do
+          create(:reference, :feedback_provided, email_address: 'iamtheone@whoknocks.com', application_form:)
+          form = described_class.new(email_address: 'iAMtheone@whoknocks.com', reference_id: application_reference.id)
+
+          form.save(application_reference)
+          expect(form.errors[:email_address]).to include('A reference has already been received from this email address')
+        end
+      end
+
+      context 'when duplicate reference is not given' do
+        it 'returns custom error message' do
+          create(:reference, :feedback_refused, email_address: 'iamtheone@whoknocks.com', application_form:)
+          form = described_class.new(email_address: 'iAMtheone@whoknocks.com', reference_id: application_reference.id)
+
+          form.save(application_reference)
+          expect(form.errors[:email_address]).to include('The person using this email address said that they cannot give a reference')
+        end
+      end
+
+      context 'when duplicate reference is bounced' do
+        it 'returns custom error message' do
+          create(:reference, :email_bounced, email_address: 'iamtheone@whoknocks.com', application_form:)
+          form = described_class.new(email_address: 'iAMtheone@whoknocks.com', reference_id: application_reference.id)
+
+          form.save(application_reference)
+          expect(form.errors[:email_address]).to include('A reference request already failed to reach this email address')
+        end
+      end
+
+      context 'when duplicate reference is cancelled' do
+        it 'returns custom error message' do
+          %i[cancelled cancelled_at_end_of_cycle].each do |reference_status|
+            create(:reference, reference_status, email_address: 'iamtheone@whoknocks.com', application_form:)
+            form = described_class.new(email_address: 'iAMtheone@whoknocks.com', reference_id: application_reference.id)
+
+            form.save(application_reference)
+            expect(form.errors[:email_address]).to be_blank
+            expect(application_reference.reload.email_address).to eq('iAMtheone@whoknocks.com')
+          end
+        end
+      end
+    end
+
+    context 'when no email is given' do
+      it 'is not valid' do
+        application_reference = create(:reference, email_address: nil)
+        form = described_class.build_from_reference(application_reference)
+
+        expect(form.valid?).to be(false)
+      end
+    end
+
+    context "when the candidate's email is given" do
+      it 'is not valid' do
+        application_form = create(:application_form)
+        candidate_email_address = application_form.candidate.email_address
+        application_reference = create(:reference, email_address: nil, application_form:)
+        form = described_class.new(email_address: candidate_email_address, reference_id: application_reference.id)
+
+        expect(form.valid?).to be(false)
+      end
+    end
+  end
+end

--- a/spec/forms/candidate_interface/reference/request_referee_email_address_form_spec.rb
+++ b/spec/forms/candidate_interface/reference/request_referee_email_address_form_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe CandidateInterface::Reference::RequestRefereeEmailAddressForm, ty
         application_reference = create(:reference, email_address: nil)
         form = described_class.build_from_reference(application_reference)
 
-        expect(form.valid?).to be(false)
+        expect(form).not_to be_valid
       end
     end
 
@@ -88,7 +88,7 @@ RSpec.describe CandidateInterface::Reference::RequestRefereeEmailAddressForm, ty
         application_reference = create(:reference, email_address: nil, application_form:)
         form = described_class.new(email_address: candidate_email_address, reference_id: application_reference.id)
 
-        expect(form.valid?).to be(false)
+        expect(form).not_to be_valid
       end
     end
   end

--- a/spec/forms/candidate_interface/reference/request_referee_email_address_form_spec.rb
+++ b/spec/forms/candidate_interface/reference/request_referee_email_address_form_spec.rb
@@ -36,6 +36,24 @@ RSpec.describe CandidateInterface::Reference::RequestRefereeEmailAddressForm, ty
           end
         end
       end
+
+      context 'when application has blank email address' do
+        it 'ignores incomplete references' do
+          create(:reference, :feedback_requested, email_address: nil, application_form:)
+          form = described_class.new(email_address: 'iAMtheone@whoknocks.com', reference_id: application_reference.id)
+
+          form.save(application_reference)
+          expect(form).to be_valid
+        end
+
+        it 'ignores blank' do
+          reference = create(:reference, :feedback_requested, email_address: nil, application_form:)
+          form = described_class.new(email_address: '', reference_id: reference.id)
+
+          form.save(application_reference)
+          expect(form.errors.any? { |error| error.type =~ /duplicate/ }).to be_falsey
+        end
+      end
     end
 
     context 'when no email is given' do


### PR DESCRIPTION
## Context

Improves our generic error message when a candidate tries to add a reference that has the same email address as one already on their application form.

Our validation errors summary pages show that this is a common issue for candidates

Now that this process is later in the application journey it should happen less often
However, this means it's more integral to get it right the first time, as people are sitting on offers and have invested a lot of time (as have providers).

