### PR TITLE
Add type and details to offer conditions

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -292,9 +292,11 @@ shared:
   offer_conditions:
     - created_at
     - id
+    - type
     - offer_id
     - status
     - text
+    - details
     - updated_at
   offers:
     - application_choice_id

--- a/db/migrate/20230119145328_add_type_to_offer_conditions.rb
+++ b/db/migrate/20230119145328_add_type_to_offer_conditions.rb
@@ -1,0 +1,5 @@
+class AddTypeToOfferConditions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :offer_conditions, :type, :string
+  end
+end

--- a/db/migrate/20230119145407_add_details_to_offer_conditions.rb
+++ b/db/migrate/20230119145407_add_details_to_offer_conditions.rb
@@ -1,0 +1,5 @@
+class AddDetailsToOfferConditions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :offer_conditions, :details, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_08_140058) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_19_145407) do
   create_sequence "qualifications_public_id_seq", start: 120000
 
   # These are extensions that must be enabled in order to support this database
@@ -537,6 +537,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_08_140058) do
     t.string "status", default: "pending", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "type"
+    t.jsonb "details"
     t.index ["offer_id"], name: "index_offer_conditions_on_offer_id"
   end
 
@@ -610,8 +612,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_08_140058) do
   create_table "provider_users_providers", force: :cascade do |t|
     t.bigint "provider_id", null: false
     t.bigint "provider_user_id", null: false
-    t.datetime "created_at", precision: nil, default: -> { "now()" }, null: false
-    t.datetime "updated_at", precision: nil, default: -> { "now()" }, null: false
+    t.datetime "created_at", precision: nil, default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "updated_at", precision: nil, default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.boolean "manage_users", default: false, null: false
     t.boolean "view_safeguarding_information", default: false, null: false
     t.boolean "make_decisions", default: false, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -612,8 +612,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_19_145407) do
   create_table "provider_users_providers", force: :cascade do |t|
     t.bigint "provider_id", null: false
     t.bigint "provider_user_id", null: false
-    t.datetime "created_at", precision: nil, default: -> { "CURRENT_TIMESTAMP" }, null: false
-    t.datetime "updated_at", precision: nil, default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "created_at", precision: nil, default: -> { "now()" }, null: false
+    t.datetime "updated_at", precision: nil, default: -> { "now()" }, null: false
     t.boolean "manage_users", default: false, null: false
     t.boolean "view_safeguarding_information", default: false, null: false
     t.boolean "make_decisions", default: false, null: false

--- a/spec/services/save_offer_conditions_from_text_spec.rb
+++ b/spec/services/save_offer_conditions_from_text_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe SaveOfferConditionsFromText do
           expect(application_choice.associated_audits.last.audited_changes).to eq({
             text: 'Condition two',
             status: 'pending',
+            details: nil,
             offer_id: application_choice.offer.id,
           }.stringify_keys)
         end
@@ -72,6 +73,7 @@ RSpec.describe SaveOfferConditionsFromText do
           expect(application_choice.associated_audits.last.audited_changes).to eq({
             text: 'Condition one',
             status: 'pending',
+            details: nil,
             offer_id: application_choice.offer.id,
           }.stringify_keys)
         end
@@ -90,6 +92,7 @@ RSpec.describe SaveOfferConditionsFromText do
           expect(audits.first.audited_changes).to eq({
             text: 'Condition one',
             status: 'pending',
+            details: nil,
             offer_id: application_choice.offer.id,
           }.stringify_keys)
 
@@ -97,6 +100,7 @@ RSpec.describe SaveOfferConditionsFromText do
           expect(audits.last.audited_changes).to eq({
             text: 'Condition two',
             status: 'pending',
+            details: nil,
             offer_id: application_choice.offer.id,
           }.stringify_keys)
         end


### PR DESCRIPTION
## Context

This will allow SKE and future structured conditions to work gracefully

The idea in the future SKE work is to have something like:

```
>  offer.conditions
=> [
  <SkeCondition details={subject: 'math', length: '8 months', reason: ''}>,
  <SkeConditions details={subject: 'french', length: '12 months', reason: '' }>,
  <FreeTextCondition details={ text: "Fitness to train to teach check" }>,
  <DegreeCondition details={ grade: '2:1 or above' }>
]
```
