### PR TITLE
Ske standard flow

### DIFF
--- a/app/controllers/provider_interface/offer/ske_lengths_controller.rb
+++ b/app/controllers/provider_interface/offer/ske_lengths_controller.rb
@@ -1,0 +1,51 @@
+module ProviderInterface
+  module Offer
+    class SkeLengthsController < ProviderInterfaceController
+      before_action :set_application_choice
+
+      def new
+        @wizard = OfferWizard.build_from_application_choice(
+          offer_store,
+          @application_choice,
+          provider_user_id: current_provider_user.id,
+          current_step: 'ske_length',
+          decision: :default,
+          action:,
+        )
+        @wizard.save_state!
+      end
+
+      def create
+        @wizard = OfferWizard.new(offer_store, { decision: :make_offer, current_step: 'ske_length' }.merge(ske_length_params))
+
+        if @wizard.valid_for_current_step?
+          @wizard.save_state!
+
+          redirect_to [:new, :provider_interface, @application_choice, :offer, @wizard.next_step]
+        else
+          track_validation_error(@wizard)
+          render 'new'
+        end
+      end
+
+    private
+
+      def offer_wizard_params
+        params[:provider_interface_offer_wizard] || ActionController::Parameters.new
+      end
+
+      def ske_length_params
+        offer_wizard_params.permit(:ske_length)
+      end
+
+      def offer_store
+        key = "offer_wizard_store_#{current_provider_user.id}_#{@application_choice.id}"
+        WizardStateStores::RedisStore.new(key:)
+      end
+
+      def action
+        'back' if !!params[:back]
+      end
+    end
+  end
+end

--- a/app/controllers/provider_interface/offer/ske_lengths_controller.rb
+++ b/app/controllers/provider_interface/offer/ske_lengths_controller.rb
@@ -1,50 +1,12 @@
 module ProviderInterface
   module Offer
-    class SkeLengthsController < ProviderInterfaceController
-      before_action :set_application_choice
-
-      def new
-        @wizard = OfferWizard.build_from_application_choice(
-          offer_store,
-          @application_choice,
-          provider_user_id: current_provider_user.id,
-          current_step: 'ske_length',
-          decision: :default,
-          action:,
-        )
-        @wizard.save_state!
-      end
-
-      def create
-        @wizard = OfferWizard.new(offer_store, { decision: :make_offer, current_step: 'ske_length' }.merge(ske_length_params))
-
-        if @wizard.valid_for_current_step?
-          @wizard.save_state!
-
-          redirect_to [:new, :provider_interface, @application_choice, :offer, @wizard.next_step]
-        else
-          track_validation_error(@wizard)
-          render 'new'
-        end
-      end
-
-    private
-
-      def offer_wizard_params
-        params[:provider_interface_offer_wizard] || ActionController::Parameters.new
-      end
-
-      def ske_length_params
+    class SkeLengthsController < SkeController
+      def ske_flow_params
         offer_wizard_params.permit(:ske_length)
       end
 
-      def offer_store
-        key = "offer_wizard_store_#{current_provider_user.id}_#{@application_choice.id}"
-        WizardStateStores::RedisStore.new(key:)
-      end
-
-      def action
-        'back' if !!params[:back]
+      def ske_flow_step
+        'ske_length'
       end
     end
   end

--- a/app/controllers/provider_interface/offer/ske_reasons_controller.rb
+++ b/app/controllers/provider_interface/offer/ske_reasons_controller.rb
@@ -1,50 +1,12 @@
 module ProviderInterface
   module Offer
-    class SkeReasonsController < ProviderInterfaceController
-      before_action :set_application_choice
-
-      def new
-        @wizard = OfferWizard.build_from_application_choice(
-          offer_store,
-          @application_choice,
-          provider_user_id: current_provider_user.id,
-          current_step: 'ske_reason',
-          decision: :default,
-          action:,
-        )
-        @wizard.save_state!
-      end
-
-      def create
-        @wizard = OfferWizard.new(offer_store, { decision: :make_offer, current_step: 'ske_reason' }.merge(ske_reason_params))
-
-        if @wizard.valid_for_current_step?
-          @wizard.save_state!
-
-          redirect_to [:new, :provider_interface, @application_choice, :offer, @wizard.next_step]
-        else
-          track_validation_error(@wizard)
-          render 'new'
-        end
-      end
-
-    private
-
-      def offer_wizard_params
-        params[:provider_interface_offer_wizard] || ActionController::Parameters.new
-      end
-
-      def ske_reason_params
+    class SkeReasonsController < SkeController
+      def ske_flow_params
         offer_wizard_params.permit(:ske_reason)
       end
 
-      def offer_store
-        key = "offer_wizard_store_#{current_provider_user.id}_#{@application_choice.id}"
-        WizardStateStores::RedisStore.new(key:)
-      end
-
-      def action
-        'back' if !!params[:back]
+      def ske_flow_step
+        'ske_reason'
       end
     end
   end

--- a/app/controllers/provider_interface/offer/ske_reasons_controller.rb
+++ b/app/controllers/provider_interface/offer/ske_reasons_controller.rb
@@ -1,0 +1,51 @@
+module ProviderInterface
+  module Offer
+    class SkeReasonsController < ProviderInterfaceController
+      before_action :set_application_choice
+
+      def new
+        @wizard = OfferWizard.build_from_application_choice(
+          offer_store,
+          @application_choice,
+          provider_user_id: current_provider_user.id,
+          current_step: 'ske_reason',
+          decision: :default,
+          action:,
+        )
+        @wizard.save_state!
+      end
+
+      def create
+        @wizard = OfferWizard.new(offer_store, { decision: :make_offer, current_step: 'ske_reason' }.merge(ske_reason_params))
+
+        if @wizard.valid_for_current_step?
+          @wizard.save_state!
+
+          redirect_to [:new, :provider_interface, @application_choice, :offer, @wizard.next_step]
+        else
+          track_validation_error(@wizard)
+          render 'new'
+        end
+      end
+
+    private
+
+      def offer_wizard_params
+        params[:provider_interface_offer_wizard] || ActionController::Parameters.new
+      end
+
+      def ske_reason_params
+        offer_wizard_params.permit(:ske_reason)
+      end
+
+      def offer_store
+        key = "offer_wizard_store_#{current_provider_user.id}_#{@application_choice.id}"
+        WizardStateStores::RedisStore.new(key:)
+      end
+
+      def action
+        'back' if !!params[:back]
+      end
+    end
+  end
+end

