### PR TITLE
Don't show references when an application is unsuccessful 

### DIFF
--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -73,7 +73,7 @@ module ProviderInterface
     end
 
     def application_withdrawable?
-      @provider_can_respond && ApplicationStateChange::UNSUCCESSFUL_END_STATES.exclude?(@application_choice.status.to_sym)
+      @provider_can_respond && ApplicationStateChange::UNSUCCESSFUL_STATES.exclude?(@application_choice.status.to_sym)
     end
     helper_method :application_withdrawable?
 

--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -49,6 +49,7 @@ module VendorAPI
       Changes::WorkHistory::AddRelevantSkillsBoolean,
       Changes::WorkHistory::AddStartAndEndMonth,
       Changes::WorkHistory::MarkDescriptionAsOptional,
+      Changes::RemoveReferencesWhenApplicationIsUnsuccessful,
     ],
   }.freeze
 end

--- a/app/lib/vendor_api/changes/remove_references_when_application_is_unsuccessful.rb
+++ b/app/lib/vendor_api/changes/remove_references_when_application_is_unsuccessful.rb
@@ -1,0 +1,9 @@
+module VendorAPI
+  module Changes
+    class RemoveReferencesWhenApplicationIsUnsuccessful < VersionChange
+      description "Don't show references when application is unsuccessful"
+
+      resource ApplicationPresenter
+    end
+  end
+end

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -69,7 +69,7 @@ class ApplicationChoice < ApplicationRecord
   end
 
   def application_unsuccessful?
-    ApplicationStateChange::UNSUCCESSFUL_END_STATES.include? status.to_sym
+    ApplicationStateChange::UNSUCCESSFUL_STATES.include? status.to_sym
   end
 
   def accepted_choice?

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -268,12 +268,12 @@ class ApplicationForm < ApplicationRecord
 
   def ended_without_success?
     application_choices.present? &&
-      application_choices.map(&:status).map(&:to_sym).all? { |status| ApplicationStateChange::UNSUCCESSFUL_END_STATES.include?(status) }
+      application_choices.map(&:status).map(&:to_sym).all? { |status| ApplicationStateChange::UNSUCCESSFUL_STATES.include?(status) }
   end
 
   def provider_decision_made?
     application_choices.present? &&
-      application_choices.map(&:status).map(&:to_sym).all? { |status| (ApplicationStateChange::SUCCESSFUL_STATES + ApplicationStateChange::UNSUCCESSFUL_END_STATES).include?(status) }
+      application_choices.map(&:status).map(&:to_sym).all? { |status| (ApplicationStateChange::SUCCESSFUL_STATES + ApplicationStateChange::UNSUCCESSFUL_STATES).include?(status) }
   end
 
   def incomplete_degree_information?
@@ -338,7 +338,7 @@ class ApplicationForm < ApplicationRecord
   end
 
   def number_of_unsuccessful_application_choices
-    application_choices.where.not(status: ApplicationStateChange::UNSUCCESSFUL_END_STATES).count
+    application_choices.where.not(status: ApplicationStateChange::UNSUCCESSFUL_STATES).count
   end
 
   def maximum_number_of_course_choices

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -71,7 +71,7 @@ class PerformanceStatistics
 
   def form_ended_without_success_sql
     sql = 'ARRAY_AGG(DISTINCT ch.status)'
-    ApplicationStateChange::UNSUCCESSFUL_END_STATES.each do |state|
+    ApplicationStateChange::UNSUCCESSFUL_STATES.each do |state|
       sql = "ARRAY_REMOVE(#{sql}, '#{state}')"
     end
 

--- a/app/presenters/vendor_api/application_presenter.rb
+++ b/app/presenters/vendor_api/application_presenter.rb
@@ -96,7 +96,8 @@ module VendorAPI
     end
 
     def show_references?
-      version_1_3_or_above? || application_is_in_an_accepted_state?
+      (version_1_3_or_above? && !application_unsuccessful?) ||
+        application_accepted?
     end
 
     def version_1_3_or_above?
@@ -104,7 +105,7 @@ module VendorAPI
     end
 
     def reference_received?(reference)
-      reference.feedback_provided? && application_is_in_an_accepted_state?
+      reference.feedback_provided? && application_accepted?
     end
 
     def safeguarding_issues_details_url
