### PR TITLE
Fix the reasons for rejections report

### DIFF
--- a/app/components/support_interface/reason_for_rejection_dashboard_section_component.html.erb
+++ b/app/components/support_interface/reason_for_rejection_dashboard_section_component.html.erb
@@ -3,7 +3,7 @@
     <%= govuk_link_to(
       @heading,
       support_interface_reasons_for_rejection_application_choices_path(
-        "structured_rejection_reasons[#{@reason_key}]" => 'Yes',
+        "structured_rejection_reasons[id]" => @reason_key,
         'recruitment_cycle_year' => @recruitment_cycle_year,
       ),
     ) %>

--- a/app/components/support_interface/reason_for_rejection_dashboard_section_component.html.erb
+++ b/app/components/support_interface/reason_for_rejection_dashboard_section_component.html.erb
@@ -3,7 +3,7 @@
     <%= govuk_link_to(
       @heading,
       support_interface_reasons_for_rejection_application_choices_path(
-        "structured_rejection_reasons[id]" => @reason_key,
+        'structured_rejection_reasons[id]' => @reason_key,
         'recruitment_cycle_year' => @recruitment_cycle_year,
       ),
     ) %>

--- a/app/components/support_interface/reason_for_rejection_dashboard_section_component.rb
+++ b/app/components/support_interface/reason_for_rejection_dashboard_section_component.rb
@@ -9,16 +9,11 @@ module SupportInterface
       @total_rejection_count = total_rejection_count
       @total_rejection_count_this_month = total_rejection_count_this_month
       @reason_key = reason_key
-      @sub_reasons_result = ordered_sub_reason_results(sub_reasons_result) if sub_reasons_result.present?
+      @sub_reasons_result = sub_reasons_result if sub_reasons_result.present?
       @recruitment_cycle_year = recruitment_cycle_year
     end
 
   private
-
-    def ordered_sub_reason_results(sub_reasons_result)
-      sub_reason_values = ReasonsForRejectionCountQuery::SUBREASON_VALUES[@reason_key]
-      sub_reasons_result.slice(*sub_reason_values.map(&:to_s)) if sub_reason_values.present?
-    end
 
     def rejection_count(time_period = :all_time)
       @rejection_reasons[@reason_key]&.send(time_period) || 0

--- a/app/components/support_interface/reasons_for_rejection_dashboard_component.html.erb
+++ b/app/components/support_interface/reasons_for_rejection_dashboard_component.html.erb
@@ -1,103 +1,11 @@
-<%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
-  heading: 'Candidate behaviour',
-  rejection_reasons: rejection_reasons,
-  total_rejection_count: total_structured_rejection_reasons_count,
-  total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
-  reason_key: :candidate_behaviour_y_n,
-  sub_reasons_result: sub_reasons_for(:candidate_behaviour_y_n),
-  recruitment_cycle_year: recruitment_cycle_year,
-) %>
-
-<%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
-  heading: 'Quality of application',
-  rejection_reasons: rejection_reasons,
-  total_rejection_count: total_structured_rejection_reasons_count,
-  total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
-  reason_key: :quality_of_application_y_n,
-  sub_reasons_result: sub_reasons_for(:quality_of_application_y_n),
-  recruitment_cycle_year: recruitment_cycle_year,
-) %>
-
-<%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
-  heading: 'Qualifications',
-  rejection_reasons: rejection_reasons,
-  total_rejection_count: total_structured_rejection_reasons_count,
-  total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
-  reason_key: :qualifications_y_n,
-  sub_reasons_result: sub_reasons_for(:qualifications_y_n),
-  recruitment_cycle_year: recruitment_cycle_year,
-) %>
-
-<%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
-  heading: 'Performance at interview',
-  rejection_reasons: rejection_reasons,
-  total_rejection_count: total_structured_rejection_reasons_count,
-  total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
-  reason_key: :performance_at_interview_y_n,
-  recruitment_cycle_year: recruitment_cycle_year,
-) %>
-
-<%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
-  heading: 'Course full',
-  rejection_reasons: rejection_reasons,
-  total_rejection_count: total_structured_rejection_reasons_count,
-  total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
-  reason_key: :course_full_y_n,
-  recruitment_cycle_year: recruitment_cycle_year,
-) %>
-
-<%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
-  heading: 'Offered on another course',
-  rejection_reasons: rejection_reasons,
-  total_rejection_count: total_structured_rejection_reasons_count,
-  total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
-  reason_key: :offered_on_another_course_y_n,
-  recruitment_cycle_year: recruitment_cycle_year,
-) %>
-
-<%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
-  heading: 'Honesty and professionalism',
-  rejection_reasons: rejection_reasons,
-  total_rejection_count: total_structured_rejection_reasons_count,
-  total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
-  reason_key: :honesty_and_professionalism_y_n,
-  sub_reasons_result: sub_reasons_for(:honesty_and_professionalism_y_n),
-  recruitment_cycle_year: recruitment_cycle_year,
-) %>
-
-<%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
-  heading: 'Safeguarding',
-  rejection_reasons: rejection_reasons,
-  total_rejection_count: total_structured_rejection_reasons_count,
-  total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
-  reason_key: :safeguarding_y_n,
-  sub_reasons_result: sub_reasons_for(:safeguarding_y_n),
-  recruitment_cycle_year: recruitment_cycle_year,
-) %>
-
-<%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
-  heading: 'Cannot sponsor visa',
-  rejection_reasons: rejection_reasons,
-  total_rejection_count: total_structured_rejection_reasons_count,
-  total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
-  reason_key: :cannot_sponsor_visa_y_n,
-  recruitment_cycle_year: recruitment_cycle_year,
-) %>
-
-<%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
-  heading: 'Other reasons',
-  rejection_reasons: rejection_reasons,
-  total_rejection_count: total_structured_rejection_reasons_count,
-  total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
-  reason_key: :why_are_you_rejecting_this_application,
-  recruitment_cycle_year: recruitment_cycle_year,
-) %>
-
-<%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
-  heading: 'Additional advice or feedback',
-  rejection_reasons: rejection_reasons,
-  total_rejection_count: total_structured_rejection_reasons_count,
-  total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
-  reason_key: :other_advice_or_feedback_y_n,
-  recruitment_cycle_year: recruitment_cycle_year,
-) %>
+<% rejection_reasons.each do |id, _| %>
+  <%= render SupportInterface::ReasonForRejectionDashboardSectionComponent.new(
+    heading: id.humanize,
+    rejection_reasons: rejection_reasons,
+    total_rejection_count: total_structured_rejection_reasons_count,
+    total_rejection_count_this_month: total_structured_rejection_reasons_count_this_month,
+    reason_key: id,
+    sub_reasons_result: sub_reasons_for(id),
+    recruitment_cycle_year: recruitment_cycle_year,
+  ) %>
+<% end %>