--- a/app/controllers/provider_interface/offer/ske_standard_flows_controller.rb
+++ b/app/controllers/provider_interface/offer/ske_standard_flows_controller.rb
@@ -1,0 +1,51 @@
+module ProviderInterface
+  module Offer
+    class SkeStandardFlowsController < ProviderInterfaceController
+      before_action :set_application_choice
+
+      def new
+        @wizard = OfferWizard.build_from_application_choice(
+          offer_store,
+          @application_choice,
+          provider_user_id: current_provider_user.id,
+          current_step: 'ske_standard_flow',
+          decision: :default,
+          action:,
+        )
+        @wizard.save_state!
+      end
+
+      def create
+        @wizard = OfferWizard.new(offer_store, { decision: :make_offer, current_step: 'ske_standard_flow' }.merge(ske_required_params))
+
+        if @wizard.valid_for_current_step?
+          @wizard.save_state!
+
+          redirect_to [:new, :provider_interface, @application_choice, :offer, @wizard.next_step]
+        else
+          track_validation_error(@wizard)
+          render 'new'
+        end
+      end
+
+    private
+
+      def offer_wizard_params
+        params[:provider_interface_offer_wizard] || ActionController::Parameters.new
+      end
+
+      def ske_required_params
+        offer_wizard_params.permit(:ske_required)
+      end
+
+      def offer_store
+        key = "offer_wizard_store_#{current_provider_user.id}_#{@application_choice.id}"
+        WizardStateStores::RedisStore.new(key:)
+      end
+
+      def action
+        'back' if !!params[:back]
+      end
+    end
+  end
+end

--- a/app/controllers/provider_interface/offer/ske_standard_flows_controller.rb
+++ b/app/controllers/provider_interface/offer/ske_standard_flows_controller.rb
@@ -1,50 +1,12 @@
 module ProviderInterface
   module Offer
-    class SkeStandardFlowsController < ProviderInterfaceController
-      before_action :set_application_choice
-
-      def new
-        @wizard = OfferWizard.build_from_application_choice(
-          offer_store,
-          @application_choice,
-          provider_user_id: current_provider_user.id,
-          current_step: 'ske_standard_flow',
-          decision: :default,
-          action:,
-        )
-        @wizard.save_state!
-      end
-
-      def create
-        @wizard = OfferWizard.new(offer_store, { decision: :make_offer, current_step: 'ske_standard_flow' }.merge(ske_required_params))
-
-        if @wizard.valid_for_current_step?
-          @wizard.save_state!
-
-          redirect_to [:new, :provider_interface, @application_choice, :offer, @wizard.next_step]
-        else
-          track_validation_error(@wizard)
-          render 'new'
-        end
-      end
-
-    private
-
-      def offer_wizard_params
-        params[:provider_interface_offer_wizard] || ActionController::Parameters.new
-      end
-
-      def ske_required_params
+    class SkeStandardFlowsController < SkeController
+      def ske_flow_params
         offer_wizard_params.permit(:ske_required)
       end
 
-      def offer_store
-        key = "offer_wizard_store_#{current_provider_user.id}_#{@application_choice.id}"
-        WizardStateStores::RedisStore.new(key:)
-      end
-
-      def action
-        'back' if !!params[:back]
+      def ske_flow_step
+        'ske_standard_flow'
       end
     end
   end

--- a/app/controllers/provider_interface/ske_controller.rb
+++ b/app/controllers/provider_interface/ske_controller.rb
@@ -1,0 +1,45 @@
+module ProviderInterface
+  class SkeController < ProviderInterfaceController
+    before_action :set_application_choice
+
+    def new
+      @wizard = OfferWizard.build_from_application_choice(
+        offer_store,
+        @application_choice,
+        provider_user_id: current_provider_user.id,
+        current_step: ske_flow_step,
+        decision: :default,
+        action:,
+      )
+      @wizard.save_state!
+    end
+
+    def create
+      @wizard = OfferWizard.new(offer_store, { decision: :make_offer, current_step: ske_flow_step }.merge(ske_flow_params))
+
+      if @wizard.valid_for_current_step?
+        @wizard.save_state!
+
+        redirect_to [:new, :provider_interface, @application_choice, :offer, @wizard.next_step]
+      else
+        track_validation_error(@wizard)
+        render 'new'
+      end
+    end
+
+  private
+
+    def offer_wizard_params
+      params[:provider_interface_offer_wizard] || ActionController::Parameters.new
+    end
+
+    def offer_store
+      key = "offer_wizard_store_#{current_provider_user.id}_#{@application_choice.id}"
+      WizardStateStores::RedisStore.new(key:)
+    end
+
+    def action
+      'back' if !!params[:back]
+    end
+  end
+end

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -13,13 +13,14 @@ module ProviderInterface
                   :standard_conditions, :further_condition_attrs, :decision,
                   :path_history,
                   :provider_user_id, :application_choice_id,
-                  :ske_required
+                  :ske_required, :ske_reason
 
     validates :decision, presence: true, on: %i[select_option]
     validates :course_option_id, presence: true, on: %i[locations save]
     validates :study_mode, presence: true, on: %i[study_modes save]
     validates :course_id, presence: true, on: %i[courses save]
     validates :ske_required, presence: true, on: %i[ske_standard_flow]
+    validates :ske_reason, presence: true, on: %i[ske_reason]
     validate :further_conditions_valid, on: %i[conditions]
     validate :max_conditions_length, on: %i[conditions]
     validate :course_option_details, if: :course_option_id, on: :save

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -3,6 +3,14 @@ module ProviderInterface
     include Wizard
     include Wizard::PathHistory
 
+    SKE_LENGTH = [
+      '8 weeks',
+      '12 weeks',
+      '16 weeks',
+      '20 weeks',
+      '24 weeks',
+      '28 weeks',
+    ].freeze
     STEPS = {
       make_offer: %i[select_option ske_standard_flow ske_reason ske_length conditions check],
       change_offer: %i[select_option providers courses study_modes locations conditions check],
@@ -13,7 +21,7 @@ module ProviderInterface
                   :standard_conditions, :further_condition_attrs, :decision,
                   :path_history,
                   :provider_user_id, :application_choice_id,
-                  :ske_required, :ske_reason
+                  :ske_required, :ske_reason, :ske_length
 
     validates :decision, presence: true, on: %i[select_option]
     validates :course_option_id, presence: true, on: %i[locations save]
@@ -21,6 +29,8 @@ module ProviderInterface
     validates :course_id, presence: true, on: %i[courses save]
     validates :ske_required, presence: true, on: %i[ske_standard_flow]
     validates :ske_reason, presence: true, on: %i[ske_reason]
+    validates :ske_length, presence: true, on: %i[ske_length]
+    validates :ske_length, inclusion: { in: SKE_LENGTH }, on: %i[ske_length], allow_blank: true
     validate :further_conditions_valid, on: %i[conditions]
     validate :max_conditions_length, on: %i[conditions]
     validate :course_option_details, if: :course_option_id, on: :save

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -128,6 +128,23 @@ module ProviderInterface
         available_study_modes.length > 1 || available_course_options.length > 1
     end
 
+    def different_degree_option(application_choice)
+      I18n.t(
+        'provider_interface.offer.ske_reasons.new.different_degree',
+        degree_subject: application_choice.current_course.subjects.first&.name,
+      )
+    end
+
+    def outdated_degree(application_choice)
+      graduation_date = application_choice.current_course.start_date - 5.years
+
+      I18n.t(
+        'provider_interface.offer.ske_reasons.new.outdated_degree',
+        degree_subject: application_choice.current_course.subjects.first&.name,
+        graduation_date: graduation_date.to_fs(:month_and_year),
+      )
+    end
+
   private
 
     def self.standard_conditions_from(offer)

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -3,8 +3,10 @@ module ProviderInterface
     include Wizard
     include Wizard::PathHistory
 
-    STEPS = { make_offer: %i[select_option conditions check],
-              change_offer: %i[select_option providers courses study_modes locations conditions check] }.freeze
+    STEPS = {
+      make_offer: %i[select_option ske_standard_flow ske_reason ske_length conditions check],
+      change_offer: %i[select_option providers courses study_modes locations conditions check]
+    }.freeze
     MAX_FURTHER_CONDITIONS = OfferValidations::MAX_CONDITIONS_COUNT - OfferCondition::STANDARD_CONDITIONS.length
 
     attr_accessor :provider_id, :course_id, :course_option_id, :study_mode,
@@ -52,6 +54,10 @@ module ProviderInterface
     def next_step(step = current_step)
       index = STEPS[decision.to_sym].index(step.to_sym)
       return unless index
+
+      if FeatureFlag.inactive?(:provider_ske)
+        @decision = :conditions
+      end
 
       next_step = STEPS[decision.to_sym][index + 1]
 

--- a/app/views/provider_interface/offer/conditions/_form.html.erb
+++ b/app/views/provider_interface/offer/conditions/_form.html.erb
@@ -31,7 +31,11 @@
           tabindex: '-1',
         },
       ) do %>
