### PR TITLE
One personal statement

### DIFF
--- a/app/components/candidate_interface/becoming_a_teacher_review_component.rb
+++ b/app/components/candidate_interface/becoming_a_teacher_review_component.rb
@@ -44,7 +44,7 @@ module CandidateInterface
     end
 
     def personal_statement_label
-      if render_single_personal_statement_values?
+      if @application_form.single_personal_statement_application?
         t('application_form.personal_statement.review.label')
       else
         t('application_form.personal_statement.becoming_a_teacher.label')
@@ -52,15 +52,11 @@ module CandidateInterface
     end
 
     def visually_hidden_text
-      if render_single_personal_statement_values?
+      if @application_form.single_personal_statement_application?
         'personal statement'
       else
         t('application_form.personal_statement.becoming_a_teacher.change_action')
       end
-    end
-
-    def render_single_personal_statement_values?
-      FeatureFlag.active?(:one_personal_statement) && @application_form.single_personal_statement?
     end
 
     def return_to_params

--- a/app/components/candidate_interface/becoming_a_teacher_review_component.rb
+++ b/app/components/candidate_interface/becoming_a_teacher_review_component.rb
@@ -33,7 +33,7 @@ module CandidateInterface
         value: @becoming_a_teacher_form.becoming_a_teacher,
         action: {
           href: candidate_interface_edit_becoming_a_teacher_path(return_to_params),
-          visually_hidden_text: 'personal statement',
+          visually_hidden_text: visually_hidden_text,
         },
         html_attributes: {
           data: {
@@ -44,11 +44,23 @@ module CandidateInterface
     end
 
     def personal_statement_label
-      if FeatureFlag.active?(:one_personal_statement) && @application_form.single_personal_statement?
+      if render_single_personal_statement_values?
         t('application_form.personal_statement.review.label')
       else
         t('application_form.personal_statement.becoming_a_teacher.label')
       end
+    end
+
+    def visually_hidden_text
+      if render_single_personal_statement_values?
+        'personal statement'
+      else
+        t('application_form.personal_statement.becoming_a_teacher.change_action')
+      end
+    end
+
+    def render_single_personal_statement_values?
+      FeatureFlag.active?(:one_personal_statement) && @application_form.single_personal_statement?
     end
 
     def return_to_params

--- a/app/components/candidate_interface/becoming_a_teacher_review_component.rb
+++ b/app/components/candidate_interface/becoming_a_teacher_review_component.rb
@@ -29,11 +29,11 @@ module CandidateInterface
 
     def becoming_a_teacher_form_row
       {
-        key: t('application_form.personal_statement.becoming_a_teacher.label'),
+        key: personal_statement_label,
         value: @becoming_a_teacher_form.becoming_a_teacher,
         action: {
           href: candidate_interface_edit_becoming_a_teacher_path(return_to_params),
-          visually_hidden_text: t('application_form.personal_statement.becoming_a_teacher.change_action'),
+          visually_hidden_text: 'personal statement',
         },
         html_attributes: {
           data: {
@@ -41,6 +41,14 @@ module CandidateInterface
           },
         },
       }
+    end
+
+    def personal_statement_label
+      if FeatureFlag.active?(:one_personal_statement) && @application_form.single_personal_statement?
+        t('application_form.personal_statement.review.label')
+      else
+        t('application_form.personal_statement.becoming_a_teacher.label')
+      end
     end
 
     def return_to_params

--- a/app/components/shared/personal_statement_component.html.erb
+++ b/app/components/shared/personal_statement_component.html.erb
@@ -1,7 +1,7 @@
 <section id="personal-statement-section" class="app-section govuk-!-width-two-thirds">
   <h2 class="govuk-heading-m govuk-!-font-size-27" id="personal-statement"><%= t('personal_statement.title') %></h2>
 
-  <h3 class="govuk-heading-s"><%= t('personal_statement.vocation') %>
+  <h3 class="govuk-heading-s"><%= header %>
     <% if @editable %>
       <%= govuk_link_to support_interface_application_form_edit_becoming_a_teacher_path, class: 'govuk-body' do %>
         Change <span class="govuk-visually-hidden">answer to ‘<%= t('personal_statement.vocation') %>’</span>
@@ -11,15 +11,19 @@
 
   <%= simple_format becoming_a_teacher, class: 'govuk-body' %>
 
-  <h3 class="govuk-heading-s"><%= t('personal_statement.subject_knowledge') %>
-    <% if @editable %>
-      <%= govuk_link_to support_interface_application_form_edit_subject_knowledge_path, class: 'govuk-body' do %>
-        Change <span class="govuk-visually-hidden">answer to ‘<%= t('personal_statement.subject_knowledge') %>’</span>
-      <% end %>
-    <% end %>
-  </h3>
+  <% if FeatureFlag.active?(:one_personal_statement) && !application_form.single_personal_statement? %>
 
-  <%= simple_format subject_knowledge, class: 'govuk-body' %>
+    <h3 class="govuk-heading-s"><%= t('personal_statement.subject_knowledge') %>
+      <% if @editable %>
+        <%= govuk_link_to support_interface_application_form_edit_subject_knowledge_path, class: 'govuk-body' do %>
+          Change <span class="govuk-visually-hidden">answer to ‘<%= t('personal_statement.subject_knowledge') %>’</span>
+        <% end %>
+      <% end %>
+    </h3>
+
+    <%= simple_format subject_knowledge, class: 'govuk-body' %>
+
+  <% end %>
 
   <h3 class="govuk-heading-s"><%= t('personal_statement.further_information') %></h3>
   <%= simple_format further_information, class: 'govuk-body' %>

--- a/app/components/shared/personal_statement_component.html.erb
+++ b/app/components/shared/personal_statement_component.html.erb
@@ -1,7 +1,7 @@
 <section id="personal-statement-section" class="app-section govuk-!-width-two-thirds">
   <h2 class="govuk-heading-m govuk-!-font-size-27" id="personal-statement"><%= t('personal_statement.title') %></h2>
 
-  <% unless single_personal_statement_application? %>
+  <% unless application_form.single_personal_statement_application? %>
     <h3 class="govuk-heading-s"><%= t('personal_statement.vocation') %>
   <% end %>
 
@@ -14,7 +14,7 @@
 
   <%= simple_format becoming_a_teacher, class: 'govuk-body' %>
 
-  <% unless single_personal_statement_application? %>
+  <% unless application_form.single_personal_statement_application? %>
 
     <h3 class="govuk-heading-s"><%= t('personal_statement.subject_knowledge') %>
       <% if @editable %>

--- a/app/components/shared/personal_statement_component.html.erb
+++ b/app/components/shared/personal_statement_component.html.erb
@@ -1,7 +1,10 @@
 <section id="personal-statement-section" class="app-section govuk-!-width-two-thirds">
   <h2 class="govuk-heading-m govuk-!-font-size-27" id="personal-statement"><%= t('personal_statement.title') %></h2>
 
-  <h3 class="govuk-heading-s"><%= header %>
+  <% unless single_personal_statement_application? %>
+    <h3 class="govuk-heading-s"><%= t('personal_statement.vocation') %>
+  <% end %>
+
     <% if @editable %>
       <%= govuk_link_to support_interface_application_form_edit_becoming_a_teacher_path, class: 'govuk-body' do %>
         Change <span class="govuk-visually-hidden">answer to ‘<%= t('personal_statement.vocation') %>’</span>
@@ -11,7 +14,7 @@
 
   <%= simple_format becoming_a_teacher, class: 'govuk-body' %>
 
-  <% if FeatureFlag.active?(:one_personal_statement) && !application_form.single_personal_statement? %>
+  <% unless single_personal_statement_application? %>
 
     <h3 class="govuk-heading-s"><%= t('personal_statement.subject_knowledge') %>
       <% if @editable %>
@@ -25,6 +28,6 @@
 
   <% end %>
 
-  <h3 class="govuk-heading-s"><%= t('personal_statement.further_information') %></h3>
+  <h2 class="govuk-heading-m"><%= t('personal_statement.further_information') %></h2>
   <%= simple_format further_information, class: 'govuk-body' %>
 </section>

--- a/app/components/shared/personal_statement_component.rb
+++ b/app/components/shared/personal_statement_component.rb
@@ -14,5 +14,9 @@ class PersonalStatementComponent < ViewComponent::Base
 
 private
 
+  def header
+    FeatureFlag.active?(:one_personal_statement) && application_form.single_personal_statement? ? I18n.t('page_titles.personal_statement') : I18n.t('personal_statement.vocation')
+  end
+
   attr_reader :application_form
 end

--- a/app/components/shared/personal_statement_component.rb
+++ b/app/components/shared/personal_statement_component.rb
@@ -14,9 +14,5 @@ class PersonalStatementComponent < ViewComponent::Base
 
 private
 
-  def single_personal_statement_application?
-    FeatureFlag.active?(:one_personal_statement) && application_form.single_personal_statement?
-  end
-
   attr_reader :application_form
 end

--- a/app/components/shared/personal_statement_component.rb
+++ b/app/components/shared/personal_statement_component.rb
@@ -14,8 +14,8 @@ class PersonalStatementComponent < ViewComponent::Base
 
 private
 
-  def header
-    FeatureFlag.active?(:one_personal_statement) && application_form.single_personal_statement? ? I18n.t('page_titles.personal_statement') : I18n.t('personal_statement.vocation')
+  def single_personal_statement_application?
+    FeatureFlag.active?(:one_personal_statement) && application_form.single_personal_statement?
   end
 
   attr_reader :application_form

--- a/app/controllers/candidate_interface/personal_statement_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement_controller.rb
@@ -19,7 +19,7 @@ module CandidateInterface
     end
 
     def create
-      @becoming_a_teacher_form = BecomingATeacherForm.build_from_application(becoming_a_teacher_params)
+      @becoming_a_teacher_form = BecomingATeacherForm.build_from_params(becoming_a_teacher_params)
 
       if @becoming_a_teacher_form.save(current_application)
         redirect_to candidate_interface_becoming_a_teacher_show_path

--- a/app/controllers/candidate_interface/personal_statement_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement_controller.rb
@@ -19,7 +19,7 @@ module CandidateInterface
     end
 
     def create
-      @becoming_a_teacher_form = BecomingATeacherForm.new(becoming_a_teacher_params)
+      @becoming_a_teacher_form = BecomingATeacherForm.build_from_application(becoming_a_teacher_params)
 
       if @becoming_a_teacher_form.save(current_application)
         redirect_to candidate_interface_becoming_a_teacher_show_path
@@ -30,7 +30,7 @@ module CandidateInterface
     end
 
     def update
-      @becoming_a_teacher_form = BecomingATeacherForm.new(becoming_a_teacher_params)
+      @becoming_a_teacher_form = BecomingATeacherForm.build_from_params(becoming_a_teacher_params)
       @return_to = return_to_after_edit(default: candidate_interface_becoming_a_teacher_show_path)
 
       if @becoming_a_teacher_form.save(current_application)
@@ -58,7 +58,7 @@ module CandidateInterface
     def becoming_a_teacher_params
       strip_whitespace params.require(:candidate_interface_becoming_a_teacher_form).permit(
         :becoming_a_teacher,
-      )
+      ).merge(single_personal_statement: current_application.single_personal_statement?)
     end
 
     def form_params

--- a/app/controllers/candidate_interface/personal_statement_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement_controller.rb
@@ -8,7 +8,7 @@ module CandidateInterface
     end
 
     def new
-      @becoming_a_teacher_form = BecomingATeacherForm.new
+      @becoming_a_teacher_form = BecomingATeacherForm.build_from_application(current_application)
     end
 
     def edit

--- a/app/controllers/candidate_interface/subject_knowledge_controller.rb
+++ b/app/controllers/candidate_interface/subject_knowledge_controller.rb
@@ -74,7 +74,7 @@ module CandidateInterface
     end
 
     def redirect_to_personal_statement_if_on_the_new_personal_statement
-      redirect_to candidate_interface_becoming_a_teacher_show_path if FeatureFlag.active?(:one_personal_statement) && current_application.single_personal_statement?
+      redirect_to candidate_interface_becoming_a_teacher_show_path if current_application.single_personal_statement_application?
     end
   end
 end

--- a/app/controllers/candidate_interface/subject_knowledge_controller.rb
+++ b/app/controllers/candidate_interface/subject_knowledge_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class SubjectKnowledgeController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted, :render_application_feedback_component
+    before_action :redirect_to_dashboard_if_submitted, :render_application_feedback_component, :redirect_to_personal_statement_if_on_the_new_personal_statement
 
     def show
       @application_form = current_application
@@ -71,6 +71,10 @@ module CandidateInterface
 
     def section_complete_form_params
       strip_whitespace params.fetch(:candidate_interface_section_complete_form, {}).permit(:completed)
+    end
+
+    def redirect_to_personal_statement_if_on_the_new_personal_statement
+      redirect_to candidate_interface_becoming_a_teacher_show_path if FeatureFlag.active?(:one_personal_statement) && current_application.single_personal_statement?
     end
   end
 end

--- a/app/forms/candidate_interface/becoming_a_teacher_form.rb
+++ b/app/forms/candidate_interface/becoming_a_teacher_form.rb
@@ -6,7 +6,7 @@ module CandidateInterface
 
     alias single_personal_statement? single_personal_statement
 
-    validates :becoming_a_teacher, presence: true
+    validate :presence_of_statement
     validates :becoming_a_teacher, word_count: { maximum: 1000 }, if: :single_personal_statement?
     validates :becoming_a_teacher, word_count: { maximum: 600 }, unless: :single_personal_statement?
 
@@ -30,6 +30,14 @@ module CandidateInterface
       application_form.update(
         becoming_a_teacher:,
       )
+    end
+
+    def presence_of_statement
+      if single_personal_statement? && becoming_a_teacher.blank?
+        errors.add(:becoming_a_teacher, 'Write your personal statement')
+      elsif becoming_a_teacher.blank?
+        errors.add(:becoming_a_teacher, :blank)
+      end
     end
   end
 end

--- a/app/forms/candidate_interface/becoming_a_teacher_form.rb
+++ b/app/forms/candidate_interface/becoming_a_teacher_form.rb
@@ -6,14 +6,21 @@ module CandidateInterface
 
     alias single_personal_statement? single_personal_statement
 
-    validates :becoming_a_teacher,
-              word_count: { maximum: 600 },
-              presence: true
+    validates :becoming_a_teacher, presence: true
+    validates :becoming_a_teacher, word_count: { maximum: 1000 }, if: :single_personal_statement?
+    validates :becoming_a_teacher, word_count: { maximum: 600 }, unless: :single_personal_statement?
 
     def self.build_from_application(application_form)
       new(
         single_personal_statement: application_form.single_personal_statement?,
         becoming_a_teacher: application_form.becoming_a_teacher,
+      )
+    end
+
+    def self.build_from_params(params)
+      new(
+        single_personal_statement: params[:single_personal_statement],
+        becoming_a_teacher: params[:becoming_a_teacher],
       )
     end
 

--- a/app/forms/candidate_interface/becoming_a_teacher_form.rb
+++ b/app/forms/candidate_interface/becoming_a_teacher_form.rb
@@ -2,7 +2,9 @@ module CandidateInterface
   class BecomingATeacherForm
     include ActiveModel::Model
 
-    attr_accessor :becoming_a_teacher
+    attr_accessor :becoming_a_teacher, :single_personal_statement
+
+    alias single_personal_statement? single_personal_statement
 
     validates :becoming_a_teacher,
               word_count: { maximum: 600 },
@@ -10,6 +12,7 @@ module CandidateInterface
 
     def self.build_from_application(application_form)
       new(
+        single_personal_statement: application_form.single_personal_statement?,
         becoming_a_teacher: application_form.becoming_a_teacher,
       )
     end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -48,6 +48,10 @@ class ApplicationForm < ApplicationRecord
   BRITISH_OR_IRISH_NATIONALITIES = %w[GB IE].freeze
   MAXIMUM_NUMBER_OF_COURSE_CHOICES = 4
 
+  # Applications created after this date include a single personal statement
+  # instead of 2 personal statement sections
+  SINGLE_PERSONAL_STATEMENT_FROM = DateTime.new(2023, 2, 10, 9, 0)
+
   BEGINNING_OF_FREE_SCHOOL_MEALS = Date.new(1964, 9, 1)
   # Free school meals were means tested from around 1980 onwards under
   # changes brought in by the Education Act 1980. Based on this, we don’t need
@@ -189,6 +193,10 @@ class ApplicationForm < ApplicationRecord
     end
 
     application_choices.touch_all
+  end
+
+  def single_personal_statement?
+    created_at.nil? || created_at >= SINGLE_PERSONAL_STATEMENT_FROM
   end
 
   def submitted?

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -512,6 +512,10 @@ class ApplicationForm < ApplicationRecord
     end
   end
 
+  def single_personal_statement_application?
+    FeatureFlag.active?(:one_personal_statement) && single_personal_statement?
+  end
+
 private
 
   def geocode_address_and_update_region_if_required

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -50,7 +50,7 @@ class ApplicationForm < ApplicationRecord
 
   # Applications created after this date include a single personal statement
   # instead of 2 personal statement sections
-  SINGLE_PERSONAL_STATEMENT_FROM = DateTime.new(2023, 2, 10, 9, 0)
+  SINGLE_PERSONAL_STATEMENT_FROM = DateTime.new(2023, 4, 3, 9, 0)
 
   BEGINNING_OF_FREE_SCHOOL_MEALS = Date.new(1964, 9, 1)
   # Free school meals were means tested from around 1980 onwards under

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -54,7 +54,7 @@ module CandidateInterface
 
         # "Personal statement and interview" section
         [:becoming_a_teacher, becoming_a_teacher_completed?, becoming_a_teacher_review_pending?],
-        [:subject_knowledge, subject_knowledge_completed?, subject_knowledge_review_pending?],
+        ([:subject_knowledge, subject_knowledge_completed?, subject_knowledge_review_pending?] unless application_form.single_personal_statement?),
         [:interview_preferences, interview_preferences_completed?],
 
         # "References" section

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -26,6 +26,17 @@ class DuplicateApplication
         )
       end
 
