### PR TITLE
Update GIT links

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,10 +36,10 @@ en:
     url_events: https://getintoteaching.education.gov.uk/events
     url_international_candidates: https://getintoteaching.education.gov.uk/non-uk-teachers
     url_support_if_you_are_disabled: https://getintoteaching.education.gov.uk/funding-and-support/if-youre-disabled
-    url_online_chat: https://getintoteaching.education.gov.uk/#talk-to-us
+    url_online_chat: https://getintoteaching.education.gov.uk/help-and-support
     url_get_school_experience: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/get-school-experience
     url_ways_to_train: https://getintoteaching.education.gov.uk/train-to-be-a-teacher
-    url_choose_your_referees: https://getintoteaching.education.gov.uk/tips-on-applying-for-teacher-training#choose-your-referees
+    url_choose_your_referees: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/how-to-apply-for-teacher-training#choose-your-references
   train_to_teach_in_england:
     url: https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration
     url_citizen_visa: https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-if-youre-a-non-uk-citizen#visa

--- a/spec/mailers/candidate_mailer_withdrawn_on_request_spec.rb
+++ b/spec/mailers/candidate_mailer_withdrawn_on_request_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe CandidateMailer do
       I18n.t!('candidate_mailer.application_withdrawn_on_request_all_applications_withdrawn.subject', provider_name: 'Arithmetic College'),
       'heading' => 'Dear Fred',
       'withdrawn sentence' => 'At your request, Arithmetic College has withdrawn your application to study Mathematics (M101)',
-      'link to support' => 'https://getintoteaching.education.gov.uk/#talk-to-us',
+      'link to support' => 'https://getintoteaching.education.gov.uk/help-and-support',
       'apply again' => 'You can apply again',
     )
 
@@ -51,7 +51,7 @@ RSpec.describe CandidateMailer do
       I18n.t!('candidate_mailer.application_withdrawn_on_request_awaiting_decision_only.subject', provider_name: 'Arithmetic College'),
       'heading' => 'Dear Fred',
       'withdrawn sentence' => 'At your request, Arithmetic College has withdrawn your application to study Mathematics (M101)',
-      'link to support' => 'https://getintoteaching.education.gov.uk/#talk-to-us',
+      'link to support' => 'https://getintoteaching.education.gov.uk/help-and-support',
       'awaiting decision content' => 'You’re waiting for Arithmetic College to make a decision about your application to study Mathematics.',
     )
 
@@ -71,7 +71,7 @@ RSpec.describe CandidateMailer do
       I18n.t!('candidate_mailer.application_withdrawn_on_request_offers_only.subject', provider_name: 'Arithmetic College', date: Time.zone.local(2021, 6, 22).to_fs(:govuk_date)),
       'heading' => 'Dear Fred',
       'withdrawn sentence' => 'At your request, Arithmetic College has withdrawn your application to study Mathematics (M101)',
-      'link to support' => 'https://getintoteaching.education.gov.uk/#talk-to-us',
+      'link to support' => 'https://getintoteaching.education.gov.uk/help-and-support',
       'offer content' => 'You’ve received an offer from Arithmetic College to study Mathematics',
     )
 
@@ -96,7 +96,7 @@ RSpec.describe CandidateMailer do
       I18n.t!('candidate_mailer.application_withdrawn_on_request_one_offer_one_awaiting_decision.subject', provider_name: 'Arithmetic College'),
       'heading' => 'Dear Fred',
       'withdrawn sentence' => 'At your request, Arithmetic College has withdrawn your application to study Mathematics (M101)',
-      'link to support' => 'https://getintoteaching.education.gov.uk/#talk-to-us',
+      'link to support' => 'https://getintoteaching.education.gov.uk/help-and-support',
       'offer content' => 'You have an offer from Arithmetic College to study Mathematics.',
       'awaiting decision content' => 'You’re waiting for Falconholt Technical College to make a decision about your application to study Forensic Science.',
     )

--- a/spec/mailers/candidate_mailer_withdrawn_on_request_spec.rb
+++ b/spec/mailers/candidate_mailer_withdrawn_on_request_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe CandidateMailer do
     it 'adds utm parameters when in production' do
       allow(HostingEnvironment).to receive(:environment_name).and_return('production')
 
-      expect(email.body).to include('https://getintoteaching.education.gov.uk/?utm_source=apply-for-teacher-training.service.gov.uk&utm_medium=referral&utm_campaign=support_footer_on_all_emails&utm_content=apply_1#talk-to-us')
+      expect(email.body).to include('https://getintoteaching.education.gov.uk/help-and-support?utm_source=apply-for-teacher-training.service.gov.uk&utm_medium=referral&utm_campaign=support_footer_on_all_emails&utm_content=apply_1')
     end
   end
 
@@ -58,7 +58,7 @@ RSpec.describe CandidateMailer do
     it 'adds utm parameters when in production' do
       allow(HostingEnvironment).to receive(:environment_name).and_return('production')
 
-      expect(email.body).to include('https://getintoteaching.education.gov.uk/?utm_source=apply-for-teacher-training.service.gov.uk&utm_medium=referral&utm_campaign=support_footer_on_all_emails&utm_content=apply_1#talk-to-us')
+      expect(email.body).to include('https://getintoteaching.education.gov.uk/help-and-support?utm_source=apply-for-teacher-training.service.gov.uk&utm_medium=referral&utm_campaign=support_footer_on_all_emails&utm_content=apply_1')
     end
   end
 
@@ -78,7 +78,7 @@ RSpec.describe CandidateMailer do
     it 'adds utm parameters when in production' do
       allow(HostingEnvironment).to receive(:environment_name).and_return('production')
 
-      expect(email.body).to include('https://getintoteaching.education.gov.uk/?utm_source=apply-for-teacher-training.service.gov.uk&utm_medium=referral&utm_campaign=support_footer_on_all_emails&utm_content=apply_1#talk-to-us')
+      expect(email.body).to include('https://getintoteaching.education.gov.uk/help-and-support?utm_source=apply-for-teacher-training.service.gov.uk&utm_medium=referral&utm_campaign=support_footer_on_all_emails&utm_content=apply_1')
     end
   end
 
@@ -104,7 +104,7 @@ RSpec.describe CandidateMailer do
     it 'adds utm parameters when in production' do
       allow(HostingEnvironment).to receive(:environment_name).and_return('production')
 
-      expect(email.body).to include('https://getintoteaching.education.gov.uk/?utm_source=apply-for-teacher-training.service.gov.uk&utm_medium=referral&utm_campaign=support_footer_on_all_emails&utm_content=apply_1#talk-to-us')
+      expect(email.body).to include('https://getintoteaching.education.gov.uk/help-and-support?utm_source=apply-for-teacher-training.service.gov.uk&utm_medium=referral&utm_campaign=support_footer_on_all_emails&utm_content=apply_1')
     end
   end
 end


### PR DESCRIPTION
The Get Into Teaching website has been restructured, and there’s now a dedicate page for online chat and support, and a new page with advice on choosing references.

🗂️ [Trello card](https://trello.com/c/sBoSPF8R/1061-update-our-links-that-point-to-get-into-teaching-following-audit-by-git)