### PR TITLE
Structuring reference history component content message

### DIFF
--- a/app/components/candidate_interface/reference_history_component.html.erb
+++ b/app/components/candidate_interface/reference_history_component.html.erb
@@ -1,9 +1,5 @@
 <% history.each do |event| %>
   <p class="govuk-body-s govuk-!-margin-top-2 govuk-!-margin-bottom-0">
     <%= formatted_title(event) %> on <%= event.time.to_fs(:govuk_date) %>
-
-    <% if can_be_cancelled?(event) %>
-      - <%= govuk_link_to(t('application_form.references.cancel_request.action'), candidate_interface_references_confirm_cancel_reference_path(reference, return_to: 'offer-dashboard')) %>
-    <% end %>
   </p>
 <% end %>

--- a/app/components/candidate_interface/reference_history_component.html.erb
+++ b/app/components/candidate_interface/reference_history_component.html.erb
@@ -1,5 +1,5 @@
 <% history.each do |event| %>
-  <p class="govuk-body-s govuk-!-margin-top-2 govuk-!-margin-bottom-0">
+  <p class="govuk-body">
     <%= formatted_title(event) %> on <%= event.time.to_fs(:govuk_date) %>
   </p>
 <% end %>

--- a/app/components/candidate_interface/reference_history_component.html.erb
+++ b/app/components/candidate_interface/reference_history_component.html.erb
@@ -1,5 +1,5 @@
 <% history.each do |event| %>
   <p class="govuk-body">
-    <%= formatted_title(event) %> on <%= event.time.to_fs(:govuk_date) %>
+    <%= formatted_title(event) %> on <%= event.time.to_fs(:govuk_date) %>.
   </p>
 <% end %>

--- a/app/components/candidate_interface/reference_history_component.rb
+++ b/app/components/candidate_interface/reference_history_component.rb
@@ -1,6 +1,8 @@
 module CandidateInterface
   class ReferenceHistoryComponent < ViewComponent::Base
     attr_reader :reference
+    delegate :application_form, to: :reference
+    delegate :application_choices, to: :application_form
 
     def initialize(reference)
       @reference = reference
@@ -11,7 +13,23 @@ module CandidateInterface
     end
 
     def formatted_title(event)
-      I18n.t("candidate_reference_history.#{event.name}", default: event.name.humanize)
+      if event.name == 'request_cancelled'
+        cancelled_title(event)
+      else
+        I18n.t("candidate_reference_history.#{event.name}", default: event.name.humanize)
+      end
+    end
+
+  private
+
+    def cancelled_title(event)
+      return I18n.t('candidate_reference_history.request_cancelled') if application_choices.any?(&:application_successful?) || application_unsuccessful.blank?
+
+      I18n.t("candidate_reference_history.#{application_unsuccessful.status}", default: event.name.humanize)
+    end
+
+    def application_unsuccessful
+      application_choices.find(&:application_unsuccessful?)
     end
   end
 end

--- a/app/components/candidate_interface/reference_history_component.rb
+++ b/app/components/candidate_interface/reference_history_component.rb
@@ -23,9 +23,9 @@ module CandidateInterface
   private
 
     def cancelled_title(event)
-      return I18n.t('candidate_reference_history.request_cancelled') if application_choices.any?(&:application_successful?) || application_unsuccessful.blank?
+      return I18n.t('candidate_reference_history.request_cancelled') unless application_form.ended_without_success?
 
-      I18n.t("candidate_reference_history.#{application_unsuccessful.status}", default: event.name.humanize)
+      I18n.t("candidate_reference_history.#{application_unsuccessful.status}", default: event.name.humanize) if application_unsuccessful.present?
     end
 
     def application_unsuccessful

--- a/app/components/candidate_interface/reference_history_component.rb
+++ b/app/components/candidate_interface/reference_history_component.rb
@@ -11,19 +11,7 @@ module CandidateInterface
     end
 
     def formatted_title(event)
