### PR TITLE
Update a title to a H1 on work history (DAC audit)

### DIFF
--- a/app/views/candidate_interface/restructured_work_history/start/choice.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/start/choice.html.erb
@@ -7,7 +7,7 @@
       <%= f.govuk_error_summary %>
 
       <div class="govuk-!-margin-top-6">
-        <%= f.govuk_radio_buttons_fieldset :choice, legend: { text: t('page_titles.restructured_work_history_choice'), size: 'xl' } do %>
+        <%= f.govuk_radio_buttons_fieldset :choice, legend: { text: t('page_titles.restructured_work_history_choice'), size: 'xl', tag: 'h1' } do %>
           <%= f.govuk_radio_button :choice, :can_complete, label: { text: t('application_form.restructured_work_history.can_complete.label') }, link_errors: true %>
           <%= f.govuk_radio_button :choice, :full_time_education, label: { text: t('application_form.restructured_work_history.full_time_education.label') } %>
           <%= f.govuk_radio_button :choice, :can_not_complete, label: { text: t('application_form.restructured_work_history.can_not_complete.label') } do %>


### PR DESCRIPTION
## Context

Our accessibility audit surfaced a few bugs that we've not yet addressed. I am attempting a tiny one based on how we handle 'h1' tags in the rest of the codebase.

## Changes proposed in this pull request

Add a `tag: 'h1'` to a title that is already sized `xl`.

## Guidance to review

Does this work?

## Link to Trello card

https://trello.com/c/ZZBysdmV/231-make-do-you-have-any-work-history-legend-also-be-an-h1

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
