### PR TITLE
Make TestSuiteTimeMachine thread-safe

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -137,18 +137,6 @@ RSpec.configure do |config|
     config.default_formatter = 'doc'
   end
 
-  # If running tests in parallel, use a unique Redis database per test process.
-  # This allocates databases from 1 onwards, as it's assumed that 0 is the
-  # development database.
-  if ENV['TEST_ENV_NUMBER']
-    redis_url_without_database = ENV['REDIS_URL']&.gsub(/\/\d+$/, '') || 'redis://localhost:6379'
-    config.around do |example|
-      ClimateControl.modify(REDIS_URL: "#{redis_url_without_database}/#{ENV['TEST_ENV_NUMBER'].to_i + 1}") do
-        example.run
-      end
-    end
-  end
-
   config.include(Clockwork::Test::RSpec::Matchers)
   config.after(:each, :clockwork) { Clockwork::Test.clear! }
 

--- a/spec/support/sidekiq.rb
+++ b/spec/support/sidekiq.rb
@@ -3,9 +3,24 @@ ActiveJob::Base.queue_adapter = :test
 RSpec.configure do |config|
   include ActiveJob::TestHelper
 
-  # Show the Redis connections being used when running tests in parallel
-  if ENV['TEST_ENV_NUMBER'] && ENV['DEBUG_REDIS_CONNECTIONS']
-    Sidekiq.redis { |c| p c }
+  # If running tests in parallel, use a unique Redis database per test process.
+  # See https://github.com/grosser/parallel_tests#add-to-configdatabaseyml
+  if ENV.key?('TEST_ENV_NUMBER')
+    redis_url_without_database = ENV['REDIS_URL']&.gsub(/\/\d+$/, '') || 'redis://localhost:6379'
+    redis_db_index = (ENV['TEST_ENV_NUMBER'].presence || 1).to_i - 1
+    redis_url_with_database = "#{redis_url_without_database}/#{redis_db_index}"
+
+    if ENV['DEBUG_REDIS_CONNECTIONS']
+      # Show the Redis connections being used when running tests in parallel
+      puts "Using Redis database URL `#{redis_url_with_database}`"
+      config.before { Sidekiq.redis { |c| p c } }
+    end
+
+    config.around do |example|
+      ClimateControl.modify(REDIS_URL: redis_url_with_database) do
+        example.run
+      end
+    end
   end
 
   # Turn Sidekiq on automatically in system tests. Use `sidekiq: false` in


### PR DESCRIPTION
## Context

@JR-G has been experiencing issues with the `TestSuiteTimeMachine` complaining about the baseline being set multiple times when running under parallel specs.  This is because the class variable being used to store the baseline was not threadsafe.

## Changes proposed in this pull request

Switches to using the thread-local (actually fiber-local) K/V store.  Also corrects a redis DB indexing issue which affects 16 core machines.

## Guidance to review

Run `bundle exec parallel_rspec` on your local machine.
