### PR TITLE
Reformat SKE bullet points depending on course type

### DIFF
--- a/app/controllers/provider_interface/ske_controller.rb
+++ b/app/controllers/provider_interface/ske_controller.rb
@@ -44,5 +44,10 @@ module ProviderInterface
       @wizard.language_course?
     end
     helper_method :language_ske?
+
+    def physics_ske?
+      @wizard.physics_course?
+    end
+    helper_method :physics_ske?
   end
 end

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -107,6 +107,10 @@ module ProviderInterface
       subject_mapping.in?(Subject::SKE_LANGUAGE_COURSES)
     end
 
+    def physics_course?
+      subject_mapping.in?(Subject::SKE_PHYSICS_COURSES)
+    end
+
     def ske_standard_course?
       subject_mapping.in?(Subject::SKE_STANDARD_COURSES)
     end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -27,4 +27,9 @@ class Subject < ApplicationRecord
     22
     24
   ].freeze
+
+  SKE_PHYSICS_COURSES = %w[
+    F0
+    F3
+  ].freeze
 end

--- a/app/views/provider_interface/offer/ske_requirements/new.html.erb
+++ b/app/views/provider_interface/offer/ske_requirements/new.html.erb
@@ -9,11 +9,20 @@
       <span class="govuk-caption-l"><%= t('caption.make_offer', name: @application_choice.application_form.full_name) %></span>
       <h1 class="govuk-heading-l"><%= t('.title') %></h1>
 
-      <% if language_ske? %>
-        <p class="govuk-body">The Department for Education (DfE) will pay candidates to take up to 2 language SKE courses if they need one, so long as they:</p>
+      <% if language_ske? || physics_ske? %>
+        <p class="govuk-body">
+          The Department for Education (DfE) will pay candidates to take up to 2 language SKE courses if they need one,
+          so long as they have a 2:2 degree or higher, or are expected to get this when they graduate.
+        </p>
+      <% else %>
+        <p class="govuk-body">The Department for Education (DfE) will pay candidates to take a SKE course if they need one, so long as they:</p>
         <ul class="govuk-list govuk-list--bullet">
           <li>have a 2:2 degree or higher, or are expected to get this when they graduate</li>
+          <li>are eligible for student finance (home fee status)</li>
         </ul>
+      <% end %>
+
+      <% if language_ske? %>
         <%= f.govuk_check_boxes_fieldset :ske_languages, legend: { text: "Do you require #{@application_choice.application_form.full_name} to take a SKE course in any of these languages?", size: 's' }, hint: { text: 'You can select a maximum of 2', size: 's' } do %>
           <% SkeCondition::VALID_LANGUAGES.each_with_index do |language, index| %>
             <%= f.govuk_check_box :ske_languages, language, label: { text: language.capitalize }, link_errors: index.zero? %>
@@ -22,11 +31,6 @@
           <%= f.govuk_check_box :ske_languages, 'no', label: { text: 'No, a SKE course is not required' }, exclusive: true %>
         <% end %>
       <% else %>
-        <p class="govuk-body">The Department for Education (DfE) will pay candidates to take a SKE course if they need one, so long as they:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>have a 2:2 degree or higher, or are expected to get this when they graduate</li>
-          <li>are eligible for student finance (home fee status)</li>
-        </ul>
         <%= f.govuk_radio_buttons_fieldset :ske_required, legend: { text: "Do you require #{@application_choice.application_form.full_name} to take a SKE course in #{@application_choice.current_course.subjects.first&.name} that will be funded by the DfE?", size: 'm' } do %>
           <%= f.govuk_radio_button :ske_required, true, label: { text: 'Yes' }, link_errors: true %>
           <%= f.govuk_radio_button :ske_required, false, label: { text: 'No' } %>


### PR DESCRIPTION
- No bullets & one paragraph for physics and languages
- Two bullets for everything else.

## Changes proposed in this pull request

### Languages
<img width="713" alt="Screenshot 2023-02-23 at 12 37 31" src="https://user-images.githubusercontent.com/109225/220908471-2fb267b7-7feb-4938-8060-d862dfc139dc.png">

### Physics
<img width="707" alt="Screenshot 2023-02-23 at 12 36 53" src="https://user-images.githubusercontent.com/109225/220908499-cabac60f-eeeb-45e1-9419-6857625b0156.png">

### Other
<img width="714" alt="Screenshot 2023-02-23 at 12 37 11" src="https://user-images.githubusercontent.com/109225/220908516-db2cd535-e112-4def-8160-c73d15c055b7.png">