+      if !original_application_form.single_personal_statement?
+        original_becoming_a_teacher = original_application_form.becoming_a_teacher
+        original_subject_knowledge = original_application_form.subject_knowledge
+        merged_personal_statement = original_becoming_a_teacher.concat(' ', original_subject_knowledge)
+
+        new_application_form.update!(
+          becoming_a_teacher_completed: false,
+          becoming_a_teacher: merged_personal_statement,
+        )
+      end
+
       if !original_application_form.restructured_immigration_status? &&
          new_application_form.restructured_immigration_status? &&
          !new_application_form.british_or_irish?

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -26,10 +26,10 @@ class DuplicateApplication
         )
       end
 
-      if !original_application_form.single_personal_statement?
+      if FeatureFlag.active?(:one_personal_statement) && !original_application_form.single_personal_statement?
         original_becoming_a_teacher = original_application_form.becoming_a_teacher
         original_subject_knowledge = original_application_form.subject_knowledge
-        merged_personal_statement = original_becoming_a_teacher.concat(' ', original_subject_knowledge)
+        merged_personal_statement = "#{original_becoming_a_teacher} #{original_subject_knowledge}"
 
         new_application_form.update!(
           becoming_a_teacher_completed: false,

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -29,11 +29,14 @@ class DuplicateApplication
       if FeatureFlag.active?(:one_personal_statement) && !original_application_form.single_personal_statement?
         original_becoming_a_teacher = original_application_form.becoming_a_teacher
         original_subject_knowledge = original_application_form.subject_knowledge
-        merged_personal_statement = "#{original_becoming_a_teacher} #{original_subject_knowledge}"
+        merged_personal_statement = "#{original_becoming_a_teacher}\n\n#{original_subject_knowledge}"
 
         new_application_form.update!(
           becoming_a_teacher_completed: false,
           becoming_a_teacher: merged_personal_statement,
+          subject_knowledge: nil,
+          subject_knowledge_completed: nil,
+          subject_knowledge_completed_at: nil,
         )
       end
 

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -36,6 +36,7 @@ class FeatureFlag
     [:provider_ske, 'SKE eligible courses providers are presented with an additional screen after making an offer', 'Tomas+James Glenn'],
     [:sample_applications_factory, 'An alternate generator for test/sample applications, uses `SampleApplicationsFactory` in place of `TestApplications.new`', 'Elliot Crosby-McCullough + Tomas Destefi'],
     [:adviser_sign_up, 'Allow candidates to sign up for a teacher training adviser', 'Ross Oliver'],
+    [:one_personal_statement, 'Combining the 2 personal statements into 1 for new applications', 'Frankie Roberto + Maeve Roseveare'],
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -124,13 +124,15 @@
     submitting_application: true,
     return_to_application_review: true,
   )) %>
