### PR TITLE
Introduce weekly stats summary

### DIFF
--- a/app/services/weekly_stats_summary.rb
+++ b/app/services/weekly_stats_summary.rb
@@ -1,0 +1,78 @@
+class WeeklyStatsSummary
+  include ActionView::Helpers::TextHelper
+
+  def as_slack_message
+    <<~MARKDOWN
+      *:flashlight: Shine a light on stats, your weekly update from Apply*
+
+      *So far this cycle we have seen:*
+
+      :key: #{pluralize(candidate_signups(current_cycle_period), 'total candidate signup')} | This point last cycle we had #{candidate_signups(previous_cycle_period)}
+      #{technologist} #{pluralize(applications_begun(current_cycle_period, current_year), 'total application')} begun | This point last cycle we had #{applications_begun(previous_cycle_period, previous_year)}
+      :postbox: #{pluralize(applications_submitted(current_cycle_period, current_year), 'total application')} submitted | This point last cycle we had #{applications_submitted(previous_cycle_period, previous_year)}
+      :yes_vote: #{pluralize(offers_made(current_cycle_period, current_year), 'total offer')} made | This point last cycle we had #{offers_made(previous_cycle_period, previous_year)}
+      :no_vote: #{pluralize(rejections_issued(current_cycle_period, current_year), 'total rejection')} issued#{rejections_issued(current_cycle_period, current_year).positive? ? ", of which #{pluralize(rbd_count(current_cycle_period, current_year), 'was')} RBD" : nil} | This point last cycle we had #{rejections_issued(previous_cycle_period, previous_year)}
+      #{teacher} #{pluralize(candidates_recruited(current_cycle_period, current_year), 'total candidate')} recruited | This point last cycle we had #{candidates_recruited(previous_cycle_period, previous_year)}
+
+      _Please note these numbers are as of 5pm and are not to be used for reporting purposes_
+
+      :wave: Have a good weekend all
+    MARKDOWN
+  end
+
+  def candidate_signups(period)
+    Candidate.where(created_at: period).count
+  end
+
+  def applications_begun(period, year)
+    ApplicationForm.where(created_at: period, recruitment_cycle_year: year).count
+  end
+
+  def applications_submitted(period, year)
+    ApplicationForm.where(submitted_at: period, recruitment_cycle_year: year).count
+  end
+
+  def offers_made(period, year)
+    Offer.joins(:application_choice).where('application_choice.current_recruitment_cycle_year': year, created_at: period).count
+  end
+
+  def candidates_recruited(period, year)
+    ApplicationChoice.where(recruited_at: period, current_recruitment_cycle_year: year).count
+  end
+
+  def rejections_issued(period, year)
+    ApplicationChoice.where(rejected_at: period, current_recruitment_cycle_year: year).count
+  end
+
+  def rbd_count(period, year)
+    ApplicationChoice.where(rejected_at: period, current_recruitment_cycle_year: year).where(rejected_by_default: true).count
+  end
+
+private
+
+  def previous_cycle_period
+    cycle_started = CycleTimetable.apply_opens(previous_year)
+    cycle_started..CycleTimetable.this_working_day_last_cycle
+  end
+
+  def current_cycle_period
+    cycle_started = CycleTimetable.apply_opens
+    cycle_started..Time.zone.now
+  end
+
+  def previous_year
+    CycleTimetable.previous_year
+  end
+
+  def current_year
+    CycleTimetable.current_year
+  end
+
+  def technologist
+    rand(2) == 1 ? ':male-technologist:' : ':female-technologist:'
+  end
+
+  def teacher
+    rand(2) == 1 ? ':male-teacher:' : ':female-teacher:'
+  end
+end

--- a/app/workers/send_weekly_stats_summary_to_slack.rb
+++ b/app/workers/send_weekly_stats_summary_to_slack.rb
@@ -1,0 +1,7 @@
+class SendWeeklyStatsSummaryToSlack
+  include Sidekiq::Worker
+
+  def perform
+    SlackNotificationWorker.perform_async(WeeklyStatsSummary.new.as_slack_message, nil, '#twd_apply')
+  end
+end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -45,8 +45,8 @@ class Clock
 
   every(1.day, 'CancelUnsubmittedApplicationsWorker', at: '00:10') { CancelUnsubmittedApplicationsWorker.perform_async }
 
