### PR TITLE
Use equivalent cycle date for slack post

### DIFF
--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -556,10 +556,10 @@ class CycleTimetable
     )
   end
 
-  def self.this_working_day_last_cycle
-    days_since_cycle_started = apply_opens.to_date.business_days_until(Time.zone.today)
+  def self.this_day_last_cycle
+    days_since_cycle_started = (Time.zone.today - CycleTimetable.apply_opens.to_date).round
     last_cycle_opening_date = apply_opens(previous_year).to_date
-    last_cycle_date = days_since_cycle_started.business_days.after(last_cycle_opening_date)
+    last_cycle_date = days_since_cycle_started.days.after(last_cycle_opening_date)
     DateTime.new(last_cycle_date.year, last_cycle_date.month, last_cycle_date.day, Time.current.hour, Time.current.min, Time.current.sec)
   end
 

--- a/app/services/stats_summary.rb
+++ b/app/services/stats_summary.rb
@@ -55,7 +55,7 @@ private
   end
 
   def this_day_last_year
-    CycleTimetable.this_working_day_last_cycle.beginning_of_day..CycleTimetable.this_working_day_last_cycle
+    CycleTimetable.this_day_last_cycle.beginning_of_day..CycleTimetable.this_day_last_cycle
   end
 
   def mailbox_emoji(message_count)

--- a/app/services/weekly_stats_summary.rb
+++ b/app/services/weekly_stats_summary.rb
@@ -59,7 +59,7 @@ private
 
   def previous_cycle_period
     cycle_started = CycleTimetable.apply_opens(previous_year)
-    cycle_started..CycleTimetable.this_working_day_last_cycle
+    cycle_started..CycleTimetable.this_day_last_cycle
   end
 
   def current_cycle_period

--- a/spec/services/stats_summary_spec.rb
+++ b/spec/services/stats_summary_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe StatsSummary do
     create(:application_choice, :with_accepted_offer, accepted_at: 1.minute.ago)
     create(:application_choice, :with_rejection_by_default)
 
-    travel_temporarily_to(CycleTimetable.this_working_day_last_cycle) do
+    travel_temporarily_to(CycleTimetable.this_day_last_cycle) do
       last_cycle_form = create(:application_form)
       create(:application_choice, :with_recruited, application_form: last_cycle_form)
       create(:application_choice, :with_offer, application_form: last_cycle_form)

--- a/spec/services/weekly_stats_summary_spec.rb
+++ b/spec/services/weekly_stats_summary_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe WeeklyStatsSummary do
     create(:application_choice, :with_rejection_by_default)
     create(:application_choice, :with_offer, application_form: apply_again_application)
 
-    travel_temporarily_to(CycleTimetable.this_working_day_last_cycle) do
+    travel_temporarily_to(CycleTimetable.this_day_last_cycle) do
       last_cycle_form = create(:application_form)
       create(:application_choice, :with_recruited, application_form: last_cycle_form)
       create(:application_choice, :with_offer, application_form: last_cycle_form)


### PR DESCRIPTION
## Context

Our daily stats Slack post is currently locked to the 20th dec for last year (and will be for a few more days), this is due to `business_days_until` excluding our Christmas holiday period as working days. And just in general our cycle point comparison is off – we originally wanted to exclude weekends, but this means we're off by ~20 days.


|exc. non-working days|inc. non-working days|
|---|---|
|![image](https://user-images.githubusercontent.com/47917431/210351489-6f807f35-832b-4f86-ae40-defdd86589cd.png)|![image](https://user-images.githubusercontent.com/47917431/210351701-351b53b9-c3c7-437c-b6df-02a05dfa0cc0.png)|

We're just going to focus on equivalent cycle point i.e. comparing day 85 of this years cycle to day 85 of last years cycle.