+      <% if FeatureFlag.active?(:provider_ske) %>
+        <p class="govuk-body">For example, completing their degree with a certain grade.</p>
+      <% else %>
         <p class="govuk-body">For example, studying a subject knowledge enhancement course.</p>
+      <% end %>
 
         <%= render 'provider_interface/offer/conditions/further_condition', form: f, model: Struct.new(:id, :condition_id, :text).new('placeholder', nil, nil), label_text: 'placeholder', disabled: true %>
 

--- a/app/views/provider_interface/offer/ske_lengths/new.html.erb
+++ b/app/views/provider_interface/offer/ske_lengths/new.html.erb
@@ -6,9 +6,7 @@
     <%= form_with model: @wizard, url: provider_interface_application_choice_offer_ske_length_path(@application_choice), method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l"><%= t('caption.make_offer', name: @application_choice.application_form.full_name) %></span>
-
-      <%= f.govuk_radio_buttons_fieldset :ske_length, legend: { text: 'How long must their SKE course be?', size: 'l' } do %>
+      <%= f.govuk_radio_buttons_fieldset :ske_length, legend: { text: 'How long must their SKE course be?', size: 'l' }, caption: { text: t('caption.make_offer', name: @application_choice.application_form.full_name), size: 'l' } do %>
           <% ProviderInterface::OfferWizard::SKE_LENGTH.each do |value| %>
             <%= f.govuk_radio_button :ske_length, value, label: { text: value }, link_errors: true %>
           <% end %>

--- a/app/views/provider_interface/offer/ske_lengths/new.html.erb
+++ b/app/views/provider_interface/offer/ske_lengths/new.html.erb
@@ -7,8 +7,8 @@
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :ske_length, legend: { text: 'How long must their SKE course be?', size: 'l' }, caption: { text: t('caption.make_offer', name: @application_choice.application_form.full_name), size: 'l' } do %>
-          <% ProviderInterface::OfferWizard::SKE_LENGTH.each do |value| %>
-            <%= f.govuk_radio_button :ske_length, value, label: { text: value }, link_errors: true %>
+          <% ProviderInterface::OfferWizard::SKE_LENGTH.each_with_index do |value, index| %>
+            <%= f.govuk_radio_button :ske_length, value, label: { text: value }, link_errors: index.zero? %>
           <% end %>
       <% end %>
       <%= f.govuk_submit t('continue') %>

--- a/app/views/provider_interface/offer/ske_lengths/new.html.erb
+++ b/app/views/provider_interface/offer/ske_lengths/new.html.erb
@@ -1,0 +1,19 @@
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, :new, back: true)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @wizard, url: provider_interface_application_choice_offer_ske_length_path(@application_choice), method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <span class="govuk-caption-l"><%= t('caption.make_offer', name: @application_choice.application_form.full_name) %></span>
+
+      <%= f.govuk_radio_buttons_fieldset :ske_length, legend: { text: 'How long must their SKE course be?', size: 'l' } do %>
+          <% ProviderInterface::OfferWizard::SKE_LENGTH.each do |value| %>
+            <%= f.govuk_radio_button :ske_length, value, label: { text: value }, link_errors: true %>
+          <% end %>
+      <% end %>
+      <%= f.govuk_submit t('continue') %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/provider_interface/offer/ske_lengths/new.html.erb
+++ b/app/views/provider_interface/offer/ske_lengths/new.html.erb
@@ -7,9 +7,9 @@
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :ske_length, legend: { text: 'How long must their SKE course be?', size: 'l' }, caption: { text: t('caption.make_offer', name: @application_choice.application_form.full_name), size: 'l' } do %>
-          <% ProviderInterface::OfferWizard::SKE_LENGTH.each_with_index do |value, index| %>
-            <%= f.govuk_radio_button :ske_length, value, label: { text: value }, link_errors: index.zero? %>
-          <% end %>
+        <% ProviderInterface::OfferWizard::SKE_LENGTH.each_with_index do |value, index| %>
+          <%= f.govuk_radio_button :ske_length, value, label: { text: value }, link_errors: index.zero? %>
+        <% end %>
       <% end %>
       <%= f.govuk_submit t('continue') %>
     <% end %>

--- a/app/views/provider_interface/offer/ske_reasons/new.html.erb
+++ b/app/views/provider_interface/offer/ske_reasons/new.html.erb
@@ -6,9 +6,7 @@
     <%= form_with model: @wizard, url: provider_interface_application_choice_offer_ske_reason_path(@application_choice), method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l"><%= t('caption.make_offer', name: @application_choice.application_form.full_name) %></span>
-
-      <%= f.govuk_radio_buttons_fieldset :ske_reason, legend: { text: 'Why do they need to take a subject knowledge enhancement (SKE) course?', size: 'l' }, hint: { text: 'We’ll show your answer to the candidate.', size: 'm' } do %>
+      <%= f.govuk_radio_buttons_fieldset :ske_reason, legend: { text: 'Why do they need to take a subject knowledge enhancement (SKE) course?', size: 'l' }, hint: { text: 'We’ll show your answer to the candidate.', size: 'm' }, caption: { text: t('caption.make_offer', name: @application_choice.application_form.full_name), size: 'l' } do %>
         <%= f.govuk_radio_button :ske_reason, t('.different_degree', degree_subject: @application_choice.current_course.name), label: { text: t('.different_degree', degree_subject: @application_choice.current_course.name) }, link_errors: true %>
         <%= f.govuk_radio_button :ske_reason, t('.outdated_degree', degree_subject: @application_choice.current_course.name, graduation_date: (@application_choice.current_course.start_date - 5.years).to_fs(:month_and_year)), label: { text: t('.outdated_degree', degree_subject: @application_choice.current_course.name, graduation_date: (@application_choice.current_course.start_date - 5.years).to_fs(:month_and_year)) } %>
       <% end %>

