### PR TITLE
Update content in candidate mailers about deferrals

### DIFF
--- a/app/components/candidate_interface/application_status_tag_component.html.erb
+++ b/app/components/candidate_interface/application_status_tag_component.html.erb
@@ -22,7 +22,7 @@
       classes: 'govuk-!-margin-bottom-0 govuk-!-margin-top-2',
     ) do %>
       <p>
-        You can defer your offer which means that you could start your course a year later.
+        You can defer your offer and start your course a year later.
       </p>
 
       <p>
@@ -30,7 +30,7 @@
       </p>
 
       <p>
-      If your provider agrees, you’ll need to accept the offer on your account first and then defer it.
+      If your provider agrees, you’ll need to accept the offer first.
       </p>
 
     <% end %>

--- a/app/components/candidate_interface/application_status_tag_component.html.erb
+++ b/app/components/candidate_interface/application_status_tag_component.html.erb
@@ -22,22 +22,13 @@
       classes: 'govuk-!-margin-bottom-0 govuk-!-margin-top-2',
     ) do %>
       <p>
-        Some providers allow you to defer your offer. This means that you could start your course a year later.
+        You can defer your offer which means that you could start your course a year later.
       </p>
 
       <p>
-        Every provider is different, so it may or may not be possible to do this.
-        Find out by contacting <%= @application_choice.current_course_option.course.provider.name %>.
+        Contact <%= @application_choice.current_course_option.course.provider.name %> to ask if it’s possible to defer, this will not affect your existing offer. If your provider agrees, you’ll need to accept the offer on your account first and then defer it.
       </p>
 
-      <p>
-        Asking if it’s possible to defer will not affect your existing offer.
-      </p>
-
-      <% if @application_choice.offer? %>
-        <p>
-          If your provider agrees to defer your offer, you’ll need to accept the offer on your account first.
-        </p>
       <% end %>
     <% end %>
 <% end %>

--- a/app/components/candidate_interface/application_status_tag_component.html.erb
+++ b/app/components/candidate_interface/application_status_tag_component.html.erb
@@ -28,7 +28,6 @@
       <p>
         Contact <%= @application_choice.current_course_option.course.provider.name %> to ask if it’s possible to defer, this will not affect your existing offer. If your provider agrees, you’ll need to accept the offer on your account first and then defer it.
       </p>
-
-      <% end %>
+      
     <% end %>
 <% end %>

--- a/app/components/candidate_interface/application_status_tag_component.html.erb
+++ b/app/components/candidate_interface/application_status_tag_component.html.erb
@@ -27,7 +27,7 @@
 
       <p>
         Contact <%= @application_choice.current_course_option.course.provider.name %> to ask if it’s possible to defer, this will not affect your existing offer.
-      </p> 
+      </p>
 
       <p>
       If your provider agrees, you’ll need to accept the offer on your account first and then defer it.

--- a/app/components/candidate_interface/application_status_tag_component.html.erb
+++ b/app/components/candidate_interface/application_status_tag_component.html.erb
@@ -26,8 +26,12 @@
       </p>
 
       <p>
-        Contact <%= @application_choice.current_course_option.course.provider.name %> to ask if it’s possible to defer, this will not affect your existing offer. If your provider agrees, you’ll need to accept the offer on your account first and then defer it.
+        Contact <%= @application_choice.current_course_option.course.provider.name %> to ask if it’s possible to defer, this will not affect your existing offer.
+      </p> 
+
+      <p>
+      If your provider agrees, you’ll need to accept the offer on your account first and then defer it.
       </p>
-      
+
     <% end %>
 <% end %>

--- a/app/views/candidate_mailer/conditions_met.text.erb
+++ b/app/views/candidate_mailer/conditions_met.text.erb
@@ -10,6 +10,6 @@ Dear <%= @application_form.first_name %>
 
   #If you’re unable to start training in <%= @start_date %>
 
