### PR TITLE
903 referee email chasers sent by statuses

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -25,8 +25,8 @@ class CandidateMailer < ApplicationMailer
 
   def chase_reference(reference)
     @reference = reference
+    @provider_name = reference.provider_name
     @application_form = @reference.application_form
-    @provider_name = @application_form.application_choices.pending_conditions.first.provider.name
 
     email_for_candidate(
       reference.application_form,
@@ -36,7 +36,7 @@ class CandidateMailer < ApplicationMailer
 
   def chase_reference_again(referee)
     @referee = referee
-    @provider_name = referee.application_form.application_choices.pending_conditions.first.provider.name
+    @provider_name = referee.provider_name
 
     email_for_candidate(
       referee.application_form,
@@ -47,7 +47,7 @@ class CandidateMailer < ApplicationMailer
   def new_referee_request(reference, reason:)
     @reference = reference
     @reason = reason
-    @provider_name = reference.application_form.application_choices.pending_conditions.first.provider.name
+    @provider_name = reference.provider_name
 
     email_for_candidate(
       reference.application_form,

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -26,6 +26,7 @@ class CandidateMailer < ApplicationMailer
   def chase_reference(reference)
     @reference = reference
     @application_form = @reference.application_form
+    @provider_name = @application_form.application_choices.pending_conditions.first.provider.name
 
     email_for_candidate(
       reference.application_form,
@@ -35,6 +36,7 @@ class CandidateMailer < ApplicationMailer
 
   def chase_reference_again(referee)
     @referee = referee
+    @provider_name = referee.application_form.application_choices.pending_conditions.first.provider.name
 
     email_for_candidate(
       referee.application_form,
@@ -45,6 +47,7 @@ class CandidateMailer < ApplicationMailer
   def new_referee_request(reference, reason:)
     @reference = reference
     @reason = reason
+    @provider_name = reference.application_form.application_choices.pending_conditions.first.provider.name
 
     email_for_candidate(
       reference.application_form,

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -136,4 +136,10 @@ class ApplicationReference < ApplicationRecord
 
     replace_referee_at < Time.zone.now
   end
+
+  def provider_name
+    application_form.application_choices.where(
+      status: GetRefereesToChase::APPLICATION_STATUSES,
+    ).first&.provider&.name
+  end
 end

--- a/app/services/get_referees_to_chase.rb
+++ b/app/services/get_referees_to_chase.rb
@@ -8,10 +8,12 @@ class GetRefereesToChase
 
   def call
     ApplicationReference.joins(:application_form)
+      .joins(application_form: :application_choices)
       .feedback_requested
       .where(
         application_forms: {
           recruitment_cycle_year: RecruitmentCycle.current_year,
+          application_choices: { status: ['pending_conditions'] },
         }.merge(only_chase_apply_again_references),
       )
       .where('requested_at < ?', chase_referee_by)

--- a/app/services/get_referees_to_chase.rb
+++ b/app/services/get_referees_to_chase.rb
@@ -1,5 +1,6 @@
 class GetRefereesToChase
   attr_accessor :chase_referee_by, :rejected_chased_ids
+  APPLICATION_STATUSES = ApplicationStateChange::SUCCESSFUL_STATES - [:offer]
 
   def initialize(chase_referee_by:, rejected_chased_ids:)
     @chase_referee_by = chase_referee_by
@@ -13,7 +14,7 @@ class GetRefereesToChase
       .where(
         application_forms: {
           recruitment_cycle_year: RecruitmentCycle.current_year,
-          application_choices: { status: ['pending_conditions'] },
+          application_choices: { status: APPLICATION_STATUSES },
         }.merge(only_chase_apply_again_references),
       )
       .where('requested_at < ?', chase_referee_by)

--- a/app/views/candidate_mailer/chase_reference.text.erb
+++ b/app/views/candidate_mailer/chase_reference.text.erb
@@ -11,4 +11,4 @@ You can sign into your account to:
 
 [Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>).
 
-<%= @application_form.application_choices.pending_conditions.first.provider.name %> must check your references before they can confirm your place on the course. Contact them if you need help getting references or choosing who to ask.
+<%= @provider_name %> must check your references before they can confirm your place on the course. Contact them if you need help getting references or choosing who to ask.

--- a/app/views/candidate_mailer/chase_reference_again.text.erb
+++ b/app/views/candidate_mailer/chase_reference_again.text.erb
@@ -2,7 +2,7 @@ Dear <%= @application_form.first_name %>
 
 You asked <%= @referee.name %> for a reference for your teacher training application. They have not replied yet.
 
-<%= @referee.application_form.application_choices.pending_conditions.first&.provider&.name %> needs to check your references before they can confirm your place on the course.
+<%= @provider_name %> needs to check your references before they can confirm your place on the course.
 
 You can sign into your account to:
 
@@ -13,4 +13,4 @@ You can sign into your account to:
 
 [Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>).
 
-Contact <%= @referee.application_form.application_choices.pending_conditions.first&.provider&.name %> if you need help getting references or choosing who to ask.
+Contact <%= @provider_name %> if you need help getting references or choosing who to ask.

--- a/app/views/candidate_mailer/new_referee_request.text.erb
+++ b/app/views/candidate_mailer/new_referee_request.text.erb
@@ -10,7 +10,7 @@ Your request did not reach <%= @reference.name %>. This could be because:
 - you entered the wrong email address
 
 
-It’s important that <%= @reference.application_form.application_choices.pending_conditions.first&.provider&.name %> receives your references as soon as possible.
+It’s important that <%= @provider_name %> receives your references as soon as possible.
 
 You can sign into your account to:
 
@@ -22,7 +22,7 @@ You can sign into your account to:
 
 <%= @reference.name %> has said that they’re unable to give you a reference.
 
-It’s important that <%= @reference.application_form.application_choices.pending_conditions.first&.provider&.name %> receives your references as soon as possible.
+It’s important that <%= @provider_name %> receives your references as soon as possible.
 
 You can sign into your account to request a reference from someone else.
 
@@ -30,7 +30,7 @@ You can sign into your account to request a reference from someone else.
 
 You asked <%= @reference.name %> for a reference for your teacher training application. They have not replied yet.
 
-It’s important that <%= @reference.application_form.application_choices.pending_conditions.first&.provider&.name %> receives your references as soon as possible.
+It’s important that <%= @provider_name %> receives your references as soon as possible.
 
 You can sign into your account to:
 
@@ -42,4 +42,4 @@ You can sign into your account to:
 <% end %>
 [Sign into your account](<%= candidate_magic_link(@candidate) %>).
 
-<%= @reference.application_form.application_choices.pending_conditions.first&.provider&.name %> must check your references before they can confirm your place on the course. Contact them if you need help getting references or choosing who to ask.
+<%= @provider_name %> must check your references before they can confirm your place on the course. Contact them if you need help getting references or choosing who to ask.

--- a/spec/services/get_referees_to_chase_spec.rb
+++ b/spec/services/get_referees_to_chase_spec.rb
@@ -2,12 +2,29 @@ require 'rails_helper'
 
 RSpec.describe GetRefereesToChase do
   describe '#call' do
+    context 'when application is not pending conditions', time: (CycleTimetable.find_reopens(2023) + 10.days) do
+      it 'does not return references to chase' do
+        application_form = create(:application_form, :minimum_info, recruitment_cycle_year: 2023)
+        create(:reference, :feedback_requested, application_form:, requested_at: 8.days.ago)
+        create(:application_choice, :with_recruited, application_form:)
+        create(:submitted_application_choice, application_form:)
+        create(:application_choice, :withdrawn, application_form:)
+
+        references = described_class.new(
+          chase_referee_by: 7.days.before(1.second.from_now),
+          rejected_chased_ids: [],
+        ).call
+        expect(references).to be_empty
+      end
+    end
+
     context 'when between apply 1 deadline and find has opened', time: (CycleTimetable.apply_1_deadline(2022) + 1.day) do
       it 'returns requested references for candidates on apply 2 only for the current cycle' do
         application_form = create(:application_form, :minimum_info, recruitment_cycle_year: 2022)
         create(:reference, :feedback_requested, application_form: application_form, requested_at: CycleTimetable.apply_1_deadline - 7.days)
 
         application_form_apply_again = create(:application_form, :minimum_info, recruitment_cycle_year: 2022, phase: 'apply_2')
+        create(:application_choice, :with_accepted_offer, application_form: application_form_apply_again)
         first_reference_apply_again = create(:reference, :feedback_requested, application_form: application_form_apply_again, requested_at: 8.days.ago)
         second_reference_apply_again = create(:reference, :feedback_requested, application_form: application_form_apply_again, requested_at: 8.days.ago)
 
@@ -29,9 +46,11 @@ RSpec.describe GetRefereesToChase do
         create(:reference, :feedback_requested, application_form: old_application_form, requested_at: CycleTimetable.find_reopens(2023) - 7.days)
 
         old_application_form_apply_again = create(:application_form, :minimum_info, recruitment_cycle_year: 2022, phase: 'apply_2')
+        create(:application_choice, :with_accepted_offer, application_form: old_application_form_apply_again)
         create(:reference, :feedback_requested, application_form: old_application_form_apply_again, requested_at: CycleTimetable.find_reopens(2023) - 7.days)
 
         application_form = create(:application_form, :minimum_info, recruitment_cycle_year: 2023)
+        create(:application_choice, :with_accepted_offer, application_form:)
         reference = create(:reference, :feedback_requested, application_form: application_form, requested_at: CycleTimetable.find_reopens(2023))
 
         references = described_class.new(

--- a/spec/services/get_referees_to_chase_spec.rb
+++ b/spec/services/get_referees_to_chase_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe GetRefereesToChase do
           chase_referee_by: 7.days.before(1.second.from_now),
           rejected_chased_ids: [],
         ).call
-        expect(references).to eq([reference, second_application_form_reference])
+        expect(references).to include(reference, second_application_form_reference)
       end
     end
 


### PR DESCRIPTION
## Context

We are seeing Sentry errors for candidates in these additional statuses. We need to agree the policy to ensure we are:

Consistent
Sensible in when we nudge referees (i.e. what our policy should be for other statuses and whether collecting references at this stage makes sense)
