### PR TITLE
Provider mailer: conditional text if eligible for IRP

### DIFF
--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -274,6 +274,7 @@ private
       :rbd_date,
       :rbd_days,
       :support_reference,
+      :international_relocation_payment_eligible,
     ).new(
       application_choice.application_form.full_name,
       application_choice.current_course_option.course.name_and_code,
@@ -284,6 +285,7 @@ private
       application_choice.reject_by_default_at&.to_fs(:govuk_date),
       application_choice.reject_by_default_days,
       application_choice.application_form.support_reference,
+      IsEligibleForInternationalRelocationPayment.new(application_choice).call,
     )
   end
 end

--- a/app/services/is_eligible_for_international_relocation_payment.rb
+++ b/app/services/is_eligible_for_international_relocation_payment.rb
@@ -1,0 +1,38 @@
+class IsEligibleForInternationalRelocationPayment
+  delegate :application_form, to: :application_choice
+
+  ELIGIBLE_SUBJECTS = %i[classics physics modern_foreign_languages].freeze
+
+  def initialize(application_choice)
+    @application_choice = application_choice
+  end
+
+  def call
+    international? && eligible_subject? && right_to_work_or_study?
+  end
+
+private
+
+  attr_reader :application_choice
+
+  def right_to_work_or_study?
+    application_form.right_to_work_or_study_yes? ||
+      application_form.right_to_work_or_study_decide_later?
+  end
+
+  def international?
+    application_form.address_type == 'international' &&
+      application_form.international_applicant?
+  end
+
+  def eligible_subject?
+    subject_codes.any? do |code|
+      subject_mapping = MinisterialReport::SUBJECT_CODE_MAPPINGS[code]
+      ELIGIBLE_SUBJECTS.include?(subject_mapping)
+    end
+  end
+
+  def subject_codes
+    application_choice.course_option.course.subject_codes
+  end
+end

--- a/app/views/provider_mailer/_international_relocation_payment.text.erb
+++ b/app/views/provider_mailer/_international_relocation_payment.text.erb
@@ -1,0 +1,3 @@
+Based on the subject this candidate is applying to train to teach, they may be entitled to £10,000 to help with the financial costs of moving to England. ‘Get an international relocation payment’ will be disbursed with the support of teacher training providers on the bursaries model.
+
+To learn more about candidate eligibility, how it will be checked and what the IRP means for providers, please visit [LINK] or email us at [teach.inengland@education.gov.uk](mailto:teach.inengland@education.gov.uk).

--- a/app/views/provider_mailer/application_submitted.text.erb
+++ b/app/views/provider_mailer/application_submitted.text.erb
@@ -8,4 +8,6 @@ View the application:
 
 <%= provider_interface_application_choice_url(@application.application_choice) %>
 
+<%= render 'international_relocation_payment' if @application.international_relocation_payment_eligible %>
+
 <% content_for :additional_footer_content do %><%= render 'notification_preferences' %><% end %>

--- a/app/views/provider_mailer/application_submitted_with_safeguarding_issues.text.erb
+++ b/app/views/provider_mailer/application_submitted_with_safeguarding_issues.text.erb
@@ -10,4 +10,6 @@ View the application:
 
 <%= provider_interface_application_choice_url(@application.application_choice) %>
 
+<%= render 'international_relocation_payment' if @application.international_relocation_payment_eligible %>
+
 <% content_for :additional_footer_content do %><%= render 'notification_preferences' %><% end %>

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -37,6 +37,18 @@ RSpec.describe ProviderMailer do
                     'link to application' => /http:\/\/localhost:3000\/provider\/applications\/\d+/,
                     'notification settings' => 'You can change your email notification settings',
                     'footer' => 'Get help, report a problem or give feedback')
+
+    context 'eligible for international relocation payment' do
+      before do
+        allow(IsEligibleForInternationalRelocationPayment)
+          .to receive(:new)
+          .and_return(instance_double(IsEligibleForInternationalRelocationPayment, call: true))
+      end
+
+      it_behaves_like('a mail with subject and content',
+                      'Harry Potter submitted an application for Computer Science - manage teacher training applications',
+                      'international relocation' => 'help with the financial costs of moving')
+    end
   end
 
   describe 'Send application submitted with safeguarding issues email' do
@@ -53,6 +65,18 @@ RSpec.describe ProviderMailer do
                     'link to application' => /http:\/\/localhost:3000\/provider\/applications\/\d+/,
                     'notification settings' => 'You can change your email notification settings',
                     'footer' => 'Get help, report a problem or give feedback')
+
+    context 'eligible for international relocation payment' do
+      before do
+        allow(IsEligibleForInternationalRelocationPayment)
+          .to receive(:new)
+          .and_return(instance_double(IsEligibleForInternationalRelocationPayment, call: true))
+      end
+
+      it_behaves_like('a mail with subject and content',
+                      'Safeguarding issues - Harry Potter submitted an application for Computer Science - manage teacher training applications',
+                      'international relocation' => 'help with the financial costs of moving')
+    end
   end
 
   describe 'Send application rejected by default email' do

--- a/spec/services/is_eligible_for_international_relocation_payment_spec.rb
+++ b/spec/services/is_eligible_for_international_relocation_payment_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe IsEligibleForInternationalRelocationPayment do
+  describe '#call' do
+    subject { described_class.new(application_choice).call }
+
+    let(:application_form) do
+      create(:application_form, :international_address, first_nationality:, right_to_work_or_study:)
+    end
+    let(:course) { create(:course, subjects: [course_subject]) }
+    let(:course_option) { create(:course_option, course:) }
+    let(:application_choice) { create(:application_choice, course_option:, application_form:) }
+    let(:first_nationality) { 'Azeri' }
+    let(:right_to_work_or_study) { 'yes' }
+    let(:course_subject) { create(:subject, name: 'Colloquial Amaraic', code: 'A0') }
+
+    context 'application meets all criteria' do
+      it { is_expected.to be true }
+    end
+
+    context 'right_to_work_or_study set to decide later' do
+      let(:right_to_work_or_study) { 'decide_later' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'subject is physics' do
+      let(:course_subject) { create(:subject, name: 'Advanced Quantum Computing', code: 'F0') }
+
+      it { is_expected.to be true }
+    end
+
+    context 'subject is modern languages' do
+      let(:course_subject) { create(:subject, name: 'Spanish with Sichuanese', code: '15') }
+
+      it { is_expected.to be true }
+    end
+
+    context 'subject not eligible' do
+      let(:course_subject) { create(:subject, name: 'Zoroastrian Cosmology', code: 'V6') }
+
+      it { is_expected.to be false }
+    end
+
+    context 'british nationality' do
+      let(:first_nationality) { 'British' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'does not have right to work or study' do
+      let(:right_to_work_or_study) { 'no' }
+
+      it { is_expected.to be false }
+    end
+
+    context 'not an international applicant' do
+      let(:application_form) { create(:application_form, first_nationality:, right_to_work_or_study:) }
+
+      it { is_expected.to be false }
+    end
+  end
+end


### PR DESCRIPTION
## Context

If an application fulfils certain criteria, it may be eligible for international relocation payment (IRP), in which case we should notify the provider.

## Changes proposed in this pull request

When a candidate submits an application that fulfils certain criteria (non-British, lives outside UK/Ireland, right to work in UK, and wishing to teach classics, modern languages or physics), the provider mailer emails include some text about the candidate's eligibility for the IRP.

## Link to Trello card

https://trello.com/c/AtS9k2PO/1170-provider-email-conditionally-render-copy-if-we-think-someone-is-eligible-for-irp

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