-  Contact <%= @provider_name %> to find out if they’ll allow you to defer your offer. This means that you could start your course a year later.
+  Contact <%= @course.provider.name %> to find out if they’ll allow you to defer your offer. This means that you could start your course a year later.
 
   Asking if it’s possible will not affect your existing offer.

--- a/app/views/candidate_mailer/conditions_met.text.erb
+++ b/app/views/candidate_mailer/conditions_met.text.erb
@@ -10,6 +10,6 @@ Dear <%= @application_form.first_name %>
 
   #If you’re unable to start training in <%= @start_date %>
 
-  Some providers allow you to defer your offer. This means that you could start your course a year later.
+  Contact <%= @provider_name %> to find out if they’ll allow you to defer your offer. This means that you could start your course a year later.
 
-  Contact <%= @course.provider.name %> to find out if they’ll allow you to defer your offer. Asking if it’s possible will not affect your existing offer.
+  Asking if it’s possible will not affect your existing offer.

--- a/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
+++ b/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
@@ -10,8 +10,8 @@ Contact <%= @provider_name %> if you have any questions about this.
 
 # What to do if you’re unable to start training in <%= @start_date %>
 
-You can defer your offer which means that you could start your course a year later.
+You can defer your offer and start your course a year later.
 
 Contact <%= @provider_name %> to ask if it’s possible to defer, this will not affect your existing offer. 
 
-If your provider agrees, you’ll need to accept the offer on your account first and then defer it.
+If your provider agrees, you’ll need to accept the offer first.

--- a/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
+++ b/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
@@ -12,4 +12,6 @@ Contact <%= @provider_name %> if you have any questions about this.
 
 You can defer your offer which means that you could start your course a year later.
 
-Contact <%= @provider_name %> to ask if it’s possible to defer, this will not affect your existing offer. If your provider agrees, you’ll need to accept the offer on your account first and then defer it.
+Contact <%= @provider_name %> to ask if it’s possible to defer, this will not affect your existing offer. 
+
+If your provider agrees, you’ll need to accept the offer on your account first and then defer it.

--- a/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
+++ b/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
@@ -10,10 +10,6 @@ Contact <%= @provider_name %> if you have any questions about this.
 
 # What to do if you’re unable to start training in <%= @start_date %>
 
-Some teacher training providers allow you to defer your offer. This means that you could start your course a year later.
+You can defer your offer which means that you could start your course a year later.
 
-Every provider is different, so it may or may not be possible to do this. Find out by contacting <%= @provider_name %>.
-
-Asking if it’s possible to defer will not affect your existing offer.
-
-If <%= @provider_name %> agrees to defer your offer, you’ll need to accept the offer on your account first.
+Contact <%= @provider_name %> to ask if it’s possible to defer, this will not affect your existing offer. If your provider agrees, you’ll need to accept the offer on your account first and then defer it.

