### PR TITLE
Support functionality: Revert applications back to pending conditions

### DIFF
--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -221,6 +221,13 @@ module SupportInterface
             text: 'Revert rejection',
           },
         }
+      elsif application_choice.recruited? || application_choice.conditions_not_met? || application_choice.offer_deferred?
+        {
+          action: {
+            href: support_interface_application_form_application_choice_revert_to_pending_conditions_path(application_form_id: @application_choice.application_form.id, application_choice_id: @application_choice.id),
+            text: 'Revert to pending conditions',
+          },
+        }
       else
         {}
       end

--- a/app/controllers/support_interface/application_forms/application_choices_controller.rb
+++ b/app/controllers/support_interface/application_forms/application_choices_controller.rb
@@ -49,6 +49,21 @@ module SupportInterface
         end
       end
 
+      def confirm_revert_to_pending_conditions
+        @form = RevertToPendingConditionsForm.new
+      end
+
+      def revert_to_pending_conditions
+        @form = RevertToPendingConditionsForm.new(revert_to_pending_conditions_params)
+
+        if @form.save(@application_choice)
+          flash[:success] = 'Application has been reverted to pending conditions'
+          redirect_to support_interface_application_form_path(@application_form.id)
+        else
+          render :confirm_revert_to_pending_conditions
+        end
+      end
+
     private
 
       def reinstate_offer_params
@@ -61,6 +76,10 @@ module SupportInterface
 
       def revert_withdrawal_params
         params.require(:support_interface_application_forms_revert_withdrawal_form).permit(:audit_comment_ticket, :accept_guidance)
+      end
+
+      def revert_to_pending_conditions_params
+        params.require(:support_interface_application_forms_revert_to_pending_conditions_form).permit(:audit_comment_ticket, :accept_guidance)
       end
 
       def build_application_form

--- a/app/forms/support_interface/application_forms/revert_to_pending_conditions_form.rb
+++ b/app/forms/support_interface/application_forms/revert_to_pending_conditions_form.rb
@@ -1,0 +1,41 @@
+module SupportInterface
+  module ApplicationForms
+    class RevertToPendingConditionsForm
+      include ActiveModel::Model
+
+      attr_accessor :accept_guidance, :audit_comment_ticket
+
+      validates :accept_guidance, :audit_comment_ticket, presence: true
+      validates_with ZendeskUrlValidator
+
+      def save(application_choice)
+        self.accept_guidance = ActiveModel::Type::Boolean.new.cast(accept_guidance)
+
+        return false unless valid?
+
+        revert_status_to_pending_conditions(application_choice)
+      end
+
+    private
+
+      def revert_status_to_pending_conditions(application_choice)
+        if application_choice.recruited?
+          SupportInterface::RevertRecruitedToPendingConditions.new(
+            application_choice:,
+            zendesk_ticket: audit_comment_ticket,
+          ).save!
+        elsif application_choice.conditions_not_met?
+          SupportInterface::RevertConditionsNotMetToPendingConditions.new(
+            application_choice:,
+            zendesk_ticket: audit_comment_ticket,
+          ).save!
+        elsif application_choice.offer_deferred?
+          SupportInterface::RevertOfferDeferredToPendingConditions.new(
+            application_choice:,
+            zendesk_ticket: audit_comment_ticket,
+          ).save!
+        end
+      end
+    end
+  end
+end

--- a/app/services/support_interface/revert_conditions_not_met_to_pending_conditions.rb
+++ b/app/services/support_interface/revert_conditions_not_met_to_pending_conditions.rb
@@ -1,0 +1,18 @@
+module SupportInterface
+  class RevertConditionsNotMetToPendingConditions
+    def initialize(application_choice:, zendesk_ticket:)
+      @application_choice = application_choice
+      @zendesk_ticket = zendesk_ticket
+    end
+
+    def save!
+      @application_choice.offer.conditions.each(&:pending!)
+
+      @application_choice.update!(
+        status: :pending_conditions,
+        conditions_not_met_at: nil,
+        audit_comment: "Support request to revert conditions not met application to pending conditions: #{@zendesk_ticket}",
+      )
+    end
+  end
+end

