### PR TITLE
Implement the rejection feedback survey on candidate interface

### DIFF
--- a/app/components/candidate_interface/application_dashboard_course_choices_component.rb
+++ b/app/components/candidate_interface/application_dashboard_course_choices_component.rb
@@ -163,6 +163,8 @@ module CandidateInterface
       return unless application_choice.rejected?
       return unless application_choice.rejection_reason.present? || application_choice.structured_rejection_reasons.present?
 
+      activate_rejection_feedback_button = FeatureFlag.active?(:is_this_feedback_helpful_survey)
+
       {
         key: 'Feedback',
         value: render(
@@ -170,6 +172,7 @@ module CandidateInterface
             application_choice:,
             render_link_to_find_when_rejected_on_qualifications: @render_link_to_find_when_rejected_on_qualifications,
             rejection_reasons_component: CandidateInterface::RejectionReasons::RejectionReasonsComponent,
+            feedback_button: activate_rejection_feedback_button,
           ),
         ),
       }

--- a/app/components/shared/rejection_reasons/rejection_feedback_survey_component.html.erb
+++ b/app/components/shared/rejection_reasons/rejection_feedback_survey_component.html.erb
@@ -1,0 +1,9 @@
+<% if answered? %>
+  <%= feedback_text %>
+<% else %>
+  <div class="govuk-button-group app-feedback">
+    Is this feedback helpful?
+    <%= govuk_button_to 'Yes', candidate_interface_rejection_feedback_survey_path(helpful: true, application_choice: @application_choice), secondary: true %> 
+    <%= govuk_button_to 'No', candidate_interface_rejection_feedback_survey_path(helpful: false, application_choice: @application_choice), secondary: true %>
+  </div>
+<% end %>

--- a/app/components/shared/rejection_reasons/rejection_feedback_survey_component.html.erb
+++ b/app/components/shared/rejection_reasons/rejection_feedback_survey_component.html.erb
@@ -1,9 +1,9 @@
-<% if answered? %>
-  <%= feedback_text %>
-<% else %>
-  <div class="govuk-button-group app-feedback-helpful">
-    Is this feedback helpful?
-    <%= govuk_button_to 'Yes', candidate_interface_rejection_feedback_survey_path(helpful: true, application_choice: @application_choice), secondary: true, class: 'govuk-!-margin-left-3' %>
-    <%= govuk_button_to 'No', candidate_interface_rejection_feedback_survey_path(helpful: false, application_choice: @application_choice), secondary: true %>
-  </div>
-<% end %>
+<div class="app-feedback-helpful">
+  <% if answered? %>
+    <%= feedback_text %>
+  <% else %>
+      Is this feedback helpful?
+      <%= govuk_button_to 'Yes', candidate_interface_rejection_feedback_survey_path(helpful: true, application_choice: @application_choice), secondary: true %>
+      <%= govuk_button_to 'No', candidate_interface_rejection_feedback_survey_path(helpful: false, application_choice: @application_choice), secondary: true %>
+  <% end %>
+</div>

--- a/app/components/shared/rejection_reasons/rejection_feedback_survey_component.html.erb
+++ b/app/components/shared/rejection_reasons/rejection_feedback_survey_component.html.erb
@@ -1,9 +1,9 @@
 <% if answered? %>
   <%= feedback_text %>
 <% else %>
-  <div class="govuk-button-group app-feedback">
+  <div class="govuk-button-group app-feedback-helpful">
     Is this feedback helpful?
-    <%= govuk_button_to 'Yes', candidate_interface_rejection_feedback_survey_path(helpful: true, application_choice: @application_choice), secondary: true %> 
+    <%= govuk_button_to 'Yes', candidate_interface_rejection_feedback_survey_path(helpful: true, application_choice: @application_choice), secondary: true, class: 'govuk-!-margin-left-3' %>
     <%= govuk_button_to 'No', candidate_interface_rejection_feedback_survey_path(helpful: false, application_choice: @application_choice), secondary: true %>
   </div>
 <% end %>

--- a/app/components/shared/rejection_reasons/rejection_feedback_survey_component.rb
+++ b/app/components/shared/rejection_reasons/rejection_feedback_survey_component.rb
@@ -13,9 +13,9 @@ class RejectionReasons::RejectionFeedbackSurveyComponent < ViewComponent::Base
 
   def feedback_text
     if feedback.helpful?
