### PR TITLE
Update TTL values pre-migration

### DIFF
--- a/dns/records/workspace-variables/apply_pentest.tfvars.json
+++ b/dns/records/workspace-variables/apply_pentest.tfvars.json
@@ -4,11 +4,11 @@
       "cnames": {
         "_2591fbd3d4123185e000682b4c838bd0.pen-assets": {
           "target": "_809c702dd45db95700825b993d095227.mvtxpqxpkb.acm-validations.aws",
-          "ttl": 60
+          "ttl": 86400
         },
         "_49618458e8b8d5047b31de62563fd8bb.pen": {
           "target": "_4456d705baa45a5964503ebaa5ab14d7.mvtxpqxpkb.acm-validations.aws",
-          "ttl": 60
+          "ttl": 86400
         }
       },
     "resource_group_name": "s189p01-applydomains-rg"

--- a/dns/records/workspace-variables/apply_production.tfvars.json
+++ b/dns/records/workspace-variables/apply_production.tfvars.json
@@ -4,11 +4,11 @@
       "cnames": {
         "www": {
           "target": "d1xbatyhdsd23r.cloudfront.net",
-          "ttl": 60
+          "ttl": 300
         },
         "_4543fa06c424e9f27d11f7fbcc365308.www": {
           "target": "_f5f9cc82aae8a4237d22a44cbfb95119.bbfvkzsszw.acm-validations.aws",
-          "ttl": 60
+          "ttl": 86400
         }
       },
     "resource_group_name": "s189p01-applydomains-rg"

--- a/dns/records/workspace-variables/apply_qa.tfvars.json
+++ b/dns/records/workspace-variables/apply_qa.tfvars.json
@@ -4,11 +4,11 @@
       "cnames": {
         "qa": {
           "target": "d25o4mearp38mh.cloudfront.net",
-          "ttl": 60
+          "ttl": 300
         },
         "_20376ff68e78b33802641a0fb5889553.qa": {
           "target": "_de9e1b635132fa1d1be8ac835db32219.bbfvkzsszw.acm-validations.aws",
-          "ttl": 60
+          "ttl": 86400
         }
       },
     "resource_group_name": "s189p01-applydomains-rg"

--- a/dns/records/workspace-variables/apply_sandbox.tfvars.json
+++ b/dns/records/workspace-variables/apply_sandbox.tfvars.json
@@ -4,11 +4,11 @@
       "cnames": {
         "sandbox": {
           "target": "d1xbatyhdsd23r.cloudfront.net",
-          "ttl": 60
+          "ttl": 300
         },
         "_229b8d2191ea3cbe7ddd6ce57066bd83.sandbox": {
           "target": "_072f14fced703e7b0f5a514df5c97fdf.bbfvkzsszw.acm-validations.aws",
-          "ttl": 60
+          "ttl": 86400
         }
       },
     "resource_group_name": "s189p01-applydomains-rg"

--- a/dns/records/workspace-variables/apply_staging.tfvars.json
+++ b/dns/records/workspace-variables/apply_staging.tfvars.json
@@ -4,11 +4,11 @@
       "cnames": {
         "staging": {
           "target": "d2hsy40vkk0kkh.cloudfront.net",
-          "ttl": 60
+          "ttl": 300
         },
         "_1d4b1f5476af8d39d1661df9e6d7e63e.staging": {
           "target": "_5a3f2a4df63ba5e370e6036e7757f323.bbfvkzsszw.acm-validations.aws",
-          "ttl": 60
+          "ttl": 86400
         }
       },
     "resource_group_name": "s189p01-applydomains-rg"


### PR DESCRIPTION


## Context

The apply-for-teacher-training.education.gov.uk was previously managed in Route 53 but is now managed in Azure DNS. Before the migration the TTL was reduced for the Route 53 and Azure DNS records to ensure the records were picked up from their new location quickly. 

The domain has been running on Azure DNS for some days now so we can update the TTL records to their previous values.

## Changes proposed in this pull request

- [x] Revert the TTL to their pre-migration values now that the domain is managed in Azure DNS
- [ ] Apply the new values when the PR is merged.

## Guidance to review

Confirm there are no typos

## Link to Trello card

https://trello.com/c/1yEerHJZ/71-migrate-apply-dns-zones-to-azure-dns

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
