### PR TITLE
Add redis cache and private endpoint

### DIFF
--- a/terraform/modules/kubernetes/data.tf
+++ b/terraform/modules/kubernetes/data.tf
@@ -16,5 +16,20 @@ data "azurerm_private_dns_zone" "postgres-dns" {
   count = var.deploy_azure_backing_services ? 1 : 0
 
   name                = local.postgres_dns_zone
-  resource_group_name = var.cluster.cluster_resource_group_name
+  resource_group_name = data.azurerm_resource_group.backing-service-resource-group[0].name
+}
+
+data "azurerm_subnet" "redis-subnet" {
+  count = var.deploy_azure_backing_services ? 1 : 0
+
+  name                 = "redis-snet"
+  virtual_network_name = local.vnet_name
+  resource_group_name  = var.cluster.cluster_resource_group_name
+}
+
+data "azurerm_private_dns_zone" "redis-dns" {
+  count = var.deploy_azure_backing_services ? 1 : 0
+
+  name                = local.redis_dns_zone
+  resource_group_name = data.azurerm_resource_group.backing-service-resource-group[0].name
 }

--- a/terraform/modules/kubernetes/redis.tf
+++ b/terraform/modules/kubernetes/redis.tf
@@ -1,4 +1,6 @@
 resource "kubernetes_deployment" "redis" {
+  count = var.deploy_azure_backing_services ? 0 : 1
+
   metadata {
     name      = local.redis_service_name
     namespace = var.namespace
@@ -43,6 +45,8 @@ resource "kubernetes_deployment" "redis" {
 }
 
 resource "kubernetes_service" "redis" {
+  count = var.deploy_azure_backing_services ? 0 : 1
+
   metadata {
     name      = local.redis_service_name
     namespace = var.namespace

--- a/terraform/modules/kubernetes/variables.tf
+++ b/terraform/modules/kubernetes/variables.tf
@@ -24,6 +24,36 @@ variable "postgres_flexible_server_storage_mb" {
   default = 32768
 }
 
+variable "redis_capacity" {
+  type    = number
+  default = 1
+}
+
+variable "redis_family" {
+  type    = string
+  default = "C"
+}
+
+variable "redis_sku_name" {
+  type    = string
+  default = "Standard"
+}
+
+variable "redis_enable_non_ssl_port" {
+  type    = bool
+  default = true
+}
+
+variable "redis_minimum_tls_version" {
+  type    = string
+  default = "1.2"
+}
+
+variable "redis_public_network_access_enabled" {
+  type    = bool
+  default = false
+}
+
 variable "resource_group_name" {}
 
 locals {
@@ -37,8 +67,12 @@ locals {
   postgres_dns_zone                    = var.cluster.dns_zone_prefix != null ? "${var.cluster.dns_zone_prefix}.internal.postgres.database.azure.com" : "internal.postgres.database.azure.com"
   postgres_server_name                 = "${var.resource_prefix}-${var.app_environment}-psql"
   postgres_service_name                = "apply-postgres-${var.app_environment}"
+  redis_dns_zone                       = "privatelink.redis.cache.windows.net"
+  redis_cache_name                     = "${var.resource_prefix}-${var.app_environment}-redis-cache"
+  redis_cache_private_endpoint_name    = "${var.resource_prefix}-${var.app_environment}-redis-cache-pe"
+  redis_queue_name                     = "${var.resource_prefix}-${var.app_environment}-redis-queue"
+  redis_queue_private_endpoint_name    = "${var.resource_prefix}-${var.app_environment}-redis-queue-pe"
   redis_service_name                   = "apply-redis-${var.app_environment}"
-  redis_url                            = "redis://${local.redis_service_name}:6379/0"
   secondary_worker_name                = "apply-secondary-worker-${var.app_environment}"
   webapp_startup_command               = var.webapp_startup_command == null ? null : ["/bin/sh", "-c", var.webapp_startup_command]
   webapp_name                          = "apply-${var.app_environment}"
@@ -62,7 +96,8 @@ locals {
     {
       DATABASE_URL        = local.database_url
       BLAZER_DATABASE_URL = local.database_url
-      REDIS_URL           = local.redis_url
+      REDIS_URL           = "redis://:${azurerm_redis_cache.redis-queue[0].primary_access_key}@${azurerm_redis_cache.redis-queue[0].hostname}:${azurerm_redis_cache.redis-queue[0].port}/0"
+      REDIS_CACHE_URL     = "redis://:${azurerm_redis_cache.redis-cache[0].primary_access_key}@${azurerm_redis_cache.redis-cache[0].hostname}:${azurerm_redis_cache.redis-cache[0].port}/0"
     }
   )
   # Create a unique name based on the values to force recreation when they change


### PR DESCRIPTION
## Context
Added the following resource deployments:
- A redis cache instance
- Private Endpoint

## Changes proposed in this pull request
Added resource blocks to create the redis-cache and private endpoint for the redis instance.

## Guidance to review
This PR will be used to deploy into `cluster6` environment based on PR #7917.

## Link to Trello card
[build Azure redis in internal subnet](https://trello.com/c/tuUYH6nM/76-build-azure-redis-in-internal-subnet)

## Things to check
- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
