### PR TITLE
Update descriptions of GCSE-equivalent qualifications

### DIFF
--- a/app/helpers/gcse_qualification_helper.rb
+++ b/app/helpers/gcse_qualification_helper.rb
@@ -1,8 +1,10 @@
 module GcseQualificationHelper
-  def select_gcse_qualification_type_options
+  def select_gcse_qualification_type_standard_options
     option = Struct.new(:id, :label)
 
-    t('application_form.gcse.qualification_types').map { |id, label| option.new(id, label) }
+    t('application_form.gcse.qualification_types')
+      .except(:other_uk, :non_uk, :missing)
+      .map { |id, label| option.new(id, label) }
   end
 
   def grade_explanation_step_title(subject)

--- a/app/views/candidate_interface/gcse/type/_form.html.erb
+++ b/app/views/candidate_interface/gcse/type/_form.html.erb
@@ -4,25 +4,25 @@
   legend: { text: t("gcse_edit_type.page_titles.#{@subject}"), size: 'l' },
   hint: { text: @subject == 'english' ? 'This should not be a qualification showing you speak English as a foreign language.' : '' } do %>
 
-  <% select_gcse_qualification_type_options.each_with_index do |option, i| %>
-    <%= f.govuk_radio_divider if i >= select_gcse_qualification_type_options.count - 2 %>
-    <% if option.id == :other_uk %>
-      <%= f.govuk_radio_button :qualification_type, option.id, label: { text: option.label }, link_errors: i.zero? do %>
-        <% f.govuk_text_field :other_uk_qualification_type, label: { text: t('application_form.gcse.other_uk.label'), size: 's' } %>
-      <% end %>
-
-    <% elsif option.id == :non_uk %>
-      <%= f.govuk_radio_button :qualification_type, option.id, label: { text: option.label }, link_errors: i.zero? do %>
-        <% f.govuk_text_field :non_uk_qualification_type, label: { text: t('application_form.gcse.non_uk.label'), size: 's' }, hint: { text: t('application_form.gcse.non_uk.hint_text') } %>
-      <% end %>
-
-    <% elsif option.id == :missing %>
-      <%= f.govuk_radio_button :qualification_type, option.id, label: { text: t('application_form.gcse.qualification_types.missing', subject: capitalize_english(@subject)) }, link_errors: i.zero? do %>
-      <% end %>
-    <% else %>
-      <%= f.govuk_radio_button :qualification_type, option.id, label: { text: option.label }, link_errors: i.zero? %>
-    <% end %>
+  <% select_gcse_qualification_type_standard_options.each_with_index do |option, i| %>
+    <%= f.govuk_radio_button :qualification_type, option.id, label: { text: option.label }, link_errors: i.zero? %>
   <% end %>
+
+  <%= f.govuk_radio_button :qualification_type, :other_uk, label: { text: t('application_form.gcse.qualification_types.other_uk') } do %>
+    <% f.govuk_text_field :other_uk_qualification_type, label: { text: t('application_form.gcse.other_uk.label'), size: 's' } %>
+  <% end %>
+
+  <%= f.govuk_radio_divider %>
+
+  <%= f.govuk_radio_button :qualification_type, :non_uk, label: { text: t('application_form.gcse.qualification_types.non_uk') } do %>
+    <% f.govuk_text_field :non_uk_qualification_type, label: { text: t('application_form.gcse.non_uk.label'), size: 's' }, hint: { text: t('application_form.gcse.non_uk.hint_text') } %>
+  <% end %>
+
+  <%= f.govuk_radio_divider %>
+
+  <%= f.govuk_radio_button :qualification_type, :missing, label: { text: t('application_form.gcse.qualification_types.missing', subject: capitalize_english(@subject)) } do %>
+  <% end %>
+
 <% end %>
 
 <%= f.govuk_submit t('save_and_continue') %>

--- a/app/views/candidate_interface/gcse/type/_form.html.erb
+++ b/app/views/candidate_interface/gcse/type/_form.html.erb
@@ -5,7 +5,7 @@
   hint: { text: @subject == 'english' ? 'This should not be a qualification showing you speak English as a foreign language.' : '' } do %>
 
   <% select_gcse_qualification_type_options.each_with_index do |option, i| %>
