### PR TITLE
Add offers accepted to the daily slack post

### DIFF
--- a/app/services/stats_summary.rb
+++ b/app/services/stats_summary.rb
@@ -10,6 +10,7 @@ class StatsSummary
       :pencil: #{pluralize(applications_begun(today), 'application')} begun | #{applications_begun(this_day_last_year)} last cycle
       :#{mailbox_emoji(applications_submitted(today))}: #{pluralize(applications_submitted(today), 'application')} submitted | #{applications_submitted(this_day_last_year)} last cycle
       :#{rand(2) == 1 ? 'wo' : nil}man-tipping-hand: #{pluralize(offers_made(today), 'offer')} made | #{offers_made(this_day_last_year)} last cycle
+      :#{rand(2) == 1 ? 'wo' : nil}man-tipping-hand: #{pluralize(offers_accepted(today), 'offer')} accepted | #{offers_accepted(this_day_last_year)} last cycle
       :#{rand(2) == 1 ? 'wo' : nil}man-gesturing-no: #{pluralize(rejections_issued(today), 'rejection')} issued#{rejections_issued(today).positive? ? ", of which #{pluralize(rbd_count(today), 'was')} RBD" : nil} | #{rejections_issued(this_day_last_year)} last cycle
       :handshake: #{pluralize(candidates_recruited(today), 'candidate')} recruited | #{candidates_recruited(this_day_last_year)} last cycle
     MARKDOWN
@@ -29,6 +30,10 @@ class StatsSummary
 
   def offers_made(period)
     Offer.where(created_at: period).count
+  end
+
+  def offers_accepted(period)
+    ApplicationChoice.where(accepted_at: period).count
   end
 
   def candidates_recruited(period)

--- a/app/services/weekly_stats_summary.rb
+++ b/app/services/weekly_stats_summary.rb
@@ -13,6 +13,7 @@ class WeeklyStatsSummary
       #{technologist} #{pluralize(number_with_delimiter(applications_begun(current_cycle_period, current_year, 'apply_2')), 'total Apply again application')} begun | This point last cycle we had #{number_with_delimiter(applications_begun(previous_cycle_period, previous_year, 'apply_2'))}
       :postbox: #{pluralize(number_with_delimiter(applications_submitted(current_cycle_period, current_year)), 'total application')} submitted | This point last cycle we had #{number_with_delimiter(applications_submitted(previous_cycle_period, previous_year))}
       :yes_vote: #{pluralize(number_with_delimiter(offers_made(current_cycle_period, current_year)), 'total offer')} made | This point last cycle we had #{number_with_delimiter(offers_made(previous_cycle_period, previous_year))}
+      :handshake: #{pluralize(number_with_delimiter(offers_accepted(current_cycle_period, current_year)), 'total offer')} accepted | This point last cycle we had #{number_with_delimiter(offers_accepted(previous_cycle_period, previous_year))}
       :no_vote: #{pluralize(number_with_delimiter(rejections_issued(current_cycle_period, current_year)), 'total rejection')} issued#{rejections_issued(current_cycle_period, current_year).positive? ? ", of which #{pluralize(number_with_delimiter(rbd_count(current_cycle_period, current_year)), 'was')} RBD" : nil} | This point last cycle we had #{number_with_delimiter(rejections_issued(previous_cycle_period, previous_year))}
       #{teacher} #{pluralize(number_with_delimiter(candidates_recruited(current_cycle_period, current_year)), 'total candidate')} recruited | This point last cycle we had #{number_with_delimiter(candidates_recruited(previous_cycle_period, previous_year))}
 
@@ -36,6 +37,10 @@ class WeeklyStatsSummary
 
   def offers_made(period, year)
     Offer.joins(:application_choice).where('application_choice.current_recruitment_cycle_year': year, created_at: period).count
+  end
+
+  def offers_accepted(period, year)
+    ApplicationChoice.where(accepted_at: period, current_recruitment_cycle_year: year).count
   end
 
   def candidates_recruited(period, year)

--- a/spec/services/stats_summary_spec.rb
+++ b/spec/services/stats_summary_spec.rb
@@ -6,9 +6,11 @@ RSpec.describe StatsSummary do
     create(:application_choice, :with_recruited)
     create(:application_choice, :with_offer)
     create(:application_choice, :with_rejection)
