### PR TITLE
Remove the document page for now

### DIFF
--- a/app/views/support_interface/docs/_docs_navigation.html.erb
+++ b/app/views/support_interface/docs/_docs_navigation.html.erb
@@ -6,7 +6,6 @@
   { name: 'Provider flow', url: support_interface_docs_provider_flow_path },
   { name: 'When emails are sent', url: support_interface_docs_when_emails_are_sent_path },
   { name: 'Qualifications', url: support_interface_docs_qualifications_path },
-  { name: 'Cycle timeline', url: support_interface_docs_end_of_cycle_timeline_path },
 ] %>
 
 <% if Rails.application.config.action_mailer.show_previews %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1110,7 +1110,6 @@ Rails.application.routes.draw do
       get '/when-emails-are-sent', to: 'docs#when_emails_are_sent', as: :docs_when_emails_are_sent
       get '/qualifications', to: 'docs#qualifications', as: :docs_qualifications
       get '/mailers' => 'docs#mailer_previews', as: :docs_mailer_previews
-      get '/end-of-cycle-timeline' => 'docs#end_of_cycle_timeline', as: :docs_end_of_cycle_timeline
     end
 
     scope '/users' do


### PR DESCRIPTION
## Context

The document page does a count in the DB that slow down the queries in the DB.

Because it is not essential for a couple days let's remove, then optimise and then put it back