--- a/app/views/provider_interface/offer/ske_reasons/new.html.erb
+++ b/app/views/provider_interface/offer/ske_reasons/new.html.erb
@@ -1,0 +1,18 @@
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, :new, back: true)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @wizard, url: provider_interface_application_choice_offer_ske_reason_path(@application_choice), method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <span class="govuk-caption-l"><%= t('caption.make_offer', name: @application_choice.application_form.full_name) %></span>
+
+      <%= f.govuk_radio_buttons_fieldset :ske_reason, legend: { text: 'Why do they need to take a subject knowledge enhancement (SKE) course?', size: 'l' }, hint: { text: 'We’ll show your answer to the candidate.', size: 'm' } do %>
+        <%= f.govuk_radio_button :ske_reason, t('.different_degree', degree_subject: @application_choice.current_course.name), label: { text: t('.different_degree', degree_subject: @application_choice.current_course.name) }, link_errors: true %>
+        <%= f.govuk_radio_button :ske_reason, t('.outdated_degree', degree_subject: @application_choice.current_course.name, graduation_date: (@application_choice.current_course.start_date - 5.years).to_fs(:month_and_year)), label: { text: t('.outdated_degree', degree_subject: @application_choice.current_course.name, graduation_date: (@application_choice.current_course.start_date - 5.years).to_fs(:month_and_year)) } %>
+      <% end %>
+      <%= f.govuk_submit t('continue') %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/provider_interface/offer/ske_reasons/new.html.erb
+++ b/app/views/provider_interface/offer/ske_reasons/new.html.erb
@@ -7,8 +7,9 @@
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :ske_reason, legend: { text: 'Why do they need to take a subject knowledge enhancement (SKE) course?', size: 'l' }, hint: { text: 'We’ll show your answer to the candidate.', size: 'm' }, caption: { text: t('caption.make_offer', name: @application_choice.application_form.full_name), size: 'l' } do %>
-        <%= f.govuk_radio_button :ske_reason, t('.different_degree', degree_subject: @application_choice.current_course.name), label: { text: t('.different_degree', degree_subject: @application_choice.current_course.name) }, link_errors: true %>
-        <%= f.govuk_radio_button :ske_reason, t('.outdated_degree', degree_subject: @application_choice.current_course.name, graduation_date: (@application_choice.current_course.start_date - 5.years).to_fs(:month_and_year)), label: { text: t('.outdated_degree', degree_subject: @application_choice.current_course.name, graduation_date: (@application_choice.current_course.start_date - 5.years).to_fs(:month_and_year)) } %>
+        <%= f.govuk_radio_button :ske_reason, f.object.different_degree_option(@application_choice),
+          label: { text: f.object.different_degree_option(@application_choice) }, link_errors: true %>
+        <%= f.govuk_radio_button :ske_reason, f.object.outdated_degree(@application_choice), label: { text: f.object.outdated_degree(@application_choice) } %>
       <% end %>
       <%= f.govuk_submit t('continue') %>
     <% end %>

--- a/app/views/provider_interface/offer/ske_standard_flows/new.html.erb
+++ b/app/views/provider_interface/offer/ske_standard_flows/new.html.erb
@@ -16,7 +16,7 @@
         <li>are eligible for student finance (home fee status)</li>
       </ul>
 
-      <%= f.govuk_radio_buttons_fieldset :ske_required, legend: { text: "Do you require #{@application_choice.application_form.full_name} to take a SKE course in #{@application_choice.current_course.name} that will be funded by the DfE?", size: 'm' } do %>
+      <%= f.govuk_radio_buttons_fieldset :ske_required, legend: { text: "Do you require #{@application_choice.application_form.full_name} to take a SKE course in #{@application_choice.current_course.subjects.first&.name} that will be funded by the DfE?", size: 'm' } do %>
         <%= f.govuk_radio_button :ske_required, true, label: { text: 'Yes' }, link_errors: true %>
         <%= f.govuk_radio_button :ske_required, false, label: { text: 'No' } %>
       <% end %>

--- a/app/views/provider_interface/offer/ske_standard_flows/new.html.erb
+++ b/app/views/provider_interface/offer/ske_standard_flows/new.html.erb
@@ -1,0 +1,26 @@
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, :new, back: true)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @wizard, url: provider_interface_application_choice_offer_ske_standard_flow_path(@application_choice), method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <span class="govuk-caption-l"><%= t('caption.make_offer', name: @application_choice.application_form.full_name) %></span>
+      <h1 class="govuk-heading-l">Subject knowledge enhancement (SKE) courses</h1>
+
+      <p class="govuk-body">The Department for Education (DfE) will pay candidates to take a SKE course if they need one, so long as they:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>have a 2:2 degree or higher, or are expected to get this when they graduate</li>
+        <li>are eligible for student finance (home fee status)</li>
+      </ul>
+
+      <%= f.govuk_radio_buttons_fieldset :ske_required, legend: { text: "Do you require #{@application_choice.application_form.full_name} to take a SKE course in mathematics that will be funded by the DfE?", size: 'm' } do %>
+        <%= f.govuk_radio_button :ske_required, true, label: { text: 'Yes' }, link_errors: true %>
+        <%= f.govuk_radio_button :ske_required, false, label: { text: 'No' } %>
+      <% end %>
+      <%= f.govuk_submit t('continue') %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/provider_interface/offer/ske_standard_flows/new.html.erb
+++ b/app/views/provider_interface/offer/ske_standard_flows/new.html.erb
@@ -16,7 +16,7 @@
         <li>are eligible for student finance (home fee status)</li>
       </ul>
 
-      <%= f.govuk_radio_buttons_fieldset :ske_required, legend: { text: "Do you require #{@application_choice.application_form.full_name} to take a SKE course in mathematics that will be funded by the DfE?", size: 'm' } do %>
+      <%= f.govuk_radio_buttons_fieldset :ske_required, legend: { text: "Do you require #{@application_choice.application_form.full_name} to take a SKE course in #{@application_choice.current_course.name} that will be funded by the DfE?", size: 'm' } do %>
         <%= f.govuk_radio_button :ske_required, true, label: { text: 'Yes' }, link_errors: true %>
         <%= f.govuk_radio_button :ske_required, false, label: { text: 'No' } %>
       <% end %>

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -84,7 +84,7 @@ en:
             ske_reason:
               blank: Select why the candidate needs to take a course
             ske_length:
