### PR TITLE
Include ratifying provider users when a reference is received

### DIFF
--- a/app/services/submit_reference.rb
+++ b/app/services/submit_reference.rb
@@ -25,7 +25,7 @@ class SubmitReference
 private
 
   def notify_provider_users
-    NotificationsList.for(accepted_application, event: :reference_received).uniq.each do |provider_user|
+    NotificationsList.for(accepted_application, include_ratifying_provider: true, event: :reference_received).uniq.each do |provider_user|
       ProviderMailer.reference_received(
         provider_user: provider_user,
         application_choice: accepted_application,


### PR DESCRIPTION
## Context

Ticket in support board that stated that they are not receiving the references for they school direct providers

This is the second support ticket around this issue and this PR adds the feature for it.