-      'You said that this feedback is helpful.'
+      I18n.t('rejection_feedback_survey.response.helpful')
     else
-      'You said that this feedback is not helpful.'
+      I18n.t('rejection_feedback_survey.response.not_helpful')
     end
   end
 

--- a/app/components/shared/rejection_reasons/rejection_feedback_survey_component.rb
+++ b/app/components/shared/rejection_reasons/rejection_feedback_survey_component.rb
@@ -1,0 +1,25 @@
+class RejectionReasons::RejectionFeedbackSurveyComponent < ViewComponent::Base
+  include ViewHelper
+
+  attr_reader :application_choice
+
+  def initialize(application_choice:)
+    @application_choice = application_choice
+  end
+
+  def answered?
+    feedback.present?
+  end
+
+  def feedback_text
+    if feedback.helpful?
+      'You said that this feedback is helpful.'
+    else
+      'You said that this feedback is not helpful.'
+    end
+  end
+
+  def feedback
+    RejectionFeedback.find_by(application_choice: application_choice)
+  end
+end

--- a/app/components/shared/rejections_component.html.erb
+++ b/app/components/shared/rejections_component.html.erb
@@ -1,1 +1,2 @@
 <%= render component_for_rejection_reasons_type %>
+<%= render_rejection_feedback_survey_button %>

--- a/app/components/shared/rejections_component.rb
+++ b/app/components/shared/rejections_component.rb
@@ -5,10 +5,17 @@
 class RejectionsComponent < ViewComponent::Base
   attr_reader :application_choice, :rejection_reasons_component
 
-  def initialize(application_choice:, render_link_to_find_when_rejected_on_qualifications: false, rejection_reasons_component: RejectionReasons::RejectionReasonsComponent)
+  def initialize(application_choice:, render_link_to_find_when_rejected_on_qualifications: false, rejection_reasons_component: RejectionReasons::RejectionReasonsComponent, feedback_button: false)
     @application_choice = application_choice
     @render_link_to_find_when_rejected_on_qualifications = render_link_to_find_when_rejected_on_qualifications
     @rejection_reasons_component = rejection_reasons_component
+    @feedback_button = feedback_button
+  end
+
+  def render_rejection_feedback_survey_button
+    return unless @feedback_button
+
+    render RejectionReasons::RejectionFeedbackSurveyComponent.new(application_choice:)
   end
 
   def component_for_rejection_reasons_type

--- a/app/controllers/candidate_interface/rejection_feedback_survey_controller.rb
+++ b/app/controllers/candidate_interface/rejection_feedback_survey_controller.rb
@@ -1,0 +1,19 @@
+module CandidateInterface
+  class RejectionFeedbackSurveyController < CandidateInterfaceController
+    def new
+      ProvideRejectionFeedback.new(application_choice_params, helpful_params).call
+      redirect_to candidate_interface_application_complete_path
+      flash[:success] = 'Feedback successfully provided'
+    end
+
+  private
+
+    def application_choice_params
+      ApplicationChoice.find(params[:application_choice])
+    end
+
+    def helpful_params
+      ActiveModel::Type::Boolean.new.cast(params[:helpful])
+    end
+  end
+end

--- a/app/frontend/styles/_feedback.scss
+++ b/app/frontend/styles/_feedback.scss
@@ -9,17 +9,23 @@
   min-height: 80px;
 }
 
-/* 'Is this feedback? helpful?' component
-This is shown on the application interface next to feedback
-received after an application has been rejected. */
 .app-feedback-helpful {
- margin-top: govuk-spacing(4);
- border-top: 1px solid $govuk-border-colour;
- padding-top: govuk-spacing(3);
- margin-right: govuk-spacing(4);
- line-height: 38px;
+  margin-top: govuk-spacing(4);
+  border-top: 1px solid $govuk-border-colour;
+  padding-top: govuk-spacing(3);
+  margin-right: govuk-spacing(1);
+  line-height: 38px;
+}
+
+.app-feedback-helpful form {
+  @include govuk-media-query($from: tablet) {
+    display: inline-block;
+  }
 }
 
 .app-feedback-helpful .govuk-button {
-   margin-bottom: 0;
- }
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: 0;
+    margin-left: govuk-spacing(1);
+  }
+}