-  <%= render(CandidateInterface::SubjectKnowledgeReviewComponent.new(
-    application_form: application_form,
-    editable: editable,
-    missing_error: missing_error,
-    submitting_application: true,
-    return_to_application_review: true,
-  )) %>
+  <% unless application_form.single_personal_statement? %>
+    <%= render(CandidateInterface::SubjectKnowledgeReviewComponent.new(
+      application_form: application_form,
+      editable: editable,
+      missing_error: missing_error,
+      submitting_application: true,
+      return_to_application_review: true,
+    )) %>
+  <% end %>
 </section>
 
 <section class="govuk-!-margin-bottom-8">

--- a/app/views/candidate_interface/personal_statement/_form.html.erb
+++ b/app/views/candidate_interface/personal_statement/_form.html.erb
@@ -6,15 +6,16 @@
     Personal statement
   </h1>
 
-  <p class="govuk-body">You should try and write between 600 and 800 words for your statement. You can write up to 1000 words if you want.</p>
-  <p class="govuk-body">Here are some examples you could write about (you do not need to mention all of them):</p>
+  <p class="govuk-body">You should write between 500 and 1000 words for your personal statement.</p>
+  <p class="govuk-body">Here are some examples you could write about (they are just a guide, you do not need to write about all of them):</p>
 
   <ul class="govuk-list govuk-list--bullet">
-    <li>your motivations for wanting to train to be a teacher</li>
-    <li>any skills you have that are relevant to teaching</li>
+    <li>skills you have that are relevant to teaching</li>
     <li>any experience of working with young people</li>
     <li>for secondary teacher training: your interest in the subject you want to teach</li>
-    <li>any training or activities you’ve done that could be relevant to teaching like first aid courses, sports coaching or volunteering</li>
+    <li>your understanding of why teaching is important</li>
+    <li>your reasons for wanting to train to be a teacher</li>
+    <li>any activities you’ve done that could be relevant to teaching like first aid courses, sports coaching or volunteering</li>
 
   </ul>
 

--- a/app/views/candidate_interface/personal_statement/_form.html.erb
+++ b/app/views/candidate_interface/personal_statement/_form.html.erb
@@ -3,16 +3,24 @@
 <% if FeatureFlag.active?(:one_personal_statement) && f.object.single_personal_statement? %>
 
   <h1 class="govuk-heading-xl">
-    Skills and experience
+    Personal statement
   </h1>
 
-  <p class="govuk-body">You could talk about:</p>
+  <p class="govuk-body">Your personal statement should show your understanding of teaching and your motivations for wanting to teach.</p>
+  <p class="govuk-body">You can include things like:</p>
 
   <ul class="govuk-list govuk-list--bullet">
-    <li>....</li>
+    <li>your understanding of the rewards and challenges of teaching</li>
+    <li>why you want to teach a certain age group or subject</li>
+    <li>skills you have that are relevant to teaching</li>
+    <li>any experience of working with young people</li>
+    <li>your interests and passions you could use in the classroom or contribute to a school (like organising clubs or activities for students after school)</li>
+    <li>qualifications or courses you’ve done that would help in your teaching career</li>
   </ul>
 
-  <%= f.govuk_text_area :becoming_a_teacher, label: { text: 'Personal statement', size: 'm' }, rows: 20, max_words: 1000 %>
+  <p class="govuk-body">If you need help, speak to our <a href="https://getintoteaching.education.gov.uk/teacher-training-advisers">teacher training advisers</a>. They were teachers and can give you free, one-to-one support with your personal statement.</p>
+
+  <%= f.govuk_text_area :becoming_a_teacher, label: { text: 'Your personal statement', size: 'm' }, rows: 20, max_words: 1000 %>
 
 <% else %>
   <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/personal_statement/_form.html.erb
+++ b/app/views/candidate_interface/personal_statement/_form.html.erb
@@ -2,7 +2,7 @@
 
 <% if FeatureFlag.active?(:one_personal_statement) && f.object.single_personal_statement? %>
 
-  <h1 class="govuk-heading-xl">
+  <h1 class="govuk-heading-l">
     Personal statement
   </h1>
 
@@ -23,7 +23,7 @@
   <%= f.govuk_text_area :becoming_a_teacher, label: { text: 'Your personal statement', size: 'm' }, rows: 20, max_words: 1000 %>
 
 <% else %>
