### PR TITLE
Only send slack summary on weekdays

### DIFF
--- a/app/services/stats_summary.rb
+++ b/app/services/stats_summary.rb
@@ -4,6 +4,7 @@ class StatsSummary
   def as_slack_message
     <<~MARKDOWN
       *Today on Apply*
+      _Please note these numbers are as of 5pm and are not to be used for reporting purposes_
 
       :wave: #{pluralize(candidate_signups(today), 'candidate signup')} | #{candidate_signups(this_day_last_year)} last cycle
       :pencil: #{pluralize(applications_begun(today), 'application')} begun | #{applications_begun(this_day_last_year)} last cycle

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -29,8 +29,6 @@ class Clock
   # Daily jobs
   every(1.day, 'DetectInvariantsDailyCheck', at: '07:00') { DetectInvariantsDailyCheck.perform_async }
 
-  every(1.day, 'SendStatsSummaryToSlack', at: '17:00') { SendStatsSummaryToSlack.new.perform }
-
   every(1.day, 'Generate export for TAD', at: '23:59') { DataAPI::TADExport.run_daily }
 
   every(1.day, 'Generate monthly statistics report and exports', at: '00:00') { GenerateMonthlyStatistics.perform_async }
@@ -47,6 +45,9 @@ class Clock
   every(1.day, 'NudgeCandidatesWorker', at: '10:00') { NudgeCandidatesWorker.perform_async }
 
   every(1.day, 'CancelUnsubmittedApplicationsWorker', at: '00:10') { CancelUnsubmittedApplicationsWorker.perform_async }
+
+  # Daily jobs - weekday only
+  every(1.day, 'SendStatsSummaryToSlack', at: '17:00', if: ->(period) { period.wday.between?(1, 5) }) { SendStatsSummaryToSlack.new.perform }
 
   # Weekly jobs
   every(7.days, 'FullSyncAllFromTeacherTrainingPublicAPI', at: 'Saturday 00:59') do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -149,6 +149,7 @@ RSpec.configure do |config|
     end
   end
 
+  config.include(Clockwork::Test::RSpec::Matchers)
   config.after(:each, :clockwork) { Clockwork::Test.clear! }
 
   # Print the 10 slowest examples and example groups at the

--- a/spec/support_specs/clockwork_spec.rb
+++ b/spec/support_specs/clockwork_spec.rb
@@ -7,6 +7,20 @@ RSpec.describe Clockwork, clockwork: true do
     TestSuiteTimeMachine.travel_permanently_to(Time.zone.now.change(hour: 0, min: 0, sec: 0))
   end
 
+  describe 'stats summary' do
+    it 'only posts on weekdays' do
+      start_time = Time.zone.now.beginning_of_week
+      end_time = Time.zone.now.end_of_week
+      Clockwork::Test.run(
+        start_time:,
+        end_time:,
+        tick_speed: 1.hour,
+      )
+
+      expect(Clockwork::Test).to have_run('SendStatsSummaryToSlack').exactly(5).times
+    end
+  end
+
   [
     { worker: DeclineOffersByDefaultWorker, task: 'DeclineOffersByDefault' },
     { worker: SendChaseEmailToProvidersWorker, task: 'SendChaseEmailToProviders' },


### PR DESCRIPTION
## Context

We added a last cycle comparison to the stats slack post, but this is only for working days so we want to silence this post over the weekends. We also want to make it clear that these numbers are not to be used for reporting purposes and are just an informative summary.

## Changes proposed in this pull request

Use the `if` argument to make sure the job only runs on weekdays