### PR TITLE
Add success and failure reference endpoints to sandbox 

### DIFF
--- a/app/controllers/vendor_api/references_controller.rb
+++ b/app/controllers/vendor_api/references_controller.rb
@@ -1,0 +1,44 @@
+module VendorAPI
+  class ReferencesController < VendorAPIController
+    before_action :workflow_testing_only
+
+    def success
+      with_requested_reference do |reference|
+        reference.update!(
+          feedback_status: 'feedback_provided',
+          feedback_provided_at: Time.zone.now,
+          feedback: Faker::Lorem.paragraph(sentence_count: 10),
+          safeguarding_concerns: '',
+          relationship_correction: '',
+        )
+      end
+    end
+
+    def failure
+      with_requested_reference do |reference|
+        reference.update!(
+          feedback_status: 'feedback_refused',
+          feedback_refused_at: Time.zone.now,
+        )
+      end
+    end
+
+  private
+
+    def workflow_testing_only
+      render json: nil, status: :not_found unless HostingEnvironment.workflow_testing?
+    end
+
+    def with_requested_reference
+      reference = current_provider.application_references.find(params[:id])
+
+      if reference.feedback_status == 'feedback_requested'
+        yield reference
+
+        render json: nil, status: :ok
+      else
+        render json: nil, status: :unprocessable_entity
+      end
+    end
+  end
+end

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -81,7 +81,7 @@ module HostingEnvironment
     TEST_ENVIRONMENTS.include?(HostingEnvironment.environment_name)
   end
 
-  def self.use_refbots?
+  def self.workflow_testing?
     test_environment? || sandbox_mode?
   end
 

--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -26,6 +26,7 @@ module VendorAPI
       Changes::PingEndpoint,
       Changes::ExperimentalClearTestData,
       Changes::ExperimentalGenerateTestData,
