### PR TITLE
Add aks staging environment

### DIFF
--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -11,6 +11,7 @@ on:
         default: qa_aks
         options:
         - qa_aks
+        - staging_aks
       sha:
         description: Commit sha to be deployed
         required: true

--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,9 @@ loadtest_aks:
 qa_aks:
 	$(eval include global_config/qa_aks.sh)
 
+staging_aks:
+	$(eval include global_config/staging_aks.sh)
+
 ci:
 	$(eval export CONFIRM_DELETE=true)
 	$(eval export DISABLE_PASSCODE=true)

--- a/global_config/staging_aks.sh
+++ b/global_config/staging_aks.sh
@@ -1,0 +1,7 @@
+CONFIG=staging_aks
+APP_ENV=${CONFIG}
+CONFIG_SHORT=stg
+AZURE_SUBSCRIPTION=s189-teacher-services-cloud-test
+RESOURCE_NAME_PREFIX=s189t01
+ENV_TAG=Test
+PLATFORM=aks

--- a/terraform/aks/workspace_variables/qa_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/qa_aks.tfvars.json
@@ -14,6 +14,6 @@
   "clock_worker_memory_max": "1024Mi",
   "webapp_replicas": 2,
   "worker_replicas": 1,
-  "secondary_worker_replicas": 0,
-  "clock_worker_replicas": 0
+  "secondary_worker_replicas": 1,
+  "clock_worker_replicas": 1
 }

--- a/terraform/aks/workspace_variables/staging_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/staging_aks.tfvars.json
@@ -1,0 +1,19 @@
+{
+  "paas_app_environment": "staging",
+  "azure_resource_prefix": "s189t01-att",
+  "key_vault_resource_group": "s189t01-att-stg-rg",
+  "key_vault_name": "s189t01-att-stg-kv",
+  "key_vault_app_secret_name": "APPLY-APP-SECRETS-STAGING",
+  "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-STAGING",
+  "cluster": "test",
+  "namespace": "bat-staging",
+  "gov_uk_host_names": ["staging2.apply-for-teacher-training.service.gov.uk","staging2.apply-for-teacher-training.education.gov.uk"],
+  "webapp_memory_max": "1024Mi",
+  "worker_memory_max": "1024Mi",
+  "secondary_worker_memory_max": "1024Mi",
+  "clock_worker_memory_max": "1024Mi",
+  "webapp_replicas": 2,
+  "worker_replicas": 1,
+  "secondary_worker_replicas": 1,
+  "clock_worker_replicas": 1
+}

--- a/terraform/aks/workspace_variables/staging_aks_backend.tfvars
+++ b/terraform/aks/workspace_variables/staging_aks_backend.tfvars
@@ -1,0 +1,4 @@
+resource_group_name  = "s189t01-att-stg-rg"
+storage_account_name = "s189t01atttfstatestgsa"
+container_name       = "att-tfstate"
+key                  = "terraform.tfstate"

--- a/terraform/custom_domains/environment_domains/workspace_variables/apply_staging.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/apply_staging.tfvars.json
@@ -9,7 +9,7 @@
       ],
       "environment_short": "stg",
       "environment_tag": "stg",
-      "origin_hostname": "apply-staging.london.cloudapps.digital",
+      "origin_hostname": "apply-staging.test.teacherservices.cloud",
       "null_host_header": true,
       "cnames": {
         "staging": {
@@ -30,7 +30,7 @@
       ],
       "environment_short": "stg",
       "environment_tag": "stg",
-      "origin_hostname": "apply-staging.london.cloudapps.digital",
+      "origin_hostname": "apply-staging.test.teacherservices.cloud",
       "null_host_header": true,
       "cnames": {
         "staging-assets": {


### PR DESCRIPTION
## Context

Create Staging environment in AKS

## Changes proposed in this pull request

Create staging global_config file
Add to Makefile
Add staging workspace variable files
Fix apply-staging front door origin for aks cluster domain
add to deploy_v2 workflow

Alongside these changes
-postgres db restored from PaaS staging database (to do)
-domains added to test DFE sign-in (to do)
-added secrets in AKS with modified settings 
i.e. sentry disabled, skylight disabled, staging2 routes

AKS Staging has been manually deployed
-webapp running with 2 replicas
-worker running with 1 replica
-secondary-worker disabled (replicas set to 0)
-clock-worker disabled (replicas set to 0)
-no assets domains i.e. staging2-assets

## Guidance to review

make staging_aks deploy-plan
check deployed app

## Link to Trello card

https://trello.com/c/HEmjgo8q/96-include-aks-in-apply-cd-pipeline-qa-staging

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
