### PR TITLE
When emailing providers about references, use the order they were received

### DIFF
--- a/app/components/candidate_interface/accept_offer_review_component.rb
+++ b/app/components/candidate_interface/accept_offer_review_component.rb
@@ -5,7 +5,7 @@ module CandidateInterface
     def initialize(application_form:, application_choice:)
       @application_form = application_form
       @application_choice = application_choice
-      @references = application_form.application_references
+      @references = application_form.application_references.creation_order
 
       super(application_form: @application_form, application_choice: @application_choice, references: @references)
     end

--- a/app/components/candidate_interface/add_reference_component.rb
+++ b/app/components/candidate_interface/add_reference_component.rb
@@ -19,7 +19,7 @@ module CandidateInterface
   private
 
     def viable_references
-      application_form.application_references.select do |reference|
+      application_form.application_references.creation_order.select do |reference|
         reference.not_requested_yet? ||
           reference.feedback_requested? ||
           reference.feedback_provided?

--- a/app/components/candidate_interface/references_component.rb
+++ b/app/components/candidate_interface/references_component.rb
@@ -9,7 +9,7 @@ module CandidateInterface
     end
 
     def references
-      application_form.application_references
+      application_form.application_references.creation_order
     end
   end
 end

--- a/app/controllers/candidate_interface/references/accept_offer/name_controller.rb
+++ b/app/controllers/candidate_interface/references/accept_offer/name_controller.rb
@@ -6,7 +6,7 @@ module CandidateInterface
       def next_path
         candidate_interface_accept_offer_references_email_address_path(
           application_choice,
-          @reference&.id || current_application.application_references.last.id,
+          @reference&.id || current_application.application_references.creation_order.last.id,
         )
       end
     end

--- a/app/controllers/candidate_interface/references/name_controller.rb
+++ b/app/controllers/candidate_interface/references/name_controller.rb
@@ -38,7 +38,7 @@ module CandidateInterface
 
       def next_path
         candidate_interface_references_email_address_path(
-          @reference&.id || current_application.application_references.last.id,
+          @reference&.id || current_application.application_references.creation_order.last.id,
         )
       end
 

--- a/app/controllers/candidate_interface/references/request_reference/name_controller.rb
+++ b/app/controllers/candidate_interface/references/request_reference/name_controller.rb
@@ -5,7 +5,7 @@ module CandidateInterface
 
       def next_path
         candidate_interface_request_reference_references_email_address_path(
-          @reference&.id || current_application.application_references.last.id,
+          @reference&.id || current_application.application_references.creation_order.last.id,
         )
       end
     end

--- a/app/forms/candidate_interface/reference/referee_email_address_form.rb
+++ b/app/forms/candidate_interface/reference/referee_email_address_form.rb
@@ -30,7 +30,7 @@ module CandidateInterface
 
     def email_address_unique
       reference = ApplicationReference.find(reference_id)
-      current_email_addresses = (reference.application_form.application_references.map(&:email_address) - [reference.email_address]).compact
+      current_email_addresses = (reference.application_form.application_references.creation_order.map(&:email_address) - [reference.email_address]).compact
       return true if current_email_addresses.blank? || email_address.blank?
 
       errors.add(:email_address, :duplicate) if current_email_addresses.map(&:downcase).include?(email_address.downcase)

--- a/app/forms/candidate_interface/reference/request_referee_email_address_form.rb
+++ b/app/forms/candidate_interface/reference/request_referee_email_address_form.rb
@@ -12,7 +12,7 @@ module CandidateInterface
 
     def other_references
       reference = ApplicationReference.find(reference_id)
-      reference.application_form.application_references.where.not(id: reference_id)
+      reference.application_form.application_references.creation_order.where.not(id: reference_id)
     end
   end
 end

--- a/app/forms/candidate_interface/reference/selection_form.rb
+++ b/app/forms/candidate_interface/reference/selection_form.rb
@@ -9,7 +9,7 @@ module CandidateInterface
     validate :correct_number_chosen?
 
     def available_references
-      application_form.application_references.includes([:application_form]).feedback_provided
+      application_form.application_references.creation_order.includes([:application_form]).feedback_provided
     end
 
     def save!

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -202,7 +202,7 @@ private
           )
         end
 
-        @application_form.application_references.feedback_requested.each do |reference|
+        @application_form.application_references.creation_order.feedback_requested.each do |reference|
           CancelReferee.new.call(reference:)
         end
 
@@ -256,12 +256,12 @@ private
     return if references_without_an_accepted_offer?
 
     # The first reference is declined by the referee
-    @application_form.application_references.feedback_requested.first.feedback_refused!
+    @application_form.application_references.creation_order.feedback_requested.first.feedback_refused!
     # Cancel 1 reference manually and receive feedback on the remaining 2.
     # Select the two references with feedback.
-    @application_form.application_references.feedback_requested.first.cancelled!
+    @application_form.application_references.creation_order.feedback_requested.first.cancelled!
 
-    @application_form.application_references.feedback_requested.each do |reference|
+    @application_form.application_references.creation_order.feedback_requested.each do |reference|
       submit_reference!(reference.reload)
       reference.update(selected: true)
       fast_forward
@@ -357,7 +357,7 @@ private
     @application_form.reload
 
     if incomplete_references
-      @application_form.application_references.each do |reference|
+      @application_form.application_references.creation_order.each do |reference|
         submit_reference!(reference.reload)
         fast_forward
       end

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -218,8 +218,8 @@ class CandidateMailer < ApplicationMailer
 
   def reference_received(reference)
     @reference = reference
