### PR TITLE
SupportInterface::ActiveProviderUsersExport - order providers

### DIFF
--- a/app/services/support_interface/active_provider_users_export.rb
+++ b/app/services/support_interface/active_provider_users_export.rb
@@ -7,7 +7,7 @@ module SupportInterface
         {
           provider_full_name: provider_user.full_name,
           provider_email_address: provider_user.email_address,
-          providers: provider_user.providers.map(&:name).join(', '),
+          providers: provider_user.providers.map(&:name).sort.join(', '),
           last_signed_in_at: provider_user.last_signed_in_at,
         }
       end

--- a/spec/services/support_interface/active_provider_users_export_spec.rb
+++ b/spec/services/support_interface/active_provider_users_export_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe SupportInterface::ActiveProviderUsersExport do
   describe '#data_for_export' do
     it 'returns provider_users who have have signed in at least once' do
       travel_temporarily_to(2020, 5, 1, 12, 0, 0) do
-        provider1 = create(:provider)
-        provider2 = create(:provider)
+        provider1 = create(:provider, name: 'A is the first letter')
+        provider2 = create(:provider, name: 'Z is the last letter')
         provider_user1 = create(:provider_user, providers: [provider1], last_signed_in_at: 5.days.ago)
         provider_user2 = create(:provider_user, providers: [provider2], last_signed_in_at: 5.days.ago)
         provider_user3 = create(:provider_user, providers: [provider1, provider2], last_signed_in_at: 3.days.ago)

--- a/spec/services/support_interface/notes_export_spec.rb
+++ b/spec/services/support_interface/notes_export_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe SupportInterface::NotesExport do
   describe 'data_for_export' do
     it 'returns a hash of notes data' do
       candidate = create(:candidate)
-      training_provider = create(:provider, code: 'AB1')
-      ratifying_provider = create(:provider, code: 'CD2')
+      training_provider = create(:provider, code: 'AB1', name: 'A is the first letter')
+      ratifying_provider = create(:provider, code: 'CD2', name: 'Z is the last letter')
       course = create(:course, provider: training_provider, accredited_provider: ratifying_provider)
       course_option = create(:course_option, course:)
       application_choice1 = create(:application_choice, candidate:, current_course_option: course_option)


### PR DESCRIPTION
Consistent ordering is a Good Thing, and it helps avoid flaky specs.

## Context

[This PR](https://github.com/DFE-Digital/apply-for-teacher-training/pull/7668) is failing due to spec flakiness caused by non-deterministic ordering.

## Changes proposed in this pull request

Order the providers in this export.

## Guidance to review

Have the specs stopped being flaky?

## Link to Trello card

https://trello.com/c/KFjxdgCY/873-wakey-wakey-specs-are-flakey

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
