### PR TITLE
Restore old API version changes notes to their former glory

### DIFF
--- a/app/helpers/api_docs_helper.rb
+++ b/app/helpers/api_docs_helper.rb
@@ -19,4 +19,12 @@ module APIDocsHelper
       end
     end
   end
+
+  def vendor_api_docs_show_version_changes?(version)
+    version.to_f > 1
+  end
+
+  def vendor_api_docs_version_changes_partial(version)
+    "v#{version.gsub('.', '_')}_changes"
+  end
 end

--- a/app/views/api_docs/vendor_api_docs/reference/_v1_1_changes.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/_v1_1_changes.html.erb
@@ -1,0 +1,92 @@
+<h2 class="govuk-heading-l" id="important">Version 1.1 changes</h2>
+
+<p class="govuk-heading-s">Interviews</p>
+<p class="govuk-body">
+  We now support <%= govuk_link_to 'creating', '#post-applications-application_id-interviews-create' %>, <%= govuk_link_to 'updating', '#post-applications-application_id-interviews-interview_id-update' %> and <%= govuk_link_to 'cancelling', '#post-applications-application_id-interviews-interview_id-cancel' %> interviews.
+</p>
+
+<p class="govuk-body">A nested <code>interviews</code> array will become populated if an interview is created. Each <%= govuk_link_to 'interview', '#interview-object' %> within the array will hold a unique <code>id</code>, which allows the update or cancelling of a specific interview.</p>
+
+<p class="govuk-body">To update an interview, the <%= govuk_link_to 'update endpoint', '#post-applications-application_id-interviews-interview_id-update' %> can be invoked with only the fields that require update. Any field that is not included will retain the current value and will not be overwritten.</p>
+
+<p class="govuk-body">To cancel an interview, the <%= govuk_link_to 'cancel endpoint', '#post-applications-application_id-interviews-interview_id-cancel' %> can be invoked with the cancellation reason. If an interview is cancelled the <code>cancelled_at</code> and <code>cancellation_reason</code> attributes will be populated.</p>
+
+<p class="govuk-body">If an applicant has an interview, the <code>interviews</code> array in the application response will be populated and can be used to determine the presence of any interviews, including cancelled ones. The status of the application will remain as <code>awaiting_provider_decision</code>.</p>
+
+<p class="govuk-body">When an applicant withdraws or declines an application, or if the application is made an offer or rejected, all upcoming interviews on that application are automatically cancelled.</p>
+
+<p class="govuk-heading-s">Notes</p>
+<p class="govuk-body">
+  We now support <%= govuk_link_to 'creating', '#post-applications-application_id-notes-create' %> notes.
+</p>
+<p class="govuk-body">To create a note the <%= govuk_link_to 'create endpoint', '#post-applications-application_id-notes-create' %> can be invoked with the message of the note.</p>
+
+<p class="govuk-body">If an applicant has any notes attached to the application, the <code>notes</code> array in the application response will be populated and can be used to determine the presence of any notes. The author of the note will be determined from the <code>full_name</code> provided in the <%= govuk_link_to 'Attribution Object', '#attribution-object' %> when making the API call.</p>
+
+<p class="govuk-body">It is not possible to update or delete existing notes.</p>
+
+<p class="govuk-heading-s">Deferring applications</p>
+<p class="govuk-body">
+  We now support <%= govuk_link_to 'deferring', '#post-applications-application_id-defer-offer' %> an offer to the next cycle, as well as <%= govuk_link_to 'confirming', '#post-applications-application_id-confirm-deferred-offer' %> a deferred offer in the next cycle.
+</p>
+<p class="govuk-body">To defer an application, the state of the application will need to either be <code>pending_conditions</code> or <code>recruited</code>, then the <%= govuk_link_to 'defer offer endpoint', '#post-applications-application_id-defer-offer' %> can be invoked. This will change the status of the application to a <b>new</b> status: <code>offer_deferred</code>. It will also populate the fields <code>offer_deferred_at</code>, <code>deferred_to_recruitment_cycle_year</code> with the year this deferred application can be confirmed, as well as maintain the status before deferral of the application in the field <code>status_before_deferral</code>. Please note that deferred applications did not previously appear in the application lists and will start appearing now when syncing with the API. If an application is deferred it can only be confirmed in the next cycle.
+</p>
+<p class="govuk-body">To confirm a deferred application in the next cycle, the <%= govuk_link_to 'confirm deferred offer endpoint', '#post-applications-application_id-confirm-deferred-offer' %> can be invoked. For successfully confirming an offer, the same course, location and study mode should be present in the new cycle. To determine success the conditions will be required to be set as met or not met, which will transition the state of the application accordingly to <code>recruited</code> or <code>pending_conditions</code>. The field <code>deferred_to_recruitment_cycle_year</code> will now be set to <code>null</code> as the application will no longer be in the <code>offer_deferred</code> status. Please note that deferred applications from the previous cycle will start appearing in the new cycle when syncing applications, with courses from the previous year initially set until confirmed.
+</p>
+<p class="govuk-body">If an application is confirmed successfully, the new course from the cycle will appear under the <%= govuk_link_to 'OfferObject', '#offer-object' %>.
+</p>
+<p class="govuk-heading-s">Withdrawing applications</p>
+<p class="govuk-body">
+  We now support <%= govuk_link_to 'withdrawing', '#post-applications-application_id-withdraw' %> an application at the candidate's request. If an application is withdrawn at a candidate's request, it will either transition to the <code>declined</code> state if the application is in the <code>offer</code> state, or the <code>withdrawn</code> state if it's in any other state. We currently don't require a reason for when an application is withdrawn at a candidate's request.
+</p>
+<p class="govuk-body">
+  If an application is withdrawn at a candidate's request the field <code>withdrawn_or_declined_for_candidate</code> will be set to true to determine the difference between a normal withdrawal and one at a candidate's request. Also either the <code>offer_declined_at</code> field or the <code>date</code> field, inside the existing <%= govuk_link_to 'Withdrawal Object', '#withdrawal-object' %>, will be populated with the timestamp the application was withdrawn or declined.
+</p>
+
+<p class="govuk-body">Only applications in the <code>offer</code> state will transition to the <code>declined</code> state.</p>
+
+<p class="govuk-body">Applications in the following states will transition to the <code>withdrawn</code> state:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <% (ApplicationStateChange::SUCCESSFUL_STATES + ApplicationStateChange::DECISION_PENDING_STATUSES).each do |state| %>
+    <li><code><%= state %></code></li>
+  <% end %>
+</ul>
+
+<p class="govuk-body">Please refer to the <%= govuk_link_to 'Application lifecycle', api_docs_lifecycle_path %> for details of application state transitions.</p>
+
+<p class="govuk-heading-s">Pagination</p>
+<p class="govuk-body">
+  Pagination has been added to the API through a <code>page</code> parameter as well as a <code>per_page</code> parameter. These parameters are both optional on the <%= govuk_link_to 'GET applications endpoint', '#get-applications' %>. If not supplied, the endpoint will return all records updated since the timestamp passed into the <code>since</code> parameter.
+</p>
+
+<p class="govuk-body">
+When using pagination, we recommend setting <code>per_page</code> to <code>50</code> and using overlapping time periods with previous application syncs for the <code>since</code> parameter. One possible strategy could be to always set <code>since</code> to two (or more) syncs ago. For example:
+</p>
+
+<p class="govuk-body">
+First GET /applications: (at time <code>D</code>, using <code>since=B</code>)
+<pre>
+A     --->    B    --->    C    --->    D    --->    E
+                           |            |
+                       last sync       now
+------------------------------------------------------
+since:                     A            B
+
+</pre>
+</p>
+
+<p class="govuk-body">
+Second GET /applications: (at time <code>E</code>, using <code>since=C</code>)
+<pre>
+A     --->    B    --->    C    --->    D    --->    E
+                                        |            |
+                                    last sync       now
+-------------------------------------------------------
+since:                                  B            C
+
+</pre>
+</p>
+
+<p class="govuk-body">
+To assist pagination for applications two new sections have been added to the response: a <%= govuk_link_to 'links', '#links-object' %> as well as a <%= govuk_link_to 'meta', '#responsemetamultiple-object' %> section. Both sections will always be returned in the API if the pagination parameters are supplied or not. The links section will determine the navigation through the API, and if no pagination is set, only the relevant fields will be populated and it can be ignored. The meta section will hold the API version, the total number of applications listed as well as the timestamp of the API call.
+</p>

