### PR TITLE
Updated subject lines on 2 candidate offer emails

### DIFF
--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -6,9 +6,9 @@ en:
       subject: "You’ve submitted your teacher training application"
     candidate_offer:
       single_offer:
-        subject: "Make a decision: successful application for %{provider_name}"
+        subject: "Successful application for %{provider_name}"
       multiple_offers:
-        subject: "Make a decision: successful application for %{provider_name}"
+        subject: "Successful application for %{provider_name}"
       decisions_pending:
         subject: "Successful application for %{provider_name}"
     chase_candidate_decision:

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe CandidateMailer do
 
     it_behaves_like(
       'a mail with subject and content',
-      'Make a decision: successful application for Brighthurst Technical College',
+      'Successful application for Brighthurst Technical College',
       'heading' => 'Dear Bob',
       'decline by default date' => "Respond by #{10.business_days.from_now.to_fs(:govuk_date)}",
       'first_condition' => 'Be cool',
@@ -54,7 +54,7 @@ RSpec.describe CandidateMailer do
 
       it_behaves_like(
         'a mail with subject and content',
-        'Make a decision: successful application for Falconholt Technical College',
+        'Successful application for Falconholt Technical College',
         'heading' => 'Dear Bob',
         'course and provider' => 'offer from Falconholt Technical College to study Computer Science (X0FO)',
         'decline by default date' => "Respond by #{10.business_days.from_now.to_fs(:govuk_date)}",
@@ -70,7 +70,7 @@ RSpec.describe CandidateMailer do
 
     it_behaves_like(
       'a mail with subject and content',
-      'Make a decision: successful application for Brighthurst Technical College',
+      'Successful application for Brighthurst Technical College',
       'heading' => 'Dear Bob',
       'decline by default date' => "Respond by #{10.business_days.from_now.to_fs(:govuk_date)}",
       'first_condition' => 'Be cool',


### PR DESCRIPTION
## Context

The subject lines of 2 of the 'new offer' candidate emails did not match the other candidate emails. Made changes to make these more consistent.

## Changes proposed in this pull request

Removed 'Make a decision:' from the 'new_offer_single_offer' and 'new_offer_multiple offers' email subject lines.

Subject lines now read: Successful application for [provider name]

## Link to Trello card

[<!-- http://trello.com/123-example-card -->](https://trello.com/c/fInCQyYW/895-review-subject-line-of-make-a-decision-emails)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
