### PR TITLE
Add reference received email to preview

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -394,20 +394,6 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
-  def course_unavailable_notification(application_choice, reason)
-    @application_choice = application_choice
-    email_for_candidate(
-      application_choice.application_form,
-      subject: I18n.t!(
-        "candidate_mailer.course_unavailable_notification.subject.#{reason}",
-        course_name: application_choice.current_course_option.course.name_and_code,
-        provider_name: application_choice.current_course_option.course.provider.name,
-        study_mode: application_choice.current_course_option.study_mode.humanize.downcase,
-      ),
-      template_name: "course_unavailable_#{reason}",
-    )
-  end
-
   def offer_withdrawn(application_choice)
     @course_name_and_code = application_choice.current_course_option.course.name_and_code
     @provider_name = application_choice.current_course_option.provider.name

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -3,18 +3,6 @@ require 'rails_helper'
 RSpec.describe CandidateMailer do
   include TestHelpers::MailerSetupHelper
 
-  subject(:mailer) { described_class }
-
-  let(:recruitment_cycle_year) { ApplicationForm::OLD_REFERENCE_FLOW_CYCLE_YEAR }
-  let(:application_form) do
-    build_stubbed(:application_form, first_name: 'Fred',
-                                     candidate:,
-                                     recruitment_cycle_year:,
-                                     application_choices:)
-  end
-  let(:candidate) { create(:candidate) }
-  let(:application_choices) { [build_stubbed(:application_choice)] }
-  let(:dbd_application) { build_stubbed(:application_choice, :dbd) }
   let(:course_option) do
     create(
       :course_option,
@@ -30,10 +18,24 @@ RSpec.describe CandidateMailer do
       ),
     )
   end
+  let(:dbd_application) { build_stubbed(:application_choice, :dbd) }
+  let(:application_choices) { [build_stubbed(:application_choice)] }
+  let(:candidate) { create(:candidate) }
+  let(:application_form) do
+    build_stubbed(:application_form, first_name: 'Fred',
+                                     candidate:,
+                                     recruitment_cycle_year:,
+                                     application_choices:)
+  end
+  let(:recruitment_cycle_year) { ApplicationForm::OLD_REFERENCE_FLOW_CYCLE_YEAR }
 
   before do
     magic_link_stubbing(candidate)
   end
+
+  it_behaves_like 'mailer previews', CandidateMailerPreview
+
+  subject(:mailer) { described_class }
 
   describe '.application_submitted' do
     let(:application_choice) { build_stubbed(:application_choice, reject_by_default_at: 5.days.from_now) }

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -713,7 +713,7 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.withdraw_last_application_choice(application_form)
   end
 
-  def conditions_statuses_updated
+  def conditions_statuses_changed
     met_conditions = FactoryBot.build_stubbed_list(:offer_condition, 1)
     pending_conditions = FactoryBot.build_stubbed_list(:offer_condition, 2)
     previously_met_conditions = FactoryBot.build_stubbed_list(:offer_condition, 1)

--- a/spec/mailers/previews/provider_mailer_preview.rb
+++ b/spec/mailers/previews/provider_mailer_preview.rb
@@ -1,4 +1,10 @@
 class ProviderMailerPreview < ActionMailer::Preview
