### PR TITLE
updated content on link expired page when signing in

### DIFF
--- a/app/views/candidate_interface/sign_in/confirm_sign_in.html.erb
+++ b/app/views/candidate_interface/sign_in/confirm_sign_in.html.erb
@@ -7,7 +7,7 @@
         <%= t('authentication.sign_in.heading') %>
       </h1>
 
-      <p class="govuk-body">You’re signing into the account you created for <%= @authentication_token.user.email_address %>.</p>
+      <p class="govuk-body">You’re signing in to the account you created for <%= @authentication_token.user.email_address %>.</p>
 
       <%= hidden_field_tag :token, params[:token], html: { autocomplete: 'off' } %>
       <div class="govuk-button-group">

--- a/app/views/candidate_interface/sign_in/expired.html.erb
+++ b/app/views/candidate_interface/sign_in/expired.html.erb
@@ -7,7 +7,7 @@
         <%= t('authentication.expired_token.heading') %>
       </h1>
       <p class="govuk-body">
-        The sign in link expires after one hour and only works once so you need a new link.
+        The sign in link expires after one hour and only works once, so you need a new link.
       </p>
 
       <%= hidden_field_tag :u, params[:u], html: { autocomplete: 'off' } %>

--- a/app/views/candidate_interface/sign_in/expired.html.erb
+++ b/app/views/candidate_interface/sign_in/expired.html.erb
@@ -7,7 +7,7 @@
         <%= t('authentication.expired_token.heading') %>
       </h1>
       <p class="govuk-body">
-        Sign in links only work once and expire after one hour, so you need to request a new one. We’ll send this by email.
+        The sign in link expires after one hour and only works once so you need a new link.
       </p>
 
       <%= hidden_field_tag :u, params[:u], html: { autocomplete: 'off' } %>

--- a/config/locales/candidate_interface/authentication.yml
+++ b/config/locales/candidate_interface/authentication.yml
@@ -18,7 +18,7 @@ en:
       email:
         subject: Check the email address you’re using to apply for teacher training
     expired_token:
-      heading: The link you clicked has expired
+      heading: The link you selected has expired
       button: Email me a new link
     confirm_authentication:
       heading: Create an account to apply for teacher training

--- a/config/locales/candidate_interface/authentication.yml
+++ b/config/locales/candidate_interface/authentication.yml
@@ -18,7 +18,7 @@ en:
       email:
         subject: Check the email address you’re using to apply for teacher training
     expired_token:
-      heading: The link you selected has expired
+      heading: The link you used to sign in has expired
       button: Email me a new link
     confirm_authentication:
       heading: Create an account to apply for teacher training

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_using_legacy_email_link_with_u_param_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_using_legacy_email_link_with_u_param_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature 'Candidate account' do
   end
 
   def then_i_am_prompted_to_get_a_new_magic_link
-    expect(page).to have_content 'The link you clicked has expired'
+    expect(page).to have_content 'The link you selected has expired'
   end
 
   def when_i_get_a_new_magic_link

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_using_legacy_email_link_with_u_param_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_using_legacy_email_link_with_u_param_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature 'Candidate account' do
   end
 
   def then_i_am_prompted_to_get_a_new_magic_link
-    expect(page).to have_content 'The link you selected has expired'
+    expect(page).to have_content 'The link you used to sign in has expired'
   end
 
   def when_i_get_a_new_magic_link

--- a/spec/system/candidate_interface/signup_and_signin/candidate_tries_to_reuse_magic_link_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_tries_to_reuse_magic_link_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature 'Candidate account' do
   end
 
   def then_i_am_prompted_to_get_a_new_magic_link
-    expect(page).to have_content 'The link you clicked has expired'
+    expect(page).to have_content 'The link you selected has expired'
   end
 
   def when_i_get_a_new_magic_link

--- a/spec/system/candidate_interface/signup_and_signin/candidate_tries_to_reuse_magic_link_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_tries_to_reuse_magic_link_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature 'Candidate account' do
   end
 
   def then_i_am_prompted_to_get_a_new_magic_link
-    expect(page).to have_content 'The link you selected has expired'
+    expect(page).to have_content 'The link you used to sign in has expired'
   end
 
   def when_i_get_a_new_magic_link

--- a/spec/system/candidate_interface/signup_and_signin/two_candidates_sign_in_on_same_machine_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/two_candidates_sign_in_on_same_machine_spec.rb
@@ -76,7 +76,7 @@ RSpec.feature 'Candidate account' do
   end
 
   def then_i_am_prompted_to_get_a_new_magic_link
-    expect(page).to have_content 'The link you selected has expired'
+    expect(page).to have_content 'The link you used to sign in has expired'
   end
 
   def when_i_click_the_link_in_the_email_after_an_hour_for(email)

--- a/spec/system/candidate_interface/signup_and_signin/two_candidates_sign_in_on_same_machine_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/two_candidates_sign_in_on_same_machine_spec.rb
@@ -76,7 +76,7 @@ RSpec.feature 'Candidate account' do
   end
 
   def then_i_am_prompted_to_get_a_new_magic_link
-    expect(page).to have_content 'The link you clicked has expired'
+    expect(page).to have_content 'The link you selected has expired'
   end
 
   def when_i_click_the_link_in_the_email_after_an_hour_for(email)


### PR DESCRIPTION
## Context

Simplified the content on the page that tells users their sign in link has expired. This work is part of the reviewing of all sign in screens.

## Changes proposed in this pull request

Content now reads:

[H1] The link you selected has expired

The sign in link expires after one hour and only works once so you need a new link.

[Button] Email me a new link

## Link to Trello card

https://trello.com/c/EnpbshwR/506-review-the-email-link-expired-screen

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
