### PR TITLE
Deploy pods to specific node pool

### DIFF
--- a/terraform/modules/kubernetes/main.tf
+++ b/terraform/modules/kubernetes/main.tf
@@ -18,7 +18,8 @@ resource "kubernetes_deployment" "webapp" {
       }
       spec {
         node_selector = {
-          "kubernetes.io/os" : "linux"
+          "kubernetes.azure.com/agentpool" = "applications"
+          "kubernetes.io/os" = "linux"
         }
         container {
           name    = local.webapp_name
@@ -156,7 +157,8 @@ resource "kubernetes_deployment" "main_worker" {
       }
       spec {
         node_selector = {
-          "kubernetes.io/os" : "linux"
+          "kubernetes.azure.com/agentpool" = "applications"
+          "kubernetes.io/os" = "linux"
         }
         container {
           name    = local.worker_name
@@ -213,7 +215,8 @@ resource "kubernetes_deployment" "secondary_worker" {
       }
       spec {
         node_selector = {
-          "kubernetes.io/os" : "linux"
+          "kubernetes.azure.com/agentpool" = "applications"
+          "kubernetes.io/os" = "linux"
         }
         container {
           name    = local.secondary_worker_name
@@ -270,7 +273,8 @@ resource "kubernetes_deployment" "clock_worker" {
       }
       spec {
         node_selector = {
-          "kubernetes.io/os" : "linux"
+          "kubernetes.azure.com/agentpool" = "applications"
+          "kubernetes.io/os" = "linux"
         }
         container {
           name    = local.clock_worker_name


### PR DESCRIPTION
## Context

Added 'agentpool' to node_selector config to deploy pods on specific node pool

## Changes proposed in this pull request

Added 'agentpool' to node_selector config to deploy pods on specific node pool
Changed `"kubernetes.io/os" : "linux"` to `"kubernetes.io/os" = "linux"` to standardise format

## Guidance to review
Verify the pods are running on the `applications` node pool by running:
`kubectl get pod -o=custom-columns=NAME:.metadata.name,STATUS:.status.phase,NODE:.spec.nodeName -n development`

Output should look similar to:
```
NAME                            STATUS    NODE
apply-worker-review-[redacted]  Running   aks-applications-[redacted]-vmss00000[0/1/3]
```

## Link to Trello card

https://trello.com/c/TxwkWqN9/78-create-1-separate-pool-for-apps

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
