### PR TITLE
Filter by subject on the support UI

### DIFF
--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -45,6 +45,10 @@ module SupportInterface
         application_forms = application_forms.joins(:application_choices).where(application_choices: { status: applied_filters[:status] })
       end
 
+      if applied_filters[:subject].present?
+        application_forms = application_forms.joins(courses: :subjects).where(subjects: { name: applied_filters[:subject] })
+      end
+
       if applied_filters[:provider_id]
         application_forms = application_forms
           .joins(:application_choices)
@@ -55,7 +59,7 @@ module SupportInterface
     end
 
     def filters
-      @filters ||= [search_filter, search_by_application_choice_filter, year_filter, phase_filter, interviews_filter, status_filter]
+      @filters ||= [search_filter, search_by_application_choice_filter, year_filter, phase_filter, interviews_filter, status_filter, subject_filter]
     end
 
   private
@@ -128,6 +132,22 @@ module SupportInterface
             checked: applied_filters[:interviews]&.include?('has_interviews'),
           },
         ],
+      }
+    end
+
+    def subject_filter
+      subject_options = MinisterialReport::SUBJECTS.map do |subject, _|
+        {
+          value: subject.to_s.humanize,
+          label: subject.to_s.humanize,
+          checked: applied_filters[:subject]&.include?(subject.to_s.humanize),
+        }
+      end
+      {
+        type: :checkboxes,
+        heading: 'Subject',
+        name: 'subject',
+        options: subject_options,
       }
     end
 

--- a/spec/models/support_interface/applications_filter_spec.rb
+++ b/spec/models/support_interface/applications_filter_spec.rb
@@ -2,7 +2,11 @@ require 'rails_helper'
 
 RSpec.describe SupportInterface::ApplicationsFilter do
   let!(:application_choice_with_offer) do
-    create(:application_choice, :offered, :previous_year)
+    primary = create(:subject, name: 'Primary', code: 'F0')
+    course = create(:course, subjects: [primary])
+    course_option = create(:course_option, course: course)
+
+    create(:application_choice, :offered, :previous_year, course_option: course_option)
   end
   let!(:application_choice_with_interview) { create(:application_choice, :interviewing) }
   let!(:application_choice_recruited) { create(:application_choice, :recruited) }
@@ -100,6 +104,17 @@ RSpec.describe SupportInterface::ApplicationsFilter do
         [expected_form],
         params: {
           status: %w[offer],
+        },
+      )
+    end
+
+    it 'can filter by subject' do
+      expected_form = application_choice_with_offer.application_form
+
+      verify_filtered_applications_for_params(
+        [expected_form],
+        params: {
+          subject: %w[Primary],
         },
       )
     end


### PR DESCRIPTION
## Context

We have a range of filters on the support UI – many non-technical colleagues use this as a quick method to filter and view applications. There is currently no option to filter by subject and they've requested if we can add one

## Changes proposed in this pull request

Use the subjects defined in the ministerial report class for subjects they can filter by.
![image](https://user-images.githubusercontent.com/47917431/217874369-c4f020cf-e729-415d-8ae1-13fa1430e9af.png)