-      if event.name == 'request_bounced'
-        "The request did not reach #{event.extra_info.bounced_email}"
-      elsif event.name == 'request_sent'
-        'Request sent'
-      elsif event.name == 'reference_received'
-        'Reference sent to provider'
-      else
-        event.name.humanize
-      end
-    end
-
-    def can_be_cancelled?(event)
-      reference.feedback_status == 'feedback_requested' && event.name == 'request_sent'
+      I18n.t("candidate_reference_history.#{event.name}", default: event.name.humanize)
     end
   end
 end

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -76,6 +76,10 @@ class ApplicationChoice < ApplicationRecord
     ApplicationStateChange::ACCEPTED_STATES.include? status.to_sym
   end
 
+  def application_successful?
+    ApplicationStateChange::SUCCESSFUL_STATES.include? status.to_sym
+  end
+
   def different_offer?
     current_course_option_id && current_course_option_id != course_option_id
   end

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -76,10 +76,6 @@ class ApplicationChoice < ApplicationRecord
     ApplicationStateChange::ACCEPTED_STATES.include? status.to_sym
   end
 
-  def application_successful?
-    ApplicationStateChange::SUCCESSFUL_STATES.include? status.to_sym
-  end
-
   def different_offer?
     current_course_option_id && current_course_option_id != course_option_id
   end

--- a/config/locales/candidate_interface/candidate_reference_history.yml
+++ b/config/locales/candidate_interface/candidate_reference_history.yml
@@ -1,0 +1,7 @@
+en:
+  candidate_reference_history:
+    request_sent: You sent the request
+    reference_received: They gave a reference to the training provider
+    request_declined: They said they cannot give a reference
+    request_cancelled: You cancelled the request
+    request_bounced: The request failed

--- a/config/locales/candidate_interface/candidate_reference_history.yml
+++ b/config/locales/candidate_interface/candidate_reference_history.yml
@@ -5,3 +5,8 @@ en:
     request_declined: They said they cannot give a reference
     request_cancelled: You cancelled the request
     request_bounced: The request failed
+    reminder_sent: You sent a reminder
+    automated_reminder_sent: A reminder was automatically sent
+    conditions_not_met: The request was automatically cancelled because you did not meet your conditions
+    withdrawn: The request was automatically cancelled because you withdrew your application
+    offer_withdrawn: The request was automatically cancelled because your offer was withdrawn

--- a/spec/components/candidate_interface/reference_history_component_spec.rb
+++ b/spec/components/candidate_interface/reference_history_component_spec.rb
@@ -1,9 +1,13 @@
 require 'rails_helper'
 
-RSpec.describe CandidateInterface::ReferenceHistoryComponent, time: Time.zone.local(2022, 10, 30), type: :component do
+RSpec.describe CandidateInterface::ReferenceHistoryComponent, time: Time.zone.local(2022, 10, 30), type: :component, with_audited: true do
+  let(:application_form) { create(:application_form) }
+  let(:reference) { create(:reference, :not_requested_yet, application_form:) }
+  let(:result) { render_inline(described_class.new(reference)) }
+  let(:events) { result.css('p').map(&:text).join("\n") }
+
   shared_examples_for 'a reference history event' do |feedback_status, event_title|
-    it 'renders the events of a reference history', with_audited: true do
-      reference = create(:reference, :not_requested_yet)
+    it 'renders the events of a reference history' do
       travel_temporarily_to(reference.created_at) { reference.feedback_requested! }
       travel_temporarily_to(reference.created_at + 1.day) do
         reference.send("#{feedback_status}!") unless feedback_status == :feedback_requested
@@ -20,4 +24,75 @@ RSpec.describe CandidateInterface::ReferenceHistoryComponent, time: Time.zone.lo
   it_behaves_like 'a reference history event', :cancelled, 'You cancelled the request on 31 October 2022'
   it_behaves_like 'a reference history event', :feedback_refused, 'They said they cannot give a reference on 31 October 2022'
   it_behaves_like 'a reference history event', :email_bounced, 'The request failed on 31 October 2022'
