### PR TITLE
Slack notification for unaccredited provider recruitment

### DIFF
--- a/app/services/make_offer.rb
+++ b/app/services/make_offer.rb
@@ -38,6 +38,7 @@ class MakeOffer
         ).call!
 
         SendNewOfferEmailToCandidate.new(application_choice:).call
+        NotifyOfOfferByClosedProviders.new(application_choice: application_choice).call
       end
     else
       raise ValidationException, offer.errors.map(&:message)

--- a/app/services/notify_of_offer_by_closed_providers.rb
+++ b/app/services/notify_of_offer_by_closed_providers.rb
@@ -88,6 +88,6 @@ private
     message = ":bangbang: #{provider.name} has made an offer to a candidate – this provider is currently closed."
     url = Rails.application.routes.url_helpers.support_interface_application_form_url(application_choice.application_form)
 
-    SlackNotificationWorker.perform_async(message, url, 'bat_provider_changes')
+    SlackNotificationWorker.perform_async(message, url, '#bat_provider_changes')
   end
 end

--- a/app/services/notify_of_offer_by_closed_providers.rb
+++ b/app/services/notify_of_offer_by_closed_providers.rb
@@ -81,11 +81,19 @@ class NotifyOfOfferByClosedProviders
 private
 
   def provider_closed?
-    CLOSED_PROVIDERS.include?(provider.code) || CLOSED_PROVIDERS.include?(accredited_provider.code)
+    CLOSED_PROVIDERS.include?(provider.code) || CLOSED_PROVIDERS.include?(accredited_provider&.code)
+  end
+
+  def provider_name
+    if CLOSED_PROVIDERS.include?(provider.code)
+      provider.name
+    elsif CLOSED_PROVIDERS.include?(accredited_provider&.code)
+      accredited_provider.name
+    end
   end
 
   def send_slack_notification
-    message = ":bangbang: #{provider.name} has made an offer to a candidate – this provider is currently closed."
+    message = ":bangbang: #{provider_name} has made an offer to a candidate – this provider is currently closed."
     url = Rails.application.routes.url_helpers.support_interface_application_form_url(application_choice.application_form)
 
     SlackNotificationWorker.perform_async(message, url, '#bat_provider_changes')

--- a/app/services/notify_of_offer_by_closed_providers.rb
+++ b/app/services/notify_of_offer_by_closed_providers.rb
@@ -1,0 +1,90 @@
+class NotifyOfOfferByClosedProviders
+  CLOSED_PROVIDERS = %w[
+    24R
+    B28
+    26T
+    B60
+    B84
+    C23
+    25P
+    C97
+    D51
+    2B6
+    M70
+    E73
+    F82
+    252
+    G10
+    G12
+    2B4
+    26U
+    2AW
+    1LP
+    2B5
+    25O
+    1WK
+    2AY
+    L26
+    L35
+    L75
+    N55
+    N46
+    25K
+    N83
+    24U
+    255
+    P38
+    2ET
+    R55
+    L06
+    G15
+    S13
+    E37
+    25D
+    T11
+    2EZ
+    T26
+    B17
+    C36
+    H17
+    L19
+    24P
+    2AZ
+    T29
+    1WW
+    T89
+    B35
+    C99
+    D86
+    E14
+    G70
+    H72
+    P60
+    S90
+    B80
+    W34
+    2B2
+  ].freeze
+
+  attr_reader :provider, :application_choice
+
+  def initialize(application_choice:)
+    @provider = application_choice.course.provider
+    @application_choice = application_choice
+  end
+
+  def call
+    if CLOSED_PROVIDERS.include?(provider.code)
+      send_slack_notification
+    end
+  end
+
+private
+
+  def send_slack_notification
+    message = ":bangbang: #{provider.name} has made an offer to a candidate – This provider is currently closed."
+    url = Rails.application.routes.url_helpers.support_interface_application_form_url(application_choice.application_form)
+
+    SlackNotificationWorker.perform_async(message, url, 'bat_provider_changes')
+  end
+end

--- a/app/workers/slack_notification_worker.rb
+++ b/app/workers/slack_notification_worker.rb
@@ -3,12 +3,12 @@ require 'http'
 class SlackNotificationWorker
   include Sidekiq::Worker
 
-  def perform(text, url = nil)
+  def perform(text, url = nil, channel = nil)
     @webhook_url = ENV['STATE_CHANGE_SLACK_URL']
 
     if @webhook_url.present?
       message = url.present? ? hyperlink(text, url) : text
-      post_to_slack message
+      post_to_slack message, channel
     end
   end
 
@@ -18,10 +18,10 @@ private
     "<#{url}|#{text}>"
   end
 
-  def post_to_slack(text)
+  def post_to_slack(text, channel)
     if HostingEnvironment.production?
       slack_message = text
-      slack_channel = '#twd_apply_support'
+      slack_channel = channel || '#twd_apply_support'
     else
       slack_message = "[#{HostingEnvironment.environment_name.upcase}] #{text}"
       slack_channel = '#twd_apply_test'

