### PR TITLE
Add link to TTA on new interview mailer

### DIFF
--- a/app/views/candidate_mailer/new_interview.text.erb
+++ b/app/views/candidate_mailer/new_interview.text.erb
@@ -13,3 +13,11 @@ Additional details:
 ^ <%= @interview.additional_details %>
 
 Contact <%= @provider_name %> if you have any questions. Let them know if you cannot attend the interview.
+
+# Prepare for your interview
+
+Do you have a teacher training adviser yet? They can help you prepare for your interview.
+
+As former teachers, they can also offer insight into teacher training and teaching as a career.
+
+[Get a teacher training adviser](<%= email_link_with_utm_params t('get_into_teaching.url_get_an_adviser_start'), 'new_interview_offered', @application_form.phase %>)

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -444,6 +444,9 @@ RSpec.describe CandidateMailer do
         'interview time' => '9:30am',
         'interview location' => 'Hogwarts Castle',
         'additional interview details' => 'Bring your magic wand for the spells test',
+        'TTA header' => 'Prepare for your interview',
+        'TTA content' => 'Do you have a teacher training adviser yet?',
+        'TTA link' => 'Get a teacher training adviser',
       )
     end
 


### PR DESCRIPTION
## Context

When a candidate is informed they have an offer via email, we don't mention that they can use a TTA to help prepare for their interview. Using one can increase their chances of performing well at interview and securing a place.

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="647" alt="image" src="https://user-images.githubusercontent.com/47917431/203774760-7505bf59-541e-4652-ba82-86d789e519f9.png">|<img width="645" alt="image" src="https://user-images.githubusercontent.com/47917431/203774656-bc17057e-465b-4a8d-b081-23f802ef3f20.png">|

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/TFxSSc1B/923-add-tta-sign-up-to-our-interview-emails-how-to-prepare-for-your-interview

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
