### PR TITLE
Terraform domain configuration

### DIFF
--- a/dns/readme.md
+++ b/dns/readme.md
@@ -1,0 +1,85 @@
+# DNS
+
+Terraform code for managing Azure DNS Zones and records.
+
+This is separated into two components
+
+- zones
+- records
+
+This is becuase a zone will be created initially and then is unlikely to have changes made to it,
+while records will be added or changed more frequently.
+
+# Resource Group
+
+Create the resource group, key vault and storage account to store the tfstate files:
+
+`make apply domain-azure-resources AUTO_APPROVE=1`
+
+# Zones
+
+To create a new zone;
+
+- Add JSON files
+
+    - dns/zones/workspace_variables/${zone}-zone.tfvars.json
+    - dns/zones/workspace_variables/backend_${zone}.tfvars
+
+- Add the zone to the Makefile
+
+- Run the make command (there is no workflow job for zone creation or update)
+
+    - `make ${zone} dnszone-plan`
+    - `make ${zone} dnszone-apply`
+
+- Provide the NS records for delegation from education.gov.uk or service.gov.uk.
+
+    - see https://www.gov.uk/service-manual/technology/get-a-domain-name#choose-where-youll-host-your-dns
+
+Notes;
+
+- Any zone updates would be made by making changes to the tfvars JSON file and running a "make ${zone} plan/apply"
+
+Taking care that if this causes a zone creation the NS records may change and/or existing records may be deleted
+
+- Some of our DNS zones have extra TXT and CAA records to protect against spoofing and invalid certificates, as per
+
+    - see https://www.gov.uk/guidance/protect-domains-that-dont-send-email
+    - see https://www.gov.uk/service-manual/technology/get-a-domain-name#set-up-security-certificates
+
+If relevant we add the following 3 records to indicate we don't send mail from these domains, and use Amazon/DigiCert/GlobalSign/Azure (update as relevant) for certificates.
+
+- TXT record (for SPF)
+```
+“v=spf1 -all”
+```
+
+- TXT record (for DMARC)
+```
+"v=DMARC1; p=reject; sp=reject; rua=mailto:dmarc-rua@dmarc.service.gov.uk; ruf=mailto:dmarc-ruf@dmarc.service.gov.uk"
+```
+
+- CAA record
+```
+0 issue "digicert.com"
+```
+
+# Records
+
+There is a JSON configuration file per env e.g. qa, staging, etc.
+
+To create (or update) records in an existing zone:
+
+- Add (or update) the relevant JSON file to:
+
+    - dns/records/workspace_variables/${zone}-${env}.tfvars.JSON
+    - dns/records/workspace_variables/backend_${zone}-${env}.tfvars (only on initial creation)
+
+- Run the make command with DNS_ENV set to the environment you are adding records too
+
+    - `make ${zone} dnsrecord-plan DNS_ENV=${env}`
+    - `make ${zone} dnsrecord-apply DNS_ENV=$env}`
+        - e.g. `make apply dnsrecord-plan DNS_ENV=qa`
+
+Note;
+- You should always check any changes via Terraform plan before applying to make sure you are not making unintended changes.

