### PR TITLE
Post the apply stats summary in apply

### DIFF
--- a/app/workers/send_stats_summary_to_slack.rb
+++ b/app/workers/send_stats_summary_to_slack.rb
@@ -2,6 +2,6 @@ class SendStatsSummaryToSlack
   include Sidekiq::Worker
 
   def perform
-    SlackNotificationWorker.perform_async(StatsSummary.new.as_slack_message)
+    SlackNotificationWorker.perform_async(StatsSummary.new.as_slack_message, nil, '#twd_apply')
   end
 end

--- a/app/workers/slack_notification_worker.rb
+++ b/app/workers/slack_notification_worker.rb
@@ -34,7 +34,7 @@ private
       slack_channel = custom_channel || '#twd_apply_support'
     else
       slack_message = "[#{HostingEnvironment.environment_name.upcase}] #{text}"
-      slack_channel = custom_channel || '#twd_apply_test'
+      slack_channel = '#twd_apply_test'
     end
 
     payload = {

--- a/spec/workers/slack_notification_worker_spec.rb
+++ b/spec/workers/slack_notification_worker_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe SlackNotificationWorker do
     end
 
     it 'prepends # to the channel name if not included' do
+      allow(HostingEnvironment).to receive(:environment_name).and_return('production')
       slack_request = stub_request(:post, 'https://example.com/webhook')
         .to_return(status: 200, headers: {})
 


### PR DESCRIPTION
## Context

We have a daily summary of application stats on Apply. This is posted into a support channel, which has a lot of traffic. Now our Slack notification worker can take a channel argument, we should post this summary in a more visible channel.

## Changes proposed in this pull request

Add '#twd_apply' to the `StatsSummary`

Also change the worker so you can only use custom channels for production – otherwise we will receive notifications for our review apps!
