### PR TITLE
reset SNYK default app scan setting

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -113,7 +113,7 @@ jobs:
           SNYK_TOKEN: ${{ steps.get-secret.outputs.snyk_token }}
         with:
           image: ${{ env.DOCKER_IMAGE }}:${{ env.IMAGE_TAG }}
-          args: --file=Dockerfile --severity-threshold=high
+          args: --file=Dockerfile --severity-threshold=high --exclude-app-vulns
 
       - name: Push ${{ env.DOCKER_IMAGE }} images
         run: docker image push --all-tags ${{ env.DOCKER_IMAGE }}

--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -92,7 +92,7 @@ jobs:
           SNYK_TOKEN: ${{ steps.get-secret.outputs.snyk_token }}
         with:
           image: ${{ env.DOCKER_IMAGE }}:${{ env.IMAGE_TAG }}
-          args: --file=Dockerfile
+          args: --file=Dockerfile --exclude-app-vulns
 
       - name: Push ${{ env.DOCKER_IMAGE }} images
         if: ${{ success() }}


### PR DESCRIPTION
## Context

SNYK have changed the default setting for scanning app vulnerabilities
https://snyk.io/blog/securing-container-applications-using-the-snyk-cli/

We only check o/s image vulnerabilities with SNYK, so need to reset this to the previous setting

## Changes proposed in this pull request

Add --exclude-app-vulns to the SNYK scan step in the build workflows

## Guidance to review

Check the build workflows

## Link to Trello card

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