-              blank: Select how long the course should be
+              blank: Select how long the course must be
             decision:
               blank: Select decision
             course_option_id:

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -8,6 +8,9 @@ en:
         title: Make a decision
         select:  Decision
     offer:
+      ske_standard_flows:
+        new:
+          title: Subject knowledge enhancement (SKE) courses
       providers:
         new:
           title: Training provider

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -16,6 +16,9 @@ en:
           title: Why do they need to take a SKE course
           different_degree: Their degree subject was not %{degree_subject}
           outdated_degree: Their degree subject was %{degree_subject}, but they graduated before %{graduation_date}
+      ske_lengths:
+        new:
+          title: How long must their SKE course be
       providers:
         new:
           title: Training provider

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -79,6 +79,12 @@ en:
       models:
         provider_interface/offer_wizard:
           attributes:
+            ske_required:
+              blank: Select if you require the candidate to do a course
+            ske_reason:
+              blank: Select why the candidate needs to take a course
+            ske_length:
+              blank: Select how long the course should be
             decision:
               blank: Select decision
             course_option_id:

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -11,6 +11,11 @@ en:
       ske_standard_flows:
         new:
           title: Subject knowledge enhancement (SKE) courses
+      ske_reasons:
+        new:
+          title: Why do they need to take a SKE course
+          different_degree: Their degree subject was not %{degree_subject}
+          outdated_degree: Their degree subject was %{degree_subject}, but they graduated before %{graduation_date}
       providers:
         new:
           title: Training provider

--- a/config/routes/provider.rb
+++ b/config/routes/provider.rb
@@ -74,8 +74,8 @@ namespace :provider_interface, path: '/provider' do
       resource :locations, only: %i[new create edit update]
       resource :conditions, only: %i[new create edit update]
       resource :check, only: %i[new edit]
-      resource :ske_standard_flow, only: %i[new create], as: :ske_standard_flow
-      resource :ske_reason, only: %i[new create]
+      resource :ske_standard_flow, only: %i[new create], as: :ske_standard_flow, path: 'ske-standard-flow'
+      resource :ske_reason, only: %i[new create], path: 'ske-reason'
       resource :ske_length, only: %i[new create], path: 'ske-length'
     end
 

--- a/config/routes/provider.rb
+++ b/config/routes/provider.rb
@@ -76,6 +76,7 @@ namespace :provider_interface, path: '/provider' do
       resource :check, only: %i[new edit]
       resource :ske_standard_flow, only: %i[new create], as: :ske_standard_flow
       resource :ske_reason, only: %i[new create]
+      resource :ske_length, only: %i[new create], path: 'ske-length'
     end
 
     namespace :courses, as: :application_choice_course do

--- a/config/routes/provider.rb
+++ b/config/routes/provider.rb
@@ -74,6 +74,7 @@ namespace :provider_interface, path: '/provider' do
       resource :locations, only: %i[new create edit update]
       resource :conditions, only: %i[new create edit update]
       resource :check, only: %i[new edit]
+      resource :ske_standard_flow, only: %i[new create], as: :ske_standard_flow
     end
 
     namespace :courses, as: :application_choice_course do

--- a/config/routes/provider.rb
+++ b/config/routes/provider.rb
@@ -75,6 +75,7 @@ namespace :provider_interface, path: '/provider' do
       resource :conditions, only: %i[new create edit update]
       resource :check, only: %i[new edit]
       resource :ske_standard_flow, only: %i[new create], as: :ske_standard_flow
+      resource :ske_reason, only: %i[new create]
     end
 
     namespace :courses, as: :application_choice_course do

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -154,6 +154,10 @@ RSpec.describe ProviderInterface::OfferWizard do
 
   describe '#next_step' do
     context 'when making an offer' do
+      before do
+        FeatureFlag.deactivate(:provider_ske)
+      end
+
       let(:decision) { :make_offer }
 
       context 'when current_step is :select_option' do

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe ProviderInterface::OfferWizard do
     it { is_expected.to validate_presence_of(:course_id).on(:courses) }
     it { is_expected.to validate_presence_of(:course_id).on(:save) }
     it { is_expected.to validate_presence_of(:ske_required).on(:ske_standard_flow) }
+    it { is_expected.to validate_presence_of(:ske_reason).on(:ske_reason) }
 
     context 'if a further condition is too long' do
       let(:further_condition_1) { Faker::Lorem.paragraph_by_chars(number: 300) }

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -58,6 +58,8 @@ RSpec.describe ProviderInterface::OfferWizard do
     it { is_expected.to validate_presence_of(:course_id).on(:save) }
     it { is_expected.to validate_presence_of(:ske_required).on(:ske_standard_flow) }
     it { is_expected.to validate_presence_of(:ske_reason).on(:ske_reason) }
+    it { is_expected.to validate_presence_of(:ske_length).on(:ske_length) }
+    it { is_expected.to validate_inclusion_of(:ske_length).in_array(described_class::SKE_LENGTH).on(:ske_length) }
 
     context 'if a further condition is too long' do
       let(:further_condition_1) { Faker::Lorem.paragraph_by_chars(number: 300) }

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe ProviderInterface::OfferWizard do
     it { is_expected.to validate_presence_of(:study_mode).on(:save) }
     it { is_expected.to validate_presence_of(:course_id).on(:courses) }
     it { is_expected.to validate_presence_of(:course_id).on(:save) }
+    it { is_expected.to validate_presence_of(:ske_required).on(:ske_standard_flow) }
 
     context 'if a further condition is too long' do
       let(:further_condition_1) { Faker::Lorem.paragraph_by_chars(number: 300) }

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe ProviderInterface::OfferWizard do
         further_condition_attrs: further_condition_attrs,
         current_step: current_step,
         decision: decision,
+        ske_required: ske_required,
       },
     )
   end
@@ -22,6 +23,7 @@ RSpec.describe ProviderInterface::OfferWizard do
   let(:course_id) { nil }
   let(:course_option_id) { nil }
   let(:study_mode) { nil }
+  let(:ske_required) { nil }
   let(:application_choice_id) { create(:application_choice).id }
   let(:standard_conditions) { OfferCondition::STANDARD_CONDITIONS }
   let(:further_condition_1) { '' }
@@ -174,6 +176,30 @@ RSpec.describe ProviderInterface::OfferWizard do
 
         it 'returns :check' do
           expect(wizard.next_step).to eq(:check)
+        end
+      end
+
+      context 'when ske feature flag is active' do
+        before do
+          FeatureFlag.activate(:provider_ske)
+        end
+
+        context 'when ske is required' do
+          let(:current_step) { :ske_standard_flow }
+          let(:ske_required) { 'true' }
+
+          it 'returns :ske_reason' do
+            expect(wizard.next_step).to eq(:ske_reason)
+          end
+        end
+
+        context 'when ske is not required' do
+          let(:current_step) { :ske_standard_flow }
+          let(:ske_required) { 'false' }
+
+          it 'returns :conditions' do
+            expect(wizard.next_step).to eq(:conditions)
+          end
         end
       end
     end

