### PR TITLE
Remove count from paas module

### DIFF
--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,5 +1,4 @@
 module "paas" {
-  count  = var.deploy_aks ? 0 : 1
   source = "./modules/paas"
 
   cf_space                             = var.paas_cf_space


### PR DESCRIPTION
## Context

The previous commit implementing the AKS deployment added a count to the paas module so we could toggle whether we deployed to paas or not. This had the impact of causing the resource name in terraform to change and include `[0]` which Terraform interprets as a different resource. This would have caused resources to be destroyed.

## Changes proposed in this pull request

Remove the count from the paas module to prevent the change in resource address from causing the existing resources to be destroyed.

## Guidance to review

Run Terraform plan against sandbox and production and confirmed no resources would be destroyed.

## Link to Trello card

https://trello.com/c/ZSlr2ShQ/77-include-aks-in-apply-cd-pipeline-review-apps

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