--- a/app/workers/slack_notification_worker.rb
+++ b/app/workers/slack_notification_worker.rb
@@ -18,13 +18,19 @@ private
     "<#{url}|#{text}>"
   end
 
+  def ensure_correct_channel_format(channel)
+    return if channel.nil?
+
+    channel.prepend('#') if channel.first != '#'
+  end
+
   def post_to_slack(text, channel)
     if HostingEnvironment.production?
       slack_message = text
-      slack_channel = channel || '#twd_apply_support'
+      slack_channel = ensure_correct_channel_format(channel) || '#twd_apply_support'
     else
       slack_message = "[#{HostingEnvironment.environment_name.upcase}] #{text}"
-      slack_channel = '#twd_apply_test'
+      slack_channel = ensure_correct_channel_format(channel) || '#twd_apply_test'
     end
 
     payload = {

--- a/spec/services/make_offer_spec.rb
+++ b/spec/services/make_offer_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe MakeOffer do
       it 'then calls various services' do
         set_declined_by_default = instance_double(SetDeclineByDefault, call: true)
         send_new_offer_email_to_candidate = instance_double(SendNewOfferEmailToCandidate, call: true)
+        notify_of_offer_by_closed_providers = instance_double(NotifyOfOfferByClosedProviders, call: true)
 
         allow(SetDeclineByDefault)
             .to receive(:new).with(application_form: application_choice.application_form)
@@ -69,11 +70,15 @@ RSpec.describe MakeOffer do
             .to receive(:new).with(application_choice:)
                     .and_return(send_new_offer_email_to_candidate)
         allow(application_choice).to receive(:update_course_option_and_associated_fields!)
+        allow(NotifyOfOfferByClosedProviders)
+            .to receive(:new).with(application_choice: application_choice)
+                    .and_return(notify_of_offer_by_closed_providers)
 
         make_offer.save!
 
         expect(set_declined_by_default).to have_received(:call)
         expect(send_new_offer_email_to_candidate).to have_received(:call)
+        expect(notify_of_offer_by_closed_providers).to have_received(:call)
         expect(update_conditions_service).to have_received(:save)
         expect(application_choice).to have_received(:update_course_option_and_associated_fields!)
       end

--- a/spec/services/notify_of_offer_by_closed_providers_spec.rb
+++ b/spec/services/notify_of_offer_by_closed_providers_spec.rb
@@ -9,13 +9,34 @@ RSpec.describe NotifyOfOfferByClosedProviders do
 
   describe '#call' do
     let(:provider) { create(:provider, code: 'X100') }
-    let(:application_choice) { create(:application_choice, course: create(:course, provider: provider)) }
+    let(:accredited_provider) { create(:provider, code: 'A67') }
+    let(:application_choice) { create(:application_choice, course: create(:course, provider: provider, accredited_provider: accredited_provider)) }
     let(:application_form_id) { application_choice.application_form.id }
 
     context 'when the provider is not closed' do
       it 'does not notify the slack channel' do
         stub_const('NotifyOfOfferByClosedProviders::CLOSED_PROVIDERS', ['B28'])
         expect(SlackNotificationWorker).not_to have_received(:perform_async)
+      end
+    end
+
+    context 'when the provider is not closed but the accredited provider is' do
+      before do
+        stub_const('NotifyOfOfferByClosedProviders::CLOSED_PROVIDERS', ['A67'])
+
+        described_class.new(
+          application_choice:,
+        ).call
+      end
+
+      it 'mentions the provider name' do
+        message = ":bangbang: #{provider.name} has made an offer to a candidate – this provider is currently closed."
+        expect(SlackNotificationWorker).to have_received(:perform_async).with(message, anything, 'bat_provider_changes')
+      end
+
+      it 'links the notification to the relevant support_interface application_form' do
+        url = helpers.support_interface_application_form_url(application_form_id)
+        expect(SlackNotificationWorker).to have_received(:perform_async).with(anything, url, 'bat_provider_changes')
       end
     end
 
@@ -29,7 +50,7 @@ RSpec.describe NotifyOfOfferByClosedProviders do
       end
 
       it 'mentions the provider name' do
-        message = ":bangbang: #{provider.name} has made an offer to a candidate – This provider is currently closed."
+        message = ":bangbang: #{provider.name} has made an offer to a candidate – this provider is currently closed."
         expect(SlackNotificationWorker).to have_received(:perform_async).with(message, anything, 'bat_provider_changes')
       end
 

--- a/spec/services/notify_of_offer_by_closed_providers_spec.rb
+++ b/spec/services/notify_of_offer_by_closed_providers_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe NotifyOfOfferByClosedProviders do
+  let(:helpers) { Rails.application.routes.url_helpers }
+
+  before do
+    allow(SlackNotificationWorker).to receive(:perform_async)
+  end
+
+  describe '#call' do
+    let(:provider) { create(:provider, code: 'X100') }
+    let(:application_choice) { create(:application_choice, course: create(:course, provider: provider)) }
+    let(:application_form_id) { application_choice.application_form.id }
+
+    context 'when the provider is not closed' do
+      it 'does not notify the slack channel' do
+        stub_const('NotifyOfOfferByClosedProviders::CLOSED_PROVIDERS', ['B28'])
+        expect(SlackNotificationWorker).not_to have_received(:perform_async)
+      end
+    end
+
+    context 'when the provider is closed' do
+      before do
+        stub_const('NotifyOfOfferByClosedProviders::CLOSED_PROVIDERS', ['X100'])
+
+        described_class.new(
+          application_choice:,
+        ).call
+      end
+
+      it 'mentions the provider name' do
+        message = ":bangbang: #{provider.name} has made an offer to a candidate – This provider is currently closed."
+        expect(SlackNotificationWorker).to have_received(:perform_async).with(message, anything, 'bat_provider_changes')
+      end
+
+      it 'links the notification to the relevant support_interface application_form' do
+        url = helpers.support_interface_application_form_url(application_form_id)
+        expect(SlackNotificationWorker).to have_received(:perform_async).with(anything, url, 'bat_provider_changes')
+      end
+    end
+  end
+end

--- a/spec/services/notify_of_offer_by_closed_providers_spec.rb
+++ b/spec/services/notify_of_offer_by_closed_providers_spec.rb
@@ -31,12 +31,12 @@ RSpec.describe NotifyOfOfferByClosedProviders do
 
       it 'mentions the provider name' do
         message = ":bangbang: #{provider.name} has made an offer to a candidate – this provider is currently closed."
-        expect(SlackNotificationWorker).to have_received(:perform_async).with(message, anything, 'bat_provider_changes')
+        expect(SlackNotificationWorker).to have_received(:perform_async).with(message, anything, '#bat_provider_changes')
       end
 
       it 'links the notification to the relevant support_interface application_form' do
         url = helpers.support_interface_application_form_url(application_form_id)
-        expect(SlackNotificationWorker).to have_received(:perform_async).with(anything, url, 'bat_provider_changes')
+        expect(SlackNotificationWorker).to have_received(:perform_async).with(anything, url, '#bat_provider_changes')
       end
     end
 

--- a/spec/services/notify_of_offer_by_closed_providers_spec.rb
+++ b/spec/services/notify_of_offer_by_closed_providers_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe NotifyOfOfferByClosedProviders do
         ).call
       end
 
