### PR TITLE
Possible fix for a flakey test

### DIFF
--- a/app/services/candidate_api/serializers/v1_2.rb
+++ b/app/services/candidate_api/serializers/v1_2.rb
@@ -61,7 +61,7 @@ module CandidateAPI
         {
           completed: application_form.references_completed,
           data:
-            application_form.application_references.sort_by(&:created_at).map do |reference|
+            application_form.application_references.sort_by(&:id).map do |reference|
               {
                 id: reference.id,
                 requested_at: reference.requested_at&.iso8601,


### PR DESCRIPTION
https://github.com/DFE-Digital/apply-for-teacher-training/actions/runs/4023322706/jobs/6914110254#step:6:72

Ordering by `created_at` is fine, but in the tests we'd need to put some arbitrary time between reference creation for it to work.  Sorting by `id` is fine; it's a mostly arbitrary order anyway and we don't change our `created_at`s in the real world.