+    create(:application_choice, :with_accepted_offer, accepted_at: 1.minute.ago)
+    create(:application_choice, :with_accepted_offer, accepted_at: 1.minute.ago)
     create(:application_choice, :with_rejection_by_default)
 
-    travel_temporarily_to(1.year.ago) do
+    travel_temporarily_to(CycleTimetable.this_working_day_last_cycle) do
       last_cycle_form = create(:application_form)
       create(:application_choice, :with_recruited, application_form: last_cycle_form)
       create(:application_choice, :with_offer, application_form: last_cycle_form)
@@ -19,12 +21,13 @@ RSpec.describe StatsSummary do
 
     output = described_class.new.as_slack_message
 
-    expect(output).to match(/5 candidate signups | 3 last cycle/)
-    expect(output).to match(/5 applications begun | 3 last cycle/)
-    expect(output).to match(/1 application submitted | 0 last cycle/)
-    expect(output).to match(/1 candidate recruited | 1 last cycle/)
-    expect(output).to match(/2 offers made | 3 last cycle/)
-    expect(output).to match(/2 rejections issued/)
-    expect(output).to match(/of which 1 was RBD | 2 last cycle/)
+    expect(output).to match('7 candidate signups \\| 3 last cycle')
+    expect(output).to match('7 applications begun \\| 3 last cycle')
+    expect(output).to match('1 application submitted \\| 0 last cycle')
+    expect(output).to match('2 offers accepted \\| 0 last cycle')
+    expect(output).to match('1 candidate recruited \\| 1 last cycle')
+    expect(output).to match('4 offers made \\| 3 last cycle')
+    expect(output).to match('2 rejections issued')
+    expect(output).to match('of which 1 was RBD \\| 2 last cycle')
   end
 end

--- a/spec/services/weekly_stats_summary_spec.rb
+++ b/spec/services/weekly_stats_summary_spec.rb
@@ -7,10 +7,12 @@ RSpec.describe WeeklyStatsSummary do
     create(:application_choice, :with_recruited)
     create(:application_choice, :with_offer)
     create(:application_choice, :with_rejection)
+    create(:application_choice, :with_accepted_offer, accepted_at: 1.minute.ago)
+    create(:application_choice, :with_accepted_offer, accepted_at: 1.minute.ago)
     create(:application_choice, :with_rejection_by_default)
     create(:application_choice, :with_offer, application_form: apply_again_application)
 
-    travel_temporarily_to(1.year.ago) do
+    travel_temporarily_to(CycleTimetable.this_working_day_last_cycle) do
       last_cycle_form = create(:application_form)
       create(:application_choice, :with_recruited, application_form: last_cycle_form)
       create(:application_choice, :with_offer, application_form: last_cycle_form)
@@ -21,12 +23,13 @@ RSpec.describe WeeklyStatsSummary do
 
     output = described_class.new.as_slack_message
 
-    expect(output).to match('6 total candidate signups \\| This point last cycle we had 3')
-    expect(output).to match('5 total initial applications begun \\| This point last cycle we had 3')
+    expect(output).to match('8 total candidate signups \\| This point last cycle we had 3')
+    expect(output).to match('7 total initial applications begun \\| This point last cycle we had 3')
     expect(output).to match('1 total Apply again application begun \\| This point last cycle we had 0')
-    expect(output).to match('4 total applications submitted \\| This point last cycle we had 2')
+    expect(output).to match('6 total applications submitted \\| This point last cycle we had 2')
     expect(output).to match('1 total candidate recruited \\| This point last cycle we had 1')
-    expect(output).to match('3 total offers made \\| This point last cycle we had 3')
+    expect(output).to match('5 total offers made \\| This point last cycle we had 3')
+    expect(output).to match('3 total offers accepted \\| This point last cycle we had 1')
     expect(output).to match('2 total rejections issued')
     expect(output).to match('of which 1 was RBD \\| This point last cycle we had 2')
   end


### PR DESCRIPTION
## Context

Now we've changed the offer process to include reference checks, we'd expect a delay to our recruited numbers but because of this we're interested to see how many offers are getting accepted

## Changes proposed in this pull request

Add `offers_accepted` as another line
