### PR TITLE
Allow candidates to add courses that aren't yet open

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.html.erb
+++ b/app/components/candidate_interface/course_choices_review_component.html.erb
@@ -4,34 +4,40 @@
       <% if application_choice.course_not_available? %>
         <%= unavailable(
           application_choice:,
-          title: "#{application_choice.course_not_available_error}.",
+          title: 'You cannot apply to this course as it is not running',
           reason: "#{application_choice.provider.name} have decided not to run this course.",
         ) %>
       <% elsif course_not_open_for_applications_yet?(application_choice) %>
         <%= unavailable(
           application_choice:,
           title: "You‘ll be able to apply for this course from #{application_choice.course.applications_open_from.to_fs(:govuk_date)}.",
+          lead_in: 'You need to either:',
           alternatives: [
             "wait until #{application_choice.course.applications_open_from.to_fs(:govuk_date)}",
+            'delete or change this course choice',
           ],
         ) %>
       <% elsif application_choice.course_full? %>
         <%= unavailable(
           application_choice:,
-          title: application_choice.course_full_error,
+          title: 'You cannot apply to this course as there are no places left on it',
+          alternatives: [
+            'You need to either delete or change this course choice.',
+            "#{application_choice.course.provider.name} may be able to recommend an alternative course.",
+          ],
         ) %>
       <% elsif application_choice.site_full? || application_choice.site_invalid? %>
         <%= unavailable(
           application_choice:,
-          title: (application_choice.site_full? ? application_choice.site_full_error : application_choice.site_invalid_error),
+          title: 'You cannot apply to this course as the chosen location is full',
           alternatives: [
-            (govuk_link_to('pick a new location', site_change_path(application_choice)) if site_change_path(application_choice)),
+            'You need to either change the location or delete this course choice.',
           ],
         ) %>
       <% elsif application_choice.study_mode_full? %>
         <%= unavailable(
           application_choice:,
-          title: application_choice.study_mode_full_error,
+          title: 'You cannot apply to this course as the chosen study mode is full',
           alternatives: [
             (govuk_link_to('pick a new location', site_change_path(application_choice)) if site_change_path(application_choice)),
           ],

--- a/app/components/candidate_interface/course_choices_review_component.html.erb
+++ b/app/components/candidate_interface/course_choices_review_component.html.erb
@@ -1,94 +1,66 @@
 <% application_choices.each do |application_choice| %>
   <div class="<%= container_class(application_choice) %>" id="course-choice-<%= application_choice.id %>" data-qa="application-choice-<%= application_choice.id %>">
-  <% if CycleTimetable.can_add_course_choice?(application_choice.application_form) && @editable %>
-    <% if application_choice.course_not_available? %>
-      <p class="app-inset-text__title"><%= application_choice.course_not_available_error %>.</p>
-      <p class="govuk-body"><%= application_choice.provider.name %> have decided not to run this course.</p>
-      <p class="govuk-body">You can:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li><%= govuk_link_to 'delete this choice', candidate_interface_confirm_destroy_course_choice_path(application_choice.id) %></li>
-        <% if course_change_path(application_choice) %>
-          <li><%= govuk_link_to 'change to another course', course_change_path(application_choice) %></li>
-        <% end %>
-        <li>
-          <%= govuk_link_to 'contact the training provider', "#{application_choice.course.find_url}#section-contact" %>
-          to discuss alternatives
-        </li>
-      </ul>
-    <% elsif application_choice.course_full? %>
-      <p class="app-inset-text__title"><%= application_choice.course_full_error %>.</p>
-      <p class="govuk-body">You can:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li><%= govuk_link_to 'delete this choice', candidate_interface_confirm_destroy_course_choice_path(application_choice.id) %></li>
-        <% if course_change_path(application_choice) %>
-          <li><%= govuk_link_to 'change to another course', course_change_path(application_choice) %></li>
-        <% end %>
-        <li>
-          <%= govuk_link_to 'contact the training provider', "#{application_choice.course.find_url}#section-contact" %>
-          to see if the course will re-open or discuss alternatives
-        </li>
-      </ul>
-    <% elsif application_choice.site_full? || application_choice.site_invalid? %>
-       <% if application_choice.site_full? %>
-         <p class="app-inset-text__title"><%= application_choice.site_full_error %>.</p>
-       <% else %>
-         <p class="app-inset-text__title"><%= application_choice.site_invalid_error %>.</p>
-       <% end %>
-      <p class="govuk-body">You can:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <% if site_change_path(application_choice) %>
-          <li><%= govuk_link_to 'pick a new location', site_change_path(application_choice) %></li>
-        <% end %>
-        <li><%= govuk_link_to 'delete this choice', candidate_interface_confirm_destroy_course_choice_path(application_choice.id) %></li>
-        <% if course_change_path(application_choice) %>
-          <li><%= govuk_link_to 'change to another course', course_change_path(application_choice) %></li>
-        <% end %>
-        <li>
-          <%= govuk_link_to 'contact the training provider', "#{application_choice.course.find_url}#section-contact" %>
-          to see if the course will re-open or discuss alternatives
-        </li>
-      </ul>
-    <% elsif application_choice.study_mode_full? %>
-      <p class="app-inset-text__title"><%= application_choice.study_mode_full_error %>.</p>
-      <p class="govuk-body">You can:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <% if site_change_path(application_choice) %>
-          <li><%= govuk_link_to 'pick a new location', site_change_path(application_choice) %></li>
-        <% end %>
-        <li><%= govuk_link_to 'delete this choice', candidate_interface_confirm_destroy_course_choice_path(application_choice.id) %></li>
-        <% if course_change_path(application_choice) %>
-          <li><%= govuk_link_to 'change to another course', course_change_path(application_choice) %></li>
-        <% end %>
-        <li>
-          <%= govuk_link_to 'contact the training provider', "#{application_choice.course.find_url}#section-contact" %>
-          to see if the course will re-open or discuss alternatives
-        </li>
-      </ul>
+    <% if CycleTimetable.can_add_course_choice?(application_choice.application_form) && @editable %>
+      <% if application_choice.course_not_available? %>
+        <%= unavailable(
+          application_choice:,
+          title: "#{application_choice.course_not_available_error}.",
+          reason: "#{application_choice.provider.name} have decided not to run this course.",
+        ) %>
+      <% elsif course_not_open_for_applications_yet?(application_choice) %>
+        <%= unavailable(
+          application_choice:,
+          title: "You‘ll be able to apply for this course from #{application_choice.course.applications_open_from.to_fs(:govuk_date)}.",
+          alternatives: [
+            "wait until #{application_choice.course.applications_open_from.to_fs(:govuk_date)}",
+          ],
+        ) %>
+      <% elsif application_choice.course_full? %>
+        <%= unavailable(
+          application_choice:,
+          title: application_choice.course_full_error,
+        ) %>
+      <% elsif application_choice.site_full? || application_choice.site_invalid? %>
+        <%= unavailable(
+          application_choice:,
+          title: (application_choice.site_full? ? application_choice.site_full_error : application_choice.site_invalid_error),
+          alternatives: [
+            (govuk_link_to('pick a new location', site_change_path(application_choice)) if site_change_path(application_choice)),
+          ],
+        ) %>
+      <% elsif application_choice.study_mode_full? %>
+        <%= unavailable(
+          application_choice:,
+          title: application_choice.study_mode_full_error,
+          alternatives: [
+            (govuk_link_to('pick a new location', site_change_path(application_choice)) if site_change_path(application_choice)),
+          ],
+        ) %>
+      <% end %>
     <% end %>
-  <% end %>
 
-  <%= render(SummaryCardComponent.new(rows: course_choice_rows(application_choice), editable: @editable)) do %>
-    <%= render(SummaryCardHeaderComponent.new(title: application_choice.current_course.provider.name, heading_level: @heading_level)) do %>
-      <div class="app-summary-card__actions">
-        <% if application_choice.offer? %>
-          <%= govuk_link_to candidate_interface_offer_path(application_choice.id), data: { action: :respond } do %>
-            <%= t('application_form.courses.view_and_respond_to_offer') %>
-            <span class="govuk-visually-hidden"> <%= application_choice.current_course.name_and_code %></span>
+    <%= render(SummaryCardComponent.new(rows: course_choice_rows(application_choice), editable: @editable)) do %>
+      <%= render(SummaryCardHeaderComponent.new(title: application_choice.current_course.provider.name, heading_level: @heading_level)) do %>
+        <div class="app-summary-card__actions">
+          <% if application_choice.offer? %>
+            <%= govuk_link_to candidate_interface_offer_path(application_choice.id), data: { action: :respond } do %>
+              <%= t('application_form.courses.view_and_respond_to_offer') %>
+              <span class="govuk-visually-hidden"> <%= application_choice.current_course.name_and_code %></span>
+            <% end %>
+          <% elsif withdrawable?(application_choice) %>
+            <%= govuk_link_to candidate_interface_withdraw_path(application_choice.id), data: { action: :withdraw } do %>
+              <%= t('application_form.courses.withdraw') %>
+              <span class="govuk-visually-hidden"> <%= application_choice.current_course.name_and_code %></span>
+            <% end %>
+          <% elsif @editable %>
+            <%= govuk_link_to candidate_interface_confirm_destroy_course_choice_path(application_choice.id), data: { action: :delete } do %>
+              <%= t('application_form.courses.delete') %>
+              <span class="govuk-visually-hidden"> <%= application_choice.current_course.name_and_code %></span>
+            <% end %>
           <% end %>
-        <% elsif withdrawable?(application_choice) %>
-          <%= govuk_link_to candidate_interface_withdraw_path(application_choice.id), data: { action: :withdraw } do %>
-            <%= t('application_form.courses.withdraw') %>
-            <span class="govuk-visually-hidden"> <%= application_choice.current_course.name_and_code %></span>
-          <% end %>
-        <% elsif @editable %>
-          <%= govuk_link_to candidate_interface_confirm_destroy_course_choice_path(application_choice.id), data: { action: :delete } do %>
-            <%= t('application_form.courses.delete') %>
-            <span class="govuk-visually-hidden"> <%= application_choice.current_course.name_and_code %></span>
-          <% end %>
-        <% end %>
-      </div>
+        </div>
+      <% end %>
     <% end %>
-  <% end %>
   </div>
 <% end %>
 

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -84,12 +84,12 @@ module CandidateInterface
       return unless @editable
 
       if application_choice.course_option_availability_error?
-        "govuk-inset-text app-inset-text--narrow-border app-inset-text--#{@application_choice_error ? 'error' : 'important'}"
+        "govuk-inset-text app-inset-text--narrow-border app-inset-text--#{@application_choice_error ? 'error' : 'important'} govuk-!-padding-top-0 govuk-!-padding-bottom-0"
       end
     end
 
     def course_not_open_for_applications_yet?(application_choice)
-      application_choice.course.applications_open_from > Time.zone.today
+      !application_choice.course.open_for_applications?
     end
 
     def application_choices
@@ -362,11 +362,12 @@ module CandidateInterface
     class UnavailableComponent < ViewComponent::Base
       include ViewHelper
 
-      def initialize(application_choice:, course_change_path:, title:, reason: nil, alternatives: [])
+      def initialize(application_choice:, course_change_path:, title:, reason: nil, lead_in: nil, alternatives: [])
         @application_choice = application_choice
         @course_change_path = course_change_path
         @title = title
         @reason = reason
+        @lead_in = lead_in
         @alternatives = alternatives.compact_blank
       end
     end

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -88,6 +88,10 @@ module CandidateInterface
       end
     end
 
+    def course_not_open_for_applications_yet?(application_choice)
+      application_choice.course.applications_open_from > Time.zone.today
+    end
+
     def application_choices
       @application_choices ||= if @display_accepted_application_choices && application_choice_with_accepted_state_present?
                                  # Reject all applications that do not have an ACCEPTED_STATE
@@ -96,6 +100,17 @@ module CandidateInterface
                                else
                                  all_application_choices
                                end
+    end
+
+    def unavailable(application_choice:, **kwargs, &block)
+      render(
+        UnavailableComponent.new(
+          course_change_path: course_change_path(application_choice),
+          application_choice:,
+          **kwargs,
+        ),
+        &block
+      )
     end
 
   private
@@ -342,6 +357,18 @@ module CandidateInterface
 
     def return_to_section_review_params
       { 'return-to' => 'section-review' }
+    end
+
+    class UnavailableComponent < ViewComponent::Base
+      include ViewHelper
+
+      def initialize(application_choice:, course_change_path:, title:, reason: nil, alternatives: [])
+        @application_choice = application_choice
+        @course_change_path = course_change_path
+        @title = title
+        @reason = reason
+        @alternatives = alternatives.compact_blank
+      end
     end
   end
 end

--- a/app/components/candidate_interface/course_choices_review_component/unavailable_component.html.erb
+++ b/app/components/candidate_interface/course_choices_review_component/unavailable_component.html.erb
@@ -1,20 +1,18 @@
-<p class="app-inset-text__title"><%= @title %></p>
+<h2 class="govuk-heading-s app-inset-text__title"><%= @title %></h2>
 
 <% if @reason %>
   <p class="govuk-body"><%= @reason %></p>
 <% end %>
 
-<p class="govuk-body">You can:</p>
-<ul class="govuk-list govuk-list--bullet">
+<% if @lead_in %>
+  <p class="govuk-body"><%= @lead_in %></p>
+  <ul class="govuk-list govuk-list--bullet">
+    <% @alternatives.each do |alternative| %>
+      <li><%= alternative %></li>
+    <% end %>
+  </ul>
+<% else %>
   <% @alternatives.each do |alternative| %>
-    <li><%= alternative %></li>
+    <p class="govuk-body"><%= alternative %></li>
   <% end %>
-  <li><%= govuk_link_to 'delete this choice', candidate_interface_confirm_destroy_course_choice_path(@application_choice.id) %></li>
-  <% if @course_change_path %>
-    <li><%= govuk_link_to 'change to another course', @course_change_path %></li>
-  <% end %>
-  <li>
-    <%= govuk_link_to 'contact the training provider', "#{@application_choice.course.find_url}#section-contact" %>
-    to see if the course will re-open or discuss alternatives
-  </li>
-</ul>
+<% end %>

--- a/app/components/candidate_interface/course_choices_review_component/unavailable_component.html.erb
+++ b/app/components/candidate_interface/course_choices_review_component/unavailable_component.html.erb
@@ -1,0 +1,20 @@
+<p class="app-inset-text__title"><%= @title %></p>
+
+<% if @reason %>
+  <p class="govuk-body"><%= @reason %></p>
+<% end %>
+
+<p class="govuk-body">You can:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <% @alternatives.each do |alternative| %>
+    <li><%= alternative %></li>
+  <% end %>
+  <li><%= govuk_link_to 'delete this choice', candidate_interface_confirm_destroy_course_choice_path(@application_choice.id) %></li>
+  <% if @course_change_path %>
+    <li><%= govuk_link_to 'change to another course', @course_change_path %></li>
+  <% end %>
+  <li>
+    <%= govuk_link_to 'contact the training provider', "#{@application_choice.course.find_url}#section-contact" %>
+    to see if the course will re-open or discuss alternatives
+  </li>
+</ul>

--- a/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
@@ -3,6 +3,7 @@ module CandidateInterface
     before_action :redirect_to_dashboard_if_submitted
     before_action :redirect_to_application_if_between_cycles, except: %w[show review]
     before_action :redirect_to_carry_over, except: %w[review]
+    before_action :set_unavailable_courses, only: %w[review submit_show]
 
     def show
       @application_form_presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
@@ -63,6 +64,11 @@ module CandidateInterface
       return unless current_application.carry_over?
 
       redirect_to candidate_interface_start_carry_over_path
+    end
+
+    def set_unavailable_courses
+      @courses_not_yet_open = GetCoursesNotYetOpenForApplication.new(application_form: current_application).call
+      @full_courses = GetFullCoursesForApplication.new(application_form: current_application).call
     end
   end
 end

--- a/app/forms/candidate_interface/pick_course_form.rb
+++ b/app/forms/candidate_interface/pick_course_form.rb
@@ -64,7 +64,7 @@ module CandidateInterface
     end
 
     def available_courses
-      @available_courses ||= courses_for_current_cycle.exposed_in_find.open_for_applications.includes(:accredited_provider, :course_options).order(:name)
+      @available_courses ||= courses_for_current_cycle.exposed_in_find.includes(:accredited_provider, :course_options).order(:name)
     end
 
     def courses_with_names

--- a/app/forms/candidate_interface/pick_provider_form.rb
+++ b/app/forms/candidate_interface/pick_provider_form.rb
@@ -9,7 +9,6 @@ module CandidateInterface
       @available_providers ||= Provider
       .joins(:courses)
       .where(courses: { recruitment_cycle_year: RecruitmentCycle.current_year, exposed_in_find: true })
-      .where('courses.applications_open_from <= ?', Time.zone.today)
       .order(:name)
       .distinct
     end

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -161,6 +161,7 @@ class ApplicationChoice < ApplicationRecord
       course_full?,
       site_full?,
       study_mode_full?,
+      !course.open_for_applications?,
     ].any?
   end
 

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -252,6 +252,10 @@ class ApplicationForm < ApplicationRecord
     choices_left_to_make.positive?
   end
 