--- a/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
+++ b/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
@@ -20,10 +20,6 @@ If you do not respond by <%= @application_choice.decline_by_default_at.to_fs(:go
 
 # What to do if you’re unable to start training in <%= @start_date %>
 
-Some teacher training providers allow you to defer your offer. This means that you could start your course a year later.
+You can defer your offer which means that you could start your course a year later.
 
-Every provider is different, so it may or may not be possible to do this. Find out by contacting <%= @provider_name %>.
-
-Asking if it’s possible to defer will not affect your existing offer.
-
-If <%= @provider_name %> agrees to defer your offer, you’ll need to accept the offer on your account first.
+Contact <%= @provider_name %> to ask if it’s possible to defer, this will not affect your existing offer. If your provider agrees, you’ll need to accept the offer on your account first and then defer it.

--- a/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
+++ b/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
@@ -22,4 +22,6 @@ If you do not respond by <%= @application_choice.decline_by_default_at.to_fs(:go
 
 You can defer your offer which means that you could start your course a year later.
 
-Contact <%= @provider_name %> to ask if it’s possible to defer, this will not affect your existing offer. If your provider agrees, you’ll need to accept the offer on your account first and then defer it.
+Contact <%= @provider_name %> to ask if it’s possible to defer, this will not affect your existing offer. 
+
+If your provider agrees, you’ll need to accept the offer on your account first and then defer it.

--- a/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
+++ b/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
@@ -20,8 +20,8 @@ If you do not respond by <%= @application_choice.decline_by_default_at.to_fs(:go
 
 # What to do if you’re unable to start training in <%= @start_date %>
 
-You can defer your offer which means that you could start your course a year later.
+You can defer your offer and start your course a year later.
 
 Contact <%= @provider_name %> to ask if it’s possible to defer, this will not affect your existing offer. 
 
-If your provider agrees, you’ll need to accept the offer on your account first and then defer it.
+If your provider agrees, you’ll need to accept the offer first.

--- a/app/views/candidate_mailer/new_offer/single_offer.text.erb
+++ b/app/views/candidate_mailer/new_offer/single_offer.text.erb
@@ -18,10 +18,6 @@ If you do not respond by <%= @application_choice.decline_by_default_at.to_fs(:go
 
 # What to do if you’re unable to start training in <%= @start_date %>
 
-Some teacher training providers allow you to defer your offer. This means that you could start your course a year later.
+You can defer your offer which means that you could start your course a year later.
 
-Every provider is different, so it may or may not be possible to do this. Find out by contacting <%= @provider_name %>.
-
-Asking if it’s possible to defer will not affect your existing offer.
-
-If <%= @provider_name %> agrees to defer your offer, you’ll need to accept the offer on your account first.
+Contact <%= @provider_name %> to ask if it’s possible to defer, this will not affect your existing offer. If your provider agrees, you’ll need to accept the offer on your account first and then defer it.

--- a/app/views/candidate_mailer/new_offer/single_offer.text.erb
+++ b/app/views/candidate_mailer/new_offer/single_offer.text.erb
@@ -20,4 +20,6 @@ If you do not respond by <%= @application_choice.decline_by_default_at.to_fs(:go
 
 You can defer your offer which means that you could start your course a year later.
 
-Contact <%= @provider_name %> to ask if it’s possible to defer, this will not affect your existing offer. If your provider agrees, you’ll need to accept the offer on your account first and then defer it.
+Contact <%= @provider_name %> to ask if it’s possible to defer, this will not affect your existing offer. 
+
+If your provider agrees, you’ll need to accept the offer on your account first and then defer it.

--- a/app/views/candidate_mailer/new_offer/single_offer.text.erb
+++ b/app/views/candidate_mailer/new_offer/single_offer.text.erb
@@ -18,8 +18,8 @@ If you do not respond by <%= @application_choice.decline_by_default_at.to_fs(:go
 
 # What to do if you’re unable to start training in <%= @start_date %>
 
-You can defer your offer which means that you could start your course a year later.
+You can defer your offer and start your course a year later.
 
 Contact <%= @provider_name %> to ask if it’s possible to defer, this will not affect your existing offer. 
 
-If your provider agrees, you’ll need to accept the offer on your account first and then defer it.
+If your provider agrees, you’ll need to accept the offer first.

--- a/app/views/candidate_mailer/offer_accepted.text.erb
+++ b/app/views/candidate_mailer/offer_accepted.text.erb
@@ -13,6 +13,6 @@ Sign into your account to check the progress of your reference requests and offe
 
 #If you’re unable to start training in <%= @start_date %>
 
-Some providers allow you to defer your offer. This means that you could start your course a year later.
+Contact <%= @provider_name%> to find out if they’ll allow you to defer your offer. This means that you could start your course a year later. 
 
-Contact <%= @provider_name%> to find out if they’ll allow you to defer your offer. Asking if it’s possible will not affect your existing offer.
+Asking if it’s possible will not affect your existing offer.

--- a/app/views/candidate_mailer/unconditional_offer_accepted.text.erb
+++ b/app/views/candidate_mailer/unconditional_offer_accepted.text.erb
@@ -12,6 +12,6 @@ Sign into your account to check the progress of your reference requests.
 
 #If you’re unable to start training in <%= @start_date %>
 
-Some providers allow you to defer your offer. This means that you could start your course a year later.
+Contact <%= @provider_name %> to find out if they’ll allow you to defer your offer. This means that you could start your course a year later.
 
-Contact <%= @provider_name %> to find out if they’ll allow you to defer your offer. Asking if it’s possible will not affect your existing offer.
+Asking if it’s possible will not affect your existing offer.

--- a/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
+++ b/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe CandidateInterface::ApplicationDashboardCourseChoicesComponent, t
 
       render_inline(described_class.new(application_form:, editable: false, show_status: true))
 
-      expect(rendered_component).to summarise(key: 'Status', value: "Offer received What to do if you’re unable to start training in #{application_choice.course_option.course.start_date.to_fs(:month_and_year)} Some providers allow you to defer your offer. This means that you could start your course a year later. Every provider is different, so it may or may not be possible to do this. Find out by contacting #{application_choice.course_option.course.provider.name}. Asking if it’s possible to defer will not affect your existing offer. If your provider agrees to defer your offer, you’ll need to accept the offer on your account first.")
+      expect(rendered_component).to summarise(key: 'Status', value: "Offer received What to do if you’re unable to start training in #{application_choice.course_option.course.start_date.to_fs(:month_and_year)} You can defer your offer which means that you could start your course a year later. Contact #{application_choice.course_option.course.provider.name}to ask if it’s possible to defer, this will not affect your existing offer. If your provider agrees, you’ll need to accept the offer on your account first and then defer it.")
       expect(rendered_component).to summarise(key: 'Conditions', value: 'DBS check Get a haircut Contact the provider to find out more about these conditions. They’ll confirm your place once you’ve met the conditions and they’ve checked your references.')
     end
 

--- a/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
+++ b/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe CandidateInterface::ApplicationDashboardCourseChoicesComponent, t
 
       render_inline(described_class.new(application_form:, editable: false, show_status: true))
 
-      expect(rendered_component).to summarise(key: 'Status', value: "Offer received What to do if you’re unable to start training in #{application_choice.course_option.course.start_date.to_fs(:month_and_year)} You can defer your offer which means that you could start your course a year later. Contact #{application_choice.course_option.course.provider.name}to ask if it’s possible to defer, this will not affect your existing offer. If your provider agrees, you’ll need to accept the offer on your account first and then defer it.")
+      expect(rendered_component).to summarise(key: 'Status', value: "Offer received What to do if you’re unable to start training in #{application_choice.course_option.course.start_date.to_fs(:month_and_year)} You can defer your offer which means that you could start your course a year later. Contact #{application_choice.course_option.course.provider.name} to ask if it’s possible to defer, this will not affect your existing offer. If your provider agrees, you’ll need to accept the offer on your account first and then defer it.")
       expect(rendered_component).to summarise(key: 'Conditions', value: 'DBS check Get a haircut Contact the provider to find out more about these conditions. They’ll confirm your place once you’ve met the conditions and they’ve checked your references.')
     end
 

--- a/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
+++ b/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe CandidateInterface::ApplicationDashboardCourseChoicesComponent, t
 
       render_inline(described_class.new(application_form:, editable: false, show_status: true))
 
-      expect(rendered_component).to summarise(key: 'Status', value: "Offer received What to do if you’re unable to start training in #{application_choice.course_option.course.start_date.to_fs(:month_and_year)} You can defer your offer which means that you could start your course a year later. Contact #{application_choice.course_option.course.provider.name} to ask if it’s possible to defer, this will not affect your existing offer. If your provider agrees, you’ll need to accept the offer on your account first and then defer it.")
+      expect(rendered_component).to summarise(key: 'Status', value: "Offer received What to do if you’re unable to start training in #{application_choice.course_option.course.start_date.to_fs(:month_and_year)} You can defer your offer and start your course a year later. Contact #{application_choice.course_option.course.provider.name} to ask if it’s possible to defer, this will not affect your existing offer. If your provider agrees, you’ll need to accept the offer first.")
       expect(rendered_component).to summarise(key: 'Conditions', value: 'DBS check Get a haircut Contact the provider to find out more about these conditions. They’ll confirm your place once you’ve met the conditions and they’ve checked your references.')
     end
 

--- a/spec/components/candidate_interface/application_status_tag_component_spec.rb
+++ b/spec/components/candidate_interface/application_status_tag_component_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe CandidateInterface::ApplicationStatusTagComponent do
           application_choice = create(:application_choice, :pending_conditions, course:)
           result = render_inline(described_class.new(application_choice:))
 
-          expect(result.text).to include('You can defer your offer which means that you could start your course a year later.')
+          expect(result.text).to include('You can defer your offer and start your course a year later.')
         end
       end
 
@@ -81,7 +81,7 @@ RSpec.describe CandidateInterface::ApplicationStatusTagComponent do
           application_choice = create(:application_choice, :recruited, course:)
           result = render_inline(described_class.new(application_choice:))
 
-          expect(result.text).to include('You can defer your offer which means that you could start your course a year later.')
+          expect(result.text).to include('You can defer your offer and start your course a year later.')
         end
       end
 
@@ -90,7 +90,7 @@ RSpec.describe CandidateInterface::ApplicationStatusTagComponent do
           application_choice = create(:application_choice, :offer, course:)
           result = render_inline(described_class.new(application_choice:))
 
-          expect(result.text).to include('If your provider agrees, you’ll need to accept the offer on your account first and then defer it.')
+          expect(result.text).to include('If your provider agrees, you’ll need to accept the offer first.')
         end
       end
     end

--- a/spec/components/candidate_interface/application_status_tag_component_spec.rb
+++ b/spec/components/candidate_interface/application_status_tag_component_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe CandidateInterface::ApplicationStatusTagComponent do
           application_choice = create(:application_choice, :offer, course:)
           result = render_inline(described_class.new(application_choice:))
 
-          expect(result.text).to include('If your provider agrees to defer your offer, you’ll need to accept the offer on your account first.')
+          expect(result.text).to include('If your provider agrees, you’ll need to accept the offer on your account first and then defer it.')
         end
       end
     end

--- a/spec/components/candidate_interface/application_status_tag_component_spec.rb
+++ b/spec/components/candidate_interface/application_status_tag_component_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe CandidateInterface::ApplicationStatusTagComponent do
           application_choice = create(:application_choice, :pending_conditions, course:)
           result = render_inline(described_class.new(application_choice:))
 
-          expect(result.text).to include('Some providers allow you to defer your offer. This means that you could start your course a year later.')
+          expect(result.text).to include('You can defer your offer which means that you could start your course a year later.')
         end
       end
 
@@ -81,7 +81,7 @@ RSpec.describe CandidateInterface::ApplicationStatusTagComponent do
           application_choice = create(:application_choice, :recruited, course:)
           result = render_inline(described_class.new(application_choice:))
 
-          expect(result.text).to include('Some providers allow you to defer your offer. This means that you could start your course a year later.')
+          expect(result.text).to include('You can defer your offer which means that you could start your course a year later.')
         end
       end
 

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe CandidateMailer do
       'heading' => 'Dear Bob',
       'decline by default date' => "Respond by #{10.business_days.from_now.to_fs(:govuk_date)}",
       'first_condition' => 'Be cool',
-      'deferral_guidance' => 'Some teacher training providers allow you to defer your offer.',
+      'deferral_guidance' => 'You can defer your offer which means that you could start your course a year later.',
     )
 
     context 'when the provider offers the candidate a different course option' do
@@ -58,7 +58,7 @@ RSpec.describe CandidateMailer do
         'heading' => 'Dear Bob',
         'course and provider' => 'offer from Falconholt Technical College to study Computer Science (X0FO)',
         'decline by default date' => "Respond by #{10.business_days.from_now.to_fs(:govuk_date)}",
-        'deferral_guidance' => 'Some teacher training providers allow you to defer your offer.',
+        'deferral_guidance' => 'You can defer your offer which means that you could start your course a year later.',
       )
     end
   end
@@ -76,7 +76,7 @@ RSpec.describe CandidateMailer do
       'first_condition' => 'Be cool',
       'first_offer' => 'Applied Science (Psychology) (3TT5) at Brighthurst Technical College',
       'second_offers' => 'Forensic Science (E0FO) at Falconholt Technical College',
-      'deferral_guidance' => 'Some teacher training providers allow you to defer your offer.',
+      'deferral_guidance' => 'You can defer your offer which means that you could start your course a year later.',
     )
   end
 
@@ -89,7 +89,7 @@ RSpec.describe CandidateMailer do
       'Successful application for Brighthurst Technical College',
       'heading' => 'Dear Bob',
       'instructions' => 'You can wait to hear back about your other application(s) before accepting or declining any offers.',
-      'deferral_guidance' => 'Some teacher training providers allow you to defer your offer.',
+      'deferral_guidance' => 'You can defer your offer which means that you could start your course a year later.',
     )
   end
 

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe CandidateMailer do
       'heading' => 'Dear Bob',
       'decline by default date' => "Respond by #{10.business_days.from_now.to_fs(:govuk_date)}",
       'first_condition' => 'Be cool',
-      'deferral_guidance' => 'You can defer your offer which means that you could start your course a year later.',
+      'deferral_guidance' => 'You can defer your offer and start your course a year later.',
     )
 
     context 'when the provider offers the candidate a different course option' do
@@ -58,7 +58,7 @@ RSpec.describe CandidateMailer do
         'heading' => 'Dear Bob',
         'course and provider' => 'offer from Falconholt Technical College to study Computer Science (X0FO)',
         'decline by default date' => "Respond by #{10.business_days.from_now.to_fs(:govuk_date)}",
-        'deferral_guidance' => 'You can defer your offer which means that you could start your course a year later.',
+        'deferral_guidance' => 'You can defer your offer and start your course a year later.',
       )
     end
   end
