### PR TITLE
Allow Register API to access applications in all cycles

### DIFF
--- a/app/controllers/register_api/applications_controller.rb
+++ b/app/controllers/register_api/applications_controller.rb
@@ -100,7 +100,7 @@ module RegisterAPI
 
     def recruitment_cycle_year_param
       year = params.fetch(:recruitment_cycle_year)
-      raise ParameterInvalid, 'Parameter is invalid: recruitment_cycle_year' unless year.in?(RecruitmentCycle.years_visible_to_providers.map(&:to_s))
+      raise ParameterInvalid, 'Parameter is invalid: recruitment_cycle_year' unless year.in?(RecruitmentCycle.years_visible_in_support.map(&:to_s))
 
       year
     end

--- a/spec/requests/register_api/get_multiple_applications_spec.rb
+++ b/spec/requests/register_api/get_multiple_applications_spec.rb
@@ -71,12 +71,18 @@ RSpec.describe 'GET /register-api/applications' do
     expect(parsed_response).to be_valid_against_openapi_schema('ParameterMissingResponse')
   end
 
-  it 'returns an error if the `recruitment_cycle_year` parameter is incorrect year' do
-    get_api_request '/register-api/applications?recruitment_cycle_year=2008', token: register_api_token
+  it 'returns an error if the `recruitment_cycle_year` parameter is before first available cycle' do
+    get_api_request '/register-api/applications?recruitment_cycle_year=2018', token: register_api_token
 
     expect(response).to have_http_status(:unprocessable_entity)
     expect(error_response['message']).to eql('Parameter is invalid: recruitment_cycle_year')
     expect(parsed_response).to be_valid_against_openapi_schema('ParameterInvalidResponse')
+  end
+
+  it 'succeeds if the `recruitment_cycle_year` parameter is within available cycles' do
+    get_api_request '/register-api/applications?recruitment_cycle_year=2019', token: register_api_token
+
+    expect(response).to have_http_status(:success)
   end
 
   it 'returns HTTP status 422 if the per_page param is too big' do


### PR DESCRIPTION
## Context

We were limiting `recruitment_cycle_year` to`RecruitmentCycle.years_visible_to_providers`, without any clear justification for doing so. This caused a fail on the Register API when trying to fetch applications for 2021.

## Changes proposed in this pull request

Limit `recruitment_cycle_year` to `RecruitmentCycle.years_visible_in_support`, that is, all cycles.

## Guidance to review

`GET /register-api/applications?recruitment_cycle_year=2020` works?

## Link to Trello card

https://trello.com/c/sStIVh5v/921-amend-register-api-so-it-exposes-all-cycle-years

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
