### PR TITLE
Return to ruby 2.7 on load testing for jmeter gem

### DIFF
--- a/jmeter/Dockerfile
+++ b/jmeter/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1.2-alpine3.15
+FROM ruby:2.7.5-alpine3.15
 ARG BUILD_DEPS="git gcc libc-dev make build-base libxml2-dev libxslt-dev"
 
 WORKDIR /app

--- a/jmeter/Gemfile
+++ b/jmeter/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '3.1.2'
+ruby '2.7.5'
 
 gem 'ruby-jmeter'

--- a/jmeter/Gemfile.lock
+++ b/jmeter/Gemfile.lock
@@ -34,7 +34,7 @@ DEPENDENCIES
   ruby-jmeter
 
 RUBY VERSION
-   ruby 3.1.2p20
+   ruby 2.7.5p203
 
 BUNDLED WITH
-   2.3.21
+   2.3.10


### PR DESCRIPTION
## Context

The jmeter gem is not compatible with ruby 3 so two options. 
One: make it compatible
Two: return to 2.7
The first one will be difficult since the gem last commit is 2017 so better the second option.
