### PR TITLE
764 sentry nil date when explaining work break

### DIFF
--- a/app/controllers/candidate_interface/restructured_work_history/break_controller.rb
+++ b/app/controllers/candidate_interface/restructured_work_history/break_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class RestructuredWorkHistory::BreakController < RestructuredWorkHistory::BaseController
+    before_action :verify_work_history_dates, only: :new
+
     def new
       @work_break = RestructuredWorkHistory::WorkHistoryBreakForm.build_from_date_params(date_params)
       @return_to = return_to_after_edit(default: candidate_interface_restructured_work_history_review_path)
@@ -56,6 +58,10 @@ module CandidateInterface
     end
 
   private
+
+    def verify_work_history_dates
+      redirect_to candidate_interface_restructured_work_history_review_path if date_params[:start_date].blank? || date_params[:end_date].blank?
+    end
 
     def current_work_history_break
       current_application.application_work_history_breaks.find(current_work_history_break_id)

--- a/spec/requests/candidate_interface/work_history_spec.rb
+++ b/spec/requests/candidate_interface/work_history_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe 'work history section' do
+  include Devise::Test::IntegrationHelpers
+  let(:candidate) { create(:candidate) }
+
+  before do
+    sign_in candidate
+  end
+
+  describe 'when adding a break explanation' do
+    context 'when explaining the start and end date' do
+      it 'returns ok' do
+        get candidate_interface_new_restructured_work_history_break_path, params: { end_date: '2019-12-01', start_date: '2018-04-01' }
+        expect(response).to be_ok
+      end
+    end
+
+    context 'when entering direct on the url without start date' do
+      it 'redirect to work history section' do
+        get candidate_interface_new_restructured_work_history_break_path
+        expect(response).to redirect_to(candidate_interface_restructured_work_history_review_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

This PR address the issue below:

```
NoMethodError
CandidateInterface::RestructuredWorkHistory::BreakController#new
undefined method `to_date' for nil:NilClass start_date_month: dates[:start_date]
```

## Sentry link

[Sentry issue](https://sentry.io/organizations/dfe-teacher-services/issues/3232498921/?project=1765973&referrer=slack)

## Explanation

The way to reproduce this bug is by removing the params in the browser. The work history explanation requires a start date and end date so if the user removes the app blows up an exception. A safeguard is to return to review page if those are blank.
