### PR TITLE
Fix several long-standing bugs around application choices

### DIFF
--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -5,12 +5,6 @@ FactoryBot.define do
     candidate
     address_type { 'uk' }
 
-    after(:create) do |application_form, evaluator|
-      if application_form.application_choices.empty? && evaluator.application_choices.any?
-        application_form.application_choices << evaluator.application_choices
-      end
-    end
-
     trait :minimum_info do
       first_name { Faker::Name.first_name }
       last_name { Faker::Name.last_name }


### PR DESCRIPTION
Original issue:
https://github.com/DFE-Digital/apply-for-teacher-training/pull/5031#issuecomment-874351713

Looks like there was some conflict with a Rails update that broke things and got patched over specifically in the `ApplicationForm` factory: https://github.com/DFE-Digital/apply-for-teacher-training/pull/5031/commits/e0db313632e1ed441cc66350bc127b585d87dfec

The problem interaction is here:
https://github.com/DFE-Digital/apply-for-teacher-training/blob/bab0a4a4e851e1d855352fcc7103d23d7484ff9f/app/models/application_form.rb#L144-L149

Also fixes a bug where any form with more than one application choice would be considered offer-deferred for certain specific behaviour regardless of deferral status.
