### PR TITLE
Allow support to revoke vendor API tokens

### DIFF
--- a/app/controllers/support_interface/api_tokens_controller.rb
+++ b/app/controllers/support_interface/api_tokens_controller.rb
@@ -16,6 +16,13 @@ module SupportInterface
       @unhashed_token = VendorAPIToken.create_with_random_token!(provider:)
     end
 
+    def confirm_revocation; end
+
+    def destroy
+      VendorAPIToken.find(params[:id]).destroy!
+      redirect_to support_interface_api_tokens_path
+    end
+
   private
 
     def raise_error_unless_provider(params)

--- a/app/views/support_interface/api_tokens/confirm_revocation.html.erb
+++ b/app/views/support_interface/api_tokens/confirm_revocation.html.erb
@@ -1,0 +1,4 @@
+<%= render 'support_interface/providers/providers_navigation', title: 'API tokens' %>
+
+<h2 class="govuk-heading-m">Confirm revocation</h2>
+<%= govuk_button_to 'Revoke', support_interface_api_token_path(params[:id]), method: :delete, warning: true %>

--- a/app/views/support_interface/api_tokens/index.html.erb
+++ b/app/views/support_interface/api_tokens/index.html.erb
@@ -12,6 +12,7 @@
       <th scope='col' class='govuk-table__header govuk-!-width-one-third'>Provider</th>
       <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Last used at</th>
       <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Created at</th>
+      <th scope='col' class='govuk-table__header'>Actions</th>
     </tr>
   </thead>
 
@@ -22,6 +23,9 @@
       <td class='govuk-table__cell'><%= token.provider.name %></td>
       <td class='govuk-table__cell'><%= token.last_used_at ? token.last_used_at.to_fs(:govuk_date_and_time) : 'Never' %></td>
       <td class='govuk-table__cell'><%= token.created_at.to_fs(:govuk_date_and_time) %></td>
+      <td class='govuk-table__cell'>
+        <%= govuk_button_link_to 'Revoke', confirm_revocation_support_interface_api_token_path(token), warning: true %>
+      </td>
     </tr>
     <% end %>
   </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -978,8 +978,11 @@ Rails.application.routes.draw do
       get 'impersonate-and-decline' => 'references#impersonate_and_decline', as: :impersonate_referee_and_decline_reference
     end
 
-    get '/tokens' => 'api_tokens#index', as: :api_tokens
-    post '/tokens' => 'api_tokens#create'
+    resources :api_tokens, path: '/tokens', only: %i[index create destroy] do
+      member do
+        get 'confirm-revocation'
+      end
+    end
 
     get '/providers' => 'providers#index', as: :providers
 

--- a/spec/factories/provider.rb
+++ b/spec/factories/provider.rb
@@ -22,5 +22,9 @@ FactoryBot.define do
         provider.vendor = Vendor.find_or_create_by(name: 'in_house')
       end
     end
+
+    trait :with_api_token do
+      vendor_api_tokens { [build(:vendor_api_token, provider: @instance)] }
+    end
   end
 end

--- a/spec/system/support_interface/api_tokens/create_token_spec.rb
+++ b/spec/system/support_interface/api_tokens/create_token_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Manage API tokens' do
+RSpec.feature 'API tokens' do
   include DfESignInHelpers
 
   scenario 'Support creates a token' do

--- a/spec/system/support_interface/api_tokens/revoke_token_spec.rb
+++ b/spec/system/support_interface/api_tokens/revoke_token_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.feature 'API tokens' do
+  include DfESignInHelpers
+
+  scenario 'Support revokes a token' do
+    given_i_am_signed_in
+    and_providers_exist_with_api_tokens
+    when_i_revoke_a_token_for_a_provider
+    then_that_provider_should_no_longer_have_an_api_token
+    but_the_other_provider_should_still_have_an_api_token
+  end
+
+  def given_i_am_signed_in
+    sign_in_as_support_user
+  end
+
+  def and_providers_exist_with_api_tokens
+    @provider_1 = create(:provider, :with_api_token, name: 'Provider 1')
+    @provider_2 = create(:provider, :with_api_token, name: 'Provider 2')
+  end
+
+  def when_i_revoke_a_token_for_a_provider
+    visit support_interface_api_tokens_path
+    row = page.find('td', text: @provider_1.name).ancestor('tr')
+
+    within row do
+      click_on 'Revoke'
+    end
+
+    expect(page).to have_content('Confirm revocation')
+    click_on 'Revoke'
+  end
+
+  def then_that_provider_should_no_longer_have_an_api_token
+    within '.govuk-table' do
+      expect(page).not_to have_content('Provider 1')
+    end
+  end
+
+  def but_the_other_provider_should_still_have_an_api_token
+    within '.govuk-table' do
+      expect(page).to have_content('Provider 2')
+    end
+  end
+end


### PR DESCRIPTION
## Context

We currently allow them to create them but not revoke them.  There's no particular reason for that.

## Changes proposed in this pull request

<img width="1190" alt="Screenshot 2022-11-30 at 12 16 26" src="https://user-images.githubusercontent.com/109225/204794601-5c260ee6-83fe-4bd6-b924-0a31e7c4b845.png">
<img width="1175" alt="Screenshot 2022-11-30 at 12 16 52" src="https://user-images.githubusercontent.com/109225/204794616-191a1055-d589-459f-b6fa-aa17e04c7695.png">