-    @selected_references = reference.application_form.application_references.select(&:selected)
-    @provided_references = reference.application_form.application_references.select(&:feedback_provided?)
+    @selected_references = reference.application_form.application_references.creation_order.select(&:selected)
+    @provided_references = reference.application_form.application_references.creation_order.select(&:feedback_provided?)
 
     email_for_candidate(
       reference.application_form,

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -12,9 +12,7 @@ class ApplicationForm < ApplicationRecord
   has_many :application_work_experiences
   has_many :application_volunteering_experiences
   has_many :application_qualifications
-  # explicit default order, so that we can preserve 'First' / 'Second' in the UI
-  # as we're using numerical IDs with autonumber, 'id' is fine to achieve this
-  has_many :application_references, -> { order('id ASC') }
+  has_many :application_references
   has_many :application_work_history_breaks
 
   belongs_to :previous_application_form, class_name: 'ApplicationForm', optional: true, inverse_of: 'subsequent_application_form'

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -10,6 +10,7 @@ class ApplicationReference < ApplicationRecord
   has_one :candidate, through: :application_form
 
   scope :selected, -> { feedback_provided.where(selected: true) }
+  scope :creation_order, -> { order(:id) }
 
   audited associated_with: :application_form
 
@@ -57,7 +58,7 @@ class ApplicationReference < ApplicationRecord
   end
 
   def self_and_siblings
-    application_form.application_references
+    application_form.application_references.creation_order
   end
 
   def email_address_not_own
@@ -98,9 +99,9 @@ class ApplicationReference < ApplicationRecord
   def order_in_application_references
     return unless feedback_provided?
 
-    self_and_siblings
+    application_form.application_references
       .feedback_provided
-      .order(:feedback_provided_at)
+      .order(:feedback_provided_at, :id)
       .index(self) + 1
   end
 

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -96,13 +96,12 @@ class ApplicationReference < ApplicationRecord
   end
 
   def order_in_application_references
-    return if failed?
+    return unless feedback_provided?
 
-    application_form
-      .application_references
+    self_and_siblings
       .feedback_provided
-      .order(id: :asc)
-      .pluck(:id).index(id) + 1
+      .order(:feedback_provided_at)
+      .index(self) + 1
   end
 
   def chase_referee_at

--- a/app/presenters/vendor_api/application_presenter.rb
+++ b/app/presenters/vendor_api/application_presenter.rb
@@ -87,9 +87,9 @@ module VendorAPI
       return [] unless show_references?
 
       references = if version_1_3_or_above?
-                     application_form.application_references
+                     application_form.application_references.creation_order
                    else
-                     application_form.application_references.feedback_provided
+                     application_form.application_references.creation_order.feedback_provided
                    end
 
       references.map { |reference| reference_to_hash(reference) }

--- a/app/services/accept_offer.rb
+++ b/app/services/accept_offer.rb
@@ -19,7 +19,7 @@ class AcceptOffer
       withdraw_and_decline_associated_application_choices!
     end
 
-    application_form.application_references.includes([:application_form]).not_requested_yet.each do |reference|
+    application_form.application_references.includes([:application_form]).not_requested_yet.creation_order.each do |reference|
       RequestReference.new.call(reference)
     end
 

--- a/app/services/accept_unconditional_offer.rb
+++ b/app/services/accept_unconditional_offer.rb
@@ -11,7 +11,7 @@ class AcceptUnconditionalOffer < AcceptOffer
       ProviderMailer.unconditional_offer_accepted(provider_user, @application_choice).deliver_later
     end
 
-    application_choice.application_form.application_references.includes([:application_form]).not_requested_yet.each do |reference|
+    application_choice.application_form.application_references.creation_order.includes([:application_form]).not_requested_yet.each do |reference|
       RequestReference.new.call(reference)
     end
 

--- a/app/services/candidate_api/serializers/v1_2.rb
+++ b/app/services/candidate_api/serializers/v1_2.rb
@@ -48,7 +48,7 @@ module CandidateAPI
         {
           completed: application_form.references_completed,
           data:
-            application_form.application_references.order(:id).map do |reference|
+            application_form.application_references.creation_order.map do |reference|
               {
                 id: reference.id,
                 requested_at: reference.requested_at&.iso8601,

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -52,6 +52,7 @@ class DuplicateApplication
 
     original_references = original_application_form.application_references
       .includes([:reference_tokens])
+      .creation_order
       .where(feedback_status: %w[feedback_provided not_requested_yet cancelled_at_end_of_cycle feedback_requested])
       .reject(&:feedback_overdue?)
 
@@ -60,11 +61,11 @@ class DuplicateApplication
         original_reference.attributes.except(*IGNORED_CHILD_ATTRIBUTES).merge!(duplicate: true),
       )
 
-      awaiting_response_references = new_application_form.application_references.feedback_requested
+      awaiting_response_references = new_application_form.application_references.creation_order.feedback_requested
       change_references_to_not_requested_yet(awaiting_response_references)
       new_application_form.update!(references_completed: false)
 
-      references_cancelled_at_eoc = new_application_form.application_references.cancelled_at_end_of_cycle
+      references_cancelled_at_eoc = new_application_form.application_references.creation_order.cancelled_at_end_of_cycle
 
       change_references_to_not_requested_yet(references_cancelled_at_eoc)
     end

--- a/app/services/submit_reference.rb
+++ b/app/services/submit_reference.rb
@@ -54,7 +54,7 @@ private
   end
 
   def cancel_feedback_requested_references
-    application_form.application_references.select(&:feedback_requested?).each do |reference|
+    application_form.application_references.creation_order.select(&:feedback_requested?).each do |reference|
       CancelReferee.new.call(reference:)
     end
   end

--- a/app/services/support_interface/application_references_export.rb
+++ b/app/services/support_interface/application_references_export.rb
@@ -11,7 +11,7 @@ module SupportInterface
           application_state: ProcessState.new(application_form).state,
         }
 
-        application_form.application_references.reject(&:duplicate).map.with_index(1) do |reference, index|
+        application_form.application_references.creation_order.reject(&:duplicate).map.with_index(1) do |reference, index|
           output[:"ref_#{index}_type"] = reference.referee_type
           output[:"ref_#{index}_state"] = reference.feedback_status
           output[:"ref_#{index}_requested_at"] = reference.requested_at

--- a/app/services/support_interface/candidate_journey_tracker.rb
+++ b/app/services/support_interface/candidate_journey_tracker.rb
@@ -153,6 +153,7 @@ module SupportInterface
       @all_references ||= @application_choice
         .application_form
         .application_references
+        .creation_order
     end
 
     def earliest_update_audit_for(model, attributes)
@@ -188,7 +189,7 @@ module SupportInterface
     end
 
     def earliest_reference_chaser_sent(chaser_type)
-      chasers = @application_choice.application_form.application_references.map(&:chasers_sent).flatten
+      chasers = @application_choice.application_form.application_references.creation_order.map(&:chasers_sent).flatten
       chasers.select { |chaser| chaser.chaser_type == chaser_type.to_s }.map(&:created_at).min
     end
 

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -142,7 +142,7 @@
 <section class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.safeguarding') %></h2>
   <h3 class="govuk-heading-m"><%= @application_form.any_offer_accepted? ? 'Reference requests' : t('page_titles.references') %></h3>
-  <%= render(CandidateInterface::ReferencesReviewComponent.new(application_form: current_application, editable: editable, references: @application_form.application_references, heading_level: 3, return_to_application_review: true, missing_error: missing_error)) %>
+  <%= render(CandidateInterface::ReferencesReviewComponent.new(application_form: current_application, editable: editable, references: @application_form.application_references.creation_order, heading_level: 3, return_to_application_review: true, missing_error: missing_error)) %>
   <h3 class="govuk-heading-m"><%= t('page_titles.suitability_to_work_with_children') %></h3>
   <%= render(CandidateInterface::SafeguardingReviewComponent.new(application_form: @application_form, editable: editable, missing_error: missing_error, submitting_application: true, return_to_application_review: true)) %>
 </section>

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -28,7 +28,7 @@
 <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">References</h2>
 
 <% if @application_form.application_references.any? %>
-  <% @application_form.application_references.includes(%i[application_form audits]).each_with_index do |reference, i| %>
+  <% @application_form.application_references.includes(%i[application_form audits]).creation_order.each_with_index do |reference, i| %>
     <%= render SupportInterface::ReferenceWithFeedbackComponent.new(reference: reference, reference_number: i + 1, editable: @application_form.editable?) %>
   <% end %>
 <% end %>

--- a/lib/test_suite_time_machine.rb
+++ b/lib/test_suite_time_machine.rb
@@ -84,6 +84,10 @@ class TestSuiteTimeMachine
       TestSuiteTimeMachine.travel_permanently_to(...)
     end
 
+    def advance_time
+      TestSuiteTimeMachine.advance
+    end
+
     def advance_time_to(...)
       TestSuiteTimeMachine.advance_time_to(...)
     end

--- a/spec/forms/candidate_interface/reference/referee_name_form_spec.rb
+++ b/spec/forms/candidate_interface/reference/referee_name_form_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe CandidateInterface::Reference::RefereeNameForm, type: :model do
         form = described_class.new(name: 'Walter White')
         form.save(application_form, 'academic')
 
-        expect(application_form.application_references.last.referee_type).to eq('academic')
-        expect(application_form.application_references.last.name).to eq('Walter White')
+        expect(application_form.application_references.creation_order.last.referee_type).to eq('academic')
+        expect(application_form.application_references.creation_order.last.name).to eq('Walter White')
       end
     end
 

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe TestApplications do
       ).first
     end
 