-  <h1 class="govuk-heading-xl">
+  <h1 class="govuk-heading-l">
     <%= t('page_titles.becoming_a_teacher') %>
   </h1>
 

--- a/app/views/candidate_interface/personal_statement/_form.html.erb
+++ b/app/views/candidate_interface/personal_statement/_form.html.erb
@@ -1,23 +1,39 @@
 <%= f.govuk_error_summary %>
 
-<h1 class="govuk-heading-xl">
-  <%= t('page_titles.becoming_a_teacher') %>
-</h1>
+<% if FeatureFlag.active?(:one_personal_statement) && f.object.single_personal_statement? %>
 
-<p class="govuk-body">Explain why you want to be a teacher.</p>
+  <h1 class="govuk-heading-xl">
+    Skills and experience
+  </h1>
 
-<p class="govuk-body">You could talk about:</p>
+  <p class="govuk-body">You could talk about:</p>
 
-<ul class="govuk-list govuk-list--bullet">
-  <li>what inspired you to apply</li>
-  <li>the personal qualities that would make you a good teacher</li>
-  <li>any experience you have working with children and what you learnt</li>
-  <li>your understanding of the demands and rewards of teaching</li>
-  <li>how you could contribute to a school outside of the classroom - for example, running extra-curricular activities and clubs</li>
-  <li>your thoughts on children’s wellbeing and the education system</li>
-</ul>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>....</li>
+  </ul>
+
+  <%= f.govuk_text_area :becoming_a_teacher, label: { text: 'Personal statement', size: 'm' }, rows: 20, max_words: 1000 %>
+
+<% else %>
+  <h1 class="govuk-heading-xl">
+    <%= t('page_titles.becoming_a_teacher') %>
+  </h1>
+
+  <p class="govuk-body">Explain why you want to be a teacher.</p>
+
+  <p class="govuk-body">You could talk about:</p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li>what inspired you to apply</li>
+    <li>the personal qualities that would make you a good teacher</li>
+    <li>any experience you have working with children and what you learnt</li>
+    <li>your understanding of the demands and rewards of teaching</li>
+    <li>how you could contribute to a school outside of the classroom - for example, running extra-curricular activities and clubs</li>
+    <li>your thoughts on children’s wellbeing and the education system</li>
+  </ul>
 
 <p class="govuk-body">Get help with your personal statement by speaking to our <%= govuk_link_to_with_utm_params('teacher training advisers', t('get_into_teaching.url_get_an_adviser'), utm_campaign(params), current_application.phase) %>. They were teachers and can give you free, one-to-one support.</p>
 
 <%= f.govuk_text_area :becoming_a_teacher, label: { text: t('application_form.personal_statement.becoming_a_teacher.label'), size: 'm' }, rows: 20, max_words: 600 %>
+
 <%= f.govuk_submit t('continue') %>

--- a/app/views/candidate_interface/personal_statement/_form.html.erb
+++ b/app/views/candidate_interface/personal_statement/_form.html.erb
@@ -6,19 +6,19 @@
     Personal statement
   </h1>
 
-  <p class="govuk-body">Your personal statement should show your understanding of teaching and your motivations for wanting to teach.</p>
-  <p class="govuk-body">You can include things like:</p>
+  <p class="govuk-body">You should try and write between 600 and 800 words for your statement. You can write up to 1000 words if you want.</p>
+  <p class="govuk-body">Here are some examples (you do not need to write about all of them):</p>
 
   <ul class="govuk-list govuk-list--bullet">
-    <li>your understanding of the rewards and challenges of teaching</li>
-    <li>why you want to teach a certain age group or subject</li>
-    <li>skills you have that are relevant to teaching</li>
+    <li>your motivations for wanting to train to be a teacher</li>
+    <li>any skills you have that are relevant to teaching</li>
     <li>any experience of working with young people</li>
-    <li>your interests and passions you could use in the classroom or contribute to a school (like organising clubs or activities for students after school)</li>
-    <li>qualifications or courses you’ve done that would help in your teaching career</li>
+    <li>for secondary teacher training: your interest in the subject you want to teach</li>
+    <li>any training you’ve done that could be relevant to teaching like first aid courses, sports coaching…find another example</li>
+
   </ul>
 
-  <p class="govuk-body">If you need help, speak to our <a href="https://getintoteaching.education.gov.uk/teacher-training-advisers">teacher training advisers</a>. They were teachers and can give you free, one-to-one support with your personal statement.</p>
+  <p class="govuk-body">Get help with your personal statement by speaking to our <a href="https://getintoteaching.education.gov.uk/teacher-training-advisers">teacher training advisers</a>. They used to be teachers and can give you free, one-to-one support.</p>
 
   <%= f.govuk_text_area :becoming_a_teacher, label: { text: 'Your personal statement', size: 'm' }, rows: 20, max_words: 1000 %>
 

--- a/app/views/candidate_interface/personal_statement/_form.html.erb
+++ b/app/views/candidate_interface/personal_statement/_form.html.erb
@@ -7,14 +7,14 @@
   </h1>
 
   <p class="govuk-body">You should try and write between 600 and 800 words for your statement. You can write up to 1000 words if you want.</p>
-  <p class="govuk-body">Here are some examples (you do not need to write about all of them):</p>
+  <p class="govuk-body">Here are some examples you could write about (you do not need to mention all of them):</p>
 
   <ul class="govuk-list govuk-list--bullet">
     <li>your motivations for wanting to train to be a teacher</li>
     <li>any skills you have that are relevant to teaching</li>
     <li>any experience of working with young people</li>
     <li>for secondary teacher training: your interest in the subject you want to teach</li>
-    <li>any training you’ve done that could be relevant to teaching like first aid courses, sports coaching…find another example</li>
+    <li>any training or activities you’ve done that could be relevant to teaching like first aid courses, sports coaching or volunteering</li>
 
   </ul>
 

--- a/app/views/candidate_interface/personal_statement/_form.html.erb
+++ b/app/views/candidate_interface/personal_statement/_form.html.erb
@@ -44,4 +44,5 @@
 
 <%= f.govuk_text_area :becoming_a_teacher, label: { text: t('application_form.personal_statement.becoming_a_teacher.label'), size: 'm' }, rows: 20, max_words: 600 %>
 
+<% end %>
 <%= f.govuk_submit t('continue') %>

--- a/app/views/candidate_interface/personal_statement/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/show.html.erb
@@ -4,9 +4,15 @@
 <%= form_with model: @section_complete_form, url: candidate_interface_becoming_a_teacher_complete_path, method: :patch do |f| %>
   <%= f.govuk_error_summary %>
 
-  <h1 class="govuk-heading-xl">
-    <%= t('page_titles.becoming_a_teacher') %>
-  </h1>
+  <% if FeatureFlag.active?(:one_personal_statement) && @application_form.single_personal_statement? %>
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.personal_statement') %>
+    </h1>
+  <% else %>
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.becoming_a_teacher') %>
+    </h1>
+  <% end %>
 
   <% if @application_form.review_pending?(:becoming_a_teacher) %>
     <%= govuk_inset_text do %>
@@ -30,7 +36,6 @@
 
   <%= render(CandidateInterface::CompleteSectionComponent.new(
     form: f,
-    hint_text: t('application_form.personal_statement.becoming_a_teacher.complete_hint_text'),
     section_review: @application_form.reviewable?(:becoming_a_teacher),
   )) %>
 

--- a/app/views/candidate_interface/personal_statement/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/show.html.erb
@@ -8,7 +8,7 @@
     <h1 class="govuk-heading-xl">
       <%= t('page_titles.personal_statement') %>
       <% if @application_form.subject_knowledge.nil? && @application_form&.previous_application_form&.subject_knowledge.present? %>
-        <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-0">Your personal statement has been combined into one statement instead of 2.</p>
+        <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-0">Your personal statement has been combined into one statement instead of two.</p>
         <p class="govuk-body">You do not need to change anything, but you should check it.</p>
       <% end %>
     </h1>

--- a/app/views/candidate_interface/personal_statement/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/show.html.erb
@@ -7,6 +7,10 @@
   <% if FeatureFlag.active?(:one_personal_statement) && @application_form.single_personal_statement? %>
     <h1 class="govuk-heading-xl">
       <%= t('page_titles.personal_statement') %>
