### PR TITLE
Tweak content for reasons for rejection report

### DIFF
--- a/app/components/support_interface/reasons_for_rejection_search_breadcrumb_component.rb
+++ b/app/components/support_interface/reasons_for_rejection_search_breadcrumb_component.rb
@@ -11,7 +11,7 @@ module SupportInterface
     def breadcrumb_items
       breadcrumb_items = {
         Performance: support_interface_performance_path,
-        'Structured reasons for rejection': support_interface_reasons_for_rejection_dashboard_path(year: @recruitment_cycle_year),
+        'Reasons for rejection': support_interface_reasons_for_rejection_dashboard_path(year: @recruitment_cycle_year),
       }
 
       unless top_level_reason?

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -6,7 +6,7 @@
   <li><%= govuk_link_to 'Course options without vacancies', support_interface_course_options_path %></li>
 </ul>
 
-<h2 class="govuk-heading-s">Structured reasons for rejection</h2>
+<h2 class="govuk-heading-s">Reasons for rejection</h2>
 <ul class="govuk-list govuk-list--spaced">
   <li>
     <%= govuk_link_to(

--- a/app/views/support_interface/performance/reasons_for_rejection_dashboard.html.erb
+++ b/app/views/support_interface/performance/reasons_for_rejection_dashboard.html.erb
@@ -1,25 +1,25 @@
-<% content_for :browser_title, 'Structured reasons for rejection' %>
+<% content_for :browser_title, 'Reasons for rejection' %>
 <% content_for :title do %>
   <span class="govuk-caption-l">
     <%= SupportInterface::ReasonsForRejectionDashboardComponent.recruitment_cycle_context(@recruitment_cycle_year) %>
   </span>
-  Structured reasons for rejection
+  Reasons for rejection
 <% end %>
 
 <% content_for :before_content do %>
   <%= breadcrumbs({
     Performance: support_interface_performance_path,
-    'Structured reasons for rejection': nil,
+    'Reasons for rejection': nil,
   }) %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">
-      The report does not include rejections made through the API.
+      The report does not include most rejections made through the API, as <a href="/api-docs/v1.2/reference#important" class="govuk-link">rejecting applications by code</a> was only added in version 1.2 of the API.
     </p>
     <p class="govuk-body">
-      Since users can choose more than one reason for rejection, the percentages for all the categories will not add up to 100%.
+      The percentages for all the categories will not add up to 100% as providers can choose more than 1 reason for rejecting a candidate.
     </p>
   </div>
 </div>

--- a/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
+++ b/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-RSpec.feature 'Structured reasons for rejection dashboard', time: Time.zone.local(2023, 1, 10) do
+RSpec.feature 'Reasons for rejection dashboard', time: Time.zone.local(2023, 1, 10) do
   include DfESignInHelpers
 
-  scenario 'View structured reasons for rejection', with_audited: true do
+  scenario 'View reasons for rejection', with_audited: true do
     given_i_am_a_support_user
     and_there_are_candidates_and_application_forms_in_the_system
 
@@ -177,7 +177,7 @@ private
 
   def then_i_should_see_reasons_for_rejection_title_and_details
     expect(page).to have_content('2022 to 2023')
-    expect(page).to have_content('current Structured reasons for rejection')
+    expect(page).to have_content('current Reasons for rejection')
     expect(page).to have_content('The report does not include rejections made through the API.')
     expect(page).to have_content('Since users can choose more than one reason for rejection, the percentages for all the categories will not add up to 100%.')
   end

--- a/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
+++ b/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
@@ -178,8 +178,8 @@ private
   def then_i_should_see_reasons_for_rejection_title_and_details
     expect(page).to have_content('2022 to 2023')
     expect(page).to have_content('current Reasons for rejection')
-    expect(page).to have_content('The report does not include rejections made through the API.')
-    expect(page).to have_content('Since users can choose more than one reason for rejection, the percentages for all the categories will not add up to 100%.')
+    expect(page).to have_content('The report does not include most rejections made through the API, as rejecting applications by code was only added in version 1.2 of the API.')
+    expect(page).to have_content('The percentages for all the categories will not add up to 100% as providers can choose more than 1 reason for rejecting a candidate.')
   end
 
   def and_i_should_see_reasons_for_rejection_course_full


### PR DESCRIPTION
Some minor content tweaks to the reasons for rejection report.

This drops the word "structured", as that kinda jargony.  It also updates the introduction to note that whilst most rejections over the API are excluded, since v1.2 providers can use rejection codes, which will now show up in this report.