### PR TITLE
Do not show next publication date if there isn't any

### DIFF
--- a/app/views/publications/monthly_statistics/show.html.erb
+++ b/app/views/publications/monthly_statistics/show.html.erb
@@ -14,8 +14,11 @@
       <dl class="gem-c-metadata">
         <dt class="gem-c-metadata__term">Published</dt>
         <dd class="gem-c-metadata__definition"><%= @presenter.publication_date.to_fs(:govuk_date) %></dd>
-        <dt class="gem-c-metadata__term">Next update</dt>
-        <dd class="gem-c-metadata__definition"><%= @presenter.next_publication_date.to_fs(:govuk_date) %></dd>
+
+        <% if @presenter.current_year == CycleTimetable.current_year %>
+          <dt class="gem-c-metadata__term">Next update</dt>
+          <dd class="gem-c-metadata__definition"><%= @presenter.next_publication_date.to_fs(:govuk_date) %></dd>
+        <% end %>
       </dl>
     </div>
   </div>


### PR DESCRIPTION
## Context

Remove "Next update 26 December 2022" from last year’s report - presumably we're no longer going to update that...