### PR TITLE
Reduce content in Success banner

### DIFF
--- a/app/components/candidate_interface/application_dashboard_guidance_component.html.erb
+++ b/app/components/candidate_interface/application_dashboard_guidance_component.html.erb
@@ -2,8 +2,10 @@
 
   <% if multiple_applications? %>
     <p class="govuk-body">Your applications have been submitted and are with the training providers.</p>
+    <p class="govuk-body">You will be emailed when a provider makes a decision.</p>
   <% else %>
     <p class="govuk-body">Your application has been submitted and is with the training provider.</p>
+    <p class="govuk-body">You will be emailed when the provider makes a decision.</p>
   <% end %>
 
   <p class="govuk-body govuk-!-margin-bottom-6">A <%= govuk_link_to_with_utm_params('teacher training adviser', I18n.t('get_into_teaching.url_get_an_adviser'), utm_campaign(params), application_form.phase) %> can help you prepare for any interviews.</p>

--- a/app/controllers/candidate_interface/feedback_form_controller.rb
+++ b/app/controllers/candidate_interface/feedback_form_controller.rb
@@ -8,8 +8,7 @@ module CandidateInterface
       @feedback_form = FeedbackForm.new(feedback_params)
       if @feedback_form.save(current_application)
         flash[:success] = [
-          'Application successfully submitted',
-          'You will get an email when something changes.',
+          'Application submitted',
         ]
         redirect_to candidate_interface_application_complete_path
       else

--- a/spec/system/candidate_interface/apply_again/candidate_applies_again_and_reviews_equality_and_diversity_responses_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_applies_again_and_reviews_equality_and_diversity_responses_spec.rb
@@ -62,7 +62,7 @@ RSpec.feature 'Apply again', time: CycleTimetableHelper.after_apply_1_deadline d
 
     click_on t('continue')
 
-    expect(page).to have_content 'Application successfully submitted'
+    expect(page).to have_content 'Application submitted'
   end
 
 private

--- a/spec/system/candidate_interface/apply_again/candidate_applies_again_and_reviews_rejection_reasons_from_previous_applications_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_applies_again_and_reviews_rejection_reasons_from_previous_applications_spec.rb
@@ -145,7 +145,7 @@ RSpec.feature 'Apply again' do
 
     click_on t('continue')
 
-    expect(page).to have_content 'Application successfully submitted'
+    expect(page).to have_content 'Application submitted'
   end
 
 private

--- a/spec/system/candidate_interface/apply_again/candidate_applies_again_and_views_redesigned_rejection_reasons_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_applies_again_and_views_redesigned_rejection_reasons_spec.rb
@@ -155,7 +155,7 @@ RSpec.feature 'Apply again' do
 
     click_on t('continue')
 
-    expect(page).to have_content 'Application successfully submitted'
+    expect(page).to have_content 'Application submitted'
   end
 
 private

--- a/spec/system/candidate_interface/apply_again/candidate_applies_again_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_applies_again_spec.rb
@@ -137,7 +137,7 @@ RSpec.feature 'Apply again with three choices', time: CycleTimetableHelper.after
   end
 
   def then_my_application_is_submitted_and_sent_to_the_provider
-    expect(page).to have_content('Application successfully submitted')
+    expect(page).to have_content('Application submitted')
     @apply_again_choice = ApplicationForm.last.application_choices.first
     expect(@apply_again_choice.status).to eq('awaiting_provider_decision')
   end

--- a/spec/system/candidate_interface/feedback/candidate_completes_the_feedback_form_spec.rb
+++ b/spec/system/candidate_interface/feedback/candidate_completes_the_feedback_form_spec.rb
@@ -38,8 +38,7 @@ RSpec.feature 'Candidate feedback form' do
 
   def then_i_see_the_application_dashboard_and_success_message
     expect(page).to have_current_path(candidate_interface_application_complete_path)
-    expect(page).to have_content('Application successfully submitted')
-    expect(page).to have_content('You will get an email when something changes.')
+    expect(page).to have_content('Application submitted')
   end
 
   def and_my_feedback_should_reflect_my_inputs

--- a/spec/system/candidate_interface/references/candidate_submits_a_duplicate_application_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_submits_a_duplicate_application_spec.rb
@@ -49,7 +49,7 @@ RSpec.feature 'Submitting an application' do
 
     # Your feedback
     click_button 'Continue'
-    expect(page).to have_content 'Application successfully submitted'
+    expect(page).to have_content 'Application submitted'
   end
 
   def and_the_duplicate_matching_service_runs

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_and_prefills_application_in_sandbox_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_and_prefills_application_in_sandbox_spec.rb
@@ -103,6 +103,6 @@ RSpec.feature 'Candidate signs in and prefills application in Sandbox', sandbox:
   end
 
   def then_my_application_is_submitted_successfully
-    expect(page).to have_content 'Application successfully submitted'
+    expect(page).to have_content 'Application submitted'
   end
 end

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
@@ -180,8 +180,7 @@ RSpec.feature 'Candidate submits the application' do
   end
 
   def then_i_can_see_my_application_has_been_successfully_submitted
-    expect(page).to have_content 'Application successfully submitted'
-    expect(page).to have_content 'You will get an email when something changes.'
+    expect(page).to have_content 'Application submitted'
   end
 
   def and_i_receive_an_email_confirmation

--- a/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
@@ -189,7 +189,6 @@ RSpec.feature 'International candidate submits the application' do
 
   def then_i_can_see_my_application_has_been_successfully_submitted
     expect(page).to have_current_path candidate_interface_application_complete_path
-    expect(page).to have_content 'Application successfully submitted'
-    expect(page).to have_content 'You will get an email when something changes.'
+    expect(page).to have_content 'Application submitted'
   end
 end


### PR DESCRIPTION
This tweaks the success message shown when submitting to:

* remove the duplicate word "successfully" (banner already has the title "Success")
* remove the line about receiving emails from the banner and move it to body text, so that it'll be shown even on later page loads
* change "when something changes" to "when the provider makes a decision" to be more specific.

Technically you'll also be emailed about other changes, eg being rejected automatically, invited to an interview, or being withdrawn (at your request) but those don't feel like they need to be explicitly mentioned.

🗂️ [Trello card](https://trello.com/c/XIuydIxs/992-improve-our-success-messaging-when-a-candidate-submits-an-application)

## Screenshots

### Before

<img width="988" alt="Screenshot 2022-12-09 at 13 57 40" src="https://user-images.githubusercontent.com/30665/206718640-3350fe74-1f92-4e61-8aa1-dacb9fa3f559.png">

### After

<img width="1027" alt="Screenshot 2022-12-09 at 13 57 24" src="https://user-images.githubusercontent.com/30665/206718662-6ed5736e-e0e2-46d1-bcc5-b13ebd2082fe.png">
