### PR TITLE
Update how A levels and other qualifications renders

### DIFF
--- a/app/components/candidate_interface/other_qualifications_review_component.rb
+++ b/app/components/candidate_interface/other_qualifications_review_component.rb
@@ -35,8 +35,8 @@ module CandidateInterface
     def no_qualification_row
       params = { change: true }.merge(return_to_params)
       [{
-        key: 'Do you want to add any A levels and other qualifications',
-        value: 'No',
+        key: 'A levels and other qualifications ',
+        value: 'None added',
         action: {
           href: candidate_interface_other_qualification_type_path(params),
           visually_hidden_text: 'if you want to add any A levels and other qualifications',

--- a/app/components/candidate_interface/other_qualifications_review_component.rb
+++ b/app/components/candidate_interface/other_qualifications_review_component.rb
@@ -35,7 +35,7 @@ module CandidateInterface
     def no_qualification_row
       params = { change: true }.merge(return_to_params)
       [{
-        key: 'A levels and other qualifications ',
+        key: 'A levels and other qualifications',
         value: 'None added',
         action: {
           href: candidate_interface_other_qualification_type_path(params),

--- a/app/components/candidate_interface/other_qualifications_review_component.rb
+++ b/app/components/candidate_interface/other_qualifications_review_component.rb
@@ -36,7 +36,7 @@ module CandidateInterface
       params = { change: true }.merge(return_to_params)
       [{
         key: 'A levels and other qualifications',
-        value: 'None added',
+        value: 'I do not want to add any A levels and other qualifications',
         action: {
           href: candidate_interface_other_qualification_type_path(params),
           visually_hidden_text: 'if you want to add any A levels and other qualifications',

--- a/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
+++ b/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
@@ -193,8 +193,8 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
       result = render_inline(described_class.new(application_form:, submitting_application: true))
 
       expect(page).not_to have_content('Adding A levels and other qualifications makes your application stronger. They demonstrate subject knowledge not covered in your degree or work experience.')
-      expect(result.css('.govuk-summary-list__key').text).to include('Do you want to add any A levels and other qualifications')
-      expect(result.css('.govuk-summary-list__value').text).to include('No')
+      expect(result.css('.govuk-summary-list__key').text).to include('A levels and other qualifications ')
+      expect(result.css('.govuk-summary-list__value').text).to include('None added')
       expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(
         Rails.application.routes.url_helpers.candidate_interface_other_qualification_type_path,
       )
@@ -215,8 +215,8 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
       result = render_inline(described_class.new(application_form:, submitting_application: false))
 
       expect(page).to have_content('Adding A levels and other qualifications makes your application stronger. They demonstrate subject knowledge not covered in your degree or work experience.')
-      expect(result.css('.govuk-summary-list__key').text).to include('Do you want to add any A levels and other qualifications')
-      expect(result.css('.govuk-summary-list__value').text).to include('No')
+      expect(result.css('.govuk-summary-list__key').text).to include('A levels and other qualifications ')
+      expect(result.css('.govuk-summary-list__value').text).to include('None added')
       expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(
         Rails.application.routes.url_helpers.candidate_interface_other_qualification_type_path,
       )

--- a/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
+++ b/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
 
       expect(page).not_to have_content('Adding A levels and other qualifications makes your application stronger. They demonstrate subject knowledge not covered in your degree or work experience.')
       expect(result.css('.govuk-summary-list__key').text).to include('A levels and other qualifications')
-      expect(result.css('.govuk-summary-list__value').text).to include('None added')
+      expect(result.css('.govuk-summary-list__value').text).to include('I do not want to add any A levels and other qualifications')
       expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(
         Rails.application.routes.url_helpers.candidate_interface_other_qualification_type_path,
       )
@@ -216,7 +216,7 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
 
       expect(page).to have_content('Adding A levels and other qualifications makes your application stronger. They demonstrate subject knowledge not covered in your degree or work experience.')
       expect(result.css('.govuk-summary-list__key').text).to include('A levels and other qualifications')
-      expect(result.css('.govuk-summary-list__value').text).to include('None added')
+      expect(result.css('.govuk-summary-list__value').text).to include('I do not want to add any A levels and other qualifications')
       expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(
         Rails.application.routes.url_helpers.candidate_interface_other_qualification_type_path,
       )

--- a/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
+++ b/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
       result = render_inline(described_class.new(application_form:, submitting_application: true))
 
       expect(page).not_to have_content('Adding A levels and other qualifications makes your application stronger. They demonstrate subject knowledge not covered in your degree or work experience.')
-      expect(result.css('.govuk-summary-list__key').text).to include('A levels and other qualifications ')
+      expect(result.css('.govuk-summary-list__key').text).to include('A levels and other qualifications')
       expect(result.css('.govuk-summary-list__value').text).to include('None added')
       expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(
         Rails.application.routes.url_helpers.candidate_interface_other_qualification_type_path,
@@ -215,7 +215,7 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
       result = render_inline(described_class.new(application_form:, submitting_application: false))
 
       expect(page).to have_content('Adding A levels and other qualifications makes your application stronger. They demonstrate subject knowledge not covered in your degree or work experience.')
-      expect(result.css('.govuk-summary-list__key').text).to include('A levels and other qualifications ')
+      expect(result.css('.govuk-summary-list__key').text).to include('A levels and other qualifications')
       expect(result.css('.govuk-summary-list__value').text).to include('None added')
       expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(
         Rails.application.routes.url_helpers.candidate_interface_other_qualification_type_path,

--- a/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_no_qualification_option_choice_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_no_qualification_option_choice_spec.rb
@@ -73,7 +73,7 @@ RSpec.feature 'Entering their other qualifications' do
   end
 
   def and_i_see_my_no_other_qualification_selection
-    expect(page).to have_content('A levels and other qualifications ')
+    expect(page).to have_content('A levels and other qualifications')
   end
 
   def and_i_click_continue
@@ -109,7 +109,7 @@ RSpec.feature 'Entering their other qualifications' do
   end
 
   def and_i_dont_see_my_no_other_qualification_selected
-    expect(page).not_to have_content('A levels and other qualifications ')
+    expect(page).not_to have_content('A levels and other qualifications')
   end
 
   def and_see_my_other_uk_qualification_has_the_correct_format

--- a/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_no_qualification_option_choice_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_no_qualification_option_choice_spec.rb
@@ -73,7 +73,7 @@ RSpec.feature 'Entering their other qualifications' do
   end
 
   def and_i_see_my_no_other_qualification_selection
-    expect(page).to have_content('Do you want to add any A levels and other qualifications')
+    expect(page).to have_content('A levels and other qualifications ')
   end
 
   def and_i_click_continue
@@ -109,7 +109,7 @@ RSpec.feature 'Entering their other qualifications' do
   end
 
   def and_i_dont_see_my_no_other_qualification_selected
-    expect(page).not_to have_content('Do you want to add any A levels and other qualifications')
+    expect(page).not_to have_content('A levels and other qualifications ')
   end
 
   def and_see_my_other_uk_qualification_has_the_correct_format


### PR DESCRIPTION
## Context

This is a change to reflect a re-wording of a question on A levels.

## Changes proposed in this pull request

Currently we say "Do you want to add any A levels and other qualifications" / "No" – with a missing question mark.

We don't actually ask this question any more, as instead we ask "What type of qualification do you want to add?" with "I do not want to add any A levels and other qualifications" as an option.

We should update this summary to be something like:

> A levels and other qualifications 
> None added

## Guidance to review

Have I amended all the correct areas? Did my find and replace hit anything else by accident?

## Link to Trello card

https://trello.com/c/SRbFlNrm/241-update-a-levels-summary-content-in-application-check

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