+      Changes::ReferenceStatus,
     ],
     '1.1' => [
       Changes::DeferOffer,

--- a/app/lib/vendor_api/changes/reference_status.rb
+++ b/app/lib/vendor_api/changes/reference_status.rb
@@ -1,0 +1,13 @@
+module VendorAPI
+  module Changes
+    class ReferenceStatus < VersionChange
+      description 'Change the status of a reference in sandbox.'
+
+      def actions
+        {
+          ReferencesController => %i[success failure],
+        }
+      end
+    end
+  end
+end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -9,6 +9,9 @@ class ApplicationForm < ApplicationRecord
 
   belongs_to :candidate, touch: true
   has_many :application_choices
+  has_many :course_options, through: :application_choices
+  has_many :courses, through: :application_choices
+  has_many :providers, through: :application_choices
   has_many :application_work_experiences
   has_many :application_volunteering_experiences
   has_many :application_qualifications

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -4,6 +4,8 @@ class Provider < ApplicationRecord
   has_many :sites
   has_many :course_options, through: :courses
   has_many :application_choices, through: :course_options
+  has_many :application_forms, through: :application_choices
+  has_many :application_references, through: :application_forms
   has_many :accredited_courses, class_name: 'Course', inverse_of: :accredited_provider, foreign_key: :accredited_provider_id
 
   has_many :provider_permissions, dependent: :destroy

--- a/app/services/request_reference.rb
+++ b/app/services/request_reference.rb
@@ -27,7 +27,7 @@ class RequestReference
 private
 
   def auto_approve_reference_in_sandbox(reference)
-    auto_approve_reference(reference) if HostingEnvironment.use_refbots? && email_address_is_a_bot?(reference)
+    auto_approve_reference(reference) if HostingEnvironment.workflow_testing? && email_address_is_a_bot?(reference)
   end
 
   def auto_approve_reference(reference)

--- a/app/views/candidate_interface/references/email_address/_shared_form.html.erb
+++ b/app/views/candidate_interface/references/email_address/_shared_form.html.erb
@@ -1,6 +1,6 @@
 <%= f.govuk_error_summary %>
 
-<% if HostingEnvironment.use_refbots? %>
+<% if HostingEnvironment.workflow_testing? %>
   <%= render SandboxFeatureComponent.new(
     description: 'Enter <code>refbot1@example.com</code> and <code>refbot2@example.com</code> as your referee email addresses to have the references automatically completed. Increment the number for each additional reference.',
   ) %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,9 +7,7 @@ require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
-
   config.cache_classes = true
-
   config.eager_load = true
 
   # Configure public file server for tests with Cache-Control for performance.
@@ -45,9 +43,6 @@ Rails.application.configure do
 
   # Forces jobs that are normally queued to Sidekiq to run immediately
   config.active_job.queue_adapter = :inline
-
-  config.after_initialize do
-  end
 
   config.x.read_only_database_url = "postgres://localhost/bat_apply_test"
 end

--- a/config/initializers/route_validators.rb
+++ b/config/initializers/route_validators.rb
@@ -20,7 +20,11 @@ end
 
 class ValidVendorApiRoute
   def self.matches?(request)
-    VersionMatcher.new(request).match?
+    VersionMatcher.new(request).match?.tap do |match|
+      if !match && (Rails.env.development? || Rails.env.test?)
+        raise 'No relevant change entry found for that controller/action.  Do you need to update `app/lib/vendor_api.rb`?'
+      end
+    end
   rescue ArgumentError, NoMethodError
     false
   end

--- a/config/routes/api/vendor.rb
+++ b/config/routes/api/vendor.rb
@@ -2,6 +2,9 @@ namespace :vendor_api, path: 'api/:api_version', api_version: /v[.0-9]+/, constr
   get '/applications' => 'applications#index'
   get '/applications/:application_id' => 'applications#show'
 
+  post '/reference/:id/success' => 'references#success'
+  post '/reference/:id/failure' => 'references#failure'
+
   scope path: '/applications/:application_id' do
     post '/offer' => 'decisions#make_offer'
     post '/confirm-conditions-met' => 'decisions#confirm_conditions_met'

--- a/config/vendor_api/experimental-v1.0.yml
+++ b/config/vendor_api/experimental-v1.0.yml
@@ -70,3 +70,41 @@ paths:
           "$ref": "#/components/responses/OK"
         "401":
           "$ref": "#/components/responses/Unauthorized"
+  "/reference/{reference_id}/success":
+    post:
+      tags:
+        - Testing
+      summary: Simulate successful reference feedback
+      description:
+        Sets the correct status and related fields for successful reference feedback.
+        Reference must exist in `feedback_requested` state.
+        Only available on the Sandbox.
+        EXPERIMENTAL — this endpoint may change or disappear.
+      responses:
+        "200":
+          "$ref": "#/components/responses/OK"
+        "401":
+          "$ref": "#/components/responses/Unauthorized"
+        "404":
+          "$ref": "#/components/responses/NotFound"
+        "422":
+          "$ref": "#/components/responses/UnprocessableEntity"
+  "/reference/{reference_id}/failure":
+    post:
+      tags:
+        - Testing
+      summary: Simulate failed reference feedback
+      description:
+        Sets the correct status and related fields for rejected reference feedback.
+        Reference must exist in `feedback_requested` state.
+        Only available on the Sandbox.
+        EXPERIMENTAL — this endpoint may change or disappear.
+      responses:
+        "200":
+          "$ref": "#/components/responses/OK"
+        "401":
+          "$ref": "#/components/responses/Unauthorized"
+        "404":
+          "$ref": "#/components/responses/NotFound"
+        "422":
+          "$ref": "#/components/responses/UnprocessableEntity"

--- a/config/vendor_api/experimental-v1.0.yml
+++ b/config/vendor_api/experimental-v1.0.yml
@@ -2,68 +2,71 @@ paths:
   "/test-data/generate":
     post:
       tags:
-      - Testing
+        - Testing
       summary: Generate test data
-      description: 'Submits a request to generate n new applications, defaulting to 100 applications with
+      description:
+        "Submits a request to generate n new applications, defaulting to 100 applications with
         one course choice per application. The applications are generated asynchronously, and will appear once they have been generated.
         Does not change existing data. Only available on the Sandbox. EXPERIMENTAL — this endpoint may change or disappear.
 
-        '
+        "
       parameters:
-      - name: count
-        description: How many applications to generate (max 100)
-        in: query
-        schema:
-          type: integer
-          default: 100
-          maximum: 100
-      - name: courses_per_application
-        description: How many courses each generated application should apply to
-        in: query
-        schema:
-          type: integer
-          default: 1
-          minimum: 1
-          maximum: 3
-      - name: for_training_courses
-        description: Generate applications for courses your organisation runs. Please specify 'true', for example for_training_courses=true. Will be set to true if neither for_ratified_courses or for_test_provider_courses are true
-        in: query
-        schema:
-          type: string
-      - name: for_ratified_courses
-        description: Generate applications for courses your organisation awards Qualified Teacher Status (QTS) for but does not run. For example, your organisation may be a Higher Education Institution ratifying School Direct courses. Please specify 'true', for example for_ratified_courses=true
-        in: query
-        schema:
-          type: string
-      - name: for_test_provider_courses
-        description: Generate applications for courses run by a test provider, separate to your organisation. Please specify 'true', for example for_test_provider_courses=true
-        in: query
-        schema:
-          type: string
-      - name: previous_cycle
-        description: Generate applications for courses in the previous recruitment cycle. Please specify 'true', for example previous_cycle=true.
-                     The application will have a ‘pending_conditions’ state and also ‘withdrawn’ if there is more than one
-                     course choice per application form.
-        in: query
-        schema:
-          type: string
-          default: false
+        - name: count
+          description: How many applications to generate (max 100)
+          in: query
+          schema:
+            type: integer
+            default: 100
+            maximum: 100
+        - name: courses_per_application
+          description: How many courses each generated application should apply to
+          in: query
+          schema:
+            type: integer
+            default: 1
+            minimum: 1
+            maximum: 3
+        - name: for_training_courses
+          description: Generate applications for courses your organisation runs. Please specify 'true', for example for_training_courses=true. Will be set to true if neither for_ratified_courses or for_test_provider_courses are true
+          in: query
+          schema:
+            type: string
+        - name: for_ratified_courses
+          description: Generate applications for courses your organisation awards Qualified Teacher Status (QTS) for but does not run. For example, your organisation may be a Higher Education Institution ratifying School Direct courses. Please specify 'true', for example for_ratified_courses=true
+          in: query
+          schema:
+            type: string
+        - name: for_test_provider_courses
+          description: Generate applications for courses run by a test provider, separate to your organisation. Please specify 'true', for example for_test_provider_courses=true
+          in: query
+          schema:
+            type: string
+        - name: previous_cycle
+          description:
+            Generate applications for courses in the previous recruitment cycle. Please specify 'true', for example previous_cycle=true.
+            The application will have a ‘pending_conditions’ state and also ‘withdrawn’ if there is more than one
+            course choice per application form.
+          in: query
+          schema:
+            type: string
+            default: false
       responses:
-        '200':
+        "200":
           "$ref": "#/components/responses/OK"
-        '401':
+        "401":
           "$ref": "#/components/responses/Unauthorized"
   "/test-data/clear":
     post:
       tags:
-      - Testing
+        - Testing
       summary: Clear test data
-      description: 'Deletes ALL application data for the current provider regardless of how it was created. Only available
+      description:
+        "Deletes ALL application data for the current provider regardless of how it was created. Only available
         on the Sandbox. EXPERIMENTAL — this endpoint may change or disappear.
 
-        '
+        "
       responses:
-        '200':
+        "200":
           "$ref": "#/components/responses/OK"
-        '401':
+        "401":
           "$ref": "#/components/responses/Unauthorized"

--- a/spec/factories/reference.rb
+++ b/spec/factories/reference.rb
@@ -15,9 +15,8 @@ FactoryBot.define do
     end
 
     trait :feedback_refused do
+      feedback_requested
       feedback_status { 'feedback_refused' }
-      feedback { nil }
-      requested_at { 1.day.ago }
       feedback_refused_at { Time.zone.now }
     end
 
@@ -43,6 +42,12 @@ FactoryBot.define do
     end
 
     trait :feedback_requested do
+      application_form do
+        association(:completed_application_form,
+                    submitted_application_choices_count: 1,
+                    references_count: 0,
+                    application_references: [instance])
+      end
       feedback_status { 'feedback_requested' }
       feedback { nil }
       requested_at { Time.zone.now }
@@ -68,9 +73,9 @@ FactoryBot.define do
     end
 
     trait :feedback_provided do
+      feedback_requested
       feedback_status { 'feedback_provided' }
       feedback { Faker::Lorem.paragraph(sentence_count: 10) }
-      requested_at { 1.day.ago }
       feedback_provided_at { Time.zone.now }
       safeguarding_concerns { '' }
       relationship_correction { '' }

--- a/spec/requests/vendor_api/sandbox/post_reference_status_spec.rb
+++ b/spec/requests/vendor_api/sandbox/post_reference_status_spec.rb
@@ -1,0 +1,162 @@
+require 'rails_helper'
+
+RSpec.describe 'Vendor API - Modifying reference state (sandbox)' do
+  include VendorAPISpecHelpers
+
+  let(:reference) { create(:reference, :feedback_requested) }
+  let(:currently_authenticated_provider) { reference.application_form.providers.first }
+  let(:version) { '1' }
+  let(:workflow_testing) { true }
+
+  before do
+    allow(HostingEnvironment).to receive(:workflow_testing?).and_return(workflow_testing)
+  end
+
+  describe 'POST /reference/:id/success' do
+    let(:path) { "/api/v#{version}/reference/#{reference.id}/success" }
+
+    it 'returns a 200 OK response' do
+      post_api_request(path)
+      expect(response).to have_http_status(:ok)
+    end
+
+    VendorAPI::VERSIONS.each do |version, _|
+      context "on specific version #{version}" do
+        let(:version) { version.gsub('pre', '') }
+
+        it 'returns a 200 OK response' do
+          post_api_request(path)
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+
+    it 'changes the reference to `feedback_provided`' do
+      post_api_request(path)
+      expect(reference.reload.feedback_status).to eq('feedback_provided')
+    end
+
+    it 'fills in various bits' do
+      post_api_request(path)
+      reference.reload
+
+      expect(reference.feedback_provided_at).not_to be_nil
+      expect(reference.feedback).not_to be_nil
+      expect(reference.safeguarding_concerns).not_to be_nil
+      expect(reference.relationship_correction).not_to be_nil
+    end
+
+    context 'when the reference is not in the `feedback_requested` state' do
+      let(:reference) { create(:reference, :feedback_provided) }
+
+      it 'returns a 422 Unprocessable Entity response' do
+        post_api_request(path)
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'does not change the reference' do
+        expect { post_api_request(path) }.not_to(change { reference.reload.feedback_status })
+      end
+    end
+
+    context 'when the reference does not exist' do
+      let(:path) { "/api/v#{version}/reference/#{reference.id + 1}/success" }
+
+      it 'returns a 404 Not Found response' do
+        post_api_request(path)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when the reference is not for the current provider' do
+      let(:currently_authenticated_provider) { create(:provider) }
+
+      it 'returns a 404 Not Found response' do
+        post_api_request(path)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when not in sandbox' do
+      let(:workflow_testing) { false }
+
+      it 'returns a 404 Not Found response' do
+        post_api_request(path)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe 'POST /reference/:id/failure' do
+    let(:path) { "/api/v#{version}/reference/#{reference.id}/failure" }
+
+    it 'returns a 200 OK response' do
+      post_api_request(path)
+      expect(response).to have_http_status(:ok)
+    end
+
+    VendorAPI::VERSIONS.each do |version, _|
+      context "on specific version #{version}" do
+        let(:version) { version.gsub('pre', '') }
+
+        it 'returns a 200 OK response' do
+          post_api_request(path)
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+
+    it 'changes the reference to `feedback_refused`' do
+      post_api_request(path)
+      expect(reference.reload.feedback_status).to eq('feedback_refused')
+    end
+
+    it 'fills in various bits' do
+      post_api_request(path)
+      reference.reload
+
+      expect(reference.feedback_refused_at).not_to be_nil
+      expect(reference.feedback).to be_nil
+    end
+
+    context 'when the reference is not in the `feedback_requested` state' do
+      let(:reference) { create(:reference, :feedback_provided) }
+
+      it 'returns a 422 Unprocessable Entity response' do
+        post_api_request(path)
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'does not change the reference' do
+        expect { post_api_request(path) }.not_to(change { reference.reload.feedback_status })
+      end
+    end
+
+    context 'when the reference does not exist' do
+      let(:path) { "/api/v#{version}/reference/#{reference.id + 1}/failure" }
+
+      it 'returns a 404 Not Found response' do
+        post_api_request(path)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when the reference is not for the current provider' do
+      let(:currently_authenticated_provider) { create(:provider) }
+
+      it 'returns a 404 Not Found response' do
+        post_api_request(path)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when not in sandbox' do
+      let(:workflow_testing) { false }
+
+      it 'returns a 404 Not Found response' do
+        post_api_request(path)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/spec/requests/vendor_api/versioning_spec.rb
+++ b/spec/requests/vendor_api/versioning_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe 'Versioning' do
 
   before do
     stub_const('VendorAPI::VERSION', '1.2')
+    allow(Rails.env).to receive(:test?).and_return(false)
   end
 
   describe 'deriving minor version when not specified' do


### PR DESCRIPTION
## Context

This allows providers to better test the references flow over the API.

## Changes proposed in this pull request

<img width="938" alt="Screenshot 2023-02-06 at 10 13 04" src="https://user-images.githubusercontent.com/109225/216945763-cb197c1b-af70-45a8-a13a-111c5d222f80.png">

## Guidance to review

API requests will need to be for a reference in `requested_feedback` state.

## Things to check

- [x] API release notes have been updated if necessary
