### PR TITLE
Fix manage bug when user clicks two times in the back link

### DIFF
--- a/app/helpers/course_path_helper.rb
+++ b/app/helpers/course_path_helper.rb
@@ -1,6 +1,6 @@
 module CoursePathHelper
   def course_path_for(application_choice, step, params = {})
-    if step.to_sym == :select_option
+    if step.to_sym.in?(%i[select_option referer])
       provider_interface_application_choice_path(application_choice, params)
     else
       [:edit, :provider_interface, application_choice, :course, step, params]

--- a/spec/helpers/course_path_helper_spec.rb
+++ b/spec/helpers/course_path_helper_spec.rb
@@ -11,6 +11,13 @@ RSpec.describe CoursePathHelper do
       end
     end
 
+    context 'when :referer' do
+      it 'returns the application choice path' do
+        expect(helper.course_path_for(application_choice, 'referer'))
+          .to eq(provider_interface_application_choice_path(application_choice, {}))
+      end
+    end
+
     context 'when any other step' do
       it 'returns the step edit path' do
         expect(helper.course_path_for(application_choice, :other_step, foo: 'bar'))


### PR DESCRIPTION
## Context

This is related to the how wizard works and when you click the back link the first step in retrieved from Redis then it is only left the :referer which we don't have a route for.

Sentry error: https://sentry.io/organizations/dfe-teacher-services/issues/3661762455/?referrer=slack

Slack thread
[https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1668525995444629 - Connect to preview](https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1668525995444629)