### PR TITLE
Remove 'references' as a reason for rejection in the current system

### DIFF
--- a/app/forms/provider_interface/rejections_wizard.rb
+++ b/app/forms/provider_interface/rejections_wizard.rb
@@ -14,6 +14,10 @@ module ProviderInterface
                 :single_attribute_names,
                 :reasons,
                 to: :rejection_reasons
+
+      def selectable_reasons
+        reasons.reject(&:deprecated?)
+      end
     end
 
     attr_accessor(*attribute_names)

--- a/app/models/rejection_reasons/reason.rb
+++ b/app/models/rejection_reasons/reason.rb
@@ -4,7 +4,7 @@ class RejectionReasons
 
     TRANSLATION_KEY_PREFIX = 'activemodel.errors.models.provider_interface/rejections_wizard.attributes'.freeze
 
-    attr_accessor :id, :details, :label, :reasons, :selected_reasons
+    attr_accessor :id, :deprecated, :details, :label, :reasons, :selected_reasons
 
     validate :reasons_selected
 
@@ -54,6 +54,10 @@ class RejectionReasons
       return details.valid? if details
 
       selected_reasons.map(&:valid?).all?(true)
+    end
+
+    def deprecated?
+      !!deprecated
     end
 
     def errors

--- a/app/views/provider_interface/rejections/new.html.erb
+++ b/app/views/provider_interface/rejections/new.html.erb
@@ -22,7 +22,7 @@
       <% end %>
 
       <%= f.govuk_check_boxes_fieldset :selected_reasons, legend: -> { content_for(:fieldset_legend) }, form_group: { classes: 'govuk-!-margin-bottom-2' } do %>
-        <% @wizard.class.reasons.each do |reason| %>
+        <% @wizard.class.selectable_reasons.each do |reason| %>
           <%= f.govuk_check_box :selected_reasons, reason.id, label: { text: reason.label }, link_errors: true do %>
             <% if reason.details.present? %>
               <%= f.govuk_text_area reason.details.id.to_sym,

--- a/config/rejection_reasons.yml
+++ b/config/rejection_reasons.yml
@@ -96,6 +96,7 @@
       :id: communication_and_scheduling_other_details
       :label: Details
 - :id: references
+  :deprecated: true
   :label: References
   :details:
     :id: references_details

--- a/spec/components/provider_interface/application_rejection_feedback_component_spec.rb
+++ b/spec/components/provider_interface/application_rejection_feedback_component_spec.rb
@@ -51,6 +51,18 @@ RSpec.describe ProviderInterface::ApplicationRejectionFeedbackComponent do
       )
     end
 
+    before do
+      # Add back in a reason that no longer exists
+      application_choice.structured_rejection_reasons['selected_reasons'] << {
+        id: 'references', label: 'References',
+        details: {
+          id: 'references_details',
+          text: 'We do not accept references from close family members, such as your mum.',
+        }
+      }
+      application_choice.save!
+    end
+
     it 'renders the date of rejection' do
       expect(render.text).to include("This application was rejected on #{application_choice.rejected_at.to_fs(:govuk_date)}")
     end
@@ -71,14 +83,14 @@ RSpec.describe ProviderInterface::ApplicationRejectionFeedbackComponent do
       expect(rows[1]).to include('Quality of writing')
       expect(rows[1]).to include('We do not accept applications written in Old Norse.')
 
-      expect(rows[2]).to include('References')
-      expect(rows[2]).to include('We do not accept references from close family members, such as your mum.')
+      expect(rows[2]).to include('Course full')
+      expect(rows[2]).to include('The course is full.')
 
-      expect(rows[3]).to include('Course full')
-      expect(rows[3]).to include('The course is full.')
+      expect(rows[3]).to include('Other')
+      expect(rows[3]).to include('So many other things were wrong...')
 
-      expect(rows[4]).to include('Other')
-      expect(rows[4]).to include('So many other things were wrong...')
+      expect(rows[4]).to include('References')
+      expect(rows[4]).to include('We do not accept references from close family members, such as your mum.')
     end
   end
 

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -205,13 +205,6 @@ FactoryBot.define do
                   label: 'Quality of writing',
                   details: { id: 'quality_of_writing_details', text: 'We do not accept applications written in Old Norse.' } },
               ] },
-            {
-              id: 'references', label: 'References',
-              details: {
-                id: 'references_details',
-                text: 'We do not accept references from close family members, such as your mum.',
-              }
-            },
             { id: 'course_full',  label: 'Course full' },
             { id: 'other', label: 'Other', details: { id: 'other_details', text: 'So many other things were wrong...' } },
           ],

--- a/spec/forms/provider_interface/rejections_wizard_spec.rb
+++ b/spec/forms/provider_interface/rejections_wizard_spec.rb
@@ -18,6 +18,26 @@ RSpec.describe ProviderInterface::RejectionsWizard do
     end
   end
 
+  describe '.reasons' do
+    it 'includes non-deprecated reasons' do
+      expect(described_class.reasons.find { |r| r.id == 'personal_statement' }).to be_present
+    end
+
+    it 'includes deprecated reasons' do
+      expect(described_class.reasons.find { |r| r.id == 'references' }).to be_present
+    end
+  end
+
+  describe '.selectable_reasons' do
+    it 'includes non-deprecated reasons' do
+      expect(described_class.selectable_reasons.find { |r| r.id == 'personal_statement' }).to be_present
+    end
+
+    it 'does not include deprecated reasons' do
+      expect(described_class.selectable_reasons.find { |r| r.id == 'references' }).to be_nil
+    end
+  end
+
   describe 'dynamic attributes' do
     it 'defines accessors for all attributes' do
       described_class.attribute_names.each do |attr_name|