--- a/app/components/support_interface/reasons_for_rejection_search_breadcrumb_component.rb
+++ b/app/components/support_interface/reasons_for_rejection_search_breadcrumb_component.rb
@@ -13,31 +13,22 @@ module SupportInterface
         Performance: support_interface_performance_path,
         'Structured reasons for rejection': support_interface_reasons_for_rejection_dashboard_path(year: @recruitment_cycle_year),
       }
-      if top_level_reason?
-        i18n_key = ReasonsForRejection::TOP_LEVEL_REASONS_TO_I18N_KEYS[@search_attribute].to_s
-        breadcrumb_items[dashboard_title(i18n_key)] = nil
-      else
-        top_level_reason = ::ReasonsForRejectionCountQuery::SUBREASONS_TO_TOP_LEVEL_REASONS[@search_attribute]
-        i18n_key = ReasonsForRejection::TOP_LEVEL_REASONS_TO_I18N_KEYS[top_level_reason].to_s
-        breadcrumb_items[dashboard_title(i18n_key)] = support_interface_reasons_for_rejection_application_choices_path(
-          "structured_rejection_reasons[#{top_level_reason}]" => 'Yes',
+
+      unless top_level_reason?
+        breadcrumb_items[@search_attribute] = support_interface_reasons_for_rejection_application_choices_path(
+          'structured_rejection_reasons[id]' => @search_attribute,
           'recruitment_cycle_year' => @recruitment_cycle_year,
         )
-        breadcrumb_items[t("reasons_for_rejection.#{i18n_key}.#{@search_value}")] = nil
       end
 
+      breadcrumb_items[@search_value] = nil
       breadcrumb_items
     end
 
   private
 
     def top_level_reason?
-      @search_attribute == ReasonsForRejection::OTHER_REASON.to_s || (
-        @search_attribute =~ /_y_n$/ && @search_value == 'Yes')
-    end
-
-    def dashboard_title(i18n_key)
-      t("reasons_for_rejection.#{i18n_key}.alt_title", default: t("reasons_for_rejection.#{i18n_key}.title", default: ''))
+      @search_attribute == 'id'
     end
   end
 end

--- a/app/components/support_interface/reasons_for_rejection_search_results_component.rb
+++ b/app/components/support_interface/reasons_for_rejection_search_results_component.rb
@@ -9,79 +9,44 @@ module SupportInterface
     end
 
     def summary_list_rows_for(application_choice)
-      application_choice.structured_rejection_reasons.map do |reason, value|
-        reason_detail_text = reason_detail_text_for(application_choice, reason)
-        next unless top_level_reason?(reason, value) && reason_detail_text.presence
+      selected_reasons = Array(
+        application_choice.structured_rejection_reasons['selected_reasons'],
+      )
+
+      selected_reasons.map do |reason|
+        key = reason['id']
+        value = reason_text_for(reason)
 
         {
-          key: reason_text_for(reason),
-          value: reason_detail_text,
+          key: mark_search_term(key.titleize, key == @search_value),
+          value: value,
         }
       end.compact
     end
 
     def search_title_text
-      if @search_value == 'Yes'
-        i18n_key = ReasonsForRejection::TOP_LEVEL_REASONS_TO_I18N_KEYS[@search_attribute].to_s
-        translated_search_title(i18n_key)
-      else
-        top_level_reason = ReasonsForRejectionCountQuery::SUBREASONS_TO_TOP_LEVEL_REASONS[@search_attribute.to_sym]
-        i18n_key = ReasonsForRejection::TOP_LEVEL_REASONS_TO_I18N_KEYS[top_level_reason].to_s
-        [
-          translated_search_title(i18n_key),
-          t("reasons_for_rejection.#{i18n_key}.#{@search_value}", default: ''),
-        ].join(' - ')
-      end
-    end
-
-    def reason_detail_text_for(application_choice, top_level_reason)
-      sub_reason = sub_reason_for(top_level_reason)
-      if sub_reason.present?
-        values_as_list(
-          application_choice.structured_rejection_reasons[sub_reason]
-            &.map { |value| sub_reason_detail_text(application_choice, top_level_reason, sub_reason, value) }
-            &.reject(&:blank?),
-        )
-      else
-        detail_reason_for(application_choice, top_level_reason)
-      end
-    end
-
-    def sub_reason_detail_text(application_choice, top_level_reason, sub_reason, value)
-      i18n_key = ReasonsForRejection::TOP_LEVEL_REASONS_TO_I18N_KEYS[top_level_reason].to_s
-      text = mark_search_term(
-        I18n.t("reasons_for_rejection.#{i18n_key}.#{value}", default: ''),
-        value.to_s == @search_value.to_s,
-      )
-
-      detail_questions = ReasonsForRejection::INITIAL_QUESTIONS.dig(
-        top_level_reason.to_sym, sub_reason.to_sym, value.to_sym
-      )
-      additional_text =
-        if detail_questions.is_a?(Array)
-          values_as_list(
-            detail_questions.map { |detail_question| application_choice.structured_rejection_reasons[detail_question.to_s] }.compact,
-          )
-        else
-          application_choice.structured_rejection_reasons[detail_questions.to_s]
-        end
-
-      [text, additional_text].compact_blank.join(' - ').html_safe
-    end
-
-    def reason_text_for(top_level_reason)
-      i18n_key = ReasonsForRejection::TOP_LEVEL_REASONS_TO_I18N_KEYS[top_level_reason].to_s
-      mark_search_term(translated_search_title(i18n_key), top_level_reason.to_s == @search_attribute.to_s)
-    end
-
-    def top_level_reason?(reason, value)
-      return true if other_reasons_question?(reason)
-
-      ReasonsForRejection::TOP_LEVEL_REASONS_TO_I18N_KEYS.key?(reason) &&
-        value == 'Yes'
+      @search_value.titleize
     end
 
   private
+
+    def reason_text_for(reason)
+      if reason['details'].present?
+        reason['details']['text']
+      elsif reason['selected_reasons'].present?
+        values = Array(reason['selected_reasons']).map do |sub_reason|
+          reason_text_for(sub_reason)
+        end
+
+        values_as_list(values)
+      else
+        reason['label']
+      end
+    end
+
+    def mark_search_term(text, mark)
+      mark ? "<mark>#{text}</mark>".html_safe : text
+    end
 
     def values_as_list(values)
       return nil if values.blank?
@@ -91,32 +56,6 @@ module SupportInterface
         values.map { |value| tag.li(value) }.join.html_safe,
         class: 'govuk-list govuk-list--bullet govuk-!-margin-left-0 govuk-!-margin-right-0',
       ).html_safe
