### PR TITLE
Relax rules for changing offer conditions on support

### DIFF
--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -92,7 +92,7 @@ module SupportInterface
     end
 
     def offer_conditions_row
-      return unless application_choice.pending_conditions? || application_choice.offer?
+      return if application_choice.pre_offer?
 
       conditions = application_choice.offer.conditions
       return if conditions.empty?
@@ -101,8 +101,6 @@ module SupportInterface
         key: 'Conditions',
         value: render(SupportInterface::ConditionsComponent.new(conditions:)),
       }
-
-      return conditions_row unless application_choice.pending_conditions?
 
       conditions_row.merge({
         action: {

--- a/spec/components/support_interface/application_choice_component_spec.rb
+++ b/spec/components/support_interface/application_choice_component_spec.rb
@@ -74,10 +74,10 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
       )
     end
 
-    it 'does not render a link to change conditions' do
+    it 'does render a link to change conditions' do
       result = render_inline(described_class.new(recruited_choice))
 
-      expect(result.css('.app-summary-card .govuk-summary-list__actions a').text.squish).not_to include 'Change conditions'
+      expect(result.css('.app-summary-card .govuk-summary-list__actions a').text.squish).to include 'Change conditions'
     end
   end
 
@@ -153,6 +153,22 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
       render_inline(described_class.new(withdrawn_application))
 
       expect(page).not_to have_selector '.govuk-summary-list__actions a', text: 'Revert withdrawal'
+    end
+  end
+
+  context 'Awaiting provider decision' do
+    let(:application_choice) do
+      create(
+        :application_choice,
+        :with_completed_application_form,
+        :awaiting_provider_decision,
+      )
+    end
+
+    it 'does not render a link to change conditions' do
+      result = render_inline(described_class.new(application_choice))
+
+      expect(result.css('.app-summary-card .govuk-summary-list__actions a').text.squish).not_to include 'Change conditions'
     end
   end
 


### PR DESCRIPTION
## Context

Currently there’s only some circumstances where the support UI shows the link to modify the conditions of an offer, sometimes leading to a catch-22 where they can’t change the conditions without changing the state but don’t want to change the state until after the conditions are changed, necessitating a dev ticket to do the exact same thing just via the console.

Tested with this application states:
* Accepted states: pending_conditions conditions_not_met recruited offer_deferred
* declined offer, offer_withdrawn