+  def reference_received
+    reference = FactoryBot.create(:reference, :feedback_provided)
+    course = FactoryBot.build_stubbed(:course, provider:)
+    ProviderMailer.reference_received(reference:, application_choice:, provider_user:, course:)
+  end
+
   def confirm_sign_in
     ProviderMailer.confirm_sign_in(
       FactoryBot.build_stubbed(:provider_user),

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -2,18 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ProviderMailer do
   include CourseOptionHelpers
-
-  let(:provider) { build_stubbed(:provider, :with_signed_agreement, code: 'ABC', provider_users: [provider_user]) }
-  let(:site) { build_stubbed(:site, provider:) }
-  let(:course) { build_stubbed(:course, provider:, name: 'Computer Science', code: '6IND') }
-  let(:course_option) { build_stubbed(:course_option, course:, site:) }
-  let(:current_course_option) { course_option }
-  let(:application_choice) do
-    build_stubbed(:submitted_application_choice, course_option:,
-                                                 current_course_option:,
-                                                 reject_by_default_at: 40.days.from_now,
-                                                 reject_by_default_days: 123)
-  end
+  let(:provider_user) { build_stubbed(:provider_user, first_name: 'Johny', last_name: 'English') }
   let!(:application_form) do
     build_stubbed(:completed_application_form, first_name: 'Harry',
                                                last_name: 'Potter',
@@ -21,7 +10,19 @@ RSpec.describe ProviderMailer do
                                                application_choices: [application_choice],
                                                submitted_at: 5.days.ago)
   end
-  let(:provider_user) { build_stubbed(:provider_user, first_name: 'Johny', last_name: 'English') }
+  let(:application_choice) do
+    build_stubbed(:submitted_application_choice, course_option:,
+                                                 current_course_option:,
+                                                 reject_by_default_at: 40.days.from_now,
+                                                 reject_by_default_days: 123)
+  end
+  let(:current_course_option) { course_option }
+  let(:course_option) { build_stubbed(:course_option, course:, site:) }
+  let(:course) { build_stubbed(:course, provider:, name: 'Computer Science', code: '6IND') }
+  let(:site) { build_stubbed(:site, provider:) }
+  let(:provider) { build_stubbed(:provider, :with_signed_agreement, code: 'ABC', provider_users: [provider_user]) }
+
+  it_behaves_like 'mailer previews', ProviderMailerPreview
 
   describe 'Send application submitted email' do
     let(:email) { described_class.application_submitted(provider_user, application_choice) }

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -2,19 +2,21 @@ require 'rails_helper'
 RSpec.describe RefereeMailer do
   subject(:mailer) { described_class }
 
-  let(:recruitment_cycle_year) { ApplicationForm::OLD_REFERENCE_FLOW_CYCLE_YEAR }
-  let(:application_form) { build_stubbed(:application_form, first_name: 'Elliot', last_name: 'Alderson', application_choices:, recruitment_cycle_year: recruitment_cycle_year) }
+  let(:course_option) { create(:course_option, course: create(:course, provider: create(:provider, name: 'University of Warwick'))) }
+  let(:application_choices) { [build_stubbed(:application_choice)] }
   let(:reference) do
     build_stubbed(:reference, name: 'Jane',
                               email_address: 'jane@education.gov.uk',
                               application_form:)
   end
-  let(:application_choices) { [build_stubbed(:application_choice)] }
-  let(:course_option) { create(:course_option, course: create(:course, provider: create(:provider, name: 'University of Warwick'))) }
+  let(:application_form) { build_stubbed(:application_form, first_name: 'Elliot', last_name: 'Alderson', application_choices:, recruitment_cycle_year: recruitment_cycle_year) }
+  let(:recruitment_cycle_year) { ApplicationForm::OLD_REFERENCE_FLOW_CYCLE_YEAR }
 
   before do
     allow(reference).to receive(:refresh_feedback_token!).and_return('raw_token')
   end
+
+  it_behaves_like 'mailer previews', RefereeMailerPreview
 
   describe 'Send request reference email' do
     let(:email) { mailer.reference_request_email(reference) }

--- a/spec/support/shared_examples/mailer_previews.rb
+++ b/spec/support/shared_examples/mailer_previews.rb
@@ -1,0 +1,18 @@
+RSpec.shared_examples_for 'mailer previews' do |preview_class|
+  let(:emails) { described_class.instance_methods(false) }
+  let(:preview_emails) { preview_class.instance_methods(false) }
+  let(:possible_emails_not_included) { emails - preview_emails }
+  let(:emails_with_prefix) do
+    possible_emails_not_included.select do |method_name|
+      # Many preview emails can have the prefix as the real mailer email name
+      # e.g new_cycle_has_started and in preview
+      # new_cycle_has_started_with_no_first_name_and_unsubmitted_application
+      preview_emails.grep(/^#{method_name}/).present?
+    end
+  end
+  let(:not_included_emails) { possible_emails_not_included - emails_with_prefix }
+
+  it 'include emails in preview' do
+    expect(not_included_emails).to be_blank
+  end
+end


### PR DESCRIPTION
## Context

We should link to all emails. This is a new one.

Also took the opportunity to add a shared example to verify that for every new email there is a correspondence one in preview.