-    end
-
-    def mark_search_term(text, mark)
-      mark ? "<mark>#{text}</mark>".html_safe : text
-    end
-
-    def sub_reason_for(top_level_reason)
-      ReasonsForRejectionCountQuery::TOP_LEVEL_REASONS_TO_SUB_REASONS[top_level_reason.to_sym].to_s
-    end
-
-    def detail_reason_for(application_choice, top_level_reason)
-      detail_questions = ReasonsForRejection::ALL_QUESTIONS[top_level_reason.to_sym]&.keys || []
-      detail_questions << top_level_reason if other_reasons_question?(top_level_reason)
-      return 'Yes' if detail_questions.empty?
-
-      values_as_list(
-        detail_questions.map { |detail_question| application_choice.structured_rejection_reasons[detail_question.to_s] }.compact,
-      )
-    end
-
-    def other_reasons_question?(question_key)
-      question_key == ReasonsForRejection::OTHER_REASON.to_s
-    end
-
-    def translated_search_title(i18n_key)
-      t("reasons_for_rejection.#{i18n_key}.alt_title", default: t("reasons_for_rejection.#{i18n_key}.title", default: ''))
     end
   end
 end

--- a/app/components/support_interface/sub_reasons_for_rejection_table_component.rb
+++ b/app/components/support_interface/sub_reasons_for_rejection_table_component.rb
@@ -17,15 +17,15 @@ module SupportInterface
     end
 
     def reason_label
-      I18n.t("reasons_for_rejection.#{reason}.title")
+      I18n.t("reasons_for_rejection.#{reason}.title", default: reason.humanize)
     end
 
     def sub_reason_key
-      ReasonsForRejectionCountQuery::TOP_LEVEL_REASONS_TO_SUB_REASONS[reason]
+      reason
     end
 
     def sub_reason_label(sub_reason)
-      I18n.t("reasons_for_rejection.#{ReasonsForRejection::TOP_LEVEL_REASONS_TO_I18N_KEYS[reason]}.#{sub_reason}")
+      sub_reason.humanize
     end
 
     def sub_reason_percentage_of_reason(sub_reason_key, time_period = :all_time)

--- a/app/controllers/support_interface/performance_controller.rb
+++ b/app/controllers/support_interface/performance_controller.rb
@@ -2,6 +2,8 @@ require 'csv'
 
 module SupportInterface
   class PerformanceController < SupportInterfaceController
+    REASONS_FOR_REJECTION_RECRUITMENT_CYCLE_YEAR = 2023
+
     def index; end
 
     def course_options
@@ -24,7 +26,7 @@ module SupportInterface
       render_404 unless RecruitmentCycle::CYCLES.keys.include?(year_param.to_s)
 
       query = ReasonsForRejectionCountQuery.new(year_param)
-      @reasons_for_rejection = query.sub_reason_counts
+      @reasons_for_rejection = query.subgrouped_reasons
       @total_structured_rejection_reasons_count = query.total_structured_reasons_for_rejection
       @total_structured_rejection_reasons_count_this_month = query.total_structured_reasons_for_rejection(time_period: :this_month)
       @recruitment_cycle_year = year_param.to_i

--- a/app/controllers/support_interface/performance_controller.rb
+++ b/app/controllers/support_interface/performance_controller.rb
@@ -23,7 +23,7 @@ module SupportInterface
     end
 
     def reasons_for_rejection_dashboard
-      render_404 unless RecruitmentCycle::CYCLES.keys.include?(year_param.to_s)
+      return render_404 unless year_param.to_i >= REASONS_FOR_REJECTION_RECRUITMENT_CYCLE_YEAR
 
       query = ReasonsForRejectionCountQuery.new(year_param)
       @reasons_for_rejection = query.subgrouped_reasons

--- a/app/queries/reasons_for_rejection_applications_query.rb
+++ b/app/queries/reasons_for_rejection_applications_query.rb
@@ -21,14 +21,25 @@ class ReasonsForRejectionApplicationsQuery
 private
 
   def apply_filters(application_choices)
-#    AND structured_rejection_reasons->'selected_reasons' @> '[ { "id": "qualifications" }]'
-#AND structured_rejection_reasons->'selected_reasons' @> '[{ "selected_reasons": [ { "id": "unsuitable_degree" }]}]'
     filters[:structured_rejection_reasons].each do |key, value|
-      application_choices = application_choices.where(
-        "application_choices.structured_rejection_reasons#{jsonb_query}", { key:, value: }
-      )
+      application_choices = if key == 'id'
+                              filter_by_top_level_group(application_choices, value)
+                            else
+                              filter_by_subgroup(application_choices, key, value)
+                            end
     end
 
     application_choices
