### PR TITLE
Updated content and links to GIT

### DIFF
--- a/app/components/candidate_interface/application_dashboard_guidance_component.html.erb
+++ b/app/components/candidate_interface/application_dashboard_guidance_component.html.erb
@@ -8,17 +8,17 @@
     <p class="govuk-body">You will be emailed when the provider makes a decision.</p>
   <% end %>
 
-  <p class="govuk-body govuk-!-margin-bottom-6">A <%= govuk_link_to_with_utm_params('teacher training adviser', I18n.t('get_into_teaching.url_get_an_adviser'), utm_campaign(params), application_form.phase) %> can help you prepare for any interviews.</p>
+  <p class="govuk-body govuk-!-margin-bottom-6">A <%= govuk_link_to_with_utm_params('teacher training adviser', I18n.t('get_into_teaching.url_get_an_adviser_start'), utm_campaign(params), application_form.phase) %> can help you prepare for any interviews. Our advisors were teachers and they can give you free, one-to-one support.</p>
 
 <% elsif multiple_offers_but_awaiting_decisions? %>
 
   <p class="govuk-body">2 of your training providers have made a decision on your application.</p>
-  <p class="govuk-body govuk-!-margin-bottom-6">A <%= govuk_link_to_with_utm_params('teacher training adviser', I18n.t('get_into_teaching.url_get_an_adviser'), utm_campaign(params), application_form.phase) %> can help you prepare for any interviews.</p>
+  <p class="govuk-body govuk-!-margin-bottom-6">A <%= govuk_link_to_with_utm_params('teacher training adviser', I18n.t('get_into_teaching.url_get_an_adviser_start'), utm_campaign(params), application_form.phase) %> can help you prepare for any interviews. Our advisors were teachers and they can give you free, one-to-one support.</p>
 
 <% elsif single_offer_but_awaiting_decisions? %>
 
   <p class="govuk-body">One of your training providers has made a decision on your application.</p>
-  <p class="govuk-body govuk-!-margin-bottom-6">A <%= govuk_link_to_with_utm_params('teacher training adviser', I18n.t('get_into_teaching.url_get_an_adviser'), utm_campaign(params), application_form.phase) %> can help you prepare for any interviews.</p>
+  <p class="govuk-body govuk-!-margin-bottom-6">A <%= govuk_link_to_with_utm_params('teacher training adviser', I18n.t('get_into_teaching.url_get_an_adviser_start'), utm_campaign(params), application_form.phase) %> can help you prepare for any interviews. Our advisors were teachers and they can give you free, one-to-one support.</p>
 
 <% elsif offer_accepted? %>
 

--- a/app/components/candidate_interface/degree_empty_component.html.erb
+++ b/app/components/candidate_interface/degree_empty_component.html.erb
@@ -4,4 +4,6 @@
 
 <p class="govuk-body">You can also add any other degrees that you have, or you’re working towards.</p>
 
+ <p class="govuk-body">Find out how you can get qualified teacher status (QTS) as part of an <%= govuk_link_to_with_utm_params 'undergraduate degree', t('get_into_teaching.url_if_you_dont_have_a_degree'), utm_campaign(params) %> if you do not have a degree yet and are not already studying for one.</p>
+
 <%= govuk_button_link_to degrees.empty? ? t('application_form.degree.add.button') : t('application_form.degree.another.button'), candidate_interface_degree_country_path, primary: true %>

--- a/app/components/candidate_interface/degree_empty_component.rb
+++ b/app/components/candidate_interface/degree_empty_component.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class DegreeEmptyComponent < ViewComponent::Base
+    include UtmLinkHelper
+
     attr_reader :application_form
 
     def initialize(application_form:)

--- a/app/views/candidate_interface/course_choices/course_decision/go_to_find.html.erb
+++ b/app/views/candidate_interface/course_choices/course_decision/go_to_find.html.erb
@@ -16,6 +16,8 @@
       <li>contact details</li>
     </ul>
 
