### PR TITLE
Update the nationality filter

### DIFF
--- a/spec/models/support_interface/applications_filter_spec.rb
+++ b/spec/models/support_interface/applications_filter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SupportInterface::ApplicationsFilter do
 
     create(:application_choice, :offered, :previous_year, course_option: course_option)
   end
-  let!(:application_choice_with_interview) { create(:application_choice, :interviewing) }
+  let!(:application_choice_with_interview) { create(:application_choice, :interviewing, application_form: create(:completed_application_form, first_nationality: 'British')) }
   let!(:application_choice_recruited) { create(:application_choice, :recruited) }
   let!(:international_application) { create(:completed_application_form, first_nationality: 'American') }
 


### PR DESCRIPTION
## Context

Previous attempt didn't quite work. The little conversion dance I was doing required me to add back on the pagination functionality but this was capping the results.

## Changes proposed in this pull request

No need to be complicated, this is just for the support. Instead I'm just going to use first nationality to determine if they are 'home' or 'international'