### PR TITLE
Update subject mappings for Monthly Statistics Report

### DIFF
--- a/app/lib/ministerial_report.rb
+++ b/app/lib/ministerial_report.rb
@@ -118,6 +118,7 @@ module MinisterialReport
     '11' => :computing,
     '12' => :physical_education,
     'C6' => :physical_education,
+    'C7' => :physical_education,
     'DT' => :design_and_technology,
     '13' => :drama,
     'Q3' => :english,

--- a/spec/lib/ministerial_report_spec.rb
+++ b/spec/lib/ministerial_report_spec.rb
@@ -51,5 +51,14 @@ RSpec.describe MinisterialReport do
 
       it { is_expected.to eq(:classics) }
     end
+
+    context 'when the course is physical education with ebacc' do
+      let(:course_name) { 'Physical education with an EBacc subject' }
+      let(:subject_names_and_codes) do
+        { 'Physics' => 'F3', 'Physical education with an EBacc subject' => 'C7' }
+      end
+
+      it { is_expected.to eq(:physical_education) }
+    end
   end
 end


### PR DESCRIPTION
## Context

We have a number of applications appearing in the MOnthly Statistics report as 'subject not recognised'. This is probably due to subject mappings changing and not being updating in this hardcoded list. A query on BigQuery suggests that PE with Ebacc was added in July 2022 as code C7, but this file has not been updated for over a year.

## Changes proposed in this pull request

Add Code C7 to the Ministerial Report subject mappings in `app/lib/ministerial_report.rb`.

## Guidance to review

Will this fix our issues?

## Link to Trello card

https://trello.com/c/zbPVVb6S/1273-subject-not-recognised-in-monthly-reports

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
