### PR TITLE
Sandbox only: update course UUIDs

### DIFF
--- a/app/services/data_migrations/backfill_sandbox_course_uuids.rb
+++ b/app/services/data_migrations/backfill_sandbox_course_uuids.rb
@@ -1,0 +1,33 @@
+module DataMigrations
+  class BackfillSandboxCourseUuids
+    TIMESTAMP = 20221117152407
+    MANUAL_RUN = true
+
+    def change
+      raise 'Sandbox only' unless HostingEnvironment.sandbox_mode?
+
+      Provider
+        .joins(:courses).where(courses: { recruitment_cycle_year: 2023 }).distinct
+        .find_each(batch_size: 100) do |provider|
+          TeacherTrainingPublicAPI::Course.where(
+            year: 2023,
+            provider_code: provider.code,
+          ).paginate(per_page: 500).each do |course_from_api|
+            next unless (match = matching_course(provider, course_from_api))
+
+            match.update(uuid: course_from_api.uuid) unless match.uuid == course_from_api.uuid
+          end
+        end
+    end
+
+  private
+
+    def matching_course(provider, course_from_api)
+      Course.find_by(
+        provider: provider,
+        code: course_from_api.code,
+        recruitment_cycle_year: 2023,
+      )
+    end
+  end
+end

--- a/app/services/data_migrations/backfill_sandbox_course_uuids.rb
+++ b/app/services/data_migrations/backfill_sandbox_course_uuids.rb
@@ -2,22 +2,34 @@ module DataMigrations
   class BackfillSandboxCourseUuids
     TIMESTAMP = 20221117152407
     MANUAL_RUN = true
+    RECRUITMENT_CYCLE_YEAR = 2023
 
     def change
       raise 'Sandbox only' unless HostingEnvironment.sandbox_mode?
 
-      Provider
-        .joins(:courses).where(courses: { recruitment_cycle_year: 2023 }).distinct
-        .find_each(batch_size: 100) do |provider|
-          TeacherTrainingPublicAPI::Course.where(
-            year: 2023,
-            provider_code: provider.code,
-          ).paginate(per_page: 500).each do |course_from_api|
-            next unless (match = matching_course(provider, course_from_api))
+      providers.find_each(batch_size: 100) do |provider|
+        courses_for_provider(provider).each do |course_from_api|
+          next unless (match = matching_course(provider, course_from_api))
 
-            match.update(uuid: course_from_api.uuid) unless match.uuid == course_from_api.uuid
-          end
+          match.update(uuid: course_from_api.uuid) unless match.uuid == course_from_api.uuid
         end
+      end
+    end
+
+    def providers
+      Provider
+        .joins(:courses)
+        .where(courses: { recruitment_cycle_year: RECRUITMENT_CYCLE_YEAR })
+        .distinct
+    end
+
+    def courses_for_provider(provider)
+      TeacherTrainingPublicAPI::Course.where(
+        year: RECRUITMENT_CYCLE_YEAR,
+        provider_code: provider.code,
+      ).paginate(per_page: 500).to_a
+    rescue JsonApiClient::Errors::NotFound
+      []
     end
 
   private
@@ -26,7 +38,7 @@ module DataMigrations
       Course.find_by(
         provider: provider,
         code: course_from_api.code,
-        recruitment_cycle_year: 2023,
+        recruitment_cycle_year: RECRUITMENT_CYCLE_YEAR,
       )
     end
   end

--- a/app/services/data_migrations/backfill_sandbox_course_uuids.rb
+++ b/app/services/data_migrations/backfill_sandbox_course_uuids.rb
@@ -11,7 +11,7 @@ module DataMigrations
         courses_for_provider(provider).each do |course_from_api|
           next unless (match = matching_course(provider, course_from_api))
 