--- a/spec/system/provider_interface/make_offer_cancels_upcoming_interview_spec.rb
+++ b/spec/system/provider_interface/make_offer_cancels_upcoming_interview_spec.rb
@@ -21,6 +21,7 @@ RSpec.feature 'Provider makes an offer on an application with interviews in the 
   scenario 'Making an offer for the requested course option cancels upcoming interviews' do
     given_i_am_a_provider_user
     and_i_am_permitted_to_make_decisions_for_my_provider
+    and_provider_ske_feature_flag_is_disabled
     and_i_sign_in_to_the_provider_interface
 
     when_i_make_an_offer_on_an_application_with_interviews
@@ -37,6 +38,10 @@ RSpec.feature 'Provider makes an offer on an application with interviews in the 
 
   def and_i_am_permitted_to_make_decisions_for_my_provider
     permit_make_decisions!
+  end
+
+  def and_provider_ske_feature_flag_is_disabled
+    FeatureFlag.deactivate(:provider_ske)
   end
 
   def and_i_sign_in_to_the_provider_interface

--- a/spec/system/provider_interface/make_offer_feature_flag_spec.rb
+++ b/spec/system/provider_interface/make_offer_feature_flag_spec.rb
@@ -21,6 +21,7 @@ RSpec.feature 'Provider makes an offer' do
   scenario 'Making an offer for the requested course option' do
     given_i_am_a_provider_user
     and_i_am_permitted_to_make_decisions_for_my_provider
+    and_provider_ske_feature_flag_is_disabled
     and_i_sign_in_to_the_provider_interface
 
     given_the_provider_has_multiple_courses
@@ -86,6 +87,10 @@ RSpec.feature 'Provider makes an offer' do
 
   def and_i_am_permitted_to_make_decisions_for_my_provider
     permit_make_decisions!
+  end
+
+  def and_provider_ske_feature_flag_is_disabled
+    FeatureFlag.deactivate(:provider_ske)
   end
 
   def and_i_sign_in_to_the_provider_interface

--- a/spec/system/provider_interface/make_offer_ske_standard_flow_feature_flag_enabled_spec.rb
+++ b/spec/system/provider_interface/make_offer_ske_standard_flow_feature_flag_enabled_spec.rb
@@ -299,7 +299,7 @@ RSpec.feature 'Provider makes an offer with SKE enabled' do
   end
 
   def then_the_ske_standard_flow_is_loaded
-    expect(page).to have_current_path("/provider/applications/#{application_choice.id}/offer/ske_standard_flow/new", ignore_query: true)
+    expect(page).to have_current_path("/provider/applications/#{application_choice.id}/offer/ske-standard-flow/new", ignore_query: true)
   end
 
   def when_i_dont_select_any_ske_answer
@@ -324,7 +324,7 @@ RSpec.feature 'Provider makes an offer with SKE enabled' do
   end
 
   def then_the_ske_reason_page_is_loaded
-    expect(page).to have_current_path("/provider/applications/#{application_choice.id}/offer/ske_reason/new", ignore_query: true)
+    expect(page).to have_current_path("/provider/applications/#{application_choice.id}/offer/ske-reason/new", ignore_query: true)
   end
 
   def when_i_dont_give_a_ske_reason
@@ -341,7 +341,7 @@ RSpec.feature 'Provider makes an offer with SKE enabled' do
   end
 
   def then_the_ske_length_page_is_loaded
-    expect(page).to have_current_path("/provider/applications/#{application_choice.id}/offer/ske_length/new", ignore_query: true)
+    expect(page).to have_current_path("/provider/applications/#{application_choice.id}/offer/ske-length/new", ignore_query: true)
   end
 
   def when_i_dont_answer_ske_length

--- a/spec/system/provider_interface/make_offer_ske_standard_flow_feature_flag_enabled_spec.rb
+++ b/spec/system/provider_interface/make_offer_ske_standard_flow_feature_flag_enabled_spec.rb
@@ -337,7 +337,7 @@ RSpec.feature 'Provider makes an offer with SKE enabled' do
   end
 
   def when_i_add_a_ske_reason
-    choose t('provider_interface.offer.ske_reasons.new.different_degree', degree_subject: application_choice.current_course.name)
+    choose t('provider_interface.offer.ske_reasons.new.different_degree', degree_subject: application_choice.current_course.subjects.first.name)
   end
 
   def then_the_ske_length_page_is_loaded

--- a/spec/system/provider_interface/make_offer_ske_standard_flow_feature_flag_enabled_spec.rb
+++ b/spec/system/provider_interface/make_offer_ske_standard_flow_feature_flag_enabled_spec.rb
@@ -354,6 +354,6 @@ RSpec.feature 'Provider makes an offer with SKE enabled' do
   end
 
   def when_i_answer_the_ske_length
-    page.find(:xpath, "//input[@value='8 weeks']").choose
+    choose '8 weeks'
   end
 end