+  def courses_not_yet_open
+    @courses_not_yet_open ||= application_choices.each.with_object([]) { |choice, array| array << choice.course if choice.course.applications_open_from > Time.zone.today }
+  end
+
   def recruited?
     application_choices.recruited.any?
   end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -256,6 +256,10 @@ class ApplicationForm < ApplicationRecord
     @courses_not_yet_open ||= application_choices.each.with_object([]) { |choice, array| array << choice.course if choice.course.applications_open_from > Time.zone.today }
   end
 
+  def full_courses
+    @full_courses ||= application_choices.each.with_object([]) { |choice, array| array << choice.course if choice.course_option.no_vacancies? }
+  end
+
   def recruited?
     application_choices.recruited.any?
   end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -252,14 +252,6 @@ class ApplicationForm < ApplicationRecord
     choices_left_to_make.positive?
   end
 
-  def courses_not_yet_open
-    @courses_not_yet_open ||= application_choices.each.with_object([]) { |choice, array| array << choice.course if choice.course.applications_open_from > Time.zone.today }
-  end
-
-  def full_courses
-    @full_courses ||= application_choices.each.with_object([]) { |choice, array| array << choice.course if choice.course_option.no_vacancies? }
-  end
-
   def recruited?
     application_choices.recruited.any?
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -123,6 +123,10 @@ class Course < ApplicationRecord
     !exposed_in_find
   end
 
