### PR TITLE
Allow duplicate match worker to notify slack on a different schedule

### DIFF
--- a/app/services/update_duplicate_matches.rb
+++ b/app/services/update_duplicate_matches.rb
@@ -1,8 +1,9 @@
 class UpdateDuplicateMatches
-  def initialize(matches: GetDuplicateMatches.call, send_email: true, block_submission: true)
+  def initialize(matches: GetDuplicateMatches.call, send_email: true, block_submission: true, notify_slack_at: nil)
     @matches = matches
     @send_email = send_email
     @block_submission = block_submission
+    @notify_slack_at = notify_slack_at
   end
 
   def save!
@@ -16,7 +17,7 @@ class UpdateDuplicateMatches
       :female-detective: In total there #{total_match_count == 1 ? 'is' : 'are'} #{total_match_count} #{'match'.pluralize(total_match_count)} :male-detective:
     MSG
 
-    SlackNotificationWorker.perform_async(message)
+    SlackNotificationWorker.perform_async(message) if @notify_slack_at.blank? || Time.zone.now.hour == @notify_slack_at
   end
 
 private

--- a/app/workers/update_duplicate_matches_worker.rb
+++ b/app/workers/update_duplicate_matches_worker.rb
@@ -3,7 +3,7 @@ class UpdateDuplicateMatchesWorker
 
   sidekiq_options retry: 0, queue: :low_priority
 
-  def perform
-    UpdateDuplicateMatches.new.save!
+  def perform(notify_slack_at: nil)
+    UpdateDuplicateMatches.new(notify_slack_at:).save!
   end
 end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -17,14 +17,14 @@ class Clock
   # Hourly jobs
 
   every(1.hour, 'SendFindStartOfCycleProviderEmails', at: '**:05') { StartOfCycleNotificationWorker.perform_async }
-
   every(1.hour, 'RejectApplicationsByDefault', at: '**:10') { RejectApplicationsByDefaultWorker.perform_async }
   every(1.hour, 'DeclineOffersByDefault', at: '**:15') { DeclineOffersByDefaultWorker.perform_async }
   every(1.hour, 'ChaseReferences', at: '**:20') { ChaseReferences.perform_async }
+  every(1.hour, 'UpdateOutOfDateProviderIdsOnApplicationChoices', at: '**:20') { UpdateOutOfDateProviderIdsOnApplicationChoices.perform_async }
+  every(1.hour, 'UpdateDuplicateMatchesWorker', at: '**:25') { UpdateDuplicateMatchesWorker.perform_async(notify_slack_at: 13) }
   every(1.hour, 'DetectInvariantsHourlyCheck', at: '**:30') { DetectInvariantsHourlyCheck.perform_async }
   every(1.hour, 'SendChaseEmailToProviders', at: '**:35') { SendChaseEmailToProvidersWorker.perform_async }
   every(1.hour, 'SendChaseEmailToCandidates', at: '**:40') { SendChaseEmailToCandidatesWorker.perform_async }
-  every(1.hour, 'UpdateOutOfDateProviderIdsOnApplicationChoices', at: '**:20') { UpdateOutOfDateProviderIdsOnApplicationChoices.perform_async }
 
   # Daily jobs
   every(1.day, 'DetectInvariantsDailyCheck', at: '07:00') { DetectInvariantsDailyCheck.perform_async }
@@ -42,7 +42,6 @@ class Clock
   every(1.day, 'SendFindHasOpenedEmailToCandidatesWorker', at: '12:00') { SendFindHasOpenedEmailToCandidatesWorker.new.perform }
   every(1.day, 'SendNewCycleStartedEmailToCandidatesWorker', at: '10:00') { SendNewCycleHasStartedEmailToCandidatesWorker.new.perform }
 
-  every(1.day, 'UpdateDuplicateMatchesWorker', at: '13:00') { UpdateDuplicateMatchesWorker.perform_async }
   every(1.day, 'TriggerFullSyncIfFindClosed', at: '00:05') { TeacherTrainingPublicAPI::TriggerFullSyncIfFindClosed.call }
   every(1.day, 'NudgeCandidatesWorker', at: '10:00') { NudgeCandidatesWorker.perform_async }
 


### PR DESCRIPTION
## Context

We want to run the worker hourly but continue to notify slack daily.  This could potentially be split into two workers but this seemed simplest.
