### PR TITLE
Remove `intersex` from the monthly reports

### DIFF
--- a/app/models/publications/monthly_statistics/by_sex.rb
+++ b/app/models/publications/monthly_statistics/by_sex.rb
@@ -31,7 +31,6 @@ module Publications
         counts = {
           'female' => {},
           'male' => {},
-          'intersex' => {},
           'other' => {},
           I18n.t('equality_and_diversity.sex.opt_out.label') => {},
         }

--- a/app/services/data_migrations/remove_intersex_from_reports.rb
+++ b/app/services/data_migrations/remove_intersex_from_reports.rb
@@ -1,0 +1,17 @@
+module DataMigrations
+  class RemoveIntersexFromReports
+    TIMESTAMP = 20230125162341
+    MANUAL_RUN = false
+
+    def change
+      Publications::MonthlyStatistics::MonthlyStatisticsReport
+        .where(month: %w[2022-10 2022-11 2022-12 2023-01 2023-02])
+        .find_each do |report|
+          if (rows = report.statistics.dig('by_sex', 'rows')).any? { |r| r['Sex'] == 'Intersex' }
+            rows.delete_if { |r| r['Sex'] == 'Intersex' }
+            report.save!
+          end
+        end
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveIntersexFromReports',
   'DataMigrations::BackfillSandboxCourseUuids',
   'DataMigrations::RemoveReferencesProviderFeatureFlag',
   'DataMigrations::RemoveCandidateReferenceFlowFeatureFlag',

--- a/spec/models/publications/monthly_statistics/by_sex_spec.rb
+++ b/spec/models/publications/monthly_statistics/by_sex_spec.rb
@@ -11,11 +11,10 @@ RSpec.describe Publications::MonthlyStatistics::BySex do
     expect_report_rows(column_headings: ['Sex', 'Recruited', 'Conditions pending', 'Deferred', 'Received an offer', 'Awaiting provider decisions', 'Unsuccessful', 'Total']) do
       [['Female',            3, 1, 1, 1, 0, 5, 11],
        ['Male',              1, 0, 0, 0, 0, 1, 2],
-       ['Other', 0, 0, 0, 0, 0, 1, 1],
-       ['Intersex', 0, 1, 0, 0, 0, 0, 1],
+       ['Other',             0, 0, 0, 0, 0, 1, 1],
        ['Prefer not to say', 0, 0, 0, 0, 1, 0, 1]]
     end
 
-    expect_column_totals(4, 2, 1, 1, 1, 7, 16)
+    expect_column_totals(4, 1, 1, 1, 1, 7, 15)
   end
 end