@@ -137,8 +138,12 @@ module VendorAPI
       application_form.country[0..1] if application_form.country.present?
     end
 
-    def application_is_in_an_accepted_state?
+    def application_accepted?
       ApplicationStateChange::ACCEPTED_STATES.include?(application_choice.status.to_sym)
+    end
+
+    def application_unsuccessful?
+      ApplicationStateChange::UNSUCCESSFUL_STATES.include?(application_choice.status.to_sym)
     end
   end
 end

--- a/app/queries/get_unsuccessful_and_unsubmitted_candidates.rb
+++ b/app/queries/get_unsuccessful_and_unsubmitted_candidates.rb
@@ -5,7 +5,7 @@ class GetUnsuccessfulAndUnsubmittedCandidates
     .where(
       application_forms: {
         recruitment_cycle_year: RecruitmentCycle.previous_year,
-        id: ApplicationChoice.where(status: ApplicationStateChange::UNSUCCESSFUL_END_STATES).select(:application_form_id),
+        id: ApplicationChoice.where(status: ApplicationStateChange::UNSUCCESSFUL_STATES).select(:application_form_id),
       },
     )
     .where.not(

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -8,10 +8,10 @@ class ApplicationStateChange
   ACCEPTED_STATES = %i[pending_conditions conditions_not_met recruited offer_deferred].freeze
   OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer offer_withdrawn]).freeze
   POST_OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer_withdrawn]).freeze
-  UNSUCCESSFUL_END_STATES = %i[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn application_not_sent].freeze
+  UNSUCCESSFUL_STATES = %i[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn application_not_sent].freeze
   SUCCESSFUL_STATES = %i[pending_conditions offer offer_deferred recruited].freeze
   DECISION_PENDING_STATUSES = %i[awaiting_provider_decision interviewing].freeze
-  TERMINAL_STATES = UNSUCCESSFUL_END_STATES + %i[recruited].freeze
+  TERMINAL_STATES = UNSUCCESSFUL_STATES + %i[recruited].freeze
 
   attr_reader :application_choice
 

--- a/app/services/course_validations.rb
+++ b/app/services/course_validations.rb
@@ -19,7 +19,7 @@ class CourseValidations
   end
 
   def course_already_exists_on_application?
-    application_choices = application_choice.self_and_siblings - [application_choice].reject { |choice| ApplicationStateChange::UNSUCCESSFUL_END_STATES.include?(choice) }
+    application_choices = application_choice.self_and_siblings - [application_choice].reject { |choice| ApplicationStateChange::UNSUCCESSFUL_STATES.include?(choice) }
 
     raise ExistingCourseError if application_choices.any? { |choice| choice.current_course_option == course_option }
   end

--- a/app/services/process_state.rb
+++ b/app/services/process_state.rb
@@ -81,7 +81,7 @@ class ProcessState
       :pending_conditions
     elsif any_state_is?('offer_deferred')
       :offer_deferred
-    elsif (states.uniq.map(&:to_sym) - ApplicationStateChange::UNSUCCESSFUL_END_STATES).empty?
+    elsif (states.uniq.map(&:to_sym) - ApplicationStateChange::UNSUCCESSFUL_STATES).empty?
       :ended_without_success
     else
       :unknown_state

--- a/app/services/reject_by_default_feedback.rb
+++ b/app/services/reject_by_default_feedback.rb
@@ -47,7 +47,7 @@ private
     application_form
       .application_choices
       .map(&:status)
-      .all? { |status| ApplicationStateChange::UNSUCCESSFUL_END_STATES.include?(status.to_sym) }
+      .all? { |status| ApplicationStateChange::UNSUCCESSFUL_STATES.include?(status.to_sym) }
   end
 
   def application_form

--- a/app/services/support_interface/candidate_journey_tracker.rb
+++ b/app/services/support_interface/candidate_journey_tracker.rb
@@ -130,7 +130,7 @@ module SupportInterface
     def ended_without_success
       earliest_update_audit_for(
         @application_choice,
-        status: ApplicationStateChange::UNSUCCESSFUL_END_STATES.map(&:to_s),
+        status: ApplicationStateChange::UNSUCCESSFUL_STATES.map(&:to_s),
       )
     end
 

