### PR TITLE
Add service.gov.uk zone and records

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,7 +266,7 @@ restore-data-from-nightly-backup: read-deployment-config read-keyvault-config # 
 	$(if $(CONFIRM_RESTORE), , $(error Restore can only run with CONFIRM_RESTORE))
 	bin/restore-nightly-backup ${SPACE} ${POSTGRES_DATABASE_NAME} apply_${APP_NAME_SUFFIX}_ ${BACKUP_DATE}
 
-domain-azure-resources: set-azure-account set-azure-template-tag set-azure-resource-group-tags# make domain domain-azure-resources AUTO_APPROVE=1
+domain-azure-resources: set-azure-account set-azure-template-tag set-azure-resource-group-tags ## make domain domain-azure-resources AUTO_APPROVE=1
 	$(if $(AUTO_APPROVE), , $(error can only run with AUTO_APPROVE))
 	az deployment sub create -l "UK South" --template-uri "https://raw.githubusercontent.com/DFE-Digital/tra-shared-services/${ARM_TEMPLATE_TAG}/azure/resourcedeploy.json" \
 		--name "${DNS_ZONE}domains" --parameters "resourceGroupName=${RESOURCE_NAME_PREFIX}-${DNS_ZONE}domains-rg" 'tags=${RG_TAGS}' \
@@ -277,10 +277,10 @@ dnszone-init: set-azure-account
 	az account show
 	cd dns/zones && terraform init -backend-config workspace-variables/backend_${DNS_ZONE}.tfvars -upgrade -reconfigure
 
-dnszone-plan: dnszone-init
+dnszone-plan: dnszone-init ## make apply dnszone-plan
 	cd dns/zones && terraform plan -var-file workspace-variables/${DNS_ZONE}-zone.tfvars.json
 
-dnszone-apply: dnszone-init
+dnszone-apply: dnszone-init ## make apply dnszone-apply
 	cd dns/zones && terraform apply -var-file workspace-variables/${DNS_ZONE}-zone.tfvars.json ${AUTO_APPROVE}
 
 dnsrecord-init: set-azure-account
@@ -289,8 +289,8 @@ dnsrecord-init: set-azure-account
 	az account show
 	cd dns/records && terraform init -backend-config workspace-variables/backend_${DNS_ZONE}_${DNS_ENV}.tfvars -upgrade -reconfigure
 
-dnsrecord-plan: dnsrecord-init
+dnsrecord-plan: dnsrecord-init ## make apply dnsrecord-plan DNS_ENV=qa
 	cd dns/records && terraform plan -var-file workspace-variables/${DNS_ZONE}_${DNS_ENV}.tfvars.json
 
-dnsrecord-apply: dnsrecord-init
+dnsrecord-apply: dnsrecord-init ## make apply dnsrecord-apply DNS_ENV=qa
 	cd dns/records && terraform apply -var-file workspace-variables/${DNS_ZONE}_${DNS_ENV}.tfvars.json ${AUTO_APPROVE}

--- a/dns/records/workspace-variables/apply_pentest.tfvars.json
+++ b/dns/records/workspace-variables/apply_pentest.tfvars.json
@@ -12,6 +12,27 @@
         }
       },
     "resource_group_name": "s189p01-applydomains-rg"
+    },
+    "apply-for-teacher-training.service.gov.uk": {
+      "cnames": {
+        "pen-assets": {
+          "target": "dxhwikmjcbucp.cloudfront.net",
+          "ttl": 60
+        },
+        "_581c4a3ec7fe8f4b4715a15fcb3cc19c.pen-assets": {
+          "target": "_8f9050178afd4cc9bc6c2d16b1ef335b.mvtxpqxpkb.acm-validations.aws",
+          "ttl": 60
+        },
+        "pen": {
+          "target": "d1xbatyhdsd23r.cloudfront.net",
+          "ttl": 60
+        },
+        "_c1ae00f2b52295d00f3760ee62eef561.pen": {
+          "target": "_31e7fb3a77e73ffa9646267e19e9aa08.mvtxpqxpkb.acm-validations.aws",
+          "ttl": 60
+        }
+      },
+    "resource_group_name": "s189p01-applydomains-rg"
     }
   }
 }

--- a/dns/records/workspace-variables/apply_production.tfvars.json
+++ b/dns/records/workspace-variables/apply_production.tfvars.json
@@ -12,6 +12,27 @@
         }
       },
     "resource_group_name": "s189p01-applydomains-rg"
+    },
+    "apply-for-teacher-training.service.gov.uk": {
+      "cnames": {
+        "assets": {
+          "target": "dxhwikmjcbucp.cloudfront.net",
+          "ttl": 60
+        },
+        "_6f431f2e0c7d110cd894fcca4c91ba0f.assets": {
+          "target": "_737dd0de6042e4c502646e7641008d9d.gwpjclltnz.acm-validations.aws",
+          "ttl": 60
+        },
+        "www": {
+          "target": "d1xbatyhdsd23r.cloudfront.net",
+          "ttl": 60
+        },
+        "_b1b5c70fa670699c7e96fc6bc285cc4b.www": {
+          "target": "_10ceec39b7b9b6f93131d0d9e9ac3a4c.bbfvkzsszw.acm-validations.aws",
+          "ttl": 60
+        }
+      },
+    "resource_group_name": "s189p01-applydomains-rg"
     }
   }
 }

--- a/dns/records/workspace-variables/apply_qa.tfvars.json
+++ b/dns/records/workspace-variables/apply_qa.tfvars.json
@@ -12,6 +12,27 @@
         }
       },
     "resource_group_name": "s189p01-applydomains-rg"
