### PR TITLE
Update key_dates_banner.yml to remove reference to COVID-19 and Christmas.

### DIFF
--- a/config/locales/key_dates_banner.yml
+++ b/config/locales/key_dates_banner.yml
@@ -2,8 +2,8 @@ en:
   key_dates_banner:
     title: Important
     christmas:
-      header: 'Extension to automatic rejection dates'
-      body: '%{non_working_days_period} are not counted when calculating automatic rejection dates. This extension is to help providers deal with the impact of coronavirus (COVID-19) in the Christmas period.'
+      header: '%{non_working_days_period} do not count as working days'
+      body: 'This period will not be included when calculating dates for applications to be automatically rejected.'
     easter:
       header: '%{non_working_days_period} do not count as working days'
       body: 'This period will not be included when calculating dates for applications to be automatically rejected.'

--- a/spec/components/provider_interface/key_dates_banner_spec.rb
+++ b/spec/components/provider_interface/key_dates_banner_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe ProviderInterface::KeyDatesBanner do
         end
 
         it 'renders the non working period content' do
-          expect(result.text).to include(t('key_dates_banner.christmas.header'))
+          expect(result.text).to include(t('key_dates_banner.christmas.header', non_working_days_period: christmas_period))
           expect(result.text).to include(t('key_dates_banner.christmas.body', non_working_days_period: christmas_period))
         end
       end


### PR DESCRIPTION
## Context

James found this content which is surfaced to providers. It references COVID-19 and extension to RBD window, which is untrue.

## Changes proposed in this pull request

I've mirrored the Easter banner.

|Before|After|
|---|---|
|<img width="1013" alt="image" src="https://user-images.githubusercontent.com/47917431/201154762-b28962ef-f3d1-498b-a184-239eaa421d95.png">|<img width="1055" alt="image" src="https://user-images.githubusercontent.com/47917431/201154597-25ceacf7-ea78-4a5b-bd65-020c7009248d.png">|

## Guidance to review

Does this render correctly?

## Link to Trello card

https://trello.com/c/E9iTi07W/880-fix-our-christmas-notification-banner-for-providers

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