+
+  context 'when automated reminder is sent' do
+    it 'renders the events of a reference history', with_audited: true do
+      travel_temporarily_to(reference.created_at) { reference.feedback_requested! }
+      travel_temporarily_to(reference.created_at + 8.days) do
+        create(:chaser_sent, chased: reference, chaser_type: :referee_reference_request)
+      end
+
+      expect(events).to include('A reminder was automatically sent on 7 November 2022')
+    end
+  end
+
+  context 'when candidate reminder is sent' do
+    it 'renders the event name' do
+      travel_temporarily_to(reference.created_at) { reference.feedback_requested! }
+      travel_temporarily_to(reference.created_at + 1.day) do
+        reference.update!(reminder_sent_at: Time.zone.now)
+      end
+
+      expect(events).to include('You sent a reminder on 31 October 2022')
+    end
+  end
+
+  context 'when is cancelled' do
+    before do
+      travel_temporarily_to(reference.created_at) { reference.feedback_requested! }
+      travel_temporarily_to(reference.created_at + 1.day) do
+        reference.cancelled!
+      end
+    end
+
+    context 'when candidate application did not meet conditions' do
+      it 'renders the event name' do
+        travel_temporarily_to(reference.created_at + 10.days) do
+          create(:application_choice, :with_conditions_not_met, application_form:)
+        end
+
+        expect(events).to include('The request was automatically cancelled because you did not meet your conditions on 31 October 2022')
+      end
+    end
+
+    context 'when candidate application is withdraw' do
+      it 'renders the event name' do
+        travel_temporarily_to(reference.created_at + 10.days) do
+          create(:application_choice, :withdrawn, application_form:)
+        end
+
+        expect(events).to include('The request was automatically cancelled because you withdrew your application on 31 October 2022')
+      end
+    end
+
+    context 'when candidate applications are withdraw and one offer accepted' do
+      it 'does not render the withdraw event name' do
+        travel_temporarily_to(reference.created_at + 10.days) do
+          create(:application_choice, :pending_conditions, application_form:)
+          create(:application_choice, :withdrawn, application_form:)
+        end
+
+        expect(events).to include('You cancelled the request on 31 October 2022')
+      end
+    end
+
+    context 'when candidate offer is withdraw' do
+      it 'renders the event name' do
+        travel_temporarily_to(reference.created_at + 10.days) do
+          create(:application_choice, :with_withdrawn_offer, application_form:)
+        end
+        expect(events).to include('The request was automatically cancelled because your offer was withdrawn on 31 October 2022')
+      end
+    end
+  end
 end

--- a/spec/components/candidate_interface/reference_history_component_spec.rb
+++ b/spec/components/candidate_interface/reference_history_component_spec.rb
@@ -1,67 +1,23 @@
 require 'rails_helper'
 
-RSpec.describe CandidateInterface::ReferenceHistoryComponent, type: :component do
-  it 'renders the events of a reference history', with_audited: true do
-    reference = create(:reference, :not_requested_yet, created_at: Time.zone.local(2020, 1, 1, 9))
-    travel_temporarily_to(reference.created_at) { reference.feedback_requested! }
-    travel_temporarily_to(reference.created_at + 1.day) { reference.feedback_provided! }
+RSpec.describe CandidateInterface::ReferenceHistoryComponent, time: Time.zone.local(2022, 10, 30), type: :component do
+  shared_examples_for 'a reference history event' do |feedback_status, event_title|
+    it 'renders the events of a reference history', with_audited: true do
+      reference = create(:reference, :not_requested_yet)
+      travel_temporarily_to(reference.created_at) { reference.feedback_requested! }
+      travel_temporarily_to(reference.created_at + 1.day) do
+        reference.send("#{feedback_status}!") unless feedback_status == :feedback_requested
+      end
+      result = render_inline(described_class.new(reference))
+      events = result.css('p').map(&:text).join("\n")
 
-    result = render_inline(described_class.new(reference))
-
-    list_items = result.css('p')
-    expect(list_items[0].text).to include 'Request sent'
-    expect(list_items[0].text.squish).to include '1 January 2020'
-    expect(list_items[1].text).to include 'Reference sent to provider'
-    expect(list_items[1].text.squish).to include '2 January 2020'
+      expect(events).to include(event_title)
+    end
   end
 
