### PR TITLE
Set Channel Island domicile codes to JE or GG

### DIFF
--- a/app/lib/domicile_resolver.rb
+++ b/app/lib/domicile_resolver.rb
@@ -20,7 +20,8 @@ class DomicileResolver
       when *POSTCODE_PREFIXES['Wales'] then 'XI'
       when *POSTCODE_PREFIXES['Scotland'] then 'XH'
       when *POSTCODE_PREFIXES['Northern Ireland'] then 'XG'
-      when *POSTCODE_PREFIXES['Channel Islands'] then 'XL'
+      when *POSTCODE_PREFIXES['Jersey'] then 'JE'
+      when *POSTCODE_PREFIXES['Guernsey'] then 'GG'
       else
         'XK'
       end
@@ -54,7 +55,8 @@ class DomicileResolver
     'Wales' => %w[CF SA],
     'Scotland' => %w[AB DD EH FK G HS IV KA KW KY ML PA PH ZE],
     'Northern Ireland' => %w[BT],
-    'Channel Islands' => %w[GY JE],
+    'Jersey' => %w[JE],
+    'Guernsey' => %w[GY],
     'Spanning Two Countries' => %w[CH DG HR LD LL NP SY TD],
   }.freeze
 end

--- a/spec/lib/domicile_resolver_spec.rb
+++ b/spec/lib/domicile_resolver_spec.rb
@@ -43,16 +43,22 @@ RSpec.describe DomicileResolver do
       expect(hesa_code_for_postcode('BT48 7NN')).to eq('XG')
     end
 
-    it 'returns XL for Channel Islands' do
-      expect(hesa_code_for_postcode('GY1 1FH')).to eq('XL')
-    end
-
     it 'returns XK for non-geographical postcodes' do
       expect(hesa_code_for_postcode('BF1 2AA')).to eq('XK')
     end
 
     it 'returns XK for postcode prefixes spanning two countries' do
       expect(hesa_code_for_postcode('HR1 2LX')).to eq('XK')
+    end
+
+    context 'when the candidate has selected UK but lives in the Channel Islands' do
+      it 'returns JE for Jersey' do
+        expect(hesa_code_for_postcode('JE2 3AA')).to eq('JE')
+      end
+
+      it 'returns GG for Guernsey' do
+        expect(hesa_code_for_postcode('GY1 1FH')).to eq('GG')
+      end
     end
   end
 


### PR DESCRIPTION
## Context

A provider has flagged to us that a candidate has come through with a domicile code of XL.

Per HESA guidance this code is no longer accepted for Channel Island candidates:

> The Channel Islands are not part of the United Kingdom and not part of the European Union. United Kingdom codes must not be used for either domicile or nationality. The Bailiwicks of Guernsey (which includes the smaller islands of Alderney and Sark) and of Jersey must be treated separately, and the codes GG and JE must be used for both domicile and nationality. The code XL may be used for either domicile or nationality, but only for student instances from 2007/08 onwards that were already current in 2006/07, to avoid the need for re-coding.

This has happened because the candidate has selected that they live in the UK, and any candidate who does that with a Guernsey or Jersey postcode gets their domicile code set to XL.

(We handle candidates who select 'outside of the uk' correctly though).

## Changes proposed in this pull request

If the prefix of the postcode is either `GY` or `JE` then we'll set this to their respective HESA code values, rather than both being mapped to `XL`.

## Guidance to review

This is quite a light touch approach to fixing this and I'm trying to think of any additional knock on impacts... API, existing candidates etc.

## Link to Trello card

https://trello.com/c/4mekf5G6/918-question-from-uni-of-york-re-jersey-and-guernsey-investigate

## Things to check

- [X] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [X] API release notes have been updated if necessary
- [X] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