--- a/dns/records/.terraform.lock.hcl
+++ b/dns/records/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "3.38.0"
+  constraints = "3.38.0"
+  hashes = [
+    "h1:Isa/rY8+4+DCatuYgmDT4TYkcp/he7RrfR6jyhrm7hQ=",
+    "zh:08df48bdaf162bf3da7ac2b09147d44f94fae6f3cfd97d6cf9c45cb7c1c36a44",
+    "zh:220b68a3f819777872281974e6621527698575096c3a2ef78cb0aabf28665161",
+    "zh:25db1128a96599ffbcc7e865579bec7c009cb4e7f7731e0e30d261ab02cc38d5",
+    "zh:279444db11f570b837143559e5df7453bd8aeda4e22a9879a5a1a795bf6612a3",
+    "zh:2d506b6b865f6d5143e54e139d9a61b18bdcc8b9485d2bc7237e95a53a9c7ed9",
+    "zh:6ddb2cbcdf15b432508fe00ee7863f6d51a136db1746e7af03bec8ce2a09bad3",
+    "zh:96b664a716678923ce0f9828eaad22b5353669fa5013ea39b7b8081a77988b85",
+    "zh:a9ca583b219a3daba171ca11908547abb1b09453934950aacff17ae8b51d0ff0",
+    "zh:aa497620c82afab7819736180f0a56b76da6f3e23bd0580383fda98104b4e5c2",
+    "zh:ab9e9f3c35288d0bd615024f213e46d16d639c281f7d850b21971b530d08e231",
+    "zh:b164a0ddb30b64c35f13dad0aa9701a4e3eb24dc8165a3e794c499f1e9070b99",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/dns/records/data.tf
+++ b/dns/records/data.tf
@@ -1,0 +1,8 @@
+# Zone
+
+data "azurerm_dns_zone" "dns_zone" {
+  for_each = var.hosted_zone
+
+  name                = each.key
+  resource_group_name = each.value.resource_group_name
+}

--- a/dns/records/resources.tf
+++ b/dns/records/resources.tf
@@ -1,0 +1,4 @@
+module "dns_records" {
+  source      = "git::https://github.com/DFE-Digital/terraform-modules.git//dns/records"
+  hosted_zone = var.hosted_zone
+}

--- a/dns/records/terraform.tf
+++ b/dns/records/terraform.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = "~> 1.2.3"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "3.38.0"
+    }
+  }
+  backend "azurerm" {
+  }
+}
+
+provider "azurerm" {
+  features {}
+
+  skip_provider_registration = true
+  subscription_id            = try(local.azure_credentials.subscriptionId, null)
+  client_id                  = try(local.azure_credentials.clientId, null)
+  client_secret              = try(local.azure_credentials.clientSecret, null)
+  tenant_id                  = try(local.azure_credentials.tenantId, null)
+}

--- a/dns/records/variables.tf
+++ b/dns/records/variables.tf
@@ -1,0 +1,11 @@
+
+variable "azure_credentials" { default = null }
+
+variable hosted_zone {
+  type = map(any)
+  default = {}
+}
+
+locals {
+  azure_credentials   = try(jsondecode(var.azure_credentials), null)
+}

--- a/dns/records/workspace-variables/apply_pentest.tfvars.json
+++ b/dns/records/workspace-variables/apply_pentest.tfvars.json
@@ -1,0 +1,17 @@
+{
+  "hosted_zone": {
+    "apply-for-teacher-training.education.gov.uk": {
+      "cnames": {
+        "_2591fbd3d4123185e000682b4c838bd0.pen-assets": {
+          "target": "_809c702dd45db95700825b993d095227.mvtxpqxpkb.acm-validations.aws",
+          "ttl": 60
+        },
+        "_49618458e8b8d5047b31de62563fd8bb.pen": {
+          "target": "_4456d705baa45a5964503ebaa5ab14d7.mvtxpqxpkb.acm-validations.aws",
+          "ttl": 60
+        }
+      },
+    "resource_group_name": "s189p01-applydomains-rg"
+    }
+  }
+}

--- a/dns/records/workspace-variables/apply_production.tfvars.json
+++ b/dns/records/workspace-variables/apply_production.tfvars.json
@@ -1,0 +1,17 @@
+{
+  "hosted_zone": {
+    "apply-for-teacher-training.education.gov.uk": {
+      "cnames": {
+        "www": {
+          "target": "d1xbatyhdsd23r.cloudfront.net",
+          "ttl": 60
+        },
+        "_4543fa06c424e9f27d11f7fbcc365308.www": {
+          "target": "_f5f9cc82aae8a4237d22a44cbfb95119.bbfvkzsszw.acm-validations.aws",
+          "ttl": 60
+        }
+      },
+    "resource_group_name": "s189p01-applydomains-rg"
+    }
+  }
+}

--- a/dns/records/workspace-variables/apply_qa.tfvars.json
+++ b/dns/records/workspace-variables/apply_qa.tfvars.json
@@ -1,0 +1,17 @@
+{
+  "hosted_zone": {
+    "apply-for-teacher-training.education.gov.uk": {
+      "cnames": {
+        "qa": {
+          "target": "d25o4mearp38mh.cloudfront.net",
+          "ttl": 60
+        },
+        "_20376ff68e78b33802641a0fb5889553.qa": {
+          "target": "_de9e1b635132fa1d1be8ac835db32219.bbfvkzsszw.acm-validations.aws",
+          "ttl": 60
+        }
+      },
+    "resource_group_name": "s189p01-applydomains-rg"
+    }
+  }
+}