-  it 'uses a special title format for request_bounced events', with_audited: true do
-    reference = create(:reference, :not_requested_yet, email_address: 'example@email.com')
-    reference.email_bounced!
-
-    result = render_inline(described_class.new(reference))
-
-    list_item = result.css('p').first
-    expect(list_item.text).to include 'The request did not reach example@email.com'
-  end
-
-  it 'uses a special title format for request_sent events', with_audited: true do
-    reference = create(:reference, :not_requested_yet, email_address: 'example@email.com')
-    reference.feedback_requested!
-
-    result = render_inline(described_class.new(reference))
-
-    list_item = result.css('p').first
-    expect(list_item.text).to include "Request sent on #{Time.zone.now.to_fs(:govuk_date)}"
-  end
-
-  it 'renders cancel request link for reference feedback_status that is feedback_requested', with_audited: true do
-    reference = create(:reference, :not_requested_yet)
-    reference.feedback_requested!
-
-    render_inline(described_class.new(reference))
-
-    expect(rendered_component).to have_text 'Cancel request'
-  end
-
-  it 'hides cancel request link for reference feedback_status that is not feedback_requested', with_audited: true do
-    reference = create(:reference, :not_requested_yet)
-    reference.feedback_requested!
-    reference.feedback_provided!
-
-    render_inline(described_class.new(reference))
-
-    expect(rendered_component).not_to have_text 'Cancel request'
-  end
-
-  it 'renders cancel request link once despite many reminders', with_audited: true do
-    reference = create(:reference, :not_requested_yet)
-    reference.feedback_requested!
-    reference.update!(reminder_sent_at: 1.day.ago)
-    reference.update!(reminder_sent_at: Time.zone.now)
-
-    render_inline(described_class.new(reference))
-
-    expect(rendered_component).to have_content('Cancel request', count: 1)
-  end
+  it_behaves_like 'a reference history event', :feedback_requested, 'You sent the request on 30 October 2022'
+  it_behaves_like 'a reference history event', :feedback_provided, 'They gave a reference to the training provider on 31 October 2022'
+  it_behaves_like 'a reference history event', :cancelled, 'You cancelled the request on 31 October 2022'
+  it_behaves_like 'a reference history event', :feedback_refused, 'They said they cannot give a reference on 31 October 2022'
+  it_behaves_like 'a reference history event', :email_bounced, 'The request failed on 31 October 2022'
 end

--- a/spec/system/candidate_interface/references/candidate_views_their_references_on_the_post_offer_dashboard_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_views_their_references_on_the_post_offer_dashboard_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature 'Post-offer references', time: CycleTimetableHelper.after_apply_1_
 
     when_i_go_back_to_the_dashboard
     then_i_should_see_the_post_offer_dashboard
-    then_i_see_the_updated_history
+    then_i_see_the_updated_history_on_the_dashboard
     and_i_click_on_my_requested_reference
     and_i_click_cancel_request
     then_i_see_the_cancellation_confirmation_page
@@ -94,7 +94,7 @@ RSpec.feature 'Post-offer references', time: CycleTimetableHelper.after_apply_1_
   end
 
   def then_i_see_the_updated_history
-    expect(page).to have_content("Reminder sent on #{Time.zone.now.to_fs(:govuk_date)}")
+    expect(page).to have_content("You sent a reminder on #{Time.zone.now.to_fs(:govuk_date)}")
   end
 
   def when_i_go_back_to_the_dashboard
@@ -117,5 +117,9 @@ RSpec.feature 'Post-offer references', time: CycleTimetableHelper.after_apply_1_
 
   def then_i_see_the_status_change
     expect(page).to have_content('Request cancelled')
+  end
+
+  def then_i_see_the_updated_history_on_the_dashboard
+    expect(page).to have_content("Reminder sent on #{Time.zone.now.to_fs(:govuk_date)}")
   end
 end


### PR DESCRIPTION
## Context

The details page for each reference has a series of entries giving the history of the request - for example when it was requested and when reminders were sent.

We want to improve these history entries. We need to:

* change the wording of the history entries
* remove the 'cancel request' links from the history entries - there's already a link to do this next to the green button
* The new wording for the history entries is in the linked design Trello card.