### PR TITLE
Update markdown and html version of candidate priv policy

### DIFF
--- a/app/views/content/service_privacy_notice.md
+++ b/app/views/content/service_privacy_notice.md
@@ -193,4 +193,4 @@ Once a candidate has enrolled with a teacher training provider, we will not be a
 
 We’ll update this privacy notice when required. You should regularly review the notice.
 
-This version was last updated on 25 October 2022.
+This version was last updated on 24 January 2023.

--- a/app/views/content/service_privacy_notice.md
+++ b/app/views/content/service_privacy_notice.md
@@ -81,6 +81,7 @@ Processing applications includes:
 - getting in touch with you to ask if you would like to participate in user research
 - getting in touch with you and providers about your applications
 - analysing application and service usage data
+- researching and analysing in conjunction with education providers' information
 
 Your data will also be shared between Apply and Get Into Teaching, which are both delivered by the Department for Education. This is to support your application journey. For example, we’ll send you relevant information and support opportunities.
 

--- a/app/views/content/service_privacy_notice.md
+++ b/app/views/content/service_privacy_notice.md
@@ -81,7 +81,7 @@ Processing applications includes:
 - getting in touch with you to ask if you would like to participate in user research
 - getting in touch with you and providers about your applications
 - analysing application and service usage data
-- researching and analysing in conjunction with education providers' information
+- using information from education providers and information from the Apply service for analysis and research about initial teacher training
 
 Your data will also be shared between Apply and Get Into Teaching, which are both delivered by the Department for Education. This is to support your application journey. For example, we’ll send you relevant information and support opportunities.
 

--- a/app/views/content/service_privacy_notice_candidate.html.erb
+++ b/app/views/content/service_privacy_notice_candidate.html.erb
@@ -308,7 +308,7 @@
 
     <p class="govuk-body">We’ll update this privacy notice when required. You should regularly review the notice.</p>
 
-    <p class="govuk-body">This version was last updated on 25 October 2022.</p>
+    <p class="govuk-body">This version was last updated on 24 January 2023.</p>
 
   </div>
 

--- a/app/views/content/service_privacy_notice_candidate.html.erb
+++ b/app/views/content/service_privacy_notice_candidate.html.erb
@@ -103,7 +103,7 @@
       <li>getting in touch with you to ask if you would like to participate in user research</li>
       <li>getting in touch with you and providers about your applications</li>
       <li>analysing application and service usage data</li>
-      <li>researching and analysing in conjunction with education providers' information</li>
+      <li>using information from education providers and information from the Apply service for analysis and research about initial teacher training</li>
     </ul>
 
     <p class="govuk-body">Your data will also be shared between Apply and Get Into Teaching, which are both delivered

--- a/app/views/content/service_privacy_notice_candidate.html.erb
+++ b/app/views/content/service_privacy_notice_candidate.html.erb
@@ -103,6 +103,7 @@
       <li>getting in touch with you to ask if you would like to participate in user research</li>
       <li>getting in touch with you and providers about your applications</li>
       <li>analysing application and service usage data</li>
+      <li>researching and analysing in conjunction with education providers' information</li>
     </ul>
 
     <p class="govuk-body">Your data will also be shared between Apply and Get Into Teaching, which are both delivered


### PR DESCRIPTION
## Context

We are planning to analyse info about how many candidates who have done UG modules at Warwick (solely for now) have then gone on to apply for ITT, and their outcomes.

## Changes proposed in this pull request

Adding of a line (researching and analysing in conjunction with education providers' information) into the policy, as suggested by our data protection team.

## Guidance to review

Does this break anything?

## Link to Trello card

https://trello.com/c/KMg6EWOa/1091-update-privacy-policy-for-undergraduate-module-research

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
