### PR TITLE
Change SKE length validation

### DIFF
--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -343,10 +343,8 @@ module ProviderInterface
     end
 
     def validate_combined_ske_length
-      if ske_conditions.sum { |sc| sc.length.to_i } > MAX_SKE_LENGTH
-        errors.add(:base, :ske_length_too_long,
-                   max_total_ske_length: MAX_SKE_LENGTH,
-                   ske_count: ske_conditions.length)
+      if ske_conditions.many? && ske_conditions.none? { |sc| sc.length == '8' }
+        errors.add(:base, :must_have_at_least_one_8_week_ske_course)
       end
     end
 

--- a/app/views/provider_interface/offer/ske_lengths/new.html.erb
+++ b/app/views/provider_interface/offer/ske_lengths/new.html.erb
@@ -10,7 +10,7 @@
       <% if language_ske? %>
         <% if @wizard.ske_conditions.many? %>
           <h1 class="govuk-heading-l"><%= t('.ske_language_length_many_title') %></h1>
-          <p class="govuk-hint">The 2 courses must not add up to more than 36 weeks.</p>
+          <p class="govuk-hint">One language course must be 8 weeks. The other course can be between 8 and 28 weeks.</p>
         <% end %>
 
         <%= render ProviderInterface::SkeLengthComponent.new(form: f, offer_wizard: f.object, radio_options: { legend: { text: t('.title'), size: 'l' } }) %>

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -107,8 +107,8 @@ en:
             base:
               blank: Select whether you require the candidate to do a course
               exceeded_max_conditions: The offer must have %{count} conditions or fewer
+              must_have_at_least_one_8_week_ske_course: Select one language course that’s 8 weeks, the other course can be between 8 and 28 weeks
               no_and_languages_selected: Select a language, or select ‘No, a SKE course is not required’
-              ske_length_too_long: The %{ske_count} courses must not add up to more than %{max_total_ske_length} weeks
               too_many: Select no more than %{count} languages
         offer_validations:
           attributes:

--- a/spec/system/provider_interface/make_offer_ske_language_flow_feature_flag_enabled_spec.rb
+++ b/spec/system/provider_interface/make_offer_ske_language_flow_feature_flag_enabled_spec.rb
@@ -72,9 +72,9 @@ RSpec.feature 'Provider makes an offer with SKE enabled on language flow' do
     when_i_dont_answer_ske_length
     then_i_should_see_a_error_message_to_give_a_ske_course_length_for_all_languages
 
-    when_i_answer_the_ske_length_is_more_than_36_weeks
+    when_i_select_both_ske_courses_over_8_weeks
     and_i_click_continue
-    then_i_should_see_a_error_message_to_give_a_ske_course_length_less_than_36_weeks
+    then_i_should_see_a_error_message_to_select_at_least_one_8_week_course
 
     when_i_answer_the_ske_length
     and_i_click_continue
@@ -225,7 +225,7 @@ RSpec.feature 'Provider makes an offer with SKE enabled on language flow' do
     click_on 'Continue'
   end
 
-  def when_i_answer_the_ske_length_is_more_than_36_weeks
+  def when_i_select_both_ske_courses_over_8_weeks
     form_groups.first.choose('28 weeks')
     form_groups.last.choose('12 weeks')
   end
@@ -240,13 +240,13 @@ RSpec.feature 'Provider makes an offer with SKE enabled on language flow' do
     expect(page).to have_content('Select how long the course must be')
   end
 
-  def then_i_should_see_a_error_message_to_give_a_ske_course_length_less_than_36_weeks
+  def then_i_should_see_a_error_message_to_select_at_least_one_8_week_course
     expect(page).to have_content('There is a problem')
-    expect(page).to have_content('The 2 courses must not add up to more than 36 weeks')
+    expect(page).to have_content('Select one language course that’s 8 weeks, the other course can be between 8 and 28 weeks')
   end
 
   def when_i_answer_the_ske_length
-    form_groups.first.choose('12 weeks')
+    form_groups.first.choose('8 weeks')
     form_groups.last.choose('12 weeks')
   end
 


### PR DESCRIPTION
Rather than checking that the combined length
is below 36 weeks, the more correct validation
is that there should be at least one 8 week
course if there's more than one SKE course.

## Changes proposed in this pull request

<img width="1002" alt="Screenshot 2023-02-23 at 14 20 02" src="https://user-images.githubusercontent.com/109225/220934500-6c455b99-b95f-47bb-91a6-a663534e0537.png">