+    },
+    "apply-for-teacher-training.service.gov.uk": {
+      "cnames": {
+        "qa-assets": {
+          "target": "d3o8h99fub56wx.cloudfront.net",
+          "ttl": 60
+        },
+        "_9527eeb2b6fd1423f4fcc8967b68b0e4.qa-assets": {
+          "target": "_f19cab8c22f1dd7d7f35328463d55490.gwpjclltnz.acm-validations.aws",
+          "ttl": 60
+        },
+        "qa": {
+          "target": "d25o4mearp38mh.cloudfront.net",
+          "ttl": 60
+        },
+        "_4de0d15d287933d3185448456765dbad.qa": {
+          "target": "_586bdf6bff29ff8a721078ed87dcbc10.bbfvkzsszw.acm-validations.aws",
+          "ttl": 60
+        }
+      },
+    "resource_group_name": "s189p01-applydomains-rg"
     }
   }
 }

--- a/dns/records/workspace-variables/apply_sandbox.tfvars.json
+++ b/dns/records/workspace-variables/apply_sandbox.tfvars.json
@@ -12,6 +12,27 @@
         }
       },
     "resource_group_name": "s189p01-applydomains-rg"
+    },
+    "apply-for-teacher-training.service.gov.uk": {
+      "cnames": {
+        "sandbox-assets": {
+          "target": "dxhwikmjcbucp.cloudfront.net",
+          "ttl": 60
+        },
+        "_030987ad117861a978cc345483658da4.sandbox-assets": {
+          "target": "_780dc56ef3289e5257ff7b71bc912fe3.gwpjclltnz.acm-validations.aws",
+          "ttl": 60
+        },
+        "sandbox": {
+          "target": "d1xbatyhdsd23r.cloudfront.net",
+          "ttl": 60
+        },
+        "_240370c345c6449ea0f019d17ad45b0e.sandbox": {
+          "target": "_eb78c4241ddbdb81c43ffc174c2d0b40.bbfvkzsszw.acm-validations.aws",
+          "ttl": 60
+        }
+      },
+    "resource_group_name": "s189p01-applydomains-rg"
     }
   }
 }

--- a/dns/records/workspace-variables/apply_staging.tfvars.json
+++ b/dns/records/workspace-variables/apply_staging.tfvars.json
@@ -12,6 +12,27 @@
         }
       },
     "resource_group_name": "s189p01-applydomains-rg"
+    },
+    "apply-for-teacher-training.service.gov.uk": {
+      "cnames": {
+        "staging-assets": {
+          "target": "d325g8v033lilj.cloudfront.net",
+          "ttl": 60
+        },
+        "_829232a7a8d7b8feb96f04e168b309a3.staging-assets": {
+          "target": "_cb8025b2433e4e200440af49798b0811.gwpjclltnz.acm-validations.aws",
+          "ttl": 60
+        },
+        "staging": {
+          "target": "d2hsy40vkk0kkh.cloudfront.net",
+          "ttl": 60
+        },
+        "_5b4d5b584c2120b1a977ec93d64580b0.staging": {
+          "target": "_6c257c0fff3b6426ce3e75937fc7c077.bbfvkzsszw.acm-validations.aws",
+          "ttl": 60
+        }
+      },
+    "resource_group_name": "s189p01-applydomains-rg"
     }
   }
 }

--- a/dns/zones/workspace-variables/apply-zone.tfvars.json
+++ b/dns/zones/workspace-variables/apply-zone.tfvars.json
@@ -8,6 +8,19 @@
           "value": "v=spf1 -all"
         },
         "_dmarc": {
+          "value": "v=DMARC1;p=quarantine;sp=quarantine;pct=100;fo=1;rua=mailto:dmarc-rua@dmarc.service.gov.uk,mailto:dmarc-rua@education.gov.uk;ruf=mailto:DMARC.Forensic@education.gov.uk"
+        }
+      },
+      "resource_group_name": "s189p01-applydomains-rg"
+    },
+    "apply-for-teacher-training.service.gov.uk" : {
+      "caa_records": {
+      },
+      "txt_records": {
+        "@": {
+          "value": "v=spf1 -all; _globalsign-domain-verification=N7_AowdZvsMd-IXSIhcRmldjG-EJe9DlKCX2WH1BQK; vsqd6b7k3ym3b2hf1whfyjp8ljpzfkrr"
+        },
+        "_dmarc": {
           "value": "v=DMARC1; p=reject; sp=reject; rua=mailto:dmarc-rua@dmarc.service.gov.uk; ruf=mailto:dmarc-ruf@dmarc.service.gov.uk"
         }
       },


### PR DESCRIPTION
## Context

To improve how we manage and control the service we are migrating the services domains from Route 53 to Azure DNS. The apply-for-teacher-training.education.gov.uk domain has been migrated already and this PR adds the records for the service.gov.uk domain.

## Changes proposed in this pull request

Add the apply-for-teacher-training.service.gov.uk records so that we can manage the services main domain using Azure DNS

## Guidance to review

- [x] Check for typos
- [x] Confirm neither domain will be used to send email:
- [x] Decide whether we need the SPF record for the education.gov.uk domain - yes, we'll keep this
- [x] Decide whether we can remove the _dmarc for the education.gov.uk domain - no, decided to keep it
- [x] Decide whether we can remove the _dmarc for the service.gov.uk domain - no, decided to keep it
- [x] Decide whether we need the SPF record for the education.gov.uk domain - yes, we'll keep this
- [x] Check TXT record format
- [x] No current CAA record for service.gov.uk

## Link to Trello card

https://trello.com/c/1yEerHJZ/71-migrate-apply-dns-zones-to-azure-dns

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
