### PR TITLE
[1064] Mark reference section complete on apply-again forms

### DIFF
--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -27,8 +27,8 @@ class DuplicateApplication
       end
 
       if !original_application_form.restructured_immigration_status? &&
-        new_application_form.restructured_immigration_status? &&
-        !new_application_form.british_or_irish?
+         new_application_form.restructured_immigration_status? &&
+         !new_application_form.british_or_irish?
         new_application_form.update(
           personal_details_completed: false,
         )
@@ -63,12 +63,13 @@ class DuplicateApplication
 
         awaiting_response_references = new_application_form.application_references.creation_order.feedback_requested
         change_references_to_not_requested_yet(awaiting_response_references)
-        new_application_form.update!(references_completed: false)
 
         references_cancelled_at_eoc = new_application_form.application_references.creation_order.cancelled_at_end_of_cycle
 
         change_references_to_not_requested_yet(references_cancelled_at_eoc)
       end
+
+      new_application_form.update!(references_completed: apply_again?)
 
       original_application_form.application_work_history_breaks.each do |w|
         new_application_form.application_work_history_breaks.create!(
@@ -89,5 +90,9 @@ private
 
   def change_references_to_not_requested_yet(references)
     references.update_all(feedback_status: 'not_requested_yet')
+  end
+
+  def apply_again?
+    target_phase == 'apply_2'
   end
 end

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -19,64 +19,63 @@ class DuplicateApplication
       recruitment_cycle_year: @recruitment_cycle_year,
     )
 
-    new_application_form = ApplicationForm.create!(attrs)
+    ApplicationForm.create!(attrs).tap do |new_application_form|
+      original_application_form.application_work_experiences.each do |w|
+        new_application_form.application_work_experiences.create!(
+          w.attributes.except(*IGNORED_CHILD_ATTRIBUTES).merge('currently_working' => infer_currently_working(w)),
+        )
+      end
 
-    original_application_form.application_work_experiences.each do |w|
-      new_application_form.application_work_experiences.create!(
-        w.attributes.except(*IGNORED_CHILD_ATTRIBUTES).merge('currently_working' => infer_currently_working(w)),
-      )
+      if !original_application_form.restructured_immigration_status? &&
+        new_application_form.restructured_immigration_status? &&
+        !new_application_form.british_or_irish?
+        new_application_form.update(
+          personal_details_completed: false,
+        )
+      end
+
+      original_application_form.application_volunteering_experiences.each do |w|
+        new_application_form.application_volunteering_experiences.create!(
+          w.attributes.except(*IGNORED_CHILD_ATTRIBUTES),
+        )
+      end
+
+      original_application_form.application_qualifications.each do |w|
+        new_application_form.application_qualifications.create!(
+          w.attributes.except(*IGNORED_CHILD_ATTRIBUTES),
+        )
+      end
+
+      if new_application_form.incomplete_degree_information?
+        new_application_form.update!(degrees_completed: false)
+      end
+
+      original_references = original_application_form.application_references
+        .includes([:reference_tokens])
+        .creation_order
+        .where(feedback_status: %w[feedback_provided not_requested_yet cancelled_at_end_of_cycle feedback_requested])
+        .reject(&:feedback_overdue?)
+
+      original_references.each do |original_reference|
+        new_application_form.application_references.create!(
+          original_reference.attributes.except(*IGNORED_CHILD_ATTRIBUTES).merge!(duplicate: true),
+        )
+
+        awaiting_response_references = new_application_form.application_references.creation_order.feedback_requested
+        change_references_to_not_requested_yet(awaiting_response_references)
+        new_application_form.update!(references_completed: false)
+
+        references_cancelled_at_eoc = new_application_form.application_references.creation_order.cancelled_at_end_of_cycle
+
+        change_references_to_not_requested_yet(references_cancelled_at_eoc)
+      end
+
+      original_application_form.application_work_history_breaks.each do |w|
+        new_application_form.application_work_history_breaks.create!(
+          w.attributes.except(*IGNORED_CHILD_ATTRIBUTES),
+        )
+      end
     end