--- a/app/frontend/styles/_feedback.scss
+++ b/app/frontend/styles/_feedback.scss
@@ -13,6 +13,10 @@
 This is shown on the application interface next to feedback
 received after an application has been rejected. */
 .app-feedback-helpful {
+ margin-top: govuk-spacing(4);
+ border-top: 1px solid $govuk-border-colour;
+ padding-top: govuk-spacing(3);
+ margin-right: govuk-spacing(4);
  line-height: 38px;
 }
 

--- a/app/frontend/styles/_feedback.scss
+++ b/app/frontend/styles/_feedback.scss
@@ -8,3 +8,14 @@
   padding: govuk-spacing(2) govuk-spacing(5);
   min-height: 80px;
 }
+
+/* 'Is this feedback? helpful?' component
+This is shown on the application interface next to feedback
+received after an application has been rejected. */
+.app-feedback-helpful {
+ line-height: 38px;
+}
+
+.app-feedback-helpful .govuk-button {
+   margin-bottom: 0;
+ }

--- a/app/services/provide_rejection_feedback.rb
+++ b/app/services/provide_rejection_feedback.rb
@@ -1,0 +1,16 @@
+class ProvideRejectionFeedback
+  def initialize(application_choice, helpful)
+    @application_choice = application_choice
+    @helpful = helpful
+  end
+
+  def call
+    return unless application_choice.rejected?
+
+    RejectionFeedback.create(application_choice:, helpful:)
+  end
+
+private
+
+  attr_reader :application_choice, :helpful
+end

--- a/config/locales/rejection_feedback_survey.yml
+++ b/config/locales/rejection_feedback_survey.yml
@@ -1,0 +1,7 @@
+en:
+  rejection_feedback_survey:
+    label: Is this feedback helpful?
+    response:
+      helpful: You said that this feedback is helpful.
+      not_helpful: You said that this feedback is not helpful.
+      

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
     get '/privacy-policy', to: 'content#privacy_policy', as: :privacy_policy
     get '/providers', to: 'content#providers', as: :providers
     get '/terms-of-use', to: 'content#terms_candidate', as: :terms
+    post '/feedback-survey' => 'rejection_feedback_survey#new', as: :rejection_feedback_survey
 
     resources :cookie_preferences, only: 'create', path: 'cookie-preferences'
     post '/cookie-preferences-hide-confirmation', to: 'cookie_preferences#hide_confirmation', as: :cookie_preferences_hide_confirmation

--- a/spec/components/shared/rejection_reasons/rejection_feedback_survey_component_spec.rb
+++ b/spec/components/shared/rejection_reasons/rejection_feedback_survey_component_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe RejectionReasons::RejectionFeedbackSurveyComponent do
+  describe 'rendered component' do
+    let(:application_choice) { create(:application_choice, :with_rejection) }
+
+    context 'when no response has been provided' do
+      it 'renders the survey button' do
+        result = render_inline(described_class.new(application_choice:))
+        expect(result.text).to include('Is this feedback helpful?')
+      end
+    end
+
+    context 'when the feedback was not helpful' do
+      it 'renders the correct text' do
+        ProvideRejectionFeedback.new(application_choice, false).call
+        result = render_inline(described_class.new(application_choice:))
+        expect(result.text).to include('You said that this feedback is not helpful.')
+      end
+    end
+
+    context 'when the feedback was helpful' do
+      it 'renders the correct text' do
+        ProvideRejectionFeedback.new(application_choice, true).call
+        result = render_inline(described_class.new(application_choice:))
+        expect(result.text).to include('You said that this feedback is helpful.')
+      end
+    end
+
+    context 'when the application choice is not rejected' do
+      let(:application_choice) { create(:application_choice, :withdrawn) }
+
+      it 'does not render the feedback button' do
+        result = render_inline(described_class.new(application_choice:))
+        expect(result.text).not_to include('Is this feedback helpful?')
+      end
+    end
+  end
+end

--- a/spec/components/shared/rejection_reasons/rejection_feedback_survey_component_spec.rb
+++ b/spec/components/shared/rejection_reasons/rejection_feedback_survey_component_spec.rb
@@ -26,14 +26,5 @@ RSpec.describe RejectionReasons::RejectionFeedbackSurveyComponent do
         expect(result.text).to include('You said that this feedback is helpful.')
       end
     end
