### PR TITLE
Fix a spacing bug

### DIFF
--- a/app/components/candidate_interface/offer_review_component.rb
+++ b/app/components/candidate_interface/offer_review_component.rb
@@ -94,7 +94,7 @@ module CandidateInterface
 
     def fee_value_row_with_fee_details
       if @course_choice.current_course.fee_international && @course_choice.current_course.fee_domestic
-        tag.p("UK Students: £#{@course_choice.current_course.fee_domestic}") + tag.p("International Students: £#{@course_choice.current_course.fee_international}", class: 'govuk-body') + markdown(@course_choice.current_course.fee_details)
+        tag.p("UK Students: £#{@course_choice.current_course.fee_domestic}", class: 'govuk-body') + tag.p("International Students: £#{@course_choice.current_course.fee_international}", class: 'govuk-body') + markdown(@course_choice.current_course.fee_details)
       elsif @course_choice.current_course.fee_domestic
         tag.p("UK Students: £#{@course_choice.current_course.fee_domestic}", class: 'govuk-body') + markdown(@course_choice.current_course.fee_details)
       elsif @course_choice.current_course.fee_international
@@ -104,7 +104,7 @@ module CandidateInterface
 
     def fee_value_row_without_fee_details
       if @course_choice.current_course.fee_international && @course_choice.current_course.fee_domestic
-        tag.p("UK Students: £#{@course_choice.current_course.fee_domestic}") + tag.p("International Students: £#{@course_choice.current_course.fee_international}", class: 'govuk-body')
+        tag.p("UK Students: £#{@course_choice.current_course.fee_domestic}", class: 'govuk-body') + tag.p("International Students: £#{@course_choice.current_course.fee_international}", class: 'govuk-body')
       elsif @course_choice.current_course.fee_domestic
         tag.p("UK Students: £#{@course_choice.current_course.fee_domestic}", class: 'govuk-body')
       elsif @course_choice.current_course.fee_international


### PR DESCRIPTION
Should use `.govuk-body` class on all paragraphs.

## Changes proposed in this pull request

### Before

<img width="722" alt="Screenshot 2023-01-18 at 16 44 29" src="https://user-images.githubusercontent.com/109225/213242312-31b2cfc4-5d61-474a-b734-9a76862c3491.png">

### After

<img width="701" alt="Screenshot 2023-01-18 at 16 44 59" src="https://user-images.githubusercontent.com/109225/213242347-0a97e937-f504-432d-a52d-8e5d1108efcb.png">

## Guidance to review

This only shows on offers where the course has both `fee_domestic` and `fee_international` set.
