### PR TITLE
Added square bracket to end of link

### DIFF
--- a/app/views/candidate_mailer/find_has_opened.erb
+++ b/app/views/candidate_mailer/find_has_opened.erb
@@ -14,6 +14,6 @@ You can submit from 9am on <%= @apply_opens %>.
 
 # Get help
 
-Call <%= t('get_into_teaching.tel') %> or (chat online)[<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'find_has_opened', @application_form.phase %>
+Call <%= t('get_into_teaching.tel') %> or (chat online)[<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'find_has_opened', @application_form.phase %>]
 
 <%= t('get_into_teaching.opening_times') %>.


### PR DESCRIPTION
## Context

Noticed the link on the Find has opened mailer was broken and needed a square bracket at the end of the 'chat online' link.

## Changes proposed in this pull request

Added a square bracket at the end of the chat online link.

## Link to Trello card

https://trello.com/c/iBKloAFg/876-fix-link-on-find-has-opened-email