--- a/dns/records/workspace-variables/apply_sandbox.tfvars.json
+++ b/dns/records/workspace-variables/apply_sandbox.tfvars.json
@@ -1,0 +1,17 @@
+{
+  "hosted_zone": {
+    "apply-for-teacher-training.education.gov.uk": {
+      "cnames": {
+        "sandbox": {
+          "target": "d1xbatyhdsd23r.cloudfront.net",
+          "ttl": 60
+        },
+        "_229b8d2191ea3cbe7ddd6ce57066bd83.sandbox": {
+          "target": "_072f14fced703e7b0f5a514df5c97fdf.bbfvkzsszw.acm-validations.aws",
+          "ttl": 60
+        }
+      },
+    "resource_group_name": "s189p01-applydomains-rg"
+    }
+  }
+}

--- a/dns/records/workspace-variables/apply_staging.tfvars.json
+++ b/dns/records/workspace-variables/apply_staging.tfvars.json
@@ -1,0 +1,17 @@
+{
+  "hosted_zone": {
+    "apply-for-teacher-training.education.gov.uk": {
+      "cnames": {
+        "staging": {
+          "target": "d2hsy40vkk0kkh.cloudfront.net",
+          "ttl": 60
+        },
+        "_1d4b1f5476af8d39d1661df9e6d7e63e.staging": {
+          "target": "_5a3f2a4df63ba5e370e6036e7757f323.bbfvkzsszw.acm-validations.aws",
+          "ttl": 60
+        }
+      },
+    "resource_group_name": "s189p01-applydomains-rg"
+    }
+  }
+}

--- a/dns/records/workspace-variables/backend_apply_pentest.tfvars
+++ b/dns/records/workspace-variables/backend_apply_pentest.tfvars
@@ -1,0 +1,4 @@
+resource_group_name  = "s189p01-applydomains-rg"
+storage_account_name = "s189p01applydomainstf"
+container_name       = "applydomains-tf"
+key                  = "applydomains_pentest.tfstate"

--- a/dns/records/workspace-variables/backend_apply_production.tfvars
+++ b/dns/records/workspace-variables/backend_apply_production.tfvars
@@ -1,0 +1,4 @@
+resource_group_name  = "s189p01-applydomains-rg"
+storage_account_name = "s189p01applydomainstf"
+container_name       = "applydomains-tf"
+key                  = "applydomains_production.tfstate"

--- a/dns/records/workspace-variables/backend_apply_qa.tfvars
+++ b/dns/records/workspace-variables/backend_apply_qa.tfvars
@@ -1,0 +1,4 @@
+resource_group_name  = "s189p01-applydomains-rg"
+storage_account_name = "s189p01applydomainstf"
+container_name       = "applydomains-tf"
+key                  = "applydomains_qa.tfstate"

--- a/dns/records/workspace-variables/backend_apply_sandbox.tfvars
+++ b/dns/records/workspace-variables/backend_apply_sandbox.tfvars
@@ -1,0 +1,4 @@
+resource_group_name  = "s189p01-applydomains-rg"
+storage_account_name = "s189p01applydomainstf"
+container_name       = "applydomains-tf"
+key                  = "applydomains_sandbox.tfstate"

--- a/dns/records/workspace-variables/backend_apply_staging.tfvars
+++ b/dns/records/workspace-variables/backend_apply_staging.tfvars
@@ -1,0 +1,4 @@
+resource_group_name  = "s189p01-applydomains-rg"
+storage_account_name = "s189p01applydomainstf"
+container_name       = "applydomains-tf"
+key                  = "applydomains_staging.tfstate"