-    let(:references) { application_choice.application_form.application_references }
+    let(:references) { application_choice.application_form.application_references.creation_order }
     let(:incomplete_references) { false }
 
     subject { references.map(&:feedback_status) }

--- a/spec/mailers/candidate_mailer_referee_mails_spec.rb
+++ b/spec/mailers/candidate_mailer_referee_mails_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe CandidateMailer do
     let(:email) do
       mailer.send(
         :reference_received,
-        application_form.application_references.first,
+        application_form.application_references.creation_order.first,
       )
     end
     let(:reference) do

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -105,13 +105,13 @@ RSpec.describe ProviderMailer do
 
   describe '.reference_received' do
     let(:provider) { create(:provider, :with_signed_agreement, code: 'ABC', provider_users: [provider_user]) }
-    let(:site) { create(:site, provider: provider) }
-    let(:course) { create(:course, provider: provider, name: 'Computer Science', code: '6IND') }
-    let(:course_option) { create(:course_option, course: course, site: site) }
+    let(:site) { create(:site, provider:) }
+    let(:course) { create(:course, provider:, name: 'Computer Science', code: '6IND') }
+    let(:course_option) { create(:course_option, course:, site:) }
     let(:current_course_option) { course_option }
     let(:application_choice) do
-      create(:submitted_application_choice, course_option: course_option,
-                                            current_course_option: current_course_option,
+      create(:submitted_application_choice, course_option:,
+                                            current_course_option:,
                                             reject_by_default_at: 40.days.from_now,
                                             reject_by_default_days: 123)
     end
@@ -120,18 +120,19 @@ RSpec.describe ProviderMailer do
                                           last_name: 'Potter',
                                           support_reference: '123A',
                                           application_choices: [application_choice],
-                                          submitted_at: 5.days.ago)
+                                          submitted_at: 5.days.ago,
+                                          references_count: 0)
     end
     let(:provider_user) { create(:provider_user, first_name: 'Johny', last_name: 'English') }
 
