### PR TITLE
655 Upload/download db backup with azcopy

### DIFF
--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -65,8 +65,9 @@ jobs:
 
     - name: Upload Backup to Azure Storage
       run: |
-        az storage blob upload --container-name prod-db-backup \
-        --file ${BACKUP_FILE_NAME}.sql.gz --name ${BACKUP_FILE_NAME}.sql.gz \
+        az config set extension.use_dynamic_install=yes_without_prompt
+        az storage azcopy blob upload --container prod-db-backup \
+        --source ${BACKUP_FILE_NAME}.sql.gz \
         --connection-string '${{ env.STORAGE_CONN_STR }}'
 
     - name: Notify Slack channel on job failure

--- a/.github/workflows/restore-production-snapshot.yml
+++ b/.github/workflows/restore-production-snapshot.yml
@@ -78,7 +78,8 @@ jobs:
 
       - name: Download backup
         run: |
-          az storage blob download --container-name ${BACKUP_CONTAINER} --name ${BACKUP_ARCHIVE_NAME} --file ${BACKUP_ARCHIVE_NAME} \
+          az config set extension.use_dynamic_install=yes_without_prompt
+          az storage azcopy blob download --container ${BACKUP_CONTAINER} --source ${BACKUP_ARCHIVE_NAME} --destination ${BACKUP_ARCHIVE_NAME} \
           --connection-string '${{ env.STORAGE_CONN_STR }}'
 
       - name: Restore backup to snapshot database

--- a/bin/download-nightly-backup
+++ b/bin/download-nightly-backup
@@ -41,5 +41,6 @@ if [[ -z ${BACKUP_ARCHIVE_FILENAME} ]]; then
   exit 1
 else
   echo "Downloading ${BACKUP_ARCHIVE_FILENAME} ..."
-  az storage blob download --connection-string ${STORAGE_CONN_STR} -c ${AZURE_BACKUP_STORAGE_CONTAINER_NAME} -n ${BACKUP_ARCHIVE_FILENAME} -f ${BACKUP_ARCHIVE_FILENAME} --output none
+  az config set extension.use_dynamic_install=yes_without_prompt
+  az storage azcopy blob download --connection-string ${STORAGE_CONN_STR} --container ${AZURE_BACKUP_STORAGE_CONTAINER_NAME} --source ${BACKUP_ARCHIVE_FILENAME} --destination ${BACKUP_ARCHIVE_FILENAME} --output none
 fi


### PR DESCRIPTION
## Context

The upload of the database backup takes a long time using the standard Azure CLI storage modules. Investigate whether using azcopy improves the upload and download of the backup file to the Azure storage account.

## Changes proposed in this pull request

- Update the `database-backup.yml` workflow to use azcopy to upload the backup to the Azure storage account
- Update the `restore-production-snapshot.yml` workflow to use azcopy to download the backup from the Azure storage account

## Guidance to review

Confirm linked workflow runs completed successfully

## Link to Trello card

https://trello.com/c/9YaOHgt2

## Testing

- [x] [Database backup test](https://github.com/DFE-Digital/apply-for-teacher-training/actions/runs/3565784002/jobs/5991378282)
- [x] [Database upload test](https://github.com/DFE-Digital/apply-for-teacher-training/actions/runs/3581527201/jobs/6024691184)
- [x] Confirm data in restored backup is OK
- [x] Confirm backup downloads using Makefile recipe script

## Tidy-up
- [x] Remove test workflow and runs from GitHub
- [x] Remove `snapshot-test` and `snapshot-test-azcopy` database instances from production space