+      <% if @application_form.subject_knowledge.nil? && @application_form&.previous_application_form&.subject_knowledge.present? %>
+        <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-0">Your personal statement has been combined into one statement instead of 2.</p>
+        <p class="govuk-body">You do not need to change anything, but you should check it.</p>
+      <% end %>
     </h1>
   <% else %>
     <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/personal_statement/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/show.html.erb
@@ -4,7 +4,7 @@
 <%= form_with model: @section_complete_form, url: candidate_interface_becoming_a_teacher_complete_path, method: :patch do |f| %>
   <%= f.govuk_error_summary %>
 
-  <% if FeatureFlag.active?(:one_personal_statement) && @application_form.single_personal_statement? %>
+  <% if @application_form.single_personal_statement_application? %>
     <h1 class="govuk-heading-xl">
       <%= t('page_titles.personal_statement') %>
       <% if @application_form.subject_knowledge.nil? && @application_form&.previous_application_form&.subject_knowledge.present? %>

--- a/app/views/candidate_interface/unsubmitted_application_form/_task_list.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/_task_list.html.erb
@@ -76,7 +76,7 @@
 
   <ol class="app-task-list">
 
-    <% if FeatureFlag.active?(:one_personal_statement) && application_form.single_personal_statement? %>
+    <% if application_form.single_personal_statement_application? %>
 
       <li class="app-task-list__item">
         <%= render(TaskListItemComponent.new(

--- a/app/views/candidate_interface/unsubmitted_application_form/_task_list.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/_task_list.html.erb
@@ -75,24 +75,38 @@
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.personal_statement') %></h2>
 
   <ol class="app-task-list">
-    <li class="app-task-list__item">
-      <%= render(TaskListItemComponent.new(
-        text: t('page_titles.becoming_a_teacher'),
-        completed: application_form_presenter.becoming_a_teacher_completed?,
-        path: application_form_presenter.becoming_a_teacher_path,
-        custom_status: application_form_presenter.becoming_a_teacher_review_pending? ? 'Review' : nil,
-        custom_color: application_form_presenter.becoming_a_teacher_review_pending? ? 'pink' : nil,
-      )) %>
-    </li>
-    <li class="app-task-list__item">
-      <%= render(TaskListItemComponent.new(
-        text: t('page_titles.subject_knowledge'),
-        completed: application_form_presenter.subject_knowledge_completed?,
-        path: application_form_presenter.subject_knowledge_valid? ? candidate_interface_subject_knowledge_show_path : candidate_interface_edit_subject_knowledge_path,
-        custom_status: application_form_presenter.subject_knowledge_review_pending? ? 'Review' : nil,
-        custom_color: application_form_presenter.subject_knowledge_review_pending? ? 'pink' : nil,
-      )) %>
-    </li>
+
+    <% if FeatureFlag.active?(:one_personal_statement) && application_form.single_personal_statement? %>
+
+      <li class="app-task-list__item">
+        <%= render(TaskListItemComponent.new(
+          text: 'Skills and experience',
+          completed: application_form_presenter.becoming_a_teacher_completed?,
+          path: application_form_presenter.becoming_a_teacher_path,
+        )) %>
+      </li>
+
+    <% else %>
+
+      <li class="app-task-list__item">
+        <%= render(TaskListItemComponent.new(
+          text: t('page_titles.becoming_a_teacher'),
+          completed: application_form_presenter.becoming_a_teacher_completed?,
+          path: application_form_presenter.becoming_a_teacher_path,
+          custom_status: application_form_presenter.becoming_a_teacher_review_pending? ? 'Review' : nil,
+          custom_color: application_form_presenter.becoming_a_teacher_review_pending? ? 'pink' : nil,
+        )) %>
+      </li>
+      <li class="app-task-list__item">
+        <%= render(TaskListItemComponent.new(
+          text: t('page_titles.subject_knowledge'),
+          completed: application_form_presenter.subject_knowledge_completed?,
+          path: application_form_presenter.subject_knowledge_valid? ? candidate_interface_subject_knowledge_show_path : candidate_interface_edit_subject_knowledge_path,
+          custom_status: application_form_presenter.subject_knowledge_review_pending? ? 'Review' : nil,
+          custom_color: application_form_presenter.subject_knowledge_review_pending? ? 'pink' : nil,
+        )) %>
+      </li>
+    <% end %>
   </ol>
 </section>
 

--- a/app/views/candidate_interface/unsubmitted_application_form/_task_list.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/_task_list.html.erb
@@ -80,7 +80,7 @@
 
       <li class="app-task-list__item">
         <%= render(TaskListItemComponent.new(
-          text: 'Skills and experience',
+          text: 'Your personal statement',
           completed: application_form_presenter.becoming_a_teacher_completed?,
           path: application_form_presenter.becoming_a_teacher_path,
         )) %>

--- a/config/locales/candidate_interface/personal_statement.yml
+++ b/config/locales/candidate_interface/personal_statement.yml
@@ -1,6 +1,8 @@
 en:
   application_form:
     personal_statement:
+      review:
+        label: Personal statement
       becoming_a_teacher:
         change_action: why you want to be a teacher
         label: Why do you want to be a teacher?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,6 +165,7 @@ en:
     qualification_details: Qualification details
     edit_other_qualification: Edit qualification
     destroy_other_qualification: Are you sure you want to delete this qualification?
+    personal_statement: Personal statement
     becoming_a_teacher: Why you want to teach
     subject_knowledge: Your suitability to teach a subject or age group
     interview_preferences:

--- a/spec/components/candidate_interface/becoming_a_teacher_review_component_spec.rb
+++ b/spec/components/candidate_interface/becoming_a_teacher_review_component_spec.rb
@@ -4,11 +4,30 @@ RSpec.describe CandidateInterface::BecomingATeacherReviewComponent do
   let(:application_form) { build_stubbed(:completed_application_form) }
 
   context 'when becoming a teacher is editable' do
-    it 'renders SummaryCardComponent with valid becoming a teacher' do
-      result = render_inline(described_class.new(application_form:))
+    context 'when the candidate is on the old personal statement' do
+      before do
+        FeatureFlag.deactivate(:one_personal_statement)
+      end
 
-      expect(result.text).to include(application_form.becoming_a_teacher)
-      expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.personal_statement.becoming_a_teacher.change_action')}")
+      it 'renders SummaryCardComponent with valid becoming a teacher' do
+        result = render_inline(described_class.new(application_form:))
+
+        expect(result.text).to include(application_form.becoming_a_teacher)
+        expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.personal_statement.becoming_a_teacher.change_action')}")
+      end
+    end
+
+    context 'when the candidate is on the new perdsonal statement' do
+      before do
+        FeatureFlag.activate(:one_personal_statement)
+      end
+
+      it 'renders SummaryCardComponent with valid personal statement' do
+        result = render_inline(described_class.new(application_form:))
+
+        expect(result.text).to include(application_form.becoming_a_teacher)
+        expect(result.css('.govuk-summary-list__actions').text).to include('Change personal statement')
+      end
     end
   end
 

--- a/spec/components/candidate_interface/becoming_a_teacher_review_component_spec.rb
+++ b/spec/components/candidate_interface/becoming_a_teacher_review_component_spec.rb
@@ -23,9 +23,10 @@ RSpec.describe CandidateInterface::BecomingATeacherReviewComponent do
       end
 
       it 'renders SummaryCardComponent with valid personal statement' do
-        result = render_inline(described_class.new(application_form:))
+        new_application_form = build_stubbed(:completed_application_form, created_at: ApplicationForm::SINGLE_PERSONAL_STATEMENT_FROM + 1.day)
+        result = render_inline(described_class.new(application_form: new_application_form))
 
-        expect(result.text).to include(application_form.becoming_a_teacher)
+        expect(result.text).to include(new_application_form.becoming_a_teacher)
         expect(result.css('.govuk-summary-list__actions').text).to include('Change personal statement')
       end
     end

--- a/spec/forms/candidate_interface/becoming_a_teacher_form_spec.rb
+++ b/spec/forms/candidate_interface/becoming_a_teacher_form_spec.rb
@@ -41,12 +41,38 @@ RSpec.describe CandidateInterface::BecomingATeacherForm, type: :model do
   end
 
   describe 'validations' do
+    let(:application_form) { create(:application_form) }
+
+    before do
+      FeatureFlag.activate(:one_personal_statement)
+    end
+
     it { is_expected.to validate_presence_of(:becoming_a_teacher) }
 
-    valid_text = Faker::Lorem.sentence(word_count: 600)
-    invalid_text = Faker::Lorem.sentence(word_count: 601)
+    context 'new single personal statement' do
+      before do
+        application_form.update!(created_at: ApplicationForm::SINGLE_PERSONAL_STATEMENT_FROM + 1.day)
+        @valid_text = Faker::Lorem.sentence(word_count: 1000)
+        @invalid_text = Faker::Lorem.sentence(word_count: 1001)
+      end
 
-    it { is_expected.to allow_value(valid_text).for(:becoming_a_teacher) }
-    it { is_expected.not_to allow_value(invalid_text).for(:becoming_a_teacher) }
+      subject { described_class.build_from_application(application_form) }
+
+      it { is_expected.to allow_value(@valid_text).for(:becoming_a_teacher) }
+      it { is_expected.not_to allow_value(@invalid_text).for(:becoming_a_teacher) }
+    end
+
+    context 'old personal statement' do
+      before do
+        application_form.update!(created_at: ApplicationForm::SINGLE_PERSONAL_STATEMENT_FROM - 1.day)
+        @valid_text = Faker::Lorem.sentence(word_count: 600)
+        @invalid_text = Faker::Lorem.sentence(word_count: 601)
+      end
+
+      subject { described_class.build_from_application(application_form) }
+
+      it { is_expected.to allow_value(@valid_text).for(:becoming_a_teacher) }
+      it { is_expected.not_to allow_value(@invalid_text).for(:becoming_a_teacher) }
+    end
   end
 end

--- a/spec/services/duplicate_application_spec.rb
+++ b/spec/services/duplicate_application_spec.rb
@@ -63,8 +63,12 @@ RSpec.describe DuplicateApplication do
       end
 
       it 'merges the personal statement' do
-        original_two_statements = "#{@original_application_form.becoming_a_teacher} #{@original_application_form.subject_knowledge}"
+        original_two_statements = "#{@original_application_form.becoming_a_teacher}\n\n#{@original_application_form.subject_knowledge}"
         expect(duplicate_application_form.becoming_a_teacher).to eq original_two_statements
+      end
+
+      it 'sets the subject knowledge to nil' do
+        expect(duplicate_application_form.subject_knowledge).to be_nil
       end
     end
   end
@@ -86,8 +90,12 @@ RSpec.describe DuplicateApplication do
       end
 
       it 'merges the personal statement' do
-        original_two_statements = "#{@original_application_form.becoming_a_teacher} #{@original_application_form.subject_knowledge}"
+        original_two_statements = "#{@original_application_form.becoming_a_teacher}\n\n#{@original_application_form.subject_knowledge}"
         expect(duplicate_application_form.becoming_a_teacher).to eq original_two_statements
+      end
+
+      it 'sets the subject knowledge to nil' do
+        expect(duplicate_application_form.subject_knowledge).to be_nil
       end
     end
   end

--- a/spec/services/duplicate_application_spec.rb
+++ b/spec/services/duplicate_application_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe DuplicateApplication do
       @original_application_form = create(
         :completed_application_form,
         :with_gcses,
+        created_at: ApplicationForm::SINGLE_PERSONAL_STATEMENT_FROM - 1.day,
         work_experiences_count: 1,
         volunteering_experiences_count: 1,
         full_work_history: true,
@@ -51,6 +52,21 @@ RSpec.describe DuplicateApplication do
     it 'marks reference as incomplete' do
       expect(duplicate_application_form).not_to be_references_completed
     end
+
+    context 'moving to the new personal statement' do
+      before do
+        FeatureFlag.activate(:one_personal_statement)
+      end
+
+      it 'marks the personal statement as incomplete' do
+        expect(duplicate_application_form).not_to be_becoming_a_teacher_completed
+      end
+
+      it 'merges the personal statement' do
+        original_two_statements = "#{@original_application_form.becoming_a_teacher} #{@original_application_form.subject_knowledge}"
+        expect(duplicate_application_form.becoming_a_teacher).to eq original_two_statements
+      end
+    end
   end
 
   context 'when apply-again' do
@@ -58,6 +74,21 @@ RSpec.describe DuplicateApplication do
 
     it 'marks reference as complete' do
       expect(duplicate_application_form).to be_references_completed
+    end
+
+    context 'moving to the new personal statement' do
+      before do
+        FeatureFlag.activate(:one_personal_statement)
+      end
+
+      it 'marks the personal statement as incomplete' do
+        expect(duplicate_application_form).not_to be_becoming_a_teacher_completed
+      end
+
+      it 'merges the personal statement' do
+        original_two_statements = "#{@original_application_form.becoming_a_teacher} #{@original_application_form.subject_knowledge}"
+        expect(duplicate_application_form.becoming_a_teacher).to eq original_two_statements
+      end
     end
   end
 end

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
@@ -4,6 +4,7 @@ RSpec.feature 'Carry over', time: CycleTimetableHelper.mid_cycle(2022) do
   include CandidateHelper
 
   it 'Candidate carries over unsubmitted application with a course to new cycle' do
+    given_the_feature_flag_is_disabled
     given_i_am_signed_in_as_a_candidate
     when_i_have_an_unsubmitted_application
     and_the_recruitment_cycle_ends
@@ -32,6 +33,10 @@ RSpec.feature 'Carry over', time: CycleTimetableHelper.mid_cycle(2022) do
     and_i_receive_references
     and_i_submit_my_application
     then_my_application_is_awaiting_provider_decision
+  end
+
+  def given_the_feature_flag_is_disabled
+    FeatureFlag.deactivate(:one_personal_statement)
   end
 
   def given_i_am_signed_in_as_a_candidate

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_without_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_without_course_to_new_cycle_spec.rb
@@ -4,6 +4,7 @@ RSpec.feature 'Carry over', time: CycleTimetableHelper.mid_cycle(2022) do
   include CandidateHelper
 
   it 'Candidate carries over unsubmitted application without course to new cycle' do
+    given_the_feature_flag_is_disabled
     given_i_am_signed_in_as_a_candidate
     when_i_have_an_unsubmitted_application_without_a_course
     and_the_recruitment_cycle_ends
@@ -28,6 +29,10 @@ RSpec.feature 'Carry over', time: CycleTimetableHelper.mid_cycle(2022) do
     and_i_receive_references
     and_i_submit_my_application
     and_my_application_is_awaiting_provider_decision
+  end
+
+  def given_the_feature_flag_is_disabled
+    FeatureFlag.deactivate(:one_personal_statement)
   end
 
   def given_i_am_signed_in_as_a_candidate

--- a/spec/system/candidate_interface/entering_details/candidate_personal_statement_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_personal_statement_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+RSpec.feature 'Entering "Personal statement"' do
+  include CandidateHelper
+
+  before do
+    TestSuiteTimeMachine.travel_permanently_to(ApplicationForm::SINGLE_PERSONAL_STATEMENT_FROM + 1.day)
+  end
+
+  scenario 'Candidate submits personal statement' do
+    given_the_feature_flag_is_active
+    given_i_am_signed_in
+    and_i_visit_the_site
+
+    when_i_click_on_personal_statement
+    and_i_submit_the_form
+    then_i_should_see_validation_errors
+    and_a_validation_error_is_logged_for_becoming_a_teacher
+
+    when_i_fill_in_an_answer
+    and_i_submit_the_form
+    then_i_can_check_my_answers
+
+    when_i_click_to_change_my_answer
+    and_i_fill_in_a_different_answer
+    and_i_submit_the_form
+    then_i_can_check_my_revised_answers
+
+    when_i_mark_the_section_as_completed
+    and_i_submit_the_form
+    then_i_should_see_the_form
+    and_that_the_section_is_completed
+
+    when_i_click_on_personal_statement
+    then_i_can_check_my_revised_answers
+  end
+
+  def given_the_feature_flag_is_active
+    FeatureFlag.activate(:one_personal_statement)
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def when_i_click_on_personal_statement
+    click_link 'Your personal statement'
+  end
+
+  def then_i_should_see_validation_errors
+    expect(page).to have_content t('activemodel.errors.models.candidate_interface/becoming_a_teacher_form.attributes.becoming_a_teacher.blank')
+  end
+
+  def and_a_validation_error_is_logged_for_becoming_a_teacher
+    validation_error = ValidationError.last
+    expect(validation_error).to be_present
+    expect(validation_error.details).to have_key('becoming_a_teacher')
+    expect(validation_error.user).to eq(current_candidate)
+    expect(validation_error.request_path).to eq(candidate_interface_new_becoming_a_teacher_path)
+    expect(validation_error.service).to eq('apply')
+  end
+
+  def and_i_fill_in_some_details_but_omit_some_required_details
+    fill_in 'Your personal statement', with: 'Hello world'
+  end
+
+  def when_i_fill_in_an_answer
+    fill_in 'Your personal statement', with: 'Hello world'
+  end
+
+  def then_i_can_check_my_answers
+    expect(page).to have_content 'Personal statement'
+    expect(page).to have_content 'Hello world'
+  end
+
+  def and_i_submit_the_form
+    click_button t('continue')
+  end
+
+  def when_i_click_to_change_my_answer
+    click_change_link('why you want to be a teacher')
+  end
+
+  def and_i_fill_in_a_different_answer
+    fill_in 'Your personal statement', with: 'Hello world again'
+  end
+
+  def then_i_can_check_my_revised_answers
+    expect(page).to have_content 'Personal statement'
+    expect(page).to have_content 'Hello world again'
+  end
+
+  def when_i_mark_the_section_as_completed
+    choose t('application_form.completed_radio')
+  end
+
+  def then_i_should_see_the_form
+    expect(page).to have_content('Your personal statement')
+  end
+
+  def and_that_the_section_is_completed
+    expect(page).to have_css('#your-personal-statement-badge-id', text: 'Completed')
+  end
+end

--- a/spec/system/candidate_interface/entering_details/candidate_personal_statement_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_personal_statement_spec.rb
@@ -52,7 +52,7 @@ RSpec.feature 'Entering "Personal statement"' do
   end
 
   def then_i_should_see_validation_errors
-    expect(page).to have_content t('activemodel.errors.models.candidate_interface/becoming_a_teacher_form.attributes.becoming_a_teacher.blank')
+    expect(page).to have_content 'Write your personal statement'
   end
 
   def and_a_validation_error_is_logged_for_becoming_a_teacher
@@ -82,7 +82,7 @@ RSpec.feature 'Entering "Personal statement"' do
   end
 
   def when_i_click_to_change_my_answer
-    click_change_link('why you want to be a teacher')
+    click_change_link('personal statement')
   end
 
   def and_i_fill_in_a_different_answer

--- a/spec/system/provider_interface/provider_views_application_submitted_in_new_cycle_feature_flag_disabled_spec.rb
+++ b/spec/system/provider_interface/provider_views_application_submitted_in_new_cycle_feature_flag_disabled_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature 'Provider views application submitted in new cycle' do
   end
 
   it 'but started in the previous one' do
+    given_the_feature_flag_is_disabled
     given_i_am_signed_in_as_a_candidate
     when_i_have_an_unsubmitted_application_without_a_course
     and_the_new_recruitment_cycle_begins
@@ -42,6 +43,10 @@ RSpec.feature 'Provider views application submitted in new cycle' do
     when_i_visit_the_provider_page
     then_i_can_see_a_filter_for_the_current_recruitment_cycle_year
     then_i_can_see_and_load_the_candidates_application
+  end
+
+  def given_the_feature_flag_is_disabled
+    FeatureFlag.deactivate(:one_personal_statement)
   end
 
   def given_i_am_signed_in_as_a_candidate

--- a/spec/system/provider_interface/see_individual_application_new_personal_statement_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_new_personal_statement_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'A Provider viewing an individual application', time: ANYTIME_IN_
     and_my_organisation_has_received_an_application_without_restructured_work_history
     and_i_am_permitted_to_see_applications_for_my_provider
     and_i_sign_in_to_the_provider_interface
+    and_the_feature_flag_is_active
 
     when_i_visit_that_application_in_the_provider_interface
 
@@ -29,6 +30,10 @@ RSpec.describe 'A Provider viewing an individual application', time: ANYTIME_IN_
     and_i_should_see_diversity_information_section
     and_i_should_see_a_link_to_download_as_pdf
     and_i_should_see_the_candidates_references
+  end
+
+  def and_the_feature_flag_is_active
+    FeatureFlag.activate(:one_personal_statement)
   end
 
   def and_i_should_not_see_the_safeguarding_declaration_details
@@ -66,6 +71,7 @@ RSpec.describe 'A Provider viewing an individual application', time: ANYTIME_IN_
     course_option = course_option_for_provider_code(provider_code: 'ABC')
     application_form = create(
       :application_form,
+      created_at: ApplicationForm::SINGLE_PERSONAL_STATEMENT_FROM + 1.day,
       submitted_at: Time.zone.now,
       becoming_a_teacher: 'This is my personal statement',
       subject_knowledge: 'This is my subject knowledge',
@@ -221,9 +227,8 @@ RSpec.describe 'A Provider viewing an individual application', time: ANYTIME_IN_
   end
 
   def and_i_should_see_the_candidates_personal_statement
+    expect(page).to have_content 'Personal statement'
     expect(page).to have_content 'This is my personal statement'
-    expect(page).to have_content 'This is my subject knowledge'
-    expect(page).to have_content 'Any date is fine'
     expect(page).to have_content 'Nothing further to add'
   end
 

--- a/spec/system/provider_interface/see_individual_application_old_personal_statement_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_old_personal_statement_spec.rb
@@ -1,0 +1,270 @@
+require 'rails_helper'
+
+ANYTIME_IN_RECRUITMENT_CYCLE_APPLY_OPEN = Time.zone.local(2022, 10, 15, 12, 0, 0)
+RSpec.describe 'A Provider viewing an individual application', time: ANYTIME_IN_RECRUITMENT_CYCLE_APPLY_OPEN, with_audited: true do
+  include CourseOptionHelpers
+  include DfESignInHelpers
+
+  scenario 'the application data is visible' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_my_organisation_has_received_an_application_without_restructured_work_history
+    and_i_am_permitted_to_see_applications_for_my_provider
+    and_i_sign_in_to_the_provider_interface
+    and_the_feature_flag_is_active
+
+    when_i_visit_that_application_in_the_provider_interface
+
+    then_i_should_see_the_candidates_degrees
+    and_i_should_see_the_candidates_gcses
+    and_i_should_not_see_the_safeguarding_declaration_details
+
+    when_i_am_permitted_to_see_safeguarding_information
+    and_i_visit_that_application_in_the_provider_interface
+
+    then_i_should_see_the_safeguarding_declaration_section
+    and_i_should_see_the_candidates_other_qualifications
+    and_i_should_see_the_candidates_work_history_and_unpaid_experience
+    and_i_should_see_the_candidates_personal_statement
+    and_i_should_see_the_candidates_language_skills
+    and_i_should_see_the_disability_disclosure
+    and_i_should_see_diversity_information_section
+    and_i_should_see_a_link_to_download_as_pdf
+    and_i_should_see_the_candidates_references
+  end
+
+  def and_the_feature_flag_is_active
+    FeatureFlag.activate(:one_personal_statement)
+  end
+
+  def and_i_should_not_see_the_safeguarding_declaration_details
+    expect(page).to have_content('Criminal record and professional misconduct')
+    expect(page).not_to have_content('View information disclosed by the candidate')
+  end
+
+  def then_i_should_see_the_safeguarding_declaration_section
+    expect(page).to have_content('Criminal record and professional misconduct')
+    expect(page).to have_content(t('provider_interface.safeguarding_declaration_component.has_safeguarding_issues_to_declare'))
+  end
+
+  def when_i_am_permitted_to_see_safeguarding_information
+    ProviderUser.find_by(dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+      .provider_permissions.update_all(view_safeguarding_information: true)
+
+    create(
+      :provider_relationship_permissions,
+      ratifying_provider: create(:provider),
+      training_provider: @application_choice.course.provider,
+      training_provider_can_view_safeguarding_information: true,
+      setup_at: Time.zone.now,
+    )
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_i_am_permitted_to_see_applications_for_my_provider
+    provider_user_exists_in_apply_database
+  end
+
+  def and_my_organisation_has_received_an_application_without_restructured_work_history
+    course_option = course_option_for_provider_code(provider_code: 'ABC')
+    application_form = create(
+      :application_form,
+      created_at: ApplicationForm::SINGLE_PERSONAL_STATEMENT_FROM - 1.day,
+      submitted_at: Time.zone.now,
+      becoming_a_teacher: 'This is my personal statement',
+      subject_knowledge: 'This is my subject knowledge',
+      interview_preferences: 'Any date is fine',
+      further_information: 'Nothing further to add',
+      english_main_language: true,
+      other_language_details: 'I also speak Spanish and German',
+      disclose_disability: true,
+      disability_disclosure: 'I am hard of hearing',
+      safeguarding_issues: 'I have something to say...',
+      safeguarding_issues_status: :has_safeguarding_issues_to_declare,
+      equality_and_diversity: { 'sex' => 'male',
+                                'disabilities' => ['Mental health condition'],
+                                'ethnic_group' => 'Asian or Asian British',
+                                'ethnic_background' => 'Chinese' },
+    )
+
+    create_list(:application_qualification, 1, application_form:, level: :degree)
+    create(:gcse_qualification, subject: 'maths', application_form:)
+    create(:gcse_qualification, subject: 'english', application_form:)
+    create_list(:application_qualification, 3, application_form:, level: :other)
+
+    create(:application_work_experience,
+           application_form:,
+           role: 'Smuggler',
+           organisation: 'The Empire',
+           details: 'I used to work for The Empire',
+           working_pattern: 'Working pattern at the Empire',
+           working_with_children: false,
+           start_date: Time.zone.local(2018, 3, 1),
+           end_date: Time.zone.local(2018, 9, 1),
+           commitment: 'part_time',
+           start_date_unknown: false,
+           end_date_unknown: false)
+
+    create(:application_work_experience,
+           application_form:,
+           role: 'Bounty Hunter',
+           organisation: 'The Empire',
+           details: 'I used to work for The Empire',
+           working_pattern: 'Working pattern at the Empire',
+           working_with_children: false,
+           start_date: Time.zone.local(2019, 3, 1),
+           end_date: Time.zone.local(2019, 9, 1),
+           commitment: 'full_time',
+           start_date_unknown: false,
+           end_date_unknown: false)
+
+    create(:application_work_history_break,
+           application_form:,
+           reason: 'Retraining to become a bounty hunter',
+           start_date: Time.zone.local(2018, 9, 1),
+           end_date: Time.zone.local(2019, 3, 1))
+
+    create(:application_volunteering_experience,
+           application_form:,
+           role: 'Defence co-ordinator',
+           organisation: 'Rebel Alliance',
+           details: 'Worked with children to help them survive clone attacks',
+           working_with_children: true,
+           start_date: Time.zone.local(2020, 5, 1),
+           end_date: nil)
+
+    create(:reference,
+           :feedback_provided,
+           application_form:,
+           name: 'R2D2',
+           email_address: 'r2d2@rebellion.org',
+           relationship: 'Astromech droid',
+           feedback: 'beep boop beep')
+
+    create(:reference,
+           :feedback_provided,
+           application_form:,
+           name: 'C3PO',
+           email_address: 'c3p0@rebellion.org',
+           relationship: 'Companion droid',
+           feedback: 'The possibility of successfully navigating training is approximately three thousand seven hundred and twenty to one')
+
+    create(:reference,
+           :feedback_refused,
+           application_form:,
+           name: 'BB-8')
+
+    @application_choice = create(:application_choice,
+                                 :accepted,
+                                 course_option:,
+                                 reject_by_default_at: 20.days.from_now,
+                                 application_form:)
+  end
+
+  def when_i_visit_that_application_in_the_provider_interface
+    visit provider_interface_application_choice_path(@application_choice)
+  end
+
+  alias_method(
+    :and_i_visit_that_application_in_the_provider_interface,
+    :when_i_visit_that_application_in_the_provider_interface,
+  )
+
+  def then_i_should_see_the_candidates_degrees
+    expect(page).to have_selector('[data-qa="degree-qualification"]', count: 1)
+  end
+
+  def and_i_should_see_the_candidates_gcses
+    expect(page).to have_selector('[data-qa="gcse-qualification"]', count: 2)
+  end
+
+  def and_i_should_see_the_candidates_other_qualifications
+    expect(page).to have_selector('[data-qa="qualifications-table-a-levels-and-other-qualifications"] tbody tr', count: 3)
+  end
+
+  def and_i_should_see_the_candidates_work_history_and_unpaid_experience
+    within '[data-qa="work-history-and-unpaid-experience"]' do
+      within 'section:eq(1)' do
+        expect(page).to have_content 'Defence co-ordinator'
+        expect(page).to have_content 'Rebel Alliance'
+        expect(page).to have_content 'survive clone attacks'
+        expect(page).to have_content 'Worked with children'
+        expect(page).to have_content 'May 2020 - Present'
+
+        # Volunteering is not editable
+        expect(page).not_to have_content 'Change'
+        expect(page).not_to have_content 'Delete'
+      end
+      within 'section:eq(2)' do
+        expect(page).to have_content 'Unexplained break (3 years and 1 month)'
+        expect(page).to have_content 'September 2019 - October 2022'
+      end
+
+      within 'section:eq(3)' do
+        expect(page).to have_content 'Bounty Hunter - Full time'
+        expect(page).to have_content 'March 2019 - September 2019'
+      end
+
+      within 'section:eq(4)' do
+        expect(page).to have_content 'Break (6 months)'
+        expect(page).to have_content 'September 2018 - March 2019'
+      end
+
+      within 'section:eq(5)' do
+        expect(page).to have_content 'Smuggler - Part time'
+        expect(page).to have_content 'March 2018 - September 2018'
+        expect(page).to have_content 'The Empire'
+        expect(page).not_to have_content 'Worked with children'
+      end
+
+      within 'section:eq(6)' do
+        expect(page).to have_content 'Unexplained break (6 months)'
+        expect(page).to have_content 'September 2017 - March 2018'
+      end
+    end
+  end
+
+  def and_i_should_see_the_candidates_personal_statement
+    expect(page).to have_content 'This is my personal statement'
+    expect(page).to have_content 'This is my subject knowledge'
+    expect(page).to have_content 'Any date is fine'
+    expect(page).to have_content 'Nothing further to add'
+  end
+
+  def and_i_should_see_the_candidates_language_skills
+    within '[data-qa="language-skills"]' do
+      expect(page).to have_content 'Yes'
+      expect(page).to have_content 'I also speak Spanish and German'
+    end
+  end
+
+  def and_i_should_see_the_candidates_references
+    click_on 'References'
+
+    expect(page).to have_content 'R2D2'
+    expect(page).to have_content 'r2d2@rebellion.org'
+    expect(page).to have_content 'Astromech droid'
+    expect(page).to have_content 'beep boop beep'
+
+    expect(page).to have_content 'C3PO'
+    expect(page).to have_content 'c3p0@rebellion.org'
+    expect(page).to have_content 'Companion droid'
+    expect(page).to have_content 'The possibility of successfully'
+
+    expect(page).not_to have_content 'BB-8'
+  end
+
+  def and_i_should_see_the_disability_disclosure
+    expect(page).to have_content 'I am hard of hearing'
+  end
+
+  def and_i_should_see_diversity_information_section
+    expect(page).to have_content 'Sex, disability and ethnicity'
+  end
+
+  def and_i_should_see_a_link_to_download_as_pdf
+    expect(page).to have_link 'Download application (PDF)'
+  end
+end

--- a/spec/system/support_interface/editing_subject_knowledge_spec.rb
+++ b/spec/system/support_interface/editing_subject_knowledge_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'Editing reference' do
   end
 
   def and_an_application_exists
-    @application_form = create(:completed_application_form, subject_knowledge: 'I know a little.')
+    @application_form = create(:completed_application_form, created_at: ApplicationForm::SINGLE_PERSONAL_STATEMENT_FROM - 1.day, subject_knowledge: 'I know a little.')
   end
 
   def when_i_visit_the_application_page


### PR DESCRIPTION
## Context

Many users have suggested that the way the current personal statement section is split across two questions ("Why you want to teach" and "Your suitability to teach a subject or age group") makes it harder to write, as there is a lot of overlap between both questions.

This is particularly true for candidates for primary courses, where there is no subject.

Instead, we’d like to merge the two sections into a single combined field. This would only apply to candidates starting a new application after the date we launch this feature.

## Changes proposed in this pull request

Candidates who sign up, or carry over/apply again, after a set date will be taken to the new personal statement section, containing a single field.

If they had an existing personal statement (across the two sections) these will be merged into one, with guidance appearing at the top of the page.

## Guidance to review

Behaviours to test for:

<img width="754" alt="image" src="https://user-images.githubusercontent.com/47917431/224688872-681a114e-2110-4d7d-8263-60417ba0ed33.png">


## Link to Trello card

https://trello.com/c/wbtTSQqc/1250