### PR TITLE
Ensure we use the training provider first if available

### DIFF
--- a/app/services/support_interface/notes_export.rb
+++ b/app/services/support_interface/notes_export.rb
@@ -15,7 +15,12 @@ module SupportInterface
         training_provider = course.provider
         ratifying_provider = course.accredited_provider
 
-        provider = providers.find { |p| p == training_provider || p == ratifying_provider }
+        provider = if providers.include?(training_provider)
+                     training_provider
+                   elsif providers.include?(ratifying_provider)
+                     ratifying_provider
+                   end
+
         training_org_permissions_count = nil
         total_org_permissions_count = nil
 


### PR DESCRIPTION
The current `find` statement looks at first glance like it does this, but really it's relying on whatever order the providers are coming out of the DB, which is undefined given the query being used.
