### PR TITLE
Fix matcher bug again

### DIFF
--- a/app/workers/update_duplicate_matches_worker.rb
+++ b/app/workers/update_duplicate_matches_worker.rb
@@ -4,6 +4,7 @@ class UpdateDuplicateMatchesWorker
   sidekiq_options retry: 0, queue: :low_priority
 
   def perform(options = {})
+    options.symbolize_keys!
     UpdateDuplicateMatches.new(**options).save!
   end
 end


### PR DESCRIPTION
Because Sidekiq is serialising the arguments to JSON, the keys are coming back as strings.

I didn't know this before, but splatting a hash as keyword arguments only works if the keys are symbols.
