### PR TITLE
Include last cycle numbers in stat summary slack post

### DIFF
--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -558,5 +558,12 @@ class CycleTimetable
     )
   end
 
+  def self.this_working_day_last_cycle
+    days_since_cycle_started = apply_opens.to_date.business_days_until(Time.zone.today)
+    last_cycle_opening_date = apply_opens(previous_year).to_date
+    last_cycle_date = days_since_cycle_started.business_days.after(last_cycle_opening_date)
+    DateTime.new(last_cycle_date.year, last_cycle_date.month, last_cycle_date.day, Time.current.hour, Time.current.min, Time.current.sec)
+  end
+
   private_class_method :last_recruitment_cycle_year?
 end

--- a/app/services/stats_summary.rb
+++ b/app/services/stats_summary.rb
@@ -5,47 +5,51 @@ class StatsSummary
     <<~MARKDOWN
       *Today on Apply*
 
-      :wave: #{pluralize(candidate_signups, 'candidate signup')}
-      :pencil: #{pluralize(applications_begun, 'application')} begun
-      :#{mailbox_emoji(applications_submitted)}: #{pluralize(applications_submitted, 'application')} submitted
-      :#{rand(2) == 1 ? 'wo' : nil}man-tipping-hand: #{pluralize(offers_made, 'offer')} made
-      :#{rand(2) == 1 ? 'wo' : nil}man-gesturing-no: #{pluralize(rejections_issued, 'rejection')} issued#{rejections_issued.positive? ? ", of which #{pluralize(rbd_count, 'was')} RBD" : nil}
-      :handshake: #{pluralize(candidates_recruited, 'candidate')} recruited
+      :wave: #{pluralize(candidate_signups(today), 'candidate signup')} | #{candidate_signups(this_day_last_year)} last cycle
+      :pencil: #{pluralize(applications_begun(today), 'application')} begun | #{applications_begun(this_day_last_year)} last cycle
+      :#{mailbox_emoji(applications_submitted(today))}: #{pluralize(applications_submitted(today), 'application')} submitted | #{applications_submitted(this_day_last_year)} last cycle
+      :#{rand(2) == 1 ? 'wo' : nil}man-tipping-hand: #{pluralize(offers_made(today), 'offer')} made | #{offers_made(this_day_last_year)} last cycle
+      :#{rand(2) == 1 ? 'wo' : nil}man-gesturing-no: #{pluralize(rejections_issued(today), 'rejection')} issued#{rejections_issued(today).positive? ? ", of which #{pluralize(rbd_count(today), 'was')} RBD" : nil} | #{rejections_issued(this_day_last_year)} last cycle
+      :handshake: #{pluralize(candidates_recruited(today), 'candidate')} recruited | #{candidates_recruited(this_day_last_year)} last cycle
     MARKDOWN
   end
 
-  def candidate_signups
-    Candidate.where('created_at > ?', beginning_of_period).count
+  def candidate_signups(period)
+    Candidate.where(created_at: period).count
   end
 
-  def applications_begun
-    ApplicationForm.where('created_at > ?', beginning_of_period).count
+  def applications_begun(period)
+    ApplicationForm.where(created_at: period).count
   end
 
-  def applications_submitted
-    ApplicationForm.where('submitted_at > ?', beginning_of_period).count
+  def applications_submitted(period)
+    ApplicationForm.where(submitted_at: period).count
   end
 
-  def offers_made
-    Offer.where('created_at > ?', beginning_of_period).count
+  def offers_made(period)
+    Offer.where(created_at: period).count
   end
 
-  def candidates_recruited
-    ApplicationChoice.where('recruited_at > ?', beginning_of_period).count
+  def candidates_recruited(period)
+    ApplicationChoice.where(recruited_at: period).count
   end
 
-  def rejections_issued
-    ApplicationChoice.where('rejected_at > ?', beginning_of_period).count
+  def rejections_issued(period)
+    ApplicationChoice.where(rejected_at: period).count
   end
 
-  def rbd_count
-    ApplicationChoice.where('rejected_at > ?', beginning_of_period).where(rejected_by_default: true).count
+  def rbd_count(period)
+    ApplicationChoice.where(rejected_at: period).where(rejected_by_default: true).count
   end
 
 private
 
-  def beginning_of_period
-    Time.zone.now.beginning_of_day
+  def today
+    Time.zone.now.beginning_of_day..Time.zone.now
+  end
+
+  def this_day_last_year
+    CycleTimetable.this_working_day_last_cycle.beginning_of_day..CycleTimetable.this_working_day_last_cycle
   end
 
   def mailbox_emoji(message_count)

--- a/spec/services/stats_summary_spec.rb
+++ b/spec/services/stats_summary_spec.rb
@@ -8,14 +8,23 @@ RSpec.describe StatsSummary do
     create(:application_choice, :with_rejection)
     create(:application_choice, :with_rejection_by_default)
 
+    travel_temporarily_to(1.year.ago) do
+      last_cycle_form = create(:application_form)
+      create(:application_choice, :with_recruited, application_form: last_cycle_form)
+      create(:application_choice, :with_offer, application_form: last_cycle_form)
+      create(:application_choice, :with_rejection, application_form: last_cycle_form)
+      create(:application_choice, :with_rejection)
+      create(:application_choice, :with_offer)
+    end
+
     output = described_class.new.as_slack_message
 
-    expect(output).to match(/5 candidate signups/)
-    expect(output).to match(/5 applications begun/)
-    expect(output).to match(/1 application submitted/)
-    expect(output).to match(/1 candidate recruited/)
-    expect(output).to match(/2 offers made/)
+    expect(output).to match(/5 candidate signups | 3 last cycle/)
+    expect(output).to match(/5 applications begun | 3 last cycle/)
+    expect(output).to match(/1 application submitted | 0 last cycle/)
+    expect(output).to match(/1 candidate recruited | 1 last cycle/)
+    expect(output).to match(/2 offers made | 3 last cycle/)
     expect(output).to match(/2 rejections issued/)
-    expect(output).to match(/of which 1 was RBD/)
+    expect(output).to match(/of which 1 was RBD | 2 last cycle/)
   end
 end


### PR DESCRIPTION
## Context

We post an end of day stat summary for the service – it would be useful to include numbers from last cycle for comparison.

## Changes proposed in this pull request

`StatsSummary` methods now take a time range, which will be an equal period for this year and the last.