--- a/spec/services/data_migrations/remove_intersex_from_reports_spec.rb
+++ b/spec/services/data_migrations/remove_intersex_from_reports_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveIntersexFromReports do
+  let!(:report) { Publications::MonthlyStatistics::MonthlyStatisticsReport.create!(month:, statistics:) }
+
+  before { advance_time }
+
+  context 'when a report has intersex data' do
+    let(:statistics) do
+      {
+        'by_sex' =>
+          { 'rows' =>
+            [{ 'Sex' => 'Female', 'Recruited' => 6, 'Conditions pending' => 5, 'Deferred' => 13, 'Received an offer' => 44, 'Awaiting provider decisions' => 72, 'Unsuccessful' => 44, 'Total' => 184 },
+             { 'Sex' => 'Male', 'Recruited' => 6, 'Conditions pending' => 1, 'Deferred' => 7, 'Received an offer' => 47, 'Awaiting provider decisions' => 91, 'Unsuccessful' => 29, 'Total' => 181 },
+             { 'Sex' => 'Intersex', 'Recruited' => 0, 'Conditions pending' => 0, 'Deferred' => 0, 'Received an offer' => 0, 'Awaiting provider decisions' => 0, 'Unsuccessful' => 0, 'Total' => 0 },
+             { 'Sex' => 'Other', 'Recruited' => 10, 'Conditions pending' => 4, 'Deferred' => 8, 'Received an offer' => 62, 'Awaiting provider decisions' => 72, 'Unsuccessful' => 38, 'Total' => 194 },
+             { 'Sex' => 'Prefer not to say', 'Recruited' => 10, 'Conditions pending' => 7, 'Deferred' => 6, 'Received an offer' => 51, 'Awaiting provider decisions' => 67, 'Unsuccessful' => 30, 'Total' => 171 }],
+            'column_totals' => [32, 17, 34, 204, 302, 141, 730] },
+      }
+    end
+
+    context 'and the report is on or after October 2022' do
+      let(:month) { '2022-10' }
+
+      # No need to change the column totals,
+      # I've checked that they're all 0 for intersex
+      # in the production database for these months.
+      it 'removes the intersex data' do
+        expect { described_class.new.change }.to(change { report.reload.updated_at })
+        expect(report.statistics.dig('by_sex', 'rows').find { |row| row['Sex'] == 'Intersex' }).to be_nil
+      end
+    end
+
+    context 'and the report is before October 2022' do
+      let(:month) { '2022-09' }
+
+      it 'does not remove the intersex data' do
+        expect { described_class.new.change }.not_to(change { report.reload.updated_at })
+        expect(report.statistics.dig('by_sex', 'rows').find { |row| row['Sex'] == 'Intersex' }).not_to be_nil
+      end
+    end
+  end
+
+  context 'when a report does not have intersex data' do
+    let(:statistics) do
+      {
+        'by_sex' =>
+          { 'rows' =>
+            [{ 'Sex' => 'Female', 'Recruited' => 6, 'Conditions pending' => 5, 'Deferred' => 13, 'Received an offer' => 44, 'Awaiting provider decisions' => 72, 'Unsuccessful' => 44, 'Total' => 184 },
+             { 'Sex' => 'Male', 'Recruited' => 6, 'Conditions pending' => 1, 'Deferred' => 7, 'Received an offer' => 47, 'Awaiting provider decisions' => 91, 'Unsuccessful' => 29, 'Total' => 181 },
+             { 'Sex' => 'Other', 'Recruited' => 10, 'Conditions pending' => 4, 'Deferred' => 8, 'Received an offer' => 62, 'Awaiting provider decisions' => 72, 'Unsuccessful' => 38, 'Total' => 194 },
+             { 'Sex' => 'Prefer not to say', 'Recruited' => 10, 'Conditions pending' => 7, 'Deferred' => 6, 'Received an offer' => 51, 'Awaiting provider decisions' => 67, 'Unsuccessful' => 30, 'Total' => 171 }],
+            'column_totals' => [32, 17, 34, 204, 302, 141, 730] },
+      }
+    end
+
+    context 'and the report is on or after October 2022' do
+      let(:month) { '2022-10' }
+
+      it 'does not update the record' do
+        expect { described_class.new.change }.not_to(change { report.reload.updated_at })
+      end
+    end
+
+    context 'and the report is before October 2022' do
+      let(:month) { '2022-09' }
+
+      it 'does not update the record' do
+        expect { described_class.new.change }.not_to(change { report.reload.updated_at })
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

This is no longer asked as an option, so reports from October 2022 don't contain it.

## Changes proposed in this pull request

### Existing report

<img width="1044" alt="Screenshot 2023-01-25 at 16 23 05" src="https://user-images.githubusercontent.com/109225/214629472-fe65326a-e3bb-4266-8fc2-56c6fc48ad33.png">

### Existing report after data migration

<img width="1022" alt="Screenshot 2023-01-25 at 16 52 42" src="https://user-images.githubusercontent.com/109225/214629576-a1c37ff5-3029-495f-b453-2f880db47fa4.png">

### Newly generated report

<img width="1017" alt="Screenshot 2023-01-25 at 16 56 11" src="https://user-images.githubusercontent.com/109225/214629636-69b89279-797c-429c-b056-450aa7ffe241.png">