-    if !original_application_form.restructured_immigration_status? &&
-       new_application_form.restructured_immigration_status? &&
-       !new_application_form.british_or_irish?
-      new_application_form.update(
-        personal_details_completed: false,
-      )
-    end
-
-    original_application_form.application_volunteering_experiences.each do |w|
-      new_application_form.application_volunteering_experiences.create!(
-        w.attributes.except(*IGNORED_CHILD_ATTRIBUTES),
-      )
-    end
-
-    original_application_form.application_qualifications.each do |w|
-      new_application_form.application_qualifications.create!(
-        w.attributes.except(*IGNORED_CHILD_ATTRIBUTES),
-      )
-    end
-
-    if new_application_form.incomplete_degree_information?
-      new_application_form.update!(degrees_completed: false)
-    end
-
-    original_references = original_application_form.application_references
-      .includes([:reference_tokens])
-      .creation_order
-      .where(feedback_status: %w[feedback_provided not_requested_yet cancelled_at_end_of_cycle feedback_requested])
-      .reject(&:feedback_overdue?)
-
-    original_references.each do |original_reference|
-      new_application_form.application_references.create!(
-        original_reference.attributes.except(*IGNORED_CHILD_ATTRIBUTES).merge!(duplicate: true),
-      )
-
-      awaiting_response_references = new_application_form.application_references.creation_order.feedback_requested
-      change_references_to_not_requested_yet(awaiting_response_references)
-      new_application_form.update!(references_completed: false)
-
-      references_cancelled_at_eoc = new_application_form.application_references.creation_order.cancelled_at_end_of_cycle
-
-      change_references_to_not_requested_yet(references_cancelled_at_eoc)
-    end
-
-    original_application_form.application_work_history_breaks.each do |w|
-      new_application_form.application_work_history_breaks.create!(
-        w.attributes.except(*IGNORED_CHILD_ATTRIBUTES),
-      )
-    end
-
-    new_application_form
   end
 
 private

--- a/spec/services/duplicate_application_spec.rb
+++ b/spec/services/duplicate_application_spec.rb
@@ -19,14 +19,12 @@ RSpec.describe DuplicateApplication do
   end
 
   subject(:duplicate_application_form) do
-    described_class.new(@original_application_form, target_phase: 'apply_2').duplicate
+    described_class.new(@original_application_form, target_phase:).duplicate
   end
 
-  context 'application form is unsuccessful' do
-    it 'marks reference as incomplete' do
-      expect(duplicate_application_form).not_to be_references_completed
-    end
+  let(:target_phase) { 'apply_2' }
 
+  context 'application form is unsuccessful' do
     it 'copies application references' do
       create(:reference, feedback_status: :not_requested_yet, application_form: @original_application_form)
       allow(@original_application_form).to receive(:ended_without_success?).and_return(true)
@@ -44,6 +42,22 @@ RSpec.describe DuplicateApplication do
 
       expect(duplicate_application_form.application_references.count).to eq 3
       expect(duplicate_application_form.application_references).to all(be_feedback_provided.or(be_not_requested_yet))
+    end
+  end
+
+  context 'when carry-over' do
+    let(:target_phase) { 'apply_1' }
+
+    it 'marks reference as incomplete' do
+      expect(duplicate_application_form).not_to be_references_completed
+    end
+  end
+
+  context 'when apply-again' do
+    let(:target_phase) { 'apply_2' }
+
+    it 'marks reference as complete' do
+      expect(duplicate_application_form).to be_references_completed
     end
   end
 end

--- a/spec/system/candidate_interface/references/candidate_apply_again_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_apply_again_spec.rb
@@ -53,7 +53,7 @@ RSpec.feature 'Candidates in the 2023 cycle, applying again' do
   end
 
   def then_i_should_see_the_new_references_section
-    expect(page).to have_content 'References to be requested if you accept an offer Incomplete'
+    expect(page).to have_content 'References to be requested if you accept an offer Complete'
   end
 
   def when_i_click_on_the_references_section


### PR DESCRIPTION
They should be marked incomplete for carry-over forms.