-    let(:reference) { create(:reference, :feedback_provided, application_form: application_form) }
-    let(:email) do
-      described_class.reference_received(
-        provider_user: provider_user,
-        application_choice: application_choice,
-        reference: reference,
-        course: course,
-      )
+    let(:reference) { create(:reference, :feedback_provided, application_form:, feedback_provided_at: Time.zone.now) }
+    let(:email) { described_class.reference_received(provider_user:, application_choice:, reference:, course:) }
+
+    before do
+      application_form.application_references << create(:reference, :feedback_provided, application_form:, feedback_provided_at: Time.zone.now)
+      advance_time
+      application_form.application_references << create(:reference, :feedback_provided, application_form:, feedback_provided_at: Time.zone.now)
+      advance_time
     end
 
     it_behaves_like('a mail with subject and content',

--- a/spec/models/application_reference_spec.rb
+++ b/spec/models/application_reference_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe ApplicationReference do
         ]
       end
 
-      it "reports position based on the order in which they were received" do
+      it 'reports position based on the order in which they were received' do
         expect(references.map(&:order_in_application_references)).to eq([nil, nil])
 
         advance_time

--- a/spec/requests/candidate_api/get_candidates_v1_2_spec.rb
+++ b/spec/requests/candidate_api/get_candidates_v1_2_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'GET /candidate-api/v1.2/candidates' do
     TestSuiteTimeMachine.advance
 
     first_application_choice = application_forms.first.application_choices.first