+  def open_for_applications?
+    applications_open_from <= Time.zone.today
+  end
+
   def fee_paying?
     funding_type == 'fee'
   end

--- a/app/queries/get_courses_not_yet_open_for_application.rb
+++ b/app/queries/get_courses_not_yet_open_for_application.rb
@@ -1,0 +1,11 @@
+class GetCoursesNotYetOpenForApplication
+  attr_reader :application_form
+
+  def initialize(application_form:)
+    @application_form = application_form
+  end
+
+  def call
+    application_form.application_choices.reject { |choice| choice.course.open_for_applications? }.map(&:course)
+  end
+end

--- a/app/queries/get_full_courses_for_application.rb
+++ b/app/queries/get_full_courses_for_application.rb
@@ -1,0 +1,13 @@
+class GetFullCoursesForApplication
+  attr_reader :application_form
+
+  def initialize(application_form:)
+    @application_form = application_form
+  end
+
+  def call
+    application_form.application_choices
+      .select { |choice| choice.course_option.no_vacancies? }
+      .map(&:course)
+  end
+end

--- a/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
@@ -42,6 +42,13 @@
   <p class='govuk-body'>You can no longer submit applications from this account. Visit your other account to continue your application.</p>
   <p class='govuk-body'>You can apply for up to 3 courses at a time.</p>
   <p class='govuk-body'>Email becomingateacher@digital.education.gov.uk if you have any questions.</p>
