### PR TITLE
Updating heading for reasons for rejection page

### DIFF
--- a/app/views/provider_interface/rejections/new.html.erb
+++ b/app/views/provider_interface/rejections/new.html.erb
@@ -16,8 +16,7 @@
             <span class="govuk-caption-l">Give feedback - <%= @application_choice.application_form.full_name %></span>
             Reasons the application was rejected
           <% else %>
-            <span class="govuk-caption-l">Reject application - <%= @application_choice.application_form.full_name %></span>
-            Reasons for rejecting the application
+            Tell <%= @application_choice.application_form.full_name %> why you are rejecting their application
           <% end %>
         </h1>
       <% end %>


### PR DESCRIPTION
This aims to make it clearer that the rejection reasons are being sent to the candidate and should be directed at them.

We have evidence that some providers do not currently understand this, as they are writing about the candidate in the third person and using very short, terse reasons such as.

## Screenshots

### Before

<img width="957" alt="Screenshot 2022-11-18 at 16 25 40" src="https://user-images.githubusercontent.com/30665/202754724-2a747920-6e52-4325-8263-b6bb85bf0726.png">

### After

<img width="1063" alt="Screenshot 2022-11-18 at 16 26 41" src="https://user-images.githubusercontent.com/30665/202754762-e390fb0f-a00e-4f64-9fa5-087afdfba0a8.png">