-      it 'mentions the provider name' do
-        message = ":bangbang: #{provider.name} has made an offer to a candidate – this provider is currently closed."
+      it 'mentions the accredited provider name' do
+        message = ":bangbang: #{accredited_provider.name} has made an offer to a candidate – this provider is currently closed."
         expect(SlackNotificationWorker).to have_received(:perform_async).with(message, anything, '#bat_provider_changes')
       end
 
@@ -51,12 +51,12 @@ RSpec.describe NotifyOfOfferByClosedProviders do
 
       it 'mentions the provider name' do
         message = ":bangbang: #{provider.name} has made an offer to a candidate – this provider is currently closed."
-        expect(SlackNotificationWorker).to have_received(:perform_async).with(message, anything, 'bat_provider_changes')
+        expect(SlackNotificationWorker).to have_received(:perform_async).with(message, anything, '#bat_provider_changes')
       end
 
       it 'links the notification to the relevant support_interface application_form' do
         url = helpers.support_interface_application_form_url(application_form_id)
-        expect(SlackNotificationWorker).to have_received(:perform_async).with(anything, url, 'bat_provider_changes')
+        expect(SlackNotificationWorker).to have_received(:perform_async).with(anything, url, '#bat_provider_changes')
       end
     end
   end

--- a/spec/workers/slack_notification_worker_spec.rb
+++ b/spec/workers/slack_notification_worker_spec.rb
@@ -55,6 +55,17 @@ RSpec.describe SlackNotificationWorker do
 
       expect(slack_request.with(body: /\[TEST\] example text/)).to have_been_made
     end
+
+    it 'prepends # to the channel name if not included' do
+      slack_request = stub_request(:post, 'https://example.com/webhook')
+        .to_return(status: 200, headers: {})
+
+      ClimateControl.modify STATE_CHANGE_SLACK_URL: 'https://example.com/webhook' do
+        described_class.new.perform('example text', nil, 'hashless_channel')
+      end
+
+      expect(slack_request.with(body: /#hashless_channel/)).to have_been_made
+    end
   end
 
   def invoke_worker


### PR DESCRIPTION
## Context

We have a number of providers who are now closed. We want to receive a notification if they continue to recruit candidates on Apply.

## Changes proposed in this pull request

Introduce a service that will be called as part of `MakeOffer`. This will check to see if the provider is closed and if so, will make a slack post alerting us they are currently recruiting.