-    <%= f.govuk_radio_divider if i == select_gcse_qualification_type_options.count - 1 %>
+    <%= f.govuk_radio_divider if i >= select_gcse_qualification_type_options.count - 2 %>
     <% if option.id == :other_uk %>
       <%= f.govuk_radio_button :qualification_type, option.id, label: { text: option.label }, link_errors: i.zero? do %>
         <% f.govuk_text_field :other_uk_qualification_type, label: { text: t('application_form.gcse.other_uk.label'), size: 's' } %>

--- a/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
@@ -13,7 +13,7 @@
     <%= f.govuk_text_field :other_uk_qualification_type, label: { text: 'Qualification name', size: 's' } %>
     <%= tag.div(id: 'other-uk-qualifications-autosuggest', data: { source: OTHER_UK_QUALIFICATIONS }) %>
   <% end %>
-  <%= f.govuk_radio_button :qualification_type, CandidateInterface::OtherQualificationTypeForm::NON_UK_TYPE, label: { text: 'Non-UK qualification' } do %>
+  <%= f.govuk_radio_button :qualification_type, CandidateInterface::OtherQualificationTypeForm::NON_UK_TYPE, label: { text: t('application_form.gcse.qualification_types.non_uk') } do %>
     <%= f.govuk_text_field :non_uk_qualification_type, label: { text: 'Qualification name', size: 's' }, hint: { text: t('application_form.other_qualification.qualification_type.non_uk.hint_text') } %>
   <% end %>
   <% if (current_application.application_qualifications.other.blank? && params[:change] == 'true') || (current_application.application_qualifications.other.blank? && !current_application.no_other_qualifications) %>

--- a/config/locales/candidate_interface/gcse.yml
+++ b/config/locales/candidate_interface/gcse.yml
@@ -7,11 +7,11 @@ en:
         label: Type of qualification
       qualification_types:
         gcse: GCSE
-        gce_o_level: O level
+        gce_o_level: UK O level (from before 1989)
         scottish_national_5: Scottish National 5
-        other_uk: Other UK qualification
-        non_uk: Non-UK qualification
-        missing: I do not have a GCSE in %{subject} (or equivalent) yet
+        other_uk: Another UK qualification
+        non_uk: Qualification from outside the UK
+        missing: I do not have a qualification in %{subject} yet
       other_uk:
         label: Qualification name
       non_uk:

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -518,7 +518,7 @@ module CandidateHelper
   end
 
   def candidate_explains_a_missing_gcse
-    choose('I do not have a GCSE in science (or equivalent) yet')
+    choose('I do not have a qualification in science yet')
     click_button t('save_and_continue')
     choose 'Yes'
     fill_in 'candidate-interface-gcse-not-completed-form-not-completed-explanation-field', with: 'In progress'

--- a/spec/system/candidate_interface/course_selection/candidate_can_view_gcse_requirements_and_guidance_for_selected_courses_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_can_view_gcse_requirements_and_guidance_for_selected_courses_spec.rb
@@ -101,7 +101,7 @@ RSpec.feature 'Viewing course choices' do
   def when_i_change_the_completed_gcse_to_a_pending_gcse
     visit candidate_interface_gcse_review_path(subject: 'english')
     click_change_link('qualification for GCSE, english')
-    choose 'I do not have a GCSE in English (or equivalent) yet'
+    choose 'I do not have a qualification in English yet'
     click_button t('save_and_continue')
     click_change_link('how you expect to gain this qualification')
     choose 'Yes'

--- a/spec/system/candidate_interface/entering_details/candidate_changing_gcse_to_international_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_changing_gcse_to_international_qualification_spec.rb
@@ -107,7 +107,7 @@ RSpec.feature 'Candidate changing UK GCSE to international qualification' do
   end
 
   def when_i_select_an_international_qualification_type
-    choose('Non-UK qualification')
+    choose('Qualification from outside the UK')
     within '#candidate-interface-gcse-qualification-type-form-qualification-type-non-uk-conditional' do
       fill_in 'Qualification name', with: 'Baccalauréat Général'
     end

--- a/spec/system/candidate_interface/entering_details/candidate_changing_their_gcse_type_from_completed_to_missing_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_changing_their_gcse_type_from_completed_to_missing_spec.rb
@@ -88,7 +88,7 @@ RSpec.feature 'Candidate changing their GCSE type' do
   end
 
   def and_i_select_i_do_not_have_a_gcse_in_maths_option
-    choose 'I do not have a GCSE in maths (or equivalent) yet'
+    choose 'I do not have a qualification in maths yet'
   end
 
   def then_i_see_the_review_page_with_updated_details

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_international_science_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_international_science_qualification_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature 'Candidate entering GCSE Science details' do
   end
 
   def when_i_select_a_non_uk_qualification
