### PR TITLE
Fix a course option choice bug

### DIFF
--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -175,7 +175,7 @@ module SupportInterface
     end
 
     def change_course_choice_link
-      return {} unless @application_choice.application_form.editable? && ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER.include?(application_choice.status.to_sym)
+      return {} unless @application_choice.application_form.editable? && ChangeApplicationChoiceCourseOption::VALID_STATES.include?(application_choice.status.to_sym)
 
       {
         action: {

--- a/app/services/support_interface/change_application_choice_course_option.rb
+++ b/app/services/support_interface/change_application_choice_course_option.rb
@@ -2,7 +2,7 @@ module SupportInterface
   class ApplicationStateError < StandardError; end
 
   class ChangeApplicationChoiceCourseOption
-    VALID_STATES = ApplicationStateChange::DECISION_PENDING_STATUSES
+    VALID_STATES = ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER
 
     attr_reader :application_choice, :provider_id, :course_code, :study_mode, :site_code, :audit_comment
     attr_accessor :confirm_course_change


### PR DESCRIPTION
These two classes were out of sync with one another.

## Context

Currently you can't change the course option for applications in the "offer" state.
