### PR TITLE
Ensure slack will use custom channel name

### DIFF
--- a/app/workers/slack_notification_worker.rb
+++ b/app/workers/slack_notification_worker.rb
@@ -22,15 +22,19 @@ private
     return if channel.nil?
 
     channel.prepend('#') if channel.first != '#'
+
+    channel
   end
 
   def post_to_slack(text, channel)
+    custom_channel = ensure_correct_channel_format(channel)
+
     if HostingEnvironment.production?
       slack_message = text
-      slack_channel = ensure_correct_channel_format(channel) || '#twd_apply_support'
+      slack_channel = custom_channel || '#twd_apply_support'
     else
       slack_message = "[#{HostingEnvironment.environment_name.upcase}] #{text}"
-      slack_channel = ensure_correct_channel_format(channel) || '#twd_apply_test'
+      slack_channel = custom_channel || '#twd_apply_test'
     end
 
     payload = {

--- a/spec/workers/slack_notification_worker_spec.rb
+++ b/spec/workers/slack_notification_worker_spec.rb
@@ -66,6 +66,17 @@ RSpec.describe SlackNotificationWorker do
 
       expect(slack_request.with(body: /#hashless_channel/)).to have_been_made
     end
+
+    it 'has a default channel if no custom channel provided' do
+      slack_request = stub_request(:post, 'https://example.com/webhook')
+        .to_return(status: 200, headers: {})
+
+      ClimateControl.modify STATE_CHANGE_SLACK_URL: 'https://example.com/webhook' do
+        described_class.new.perform('example text')
+      end
+
+      expect(slack_request.with(body: /#twd_apply_test/)).to have_been_made
+    end
   end
 
   def invoke_worker


### PR DESCRIPTION
## Context

Slack is still using `#twd_apply_support` even if a channel name is passed in.

This is because the `ensure_correct_channel_format` was returning `nil` if the channel name already had a # at the start

