### PR TITLE
Select either Azure or AKS container Redis URL

### DIFF
--- a/terraform/aks/.terraform.lock.hcl
+++ b/terraform/aks/.terraform.lock.hcl
@@ -27,6 +27,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.17.0"
   constraints = "2.17.0"
   hashes = [
+    "h1:Dq/EHg8mKP9wDDTJx5CzZ+w44wutIZJGfQLrAIznAqY=",
     "h1:p2sgF62c2svJSKuImL3/zq/SSPOZFyd4Vj7K0UF2VrQ=",
     "zh:1cbafea8c404195d8ad2490d75dbeebef131563d3e38dec87231ceb3923a3012",
     "zh:26d9584423ee77e607999b082de7d9dc3e937934aa83341e0832e7253caf4f51",

--- a/terraform/modules/kubernetes/variables.tf
+++ b/terraform/modules/kubernetes/variables.tf
@@ -87,6 +87,9 @@ locals {
   redis_queue_name                     = "${var.resource_prefix}-${var.app_environment}-redis-queue"
   redis_queue_private_endpoint_name    = "${var.resource_prefix}-${var.app_environment}-redis-queue-pe"
   redis_service_name                   = "apply-redis-${var.app_environment}"
+  redis_container_url                  = "redis://${local.redis_service_name}:6379/0"
+  redis_azure_url                      = var.deploy_azure_backing_services ? "redis://:${azurerm_redis_cache.redis-cache[0].primary_access_key}@${azurerm_redis_cache.redis-cache[0].hostname}:${azurerm_redis_cache.redis-cache[0].port}/0" : null
+  redis_url                            = var.deploy_azure_backing_services ? local.redis_azure_url : local.redis_container_url
   secondary_worker_name                = "apply-secondary-worker-${var.app_environment}"
   webapp_startup_command               = var.webapp_startup_command == null ? null : ["/bin/sh", "-c", var.webapp_startup_command]
   webapp_name                          = "apply-${var.app_environment}"
@@ -108,8 +111,8 @@ locals {
     {
       DATABASE_URL        = local.database_url
       BLAZER_DATABASE_URL = local.database_url
-      REDIS_URL           = "redis://:${azurerm_redis_cache.redis-queue[0].primary_access_key}@${azurerm_redis_cache.redis-queue[0].hostname}:${azurerm_redis_cache.redis-queue[0].port}/0"
-      REDIS_CACHE_URL     = "redis://:${azurerm_redis_cache.redis-cache[0].primary_access_key}@${azurerm_redis_cache.redis-cache[0].hostname}:${azurerm_redis_cache.redis-cache[0].port}/0"
+      REDIS_URL           = local.redis_url
+      REDIS_CACHE_URL     = local.redis_url
     }
   )
   # Create a unique name based on the values to force recreation when they change


### PR DESCRIPTION
Use a different value for the redis_url depending on whether we are a review app using Redis in an AKS container or using Azure Redis

## Context

Since adding Azure Redis we also need to ensure we select either the Azure or AKS container URL depending on whether the environment is review.

## Changes proposed in this pull request

Add locals to support selection of AKS or Azure Redis URLs

## Guidance to review

Ran using `make review_aks deploy-plan PR_NUMBER=99999 PASSCODE=1` with the `"deploy_azure_backing_services": true,` set to true and false in the `review_aks.tfvars.json` file and got a green plan with no errors as per the ticket.

## Link to Trello card

https://trello.com/c/eWeHgJaJ

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