-    first_reference = application_forms.first.application_references.first
+    first_reference = application_forms.first.application_references.creation_order.first
 
     create(
       :interview,

--- a/spec/requests/vendor_api/application_references_spec.rb
+++ b/spec/requests/vendor_api/application_references_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Vendor API application references' do
   let(:returned_references) { parsed_response.dig('data', 'attributes', 'references') }
   let(:returned_reference) { returned_references.first&.deep_symbolize_keys }
 
-  let(:reference) { application_choice.application_form.application_references.first }
+  let(:reference) { application_choice.application_form.application_references.creation_order.first }
 
   before do
     get_api_request "/api/v#{version}/applications/#{application_choice.id}"

--- a/spec/services/accept_unconditional_offer_spec.rb
+++ b/spec/services/accept_unconditional_offer_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe AcceptUnconditionalOffer do
       application_choice = create(:application_choice, status: :offer, application_form: application_form)
 
       expect { described_class.new(application_choice:).save! }.to change { ActionMailer::Base.deliveries.count }.by(3)
-      expect(ActionMailer::Base.deliveries.first.to).to eq [application_choice.application_form.application_references.first.email_address]
+      expect(ActionMailer::Base.deliveries.first.to).to eq [application_choice.application_form.application_references.creation_order.first.email_address]
       expect(ActionMailer::Base.deliveries.first.subject).to match(/ Teacher training reference needed for /)
     end
   end

--- a/spec/services/carry_over_application_spec.rb
+++ b/spec/services/carry_over_application_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe CarryOverApplication do
 
       expect(ApplicationForm.count).to eq 2
       expect(ApplicationForm.last.application_references.count).to eq 3
-      expect(ApplicationForm.last.application_references.map(&:feedback_status)).to eq(
+      expect(ApplicationForm.last.application_references.creation_order.map(&:feedback_status)).to eq(
         %w[feedback_provided not_requested_yet not_requested_yet],
       )
     end

--- a/spec/services/delete_reference_spec.rb
+++ b/spec/services/delete_reference_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe DeleteReference do
       application_form = create(:application_form, references_completed: true)
       create_list(:reference, 2, :feedback_provided, selected: true, application_form:)
 
-      described_class.new.call(reference: application_form.application_references.first)
+      described_class.new.call(reference: application_form.application_references.creation_order.first)
 
       expect(application_form.reload.references_completed).to be false
     end

--- a/spec/services/duplicate_application_shared_examples.rb
+++ b/spec/services/duplicate_application_shared_examples.rb
@@ -38,8 +38,8 @@ RSpec.shared_examples 'duplicates application form' do |expected_phase, expected
   it 'copies application references and marks them as duplicates' do
     expect(duplicate_application_form.application_references.count).to eq 2
     expect(duplicate_application_form.application_references).to all(be_feedback_provided.or(be_not_requested_yet))
-    expect(duplicate_application_form.application_references.first.duplicate).to be true
-    expect(duplicate_application_form.application_references.second.duplicate).to be true
+    expect(duplicate_application_form.application_references.creation_order.first.duplicate).to be true
+    expect(duplicate_application_form.application_references.creation_order.second.duplicate).to be true
   end
 
   it 'copies work and volunteering experiences' do

--- a/spec/services/submit_reference_spec.rb
+++ b/spec/services/submit_reference_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe SubmitReference, sidekiq: true do
       ratifying_provider = create(:provider)
       ratifying_provider_user = create(:provider_user, :with_notifications_enabled, providers: [ratifying_provider])
       application_form = create(:application_form, :minimum_info)
-      create(:reference, :feedback_provided, application_form:)
+      create(:reference, :feedback_provided, application_form:, feedback_provided_at: Time.zone.now)
       create(:reference, :feedback_requested, application_form:)
       reference = create(:reference, :feedback_requested, application_form:)
       application_choice = create(:application_choice, :with_accepted_offer, application_form:, course_option: create(:course_option, course: create(:course, accredited_provider: ratifying_provider)))
@@ -48,6 +48,7 @@ RSpec.describe SubmitReference, sidekiq: true do
 
       create(:provider_user_notification_preferences, :all_off, provider_user: create(:provider_user, providers: [application_choice.course.provider]))
 
+      advance_time
       described_class.new(reference: reference).save!
 
       expect(reference).to be_feedback_provided

--- a/spec/services/support_interface/application_references_export_spec.rb
+++ b/spec/services/support_interface/application_references_export_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe SupportInterface::ApplicationReferencesExport, bullet: true do
     it 'returns an array of hashes containing non duplicate reference types' do
       application_form_one = create(:application_form, created_at: 1.day.ago)
 
-      create(:reference, feedback_status: 'feedback_refused', referee_type: 'academic', application_form: application_form_one)
-      create(:reference, feedback_status: 'feedback_refused', referee_type: 'professional', application_form: application_form_one)
-      create(:reference, feedback_status: 'feedback_requested', referee_type: 'school-based', application_form: application_form_one)
-      create(:reference, feedback_status: 'feedback_requested', referee_type: 'character', application_form: application_form_one)
+      ref1 = create(:reference, feedback_status: 'feedback_refused', referee_type: 'academic', application_form: application_form_one)
+      ref2 = create(:reference, feedback_status: 'feedback_refused', referee_type: 'professional', application_form: application_form_one)
+      ref3 = create(:reference, feedback_status: 'feedback_requested', referee_type: 'school-based', application_form: application_form_one)
+      ref4 = create(:reference, feedback_status: 'feedback_requested', referee_type: 'character', application_form: application_form_one)
 
-      application_form_one.application_references[2].update!(feedback_status: 'feedback_provided')
-      application_form_one.application_references[3].update!(feedback_status: 'feedback_provided')
+      ref3.update!(feedback_status: 'feedback_provided')
+      ref4.update!(feedback_status: 'feedback_provided')
 
       application_form_two = DuplicateApplication.new(
         application_form_one,
@@ -41,22 +41,22 @@ RSpec.describe SupportInterface::ApplicationReferencesExport, bullet: true do
           support_reference: application_form_one.support_reference,
           phase: application_form_one.phase,
           application_state: ProcessState.new(application_form_one).state,
-          ref_1_type: application_form_one.application_references[0].referee_type,
-          ref_1_state: application_form_one.application_references[0].feedback_status,
-          ref_1_requested_at: application_form_one.application_references[0].requested_at,
+          ref_1_type: ref1.referee_type,
+          ref_1_state: ref1.feedback_status,
+          ref_1_requested_at: ref1.requested_at,
           ref_1_received_at: nil,
-          ref_2_type: application_form_one.application_references[1].referee_type,
-          ref_2_state: application_form_one.application_references[1].feedback_status,
-          ref_2_requested_at: application_form_one.application_references[1].requested_at,
+          ref_2_type: ref2.referee_type,
+          ref_2_state: ref2.feedback_status,
+          ref_2_requested_at: ref2.requested_at,
           ref_2_received_at: nil,
-          ref_3_type: application_form_one.application_references[2].referee_type,
-          ref_3_state: application_form_one.application_references[2].feedback_status,
-          ref_3_requested_at: application_form_one.application_references[2].requested_at,
-          ref_3_received_at: application_form_one.application_references[2].feedback_provided_at,
-          ref_4_type: application_form_one.application_references[3].referee_type,
-          ref_4_state: application_form_one.application_references[3].feedback_status,
-          ref_4_requested_at: application_form_one.application_references[3].requested_at,
-          ref_4_received_at: application_form_one.application_references[3].feedback_provided_at,
+          ref_3_type: ref3.referee_type,
+          ref_3_state: ref3.feedback_status,
+          ref_3_requested_at: ref3.requested_at,
+          ref_3_received_at: ref3.feedback_provided_at,
+          ref_4_type: ref4.referee_type,
+          ref_4_state: ref4.feedback_status,
+          ref_4_requested_at: ref4.requested_at,
+          ref_4_received_at: ref4.feedback_provided_at,
         },
         {
           recruitment_cycle_year: application_form_two.recruitment_cycle_year,
@@ -74,7 +74,7 @@ RSpec.describe SupportInterface::ApplicationReferencesExport, bullet: true do
         },
       )
 
-      expect(application_form_two.reload.application_references.count).to eq 4
+      expect(application_form_two.reload.application_references.count).to eq(4)
     end
   end
 end

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -151,7 +151,7 @@ module CandidateHelper
 
   def receive_references
     application_form = ApplicationForm.last
-    first_reference = application_form.application_references.first
+    first_reference = application_form.application_references.creation_order.first
 
     first_reference.update!(
       feedback: 'My ideal person',
@@ -163,7 +163,7 @@ module CandidateHelper
       reference: first_reference,
     ).save!
 
-    second_reference = application_form.application_references.second
+    second_reference = application_form.application_references.creation_order.second
 
     second_reference.update!(
       feedback: 'Lovable',

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_spec.rb
@@ -180,7 +180,7 @@ RSpec.feature 'Candidate accepts an offer' do
   end
 
   def then_i_should_be_seeing_my_references
-    @application_form.reload.application_references.each do |reference|
+    @application_form.reload.application_references.creation_order.each do |reference|
       expect(page).to have_content(reference.name)
       expect(page).to have_content(reference.email_address)
       expect(page).to have_content(reference.relationship)
@@ -194,7 +194,7 @@ RSpec.feature 'Candidate accepts an offer' do
   end
 
   def and_i_click_delete_the_first_reference
-    click_on "Delete reference from #{@application_form.application_references.first.name}"
+    click_on "Delete reference from #{@application_form.application_references.creation_order.first.name}"
   end
 
   def then_the_back_link_should_point_to_the_accept_offer_page
@@ -253,7 +253,7 @@ RSpec.feature 'Candidate accepts an offer' do
       candidate_interface_accept_offer_references_name_path(
         @application_choice,
         'school-based',
-        @application_form.reload.application_references.last.id,
+        @application_form.reload.application_references.creation_order.last.id,
       ),
     )
   end
@@ -264,7 +264,7 @@ RSpec.feature 'Candidate accepts an offer' do
     ).to eq(
       candidate_interface_accept_offer_references_email_address_path(
         @application_choice,
-        @application_form.reload.application_references.last.id,
+        @application_form.reload.application_references.creation_order.last.id,
       ),
     )
   end