-    choose('Non-UK qualification')
+    choose('Qualification from outside the UK')
     within '#candidate-interface-gcse-qualification-type-form-qualification-type-non-uk-conditional' do
       fill_in 'Qualification name', with: 'Diploma'
     end

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_other_uk_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_other_uk_qualification_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature 'Candidate entering GCSE details' do
   end
 
   def when_i_select_other_uk_qualification_option
-    choose('Other UK qualification')
+    choose('Another UK qualification')
   end
 
   def and_i_fill_in_the_type_of_qualification

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_with_missing_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_with_missing_qualification_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature 'Candidate entering GCSE details' do
   end
 
   def and_i_select_i_do_not_have_yet
-    choose 'I do not have a GCSE in English (or equivalent) yet'
+    choose 'I do not have a qualification in English yet'
   end
 
   def and_i_click_save_and_continue

--- a/spec/system/candidate_interface/entering_details/candidate_entering_international_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_international_gcse_spec.rb
@@ -77,7 +77,7 @@ RSpec.feature 'Candidate entering Non UK GCSE equivalency details' do
   end
 
   def when_i_select_non_uk_qualification
-    choose('Non-UK qualification')
+    choose('Qualification from outside the UK')
   end
 
   def and_i_fill_in_my_qualification_type

--- a/spec/system/candidate_interface/entering_details/change_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/change_gcse_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature 'Change GCSE' do
   end
 
   def when_i_choose_other_uk_qualification
-    choose 'Other UK qualification'
+    choose 'Another UK qualification'
   end
 
   def and_click_save_and_continue

--- a/spec/system/candidate_interface/entering_details/international_candidate_enters_their_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/international_candidate_enters_their_other_qualification_spec.rb
@@ -101,7 +101,7 @@ RSpec.feature 'Non-uk Other qualifications', mid_cycle: false do
   def when_i_do_not_select_any_type_option; end
 
   def when_i_select_add_other_non_uk_qualification
-    choose 'Non-UK qualification'
+    choose 'Qualification from outside the UK'
   end
   alias_method :and_i_select_add_other_non_uk_qualification, :when_i_select_add_other_non_uk_qualification
 

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_qualifications_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_qualifications_spec.rb
@@ -353,7 +353,7 @@ RSpec.feature 'Candidate is redirected correctly' do
   def when_i_update_english_gcse_qualification
     when_i_click_change_english_gcse_qualification
 
-    choose 'Non-UK qualification'
+    choose 'Qualification from outside the UK'
 
     within '#candidate-interface-gcse-qualification-type-form-qualification-type-non-uk-conditional' do
       fill_in 'Qualification name', with: 'School Certificate English'
@@ -403,7 +403,7 @@ RSpec.feature 'Candidate is redirected correctly' do
   def when_i_update_the_other_qualification_type
     when_i_click_change_other_qualification_type
 
-    choose 'Non-UK qualification'
+    choose 'Qualification from outside the UK'
     within '#candidate-interface-other-qualification-type-form-qualification-type-non-uk-conditional' do
       fill_in 'Qualification name', with: 'First Aid Certificate'
     end


### PR DESCRIPTION
Evidence from validation error logs show that a lot of users are seeing an error message when adding an O level with a qualification year after 1988 (9,660 errors as of Feb 2023).

Most of these are due to people adding qualifications from Nigeria, which still has O levels today.

We think people are doing this as they don't read the full list of options and then realise that there is a separate section for non-UK qualifications.

To improve this, we’ve relabelled "O level" to "UK O level (from before 1989)" to make it clearer that this option is only for UK O levels.

We've also relabelled "Non-UK qualification" to "Qualification from outside the UK" to distinguish it more from "Another UK qualification", and have added an additional "or" divider.

🗂️ [Trello card](https://trello.com/c/NGfBFZFn/1161-make-it-clearer-that-o-level-means-a-uk-o-level-and-not-a-nigerian-one)

## Screenshots

| Before | After |
| ----- | ----- |
| <img width="820" alt="Screenshot 2023-02-17 at 15 46 28" src="https://user-images.githubusercontent.com/30665/219700523-2c5dd80f-a0c5-41f6-acbd-891221852f08.png"> | <img width="833" alt="Screenshot 2023-02-17 at 15 46 16" src="https://user-images.githubusercontent.com/30665/219700575-c14a6965-8a66-4d0e-95bf-c0171e0c7dc4.png"> |