--- a/spec/system/provider_interface/make_offer_ske_standard_flow_feature_flag_enabled_spec.rb
+++ b/spec/system/provider_interface/make_offer_ske_standard_flow_feature_flag_enabled_spec.rb
@@ -1,0 +1,359 @@
+require 'rails_helper'
+
+RSpec.feature 'Provider makes an offer with SKE enabled' do
+  include DfESignInHelpers
+  include ProviderUserPermissionsHelper
+
+  let(:provider_user) { create(:provider_user, :with_dfe_sign_in) }
+  let(:provider) { provider_user.providers.first }
+  let(:ratifying_provider) { create(:provider) }
+  let(:application_form) { build(:application_form, :minimum_info) }
+  let!(:application_choice) do
+    create(:application_choice, :awaiting_provider_decision,
+           application_form:,
+           course_option:)
+  end
+  let(:course) do
+    build(:course, :full_time, provider:, accredited_provider: ratifying_provider)
+  end
+  let(:course_option) { build(:course_option, course:) }
+
+  scenario 'Making an offer for the requested course option' do
+    given_i_am_a_provider_user
+    and_i_am_permitted_to_make_decisions_for_my_provider
+    and_i_sign_in_to_the_provider_interface
+    and_provider_ske_feature_flag_is_enabled
+
+    given_the_provider_has_multiple_courses
+    given_the_provider_user_can_offer_multiple_provider_courses
+
+    when_i_visit_the_provider_interface
+    and_i_click_an_application_choice_awaiting_decision
+    and_i_click_on_make_decision
+    then_i_see_the_decision_page
+
+    when_i_choose_to_make_an_offer
+
+    then_the_ske_standard_flow_is_loaded
+    when_i_dont_select_any_ske_answer
+    then_i_should_see_a_error_message_to_select_if_ske_required
+
+    when_i_select_no_ske_required
+    and_i_click_continue
+    then_the_conditions_page_is_loaded
+
+    and_i_click_back
+
+    when_i_select_ske_is_required
+    and_i_click_continue
+    then_the_ske_reason_page_is_loaded
+
+    when_i_dont_give_a_ske_reason
+    then_i_should_see_a_error_message_to_give_a_reason_for_ske
+
+    when_i_add_a_ske_reason
+    and_i_click_continue
+    then_the_ske_length_page_is_loaded
+
+    when_i_dont_answer_ske_length
+    then_i_should_see_a_error_message_to_give_a_ske_course_length
+
+    when_i_answer_the_ske_length
+    and_i_click_continue
+    then_the_conditions_page_is_loaded
+    and_the_default_conditions_are_checked
+
+    when_i_add_further_conditions
+    and_i_add_and_remove_another_condition
+    and_i_click_continue
+    then_the_review_page_is_loaded
+    and_i_can_confirm_my_answers
+
+    when_i_click_change_course
+    then_i_am_taken_to_the_change_course_page
+    when_i_select_a_course_with_one_study_mode
+    and_i_click_continue
+    when_i_select_a_new_location
+    and_i_click_continue
+    then_the_conditions_page_is_loaded
+    and_i_click_continue
+    then_the_review_page_is_loaded
+
+    and_i_can_confirm_the_new_course_selection
+    and_i_can_confirm_the_new_study_mode_selection
+    and_i_can_confirm_the_new_location_selection
+
+    when_i_click_change_provider
+    then_i_am_taken_to_the_change_provider_page
+
+    when_i_select_a_different_provider
+    and_i_click_continue
+    when_i_select_a_different_course
+    and_i_click_continue
+    when_i_select_a_different_study_mode
+    and_i_click_continue
+    when_i_select_a_new_location
+    and_i_click_continue
+    then_the_conditions_page_is_loaded
+    and_i_click_continue
+    then_the_review_page_is_loaded
+
+    and_i_can_confirm_the_new_provider_selection
+    and_i_can_confirm_the_new_course_selection
+    and_i_can_confirm_the_new_study_mode_selection
+    and_i_can_confirm_the_new_location_selection
+
+    when_i_send_the_offer
+    then_i_see_that_the_offer_was_successfuly_made
+  end
+
+  def given_i_am_a_provider_user
+    user_exists_in_dfe_sign_in(email_address: provider_user.email_address)
+  end
+
+  def and_i_am_permitted_to_make_decisions_for_my_provider
+    permit_make_decisions!
+  end
+
+  def and_i_sign_in_to_the_provider_interface
+    provider_signs_in_using_dfe_sign_in
+  end
+
+  def and_provider_ske_feature_flag_is_enabled
+    FeatureFlag.activate(:provider_ske)
+  end
+
+  def when_i_visit_the_provider_interface
+    visit provider_interface_applications_path
+  end
+
+  def and_i_click_an_application_choice_awaiting_decision
+    click_on application_choice.application_form.full_name
+  end
+
+  def and_i_click_on_make_decision
+    click_on 'Make decision'
+  end
+
+  def then_i_see_the_decision_page
+    expect(page).to have_content('Make a decision')
+    expect(page).to have_content('Course applied for')
+  end
+
+  def when_i_choose_to_make_an_offer
+    choose 'Make an offer'
+    and_i_click_continue
+  end
+
+  def then_the_conditions_page_is_loaded
+    expect(page).to have_content('Conditions of offer')
+  end
+
+  def and_the_default_conditions_are_checked
+    expect(find("input[value='Fitness to train to teach check']")).to be_checked
+    expect(find("input[value='Disclosure and Barring Service (DBS) check']")).to be_checked
+  end
+
+  def when_i_add_further_conditions
+    click_on 'Add another condition'
+    fill_in('provider_interface_offer_wizard[further_conditions][0][text]', with: 'A* on Maths A Level')
+    expect(page.current_url).to include('#provider-interface-offer-wizard-further-conditions-0-text-field')
+  end
+
+  def and_i_add_and_remove_another_condition
+    click_on 'Add another condition'
+    fill_in('provider_interface_offer_wizard[further_conditions][1][text]', with: 'A condition that will be removed')
+    click_on 'Remove condition 2'
+  end
+
+  def and_i_click_continue
+    click_on t('continue')
+  end
+
+  def then_the_review_page_is_loaded
+    expect(page).to have_content('Check and send offer')
+  end
+
+  def and_i_can_confirm_my_answers
+    within('.app-offer-panel') do
+      expect(page).to have_content('A* on Maths A Level')
+    end
+  end
+
+  def when_i_select_a_new_location
+    choose @selected_course_option.site_name
+  end
+
+  def and_i_can_confirm_the_new_location_selection
+    within(all('.govuk-summary-list__row')[3]) do
+      expect(page).to have_content(@selected_course_option.site.name_and_address(' '))
+    end
+  end
+
+  def when_i_select_a_different_study_mode
+    choose @selected_course_option.study_mode.humanize
+  end
+
+  def and_i_can_confirm_the_new_study_mode_selection
+    within(all('.govuk-summary-list__row')[2]) do
+      expect(page).to have_content(@selected_course_option.study_mode.humanize)
+    end
+  end
+
+  def given_the_provider_has_multiple_courses
+    @provider_available_course = create(:course, :open_on_apply, study_mode: :full_time, provider:, accredited_provider: ratifying_provider)
+    create(:course, :open_on_apply, provider:)
+    course_options = [create(:course_option, :full_time, course: @provider_available_course),
+                      create(:course_option, :full_time, course: @provider_available_course),
+                      create(:course_option, :full_time, course: @provider_available_course)]
+
+    @provider_available_course_option = course_options.sample
+  end
+
+  def when_i_select_a_different_course
+    choose @selected_course.name_and_code
+  end
+
+  alias_method :when_i_select_a_course_with_one_study_mode, :when_i_select_a_different_course
+
+  def when_i_click_change_course
+    @selected_course = @provider_available_course
+    @selected_course_option = @provider_available_course_option
+
+    within(all('.govuk-summary-list__row')[1]) do
+      click_on 'Change'
+    end
+  end
+
+  def then_i_am_taken_to_the_change_course_page
+    expect(page).to have_content('Course')
+  end
+
+  def and_i_can_confirm_the_new_course_selection
+    within(all('.govuk-summary-list__row')[1]) do
+      expect(page).to have_content(@selected_course.name_and_code)
+    end
+  end
+
+  def given_the_provider_user_can_offer_multiple_provider_courses
+    @available_provider = create(:provider, :with_signed_agreement)
+    create(:provider_permissions, provider: @available_provider, provider_user:, make_decisions: true)
+    courses = [create(:course, study_mode: :full_time_or_part_time, provider: @available_provider, accredited_provider: ratifying_provider),
+               create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @available_provider, accredited_provider: ratifying_provider)]
+    @selected_provider_available_course = courses.sample
+
+    course_options = [create(:course_option, :part_time, course: @selected_provider_available_course),
+                      create(:course_option, :full_time, course: @selected_provider_available_course),
+                      create(:course_option, :full_time, course: @selected_provider_available_course),
+                      create(:course_option, :part_time, course: @selected_provider_available_course)]
+
+    create(
+      :provider_relationship_permissions,
+      training_provider: provider,
+      ratifying_provider:,
+      ratifying_provider_can_make_decisions: true,
+    )
+
+    create(
+      :provider_relationship_permissions,
+      training_provider: @available_provider,
+      ratifying_provider:,
+      ratifying_provider_can_make_decisions: true,
+    )
+
+    @selected_provider_available_course_option = course_options.sample
+  end
+
+  def when_i_click_change_provider
+    @selected_provider = @available_provider
+    @selected_course = @selected_provider_available_course
+    @selected_course_option = @selected_provider_available_course_option
+
+    within(all('.govuk-summary-list__row')[0]) do
+      click_on 'Change'
+    end
+  end
+
+  def then_i_am_taken_to_the_change_provider_page
+    expect(page).to have_content('Training provider')
+  end
+
+  def when_i_select_a_different_provider
+    choose @selected_provider.name_and_code
+  end
+
+  def and_i_can_confirm_the_new_provider_selection
+    within(all('.govuk-summary-list__row')[0]) do
+      expect(page).to have_content(@selected_provider.name_and_code)
+    end
+  end
+
+  def when_i_send_the_offer
+    click_on 'Send offer'
+  end
+
+  def then_i_see_that_the_offer_was_successfuly_made
+    within('.govuk-notification-banner--success') do
+      expect(page).to have_content('Offer sent')
+    end
+  end
+
+  def then_the_ske_standard_flow_is_loaded
+    expect(page).to have_current_path("/provider/applications/#{application_choice.id}/offer/ske_standard_flow/new", ignore_query: true)
+  end
+
+  def when_i_dont_select_any_ske_answer
+    click_on 'Continue'
+  end
+
+  def then_i_should_see_a_error_message_to_select_if_ske_required
+    expect(page).to have_content('There is a problem')
+    expect(page).to have_content('Select if you require the candidate to do a course')
+  end
+
+  def when_i_select_no_ske_required
+    choose 'No'
+  end
+
+  def and_i_click_back
+    click_link 'Back'
+  end
+
+  def when_i_select_ske_is_required
+    choose 'Yes'
+  end
+
+  def then_the_ske_reason_page_is_loaded
+    expect(page).to have_current_path("/provider/applications/#{application_choice.id}/offer/ske_reason/new", ignore_query: true)
+  end
+
+  def when_i_dont_give_a_ske_reason
+    click_on 'Continue'
+  end
+
+  def then_i_should_see_a_error_message_to_give_a_reason_for_ske
+    expect(page).to have_content('There is a problem')
+    expect(page).to have_content('Select why the candidate needs to take a course')
+  end
+
+  def when_i_add_a_ske_reason
+    choose t('provider_interface.offer.ske_reasons.new.different_degree', degree_subject: application_choice.current_course.name)
+  end
+
+  def then_the_ske_length_page_is_loaded
+    expect(page).to have_current_path("/provider/applications/#{application_choice.id}/offer/ske_length/new", ignore_query: true)
+  end
+
+  def when_i_dont_answer_ske_length
+    click_on 'Continue'
+  end
+
+  def then_i_should_see_a_error_message_to_give_a_ske_course_length
+    expect(page).to have_content('There is a problem')
+    expect(page).to have_content('Select how long the course should be')
+  end
+
+  def when_i_answer_the_ske_length
+    page.find(:xpath, "//input[@value='8 weeks']").choose
+  end
+end

