### PR TITLE
Add delimiter and application phase to slack post

### DIFF
--- a/app/services/weekly_stats_summary.rb
+++ b/app/services/weekly_stats_summary.rb
@@ -1,5 +1,6 @@
 class WeeklyStatsSummary
   include ActionView::Helpers::TextHelper
+  include ActionView::Helpers::NumberHelper
 
   def as_slack_message
     <<~MARKDOWN
@@ -7,12 +8,13 @@ class WeeklyStatsSummary
 
       *So far this cycle we have seen:*
 
-      :key: #{pluralize(candidate_signups(current_cycle_period), 'total candidate signup')} | This point last cycle we had #{candidate_signups(previous_cycle_period)}
-      #{technologist} #{pluralize(applications_begun(current_cycle_period, current_year), 'total application')} begun | This point last cycle we had #{applications_begun(previous_cycle_period, previous_year)}
-      :postbox: #{pluralize(applications_submitted(current_cycle_period, current_year), 'total application')} submitted | This point last cycle we had #{applications_submitted(previous_cycle_period, previous_year)}
-      :yes_vote: #{pluralize(offers_made(current_cycle_period, current_year), 'total offer')} made | This point last cycle we had #{offers_made(previous_cycle_period, previous_year)}
-      :no_vote: #{pluralize(rejections_issued(current_cycle_period, current_year), 'total rejection')} issued#{rejections_issued(current_cycle_period, current_year).positive? ? ", of which #{pluralize(rbd_count(current_cycle_period, current_year), 'was')} RBD" : nil} | This point last cycle we had #{rejections_issued(previous_cycle_period, previous_year)}
-      #{teacher} #{pluralize(candidates_recruited(current_cycle_period, current_year), 'total candidate')} recruited | This point last cycle we had #{candidates_recruited(previous_cycle_period, previous_year)}
+      :key: #{pluralize(number_with_delimiter(candidate_signups(current_cycle_period)), 'total candidate signup')} | This point last cycle we had #{number_with_delimiter(candidate_signups(previous_cycle_period))}
+      #{technologist} #{pluralize(number_with_delimiter(applications_begun(current_cycle_period, current_year, 'apply_1')), 'total initial application')} begun | This point last cycle we had #{number_with_delimiter(applications_begun(previous_cycle_period, previous_year, 'apply_1'))}
+      #{technologist} #{pluralize(number_with_delimiter(applications_begun(current_cycle_period, current_year, 'apply_2')), 'total Apply again application')} begun | This point last cycle we had #{number_with_delimiter(applications_begun(previous_cycle_period, previous_year, 'apply_2'))}
+      :postbox: #{pluralize(number_with_delimiter(applications_submitted(current_cycle_period, current_year)), 'total application')} submitted | This point last cycle we had #{number_with_delimiter(applications_submitted(previous_cycle_period, previous_year))}
+      :yes_vote: #{pluralize(number_with_delimiter(offers_made(current_cycle_period, current_year)), 'total offer')} made | This point last cycle we had #{number_with_delimiter(offers_made(previous_cycle_period, previous_year))}
+      :no_vote: #{pluralize(number_with_delimiter(rejections_issued(current_cycle_period, current_year)), 'total rejection')} issued#{rejections_issued(current_cycle_period, current_year).positive? ? ", of which #{pluralize(number_with_delimiter(rbd_count(current_cycle_period, current_year)), 'was')} RBD" : nil} | This point last cycle we had #{number_with_delimiter(rejections_issued(previous_cycle_period, previous_year))}
+      #{teacher} #{pluralize(number_with_delimiter(candidates_recruited(current_cycle_period, current_year)), 'total candidate')} recruited | This point last cycle we had #{number_with_delimiter(candidates_recruited(previous_cycle_period, previous_year))}
 
       _Please note these numbers are as of 5pm and are not to be used for reporting purposes_
 
@@ -24,8 +26,8 @@ class WeeklyStatsSummary
     Candidate.where(created_at: period).count
   end
 
-  def applications_begun(period, year)
-    ApplicationForm.where(created_at: period, recruitment_cycle_year: year).count
+  def applications_begun(period, year, phase)
+    ApplicationForm.where(created_at: period, recruitment_cycle_year: year, phase: phase).count
   end
 
   def applications_submitted(period, year)

--- a/spec/services/weekly_stats_summary_spec.rb
+++ b/spec/services/weekly_stats_summary_spec.rb
@@ -3,10 +3,12 @@ require 'rails_helper'
 RSpec.describe WeeklyStatsSummary do
   it 'posts the correct stats' do
     create(:application_form, submitted_at: 1.minute.ago)
+    apply_again_application = create(:application_form, phase: 'apply_2')
     create(:application_choice, :with_recruited)
     create(:application_choice, :with_offer)
     create(:application_choice, :with_rejection)
     create(:application_choice, :with_rejection_by_default)
+    create(:application_choice, :with_offer, application_form: apply_again_application)
 
     travel_temporarily_to(1.year.ago) do
       last_cycle_form = create(:application_form)
@@ -19,12 +21,13 @@ RSpec.describe WeeklyStatsSummary do
 
     output = described_class.new.as_slack_message
 
-    expect(output).to match(/5 total candidate signups | This point last cycle we had 3/)
-    expect(output).to match(/5 total applications begun | This point last cycle we had 3/)
-    expect(output).to match(/5 total applications submitted | This point last cycle we had 3/)
-    expect(output).to match(/1 total candidate recruited | This point last cycle we had 1/)
-    expect(output).to match(/2 total offers made | This point last cycle we had 3/)
-    expect(output).to match(/2 total rejections issued/)
-    expect(output).to match(/of which 1 was RBD | This point last cycle we had 2/)
+    expect(output).to match('6 total candidate signups \\| This point last cycle we had 3')
+    expect(output).to match('5 total initial applications begun \\| This point last cycle we had 3')
+    expect(output).to match('1 total Apply again application begun \\| This point last cycle we had 0')
+    expect(output).to match('4 total applications submitted \\| This point last cycle we had 2')
+    expect(output).to match('1 total candidate recruited \\| This point last cycle we had 1')
+    expect(output).to match('3 total offers made \\| This point last cycle we had 3')
+    expect(output).to match('2 total rejections issued')
+    expect(output).to match('of which 1 was RBD \\| This point last cycle we had 2')
   end
 end


### PR DESCRIPTION
## Context

Applications begun number is higher than candidates sign up figure. This is because we're not splitting the number out by application phase.

Also add a delimiter to the numbers for readability.

Test format has been updated as these will return false positives due to the `|` symbol