--- a/spec/requests/vendor_api/reasons_for_rejection_spec.rb
+++ b/spec/requests/vendor_api/reasons_for_rejection_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'Vendor API reasons for rejection' do
+  include VendorAPISpecHelpers
+
+  let(:application_choice) do
+    create_application_choice_for_currently_authenticated_provider({}, [:with_current_rejection_reasons]).tap do |ac|
+      ac.structured_rejection_reasons['selected_reasons'] << {
+        id: 'references', label: 'References',
+        details: {
+          id: 'references_details',
+          text: 'We do not accept references from close family members, such as your mum.',
+        }
+      }
+      ac.save!
+    end
+  end
+
+  let(:returned_rejection_reasons) { parsed_response.dig('data', 'attributes', 'rejection', 'reason') }
+
+  before do
+    get_api_request "/api/v#{version}/applications/#{application_choice.id}"
+  end
+
+  %w[1.0 1.1 1.2 1.3].each do |api_version|
+    context "for version #{api_version}" do
+      let(:version) { api_version }
+
+      it "returns the full rejection reasons, including ones that don't exist anymore" do
+        expect(returned_rejection_reasons).to include('Quality of writing')
+        expect(returned_rejection_reasons).to include('such as your mum')
+      end
+    end
+  end
+end

--- a/spec/system/candidate_interface/rejection/candidate_reviews_reasons_for_rejection_spec.rb
+++ b/spec/system/candidate_interface/rejection/candidate_reviews_reasons_for_rejection_spec.rb
@@ -1,12 +1,10 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate can see their structured reasons for rejection when reviewing their application' do
+RSpec.feature 'Candidate can see their structured reasons for rejection when reviewing their application', time: CycleTimetableHelper.mid_cycle do
   scenario 'when a candidate visits their apply again application form they can see apply1 rejection reasons' do
-    TestSuiteTimeMachine.travel_permanently_to(mid_cycle)
-
     given_i_am_signed_in
 
-    and_i_have_an_apply1_application_with_2_rejections
+    and_i_have_an_apply1_application_with_rejections
 
     when_i_visit_my_application_complete_page
     then_i_can_see_my_rejection_reasons
@@ -24,7 +22,7 @@ RSpec.feature 'Candidate can see their structured reasons for rejection when rev
     login_as(@candidate)
   end
 
-  def and_i_have_an_apply1_application_with_2_rejections
+  def and_i_have_an_apply1_application_with_rejections
     travel_temporarily_to(mid_cycle(CycleTimetable.previous_year)) do
       @application_form = create(:completed_application_form, :with_completed_references, candidate: @candidate)
       @application_choice_with_feedback = create(:application_choice, :with_structured_rejection_reasons, application_form: @application_form)

--- a/spec/system/candidate_interface/rejection/deleting_a_reason_for_rejection_does_not_impact_the_candidate_interface_spec.rb
+++ b/spec/system/candidate_interface/rejection/deleting_a_reason_for_rejection_does_not_impact_the_candidate_interface_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate can see their structured reasons for rejection when reviewing their application', time: CycleTimetableHelper.mid_cycle do
+  scenario 'despite us removing one of them as a valid reason for rejection' do
+    given_i_am_signed_in
+
+    and_i_have_an_apply1_application_with_rejections
+
+    when_i_visit_my_application_complete_page
+    then_i_can_see_my_rejection_reasons
+
+    when_i_apply_again
+    then_i_can_see_rejection_reasons_from_the_earlier_application
+    and_i_should_see_unsuccessful_status
+    and_i_should_not_see_a_link_to_the_course_on_find
+  end
+
+  def given_i_am_signed_in
+    @candidate = create(:candidate)
+    login_as(@candidate)
+  end
+
+  def and_i_have_an_apply1_application_with_rejections
+    travel_temporarily_to(mid_cycle(CycleTimetable.previous_year)) do
+      @application_form = create(:completed_application_form, :with_completed_references, candidate: @candidate)
+      @application_choice = create(:application_choice, :with_current_rejection_reasons, application_form: @application_form).tap do |ac|
+        ac.structured_rejection_reasons['selected_reasons'] << {
+          id: 'references', label: 'References',
+          details: {
+            id: 'references_details',
+            text: 'We do not accept references from close family members, such as your mum.',
+          }
+        }
+        ac.save!
+      end
+    end
+  end
+
+  def when_i_visit_my_application_complete_page
+    visit candidate_interface_application_complete_path
+  end
+
+  def then_i_can_see_my_rejection_reasons
+    expect(page).to have_content('Quality of writing')
+    expect(page).to have_content('such as your mum')
+  end
+
+  def when_i_apply_again
+    click_on 'Apply again'
+  end
+
+  def then_i_can_see_rejection_reasons_from_the_earlier_application
+    expect(page).to have_content('Quality of writing')
+    expect(page).to have_content('such as your mum')
+  end
+
+  def and_i_should_see_unsuccessful_status
+    expect(page).to have_content('Unsuccessful')
+  end
+
+  def and_i_should_not_see_a_link_to_the_course_on_find
+    course_name = @application_choice.current_course.name_and_code
+    expect(page).to have_content(course_name)
+    expect(page).not_to have_link(course_name)
+  end
+end


### PR DESCRIPTION
Adds a few tests to make sure nothing explodes.

I've left references in the "old" list since I don't think it's doing any harm there, and might make rendering them easier.

## Changes proposed in this pull request

<img width="685" alt="Screenshot 2022-11-28 at 12 20 26" src="https://user-images.githubusercontent.com/109225/204276894-b32fe526-c62d-4042-9dc3-8da65b916886.png">