-
-    context 'when the application choice is not rejected' do
-      let(:application_choice) { create(:application_choice, :withdrawn) }
-
-      it 'does not render the feedback button' do
-        result = render_inline(described_class.new(application_choice:))
-        expect(result.text).not_to include('Is this feedback helpful?')
-      end
-    end
   end
 end

--- a/spec/components/shared/rejection_reasons/rejection_feedback_survey_component_spec.rb
+++ b/spec/components/shared/rejection_reasons/rejection_feedback_survey_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RejectionReasons::RejectionFeedbackSurveyComponent do
     context 'when no response has been provided' do
       it 'renders the survey button' do
         result = render_inline(described_class.new(application_choice:))
-        expect(result.text).to include('Is this feedback helpful?')
+        expect(result.text).to include(I18n.t('rejection_feedback_survey.label'))
       end
     end
 
@@ -15,7 +15,7 @@ RSpec.describe RejectionReasons::RejectionFeedbackSurveyComponent do
       it 'renders the correct text' do
         ProvideRejectionFeedback.new(application_choice, false).call
         result = render_inline(described_class.new(application_choice:))
-        expect(result.text).to include('You said that this feedback is not helpful.')
+        expect(result.text).to include(I18n.t('rejection_feedback_survey.response.not_helpful'))
       end
     end
 
@@ -23,7 +23,7 @@ RSpec.describe RejectionReasons::RejectionFeedbackSurveyComponent do
       it 'renders the correct text' do
         ProvideRejectionFeedback.new(application_choice, true).call
         result = render_inline(described_class.new(application_choice:))
-        expect(result.text).to include('You said that this feedback is helpful.')
+        expect(result.text).to include(I18n.t('rejection_feedback_survey.response.helpful'))
       end
     end
   end

--- a/spec/services/provide_rejection_feedback_spec.rb
+++ b/spec/services/provide_rejection_feedback_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe ProvideRejectionFeedback do
+  let(:provide_feedback) do
+    described_class.new(
+      application_choice,
+      helpful,
+    )
+  end
+
+  describe '#call' do
+    context 'when the application choice is not rejected' do
+      let(:application_choice) { create(:application_choice, :awaiting_provider_decision) }
+      let(:helpful) { true }
+
+      it 'does not call the service' do
+        provide_feedback.call
+        expect(RejectionFeedback.find_by(application_choice: application_choice).present?).to be false
+      end
+    end
+
+    context 'when the application choice is rejected' do
+      let(:application_choice) { create(:application_choice, :with_rejection) }
+      let(:helpful) { false }
+
+      it 'creates a rejection feedback association with the application choice' do
+        provide_feedback.call
+        expect(RejectionFeedback.find_by(application_choice: application_choice).present?).to be true
+        expect(RejectionFeedback.find_by(application_choice: application_choice).helpful).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

We'd like to know whether candidates find the rejection reasons given by providers helpful or not, and which types of feedback are more helpful than others.

To do this, we’d like to trial a one-question survey on the candidate interface asking "Is this feedback helpful?" with Yes and No buttons.

## Changes proposed in this pull request

- Introduce a new service that will use the Reject Feedback model to associate the feedback response
- Add a new component that will render the feedback buttons
- Include this within the application dashboard

|Before|After|
|---|---|
|<img width="648" alt="image" src="https://user-images.githubusercontent.com/47917431/201073925-012ff2a0-0155-4e1c-9932-6227e4a36383.png">|<img width="650" alt="image" src="https://user-images.githubusercontent.com/47917431/201541260-5e4d2590-b4cb-4833-80cb-f1c5e476d0d3.png">|


|Feedback helpful|Feedback not helpful|
|---|---|
|<img width="657" alt="image" src="https://user-images.githubusercontent.com/47917431/201541229-18727e81-bf37-4050-960a-f6229b9fdf94.png">|<img width="666" alt="image" src="https://user-images.githubusercontent.com/47917431/201541213-55123370-8c03-4531-a8b1-0ba100f783d7.png">|

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/5FcCz7Q5/801-implement-is-this-feedback-helpful-survey-on-candidate-interface

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
