### PR TITLE
Ignore duplicate site codes for archived sites

### DIFF
--- a/spec/queries/get_course_option_from_codes_spec.rb
+++ b/spec/queries/get_course_option_from_codes_spec.rb
@@ -49,6 +49,39 @@ RSpec.describe GetCourseOptionFromCodes, type: :model do
       end
     end
 
+    context 'when there are duplicate sites' do
+      let(:duplicate_site) do
+        create(:site, code: course_option.site.code, provider: course_option.provider)
+      end
+      let!(:another_course_option) do
+        create(
+          :course_option,
+          course: course_option.course,
+          site: duplicate_site,
+          study_mode: course_option.study_mode,
+          site_still_valid: site_still_valid,
+        )
+      end
+
+      context 'matching course option is selectable' do
+        let(:site_still_valid) { true }
+
+        it 'is not valid' do
+          expect(service).to be_invalid
+          expected_message = "Found multiple #{course_option.course.study_mode} options for course #{course_option.course.code}"
+          expect(service.errors[:course_option]).to contain_exactly(expected_message)
+        end
+      end
+
+      context 'matching course option is not selectable' do
+        let(:site_still_valid) { false }
+
+        it 'is valid' do
+          expect(service).to be_valid
+        end
+      end
+    end
+
     context 'when the site code is blank and ambiguous' do
       let!(:another_course_option) { create(:course_option, course: course_option.course) }
 


### PR DESCRIPTION
## Context

A provider is seeing “Found multiple full_time options for course” error, because there are two full-time course options for that course, connected to sites with matching site codes ("-", ie main site). One of these sites is effectively archived, in that it has been removed from Publish and we have set all course options associated with it as `site_still_valid: false`.

## Changes proposed in this pull request

When validating an application choice, do not wish raise an error if the selected site code matches a site which has effectively been archived (ie removed from Publish). That is, limit the uniqueness validation to selectable sites.

## Guidance to review

Tests pass?

## Link to Trello card

https://trello.com/c/JKp5dQQ4/980-prevent-multiple-course-options-at-a-given-site-error-from-occurring-when-theres-only-one-valid-site

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
