### PR TITLE
Add failed gcse information

### DIFF
--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -181,7 +181,7 @@ module CandidateInterface
     def not_completed_explanation_row
       {
         key: 'Are you currently studying for this qualification?',
-        value: not_completed_explanation_value_row,
+        value: not_completed_explanation_value_row(application_qualification),
         action: {
           href: candidate_interface_gcse_edit_not_yet_completed_path(change_path_params),
           visually_hidden_text: 'how you expect to gain this qualification',

--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class GcseQualificationReviewComponent < ViewComponent::Base
+    include GcseQualificationHelper
+
     def initialize(application_form:, application_qualification:, subject:, editable: true, heading_level: 2, missing_error: false, submitting_application: false, return_to_application_review: false)
       @application_form = application_form
       @application_qualification = application_qualification
@@ -108,7 +110,7 @@ module CandidateInterface
 
       {
         key: 'Are you currently studying to retake this qualification?',
-        value: failing_grade_row_value,
+        value: failing_grade_row_value(application_qualification),
         action: {
           href: candidate_interface_gcse_details_edit_grade_explanation_path(change_path_params),
           visually_hidden_text: 'if you are working towards this qualification at grade 4 (C) or above, give us details',
@@ -324,19 +326,5 @@ module CandidateInterface
     def capitalize_english(subject)
       subject == 'english' ? 'English' : subject
     end
-
-    def failing_grade_row_value
-      return application_qualification.not_completed_explanation if application_qualification.not_completed_explanation.present?
-
-      case application_qualification.currently_completing_qualification
-      when true
-        'Yes'
-      when false
-        'No'
-      when nil
-        'Not provided'
-      end
-    end
-    alias not_completed_explanation_value_row failing_grade_row_value
   end
 end

--- a/app/components/shared/gcse_qualification_cards_component.html.erb
+++ b/app/components/shared/gcse_qualification_cards_component.html.erb
@@ -16,7 +16,7 @@
                 <dd class="app-qualification__value"><%= qualification.not_completed_explanation %></dd>
               <% else %>
                 <dt class="app-qualification__key">Other evidence I have the skills required</dt>
-                <dd class="app-qualification__value"><%= qualification.missing_explanation || 'Not provided' %></dd>
+                <dd class="app-qualification__value"><%= qualification.missing_explanation.presence || 'Not provided' %></dd>
               <% end %>
             </dl>
 
@@ -65,7 +65,7 @@
                     Other evidence I have the skills required
                   </dt>
                   <dd class="app-qualification__value app-qualification__value--caption">
-                    <%= qualification.missing_explanation || 'Not provided' %>
+                    <%= qualification.missing_explanation %>
                   </dd>
                 <% end %>
               <% end %>

--- a/app/components/shared/gcse_qualification_cards_component.html.erb
+++ b/app/components/shared/gcse_qualification_cards_component.html.erb
@@ -11,8 +11,13 @@
             <h4 class="govuk-heading-s govuk-!-margin-bottom-1"><%= subject(qualification) %></h4>
             <dl class="app-qualification">
               <dd class="app-qualification__value"> <%= candidate_does_not_have %> </dd>
-              <dt class="app-qualification__key">Details of qualification currently studying for</dt>
-              <dd class="app-qualification__value"><%= qualification.not_completed_explanation || qualification.missing_explanation %></dd>
+              <% if qualification.not_completed_explanation.present? %>
+                <dt class="app-qualification__key">Details of qualification currently studying for</dt>
+                <dd class="app-qualification__value"><%= qualification.not_completed_explanation %></dd>
+              <% else %>
+                <dt class="app-qualification__key">Other evidence I have the skills required</dt>
+                <dd class="app-qualification__value"><%= qualification.missing_explanation || 'Not provided' %></dd>
+              <% end %>
             </dl>
 
           <%# International qualification %>

--- a/app/components/shared/gcse_qualification_cards_component.html.erb
+++ b/app/components/shared/gcse_qualification_cards_component.html.erb
@@ -32,7 +32,6 @@
                 <dd class="app-qualification__value"><%= enic_statement(qualification) %></dd>
               <% end %>
             </dl>
-
           <%# UK or UK Other qualification %>
           <% else %>
             <h4 class="govuk-heading-s govuk-!-margin-bottom-1">
@@ -45,7 +44,23 @@
               </dd>
               <dt class="app-qualification__key">Grade</dt>
               <% grade_details(qualification).each do |grade| %>
-                <dd class="app-qualification__value govuk-!-margin-bottom-0"><%= grade %></dd>
+                <dd class="app-qualification__value"><%= grade %></dd>
+              <% end %>
+
+              <% if qualification.failed_required_gcse? %>
+                <dt class="app-qualification__key">
+                  Are you currently studying to retake this qualification?
+                </dt>
+                <dd class="app-qualification__value app-qualification__value--caption">
+                  <%= failing_grade_row_value(qualification) %>
+                </dd>
+
+                <dt class="app-qualification__key">
+                  Other evidence I have the skills required (optional)
+                </dt>
+                <dd class="app-qualification__value app-qualification__value--caption">
+                  <%= qualification.missing_explanation.presence || 'Not provided' %>
+                </dd>
               <% end %>
             </dl>
           <% end %>

--- a/app/components/shared/gcse_qualification_cards_component.html.erb
+++ b/app/components/shared/gcse_qualification_cards_component.html.erb
@@ -49,14 +49,14 @@
 
               <% if qualification.failed_required_gcse? %>
                 <dt class="app-qualification__key">
-                  Are you currently studying to retake this qualification?
+                  Currently studying to retake this qualification?
                 </dt>
                 <dd class="app-qualification__value app-qualification__value--caption">
                   <%= failing_grade_row_value(qualification) %>
                 </dd>
 
                 <dt class="app-qualification__key">
-                  Other evidence I have the skills required (optional)
+                  Other evidence I have the skills required
                 </dt>
                 <dd class="app-qualification__value app-qualification__value--caption">
                   <%= qualification.missing_explanation.presence || 'Not provided' %>

--- a/app/components/shared/gcse_qualification_cards_component.html.erb
+++ b/app/components/shared/gcse_qualification_cards_component.html.erb
@@ -65,7 +65,7 @@
                     Other evidence I have the skills required
                   </dt>
                   <dd class="app-qualification__value app-qualification__value--caption">
-                    <%= qualification.missing_explanation %>
+                    <%= qualification.missing_explanation || 'Not provided' %>
                   </dd>
                 <% end %>
               <% end %>

--- a/app/components/shared/gcse_qualification_cards_component.html.erb
+++ b/app/components/shared/gcse_qualification_cards_component.html.erb
@@ -11,7 +11,7 @@
             <h4 class="govuk-heading-s govuk-!-margin-bottom-1"><%= subject(qualification) %></h4>
             <dl class="app-qualification">
               <dd class="app-qualification__value"> <%= candidate_does_not_have %> </dd>
-              <dt class="app-qualification__key">Reason given</dt>
+              <dt class="app-qualification__key">Details of qualification currently studying for</dt>
               <dd class="app-qualification__value"><%= qualification.not_completed_explanation || qualification.missing_explanation %></dd>
             </dl>
 

--- a/app/components/shared/gcse_qualification_cards_component.html.erb
+++ b/app/components/shared/gcse_qualification_cards_component.html.erb
@@ -55,12 +55,14 @@
                   <%= failing_grade_row_value(qualification) %>
                 </dd>
 
-                <dt class="app-qualification__key">
-                  Other evidence I have the skills required
-                </dt>
-                <dd class="app-qualification__value app-qualification__value--caption">
-                  <%= qualification.missing_explanation.presence || 'Not provided' %>
-                </dd>
+                <% if qualification.missing_explanation.present? %>
+                  <dt class="app-qualification__key">
+                    Other evidence I have the skills required
+                  </dt>
+                  <dd class="app-qualification__value app-qualification__value--caption">
+                    <%= qualification.missing_explanation %>
+                  </dd>
+                <% end %>
               <% end %>
             </dl>
           <% end %>

--- a/app/components/shared/gcse_qualification_cards_component.rb
+++ b/app/components/shared/gcse_qualification_cards_component.rb
@@ -1,6 +1,7 @@
 # NOTE: This component is used by both provider and support UIs
 class GcseQualificationCardsComponent < ViewComponent::Base
   include ViewHelper
+  include GcseQualificationHelper
 
   attr_reader :application_form
 

--- a/app/helpers/gcse_qualification_helper.rb
+++ b/app/helpers/gcse_qualification_helper.rb
@@ -27,6 +27,20 @@ module GcseQualificationHelper
     subject == 'english' ? 'English' : subject
   end
 
+  def failing_grade_row_value(application_qualification)
+    return application_qualification.not_completed_explanation if application_qualification.not_completed_explanation.present?
+
+    case application_qualification.currently_completing_qualification
+    when true
+      'Yes'
+    when false
+      'No'
+    when nil
+      'Not provided'
+    end
+  end
+  alias not_completed_explanation_value_row failing_grade_row_value
+
 private
 
   def get_qualification_type_name(qualification_type)

--- a/spec/components/utility/gcse_qualification_cards_component_spec.rb
+++ b/spec/components/utility/gcse_qualification_cards_component_spec.rb
@@ -47,6 +47,28 @@ RSpec.describe GcseQualificationCardsComponent, type: :component do
       end
     end
 
+    context 'when failed required gcse' do
+      let(:application_form) do
+        create(
+          :application_form,
+          application_qualifications: [
+            create(:gcse_qualification, subject: 'maths', grade: 'D', award_year: 2006, missing_explanation: 'I have 10 years experience teaching English Language', currently_completing_qualification: true),
+          ],
+        )
+      end
+
+      it 'renders all expected detail' do
+        result = render_inline(described_class.new(application_form))
+
+        expect(result.text).to include 'GCSEs or equivalent'
+        expect(result.text).to include 'Maths GCSE'
+        expect(result.text).to include '2006'
+        expect(result.text).to include 'D'
+        expect(result.text).to include 'Yes'
+        expect(result.text).to include 'I have 10 years experience teaching English Language'
+      end
+    end
+
     context 'when it\'s a non_uk qualification' do
       let(:application_form) do
         create(


### PR DESCRIPTION
## Context

If a candidate does not have a GCSE A to C (or 4 or above) in English, Maths and Science, we ask them some follow-up question to see whether they are retaking their GCSE, or if they have any other evidence of meeting the GCSE requirement.

We should update the Support interface to surface this information.