-          match.update(uuid: course_from_api.uuid) unless match.uuid == course_from_api.uuid
+          match.update_columns(uuid: course_from_api.uuid) unless match.uuid == course_from_api.uuid
         end
       end
     end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillSandboxCourseUuids',
   'DataMigrations::RemoveReferencesProviderFeatureFlag',
   'DataMigrations::RemoveCandidateReferenceFlowFeatureFlag',
   'DataMigrations::RemoveNewDegreeFlowFeatureFlag',

--- a/spec/services/data_migrations/backfill_sandbox_course_uuids_spec.rb
+++ b/spec/services/data_migrations/backfill_sandbox_course_uuids_spec.rb
@@ -50,4 +50,14 @@ RSpec.describe DataMigrations::BackfillSandboxCourseUuids do
       expect { described_class.new.change }.to raise_error(StandardError)
     end
   end
+
+  describe 'continues if provider is not on the API' do
+    before do
+      allow(TeacherTrainingPublicAPI::Course).to receive(:where).with(year: 2023, provider_code: provider.code).and_raise(JsonApiClient::Errors::NotFound, '404')
+    end
+
+    it 'returns empty array' do
+      expect(described_class.new.courses_for_provider(provider)).to be_empty
+    end
+  end
 end

--- a/spec/services/data_migrations/backfill_sandbox_course_uuids_spec.rb
+++ b/spec/services/data_migrations/backfill_sandbox_course_uuids_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillSandboxCourseUuids do
+  include TeacherTrainingPublicAPIHelper
+
+  let(:provider) { create(:provider) }
+  let(:up_to_date_course_uuid) { SecureRandom.uuid }
+  let(:out_of_date_course_uuid) { SecureRandom.uuid }
+  let(:new_course_uuid) { SecureRandom.uuid }
+  let!(:up_to_date_course) { create(:course, provider:, uuid: up_to_date_course_uuid) }
+  let!(:out_of_date_course) { create(:course, provider:, uuid: out_of_date_course_uuid) }
+
+  before do
+    allow(HostingEnvironment).to receive(:sandbox_mode?).and_return(true)
+
+    stub_teacher_training_api_courses(
+      provider_code: provider.code,
+      recruitment_cycle_year: RecruitmentCycle.current_year,
+      specified_attributes: [
+        { code: up_to_date_course.code, uuid: up_to_date_course_uuid },
+        { code: out_of_date_course.code, uuid: new_course_uuid },
+      ],
+    )
+  end
+
+  describe '#change' do
+    context 'course uuid varies between TTAPI and apply' do
+      it 'updates the uuid' do
+        expect { described_class.new.change }
+          .to change { out_of_date_course.reload.uuid }
+          .from(out_of_date_course_uuid)
+          .to(new_course_uuid)
+      end
+    end
+
+    context 'course uuid does not vary between TTAPI and apply' do
+      it 'does not update the uuid' do
+        expect { described_class.new.change }
+          .not_to(change { up_to_date_course.reload.uuid })
+      end
+    end
+  end
+
+  describe 'failing in non-sandbox environment' do
+    before do
+      allow(HostingEnvironment).to receive(:sandbox_mode?).and_return(false)
+    end
+
+    it 'throws an exception' do
+      expect { described_class.new.change }.to raise_error(StandardError)
+    end
+  end
+end


### PR DESCRIPTION
## Context

We have seen an issue on Sandbox whereby courses aren't showing up, because `exposed_on_find == false`, which doesn't correspond to the `exposed` property on the Publish API. It turns out the sync job is failing due to a validation error.

When the sync job syncs a given course from the API, it tries to find a match on the Apply database by uuid and recruitment_cycle_year. However, as Sandbox Publish courses have changed UUIDs following a backup-and-restore from Production, course UUIDs are no longer matching. Hence we get a validation error when trying to create a new course with the same provider, course code and recruitment cycle.

## Changes proposed in this pull request

This data migration runs on Sandbox only to update Course#uuid to match the corresponding value on Publish. Once it has run, a full Publish API sync should update the rest of the data.

## Guidance to review

Run the data migration against a snapshot.

## Link to Trello card

https://trello.com/c/3Wgs9iw0/815-problem-with-sandbox-sync

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