+<% elsif (closed_courses = @application_form.courses_not_yet_open).any? %>
+  <p class='govuk-body'>You cannot submit this application because:<p>
+  <ul class="govuk-list govuk-list--bullet">
+    <% closed_courses.each do |course| %>
+    <li> you can only apply for <%= course.name_and_code %> from <%= course.applications_open_from.to_fs(:govuk_date) %></li>
+  <% end %>
+  </ul>
 <% elsif !CycleTimetable.between_cycles?(@application_form.phase) %>
   <%= govuk_button_link_to t('continue'), candidate_interface_start_equality_and_diversity_path %>
 <% end %>

--- a/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
@@ -42,13 +42,13 @@
   <p class='govuk-body'>You can no longer submit applications from this account. Visit your other account to continue your application.</p>
   <p class='govuk-body'>You can apply for up to 3 courses at a time.</p>
   <p class='govuk-body'>Email becomingateacher@digital.education.gov.uk if you have any questions.</p>
-<% elsif @application_form.courses_not_yet_open.any? || @application_form.full_courses.any? %>
+<% elsif @courses_not_yet_open.any? || @full_courses.any? %>
   <p class='govuk-body'>You cannot submit this application as:<p>
   <ul class="govuk-list govuk-list--bullet">
-    <% @application_form.courses_not_yet_open.each do |course| %>
+    <% @courses_not_yet_open.each do |course| %>
       <li><%= course.name_and_code %> will not open for applications until <%= course.applications_open_from.to_fs(:govuk_date) %></li>
     <% end %>
-    <% @application_form.full_courses.each do |course| %>
+    <% @full_courses.each do |course| %>
       <li><%= course.name_and_code %> has no vacancies </li>
     <% end %>
   </ul>

--- a/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
@@ -49,7 +49,7 @@
       <li><%= course.name_and_code %> will not open for applications until <%= course.applications_open_from.to_fs(:govuk_date) %></li>
     <% end %>
     <% @application_form.full_courses.each do |course| %>