--- a/app/services/support_interface/revert_offer_deferred_to_pending_conditions.rb
+++ b/app/services/support_interface/revert_offer_deferred_to_pending_conditions.rb
@@ -1,0 +1,19 @@
+module SupportInterface
+  class RevertOfferDeferredToPendingConditions
+    def initialize(application_choice:, zendesk_ticket:)
+      @application_choice = application_choice
+      @zendesk_ticket = zendesk_ticket
+    end
+
+    def save!
+      @application_choice.offer.conditions.each(&:pending!)
+
+      @application_choice.update!(
+        status: :pending_conditions,
+        offer_deferred_at: nil,
+        status_before_deferral: nil,
+        audit_comment: "Support request to revert offer deferred application to pending conditions: #{@zendesk_ticket}",
+      )
+    end
+  end
+end

--- a/app/services/support_interface/revert_recruited_to_pending_conditions.rb
+++ b/app/services/support_interface/revert_recruited_to_pending_conditions.rb
@@ -1,0 +1,19 @@
+module SupportInterface
+  class RevertRecruitedToPendingConditions
+    def initialize(application_choice:, zendesk_ticket:)
+      @application_choice = application_choice
+      @zendesk_ticket = zendesk_ticket
+    end
+
+    def save!
+      @application_choice.offer.conditions.each(&:pending!)
+
+      @application_choice.update!(
+        status: :pending_conditions,
+        recruited_at: nil,
+        accepted_at: nil,
+        audit_comment: "Support request to revert recruited application to pending conditions: #{@zendesk_ticket}",
+      )
+    end
+  end
+end

--- a/app/views/support_interface/application_forms/application_choices/confirm_revert_to_pending_conditions.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/confirm_revert_to_pending_conditions.html.erb
@@ -1,0 +1,39 @@
+<% content_for :browser_title, title_with_error_prefix('Are you sure you want to revert this application to pending conditions?', @application_choice.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(application_form_id: params[:application_form_id]), 'Back to application') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+      model: @form,
+      url: support_interface_application_form_application_choice_revert_to_pending_conditions_path(application_form_id: params[:application_form_id], application_choice_id: params[:application_choice_id]),
+      method: :patch,
+    ) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">Are you sure you want to revert this application to pending conditions?</h1>
+
+      <p class="govuk-body">An application can only be reverted to pending conditions if:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>The candidate hasn’t started a new application</li>
+        <li>The request has been made by the provider</li>
+      </ul>
+      <p class="govuk-body">Once the application has been reverted, please email the candidate and the provider to let them know.</p>
+
+      <%= f.govuk_text_field(
+        :audit_comment_ticket,
+        label: {
+          text: t('support_interface.audit_comment_ticket.label'),
+          size: 'm',
+        },
+        rows: 1,
+        hint: { text: t('support_interface.audit_comment_ticket.hint') },
+      ) %>
+
+      <%= f.govuk_check_boxes_fieldset :accept_guidance, legend: nil do %>
+        <%= f.govuk_check_box :accept_guidance, true, multiple: false, label: { text: 'I have read the guidance' }, link_errors: true %>
+      <% end %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -261,6 +261,13 @@ en:
             audit_comment_ticket:
               blank: Enter a Zendesk ticket URL
               invalid: Enter a valid Zendesk ticket URL
