### PR TITLE
Allow support to change gcse grade

### DIFF
--- a/app/components/shared/gcse_qualification_cards_component.html.erb
+++ b/app/components/shared/gcse_qualification_cards_component.html.erb
@@ -53,15 +53,28 @@
               <% end %>
               </dd>
               <dt class="app-qualification__key">Grade</dt>
-              <% grade_details(qualification).each_with_index do |grade, index| %>
+              <% if qualification.grade.present? %>
                 <dd class="app-qualification__value">
-                  <%= grade %>
+                  <%= qualification.grade %>
                   <% if editable? %>
-                    <%= govuk_link_to support_interface_application_form_edit_gcse_grade_path(gcse_id: qualification.id, constituent_grades: qualification.constituent_grades.present?, index: index) do %>
+                    <%= govuk_link_to support_interface_application_form_edit_gcse_grade_path(gcse_id: qualification.id) do %>
                       Change <span class="govuk-visually-hidden">grade</span>
                     <% end %>
                   <% end %>
                 </dd>
+              <% elsif (grades = qualification.constituent_grades).present? %>
+                <% grades.each do |(subject, details)| %>
+                  <dd class="app-qualification__value">
+                    <%= ApplicationQualificationDecorator.new(qualification).grade_details.fetch(subject) %>
+                    <% if editable? %>
+                      <%= govuk_link_to support_interface_application_form_edit_gcse_grade_path(gcse_id: qualification.id, constituent_subject: subject) do %>
+                        Change <span class="govuk-visually-hidden">grade</span>
+                      <% end %>
+                    <% end %>
+                  </dd>
+                <% end %>
+              <% else %>
+                <% raise 'Neither `grade` nor `constituent_grades` found' %>
               <% end %>
 
               <% if qualification.failed_required_gcse? %>

--- a/app/components/shared/gcse_qualification_cards_component.html.erb
+++ b/app/components/shared/gcse_qualification_cards_component.html.erb
@@ -53,11 +53,11 @@
               <% end %>
               </dd>
               <dt class="app-qualification__key">Grade</dt>
-              <% grade_details(qualification).each do |grade| %>
+              <% grade_details(qualification).each_with_index do |grade, index| %>
                 <dd class="app-qualification__value">
                   <%= grade %>
                   <% if editable? %>
-                    <%= govuk_link_to support_interface_application_form_edit_gcse_grade_path(gcse_id: qualification.id) do %>
+                    <%= govuk_link_to support_interface_application_form_edit_gcse_grade_path(gcse_id: qualification.id, constituent_grades: qualification.constituent_grades.present?, index: index) do %>
                       Change <span class="govuk-visually-hidden">grade</span>
                     <% end %>
                   <% end %>

--- a/app/components/shared/gcse_qualification_cards_component.html.erb
+++ b/app/components/shared/gcse_qualification_cards_component.html.erb
@@ -44,8 +44,8 @@
             </h4>
             <dl class="app-qualification">
               <dt class="app-qualification__key">Awarded</dt>
-              <dd class="app-qualification__value app-qualification__value--caption">
-              <%= qualification.award_year %> 
+              <dd class="app-qualification__value">
+              <%= qualification.award_year %>
               <% if editable? %>
                 <%= govuk_link_to 'Change', support_interface_application_form_edit_gcse_award_year_path(gcse_id: qualification.id) %>
               <% end %>

--- a/app/components/shared/gcse_qualification_cards_component.html.erb
+++ b/app/components/shared/gcse_qualification_cards_component.html.erb
@@ -47,12 +47,21 @@
               <dd class="app-qualification__value">
               <%= qualification.award_year %>
               <% if editable? %>
-                <%= govuk_link_to 'Change', support_interface_application_form_edit_gcse_award_year_path(gcse_id: qualification.id) %>
+                <%= govuk_link_to support_interface_application_form_edit_gcse_award_year_path(gcse_id: qualification.id) do %>
+                  Change <span class="govuk-visually-hidden">award year</span>
+                <% end %>
               <% end %>
               </dd>
               <dt class="app-qualification__key">Grade</dt>
               <% grade_details(qualification).each do |grade| %>
-                <dd class="app-qualification__value"><%= grade %></dd>
+                <dd class="app-qualification__value">
+                  <%= grade %>
+                  <% if editable? %>
+                    <%= govuk_link_to support_interface_application_form_edit_gcse_grade_path(gcse_id: qualification.id) do %>
+                      Change <span class="govuk-visually-hidden">grade</span>
+                    <% end %>
+                  <% end %>
+                </dd>
               <% end %>
 
               <% if qualification.failed_required_gcse? %>

--- a/app/components/shared/gcse_qualification_cards_component.html.erb
+++ b/app/components/shared/gcse_qualification_cards_component.html.erb
@@ -43,9 +43,12 @@
               <%= subject(qualification) %> <span class="govuk-!-font-weight-regular"><%= presentable_qualification_type(qualification) %></span>
             </h4>
             <dl class="app-qualification">
-              <dt class="app-qualification__key govuk-visually-hidden">Awarded</dt>
+              <dt class="app-qualification__key">Awarded</dt>
               <dd class="app-qualification__value app-qualification__value--caption">
-              <%= qualification.award_year %>
+              <%= qualification.award_year %> 
+              <% if editable? %>
+                <%= govuk_link_to 'Change', support_interface_application_form_edit_gcse_award_year_path(gcse_id: qualification.id) %>
+              <% end %>
               </dd>
               <dt class="app-qualification__key">Grade</dt>
               <% grade_details(qualification).each do |grade| %>
@@ -70,10 +73,6 @@
                 <% end %>
               <% end %>
             </dl>