-      <li><%= course.name_and_code %> has not vacancies </li>
+      <li><%= course.name_and_code %> has no vacancies </li>
     <% end %>
   </ul>
 <% elsif !CycleTimetable.between_cycles?(@application_form.phase) %>

--- a/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
@@ -42,12 +42,15 @@
   <p class='govuk-body'>You can no longer submit applications from this account. Visit your other account to continue your application.</p>
   <p class='govuk-body'>You can apply for up to 3 courses at a time.</p>
   <p class='govuk-body'>Email becomingateacher@digital.education.gov.uk if you have any questions.</p>
-<% elsif (closed_courses = @application_form.courses_not_yet_open).any? %>
-  <p class='govuk-body'>You cannot submit this application because:<p>
+<% elsif @application_form.courses_not_yet_open.any? || @application_form.full_courses.any? %>
+  <p class='govuk-body'>You cannot submit this application as:<p>
   <ul class="govuk-list govuk-list--bullet">
-    <% closed_courses.each do |course| %>
-    <li> you can only apply for <%= course.name_and_code %> from <%= course.applications_open_from.to_fs(:govuk_date) %></li>
-  <% end %>
+    <% @application_form.courses_not_yet_open.each do |course| %>
+      <li><%= course.name_and_code %> will not open for applications until <%= course.applications_open_from.to_fs(:govuk_date) %></li>
+    <% end %>
+    <% @application_form.full_courses.each do |course| %>
+      <li><%= course.name_and_code %> has not vacancies </li>
+    <% end %>
   </ul>
 <% elsif !CycleTimetable.between_cycles?(@application_form.phase) %>
   <%= govuk_button_link_to t('continue'), candidate_interface_start_equality_and_diversity_path %>

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -260,14 +260,14 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true
         )
 
         render_inline(described_class.new(application_form:))
-        expect(page).to have_text('because it has no vacancies')
+        expect(page).to have_text('You cannot apply to this course as there are no places left on it')
       end
 
       it 'renders the guidance when the site is full' do
         application_form = build(:application_form)
         course = build(:course, :open_on_apply)
 