--- a/dns/zones/.terraform.lock.hcl
+++ b/dns/zones/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "3.38.0"
+  constraints = "3.38.0"
+  hashes = [
+    "h1:Isa/rY8+4+DCatuYgmDT4TYkcp/he7RrfR6jyhrm7hQ=",
+    "zh:08df48bdaf162bf3da7ac2b09147d44f94fae6f3cfd97d6cf9c45cb7c1c36a44",
+    "zh:220b68a3f819777872281974e6621527698575096c3a2ef78cb0aabf28665161",
+    "zh:25db1128a96599ffbcc7e865579bec7c009cb4e7f7731e0e30d261ab02cc38d5",
+    "zh:279444db11f570b837143559e5df7453bd8aeda4e22a9879a5a1a795bf6612a3",
+    "zh:2d506b6b865f6d5143e54e139d9a61b18bdcc8b9485d2bc7237e95a53a9c7ed9",
+    "zh:6ddb2cbcdf15b432508fe00ee7863f6d51a136db1746e7af03bec8ce2a09bad3",
+    "zh:96b664a716678923ce0f9828eaad22b5353669fa5013ea39b7b8081a77988b85",
+    "zh:a9ca583b219a3daba171ca11908547abb1b09453934950aacff17ae8b51d0ff0",
+    "zh:aa497620c82afab7819736180f0a56b76da6f3e23bd0580383fda98104b4e5c2",
+    "zh:ab9e9f3c35288d0bd615024f213e46d16d639c281f7d850b21971b530d08e231",
+    "zh:b164a0ddb30b64c35f13dad0aa9701a4e3eb24dc8165a3e794c499f1e9070b99",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/dns/zones/resources.tf
+++ b/dns/zones/resources.tf
@@ -1,0 +1,5 @@
+module "dns_zones" {
+  source      = "git::https://github.com/DFE-Digital/terraform-modules.git//dns/zones"
+  hosted_zone = var.hosted_zone
+  tags        = local.tags
+}

--- a/dns/zones/terraform.tf
+++ b/dns/zones/terraform.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = "~> 1.2.3"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "3.38.0"
+    }
+  }
+  backend "azurerm" {
+  }
+}
+
+provider "azurerm" {
+  features {}
+
+  skip_provider_registration = true
+  subscription_id            = try(local.azure_credentials.subscriptionId, null)
+  client_id                  = try(local.azure_credentials.clientId, null)
+  client_secret              = try(local.azure_credentials.clientSecret, null)
+  tenant_id                  = try(local.azure_credentials.tenantId, null)
+}

--- a/dns/zones/variables.tf
+++ b/dns/zones/variables.tf
@@ -1,0 +1,17 @@
+
+variable "azure_credentials" { default = null }
+
+variable "hosted_zone" {
+  type    = map(any)
+  default = {}
+}
+
+locals {
+  azure_credentials = try(jsondecode(var.azure_credentials), null)
+  tags = {
+    "Environment" = "Prod"
+    "Portfolio"   = "Early Years and Schools Group"
+    "Product"     = "Find postgraduate teacher training"
+    "Service"     = "Teacher services"
+  }
+}

--- a/dns/zones/workspace-variables/apply-zone.tfvars.json
+++ b/dns/zones/workspace-variables/apply-zone.tfvars.json
@@ -1,0 +1,17 @@
+{
+  "hosted_zone": {
+    "apply-for-teacher-training.education.gov.uk" : {
+      "caa_records": {
+      },
+      "txt_records": {
+        "@": {
+          "value": "v=spf1 -all"
+        },
+        "_dmarc": {
+          "value": "v=DMARC1; p=reject; sp=reject; rua=mailto:dmarc-rua@dmarc.service.gov.uk; ruf=mailto:dmarc-ruf@dmarc.service.gov.uk"
+        }
+      },
+      "resource_group_name": "s189p01-applydomains-rg"
+    }
+  }
+}

--- a/dns/zones/workspace-variables/backend_apply.tfvars
+++ b/dns/zones/workspace-variables/backend_apply.tfvars
@@ -1,0 +1,4 @@
+resource_group_name  = "s189p01-applydomains-rg"
+storage_account_name = "s189p01applydomainstf"
+container_name       = "applydomains-tf"
+key                  = "applydomains.tfstate"


### PR DESCRIPTION
## Context
Currently the DNS for the Apply service is managed in AWS Route 53 and the process of updating records is quite a manual one which requires various requests to be raised.

This change will create the Azure resources required to managed the DNS using Azure DNS. It will improve the traceability of changes, and lead to the ability to quickly make changes to the services DNS records as required.

## Changes proposed in this pull request

Add the Terraform code to manage the services domains using Azure DNS.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/1yEerHJZ/71-migrate-apply-dns-zones-to-azure-dns

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
