### PR TITLE
Change "details" to "the email address" on reference intro page

### DIFF
--- a/app/components/candidate_interface/add_new_reference_component.html.erb
+++ b/app/components/candidate_interface/add_new_reference_component.html.erb
@@ -1,4 +1,4 @@
-<p class="govuk-body">You need to give email address of 2 people who can give a reference for you. They’ll only be contacted if you accept an offer on a course.</p>
+<p class="govuk-body">You need to give the email address of 2 people who can give a reference for you. They’ll only be contacted if you accept an offer on a course.</p>
 
 <p class="govuk-body">You should include:</p>
 

--- a/app/components/candidate_interface/add_new_reference_component.html.erb
+++ b/app/components/candidate_interface/add_new_reference_component.html.erb
@@ -1,4 +1,4 @@
-<p class="govuk-body">You need to give details of 2 people who can give a reference for you. They’ll only be contacted if you accept an offer on a course.</p>
+<p class="govuk-body">You need to give email address of 2 people who can give a reference for you. They’ll only be contacted if you accept an offer on a course.</p>
 
 <p class="govuk-body">You should include:</p>
 


### PR DESCRIPTION
Evidence from validation error logs shows that many candidates get errors when leaving the email address field blank when adding a reference (14,000+ errors as of Feb 2023).

We think this may be because they don't have the email address to hand. Adding "email address" to the intro screen may help by encouraging users to find the email address before starting.

🗂️ [Trello card](https://trello.com/c/yY1Uy1Oe/1163-update-the-content-on-the-references-section-initial-page-to-make-it-clearer-that-youll-need-the-email-addresses-of-the-2-people)

## Screenshots

| Before | After |
|-----|------|
| <img width="742" alt="Screenshot 2023-02-17 at 15 28 24" src="https://user-images.githubusercontent.com/30665/219696080-2d5e4f7c-f7aa-4d79-bd41-0ccb4035e55b.png"> | <img width="809" alt="Screenshot 2023-02-17 at 15 29 35" src="https://user-images.githubusercontent.com/30665/219696354-f55622e9-6289-44b9-bd5a-ca6fd37c6e01.png">  |