--- a/app/views/api_docs/vendor_api_docs/reference/_v1_2_changes.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/_v1_2_changes.html.erb
@@ -1,0 +1,9 @@
+<h2 class="govuk-heading-l" id="important">Version 1.2 changes</h2>
+
+<p class="govuk-heading-s">Reject applications by code(s)</p>
+<p class="govuk-body">
+  We now support <%= govuk_link_to 'rejecting applications by codes', '#post-applications-application_id-reject-by-codes' %>.
+  Reference data for valid reason codes can be requested via the <%= govuk_link_to 'rejection-reason-codes', '#get-reference-data-rejection-reason-codes' %> endpoint.
+</p>
+
+<p class="govuk-body">Please refer to the <%= govuk_link_to 'Application lifecycle', api_docs_lifecycle_path %> for details of application state transitions.</p>

--- a/app/views/api_docs/vendor_api_docs/reference/_v1_3_changes.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/_v1_3_changes.html.erb
@@ -1,0 +1,63 @@
+<h2 class="govuk-heading-l" id="important">Version 1.3 changes</h2>
+
+<p class="govuk-heading-s">Show referee details before offer acceptance</p>
+
+<p class="govuk-body">
+  Referee details will appear as soon as a reference is added by the candidate,
+  but reference feedback will only be included once a candidate has accepted
+  an offer and has received a reference.
+</p>
+
+<p class="govuk-body">
+  As such the following fields have been marked as optional in the <%= govuk_link_to 'reference', '#reference-object' %> objects:
+</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li><code>reference</code></li>
+  <li><code>safeguarding_concerns</code></li>
+</ul>
+
+<p class="govuk-body">
+  References will not appear if their application is unsuccessful (e.g. offer declined, application rejected).
+</p>
+
+<p class="govuk-heading-s">Add missing fields to work/volunteering experience</p>
+
+<p class="govuk-body">
+  The following object types have been added:
+</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li><%= govuk_link_to 'Month', '#month-object' %></li>
+</ul>
+
+<p class="govuk-body">
+  The following fields have been added to the <%= govuk_link_to 'work (and volunteering) experience', '#workexperience-object' %> objects:
+</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li><code>skills_relevant_to_teaching</code> (boolean, optional)</li>
+  <li><code>start_month</code> (<%= govuk_link_to 'Month', '#month-object' %>)</li>
+  <li><code>end_month</code> (<%= govuk_link_to 'Month', '#month-object' %>, optional)</li>
+</ul>
+
+<p class="govuk-body">
+  The following fields have been deprecated in the <%= govuk_link_to 'work (and volunteering) experience', '#workexperience-object' %> objects:
+</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li><code>start_date</code></li>
+  <li><code>end_date</code></li>
+</ul>
+
+<p class="govuk-body">
+  The following fields have been marked as optional in the <%= govuk_link_to 'work (and volunteering) experience', '#workexperience-object' %> objects:
+</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li><code>description</code></li>
+</ul>
+
+<p class="govuk-heading-s">Mark fields as deprecated in <%= govuk_link_to 'application attributes', '#applicationattributes-object' %></p>
+
+<p class="govuk-body">
+  The following fields have been marked as deprecated and will be removed in a future release:
+</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li><code>phase</code></li>
+</ul>

