### PR TITLE
surface reference feedback on BQ

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -401,6 +401,7 @@ shared:
     - selected
     - updated_at
     - refused
+    - feedback
   rejection_feedbacks:
     - id
     - helpful

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -108,7 +108,6 @@
   - updated_at
   :references:
   - email_address
-  - feedback
   - name
   - relationship
   - safeguarding_concerns


### PR DESCRIPTION
## Context

We currently don't surface the actual reference feedback on BiQuery but would like to perform some analysis using it.

## Changes proposed in this pull request

Remove `feedback` from our blocklist
