### PR TITLE
Change breacrumb content on reasons for rejection report

### DIFF
--- a/app/components/support_interface/reasons_for_rejection_search_breadcrumb_component.rb
+++ b/app/components/support_interface/reasons_for_rejection_search_breadcrumb_component.rb
@@ -3,8 +3,8 @@ module SupportInterface
     include ViewHelper
 
     def initialize(search_attribute:, search_value:, recruitment_cycle_year: RecruitmentCycle.current_year)
-      @search_attribute = search_attribute
-      @search_value = search_value
+      @search_attribute = search_attribute.to_s
+      @search_value = search_value.to_s
       @recruitment_cycle_year = recruitment_cycle_year
     end
 
@@ -15,13 +15,13 @@ module SupportInterface
       }
 
       unless top_level_reason?
-        breadcrumb_items[@search_attribute] = support_interface_reasons_for_rejection_application_choices_path(
+        breadcrumb_items[@search_attribute.titleize] = support_interface_reasons_for_rejection_application_choices_path(
           'structured_rejection_reasons[id]' => @search_attribute,
           'recruitment_cycle_year' => @recruitment_cycle_year,
         )
       end
 
-      breadcrumb_items[@search_value] = nil
+      breadcrumb_items[@search_value.titleize] = nil
       breadcrumb_items
     end
 

--- a/spec/components/support_interface/reasons_for_rejection_search_breadcrumb_component_spec.rb
+++ b/spec/components/support_interface/reasons_for_rejection_search_breadcrumb_component_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchBreadcrumbComponent do
     end
 
     it 'renders the correct title' do
-      expect(@rendered_result.text).to include('qualifications')
+      expect(@rendered_result.text).to include('Qualifications')
     end
   end
 
@@ -33,7 +33,7 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchBreadcrumbComponent do
     end
 
     it 'renders the correct title' do
-      expect(@rendered_result.text).to include('communication_and_scheduling_other')
+      expect(@rendered_result.text).to include('Communication And Scheduling Other')
     end
 
     it 'renders the link back to the dashboard' do


### PR DESCRIPTION
## Context

Breadcrumb on 2nd page (eg No science GCSE) is showing page titles as lowercase and including underscores instead of spaces.

eg qualifications instead of Qualifications 

