### PR TITLE
Remove dead DB migration content

### DIFF
--- a/db/migrate/20200723160935_give_make_decisions_and_manage_users_to_provider_users.rb
+++ b/db/migrate/20200723160935_give_make_decisions_and_manage_users_to_provider_users.rb
@@ -1,7 +1,0 @@
-class GiveMakeDecisionsAndManageUsersToProviderUsers < ActiveRecord::Migration[6.0]
-  def up
-    LaunchMakeDecisionsAndManageUsers.new.update_provider_user_permissions!
-  end
-
-  def down; end
-end


### PR DESCRIPTION
We've removed this code now.  This is only a problem when running all the migrations from the start, e.g. on review apps.

We can perhaps delete this entirely?  Not sure whether that would cause more problems.
