### PR TITLE
Fix a sidekiq scheduling matcher worker bug

### DIFF
--- a/app/workers/update_duplicate_matches_worker.rb
+++ b/app/workers/update_duplicate_matches_worker.rb
@@ -3,7 +3,7 @@ class UpdateDuplicateMatchesWorker
 
   sidekiq_options retry: 0, queue: :low_priority
 
-  def perform(notify_slack_at: nil)
-    UpdateDuplicateMatches.new(notify_slack_at:).save!
+  def perform(options = {})
+    UpdateDuplicateMatches.new(**options).save!
   end
 end


### PR DESCRIPTION
You seemingly can't pass through keyword arguments via sidekiq, so let's go back to options hashes to achieve the same thing.

## Context

https://sentry.io/organizations/dfe-teacher-services/issues/3754948935/?project=1765973&referrer=slack
