### PR TITLE
Support filters – nationality

### DIFF
--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -155,7 +155,7 @@ module SupportInterface
         }
       end
       {
-        type: :checkboxes,
+        type: :checkbox_filter,
         heading: 'Subject',
         name: 'subject',
         options: subject_options,

--- a/spec/models/support_interface/applications_filter_spec.rb
+++ b/spec/models/support_interface/applications_filter_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe SupportInterface::ApplicationsFilter do
   end
   let!(:application_choice_with_interview) { create(:application_choice, :interviewing) }
   let!(:application_choice_recruited) { create(:application_choice, :recruited) }
+  let!(:international_application) { create(:completed_application_form, first_nationality: 'American') }
 
   def verify_filtered_applications_for_params(expected_applications, params:)
     applications = ApplicationForm.all
@@ -126,6 +127,24 @@ RSpec.describe SupportInterface::ApplicationsFilter do
         [expected_form],
         params: {
           status: %w[recruited],
+        },
+      )
+    end
+
+    it 'can filter by home nationality' do
+      verify_filtered_applications_for_params(
+        [application_choice_recruited.application_form, application_choice_with_offer.application_form, application_choice_with_interview.application_form],
+        params: {
+          nationality: ['false'],
+        },
+      )
+    end
+
+    it 'can filter by international nationality' do
+      verify_filtered_applications_for_params(
+        [international_application],
+        params: {
+          nationality: ['true'],
         },
       )
     end


### PR DESCRIPTION
## Context

Further enhancing the support UI filters following feedback after we introduced the ability to filter by subject.

Now adding the option to filter by nationality (well, two groups).

## Changes proposed in this pull request

- Add a filter to filter by 'home' or 'international' candidates
- Change the type of checkbox used by subject (condense it)

<img width="390" alt="image" src="https://user-images.githubusercontent.com/47917431/220758045-c0e3235e-4037-4831-819b-e871f3efc118.png">

## Guidance to review

This was unexpectedly tricky. `international_applicant?` is a model method so can't be called in an `ActiveRecord` query. I needed to use `select` in order to be able to query the method but the rest of the code expects an `ActiveRecord::Relation`, so I have to convert it back.

Completely open to suggestions for alternatives!

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