-          <% end %>
-          <% if editable? %>
-            <br>
-            <%= govuk_link_to 'Change', support_interface_application_form_edit_gcse_path(gcse_id: qualification.id) %>
           <% end %>
         </div>
       </div>

--- a/app/controllers/support_interface/application_forms/gcses_controller.rb
+++ b/app/controllers/support_interface/application_forms/gcses_controller.rb
@@ -25,12 +25,16 @@ module SupportInterface
       def edit_grade
         @gcse_grade_form = EditGcseGradeForm.new(
           ApplicationQualification.find(params[:gcse_id]),
+          params[:constituent_grades],
+          params[:index],
         )
       end
 
       def update_grade
         @gcse_grade_form = EditGcseGradeForm.new(
           ApplicationQualification.find(params[:gcse_id]),
+          params[:constituent_grades],
+          params[:index],
         )
 
         @gcse_grade_form.assign_attributes(edit_grade_params)
@@ -54,7 +58,7 @@ module SupportInterface
       def edit_grade_params
         params.require(
           :support_interface_application_forms_edit_gcse_grade_form,
-        ).permit(:grade, :audit_comment)
+        ).permit(:grade, :constituent_grades, :index, :audit_comment)
       end
     end
   end

--- a/app/controllers/support_interface/application_forms/gcses_controller.rb
+++ b/app/controllers/support_interface/application_forms/gcses_controller.rb
@@ -1,32 +1,32 @@
 module SupportInterface
   module ApplicationForms
     class GcsesController < SupportInterfaceController
