### PR TITLE
Fix: use typographic apostrophe

### DIFF
--- a/app/views/candidate_interface/subject_knowledge/_form.html.erb
+++ b/app/views/candidate_interface/subject_knowledge/_form.html.erb
@@ -7,7 +7,7 @@
 
 <p class="govuk-body">If you’re applying for primary teacher training, say why you’d like to teach this age group.</p>
 
-<p class="govuk-body">If you're applying for a primary course with a subject specialism, or you're particularly interested in certain primary subjects, you can also talk about that.</p>
+<p class="govuk-body">If you’re applying for a primary course with a subject specialism, or you're particularly interested in certain primary subjects, you can also talk about that.</p>
 
 <p class="govuk-body">You could talk about your:</p>
 <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
This page currently uses a mix of straight (`'`) and curly (typographic) apostrophes (`’`). This fixes it.