+        support_interface/application_forms/revert_to_pending_conditions_form:
+          attributes:
+            accept_guidance:
+              blank: Select that you have read the guidance
+            audit_comment_ticket:
+              blank: Enter a Zendesk ticket URL
+              invalid: Enter a valid Zendesk ticket URL
         support_interface/remove_access_form:
           attributes:
             accept_guidance:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -945,6 +945,9 @@ Rails.application.routes.draw do
 
       get '/revert-withdrawal/:application_choice_id' => 'application_forms/application_choices#confirm_revert_withdrawal', as: :application_form_application_choice_revert_withdrawal
       patch '/revert-withdrawal/:application_choice_id' => 'application_forms/application_choices#revert_withdrawal'
+
+      get '/revert-to-pending-conditions/:application_choice_id' => 'application_forms/application_choices#confirm_revert_to_pending_conditions', as: :application_form_application_choice_revert_to_pending_conditions
+      patch '/revert-to-pending-conditions/:application_choice_id' => 'application_forms/application_choices#revert_to_pending_conditions'
     end
 
     get '/duplicate-matches' => 'duplicate_matches#index', as: :duplicate_matches

--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -130,12 +130,6 @@ If the current application status is `offer` use [ChangeOffer](../app/services/c
 
 This is possible via the support UI.
 
-## Reverting an application choice to `pending_conditions` from `recruited`
-
-```ruby
-ac = ApplicationChoice.find(id)
-ac.update!(status: 'pending_conditions', recruited_at: nil, accepted_at: nil, audit_comment: 'Support request...')
-```
 Conditions can be added by creating a new [OfferCondition](../app/models/offer_condition.rb) object and then pushing it into the `conditions` collection, for example:
 
 ```ruby
@@ -144,22 +138,9 @@ ac.offer.conditions << condition
 ```
 The default state for an `OfferCondition` object is `pending`.
 
-### Revert an application choice to `pending_conditions` from `conditions_not_met`
+### Reverting an application choice to pending conditions
 
-This can be requested if a provider accidentally marks an application as conditions not met.
-
-```ruby
-a = ApplicationForm.find_by!(support_reference:'$REF')
-a.application_choices.select(&:conditions_not_met?).first.update!(status: :pending_conditions, conditions_not_met_at: nil, audit_comment: 'Support request following provider accidentally marking them as conditions_not_met.')
-```
-### Revert an application choice to `pending_conditions` from `offer_deferred`
-
-This normally occurs after a candidate changes their mind and wants to start the course in the current recruitment cycle
-
-```ruby
-ac = ApplicationChoice.find(id)
-ac.update!(status: 'pending_conditions', offer_deferred_at: nil, status_before_deferral: nil, audit_comment: 'Support request...')
-```
+If an application choice status is `recruited`, `conditions_not_met` or `offr_deferred` it can be reverted to `pending_conditions` using the support UI.
 ### Revert a rejection
 
 Providers may need to revert a rejection so that they can offer a different course or if it was done in error.

--- a/spec/components/support_interface/application_choice_component_spec.rb
+++ b/spec/components/support_interface/application_choice_component_spec.rb
@@ -74,10 +74,66 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
       )
     end
 
+    it 'renders a link to revert the application choice to pending conditions' do
+      result = render_inline(described_class.new(recruited_choice))
+
+      expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(
+        Rails.application.routes.url_helpers.support_interface_application_form_application_choice_revert_to_pending_conditions_path(
+          application_form_id: recruited_choice.application_form.id,
+          application_choice_id: recruited_choice.id,
+        ),
+      )
+      expect(result.css('.govuk-summary-list__actions a').text.strip).to include('Revert to pending conditions')
+    end
+
     it 'does render a link to change conditions' do
       result = render_inline(described_class.new(recruited_choice))
 
       expect(result.css('.app-summary-card .govuk-summary-list__actions a').text.squish).to include 'Change conditions'