--- a/app/views/api_docs/vendor_api_docs/reference/reference.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/reference.html.erb
@@ -6,8 +6,8 @@
 
 <ol class="app-contents-list__list">
   <li class="app-contents-list__list-item app-contents-list__list-item--parent"><%= govuk_link_to 'API Versions', '#versions', class: 'app-contents-list__link' %></li>
-  <% if version == "1.3" %>
-    <li class="app-contents-list__list-item app-contents-list__list-item--parent"><%= govuk_link_to 'Version 1.3 changes', '#important', class: 'app-contents-list__link' %></li>
+  <% if vendor_api_docs_show_version_changes?(version) %>
+    <li class="app-contents-list__list-item app-contents-list__list-item--parent"><%= govuk_link_to "Version #{version} changes", '#important', class: 'app-contents-list__link' %></li>
   <% end %>
   <li class="app-contents-list__list-item app-contents-list__list-item--parent"><%= govuk_link_to 'Developing on the API', '#developing', class: 'app-contents-list__link' %></li>
   <li class="app-contents-list__list-item app-contents-list__list-item--parent">
@@ -50,70 +50,9 @@
   <li>using the correct version of the API</li>
 </ul>
 
-<% if version == "1.3" %>
-  <h2 class="govuk-heading-l" id="important">Version 1.3 changes</h2>
-
-  <p class="govuk-heading-s">Show referee details before offer acceptance</p>
-
-  <p class="govuk-body">
-    Referee details will appear as soon as a reference is added by the candidate,
-    but reference feedback will only be included once a candidate has accepted
-    an offer and has received a reference.
-  </p>
-
-  <p class="govuk-body">
-    As such the following fields have been marked as optional in the <%= govuk_link_to 'reference', '#reference-object' %> objects:
-  </p>
-  <ul class="govuk-list govuk-list--bullet">
-    <li><code>reference</code></li>
-    <li><code>safeguarding_concerns</code></li>
-  </ul>
-
-  <p class="govuk-body">
-    References will not appear if their application is unsuccessful (e.g. offer declined, application rejected).
-  </p>
-
-  <p class="govuk-heading-s">Add missing fields to work/volunteering experience</p>
-
-  <p class="govuk-body">
-    The following object types have been added:
-  </p>
-  <ul class="govuk-list govuk-list--bullet">
-    <li><%= govuk_link_to 'Month', '#month-object' %></li>
-  </ul>
-
-  <p class="govuk-body">
-    The following fields have been added to the <%= govuk_link_to 'work (and volunteering) experience', '#workexperience-object' %> objects:
-  </p>
-  <ul class="govuk-list govuk-list--bullet">
-    <li><code>skills_relevant_to_teaching</code> (boolean, optional)</li>
-    <li><code>start_month</code> (<%= govuk_link_to 'Month', '#month-object' %>)</li>
-    <li><code>end_month</code> (<%= govuk_link_to 'Month', '#month-object' %>, optional)</li>
-  </ul>
-
-  <p class="govuk-body">
-    The following fields have been deprecated in the <%= govuk_link_to 'work (and volunteering) experience', '#workexperience-object' %> objects:
-  </p>
-  <ul class="govuk-list govuk-list--bullet">
-    <li><code>start_date</code></li>
-    <li><code>end_date</code></li>
-  </ul>
-
-  <p class="govuk-body">
-    The following fields have been marked as optional in the <%= govuk_link_to 'work (and volunteering) experience', '#workexperience-object' %> objects:
-  </p>
-  <ul class="govuk-list govuk-list--bullet">
-    <li><code>description</code></li>
-  </ul>
-
-  <p class="govuk-heading-s">Mark fields as deprecated in <%= govuk_link_to 'application attributes', '#applicationattributes-object' %></p>
-
-  <p class="govuk-body">
-    The following fields have been marked as deprecated and will be removed in a future release:
-  </p>
-  <ul class="govuk-list govuk-list--bullet">
-    <li><code>phase</code></li>
-  </ul>
+<% if vendor_api_docs_show_version_changes?(version) %>
+  <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-6 govuk-!-margin-bottom-6">
+  <%= render partial: vendor_api_docs_version_changes_partial(version) %>
 <% end %>
 
 <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-6 govuk-!-margin-bottom-6">


### PR DESCRIPTION
## Context

Previous commits had got rid of the version changes notes for versions 1.1 and 1.2. However, users that are now trying to upgrade to those versions would like to see these notes.

## Changes proposed in this pull request

Restore the old version changes notes, and move them into partials which are loaded based on the current version being viewed.

## Guidance to review

Does it look about right?

## Before

<img width="397" alt="CleanShot 2023-02-09 at 16 00 01@2x" src="https://user-images.githubusercontent.com/168365/217867303-96e0986b-1563-4708-94e9-aff75f30e8e9.png">

## After

<img width="397" alt="CleanShot 2023-02-09 at 16 00 13@2x" src="https://user-images.githubusercontent.com/168365/217867298-f3c61969-95db-47bb-9069-6e67aad8dd6b.png">

## Link to Trello card

https://trello.com/c/X51stgYk/1175-restore-version-11-and-12-api-changes-to-the-docs

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