-        full_choice = create(
+        create(
           :submitted_application_choice,
           application_form:,
           course_option: build(:course_option,
@@ -278,14 +278,14 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true
         create(:course_option, course:)
 
         render_inline(described_class.new(application_form:))
-        expect(page).to have_text(full_choice.site_full_error)
+        expect(page).to have_text('You cannot apply to this course as the chosen location is full')
       end
 
       it 'renders the guidance when the site is invalid' do
         application_form = build(:application_form)
         course = build(:course, :open_on_apply)
 
-        invalid_choice = create(
+        create(
           :submitted_application_choice,
           application_form:,
           course_option: build(:course_option,
@@ -296,7 +296,7 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true
         create(:course_option, course:)
 
         render_inline(described_class.new(application_form:))
-        expect(page).to have_text(invalid_choice.site_invalid_error)
+        expect(page).to have_text('You cannot apply to this course as the chosen location is full')
       end
 
       it 'renders the guidance when the study mode is full' do
@@ -307,7 +307,7 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true
                               :full_time,
                               course:)
 
-        full_choice = create(
+        create(
           :submitted_application_choice,
           application_form:,
           course_option:,
@@ -316,7 +316,7 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true
         create(:course_option, :part_time, course:, site: course_option.site)
 
         render_inline(described_class.new(application_form:))
-        expect(page).to have_text(full_choice.study_mode_full_error)
+        expect(page).to have_text('You cannot apply to this course as the chosen study mode is full')
       end
     end
   end

--- a/spec/factories/course.rb
+++ b/spec/factories/course.rb
@@ -18,6 +18,10 @@ FactoryBot.define do
     funding_type { %w[fee salary apprenticeship].sample }
     course_subjects { [association(:course_subject, course: instance)] }
 
+    trait :unavailable do
+      exposed_in_find { false }
+    end
+
     trait :open_on_apply do
       open_on_apply { true }
       exposed_in_find { true }

--- a/spec/forms/candidate_interface/pick_course_form_spec.rb
+++ b/spec/forms/candidate_interface/pick_course_form_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CandidateInterface::PickCourseForm do
 
       form = described_class.new(provider_id: provider.id)
 
-      expect(form.radio_available_courses.map(&:name)).to eql(['Course you can apply to'])
+      expect(form.radio_available_courses.map(&:name)).to eql(['Course that is not accepting applications', 'Course you can apply to'])
     end
   end
 
@@ -68,18 +68,6 @@ RSpec.describe CandidateInterface::PickCourseForm do
       form = described_class.new(provider_id: provider.id)
 
       expect(form.dropdown_available_courses.map(&:name)).to eql(['This cycle (A)'])
-    end
-
-    it 'only shows courses which are open for applications' do
-      provider = create(:provider)
-      course = create(:course, :open_on_apply, name: 'Course is open for applications', code: 'A', provider:)
-      create(:course, :open_on_apply, name: 'Course is not open for applications', provider:, applications_open_from: Time.zone.tomorrow)
-
-      create(:course_option, course:)
-
-      form = described_class.new(provider_id: provider.id)
-
-      expect(form.dropdown_available_courses.map(&:name)).to eql(['Course is open for applications (A)'])
     end
 
     context 'with no ambiguous courses' do

--- a/spec/forms/candidate_interface/pick_provider_form_spec.rb
+++ b/spec/forms/candidate_interface/pick_provider_form_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::PickProviderForm do
   describe '#available_providers' do
-    it 'returns providers with a course exposed in find in the current cycle which are open to applications' do
+    it 'returns providers with a course exposed in find in the current cycle' do
       create(:provider, name: 'School without courses')
       create(:course, open_on_apply: true, exposed_in_find: false, provider: create(:provider, name: 'School with disabled courses'))
       create(:course, open_on_apply: true, exposed_in_find: true, applications_open_from: Time.zone.today, provider: create(:provider, name: 'School with courses'))
@@ -11,7 +11,7 @@ RSpec.describe CandidateInterface::PickProviderForm do
 
       form = described_class.new({})
 
-      expect(form.available_providers.map(&:name)).to eq(['School with courses'])
+      expect(form.available_providers.map(&:name)).to eq(['School with courses', 'School with courses but not open for applications'])
     end
   end
 end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -947,4 +947,17 @@ RSpec.describe ApplicationForm do
       end
     end
   end
+
+  describe '#courses_not_yet_open' do
+    context 'when the candidate selects a course that is not open' do
+      it 'returns the course' do
+        course = create(:course, :open_on_apply, applications_open_from: 1.day.from_now)
+        course_option = create(:course_option, course: course)
+        application_choice = create(:application_choice, course_option: course_option)
+        application_form = create(:application_form, application_choices: [application_choice])
+
+        expect(application_form.courses_not_yet_open).to eq [course]
+      end
+    end
+  end
 end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -960,4 +960,17 @@ RSpec.describe ApplicationForm do
       end
     end
   end
+
+  describe '#full_courses' do
+    context 'when the candidate selects a course that is full' do
+      it 'returns the course' do
+        course = create(:course, :open_on_apply)
+        course_option = create(:course_option, course: course, vacancy_status: 'no_vacancies')
+        application_choice = create(:application_choice, course_option: course_option)
+        application_form = create(:application_form, application_choices: [application_choice])
+
+        expect(application_form.full_courses).to eq [course]
+      end
+    end
+  end
 end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -947,30 +947,4 @@ RSpec.describe ApplicationForm do
       end
     end
   end
-
-  describe '#courses_not_yet_open' do
-    context 'when the candidate selects a course that is not open' do
-      it 'returns the course' do
-        course = create(:course, :open_on_apply, applications_open_from: 1.day.from_now)
-        course_option = create(:course_option, course: course)
-        application_choice = create(:application_choice, course_option: course_option)
-        application_form = create(:application_form, application_choices: [application_choice])
-
-        expect(application_form.courses_not_yet_open).to eq [course]
-      end
-    end
-  end
-
-  describe '#full_courses' do
-    context 'when the candidate selects a course that is full' do
-      it 'returns the course' do
-        course = create(:course, :open_on_apply)
-        course_option = create(:course_option, course: course, vacancy_status: 'no_vacancies')
-        application_choice = create(:application_choice, course_option: course_option)
-        application_form = create(:application_form, application_choices: [application_choice])
-
-        expect(application_form.full_courses).to eq [course]
-      end
-    end
-  end
 end

--- a/spec/queries/get_courses_not_yet_open_for_application_spec.rb
+++ b/spec/queries/get_courses_not_yet_open_for_application_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe GetCoursesNotYetOpenForApplication do
+  let(:course) { create(:course, :open_on_apply, applications_open_from: 1.day.from_now) }
+  let(:course_option) { create(:course_option, course: course) }
+  let(:application_choice) { create(:application_choice, course_option: course_option) }
+  let(:application_form) { create(:application_form, application_choices: [application_choice]) }
+
+  describe '#call' do
+    context 'when an application form has closed choices' do
+      it 'returns the course' do
+        service = described_class.new(application_form:).call
+
+        expect(service).to eq [course]
+      end
+    end
+  end
+end

--- a/spec/queries/get_full_courses_for_application_spec.rb
+++ b/spec/queries/get_full_courses_for_application_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe GetFullCoursesForApplication do
+  let(:course) { create(:course, :open_on_apply) }
+  let(:course_option) { create(:course_option, course: course, vacancy_status: 'no_vacancies') }
+  let(:application_choice) { create(:application_choice, course_option: course_option) }
+  let(:application_form) { create(:application_form, application_choices: [application_choice]) }
+
+  describe '#call' do
+    context 'when an application form has a full choice' do
+      it 'returns the course' do
+        service = described_class.new(application_form:).call
+
+        expect(service).to eq [course]
+      end
+    end
+  end
+end

--- a/spec/system/candidate_interface/submitting/candidate_reviewing_application_with_unavailable_course_options_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviewing_application_with_unavailable_course_options_spec.rb
@@ -58,21 +58,21 @@ RSpec.feature 'Candidate reviewing an application with unavailable course option
   end
 
   def then_i_see_a_warning_for_the_course_that_is_not_running
-    expect(page).to have_content course_not_running_message
+    expect(page).to have_content 'You cannot apply to this course as it is not running'
   end
 
   def then_i_see_a_warning_for_the_course_with_no_vacancies
-    expect(page).to have_content course_has_no_vacancies_message
+    expect(page).to have_content 'You cannot apply to this course as there are no places left on it'
   end
 
   def then_i_see_a_warning_for_the_course_with_no_vacancies_at_my_chosen_site
-    expect(page).to have_content chosen_site_has_no_vacancies_message
+    expect(page).to have_content 'You cannot apply to this course as the chosen location is full'
   end
 
   def then_i_cannot_submit_the_application
-    expect(page).to have_content 'You cannot submit this application because:'
-    expect(page).to have_content "there are no places left on the #{@option_where_course_has_no_vacancies.course.name_and_code} course"
-    expect(page).to have_content "there are no places left on the #{@option_where_no_vacancies_at_chosen_site.course.name_and_code} course"
+    expect(page).to have_content 'You cannot submit this application as:'
+    expect(page).to have_content "#{@option_where_course_has_no_vacancies.course.name_and_code} has no vacancies"
+    expect(page).to have_content "#{@option_where_no_vacancies_at_chosen_site.course.name_and_code} has no vacancies"
   end
 
 private

--- a/spec/system/candidate_interface/submitting/candidate_reviewing_application_with_unavailable_course_options_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviewing_application_with_unavailable_course_options_spec.rb
@@ -12,8 +12,7 @@ RSpec.feature 'Candidate reviewing an application with unavailable course option
     then_i_see_a_warning_for_the_course_with_no_vacancies
     then_i_see_a_warning_for_the_course_with_no_vacancies_at_my_chosen_site
 
-    when_i_submit_the_application
-    then_i_see_error_messages_for_the_things_i_was_warned_about
+    then_i_cannot_submit_the_application
   end
 
   def given_i_am_signed_in
@@ -70,14 +69,10 @@ RSpec.feature 'Candidate reviewing an application with unavailable course option
     expect(page).to have_content chosen_site_has_no_vacancies_message
   end
 
-  def when_i_submit_the_application
-    click_link t('continue')
-  end
-
-  def then_i_see_error_messages_for_the_things_i_was_warned_about
-    within('.govuk-error-summary') do
-      expect(page).to have_content course_not_running_message
-    end
+  def then_i_cannot_submit_the_application
+    expect(page).to have_content 'You cannot submit this application because:'
+    expect(page).to have_content "there are no places left on the #{@option_where_course_has_no_vacancies.course.name_and_code} course"
+    expect(page).to have_content "there are no places left on the #{@option_where_no_vacancies_at_chosen_site.course.name_and_code} course"
   end
 
 private

--- a/spec/system/candidate_interface/submitting/candidate_submits_application_with_course_not_yet_available_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submits_application_with_course_not_yet_available_spec.rb
@@ -1,12 +1,12 @@
-
 require 'rails_helper'
 
-RSpec.feature 'Candidate submits the application with full course study mode' do
+RSpec.feature 'Candidate submits the application with a course that is not available and full' do
   include CandidateHelper
 
-  it 'The location that the candidate picked has no full time vacancies but does have part time vacancies' do
+  it 'Candidate with a completed application form' do
     given_i_complete_my_application
     and_the_selected_course_is_not_yet_open
+    and_my_second_choice_is_full
     and_i_submit_my_application
 
     then_i_see_a_message_that_i_cannot_submit_my_application
@@ -21,6 +21,12 @@ RSpec.feature 'Candidate submits the application with full course study mode' do
     @course.update!(applications_open_from: 1.day.from_now)
   end
 
+  def and_my_second_choice_is_full
+    @second_course = create(:course)
+    course_option = create(:course_option, vacancy_status: 'no_vacancies', course: @second_course)
+    create(:application_choice, application_form: current_candidate.current_application, course_option: course_option)
+  end
+
   def and_i_submit_my_application
     click_link 'Check and submit your application'
   end
@@ -28,5 +34,6 @@ RSpec.feature 'Candidate submits the application with full course study mode' do
   def then_i_see_a_message_that_i_cannot_submit_my_application
     expect(page).to have_text 'You cannot submit this application because:'
     expect(page).to have_text "you can only apply for #{@course.name_and_code} from #{@course.applications_open_from.to_fs(:govuk_date)}"
+    expect(page).to have_text "there are no places left on the #{@second_course.name_and_code} course"
   end
 end

--- a/spec/system/candidate_interface/submitting/candidate_submits_application_with_course_not_yet_available_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submits_application_with_course_not_yet_available_spec.rb
@@ -32,8 +32,8 @@ RSpec.feature 'Candidate submits the application with a course that is not avail
   end
 
   def then_i_see_a_message_that_i_cannot_submit_my_application
-    expect(page).to have_text 'You cannot submit this application because:'
-    expect(page).to have_text "you can only apply for #{@course.name_and_code} from #{@course.applications_open_from.to_fs(:govuk_date)}"
-    expect(page).to have_text "there are no places left on the #{@second_course.name_and_code} course"
+    expect(page).to have_text 'You cannot submit this application as:'
+    expect(page).to have_text "#{@course.name_and_code} will not open for applications until #{@course.applications_open_from.to_fs(:govuk_date)}"
+    expect(page).to have_text "#{@second_course.name_and_code} has no vacancies"
   end
 end

--- a/spec/system/candidate_interface/submitting/candidate_submits_application_with_course_not_yet_available_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submits_application_with_course_not_yet_available_spec.rb
@@ -1,0 +1,32 @@
+
+require 'rails_helper'
+
+RSpec.feature 'Candidate submits the application with full course study mode' do
+  include CandidateHelper
+
+  it 'The location that the candidate picked has no full time vacancies but does have part time vacancies' do
+    given_i_complete_my_application
+    and_the_selected_course_is_not_yet_open
+    and_i_submit_my_application
+
+    then_i_see_a_message_that_i_cannot_submit_my_application
+  end
+
+  def given_i_complete_my_application
+    candidate_completes_application_form
+  end
+
+  def and_the_selected_course_is_not_yet_open
+    @course = current_candidate.current_application.application_choices.first.course
+    @course.update!(applications_open_from: 1.day.from_now)
+  end
+
+  def and_i_submit_my_application
+    click_link 'Check and submit your application'
+  end
+
+  def then_i_see_a_message_that_i_cannot_submit_my_application
+    expect(page).to have_text 'You cannot submit this application because:'
+    expect(page).to have_text "you can only apply for #{@course.name_and_code} from #{@course.applications_open_from.to_fs(:govuk_date)}"
+  end
+end

--- a/spec/system/candidate_interface/submitting/candidate_submits_application_with_full_course_location_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submits_application_with_full_course_location_spec.rb
@@ -36,11 +36,11 @@ RSpec.feature 'Candidate submits the application with full course choice locatio
   end
 
   def then_i_see_a_warning_that_there_are_no_vacancies_at_my_chosen_location
-    expect(page).to have_content("Your chosen location for ‘#{current_candidate.current_application.application_choices.first.course.provider_and_name_code}’ has no vacancies")
+    expect(page).to have_content 'You cannot apply to this course as the chosen location is full'
   end
 
   def and_i_cannot_proceed
-    expect(page).to have_content 'You cannot submit this application because:'
-    expect(page).to have_content "there are no places left on the #{current_candidate.current_application.application_choices.first.course.name_and_code} course"
+    expect(page).to have_content 'You cannot submit this application as:'
+    expect(page).to have_content "#{current_candidate.current_application.application_choices.first.course.name_and_code} has no vacancies"
   end
 end

--- a/spec/system/candidate_interface/submitting/candidate_submits_application_with_full_course_location_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submits_application_with_full_course_location_spec.rb
@@ -40,8 +40,7 @@ RSpec.feature 'Candidate submits the application with full course choice locatio
   end
 
   def and_i_cannot_proceed
-    click_link t('continue')
-    expect(page).to have_content('There is a problem')
-    expect(page).to have_content("Your chosen location for ‘#{current_candidate.current_application.application_choices.first.course.provider_and_name_code}’ has no vacancies")
+    expect(page).to have_content 'You cannot submit this application because:'
+    expect(page).to have_content "there are no places left on the #{current_candidate.current_application.application_choices.first.course.name_and_code} course"
   end
 end

--- a/spec/system/candidate_interface/submitting/candidate_submits_application_with_full_course_study_mode_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submits_application_with_full_course_study_mode_spec.rb
@@ -41,8 +41,7 @@ RSpec.feature 'Candidate submits the application with full course study mode' do
   end
 
   def and_i_cannot_proceed
-    click_link t('continue')
-    expect(page).to have_content('There is a problem')
-    expect(page).to have_content("Your chosen location for ‘#{current_candidate.current_application.application_choices.first.course.provider_and_name_code}’ has no full time vacancies")
+    expect(page).to have_content 'You cannot submit this application because:'
+    expect(page).to have_content "there are no places left on the #{current_candidate.current_application.application_choices.first.course.name_and_code} course"
   end
 end

--- a/spec/system/candidate_interface/submitting/candidate_submits_application_with_full_course_study_mode_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submits_application_with_full_course_study_mode_spec.rb
@@ -37,11 +37,11 @@ RSpec.feature 'Candidate submits the application with full course study mode' do
   end
 
   def then_i_see_a_warning_that_there_are_no_full_time_vacancies
-    expect(page).to have_content("Your chosen location for ‘#{current_candidate.current_application.application_choices.first.course.provider_and_name_code}’ has no full time vacancies")
+    expect(page).to have_content 'You cannot apply to this course as the chosen study mode is full'
   end
 
   def and_i_cannot_proceed
-    expect(page).to have_content 'You cannot submit this application because:'
-    expect(page).to have_content "there are no places left on the #{current_candidate.current_application.application_choices.first.course.name_and_code} course"
+    expect(page).to have_content 'You cannot submit this application as:'
+    expect(page).to have_content "#{current_candidate.current_application.application_choices.first.course.name_and_code} has no vacancies"
   end
 end


### PR DESCRIPTION
## Context

Currently it's not possibly to add a course to your application via the dropdowns if it is not yet open for applications. (But it is if you use the button on Find).

We’d like to allow candidates to add courses even if they're not yet open, but to then show a message on the Courses page and the Review application page explaining that they cannot submit yet and giving the date the course opens.

## Changes proposed in this pull request

|Course not yet open for applications|
|---|
|<img width="658" alt="image" src="https://user-images.githubusercontent.com/47917431/202507884-c5e0d6df-c543-416c-a99d-14d8096e87a2.png">|

|Course has no vacancies|
|---|
|<img width="640" alt="image" src="https://user-images.githubusercontent.com/47917431/202517937-8dad7dde-8c5a-4b76-a8b5-5ac7fc63745e.png">|

|Chosen location is full but others are available|
|---|
|<img width="660" alt="image" src="https://user-images.githubusercontent.com/47917431/202733085-4dfb3c66-c878-4dbf-bc0f-a62be3a04f5e.png">|

|Course is no longer running|
|---|
|<img width="639" alt="image" src="https://user-images.githubusercontent.com/47917431/202518092-274fda7a-1214-4271-8b1a-62ce489b3077.png">|

|Study mode is full|
|---|
|<img width="651" alt="image" src="https://user-images.githubusercontent.com/47917431/202731961-f06312c4-7f16-46bb-a1e7-dc42860bc483.png">|

|Prevent submissions at review|
|---|
|<img width="875" alt="image" src="https://user-images.githubusercontent.com/47917431/202521704-4e750914-36e6-450b-8973-93b1a3e1e198.png">|


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/gtUT82J2/839-allow-candidate-to-add-courses-that-arent-yet-open-for-applications-but-show-a-message-and-dont-let-them-submit

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