-  # Daily jobs - weekday only
-  every(1.day, 'SendStatsSummaryToSlack', at: '17:00', if: ->(period) { period.wday.between?(1, 5) }) { SendStatsSummaryToSlack.new.perform }
+  # Daily jobs - mon-thurs only
+  every(1.day, 'SendStatsSummaryToSlack', at: '17:00', if: ->(period) { period.wday.between?(1, 4) }) { SendStatsSummaryToSlack.new.perform }
 
   # Weekly jobs
   every(7.days, 'FullSyncAllFromTeacherTrainingPublicAPI', at: 'Saturday 00:59') do
@@ -56,6 +56,9 @@ class Clock
   every(7.days, 'TADSubjectDomicileNationalityExport', at: 'Sunday 23:59') do
     DataAPI::TADSubjectDomicileNationalityExport.run_weekly
   end
+
+  every(7.days, 'SendWeeklyStatsSummaryToSlack', at: 'Friday 17:00') { SendWeeklyStatsSummaryToSlack.new.perform }
+
   every(7.days, 'ApplicationsBySubjectRouteAndDegreeGradeExport', at: 'Sunday 23:55') { SupportInterface::ApplicationsBySubjectRouteAndDegreeGradeExport.run_weekly }
   every(7.days, 'ApplicationsByDemographicDomicileAndDegreeClassExport', at: 'Sunday 23:57') { SupportInterface::ApplicationsByDemographicDomicileAndDegreeClassExport.run_weekly }
 end

--- a/spec/services/weekly_stats_summary_spec.rb
+++ b/spec/services/weekly_stats_summary_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe WeeklyStatsSummary do
+  it 'posts the correct stats' do
+    create(:application_form, submitted_at: 1.minute.ago)
+    create(:application_choice, :with_recruited)
+    create(:application_choice, :with_offer)
+    create(:application_choice, :with_rejection)
+    create(:application_choice, :with_rejection_by_default)
+
+    travel_temporarily_to(1.year.ago) do
+      last_cycle_form = create(:application_form)
+      create(:application_choice, :with_recruited, application_form: last_cycle_form)
+      create(:application_choice, :with_offer, application_form: last_cycle_form)
+      create(:application_choice, :with_rejection, application_form: last_cycle_form)
+      create(:application_choice, :with_rejection)
+      create(:application_choice, :with_offer)
+    end
+
+    output = described_class.new.as_slack_message
+
+    expect(output).to match(/5 total candidate signups | This point last cycle we had 3/)
+    expect(output).to match(/5 total applications begun | This point last cycle we had 3/)
+    expect(output).to match(/5 total applications submitted | This point last cycle we had 3/)
+    expect(output).to match(/1 total candidate recruited | This point last cycle we had 1/)
+    expect(output).to match(/2 total offers made | This point last cycle we had 3/)
+    expect(output).to match(/2 total rejections issued/)
+    expect(output).to match(/of which 1 was RBD | This point last cycle we had 2/)
+  end
+end

--- a/spec/support_specs/clockwork_spec.rb
+++ b/spec/support_specs/clockwork_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Clockwork, clockwork: true do
         tick_speed: 1.hour,
       )
 
-      expect(Clockwork::Test).to have_run('SendStatsSummaryToSlack').exactly(5).times
+      expect(Clockwork::Test).to have_run('SendStatsSummaryToSlack').exactly(4).times
     end
   end
 


### PR DESCRIPTION
## Context

At 5pm there is an automated Slack post summarising some of our stats for the day.

We're adding another one, posted on a Friday, that shows our numbers cumulatively for the cycle, including a comparison of last cycle.

## Changes proposed in this pull request

|New Slack message|
|----|
|<img width="519" alt="image" src="https://user-images.githubusercontent.com/47917431/203316437-947800d0-b474-49a6-9758-25c0d33a34df.png">|

Will also stop the daily message from posting on a Friday.

## Link to Trello card

https://trello.com/c/Ov9XMrC8/915-weekly-automated-cumulative-stats-summary

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