+    end
+  end
+
+  context 'Conditions not met' do
+    let(:conditions_not_met_choice) do
+      create(
+        :application_choice,
+        :with_completed_application_form,
+        :with_conditions_not_met,
+      )
+    end
+
+    it 'renders a link to revert the application choice to pending conditions' do
+      result = render_inline(described_class.new(conditions_not_met_choice))
+
+      expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(
+        Rails.application.routes.url_helpers.support_interface_application_form_application_choice_revert_to_pending_conditions_path(
+          application_form_id: conditions_not_met_choice.application_form.id,
+          application_choice_id: conditions_not_met_choice.id,
+        ),
+      )
+      expect(result.css('.govuk-summary-list__actions a').text.strip).to include('Revert to pending conditions')
+    end
+  end
+
+  context 'Offer deferred' do
+    let(:offer_deferred_choice) do
+      create(
+        :application_choice,
+        :with_completed_application_form,
+        :with_deferred_offer,
+      )
+    end
+
+    it 'renders a link to revert the application choice to pending conditions' do
+      result = render_inline(described_class.new(offer_deferred_choice))
+
+      expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(
+        Rails.application.routes.url_helpers.support_interface_application_form_application_choice_revert_to_pending_conditions_path(
+          application_form_id: offer_deferred_choice.application_form.id,
+          application_choice_id: offer_deferred_choice.id,
+        ),
+      )
+      expect(result.css('.govuk-summary-list__actions a').text.strip).to include('Revert to pending conditions')
     end
   end
 
@@ -93,7 +149,7 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
     it 'renders a link to the change the offered course choice' do
       result = render_inline(described_class.new(unconditional_offer))
 