@@ -76,7 +76,7 @@ RSpec.describe CandidateMailer do
       'first_condition' => 'Be cool',
       'first_offer' => 'Applied Science (Psychology) (3TT5) at Brighthurst Technical College',
       'second_offers' => 'Forensic Science (E0FO) at Falconholt Technical College',
-      'deferral_guidance' => 'You can defer your offer which means that you could start your course a year later.',
+      'deferral_guidance' => 'You can defer your offer and start your course a year later.',
     )
   end
 
@@ -89,7 +89,7 @@ RSpec.describe CandidateMailer do
       'Successful application for Brighthurst Technical College',
       'heading' => 'Dear Bob',
       'instructions' => 'You can wait to hear back about your other application(s) before accepting or declining any offers.',
-      'deferral_guidance' => 'You can defer your offer which means that you could start your course a year later.',
+      'deferral_guidance' => 'You can defer your offer and start your course a year later.',
     )
   end
 


### PR DESCRIPTION
## Context

We noticed that when a candidate receives an offer email, and emails after they have accepted an offer, half the email content talks about deferring the offer. we don't want to encourage candidates to do this, so we've simplified the content to make it shorter. We'll still tell candidates about the option of deferring, but it now doesn't take up half the email.

We also made a change to a page within the interface where the content is the same as the emails.

## Changes proposed in this pull request

Updating content in new offer emails and accepted offer emails
Updating content once a candidate receives an offer before they accept it

## Link to Trello card

https://trello.com/c/lIsLoOXQ/1003-review-our-offer-emails-to-try-and-remove-encouragement-for-deferrals

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