-      def edit
-        @gcse_form = EditGcseForm.new(
+      def edit_award_year
+        @gcse_award_year_form = EditGcseAwardYearForm.new(
           ApplicationQualification.find(params[:gcse_id]),
         )
       end
 
-      def update
-        @gcse_form = EditGcseForm.new(
+      def update_award_year
+        @gcse_award_year_form = EditGcseAwardYearForm.new(
           ApplicationQualification.find(params[:gcse_id]),
         )
 
-        @gcse_form.assign_attributes(edit_application_params)
-        if @gcse_form.valid?
-          @gcse_form.save!
-          flash[:success] = 'GCSE updated'
-          redirect_to support_interface_application_form_path(@gcse_form.application_form)
+        @gcse_award_year_form.assign_attributes(edit_award_year_params)
+        if @gcse_award_year_form.valid?
+          @gcse_award_year_form.save!
+          flash[:success] = 'GCSE award year updated'
+          redirect_to support_interface_application_form_path(@gcse_award_year_form.application_form)
         else
-          render :edit
+          render :edit_award_year
         end
       end
 
     private
 
-      def edit_application_params
+      def edit_award_year_params
         params.require(
-          :support_interface_application_forms_edit_gcse_form,
+          :support_interface_application_forms_edit_gcse_award_year_form,
         ).permit(:award_year, :audit_comment)
       end
     end

--- a/app/controllers/support_interface/application_forms/gcses_controller.rb
+++ b/app/controllers/support_interface/application_forms/gcses_controller.rb
@@ -25,16 +25,14 @@ module SupportInterface
       def edit_grade
         @gcse_grade_form = EditGcseGradeForm.new(
           ApplicationQualification.find(params[:gcse_id]),
-          params[:constituent_grades],
-          params[:index],
+          params[:constituent_subject],
         )
       end
 
       def update_grade
         @gcse_grade_form = EditGcseGradeForm.new(
           ApplicationQualification.find(params[:gcse_id]),
-          params[:constituent_grades],
-          params[:index],
+          params[:constituent_subject],
         )
 
         @gcse_grade_form.assign_attributes(edit_grade_params)

--- a/app/controllers/support_interface/application_forms/gcses_controller.rb
+++ b/app/controllers/support_interface/application_forms/gcses_controller.rb
@@ -22,12 +22,39 @@ module SupportInterface
         end
       end
 
+      def edit_grade
+        @gcse_grade_form = EditGcseGradeForm.new(
+          ApplicationQualification.find(params[:gcse_id]),
+        )
+      end
+
+      def update_grade
+        @gcse_grade_form = EditGcseGradeForm.new(
+          ApplicationQualification.find(params[:gcse_id]),
+        )
+
+        @gcse_grade_form.assign_attributes(edit_grade_params)
+        if @gcse_grade_form.valid?
+          @gcse_grade_form.save!
+          flash[:success] = 'GCSE grade updated'
+          redirect_to support_interface_application_form_path(@gcse_grade_form.application_form)
+        else
+          render :edit_grade
+        end
+      end
+
     private
 
       def edit_award_year_params
         params.require(
           :support_interface_application_forms_edit_gcse_award_year_form,
         ).permit(:award_year, :audit_comment)
+      end
+
+      def edit_grade_params
+        params.require(
+          :support_interface_application_forms_edit_gcse_grade_form,
+        ).permit(:grade, :audit_comment)
       end
     end
   end

--- a/app/decorators/application_choice_export_decorator.rb
+++ b/app/decorators/application_choice_export_decorator.rb
@@ -91,7 +91,7 @@ private
     qualification_type = formatted_qualification_type(qualification.qualification_type)
     qualification_subject = formatted_qualification_subject(qualification.subject)
 
-    "#{qualification_type} #{qualification_subject}, #{qualification.grade_details.join(' ')}, #{qualification_period(qualification)}"
+    "#{qualification_type} #{qualification_subject}, #{qualification.grade_details.values.join(' ')}, #{qualification_period(qualification)}"
   end
 
   def formatted_qualification_type(qualification_type)

--- a/app/decorators/application_qualification_decorator.rb
+++ b/app/decorators/application_qualification_decorator.rb
@@ -1,52 +1,27 @@
 class ApplicationQualificationDecorator < SimpleDelegator
   attr_reader :qualification
 
-  ENGLISH_AWARDS = { english_single_award: 'English single award',
-                     english_double_award: 'English double award',
-                     english_studies_single_award: 'English Studies single award',
-                     english_studies_double_award: 'English Studies double award' }.freeze
-
   def initialize(qualification)
     @qualification = qualification
     super(qualification)
   end
 
   def grade_details
-    return [] if qualification.missing_qualification?
+    return {} if qualification.missing_qualification?
 
-    case qualification.subject
-    when ApplicationQualification::SCIENCE_TRIPLE_AWARD
-      [
-        "#{constituent_grade_for('biology')} (biology)",
-        "#{constituent_grade_for('chemistry')} (chemistry)",
-        "#{constituent_grade_for('physics')} (physics)",
-      ]
-    when ApplicationQualification::SCIENCE_DOUBLE_AWARD
-      ["#{qualification.grade} (double award)"]
-    when ApplicationQualification::SCIENCE_SINGLE_AWARD
-      ["#{qualification.grade} (single award)"]
-    when ->(_n) { constituent_grades.present? }
-      present_constituent_grades
+    if (grades = qualification.constituent_grades).present?
+      grades.each.with_object({}) do |(subject, details), hash|
+        grade = details['grade'] || 'Grade information not available'
+        hash[subject] = "#{grade} (#{subject.humanize})"
+      end
+    elsif qualification.subject == ApplicationQualification::SCIENCE_TRIPLE_AWARD
+      %w[biology chemistry physics].index_with { |subject| "Grade information not available (#{subject})" }
+    elsif qualification.subject == ApplicationQualification::SCIENCE_DOUBLE_AWARD
+      { qualification.subject => "#{qualification.grade} (double award)" }
+    elsif qualification.subject == ApplicationQualification::SCIENCE_SINGLE_AWARD
+      { qualification.subject => "#{qualification.grade} (single award)" }
     else
-      [qualification.grade]
+      { qualification.subject => qualification.grade }
     end
-  end
-
-private
-
-  def present_constituent_grades
-    constituent_grades.map do |award, details|
-      return "#{details['grade']} (#{ENGLISH_AWARDS[award]})" if ENGLISH_AWARDS.include?(award)
-
-      "#{details['grade']} (#{award.humanize(capitalize: false).sub('english', 'English')})"
-    end
-  end
-
-  def constituent_grades
-    @constituent_grades ||= qualification.constituent_grades || {}
-  end
-
-  def constituent_grade_for(subject)
-    constituent_grades.dig(subject, 'grade') || 'Grade information not available'
   end
 end

--- a/app/forms/support_interface/application_forms/edit_gcse_award_year_form.rb
+++ b/app/forms/support_interface/application_forms/edit_gcse_award_year_form.rb
@@ -2,11 +2,12 @@ module SupportInterface
   module ApplicationForms
     class EditGcseAwardYearForm
       include ActiveModel::Model
+      include DateValidationHelper
 
       attr_reader :gcse
       attr_accessor :award_year, :audit_comment
 
-      validates :award_year, presence: true, length: { is: 4 }
+      validates :award_year, year: { presence: true, future: true }
       validates :audit_comment, presence: true
       validates_with ZendeskUrlValidator
 

--- a/app/forms/support_interface/application_forms/edit_gcse_award_year_form.rb
+++ b/app/forms/support_interface/application_forms/edit_gcse_award_year_form.rb
@@ -6,8 +6,9 @@ module SupportInterface
       attr_reader :gcse
       attr_accessor :award_year, :audit_comment
 
-      validates :award_year, presence: true
+      validates :award_year, presence: true, length: { is: 4 }
       validates :audit_comment, presence: true
+      validates_with ZendeskUrlValidator
 
       delegate :application_form, :subject, to: :gcse
 

--- a/app/forms/support_interface/application_forms/edit_gcse_award_year_form.rb
+++ b/app/forms/support_interface/application_forms/edit_gcse_award_year_form.rb
@@ -1,6 +1,6 @@
 module SupportInterface
   module ApplicationForms
-    class EditGcseForm
+    class EditGcseAwardYearForm
       include ActiveModel::Model
 
       attr_reader :gcse

--- a/app/forms/support_interface/application_forms/edit_gcse_grade_form.rb
+++ b/app/forms/support_interface/application_forms/edit_gcse_grade_form.rb
@@ -1,0 +1,31 @@
+module SupportInterface
+  module ApplicationForms
+    class EditGcseGradeForm
+      include ActiveModel::Model
+
+      attr_reader :gcse
+      attr_accessor :grade, :audit_comment
+
+      validates :grade, presence: true
+      validates :audit_comment, presence: true
+      validates_with ZendeskUrlValidator
+
+      delegate :application_form, :subject, to: :gcse
+
+      def initialize(gcse)
+        @gcse = gcse
+
+        super(
+          grade: @gcse.grade,
+        )
+      end
+
+      def save!
+        @gcse.update!(
+          grade:,
+          audit_comment:,
+        )
+      end
+    end
+  end
+end

--- a/app/forms/support_interface/application_forms/edit_gcse_grade_form.rb
+++ b/app/forms/support_interface/application_forms/edit_gcse_grade_form.rb
@@ -4,7 +4,7 @@ module SupportInterface
       include ActiveModel::Model
 
       attr_reader :gcse
-      attr_accessor :grade, :audit_comment
+      attr_accessor :grade, :constituent, :index, :audit_comment
 
       validates :grade, presence: true
       validates :audit_comment, presence: true
@@ -12,19 +12,31 @@ module SupportInterface
 
       delegate :application_form, :subject, to: :gcse
 
-      def initialize(gcse)
+      def initialize(gcse, constituent, index)
         @gcse = gcse
+        @constituent = constituent
+        @index = index
 
         super(
-          grade: @gcse.grade,
+          grade: @gcse.grade || @gcse.constituent_grades.values[index.to_i]['grade'],
         )
       end
 
       def save!
-        @gcse.update!(
-          grade:,
-          audit_comment:,
-        )
+        if ActiveModel::Type::Boolean.new.cast(constituent)
+          constituent_grades = @gcse.constituent_grades
+          constituent_grades.values[index.to_i]['grade'] = grade
+
+          @gcse.update!(
+            constituent_grades: constituent_grades,
+            audit_comment:,
+          )
+        else
+          @gcse.update!(
+            grade:,
+            audit_comment:,
+          )
+        end
       end
     end
   end

--- a/app/views/support_interface/application_forms/gcses/edit_award_year.html.erb
+++ b/app/views/support_interface/application_forms/gcses/edit_award_year.html.erb
@@ -10,7 +10,7 @@
         <%= f.govuk_text_field :award_year, label: { text: 'Award year', size: 'm' } %>
       <% end %>
 
-        <%= f.govuk_text_field :audit_comment, label: { text: t('support_interface.edit_address_details_form.audit_comment.label'), size: 'm' }, hint: { text: t('support_interface.edit_address_details_form.audit_comment.hint') } %>
+        <%= f.govuk_text_field :audit_comment, label: { text: t('support_interface.audit_comment_ticket.label'), size: 'm' }, hint: { text: t('support_interface.audit_comment_ticket.hint') } %>
 
       <%= f.govuk_submit 'Update details' %>
     <% end %>

--- a/app/views/support_interface/application_forms/gcses/edit_award_year.html.erb
+++ b/app/views/support_interface/application_forms/gcses/edit_award_year.html.erb
@@ -1,12 +1,12 @@
-<% content_for :browser_title, title_with_error_prefix('Edit GCSE', @gcse_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(@gcse_form.application_form)) %>
+<% content_for :browser_title, title_with_error_prefix('Edit GCSE award year', @gcse_award_year_form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(@gcse_award_year_form.application_form)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @gcse_form, url: support_interface_application_form_update_gcse_path do |f| %>
+    <%= form_with model: @gcse_award_year_form, url: support_interface_application_form_update_gcse_award_year_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_fieldset legend: { text: "Edit #{@gcse_form.subject.capitalize} GCSE details", size: 'l' } do %>
+      <%= f.govuk_fieldset legend: { text: "Edit #{@gcse_award_year_form.subject.capitalize} GCSE details", size: 'l' } do %>
         <%= f.govuk_text_field :award_year, label: { text: 'Award year', size: 'm' } %>
       <% end %>
 

--- a/app/views/support_interface/application_forms/gcses/edit_grade.html.erb
+++ b/app/views/support_interface/application_forms/gcses/edit_grade.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @gcse_grade_form, url: support_interface_application_form_update_gcse_grade_path do |f| %>
+    <%= form_with model: @gcse_grade_form, url: support_interface_application_form_update_gcse_grade_path(constituent_grades: params[:constituent_grades], index: params[:index]) do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_fieldset legend: { text: "Edit #{@gcse_grade_form.subject.capitalize} GCSE details", size: 'l' } do %>

--- a/app/views/support_interface/application_forms/gcses/edit_grade.html.erb
+++ b/app/views/support_interface/application_forms/gcses/edit_grade.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @gcse_grade_form, url: support_interface_application_form_update_gcse_grade_path(constituent_grades: params[:constituent_grades], index: params[:index]) do |f| %>
+    <%= form_with model: @gcse_grade_form, url: support_interface_application_form_update_gcse_grade_path(constituent_subject: params[:constituent_subject]) do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_fieldset legend: { text: "Edit #{@gcse_grade_form.subject.capitalize} GCSE details", size: 'l' } do %>

--- a/app/views/support_interface/application_forms/gcses/edit_grade.html.erb
+++ b/app/views/support_interface/application_forms/gcses/edit_grade.html.erb
@@ -1,0 +1,17 @@
+<% content_for :browser_title, title_with_error_prefix('Edit GCSE grade', @gcse_grade_form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(@gcse_grade_form.application_form)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @gcse_grade_form, url: support_interface_application_form_update_gcse_grade_path do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_fieldset legend: { text: "Edit #{@gcse_grade_form.subject.capitalize} GCSE details", size: 'l' } do %>
+        <%= f.govuk_text_field :grade, label: { text: 'Grade', size: 'm' } %>
+      <% end %>
+
+        <%= f.govuk_text_field :audit_comment, label: { text: t('support_interface.audit_comment_ticket.label'), size: 'm' }, hint: { text: t('support_interface.audit_comment_ticket.hint') } %>
+
+      <%= f.govuk_submit 'Update details' %>
+    <% end %>
+  </div>

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -195,13 +195,13 @@ en:
           attributes:
             award_year:
               blank: Award year cannot be blank
-              wrong_length: Enter a valid award year (for exmaple, 2001)
+              wrong_length: Year must include 4 numbers 
             audit_comment:
               blank: Enter a Zendesk ticket URL
         support_interface/application_forms/edit_gcse_grade_form:
           attributes:
             grade:
-              blank: Grade cannot be blank
+              blank: Enter the grade
             audit_comment:
               blank: Enter a Zendesk ticket URL
         support_interface/application_forms/edit_degree_form:

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -198,6 +198,12 @@ en:
               wrong_length: Enter a valid award year (for exmaple, 2001)
             audit_comment:
               blank: Enter a Zendesk ticket URL
+        support_interface/application_forms/edit_gcse_grade_form:
+          attributes:
+            grade:
+              blank: Grade cannot be blank
+            audit_comment:
+              blank: Enter a Zendesk ticket URL
         support_interface/application_forms/edit_degree_form:
           attributes:
             award_year:

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -195,8 +195,9 @@ en:
           attributes:
             award_year:
               blank: Award year cannot be blank
+              wrong_length: Enter a valid award year (for exmaple, 2001)
             audit_comment:
-              blank: You must provide an audit comment
+              blank: Enter a Zendesk ticket URL
         support_interface/application_forms/edit_degree_form:
           attributes:
             award_year:

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -191,7 +191,7 @@ en:
               too_many_words: Tell us about the candidate’s subject knowledge in %{count} words or fewer
             audit_comment:
               blank: You must provide an audit comment
-        support_interface/application_forms/edit_gcse_form:
+        support_interface/application_forms/edit_gcse_award_year_form:
           attributes:
             award_year:
               blank: Award year cannot be blank

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -897,8 +897,8 @@ Rails.application.routes.draw do
       get '/applicant-details' => 'application_forms/applicant_details#edit', as: :application_form_edit_applicant_details
       post '/applicant-details' => 'application_forms/applicant_details#update', as: :application_form_update_applicant_details
 
-      get '/gcses/:gcse_id' => 'application_forms/gcses#edit', as: :application_form_edit_gcse
-      post '/gcses/:gcse_id' => 'application_forms/gcses#update', as: :application_form_update_gcse
+      get '/gcses/:gcse_id' => 'application_forms/gcses#edit_award_year', as: :application_form_edit_gcse_award_year
+      post '/gcses/:gcse_id' => 'application_forms/gcses#update_award_year', as: :application_form_update_gcse_award_year
 
       get '/degrees/:degree_id' => 'application_forms/degrees#edit', as: :application_form_edit_degree
       post '/degrees/:degree_id' => 'application_forms/degrees#update', as: :application_form_update_degree

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -897,8 +897,11 @@ Rails.application.routes.draw do
       get '/applicant-details' => 'application_forms/applicant_details#edit', as: :application_form_edit_applicant_details
       post '/applicant-details' => 'application_forms/applicant_details#update', as: :application_form_update_applicant_details
 
-      get '/gcses/:gcse_id' => 'application_forms/gcses#edit_award_year', as: :application_form_edit_gcse_award_year
-      post '/gcses/:gcse_id' => 'application_forms/gcses#update_award_year', as: :application_form_update_gcse_award_year
+      get '/gcses-award-year/:gcse_id' => 'application_forms/gcses#edit_award_year', as: :application_form_edit_gcse_award_year
+      post '/gcses-award-year/:gcse_id' => 'application_forms/gcses#update_award_year', as: :application_form_update_gcse_award_year
+
+      get '/gcses-grade/:gcse_id' => 'application_forms/gcses#edit_grade', as: :application_form_edit_gcse_grade
+      post '/gcses-grade/:gcse_id' => 'application_forms/gcses#update_grade', as: :application_form_update_gcse_grade
 
       get '/degrees/:degree_id' => 'application_forms/degrees#edit', as: :application_form_edit_degree
       post '/degrees/:degree_id' => 'application_forms/degrees#update', as: :application_form_update_degree

--- a/spec/components/utility/gcse_qualification_cards_component_spec.rb
+++ b/spec/components/utility/gcse_qualification_cards_component_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe GcseQualificationCardsComponent, type: :component do
       create(
         :application_form,
         application_qualifications: [
-          create(:gcse_qualification, subject: 'english', constituent_grades: { english_language: { grade: 'E' }, english_literature: { grade: 'E' }, 'Cockney Rhyming Slang': { grade: 'A*' } }, award_year: 2006),
+          create(:gcse_qualification, grade: nil, subject: 'english', constituent_grades: { english_language: { grade: 'E' }, english_literature: { grade: 'E' }, 'Cockney Rhyming Slang': { grade: 'A*' } }, award_year: 2006),
         ],
       )
     end
@@ -216,22 +216,16 @@ RSpec.describe GcseQualificationCardsComponent, type: :component do
 
       expect(card.text).to include 'E (English language)'
       expect(card.text).to include 'E (English literature)'
-      expect(card.text).to include 'A* (cockney rhyming slang)'
+      expect(card.text).to include 'A* (Cockney rhyming slang)'
     end
   end
 
   describe 'rendering multiple Science GCSEs' do
-    science_triple_awards = {
-      biology: { grade: 'A' },
-      chemistry: { grade: 'B' },
-      physics: { grade: 'C' },
-    }
-
     let(:application_form) do
       create(
         :application_form,
         application_qualifications: [
-          create(:gcse_qualification, subject: 'science triple award', constituent_grades: science_triple_awards, award_year: 2006),
+          create(:gcse_qualification, :science_triple_award, award_year: 2006),
         ],
       )
     end
@@ -241,9 +235,9 @@ RSpec.describe GcseQualificationCardsComponent, type: :component do
 
       card = result.css('.app-card--outline')
 
-      expect(card.text).to include 'A (biology)'
-      expect(card.text).to include 'B (chemistry)'
-      expect(card.text).to include 'C (physics)'
+      expect(card.text).to include 'A (Biology)'
+      expect(card.text).to include 'B (Chemistry)'
+      expect(card.text).to include 'D (Physics)'
     end
   end
 end

--- a/spec/decorators/application_qualification_decorator_spec.rb
+++ b/spec/decorators/application_qualification_decorator_spec.rb
@@ -3,15 +3,15 @@ RSpec.describe ApplicationQualificationDecorator do
   describe '#grade_details' do
     describe 'rendering multiple English GCSEs' do
       let(:application_qualification) do
-        create(:gcse_qualification, subject: 'english', constituent_grades: { english_language: { grade: 'E' }, english_literature: { grade: 'E' }, 'Cockney Rhyming Slang': { grade: 'A*' } }, award_year: 2006)
+        create(:gcse_qualification, grade: nil, subject: 'english', constituent_grades: { english_language: { grade: 'E' }, english_literature: { grade: 'E' }, 'Cockney Rhyming Slang': { grade: 'A*' } }, award_year: 2006)
       end
 
       it 'renders grades for multiple English GCSEs' do
         grade_details = described_class.new(application_qualification).grade_details
 
-        expect(grade_details).to include('E (English language)')
-        expect(grade_details).to include('E (English literature)')
-        expect(grade_details).to include('A* (cockney rhyming slang)')
+        expect(grade_details['english_language']).to eq('E (English language)')
+        expect(grade_details['english_literature']).to eq('E (English literature)')
+        expect(grade_details['Cockney Rhyming Slang']).to eq('A* (Cockney rhyming slang)')
       end
     end
 
@@ -39,9 +39,9 @@ RSpec.describe ApplicationQualificationDecorator do
       it 'renders grades for multiple Science GCSEs' do
         grade_details = described_class.new(application_qualification).grade_details
 
-        expect(grade_details).to include('A (biology)')
-        expect(grade_details).to include('B (chemistry)')
-        expect(grade_details).to include('C (physics)')
+        expect(grade_details['biology']).to eq('A (Biology)')
+        expect(grade_details['chemistry']).to eq('B (Chemistry)')
+        expect(grade_details['physics']).to eq('C (Physics)')
       end
 
       context 'when the constituent grades are not present' do
@@ -50,9 +50,9 @@ RSpec.describe ApplicationQualificationDecorator do
         it 'renders "grade information not available" for each subject' do
           grade_details = described_class.new(application_qualification).grade_details
 
-          expect(grade_details).to include('Grade information not available (biology)')
-          expect(grade_details).to include('Grade information not available (chemistry)')
-          expect(grade_details).to include('Grade information not available (physics)')
+          expect(grade_details['biology']).to include('Grade information not available (biology)')
+          expect(grade_details['chemistry']).to include('Grade information not available (chemistry)')
+          expect(grade_details['physics']).to include('Grade information not available (physics)')
         end
       end
 
@@ -62,7 +62,7 @@ RSpec.describe ApplicationQualificationDecorator do
         it 'renders nothing for the grade details' do
           grade_details = described_class.new(application_qualification).grade_details
 
-          expect(grade_details).to eq([])
+          expect(grade_details).to eq({})
         end
       end
     end

--- a/spec/factories/application_qualification.rb
+++ b/spec/factories/application_qualification.rb
@@ -64,6 +64,12 @@ FactoryBot.define do
         }
       end
 
+      trait :science_triple_award do
+        science_gcse
+
+        subject { 'science triple award' }
+      end
+
       trait :multiple_english_gcses do
         grade { nil }
         subject { 'english' }

--- a/spec/system/support_interface/editing_gcse_award_year_spec.rb
+++ b/spec/system/support_interface/editing_gcse_award_year_spec.rb
@@ -52,7 +52,7 @@ RSpec.feature 'Editing GCSE' do
   end
 
   def then_i_see_an_error_message
-    expect(page).to have_content 'Enter a valid award year (for exmaple, 2001)'
+    expect(page).to have_content 'Enter a real award year'
   end
 
   def when_i_update_the_form

--- a/spec/system/support_interface/editing_gcse_award_year_spec.rb
+++ b/spec/system/support_interface/editing_gcse_award_year_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.feature 'Editing GCSE' do
+  include DfESignInHelpers
+
+  scenario 'Support user edits GCSE award year', with_audited: true do
+    given_i_am_a_support_user
+    and_an_application_exists
+
+    when_i_visit_the_application_page
+    and_i_click_the_change_link_next_to_the_first_gcse
+    then_i_should_see_a_prepopulated_form
+
+    when_i_provide_an_invalid_award_year
+    and_i_submit_the_form
+    then_i_see_an_error_message
+
+    when_i_update_the_form
+    and_i_submit_the_form
+    then_i_should_see_a_flash_message
+    and_i_should_see_the_new_details
+    and_i_should_see_my_details_comment_in_the_audit_log
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_an_application_exists
+    @form = create(:completed_application_form)
+    create(:gcse_qualification, subject: 'maths', award_year: '1999', application_form: @form)
+  end
+
+  def when_i_visit_the_application_page
+    visit support_interface_application_form_path(@form)
+  end
+
+  def and_i_click_the_change_link_next_to_the_first_gcse
+    within('[data-qa="gcse-qualification"]') do
+      click_link 'Change award year'
+    end
+  end
+
+  def then_i_should_see_a_prepopulated_form
+    expect(page).to have_content('Edit Maths GCSE')
+    expect(page).to have_selector("input[value='1999']")
+  end
+
+  def when_i_provide_an_invalid_award_year
+    fill_in 'Award year', with: '201'
+    fill_in 'Zendesk ticket URL', with: 'https://becomingateacher.zendesk.com/agent/tickets/12345'
+  end
+
+  def then_i_see_an_error_message
+    expect(page).to have_content 'Enter a valid award year (for exmaple, 2001)'
+  end
+
+  def when_i_update_the_form
+    fill_in 'Award year', with: '2001'
+    fill_in 'Zendesk ticket URL', with: 'https://becomingateacher.zendesk.com/agent/tickets/12345'
+  end
+
+  def and_i_submit_the_form
+    click_button 'Update'
+  end
+
+  def then_i_should_see_a_flash_message
+    expect(page).to have_content 'GCSE award year updated'
+  end
+
+  def and_i_should_see_the_new_details
+    within('.app-qualification') do
+      expect(page).to have_content '2001'
+    end
+  end
+
+  def and_i_should_see_my_details_comment_in_the_audit_log
+    click_link 'History'
+    expect(page).to have_content 'https://becomingateacher.zendesk.com/agent/tickets/12345'
+  end
+end

--- a/spec/system/support_interface/editing_gcse_constituent_grade_spec.rb
+++ b/spec/system/support_interface/editing_gcse_constituent_grade_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.feature 'Editing GCSE' do
+  include DfESignInHelpers
+
+  scenario 'Support user edits GCSE constituent grade', with_audited: true do
+    given_i_am_a_support_user
+    and_an_application_exists
+
+    when_i_visit_the_application_page
+    and_i_click_the_change_link_next_to_the_first_gcse
+    then_i_should_see_a_prepopulated_form
+
+    when_i_provide_an_invalid_grade
+    and_i_submit_the_form
+    then_i_see_an_error_message
+
+    when_i_update_the_form
+    and_i_submit_the_form
+    then_i_should_see_a_flash_message
+    and_i_should_see_the_new_details
+    and_i_should_see_my_details_comment_in_the_audit_log
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_an_application_exists
+    @form = create(:completed_application_form)
+    create(:gcse_qualification, :multiple_english_gcses, application_form: @form)
+  end
+
+  def when_i_visit_the_application_page
+    visit support_interface_application_form_path(@form)
+  end
+
+  def and_i_click_the_change_link_next_to_the_first_gcse
+    within('[data-qa="gcse-qualification"]') do
+      click_link 'Change grade', match: :first
+    end
+  end
+
+  def then_i_should_see_a_prepopulated_form
+    expect(page).to have_content('Edit English GCSE')
+    expect(page).to have_selector("input[value='A']")
+  end
+
+  def when_i_provide_an_invalid_grade
+    fill_in 'Grade', with: ''
+    fill_in 'Zendesk ticket URL', with: 'https://becomingateacher.zendesk.com/agent/tickets/12345'
+  end
+
+  def then_i_see_an_error_message
+    expect(page).to have_content 'Enter the grade'
+  end
+
+  def when_i_update_the_form
+    fill_in 'Grade', with: 'B'
+    fill_in 'Zendesk ticket URL', with: 'https://becomingateacher.zendesk.com/agent/tickets/12345'
+  end
+
+  def and_i_submit_the_form
+    click_button 'Update'
+  end
+
+  def then_i_should_see_a_flash_message
+    expect(page).to have_content 'GCSE grade updated'
+  end
+
+  def and_i_should_see_the_new_details
+    within('.app-qualification') do
+      expect(page).to have_content 'B'
+    end
+  end
+
+  def and_i_should_see_my_details_comment_in_the_audit_log
+    click_link 'History'
+    expect(page).to have_content 'https://becomingateacher.zendesk.com/agent/tickets/12345'
+  end
+end

--- a/spec/system/support_interface/editing_gcse_constituent_grade_spec.rb
+++ b/spec/system/support_interface/editing_gcse_constituent_grade_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature 'Editing GCSE' do
 
   def and_an_application_exists
     @form = create(:completed_application_form)
-    create(:gcse_qualification, :multiple_english_gcses, application_form: @form)
+    create(:gcse_qualification, :science_triple_award, application_form: @form)
   end
 
   def when_i_visit_the_application_page
@@ -36,14 +36,14 @@ RSpec.feature 'Editing GCSE' do
   end
 
   def and_i_click_the_change_link_next_to_the_first_gcse
-    within('[data-qa="gcse-qualification"]') do
-      click_link 'Change grade', match: :first
+    within page.find('.app-qualification__value', text: 'Chemistry') do
+      click_link 'Change grade'
     end
   end
 
   def then_i_should_see_a_prepopulated_form
-    expect(page).to have_content('Edit English GCSE')
-    expect(page).to have_selector("input[value='A']")
+    expect(page).to have_content('Edit Science triple award GCSE')
+    expect(page).to have_selector("input[value='B']")
   end
 
   def when_i_provide_an_invalid_grade
@@ -56,7 +56,7 @@ RSpec.feature 'Editing GCSE' do
   end
 
   def when_i_update_the_form
-    fill_in 'Grade', with: 'B'
+    fill_in 'Grade', with: 'C'
     fill_in 'Zendesk ticket URL', with: 'https://becomingateacher.zendesk.com/agent/tickets/12345'
   end
 
@@ -69,9 +69,7 @@ RSpec.feature 'Editing GCSE' do
   end
 
   def and_i_should_see_the_new_details
-    within('.app-qualification') do
-      expect(page).to have_content 'B'
-    end
+    expect(page).to have_content('C (Chemistry)')
   end
 
   def and_i_should_see_my_details_comment_in_the_audit_log

--- a/spec/system/support_interface/editing_gcse_grade_spec.rb
+++ b/spec/system/support_interface/editing_gcse_grade_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Editing GCSE' do
   include DfESignInHelpers
 
-  scenario 'Support user edits GCSE', with_audited: true do
+  scenario 'Support user edits GCSE grade', with_audited: true do
     given_i_am_a_support_user
     and_an_application_exists
 
@@ -11,7 +11,7 @@ RSpec.feature 'Editing GCSE' do
     and_i_click_the_change_link_next_to_the_first_gcse
     then_i_should_see_a_prepopulated_form
 
-    when_i_provide_an_invalid_award_year
+    when_i_provide_an_invalid_grade
     and_i_submit_the_form
     then_i_see_an_error_message
 
@@ -28,7 +28,7 @@ RSpec.feature 'Editing GCSE' do
 
   def and_an_application_exists
     @form = create(:completed_application_form)
-    create(:gcse_qualification, subject: 'maths', award_year: '1999', application_form: @form)
+    create(:gcse_qualification, subject: 'maths', award_year: '1999', grade: 'C', application_form: @form)
   end
 
   def when_i_visit_the_application_page
@@ -37,27 +37,27 @@ RSpec.feature 'Editing GCSE' do
 
   def and_i_click_the_change_link_next_to_the_first_gcse
     within('[data-qa="gcse-qualification"]') do
-      click_link 'Change'
+      click_link 'Change grade'
     end
   end
 
   def then_i_should_see_a_prepopulated_form
     expect(page).to have_content('Edit Maths GCSE')
-    expect(page).to have_selector("input[value='1999']")
+    expect(page).to have_selector("input[value='C']")
   end
 
-  def when_i_provide_an_invalid_award_year
-    fill_in 'Award year', with: '201'
-    fill_in 'Audit log comment', with: 'https://becomingateacher.zendesk.com/agent/tickets/12345'
+  def when_i_provide_an_invalid_grade
+    fill_in 'Grade', with: ''
+    fill_in 'Zendesk ticket URL', with: 'https://becomingateacher.zendesk.com/agent/tickets/12345'
   end
 
   def then_i_see_an_error_message
-    expect(page).to have_content 'Enter a valid award year (for exmaple, 2001)'
+    expect(page).to have_content 'Enter the grade'
   end
 
   def when_i_update_the_form
-    fill_in 'Award year', with: '2001'
-    fill_in 'Audit log comment', with: 'https://becomingateacher.zendesk.com/agent/tickets/12345'
+    fill_in 'Grade', with: 'A'
+    fill_in 'Zendesk ticket URL', with: 'https://becomingateacher.zendesk.com/agent/tickets/12345'
   end
 
   def and_i_submit_the_form
@@ -65,12 +65,12 @@ RSpec.feature 'Editing GCSE' do
   end
 
   def then_i_should_see_a_flash_message
-    expect(page).to have_content 'GCSE award year updated'
+    expect(page).to have_content 'GCSE grade updated'
   end
 
   def and_i_should_see_the_new_details
     within('.app-qualification') do
-      expect(page).to have_content '2001'
+      expect(page).to have_content 'A'
     end
   end
 

--- a/spec/system/support_interface/editing_gcse_spec.rb
+++ b/spec/system/support_interface/editing_gcse_spec.rb
@@ -52,7 +52,7 @@ RSpec.feature 'Editing GCSE' do
   end
 
   def then_i_should_see_a_flash_message
-    expect(page).to have_content 'GCSE updated'
+    expect(page).to have_content 'GCSE award year updated'
   end
 
   def and_i_should_see_the_new_details

--- a/spec/system/support_interface/editing_gcse_spec.rb
+++ b/spec/system/support_interface/editing_gcse_spec.rb
@@ -11,6 +11,10 @@ RSpec.feature 'Editing GCSE' do
     and_i_click_the_change_link_next_to_the_first_gcse
     then_i_should_see_a_prepopulated_form
 
+    when_i_provide_an_invalid_award_year
+    and_i_submit_the_form
+    then_i_see_an_error_message
+
     when_i_update_the_form
     and_i_submit_the_form
     then_i_should_see_a_flash_message
@@ -42,9 +46,18 @@ RSpec.feature 'Editing GCSE' do
     expect(page).to have_selector("input[value='1999']")
   end
 
+  def when_i_provide_an_invalid_award_year
+    fill_in 'Award year', with: '201'
+    fill_in 'Audit log comment', with: 'https://becomingateacher.zendesk.com/agent/tickets/12345'
+  end
+
+  def then_i_see_an_error_message
+    expect(page).to have_content 'Enter a valid award year (for exmaple, 2001)'
+  end
+
   def when_i_update_the_form
     fill_in 'Award year', with: '2001'
-    fill_in 'Audit log comment', with: 'Got to change it'
+    fill_in 'Audit log comment', with: 'https://becomingateacher.zendesk.com/agent/tickets/12345'
   end
 
   def and_i_submit_the_form
@@ -63,6 +76,6 @@ RSpec.feature 'Editing GCSE' do
 
   def and_i_should_see_my_details_comment_in_the_audit_log
     click_link 'History'
-    expect(page).to have_content 'Got to change it'
+    expect(page).to have_content 'https://becomingateacher.zendesk.com/agent/tickets/12345'
   end
 end


### PR DESCRIPTION
## Context

Currently support can only change the award year of a GCSE. In order to empower the support team and reduce the support burden on developers we're going to enable this functionality in the support UI.

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="383" alt="image" src="https://user-images.githubusercontent.com/47917431/211263236-404e7038-6738-49e4-9834-0d7765320992.png">|<img width="390" alt="image" src="https://user-images.githubusercontent.com/47917431/211263148-18d86d91-b8e1-4240-a3c4-635baf20a753.png">|

## Guidance to review

The grade value does not always appear in the `grade` attribute, with english and science it can appear in `constituent_grades` like so:

![image](https://user-images.githubusercontent.com/47917431/211263768-6c42e8fa-7300-450f-b56c-4670801bd3cd.png)

It would be helpful to get a second opinion on my approach with handling these.

## Link to Trello card

https://trello.com/c/AId1lLpD/1063-support-change-gcse-grades

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