+    <p class="govuk-body">A <%= govuk_link_to_with_utm_params 'teacher training adviser', t('get_into_teaching.url_get_an_adviser'), utm_campaign(params), @current_application.phase %> can help you understand your course options and support you with your application.</p>
+
     <%= govuk_button_link_to t('continue'), find_url %>
 
     <p class="govuk-body">You can also speak to training providers at <%= govuk_link_to_with_utm_params 'teacher training events', t('get_into_teaching.url_events'), 'apply_find_a_course' %>.</p>

--- a/app/views/candidate_interface/gcse/missing_qualification/_form.html.erb
+++ b/app/views/candidate_interface/gcse/missing_qualification/_form.html.erb
@@ -10,7 +10,7 @@
 
         <p class="govuk-body">Some providers may let you sit an equivalency test to show you have the required skills.</p>
 
-        <p class="govuk-body">For advice, contact your chosen training provider or a teacher training adviser.</p>
+        <p class="govuk-body">For advice, contact your chosen training provider or a <%= govuk_link_to_with_utm_params('teacher training adviser', I18n.t('get_into_teaching.url_get_an_adviser'), utm_campaign(params)) %>. An adviser can help you understand the qualifications you need and how to get them.</p>
 
         <%= f.govuk_text_area :missing_explanation, label: { text: "If you have other evidence of having #{capitalize_english(@subject)} skills at the required standard, give details (optional)", size: 'm' }, rows: 12, max_words: 200, threshold: 90 do %>
         <% end %>

--- a/app/views/candidate_interface/subject_knowledge/_form.html.erb
+++ b/app/views/candidate_interface/subject_knowledge/_form.html.erb
@@ -18,9 +18,7 @@
   <li>understanding of the national curriculum</li>
 </ul>
 
-<%= govuk_inset_text do %>
-  <p class="govuk-body">A <%= govuk_link_to_with_utm_params 'teacher training adviser', t('get_into_teaching.url_get_an_adviser'), utm_campaign(params), @current_application.phase %> can help you with this section.</p>
-<% end %>
+<p class="govuk-body">If you need help, you can speak to our <%= govuk_link_to_with_utm_params 'teacher training advisers', t('get_into_teaching.url_get_an_adviser_start'), utm_campaign(params), @current_application.phase %>. Our advisors were teachers and they can give you free, one-to-one support with your personal statement.</p>
 
 <%= f.govuk_text_area :subject_knowledge, label: { text: t('application_form.personal_statement.subject_knowledge.label'), size: 'm' }, rows: 20, max_words: 400 %>
 <%= f.govuk_submit t('continue') %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,7 @@ en:
     url_get_school_experience: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/get-school-experience
     url_ways_to_train: https://getintoteaching.education.gov.uk/train-to-be-a-teacher
     url_choose_your_referees: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/how-to-apply-for-teacher-training#choose-your-references
+    url_if_you_dont_have_a_degree: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/if-you-dont-have-a-degree
   train_to_teach_in_england:
     url: https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration
     url_citizen_visa: https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-if-youre-a-non-uk-citizen#visa


### PR DESCRIPTION
## Context

Get into teaching team have asked us to update links and content across Apply so they can track where people are coming to GIT from.

## Changes proposed in this pull request

Updating links to Get Into Teaching - teacher training advisors page across various Apply pages.

## Guidance to review

Check links are going to the 'Get an advisor' page on GOV.UK and 'Teacher training advisors' page on GIT.
Use this spreadsheet tab 'production changes' to check these are correct: https://docs.google.com/spreadsheets/d/1cc0W33jXA5EjpFQsVOQPAKEr0-a5_OphUSUcnoPlbF0/edit#gid=1117888604 

## Link to Trello card

https://trello.com/c/06Nbw6Sg/1011-go-through-and-add-link-from-apply-to-git
