### PR TITLE
Change "School based" to "School experience" in provider interface

### DIFF
--- a/app/views/provider_interface/references/_references.html.erb
+++ b/app/views/provider_interface/references/_references.html.erb
@@ -3,6 +3,6 @@
     rows: ProviderInterface::NewReferenceWithFeedbackComponent.new(reference:, index:, application_choice: @application_choice).rows,
     editable: false,
   )) do %>
-    <%= render SummaryCardHeaderComponent.new(title: "#{reference.referee_type.humanize} reference from #{reference.name}", heading_level: 3) %>
+    <%= render SummaryCardHeaderComponent.new(title: t(reference.referee_type, scope: 'provider_interface.references.card_title', name: reference.name), heading_level: 3) %>
   <% end %>
 <% end %>

--- a/config/locales/provider_interface/references.yml
+++ b/config/locales/provider_interface/references.yml
@@ -1,6 +1,11 @@
 en:
   provider_interface:
     references:
+      card_title:
+        school_based: School experience reference from %{name}
+        academic: Academic reference from %{name}
+        professional: Academic reference from %{name}
+        character: Character reference from %{name}
       candidate_has_said: "The candidate said:"
       referee_has_said: "%{name} said:"
       confirmed_by: This was confirmed by %{name}.

--- a/spec/system/provider_interface/provider_views_the_references_tab_on_manage_spec.rb
+++ b/spec/system/provider_interface/provider_views_the_references_tab_on_manage_spec.rb
@@ -78,8 +78,8 @@ RSpec.feature 'Provider views an application in new cycle' do
 
     expect(page).to have_content pre_offer_message
 
-    expect(page).to have_content "#{references.first.referee_type.humanize} reference from #{references.first.name}"
-    expect(page).to have_content "#{references.second.referee_type.humanize} reference from #{references.second.name}"
+    expect(page).to have_content I18n.t(references.first.referee_type, scope: 'provider_interface.references.card_title', name: references.first.name)
+    expect(page).to have_content I18n.t(references.second.referee_type, scope: 'provider_interface.references.card_title', name: references.second.name)
   end
 
   def when_the_candidate_accepts_an_offer


### PR DESCRIPTION
This change is for consistency with the candidate interface, where we changed it because "school based" was being interpreted as when someone was at school...

Also moves the text to the locale files rather instead of using ruby code to convert the referee type code into a readable string.

🗂️ [Trello card](https://trello.com/c/lMfcocEQ/836-change-school-based-reference-type-to-school-experience-in-manage)

## Screenshots

### Before

<img width="1009" alt="Screenshot 2022-12-01 at 16 00 46" src="https://user-images.githubusercontent.com/30665/205100765-9bdfe2c0-7713-4ae2-a899-7057ffc21582.png">

### After

<img width="1005" alt="Screenshot 2022-12-01 at 16 00 58" src="https://user-images.githubusercontent.com/30665/205100739-f468917a-7769-4beb-8285-a51c7cce50b4.png">