@@ -307,7 +307,7 @@ RSpec.feature 'Candidate accepts an offer' do
       candidate_interface_accept_offer_references_type_path(
         @application_choice,
         'professional',
-        @application_form.reload.application_references.last.id,
+        @application_form.reload.application_references.creation_order.last.id,
       ),
     )
   end
@@ -326,7 +326,7 @@ RSpec.feature 'Candidate accepts an offer' do
       candidate_interface_accept_offer_references_name_path(
         @application_choice,
         'professional',
-        @application_form.reload.application_references.last.id,
+        @application_form.reload.application_references.creation_order.last.id,
       ),
     )
   end
@@ -335,7 +335,7 @@ RSpec.feature 'Candidate accepts an offer' do
     expect(page).to have_current_path(
       candidate_interface_accept_offer_references_email_address_path(
         @application_choice,
-        @application_form.reload.application_references.last.id,
+        @application_form.reload.application_references.creation_order.last.id,
       ),
     )
   end
@@ -344,7 +344,7 @@ RSpec.feature 'Candidate accepts an offer' do
     expect(page).to have_current_path(
       candidate_interface_accept_offer_references_relationship_path(
         @application_choice,
-        @application_form.reload.application_references.last.id,
+        @application_form.reload.application_references.creation_order.last.id,
       ),
     )
   end

--- a/spec/system/candidate_interface/references/candidate_add_references_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_add_references_spec.rb
@@ -189,7 +189,7 @@ RSpec.feature 'References', time: CycleTimetableHelper.after_apply_1_deadline do
   end
 
   def then_i_see_the_referee_email_page
-    expect(page).to have_current_path candidate_interface_references_email_address_path(@application.application_references.last.id)
+    expect(page).to have_current_path candidate_interface_references_email_address_path(@application.application_references.creation_order.last.id)
   end
 
   def when_i_click_save_and_continue_without_providing_an_emailing
@@ -221,7 +221,7 @@ RSpec.feature 'References', time: CycleTimetableHelper.after_apply_1_deadline do
   end
 
   def then_i_see_the_relationship_page
-    expect(page).to have_current_path candidate_interface_references_relationship_path(@application.application_references.last.id)
+    expect(page).to have_current_path candidate_interface_references_relationship_path(@application.application_references.creation_order.last.id)
   end
 
   def when_i_click_save_and_continue_without_providing_a_relationship
@@ -320,7 +320,7 @@ RSpec.feature 'References', time: CycleTimetableHelper.after_apply_1_deadline do
   end
 
   def then_i_see_the_candidate_name_page
-    expect(page).to have_current_path candidate_interface_references_create_candidate_name_path(@application.application_references.last.id)
+    expect(page).to have_current_path candidate_interface_references_create_candidate_name_path(@application.application_references.creation_order.last.id)
   end
 
   def and_i_should_be_told_my_reference_request_has_been_sent

--- a/spec/system/candidate_interface/references/candidate_apply_again_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_apply_again_spec.rb
@@ -65,16 +65,19 @@ RSpec.feature 'Candidates in the 2023 cycle, applying again' do
   end
 
   def then_i_see_the_new_states_of_my_references
-    expect(new_application_form.application_references.map(&:name)).not_to include(%w[Mr cancelled Mr declined])
-    expect(new_application_form.application_references.count).to eq 3
-    expect(new_application_form.application_references.first.feedback_status).to eq 'not_requested_yet'
-    expect(new_application_form.application_references.second.feedback_status).to eq 'not_requested_yet'
-    expect(new_application_form.application_references.third.feedback_status).to eq 'feedback_provided'
+    references = new_application_form.application_references.creation_order
+
+    expect(references.map(&:name).intersect?(['Mr cancelled', 'Mr declined'])).not_to be(true)
+    expect(references.count).to eq(3)
+    expect(references.first.feedback_status).to eq('not_requested_yet')
+    expect(references.second.feedback_status).to eq('not_requested_yet')
+    expect(references.third.feedback_status).to eq('feedback_provided')
+
     expect(page).to have_current_path(candidate_interface_references_review_path)
-    expect(page.text).to include @pending_reference.name
-    expect(page.text).to include @not_sent_reference.name
-    expect(page.text).to include "#{@selected_reference.name} has already given a reference."
-    expect(page.text).to include 'If you accept an offer, the training provider will see the reference.'
+    expect(page.text).to include(@pending_reference.name)
+    expect(page.text).to include(@not_sent_reference.name)
+    expect(page.text).to include("#{@selected_reference.name} has already given a reference.")
+    expect(page.text).to include('If you accept an offer, the training provider will see the reference.')
   end
 
   def and_i_sign_in_again

