### PR TITLE
Update the doc link for SP secret renewal

### DIFF
--- a/.github/workflows/check_sp.yml
+++ b/.github/workflows/check_sp.yml
@@ -35,5 +35,6 @@ jobs:
           SLACK_MESSAGE: |
             The Service Principal *${{ fromJson(steps.pwsh_check_expire.outputs.json_data).data.Application }}*
             secret *${{ fromJson(steps.pwsh_check_expire.outputs.json_data).data.Name }}* is due to expire in *${{fromJson(steps.pwsh_check_expire.outputs.json_data).data.ExpiresDays}}* days.
-            Please follow the <https://dfe-technical-guidance.london.cloudapps.digital/infrastructure/hosting/azure-cip/#service-principal|Use the service principal in external systems> process to renew.
+            Please follow the <https://dfe-technical-guidance.london.cloudapps.digital/infrastructure/hosting/azure-cip/#use-the-service-principal-in-external-systems|Use the service principal in external systems> process to renew.
+            This secret is used by all BAT apps so be sure to update the publish, find and register secrets too.
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## Context

The link to the docs for renewing an SP secret has changed. This PR updates the link to hit the right point on the page.

## Changes proposed in this pull request

Update the Check Service Principal workflow

## Guidance to review

Confirm changes are suitable

## Link to Trello card

https://trello.com/c/6dybWoon/740-renew-apply-service-principal-secrets

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
