### PR TITLE
Add clock to AKS deployment

### DIFF
--- a/terraform/modules/kubernetes/variables.tf
+++ b/terraform/modules/kubernetes/variables.tf
@@ -18,6 +18,7 @@ locals {
   secondary_worker_name  = "apply-secondary-worker-${var.app_environment}"
   webapp_startup_command = var.webapp_startup_command == null ? null : ["/bin/sh", "-c", var.webapp_startup_command]
   worker_name            = "apply-worker-${var.app_environment}"
+  clock_worker_name      = "apply-clock-worker-${var.app_environment}"
 
   webapp_env_variables = merge(
     var.app_environment_variables,


### PR DESCRIPTION
## Context

Add the clock container to the AKS deployment and update the deployment strategy for all 3 workers to `Recreate` so that only one container ever exists. This will prevent duplicate jobs and activities.

## Changes proposed in this pull request

- Add clock container to resources
- Update worker deployment strategy

## Guidance to review

Confirm from deployments that clock is deployed

## Link to Trello card

https://trello.com/c/lobIH6vR

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