--- a/spec/system/candidate_interface/references/candidate_can_continuously_request_references_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_can_continuously_request_references_spec.rb
@@ -49,7 +49,7 @@ RSpec.feature 'References' do
   end
 
   def and_i_can_receive_more_references
-    reference = @application.application_references.last
+    reference = @application.application_references.creation_order.last
     SubmitReference.new(reference:).save!
     expect(reference.reload.feedback_status).to eq('feedback_provided')
   end

--- a/spec/system/candidate_interface/references/candidate_carries_over_unsubmitted_application_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_carries_over_unsubmitted_application_spec.rb
@@ -72,7 +72,7 @@ RSpec.feature 'References' do
   end
 
   def then_i_see_the_new_states_of_my_references
-    expect(new_application_form.application_references.map(&:feedback_status)).to eq(
+    expect(new_application_form.application_references.creation_order.map(&:feedback_status)).to eq(
       %w[feedback_provided feedback_provided feedback_provided],
     )
   end

--- a/spec/system/candidate_interface/references/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   def then_i_see_the_new_states_of_my_references
-    expect(new_application_form.application_references.map(&:feedback_status)).to eq(
+    expect(new_application_form.application_references.creation_order.map(&:feedback_status)).to eq(
       %w[feedback_provided feedback_provided not_requested_yet],
     )
   end

--- a/spec/system/candidate_interface/references/candidate_replaces_reference_after_applying_again_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_replaces_reference_after_applying_again_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature 'Candidate applying again' do
       safeguarding_issues_status: :no_safeguarding_issues_to_declare,
     )
     create(:application_choice, status: :rejected, application_form: @application_form)
-    @completed_references = @application_form.application_references
+    @completed_references = @application_form.application_references.creation_order
     @refused_reference = create(:reference, feedback_status: :feedback_refused, application_form: @application_form)
   end
 

--- a/spec/system/candidate_interface/references/candidate_request_references_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_request_references_spec.rb
@@ -128,7 +128,7 @@ RSpec.feature 'New References', time: CycleTimetableHelper.after_apply_1_deadlin
   def and_i_should_be_on_add_email_address_page
     expect(page).to have_current_path(
       candidate_interface_request_reference_references_email_address_path(
-        @application_form.reload.application_references.last.id,
+        @application_form.reload.application_references.creation_order.last.id,
       ),
     )
   end
@@ -137,7 +137,7 @@ RSpec.feature 'New References', time: CycleTimetableHelper.after_apply_1_deadlin
     expect(back_link).to eq(
       candidate_interface_request_reference_references_name_path(
         'character',
-        @application_form.reload.application_references.last.id,
+        @application_form.reload.application_references.creation_order.last.id,
       ),
     )
   end
@@ -145,7 +145,7 @@ RSpec.feature 'New References', time: CycleTimetableHelper.after_apply_1_deadlin
   def and_i_should_be_on_add_email_address_page
     expect(page).to have_current_path(
       candidate_interface_request_reference_references_email_address_path(
-        @application_form.reload.application_references.last.id,
+        @application_form.reload.application_references.creation_order.last.id,
       ),
     )
   end
@@ -157,7 +157,7 @@ RSpec.feature 'New References', time: CycleTimetableHelper.after_apply_1_deadlin
   def and_i_should_be_on_add_relationship_page
     expect(page).to have_current_path(
       candidate_interface_request_reference_references_relationship_path(
-        @application_form.reload.application_references.last.id,
+        @application_form.reload.application_references.creation_order.last.id,
       ),
     )
   end
@@ -165,7 +165,7 @@ RSpec.feature 'New References', time: CycleTimetableHelper.after_apply_1_deadlin
   def and_the_back_link_should_point_to_the_add_email_address_page
     expect(back_link).to eq(
       candidate_interface_request_reference_references_email_address_path(
-        @application_form.reload.application_references.last.id,
+        @application_form.reload.application_references.creation_order.last.id,
       ),
     )
   end
@@ -177,7 +177,7 @@ RSpec.feature 'New References', time: CycleTimetableHelper.after_apply_1_deadlin
   def and_i_should_be_on_check_your_answers
     expect(page).to have_current_path(
       candidate_interface_references_request_reference_review_path(
-        @application_form.reload.application_references.last.id,
+        @application_form.reload.application_references.creation_order.last.id,
       ),
     )
   end
@@ -187,7 +187,7 @@ RSpec.feature 'New References', time: CycleTimetableHelper.after_apply_1_deadlin
   end
 
   def and_the_reference_should_be_not_sent_yet
-    expect(@application_form.reload.application_references.last.feedback_status).to eq('not_requested_yet')
+    expect(@application_form.reload.application_references.creation_order.last.feedback_status).to eq('not_requested_yet')
   end
 
   def and_i_return_to_the_offer_dashboard
@@ -239,7 +239,7 @@ RSpec.feature 'New References', time: CycleTimetableHelper.after_apply_1_deadlin
   end
 
   def then_the_reference_should_be_requested
-    expect(@application_form.reload.application_references.last.feedback_status).to eq('feedback_requested')
+    expect(@application_form.reload.application_references.creation_order.last.feedback_status).to eq('feedback_requested')
     expect(reference_row.text).to include('Requested')
   end
 

--- a/spec/system/provider_interface/provider_views_the_references_tab_on_manage_spec.rb
+++ b/spec/system/provider_interface/provider_views_the_references_tab_on_manage_spec.rb
@@ -72,7 +72,7 @@ RSpec.feature 'Provider views an application in new cycle' do
   end
 
   def then_i_see_the_candidates_references
-    references = @my_provider_choice.application_form.application_references
+    references = @my_provider_choice.application_form.application_references.creation_order
     link = page.find_link('References', class: 'app-tab-navigation__link')
     expect(link['aria-current']).to eq('page')
 
@@ -87,7 +87,7 @@ RSpec.feature 'Provider views an application in new cycle' do
   end
 
   def when_the_candidate_receives_a_reference
-    @my_provider_choice.application_form.application_references.first.update(feedback_status: 'feedback_provided')
+    @my_provider_choice.application_form.application_references.creation_order.first.update(feedback_status: 'feedback_provided')
   end
 
   def and_i_revisit_references
@@ -98,11 +98,11 @@ RSpec.feature 'Provider views an application in new cycle' do
     expect(page).not_to have_content pre_offer_message
     expect(page).to have_content 'Requested references'
     expect(page).to have_content 'The candidate has requested 2 references.'
-    expect(page).to have_content @my_provider_choice.application_form.application_references.first.feedback
+    expect(page).to have_content @my_provider_choice.application_form.application_references.creation_order.first.feedback
   end
 
   def then_i_see_the_reference_feedback
-    expect(page).to have_content @my_provider_choice.application_form.application_references.first.feedback
+    expect(page).to have_content @my_provider_choice.application_form.application_references.creation_order.first.feedback
   end
 
   def pre_offer_message

--- a/spec/system/support_interface/editing_reference_spec.rb
+++ b/spec/system/support_interface/editing_reference_spec.rb
@@ -49,7 +49,7 @@ RSpec.feature 'Editing reference' do
   end
 
   def and_i_click_the_change_link_next_to_referee_name
-    within_summary_card(@form.application_references.first.name) do
+    within_summary_card(@form.application_references.creation_order.first.name) do
       within_summary_row('Name') do
         click_link 'Change'
       end
@@ -95,7 +95,7 @@ RSpec.feature 'Editing reference' do
   end
 
   def and_i_click_the_change_link_next_to_feedback
-    within_summary_card(@form.application_references.first.name) do
+    within_summary_card(@form.application_references.creation_order.first.name) do
       click_link 'Add reference'
     end
   end

--- a/spec/system/support_interface/provide_or_refuse_feedback_for_a_feedback_requested_reference_spec.rb
+++ b/spec/system/support_interface/provide_or_refuse_feedback_for_a_feedback_requested_reference_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature 'Support user can access the RefereeInterface' do
   end
 
   def when_the_candidates_reference_is_in_the_feedback_provided_state
-    @application.application_references.first.feedback_provided!
+    @application.application_references.creation_order.first.feedback_provided!
   end
 
   def and_i_visit_the_application_form_page

--- a/spec/system/support_interface/see_individual_application_spec.rb
+++ b/spec/system/support_interface/see_individual_application_spec.rb
@@ -48,9 +48,9 @@ RSpec.feature 'See an application' do
   end
 
   def and_an_application_has_received_a_reference
-    @application_with_reference.application_references.first.update(consent_to_be_contacted: true)
+    @application_with_reference.application_references.creation_order.first.update(consent_to_be_contacted: true)
 
-    reference = @application_with_reference.reload.application_references.first
+    reference = @application_with_reference.reload.application_references.creation_order.first
     reference.update!(
       feedback: 'This is my feedback',
       safeguarding_concerns: '',

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -286,7 +286,7 @@ RSpec.feature 'Vendor receives the application', time: CycleTimetableHelper.mid_
     expect(received_attributes.dig(:attributes, :references)).to be_present
     expect(received_attributes.dig(:attributes, :references)).to match_array([
       {
-        id: @application.application_references.first.id,
+        id: @application.application_references.creation_order.first.id,
         name: 'Terri Tudor',
         email: 'terri@example.com',
         referee_type: 'academic',
@@ -295,7 +295,7 @@ RSpec.feature 'Vendor receives the application', time: CycleTimetableHelper.mid_
         safeguarding_concerns: false,
       },
       {
-        id: @application.application_references.last.id,
+        id: @application.application_references.creation_order.last.id,
         name: 'Anne Other',
         email: 'anne.other@example.com',
         referee_type: 'professional',

--- a/spec/workers/generate_test_applications_spec.rb
+++ b/spec/workers/generate_test_applications_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe GenerateTestApplications, mid_cycle: true do
       described_class.new.perform(true)
     end
 
-    pending_references = ApplicationChoice.where(status: :pending_conditions).first.application_form.application_references.flat_map(&:feedback_status)
-    processed_references = ApplicationChoice.where(status: :pending_conditions).last.application_form.application_references.flat_map(&:feedback_status)
+    pending_references = ApplicationChoice.where(status: :pending_conditions).first.application_form.application_references.creation_order.flat_map(&:feedback_status)
+    processed_references = ApplicationChoice.where(status: :pending_conditions).last.application_form.application_references.creation_order.flat_map(&:feedback_status)
 
     expect(ApplicationChoice.pluck(:status)).to include(
       'awaiting_provider_decision',


### PR DESCRIPTION
Removing this default order scope will probably cause problems somewhere else but it's gotta be done.  They're a menace.

## Context

When providers are emailed about a candidate's reference coming in, they're told whether it's the first, second etc.  The code to produce this was a bit off as it was basing on the order they were created rather than the order they came in.