### PR TITLE
Correct typos in how we spell 'adviser'

### DIFF
--- a/app/components/candidate_interface/application_dashboard_guidance_component.html.erb
+++ b/app/components/candidate_interface/application_dashboard_guidance_component.html.erb
@@ -8,17 +8,17 @@
     <p class="govuk-body">You will be emailed when the provider makes a decision.</p>
   <% end %>
 
-  <p class="govuk-body govuk-!-margin-bottom-6">A <%= govuk_link_to_with_utm_params('teacher training adviser', I18n.t('get_into_teaching.url_get_an_adviser_start'), utm_campaign(params), application_form.phase) %> can help you prepare for any interviews. Our advisors were teachers and they can give you free, one-to-one support.</p>
+  <p class="govuk-body govuk-!-margin-bottom-6">A <%= govuk_link_to_with_utm_params('teacher training adviser', I18n.t('get_into_teaching.url_get_an_adviser_start'), utm_campaign(params), application_form.phase) %> can help you prepare for any interviews. Our advisers were teachers and they can give you free, one-to-one support.</p>
 
 <% elsif multiple_offers_but_awaiting_decisions? %>
 
   <p class="govuk-body">2 of your training providers have made a decision on your application.</p>
-  <p class="govuk-body govuk-!-margin-bottom-6">A <%= govuk_link_to_with_utm_params('teacher training adviser', I18n.t('get_into_teaching.url_get_an_adviser_start'), utm_campaign(params), application_form.phase) %> can help you prepare for any interviews. Our advisors were teachers and they can give you free, one-to-one support.</p>
+  <p class="govuk-body govuk-!-margin-bottom-6">A <%= govuk_link_to_with_utm_params('teacher training adviser', I18n.t('get_into_teaching.url_get_an_adviser_start'), utm_campaign(params), application_form.phase) %> can help you prepare for any interviews. Our advisers were teachers and they can give you free, one-to-one support.</p>
 
 <% elsif single_offer_but_awaiting_decisions? %>
 
   <p class="govuk-body">One of your training providers has made a decision on your application.</p>
-  <p class="govuk-body govuk-!-margin-bottom-6">A <%= govuk_link_to_with_utm_params('teacher training adviser', I18n.t('get_into_teaching.url_get_an_adviser_start'), utm_campaign(params), application_form.phase) %> can help you prepare for any interviews. Our advisors were teachers and they can give you free, one-to-one support.</p>
+  <p class="govuk-body govuk-!-margin-bottom-6">A <%= govuk_link_to_with_utm_params('teacher training adviser', I18n.t('get_into_teaching.url_get_an_adviser_start'), utm_campaign(params), application_form.phase) %> can help you prepare for any interviews. Our advisers were teachers and they can give you free, one-to-one support.</p>
 
 <% elsif offer_accepted? %>
 

--- a/app/views/candidate_interface/subject_knowledge/_form.html.erb
+++ b/app/views/candidate_interface/subject_knowledge/_form.html.erb
@@ -18,7 +18,7 @@
   <li>understanding of the national curriculum</li>
 </ul>
 
-<p class="govuk-body">If you need help, you can speak to our <%= govuk_link_to_with_utm_params 'teacher training advisers', t('get_into_teaching.url_get_an_adviser_start'), utm_campaign(params), @current_application.phase %>. Our advisors were teachers and they can give you free, one-to-one support with your personal statement.</p>
+<p class="govuk-body">If you need help, you can speak to our <%= govuk_link_to_with_utm_params 'teacher training advisers', t('get_into_teaching.url_get_an_adviser_start'), utm_campaign(params), @current_application.phase %>. Our advisers were teachers and they can give you free, one-to-one support with your personal statement.</p>
 
 <%= f.govuk_text_area :subject_knowledge, label: { text: t('application_form.personal_statement.subject_knowledge.label'), size: 'm' }, rows: 20, max_words: 400 %>
 <%= f.govuk_submit t('continue') %>


### PR DESCRIPTION
## Context

I found this typo when looking at some info on TTAs.

## Changes proposed in this pull request

Advisor -> Adviser

## Guidance to review

Can you verify this all looks okay?

## Link to Trello card

N/A

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