--- a/app/views/api_docs/vendor_api_docs/reference/draft.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/draft.html.erb
@@ -88,6 +88,10 @@
   <li><code>safeguarding_concerns</code></li>
 </ul>
 
+<p class="govuk-body">
+  References will not appear if their application is unsuccessful (e.g. offer declined, application rejected).
+</p>
+
 <p class="govuk-heading-s">Add missing fields to work/volunteering experience</p>
 
 <p class="govuk-body">

--- a/config/vendor_api/draft.yml
+++ b/config/vendor_api/draft.yml
@@ -15,6 +15,7 @@ components:
           description: |
             Referee details will appear as soon as a reference is added by the candidate.
             Reference feedback will only be included once a candidate has accepted an offer and has received a reference.
+            References will not appear if their application is unsuccessful (e.g. offer declined, application rejected).
             There is no limit to the number of references.
     Reference:
       properties:

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -61,14 +61,14 @@ FactoryBot.define do
     end
 
     trait :withdrawn do
+      association(:application_form, :submitted)
       status { :withdrawn }
       withdrawn_at { Time.zone.now }
       withdrawn_or_declined_for_candidate_by_provider { false }
     end
 
     trait :withdrawn_at_candidates_request do
-      status { :withdrawn }
-      withdrawn_at { Time.zone.now }
+      withdrawn
       withdrawn_or_declined_for_candidate_by_provider { true }
     end
 
@@ -100,6 +100,8 @@ FactoryBot.define do
     end
 
     trait :with_rejection do
+      association(:application_form, :submitted)
+
       status { 'rejected' }
       rejection_reason { Faker::Lorem.paragraph_by_chars(number: 300) }
       rejection_reasons_type { 'rejection_reason' }

--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -23,6 +23,10 @@ FactoryBot.define do
       submitted_at { Faker::Time.backward(days: 7, period: :day) }
     end
 
+    trait :submitted do
+      minimum_info
+    end
+
     trait :duplicate_candidates do
       date_of_birth { ApplicationForm.last&.date_of_birth || '01-01-1996' }
       postcode { ApplicationForm.last&.postcode || 'W6 9BH' }

--- a/spec/presenters/vendor_api/v1.3/application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.3/application_presenter_spec.rb
@@ -64,5 +64,55 @@ RSpec.describe VendorAPI::ApplicationPresenter do
         expect(application_json.dig(:attributes, :references, 0, :reference_received)).to be(false)
       end
     end
+
+    context 'when offer is withdrawn' do
+      let(:application_choice) do
+        create(:application_choice, :with_withdrawn_offer)
+      end
+
+      it 'returns no references' do
+        expect(attributes[:references]).to be_empty
+      end
+    end
+
+    context 'when offer is declined' do
+      let(:application_choice) do
+        create(:application_choice, :with_declined_offer)
+      end
+
+      it 'returns no references' do
+        expect(attributes[:references]).to be_empty
+      end
+    end
+
+    context 'when the application is withdrawn' do
+      let(:application_choice) do
+        create(:application_choice, :withdrawn)
+      end
+
+      it 'returns no references' do
+        expect(attributes[:references]).to be_empty
+      end
+    end
+
+    context 'when the application is rejected' do
+      let(:application_choice) do
+        create(:application_choice, :with_rejection)
+      end
+
+      it 'returns no references' do
+        expect(attributes[:references]).to be_empty
+      end
+    end
+
+    context 'when the offer conditions are not met' do
+      let(:application_choice) do
+        create(:application_choice, :with_conditions_not_met)
+      end
+
+      it 'returns references' do
+        expect(attributes[:references]).not_to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

The only odd case here is that `conditions_not_met` is considered both
an "unsuccessful" and "accepted" state, and references are always shown
for applications in an "accepted" state.

## Changes proposed in this pull request

<img width="985" alt="Screenshot 2022-11-23 at 13 23 36" src="https://user-images.githubusercontent.com/109225/203558497-9d6ebb00-5e3e-4212-a147-f1691a087402.png">
<img width="791" alt="Screenshot 2022-11-23 at 13 24 03" src="https://user-images.githubusercontent.com/109225/203558518-92f3882f-72da-4c75-992e-f33bf57aef56.png">

## Things to check

- [x] API release notes have been updated if necessary