--- a/spec/system/provider_interface/make_offer_ske_standard_flow_feature_flag_enabled_spec.rb
+++ b/spec/system/provider_interface/make_offer_ske_standard_flow_feature_flag_enabled_spec.rb
@@ -350,7 +350,7 @@ RSpec.feature 'Provider makes an offer with SKE enabled' do
 
   def then_i_should_see_a_error_message_to_give_a_ske_course_length
     expect(page).to have_content('There is a problem')
-    expect(page).to have_content('Select how long the course should be')
+    expect(page).to have_content('Select how long the course must be')
   end
 
   def when_i_answer_the_ske_length

--- a/spec/system/provider_interface/make_offer_spec.rb
+++ b/spec/system/provider_interface/make_offer_spec.rb
@@ -21,6 +21,7 @@ RSpec.feature 'Provider makes an offer' do
   scenario 'Making an offer for the requested course option' do
     given_i_am_a_provider_user
     and_i_am_permitted_to_make_decisions_for_my_provider
+    and_provider_ske_feature_flag_is_disabled
     and_i_sign_in_to_the_provider_interface
 
     given_the_provider_has_multiple_courses
@@ -85,6 +86,10 @@ RSpec.feature 'Provider makes an offer' do
 
   def and_i_am_permitted_to_make_decisions_for_my_provider
     permit_make_decisions!
+  end
+
+  def and_provider_ske_feature_flag_is_disabled
+    FeatureFlag.deactivate(:provider_ske)
   end
 
   def and_i_sign_in_to_the_provider_interface

--- a/spec/system/provider_interface/set_offer_conditions_js_spec.rb
+++ b/spec/system/provider_interface/set_offer_conditions_js_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'Provider makes an offer with JS enabled', js: true do
   scenario 'Setting offer conditions' do
     given_i_am_a_provider_user
     and_i_am_permitted_to_make_decisions_for_my_provider
+    and_provider_ske_feature_flag_is_disabled
     and_i_sign_in_to_the_provider_interface
 
     given_there_is_an_application_to_a_course_i_can_make_decisions_on
@@ -51,6 +52,10 @@ RSpec.describe 'Provider makes an offer with JS enabled', js: true do
 
   def and_i_am_permitted_to_make_decisions_for_my_provider
     permit_make_decisions!
+  end
+
+  def and_provider_ske_feature_flag_is_disabled
+    FeatureFlag.deactivate(:provider_ske)
   end
 
   def and_i_sign_in_to_the_provider_interface


### PR DESCRIPTION
## Context

On SKE eligible courses providers are presented with an additional screen after making an offer asking them if a SKE course is required.

This PR covers the main SKE condition journey – it does not include viewing the condition on the check screen.

## Changes proposed in this pull request

New screen after select 'Make offer':
<img src=https://user-images.githubusercontent.com/47917431/214558898-f3d2398a-0ae4-4646-a013-fe968dd12e05.png width="70%">


**Selecting ‘No’ journey**

Take them through the rest of the standard offer journey.

**Selecting ‘Yes’ journey**

<img src=https://user-images.githubusercontent.com/47917431/214558545-7877f067-9748-4c05-9f11-44346bb08b35.png width="70%">


Then they select the length of the SKE course:

<img src=https://user-images.githubusercontent.com/47917431/214558658-1698abb0-78f4-449d-b6b5-63515d619b49.png width="70%">


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/qTImD6PN

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
