### PR TITLE
Remove references as a possible reason for rejection if via the API

### DIFF
--- a/config/rejection_reason_codes.yml
+++ b/config/rejection_reason_codes.yml
@@ -30,13 +30,6 @@ R04:
     :label: Details
     :text: |
       You did not reply to messages or failed to attend an interview or we could not successfully arrange and interview with you.
-R05:
-  :id: references
-  :label: References
-  :details:
-    :id: references_details
-    :label: Details
-    :text: Your references were either missing or not satisfactory.
 R06:
   :id: safeguarding
   :label: Safeguarding


### PR DESCRIPTION
## Context

This has not yet been used in production, so we're removing is as an option first, then following up with removing it from the Manage side.

## Guidance to review

Try [fetching the R4R codes](https://www.apply-for-teacher-training.service.gov.uk/api-docs/v1.2/reference#get-reference-data-rejection-reason-codes) and/or [rejecting an application](https://www.apply-for-teacher-training.service.gov.uk/api-docs/v1.2/reference#post-applications-application_id-reject-by-codes) with code `R05`.

## Things to check

- [x] API release notes have been updated if necessary
