### PR TITLE
Ignore deleted applications when generating the monthly report

### DIFF
--- a/app/models/publications/monthly_statistics/base.rb
+++ b/app/models/publications/monthly_statistics/base.rb
@@ -84,6 +84,7 @@ module Publications
                     application_choices ch ON ch.application_form_id = f.id
                 WHERE
                     NOT c.hide_in_reporting
+                    AND c.email_address NOT LIKE 'deleted-application-%@example.com'
                     AND ch.current_recruitment_cycle_year = #{RecruitmentCycle.current_year}
                     #{where_clause.presence}
                     AND ch.status IN (#{ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER.map { |status| "'#{status}'" }.join(',')})

--- a/spec/models/publications/monthly_statistics/by_age_group_spec.rb
+++ b/spec/models/publications/monthly_statistics/by_age_group_spec.rb
@@ -3,7 +3,10 @@ require 'rails_helper'
 RSpec.describe Publications::MonthlyStatistics::ByAgeGroup do
   include StatisticsTestHelper
 
-  before { generate_statistics_test_data }
+  before do
+    generate_statistics_test_data
+    generate_deleted_application
+  end
 
   let(:statistics) do
     described_class.new.table_data
@@ -27,5 +30,14 @@ RSpec.describe Publications::MonthlyStatistics::ByAgeGroup do
     end
 
     expect_column_totals(4, 2, 1, 1, 1, 7, 16)
+  end
+
+  def generate_deleted_application
+    deleted_candidate = create_and_advance(:candidate, hide_in_reporting: false, email_address: 'deleted-application-gh1111@example.com')
+    deleted_application = create_and_advance(:application_form, date_of_birth: nil, candidate: deleted_candidate)
+    create_and_advance(:application_choice,
+                       :with_rejection,
+                       course_option: course_option_with(level: 'primary', program_type: 'higher_education_programme', region: 'eastern', subjects: [primary_subject(:mathematics)]),
+                       application_form: deleted_application)
   end
 end


### PR DESCRIPTION
## Context

The monthly report wasn't generated for this month.

Sentry error
https://sentry.io/organizations/dfe-teacher-services/issues/3821255107/?project=1765973&referrer=slack

Reason
The reason is one of the rejected applications doesn’t have a date of birth

The solution was to ignore the deleted application when get the raw data

