### PR TITLE
Update content with links to Get Into Teaching

### DIFF
--- a/app/views/candidate_mailer/new_cycle_has_started.erb
+++ b/app/views/candidate_mailer/new_cycle_has_started.erb
@@ -21,3 +21,5 @@ Sign into your account to make changes to your previous application and apply ag
 A teacher training adviser can help you write a strong application:
 
 [Get a teacher training adviser](<%= email_link_with_utm_params I18n.t('get_into_teaching.url_get_an_adviser_start'), 'new_cycle_has_started', @application_form.phase %>)
+
+All our advisers are experienced former teachers who provide free, one-to-one support and can help you with your personal statement and interview preparation.

--- a/app/views/content/complaints.html.erb
+++ b/app/views/content/complaints.html.erb
@@ -12,10 +12,6 @@
 
     <p class="govuk-body">We’ll respond within 5 to 7 working days, or one working day if a technical problem prevents you from progressing your application.</p>
 
-    <h2 class="govuk-heading-m">If you need advice about your teacher training application</h2>
-
-    <p class="govuk-body"><%= govuk_link_to_with_utm_params 'Call us or chat online', t('get_into_teaching.url_online_chat'), utm_campaign(params), current_candidate&.current_application.present? ? current_application.phase : t('layout.support_links.not_logged_in') %> instead.</p>
-
     <h2 class="govuk-heading-m">What to do if a teacher training provider has treated you unfairly</h2>
 
     <p class="govuk-body">If you’ve been treated unfairly - for example, you’ve experienced discrimination or bias - you can raise your concern with the teacher training provider. They should have an established complaints procedure.</p>


### PR DESCRIPTION
## Context

Get Into Teaching team requested we add links to their 'teacher training advisors' page on various places in Apply. The pages edited below are not in the prototype so have done them directly on production.

## Changes proposed in this pull request

Updated content on:
- New cycle mailer to add more information about teacher training advisers
- Complaints page to remove paragraph about chatting online

## Link to Trello card

https://trello.com/c/06Nbw6Sg/1011-go-through-and-add-link-from-apply-to-git

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
