### PR TITLE
Silence the closed provider notification for now

### DIFF
--- a/app/services/make_offer.rb
+++ b/app/services/make_offer.rb
@@ -38,7 +38,6 @@ class MakeOffer
         ).call!
 
         SendNewOfferEmailToCandidate.new(application_choice:).call
-        NotifyOfOfferByClosedProviders.new(application_choice: application_choice).call
       end
     else
       raise ValidationException, offer.errors.map(&:message)

--- a/spec/services/make_offer_spec.rb
+++ b/spec/services/make_offer_spec.rb
@@ -61,7 +61,6 @@ RSpec.describe MakeOffer do
       it 'then calls various services' do
         set_declined_by_default = instance_double(SetDeclineByDefault, call: true)
         send_new_offer_email_to_candidate = instance_double(SendNewOfferEmailToCandidate, call: true)
-        notify_of_offer_by_closed_providers = instance_double(NotifyOfOfferByClosedProviders, call: true)
 
         allow(SetDeclineByDefault)
             .to receive(:new).with(application_form: application_choice.application_form)
@@ -70,15 +69,11 @@ RSpec.describe MakeOffer do
             .to receive(:new).with(application_choice:)
                     .and_return(send_new_offer_email_to_candidate)
         allow(application_choice).to receive(:update_course_option_and_associated_fields!)
-        allow(NotifyOfOfferByClosedProviders)
-            .to receive(:new).with(application_choice: application_choice)
-                    .and_return(notify_of_offer_by_closed_providers)
 
         make_offer.save!
 
         expect(set_declined_by_default).to have_received(:call)
         expect(send_new_offer_email_to_candidate).to have_received(:call)
-        expect(notify_of_offer_by_closed_providers).to have_received(:call)
         expect(update_conditions_service).to have_received(:save)
         expect(application_choice).to have_received(:update_course_option_and_associated_fields!)
       end


### PR DESCRIPTION
## Context

‼️ 

We set up a slack notification that will alert a channel when a "closed" provider makes an offer. The volume of these notifications is too high, so we'll pause it for now and reactivate it once we have it in a better format
