### PR TITLE
Change duplicate match email content

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -8,6 +8,7 @@ class CandidateMailer < ApplicationMailer
       nudge_unsubmitted_with_incomplete_courses
       nudge_unsubmitted_with_incomplete_personal_statement
       nudge_unsubmitted_with_incomplete_references
+      duplicate_match_email
     ],
   )
   include QualificationValueHelper

--- a/app/views/candidate_mailer/duplicate_match_email.text.erb
+++ b/app/views/candidate_mailer/duplicate_match_email.text.erb
@@ -8,4 +8,6 @@ You’ve created more than one account on Apply for teacher training.
   Your access to the account you set up most recently will be removed.
 <% end %>
 
+# Get help
+
 If you think this is a mistake, reply to this email to let us know.


### PR DESCRIPTION
Duplicate matching emails should go direct to our support inbox Update the footer.

Co-authored-by: Maeve Roseveare <68232608+MaeveRoseveare@users.noreply.github.com>