-      expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(
+      expect(result.css('.govuk-summary-list__actions a')[1].attr('href')).to include(
         Rails.application.routes.url_helpers.support_interface_application_form_application_choice_change_offered_course_search_path(
           application_form_id: unconditional_offer.application_form.id,
           application_choice_id: unconditional_offer.id,

--- a/spec/forms/support_interface/application_forms/revert_to_pending_conditions_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/revert_to_pending_conditions_form_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ApplicationForms::RevertToPendingConditionsForm, type: :model, with_audited: true do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:accept_guidance) }
+    it { is_expected.to validate_presence_of(:audit_comment_ticket) }
+
+    context 'for an invalid zendesk link' do
+      invalid_link = 'nonsense'
+      it { is_expected.not_to allow_value(invalid_link).for(:audit_comment_ticket) }
+    end
+
+    context 'for an valid zendesk link' do
+      valid_link = 'www.becomingateacher.zendesk.com/agent/tickets/example'
+      it { is_expected.to allow_value(valid_link).for(:audit_comment_ticket) }
+    end
+  end
+
+  describe '#save' do
+    let(:zendesk_ticket) { 'www.becomingateacher.zendesk.com/agent/tickets/example' }
+
+    context 'when the application choice status is recruited' do
+      it 'updates the provided ApplicationChoice status to pending_conditions if valid' do
+        application_choice = create(:application_choice, :with_recruited)
+
+        form = described_class.new(
+          audit_comment_ticket: zendesk_ticket,
+          accept_guidance: true,
+        )
+
+        expect(form.save(application_choice)).to be(true)
+
+        expect(application_choice).to have_attributes({
+          status: 'pending_conditions',
+        })
+
+        expect(application_choice.audits.last.comment).to include(zendesk_ticket)
+      end
+    end
+
+    context 'when the application choice status is conditions_not_met' do
+      it 'updates the provided ApplicationChoice status to pending_conditions if valid' do
+        application_choice = create(:application_choice, :with_conditions_not_met)
+
+        form = described_class.new(
+          audit_comment_ticket: zendesk_ticket,
+          accept_guidance: true,
+        )
+
+        expect(form.save(application_choice)).to be(true)
+
+        expect(application_choice).to have_attributes({
+          status: 'pending_conditions',
+        })
+
+        expect(application_choice.audits.last.comment).to include(zendesk_ticket)
+      end
+    end
+
+    context 'when the application choice status is offer_deferred' do
+      it 'updates the provided ApplicationChoice status to pending_conditions if valid' do
+        application_choice = create(:application_choice, :with_deferred_offer)
+
+        form = described_class.new(
+          audit_comment_ticket: zendesk_ticket,
+          accept_guidance: true,
+        )
+
+        expect(form.save(application_choice)).to be(true)
+
+        expect(application_choice).to have_attributes({
+          status: 'pending_conditions',
+        })
+
+        expect(application_choice.audits.last.comment).to include(zendesk_ticket)
+      end
+    end
+  end
+end

--- a/spec/services/support_interface/revert_conditions_not_met_to_pending_conditions_spec.rb
+++ b/spec/services/support_interface/revert_conditions_not_met_to_pending_conditions_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::RevertConditionsNotMetToPendingConditions, with_audited: true do
+  let(:application_choice) { create(:application_choice, :with_deferred_offer) }
+  let(:zendesk_ticket) { 'becomingateacher.zendesk.com/agent/tickets/example' }
+
+  describe '#save!' do
+    it 'reverts the application choice status back to `pending_conditions` and sets an audit comment' do
+      described_class.new(
+        application_choice:,
+        zendesk_ticket:,
+      ).save!
+
+      expect(application_choice.audits.last.comment).to include(zendesk_ticket)
+      expect(application_choice.attributes.symbolize_keys).to match(
+        a_hash_including({
+          conditions_not_met_at: nil,
+          status: 'pending_conditions',
+        }),
+      )
+    end
+
+    it 'updates the status of all conditions to pending' do
+      application_choice.offer.conditions.update(status: :met)
+
+      expect { described_class.new(application_choice:, zendesk_ticket:).save! }.to change { application_choice.offer.conditions.first.status }.from('met').to('pending')
+    end
+  end
+end

--- a/spec/services/support_interface/revert_offer_deferred_to_pending_conditions_spec.rb
+++ b/spec/services/support_interface/revert_offer_deferred_to_pending_conditions_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::RevertOfferDeferredToPendingConditions, with_audited: true do
+  let(:application_choice) { create(:application_choice, :with_deferred_offer) }
+  let(:zendesk_ticket) { 'becomingateacher.zendesk.com/agent/tickets/example' }
+
+  describe '#save!' do
+    it 'reverts the application choice status back to `pending_conditions` and sets an audit comment' do
+      described_class.new(
+        application_choice:,
+        zendesk_ticket:,
+      ).save!
+
+      expect(application_choice.audits.last.comment).to include(zendesk_ticket)
+      expect(application_choice.attributes.symbolize_keys).to match(
+        a_hash_including({
+          offer_deferred_at: nil,
+          status_before_deferral: nil,
+          status: 'pending_conditions',
+        }),
+      )
+    end
+
+    it 'updates the status of all conditions to pending' do
+      application_choice.offer.conditions.update(status: :met)
+
+      expect { described_class.new(application_choice:, zendesk_ticket:).save! }.to change { application_choice.offer.conditions.first.status }.from('met').to('pending')
+    end
+  end
+end

--- a/spec/services/support_interface/revert_recruited_to_pending_conditions_spec.rb
+++ b/spec/services/support_interface/revert_recruited_to_pending_conditions_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::RevertRecruitedToPendingConditions, with_audited: true do
+  let(:application_choice) { create(:application_choice, :with_recruited) }
+  let(:zendesk_ticket) { 'becomingateacher.zendesk.com/agent/tickets/example' }
+
+  describe '#save!' do
+    it 'reverts the application choice status back to `pending_conditions` and sets an audit comment' do
+      described_class.new(
+        application_choice:,
+        zendesk_ticket:,
+      ).save!
+
+      expect(application_choice.audits.last.comment).to include(zendesk_ticket)
+      expect(application_choice.attributes.symbolize_keys).to match(
+        a_hash_including({
+          recruited_at: nil,
+          accepted_at: nil,
+          status: 'pending_conditions',
+        }),
+      )
+    end
+
+    it 'updates the status of all conditions to pending' do
+      application_choice.offer.conditions.update(status: :met)
+
+      expect { described_class.new(application_choice:, zendesk_ticket:).save! }.to change { application_choice.offer.conditions.first.status }.from('met').to('pending')
+    end
+  end
+end

--- a/spec/system/support_interface/revert_application_to_pending_conditions_spec.rb
+++ b/spec/system/support_interface/revert_application_to_pending_conditions_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.feature 'Revert an application choice to pending conditions' do
+  include DfESignInHelpers
+
+  scenario 'Revert a recruited application and return it to the `pending_conditions` status', with_audited: true do
+    given_i_am_a_support_user
+    and_there_is_a_recruited_application
+
+    when_i_visit_the_application_page
+    then_i_see_a_revert_to_pending_conditions_link
+
+    when_i_click_revert_to_pending_conditions
+    then_i_see_a_confirmation_page_prompting_for_an_audit_comment
+
+    when_i_click_continue
+    then_i_see_a_validation_error
+
+    when_i_add_an_audit_comment_and_click_continue
+    then_i_see_the_application_page
+    and_the_application_is_now_pending_conditions
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_is_a_recruited_application
+    @application_choice = create(
+      :application_choice,
+      :with_recruited,
+      :with_completed_application_form,
+    )
+  end
+
+  def when_i_visit_the_application_page
+    visit support_interface_application_form_path(@application_choice.application_form_id)
+  end
+
+  def then_i_see_a_revert_to_pending_conditions_link
+    expect(page).to have_link('Revert to pending conditions')
+  end
+
+  def when_i_click_revert_to_pending_conditions
+    click_link('Revert to pending conditions')
+  end
+
+  def then_i_see_a_confirmation_page_prompting_for_an_audit_comment
+    expect(page).to have_current_path(
+      support_interface_application_form_application_choice_revert_to_pending_conditions_path(
+        application_form_id: @application_choice.application_form_id,
+        application_choice_id: @application_choice.id,
+      ),
+    )
+    expect(page).to have_content('Are you sure you want to revert this application to pending conditions?')
+  end
+
+  def when_i_click_continue
+    click_on 'Continue'
+  end
+
+  def then_i_see_a_validation_error
+    expect(page).to have_current_path(
+      support_interface_application_form_application_choice_revert_to_pending_conditions_path(
+        application_form_id: @application_choice.application_form_id,
+        application_choice_id: @application_choice.id,
+      ),
+    )
+    expect(page).to have_content('Enter a Zendesk ticket URL')
+    expect(page).to have_content('Select that you have read the guidance')
+  end
+
+  def when_i_add_an_audit_comment_and_click_continue
+    fill_in 'Zendesk ticket URL', with: 'https://becomingateacher.zendesk.com/agent/tickets/123'
+    check 'I have read the guidance'
+    click_on 'Continue'
+  end
+
+  def then_i_see_the_application_page
+    expect(page).to have_current_path(support_interface_application_form_path(@application_choice.application_form_id))
+  end
+
+  def and_the_application_is_now_pending_conditions
+    expect(@application_choice.reload.pending_conditions?).to be true
+  end
+end


### PR DESCRIPTION
## Context

When we receive a support request to revert application choices back to pending conditions, this is currently done in the console by a dev. We want to give the support team the functionality to be able to perform this action themselves.

## Changes proposed in this pull request

<img width="1132" alt="image" src="https://user-images.githubusercontent.com/47917431/211592120-d905b52c-c89e-41e9-83c3-ae4fd3acd088.png">
<img width="830" alt="image" src="https://user-images.githubusercontent.com/47917431/211617907-b2f74470-e74f-4fd2-9627-db1f69a95829.png">



## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/UYQEur1h/1070-support-change-applications-back-to-pending-conditions

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