+  end
+
+  def filter_by_top_level_group(application_choices, top_level_group)
+    application_choices
+      .where("structured_rejection_reasons->'selected_reasons' @> '[{ \"id\": \"#{top_level_group}\"}]'")
+  end
+
+  def filter_by_subgroup(application_choices, top_level_group, subgroup)
+    application_choices
+      .where("structured_rejection_reasons->'selected_reasons' @> '[ { \"id\": \"#{top_level_group}\" }]'")
+      .where("structured_rejection_reasons->'selected_reasons' @> '[{ \"selected_reasons\": [{ \"id\": \"#{subgroup}\" }]}]'")
   end
 end

--- a/app/queries/reasons_for_rejection_applications_query.rb
+++ b/app/queries/reasons_for_rejection_applications_query.rb
@@ -34,12 +34,17 @@ private
 
   def filter_by_top_level_group(application_choices, top_level_group)
     application_choices
-      .where("structured_rejection_reasons->'selected_reasons' @> '[{ \"id\": \"#{top_level_group}\"}]'")
+      .where(
+        "structured_rejection_reasons->'selected_reasons' @> ?",
+        JSON.generate([{ id: top_level_group }])
+      )
   end
 
   def filter_by_subgroup(application_choices, top_level_group, subgroup)
-    application_choices
-      .where("structured_rejection_reasons->'selected_reasons' @> '[ { \"id\": \"#{top_level_group}\" }]'")
-      .where("structured_rejection_reasons->'selected_reasons' @> '[{ \"selected_reasons\": [{ \"id\": \"#{subgroup}\" }]}]'")
+    filter_by_top_level_group(application_choices, top_level_group)
+      .where(
+        "structured_rejection_reasons->'selected_reasons' @> ?",
+        JSON.generate([{ selected_reasons: [{ id: subgroup }]}])
+      )
   end
 end

--- a/app/queries/reasons_for_rejection_applications_query.rb
+++ b/app/queries/reasons_for_rejection_applications_query.rb
@@ -21,16 +21,9 @@ class ReasonsForRejectionApplicationsQuery
 private
 
   def apply_filters(application_choices)
+#    AND structured_rejection_reasons->'selected_reasons' @> '[ { "id": "qualifications" }]'
+#AND structured_rejection_reasons->'selected_reasons' @> '[{ "selected_reasons": [ { "id": "unsuitable_degree" }]}]'
     filters[:structured_rejection_reasons].each do |key, value|
-      jsonb_query = case key
-                    when ReasonsForRejection::OTHER_REASON.to_s
-                      "->>:key != ''"
-                    when /_y_n$/
-                      '->>:key = :value'
-                    else
-                      '->:key ? :value'
-                    end
-
       application_choices = application_choices.where(
         "application_choices.structured_rejection_reasons#{jsonb_query}", { key:, value: }
       )

--- a/app/queries/reasons_for_rejection_applications_query.rb
+++ b/app/queries/reasons_for_rejection_applications_query.rb
@@ -36,7 +36,7 @@ private
     application_choices
       .where(
         "structured_rejection_reasons->'selected_reasons' @> ?",
-        JSON.generate([{ id: top_level_group }])
+        JSON.generate([{ id: top_level_group }]),
       )
   end
 
@@ -44,7 +44,7 @@ private
     filter_by_top_level_group(application_choices, top_level_group)
       .where(
         "structured_rejection_reasons->'selected_reasons' @> ?",
-        JSON.generate([{ selected_reasons: [{ id: subgroup }]}])
+        JSON.generate([{ selected_reasons: [{ id: subgroup }] }]),
       )
   end
 end

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -14,10 +14,4 @@
       support_interface_reasons_for_rejection_dashboard_path,
     ) %>
   </li>
-  <li>
-    <%= govuk_link_to(
-      "#{RecruitmentCycle.cycle_name(RecruitmentCycle.previous_year)} (starts #{RecruitmentCycle.previous_year})",
-      support_interface_reasons_for_rejection_dashboard_path(year: RecruitmentCycle.previous_year),
-    ) %>
-  </li>
 </ul>

--- a/spec/components/support_interface/reasons_for_rejection_dashboard_component_spec.rb
+++ b/spec/components/support_interface/reasons_for_rejection_dashboard_component_spec.rb
@@ -19,36 +19,41 @@ RSpec.describe SupportInterface::ReasonsForRejectionDashboardComponent do
 
   let(:rejection_reasons) do
     ActiveSupport::HashWithIndifferentAccess.new({
-      candidate_behaviour_y_n: result(3, 1, {
-        'didnt_reply_to_interview_offer' => result(1, 0),
-        'didnt_attend_interview' => result(2, 1),
-        'other' => result,
+      communication_and_scheduling: result(3, 1, {
+        'did_not_reply' => result(1, 0),
+        'did_not_attend_interview' => result(2, 1),
+        'communication_and_scheduling_other' => result,
+        'could_not_arrange_interview' => result,
       }),
-      qualifications_y_n: result(4, 2, {
-        'no_maths_gcse' => result,
-        'no_english_gcse' => result(2, 1),
-        'no_science_gcse' => result(1, 1),
+      course_full: result(4, 2, {}),
+      other: result,
+      personal_statement: result(4, 1, {
+        'quality_of_writing' => result(1, 1),
+        'personal_statement_other' => result(3, 0),
+      }),
+      qualifications: result(7, 4, {
+        'unsuitable_degree' => result(1, 1),
+        'qualifications_other' => result(1, 1),
+        'no_maths_gcse' => result(1, 1),
+        'no_english_gcse' => result(1, 1),
         'no_degree' => result(1, 0),
-        'other' => result,
+        'unverified_qualifications' => result(2, 0),
       }),
-      quality_of_application_y_n: result,
-      honesty_and_professionalism_y_n: result,
-      safeguarding_y_n: result(1, 1, {
-        'candidate_disclosed_information' => result,
-        'vetting_disclosed_information' => result(1, 1),
-        'other' => result,
+      safeguarding: result(1, 1, {}),
+      teaching_knowledge: result(6, 3, {
+        'subject_knowledge' => result(1, 1),
+        'teaching_knowledge_other' => result(1, 1),
+        'teaching_role_knowledge' => result(1, 1),
+        'teaching_demonstration' => result(1, 1),
+        'teaching_method_knowledge' => result(1, 0),
+        'safeguarding_knowledge' => result(1, 0),
       }),
-      cannot_sponsor_visa_y_n: result(2, 0),
-      course_full_y_n: result(1, 1),
-      offered_on_another_course_y_n: result,
-      performance_at_interview_y_n: result,
-      why_are_you_rejecting_this_application: result(2, 1),
-      other_advice_or_feedback_y_n: result,
+      visa_sponsorship: result(2, 0),
     })
   end
 
   subject(:component) do
-    described_class.new(rejection_reasons, 12, 9)
+    described_class.new(rejection_reasons, 23, 14)
   end
 
   describe 'rendered component' do
@@ -66,87 +71,34 @@ RSpec.describe SupportInterface::ReasonsForRejectionDashboardComponent do
       end
     end
 
-    it 'renders detailed candidate behaviour section' do
-      section = rendered_component.css('.app-section')[0]
-      expect(heading_text(section)).to eq('Candidate behaviour')
-      expect(summary_text(section)).to eq(['25%', '3 of 12 rejections included this category'])
-      expect(details_text(section, 1)).to eq(['Didn’t reply to our interview offer', '8.33%', '1 of 12', '33.33%', '1 of 3', '0%', '0 of 9', '0%', '0 of 1'])
-      expect(details_text(section, 2)).to eq(['Didn’t attend interview', '16.67%', '2 of 12', '66.67%', '2 of 3', '11.11%', '1 of 9', '100%', '1 of 1'])
-    end
-
-    it 'renders quality of application section' do
+    it 'renders detailed top level section' do
       section = rendered_component.css('.app-section')[1]
-      expect(heading_text(section)).to eq('Quality of application')
-      expect(summary_text(section)).to eq(['0%', '0 of 12 rejections included this category'])
+      expect(heading_text(section)).to eq('Course full')
+      expect(summary_text(section)).to eq(['17.39%', '4 of 23 rejections included this category'])
     end
 
     it 'renders qualifications section' do
-      section = rendered_component.css('.app-section')[2]
-      expect(heading_text(section)).to eq('Qualifications')
-      expect(summary_text(section)).to eq(['33.33%', '4 of 12 rejections included this category'])
-      expect(details_text(section, 1)).to eq(['No Maths GCSE grade 4 (C) or above, or valid equivalent', '0%', '0 of 12', '0%', '0 of 4', '0%', '0 of 9', '0%', '0 of 2'])
-      expect(details_text(section, 2)).to eq(['No English GCSE grade 4 (C) or above, or valid equivalent', '16.67%', '2 of 12', '50%', '2 of 4', '11.11%', '1 of 9', '50%', '1 of 2'])
-      expect(details_text(section, 3)).to eq(['No Science GCSE grade 4 (C) or above, or valid equivalent (for primary applicants)', '8.33%', '1 of 12', '25%', '1 of 4', '11.11%', '1 of 9', '50%', '1 of 2'])
-    end
-
-    it 'renders interview section' do
-      section = rendered_component.css('.app-section')[3]
-      expect(heading_text(section)).to eq('Performance at interview')
-      expect(summary_text(section)).to eq(['0%', '0 of 12 rejections included this category'])
-    end
-
-    it 'renders course full section' do
       section = rendered_component.css('.app-section')[4]
-      expect(heading_text(section)).to eq('Course full')
-      expect(summary_text(section)).to eq(['8.33%', '1 of 12 rejections included this category'])
+      expect(heading_text(section)).to eq('Qualifications')
+      expect(summary_text(section)).to eq(['30.43%', '7 of 23 rejections included this category'])
+      expect(details_text(section, 1)).to eq(['Unsuitable degree', '4.35%', '1 of 23', '14.29%', '1 of 7', '7.14%', '1 of 14', '25%', '1 of 4'])
+      expect(details_text(section, 2)).to eq(['Qualifications other', '4.35%', '1 of 23', '14.29%', '1 of 7', '7.14%', '1 of 14', '25%', '1 of 4'])
+      expect(details_text(section, 3)).to eq(['No maths gcse', '4.35%', '1 of 23', '14.29%', '1 of 7', '7.14%', '1 of 14', '25%', '1 of 4'])
+      expect(details_text(section, 4)).to eq(['No english gcse', '4.35%', '1 of 23', '14.29%', '1 of 7', '7.14%', '1 of 14', '25%', '1 of 4'])
+      expect(details_text(section, 5)).to eq(['No degree', '4.35%', '1 of 23', '14.29%', '1 of 7', '0%', '0 of 14', '0%', '0 of 4'])
+      expect(details_text(section, 6)).to eq(['Unverified qualifications', '8.7%', '2 of 23', '28.57%', '2 of 7', '0%', '0 of 14', '0%', '0 of 4'])
     end
 
-    it 'renders alternative course section' do
-      section = rendered_component.css('.app-section')[5]
-      expect(heading_text(section)).to eq('Offered on another course')
-      expect(summary_text(section)).to eq(['0%', '0 of 12 rejections included this category'])
-    end
-
-    it 'renders honesty and professionalism section' do
+    it 'renders teaching knowledge section' do
       section = rendered_component.css('.app-section')[6]
-      expect(heading_text(section)).to eq('Honesty and professionalism')
-      expect(summary_text(section)).to eq(['0%', '0 of 12 rejections included this category'])
-    end
-
-    it 'renders safeguarding section' do
-      section = rendered_component.css('.app-section')[7]
-      expect(heading_text(section)).to eq('Safeguarding')
-      expect(summary_text(section)).to eq(['8.33%', '1 of 12 rejections included this category'])
-      expect(details_text(section, 2)).to eq(['Information revealed by our vetting process makes the candidate unsuitable to work with children', '8.33%', '1 of 12', '100%', '1 of 1', '11.11%', '1 of 9', '100%', '1 of 1'])
+      expect(heading_text(section)).to eq('Teaching knowledge')
+      expect(summary_text(section)).to eq(['26.09%', '6 of 23 rejections included this category'])
     end
 
     it 'renders visa section' do
-      section = rendered_component.css('.app-section')[8]
-      expect(heading_text(section)).to eq('Cannot sponsor visa')
-      expect(summary_text(section)).to eq(['16.67%', '2 of 12 rejections included this category'])
-    end
-
-    it 'renders other reasons section' do
-      section = rendered_component.css('.app-section')[9]
-      expect(heading_text(section)).to eq('Other reasons')
-      expect(summary_text(section)).to eq(['16.67%', '2 of 12 rejections included this category'])
-    end
-
-    it 'renders other advice section' do
-      section = rendered_component.css('.app-section')[10]
-      expect(heading_text(section)).to eq('Additional advice or feedback')
-      expect(summary_text(section)).to eq(['0%', '0 of 12 rejections included this category'])
-    end
-
-    context 'for a previous recruitment cycle' do
-      subject(:component) do
-        described_class.new(rejection_reasons, 12, 9, RecruitmentCycle.previous_year)
-      end
-
-      it 'only renders the all time glance metrics' do
-        section = rendered_component.css('.app-section')[0]
-        expect(section.css('.app-card').text.gsub(/\s+/, ' ').strip).to eq('25% 3 of 12 rejections included this category')
-      end
+      section = rendered_component.css('.app-section')[-1]
+      expect(heading_text(section)).to eq('Visa sponsorship')
+      expect(summary_text(section)).to eq(['8.7%', '2 of 23 rejections included this category'])
     end
   end
 

--- a/spec/components/support_interface/reasons_for_rejection_search_breadcrumb_component_spec.rb
+++ b/spec/components/support_interface/reasons_for_rejection_search_breadcrumb_component_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchBreadcrumbComponent do
   include Rails.application.routes.url_helpers
 
   def render_result(
-    search_attribute = :quality_of_application_y_n,
-    search_value = 'Yes',
+    search_attribute = :id,
+    search_value = 'qualifications',
     recruitment_cycle_year = RecruitmentCycle.current_year
   )
     @rendered_result ||= render_inline(
@@ -23,17 +23,17 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchBreadcrumbComponent do
     end
 
     it 'renders the correct title' do
-      expect(@rendered_result.text).to include('Quality of application')
+      expect(@rendered_result.text).to include('qualifications')
     end
   end
 
   context 'for a sub-reason' do
     before do
-      render_result(:qualifications_which_qualifications, :no_degree)
+      render_result(:communication_and_scheduling, :communication_and_scheduling_other)
     end
 
     it 'renders the correct title' do
-      expect(@rendered_result.text).to include('No degree')
+      expect(@rendered_result.text).to include('communication_and_scheduling_other')
     end
 
     it 'renders the link back to the dashboard' do
@@ -42,34 +42,13 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchBreadcrumbComponent do
       expect(@rendered_result.css("a[href='#{dashboard_path}']")).to be_present
     end
 
-    it 'renders the link back to qualifications' do
-      subreason_path = support_interface_reasons_for_rejection_application_choices_path(
-        'structured_rejection_reasons[qualifications_y_n]' => 'Yes',
+    it 'renders the link back to communication' do
+      reason_path = support_interface_reasons_for_rejection_application_choices_path(
+        'structured_rejection_reasons[id]' => 'communication_and_scheduling',
         'recruitment_cycle_year' => RecruitmentCycle.current_year,
       )
 
-      expect(@rendered_result.css("a[href='#{subreason_path}']")).to be_present
-    end
-  end
-
-  context 'for a previous recruitment cycle' do
-    before do
-      render_result(:qualifications_which_qualifications, :no_degree, RecruitmentCycle.previous_year)
-    end
-
-    it 'renders the link back to the dashboard including the correct year param' do
-      dashboard_path = support_interface_reasons_for_rejection_dashboard_path(year: RecruitmentCycle.previous_year)
-
-      expect(@rendered_result.css("a[href='#{dashboard_path}']")).to be_present
-    end
-
-    it 'renders the link back to qualifications including the correct recruitment cycle year' do
-      subreason_path = support_interface_reasons_for_rejection_application_choices_path(
-        'structured_rejection_reasons[qualifications_y_n]' => 'Yes',
-        'recruitment_cycle_year' => RecruitmentCycle.previous_year,
-      )
-
-      expect(@rendered_result.css("a[href='#{subreason_path}']")).to be_present
+      expect(@rendered_result.css("a[href='#{reason_path}']")).to be_present
     end
   end
 end

--- a/spec/components/support_interface/sub_reasons_for_rejection_table_component_spec.rb
+++ b/spec/components/support_interface/sub_reasons_for_rejection_table_component_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe SupportInterface::SubReasonsForRejectionTableComponent do
         expect(table_headings[4].text.strip).to eq('Percentage of all rejections in September within this category')
 
         table_cells = rendered_component.css('tbody td')
-        expect(rendered_component.css('tbody th').text.strip).to eq('Didn’t attend interview')
+        expect(rendered_component.css('tbody th').text.strip).to eq('Didnt attend interview')
         expect(table_cells.size).to eq(4)
         expect(table_cells[0].text.strip).to start_with('3%')
         expect(table_cells[1].text.strip).to start_with('12%')
@@ -100,7 +100,7 @@ RSpec.describe SupportInterface::SubReasonsForRejectionTableComponent do
       expect(table_headings[2].text.strip).to eq('Percentage of all rejections within this category')
 
       table_cells = rendered_component.css('tbody td')
-      expect(rendered_component.css('tbody th').text.strip).to eq('Didn’t attend interview')
+      expect(rendered_component.css('tbody th').text.strip).to eq('Didnt attend interview')
       expect(table_cells.size).to eq(2)
       expect(table_cells[0].text.strip).to start_with('3%')
       expect(table_cells[1].text.strip).to start_with('12%')

--- a/spec/queries/reasons_for_rejection_applications_query_spec.rb
+++ b/spec/queries/reasons_for_rejection_applications_query_spec.rb
@@ -2,22 +2,78 @@ require 'rails_helper'
 
 RSpec.describe ReasonsForRejectionApplicationsQuery do
   describe '#call' do
-    let!(:application_choice) { create(:application_choice, :with_structured_rejection_reasons) }
+    let!(:application_choice) do
+      reject_application(
+        {
+          id: 'personal_statement',
+          label: 'Personal statement',
+          selected_reasons: [
+            {
+              id: 'quality_of_writing',
+              label: 'Quality of writing',
+              details: {
+                id: 'quality_of_writing_details',
+                text: 'The statement lack detail and depth',
+              },
+            },
+          ],
+        },
+      )
+    end
+    let!(:second_application_choice) do
+      reject_application(
+        {
+          id: 'visa_sponsorship',
+          label: 'Visa sponsorship',
+          details: {
+            id: 'visa_sponsorship_details',
+            text: 'Cannot sponsor visa',
+          },
+        },
+      )
+    end
     let!(:application_choice_without_sr4r) { create(:application_choice) }
     let!(:application_choice_from_previous_year) do
       create(:application_choice, :with_structured_rejection_reasons, current_recruitment_cycle_year: RecruitmentCycle.previous_year)
     end
-    let(:filter_params) do
-      {
-        structured_rejection_reasons: { 'candidate_behaviour_y_n' => 'Yes' },
-        recruitment_cycle_year: RecruitmentCycle.current_year,
-      }
-    end
 
     subject(:query) { described_class.new(filter_params) }
 
-    it 'filters by rejection reason key and recruitment cycle' do
-      expect(query.call).to eq([application_choice])
+    context 'when searching for top level reasons' do
+      let(:filter_params) do
+        {
+          structured_rejection_reasons: { 'id' => 'visa_sponsorship' },
+          recruitment_cycle_year: RecruitmentCycle.current_year,
+        }
+      end
+
+      it 'filters by rejection reason key and recruitment cycle' do
+        expect(query.call).to eq([second_application_choice])
+      end
+    end
+
+    context 'when searching for sub groups' do
+      let(:filter_params) do
+        {
+          structured_rejection_reasons: { 'personal_statement' => 'quality_of_writing' },
+          recruitment_cycle_year: RecruitmentCycle.current_year,
+        }
+      end
+
+      it 'filters by rejection reason key and recruitment cycle' do
+        expect(query.call).to eq([application_choice])
+      end
+    end
+
+    def reject_application(reason)
+      create(
+        :application_choice,
+        rejected_at: 2.minutes.ago,
+        rejection_reasons_type: 'reasons_for_rejection',
+        structured_rejection_reasons: {
+          selected_reasons: [reason],
+        },
+      )
     end
   end
 end

--- a/spec/queries/reasons_for_rejection_count_query_spec.rb
+++ b/spec/queries/reasons_for_rejection_count_query_spec.rb
@@ -4,9 +4,37 @@ RSpec.describe ReasonsForRejectionCountQuery do
   def reject_application(application_choice, reasons)
     ApplicationStateChange.new(application_choice).reject!
     application_choice.update!(
-      structured_rejection_reasons: reasons,
+      structured_rejection_reasons: { selected_reasons: reasons },
       rejected_at: Time.zone.now,
     )
+  end
+
+  let(:qualifications) do
+    {
+      id: 'qualifications',
+      label: 'Qualifications',
+      selected_reasons: [
+        {
+          id: 'unsuitable_degree',
+          label: 'Degree does not meet course requirements',
+          details: {
+            id: 'unsuitable_degree_details',
+            text: 'details about this rejection',
+          },
+        },
+      ],
+    }
+  end
+
+  let(:visa_sponsorship) do
+    {
+      id: 'visa_sponsorship',
+      label: 'Visa sponsorship',
+      details: {
+        id: 'visa_sponsorship_details',
+        text: 'details about this rejection',
+      },
+    }
   end
 
   before do
@@ -16,52 +44,26 @@ RSpec.describe ReasonsForRejectionCountQuery do
 
     reject_application(
       @application_choice1,
-      {
-        candidate_behaviour_y_n: 'Yes',
-        candidate_behaviour_what_did_the_candidate_do: %w[other],
-        candidate_behaviour_other: 'Mumbled',
-        candidate_behaviour_what_to_improve: 'Speak clearly',
-        quality_of_application_y_n: 'Yes',
-        quality_of_application_which_parts_needed_improvement: %w[personal_statement other],
-        quality_of_application_personal_statement_what_to_improve: 'Was too personal',
-        quality_of_application_other_details: 'Written in crayon',
-        quality_of_application_other_what_to_improve: 'Write with a pen',
-        qualifications_y_n: 'Yes',
-        qualifications_which_qualifications: %w[no_maths_gcse],
-        qualifications_other_details: 'You need maths',
-        performance_at_interview_y_n: 'Yes',
-        performance_at_interview_what_to_improve: 'Be on time',
-      },
+      [qualifications, visa_sponsorship],
     )
     reject_application(
       @application_choice2,
-      {
-        qualifications_y_n: 'No',
-        candidate_behaviour_y_n: 'Yes',
-        candidate_behaviour_what_did_the_candidate_do: %w[other],
-      },
+      [visa_sponsorship],
     )
     reject_application(
       @application_choice3,
-      {
-        candidate_behaviour_y_n: 'Yes',
-        candidate_behaviour_what_did_the_candidate_do: %w[other],
-        candidate_behaviour_other: 'Mumbled',
-        candidate_behaviour_what_to_improve: 'Speak clearly',
-        quality_of_application_y_n: 'Yes',
-        quality_of_application_which_parts_needed_improvement: %w[personal_statement other],
-      },
+      [visa_sponsorship],
     )
     @application_choice3.update!(rejected_at: 2.months.ago)
   end
 
-  describe '#reason_counts' do
+  describe '#grouped_reasons' do
     it 'returns correct values' do
-      counts = described_class.new.reason_counts
-      expect(counts[:candidate_behaviour_y_n]).to eq(
+      counts = described_class.new.grouped_reasons
+      expect(counts[:visa_sponsorship]).to eq(
         described_class::Result.new(3, 2, {}),
       )
-      expect(counts[:qualifications_y_n]).to eq(
+      expect(counts[:qualifications]).to eq(
         described_class::Result.new(1, 1, {}),
       )
     end
@@ -69,63 +71,41 @@ RSpec.describe ReasonsForRejectionCountQuery do
     it 'defaults to counts for current recruitment cycle' do
       reject_application(
         create(:application_choice, :awaiting_provider_decision, current_recruitment_cycle_year: RecruitmentCycle.previous_year),
-        {
-          qualifications_y_n: 'No',
-          candidate_behaviour_y_n: 'Yes',
-          candidate_behaviour_what_did_the_candidate_do: %w[other],
-        },
+        [qualifications, visa_sponsorship],
       )
-      counts = described_class.new.reason_counts
-      expect(counts[:candidate_behaviour_y_n]).to eq(described_class::Result.new(3, 2, {}))
-      expect(counts[:qualifications_y_n]).to eq(described_class::Result.new(1, 1, {}))
+      counts = described_class.new.grouped_reasons
+      expect(counts[:visa_sponsorship]).to eq(described_class::Result.new(3, 2, {}))
+      expect(counts[:qualifications]).to eq(described_class::Result.new(1, 1, {}))
     end
 
     it 'can be initialized for a specific recruitment cycle year' do
       reject_application(
         create(:application_choice, :awaiting_provider_decision, current_recruitment_cycle_year: RecruitmentCycle.previous_year),
-        {
-          qualifications_y_n: 'Yes',
-          candidate_behaviour_y_n: 'Yes',
-          candidate_behaviour_what_did_the_candidate_do: %w[other],
-        },
+        [visa_sponsorship, qualifications],
       )
-      counts = described_class.new(RecruitmentCycle.previous_year).reason_counts
-      expect(counts[:candidate_behaviour_y_n]).to eq(described_class::Result.new(1, 1, {}))
-      expect(counts[:qualifications_y_n]).to eq(described_class::Result.new(1, 1, {}))
+      counts = described_class.new(RecruitmentCycle.previous_year).grouped_reasons
+      expect(counts[:visa_sponsorship]).to eq(described_class::Result.new(1, 1, {}))
+      expect(counts[:qualifications]).to eq(described_class::Result.new(1, 1, {}))
     end
   end
 
-  describe '#sub_reason_counts' do
+  describe '#subgrouped_reasons' do
     it 'returns correct values' do
-      counts = described_class.new.sub_reason_counts
-      expect(counts[:candidate_behaviour_y_n].sub_reasons[:other]).to eq(
-        described_class::Result.new(3, 2, nil),
+      counts = described_class.new.subgrouped_reasons
+      expect(counts[:qualifications].sub_reasons[:unsuitable_degree]).to eq(
+        described_class::Result.new(1, 1, nil),
       )
-      expect(counts[:quality_of_application_y_n].sub_reasons[:personal_statement]).to eq(
-        described_class::Result.new(2, 1, nil),
-      )
-    end
-
-    it 'includes zero values' do
-      counts = described_class.new.sub_reason_counts
-      expect(counts[:qualifications_y_n].sub_reasons.count).to be(5)
-      expect(counts[:qualifications_y_n].sub_reasons[:no_english_gcse]).to eq(
-        described_class::Result.new(0, 0, nil),
-      )
+      expect(counts[:visa_sponsorship].sub_reasons).to eq({})
     end
 
     it 'only returns counts for current recruitment cycle' do
       reject_application(
         create(:application_choice, :awaiting_provider_decision, current_recruitment_cycle_year: RecruitmentCycle.previous_year),
-        {
-          qualifications_y_n: 'No',
-          candidate_behaviour_y_n: 'Yes',
-          candidate_behaviour_what_did_the_candidate_do: %w[other],
-        },
+        [visa_sponsorship, qualifications],
       )
-      counts = described_class.new.sub_reason_counts
-      expect(counts[:candidate_behaviour_y_n].sub_reasons[:other]).to eq(described_class::Result.new(3, 2, nil))
-      expect(counts[:quality_of_application_y_n].sub_reasons[:personal_statement]).to eq(described_class::Result.new(2, 1, nil))
+      counts = described_class.new.subgrouped_reasons
+      expect(counts[:qualifications].sub_reasons[:unsuitable_degree]).to eq(described_class::Result.new(1, 1, nil))
+      expect(counts[:visa_sponsorship]).to eq(described_class::Result.new(3, 2, {}))
     end
   end
 

--- a/spec/requests/support_interface/performance_spec.rb
+++ b/spec/requests/support_interface/performance_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe 'Support Interface - Performance pages' do
+  def support_user
+    @support_user ||= SupportUser.new(
+      email_address: 'alice@example.com',
+      dfe_sign_in_uid: 'ABC',
+    )
+  end
+
+  before do
+    allow(SupportUser).to receive(:load_from_session).and_return(support_user)
+  end
+
+  context 'when requesting a year when structure reasons for rejection was not implemented' do
+    it 'renders not found' do
+      get support_interface_reasons_for_rejection_dashboard_path(params: { year: 2022 })
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context 'when requesting a year when structure reasons for rejection is implemented' do
+    it 'renders the report' do
+      get support_interface_reasons_for_rejection_dashboard_path
+      expect(response).to be_ok
+    end
+  end
+end


### PR DESCRIPTION
## Context

Fix the reasons for the rejections report, which is showing no data.

## Root cause

The whole structure reasons for rejection were changed Last April, the whole format then this report stopped showing the new data leaving to an inaccurate report.

Rewriting the report generation and it's next pages (when you click on group and subgroups links in the report) was the only solution.

Now the generation is also dynamic (it is not hardcoding any group or subgroup) - just showing whathever groups are on the DB.
