### PR TITLE
[202] Fix REDIS_URL and REDIS_CACHE_URL

### DIFF
--- a/terraform/modules/kubernetes/azure-resources.tf
+++ b/terraform/modules/kubernetes/azure-resources.tf
@@ -40,13 +40,13 @@ resource "azurerm_postgresql_flexible_server_configuration" "postgres-extensions
 resource "azurerm_redis_cache" "redis-cache" {
   count = var.deploy_azure_backing_services ? 1 : 0
 
-  name                = local.redis_cache_name
-  location            = data.azurerm_resource_group.backing-service-resource-group[0].location
-  resource_group_name = data.azurerm_resource_group.backing-service-resource-group[0].name
-  capacity            = var.redis_capacity
-  family              = var.redis_family
-  sku_name            = var.redis_sku_name
-  minimum_tls_version = var.redis_minimum_tls_version
+  name                          = local.redis_cache_name
+  location                      = data.azurerm_resource_group.backing-service-resource-group[0].location
+  resource_group_name           = data.azurerm_resource_group.backing-service-resource-group[0].name
+  capacity                      = var.redis_capacity
+  family                        = var.redis_family
+  sku_name                      = var.redis_sku_name
+  minimum_tls_version           = var.redis_minimum_tls_version
   public_network_access_enabled = var.redis_public_network_access_enabled
 
   redis_configuration {
@@ -95,13 +95,13 @@ resource "azurerm_private_endpoint" "redis-cache-private-endpoint" {
 resource "azurerm_redis_cache" "redis-queue" {
   count = var.deploy_azure_backing_services ? 1 : 0
 
-  name                = local.redis_queue_name
-  location            = data.azurerm_resource_group.backing-service-resource-group[0].location
-  resource_group_name = data.azurerm_resource_group.backing-service-resource-group[0].name
-  capacity            = var.redis_capacity
-  family              = var.redis_family
-  sku_name            = var.redis_sku_name
-  minimum_tls_version = var.redis_minimum_tls_version
+  name                          = local.redis_queue_name
+  location                      = data.azurerm_resource_group.backing-service-resource-group[0].location
+  resource_group_name           = data.azurerm_resource_group.backing-service-resource-group[0].name
+  capacity                      = var.redis_capacity
+  family                        = var.redis_family
+  sku_name                      = var.redis_sku_name
+  minimum_tls_version           = var.redis_minimum_tls_version
   public_network_access_enabled = var.redis_public_network_access_enabled
 
   redis_configuration {

--- a/terraform/modules/kubernetes/azure-resources.tf
+++ b/terraform/modules/kubernetes/azure-resources.tf
@@ -46,7 +46,6 @@ resource "azurerm_redis_cache" "redis-cache" {
   capacity            = var.redis_capacity
   family              = var.redis_family
   sku_name            = var.redis_sku_name
-  enable_non_ssl_port = var.redis_enable_non_ssl_port
   minimum_tls_version = var.redis_minimum_tls_version
   public_network_access_enabled = var.redis_public_network_access_enabled
 
@@ -102,7 +101,6 @@ resource "azurerm_redis_cache" "redis-queue" {
   capacity            = var.redis_capacity
   family              = var.redis_family
   sku_name            = var.redis_sku_name
-  enable_non_ssl_port = var.redis_enable_non_ssl_port
   minimum_tls_version = var.redis_minimum_tls_version
   public_network_access_enabled = var.redis_public_network_access_enabled
 

--- a/terraform/modules/kubernetes/variables.tf
+++ b/terraform/modules/kubernetes/variables.tf
@@ -88,8 +88,14 @@ locals {
   redis_queue_private_endpoint_name    = "${var.resource_prefix}-${var.app_environment}-redis-queue-pe"
   redis_service_name                   = "apply-redis-${var.app_environment}"
   redis_container_url                  = "redis://${local.redis_service_name}:6379/0"
-  redis_azure_url                      = var.deploy_azure_backing_services ? "redis://:${azurerm_redis_cache.redis-cache[0].primary_access_key}@${azurerm_redis_cache.redis-cache[0].hostname}:${azurerm_redis_cache.redis-cache[0].port}/0" : null
-  redis_url                            = var.deploy_azure_backing_services ? local.redis_azure_url : local.redis_container_url
+  redis_queue_azure_url                = ( var.deploy_azure_backing_services ?
+    "redis://:${azurerm_redis_cache.redis-queue[0].primary_access_key}@${azurerm_redis_cache.redis-queue[0].hostname}:${azurerm_redis_cache.redis-queue[0].port}/0" :
+    local.redis_container_url
+  )
+  redis_cache_azure_url                = ( var.deploy_azure_backing_services ?
+    "redis://:${azurerm_redis_cache.redis-queue[0].primary_access_key}@${azurerm_redis_cache.redis-queue[0].hostname}:${azurerm_redis_cache.redis-queue[0].port}/0" :
+    local.redis_container_url
+  )
   secondary_worker_name                = "apply-secondary-worker-${var.app_environment}"
   webapp_startup_command               = var.webapp_startup_command == null ? null : ["/bin/sh", "-c", var.webapp_startup_command]
   webapp_name                          = "apply-${var.app_environment}"
@@ -100,7 +106,7 @@ locals {
   webapp_env_variables = merge(
     var.app_environment_variables,
     {
-      SERVICE_TYPE     = "web"
+      SERVICE_TYPE = "web"
     }
   )
   # Create a unique name based on the values to force recreation when they change
@@ -111,8 +117,8 @@ locals {
     {
       DATABASE_URL        = local.database_url
       BLAZER_DATABASE_URL = local.database_url
-      REDIS_URL           = local.redis_url
-      REDIS_CACHE_URL     = local.redis_url
+      REDIS_URL           = local.redis_queue_azure_url
+      REDIS_CACHE_URL     = local.redis_cache_azure_url
     }
   )
   # Create a unique name based on the values to force recreation when they change

--- a/terraform/modules/kubernetes/variables.tf
+++ b/terraform/modules/kubernetes/variables.tf
@@ -83,20 +83,20 @@ locals {
   redis_queue_private_endpoint_name    = "${var.resource_prefix}-${var.app_environment}-redis-queue-pe"
   redis_service_name                   = "apply-redis-${var.app_environment}"
   redis_container_url                  = "redis://${local.redis_service_name}:6379/0"
-  redis_queue_azure_url                = ( var.deploy_azure_backing_services ?
+  redis_queue_azure_url = (var.deploy_azure_backing_services ?
     "rediss://:${azurerm_redis_cache.redis-queue[0].primary_access_key}@${azurerm_redis_cache.redis-queue[0].hostname}:${azurerm_redis_cache.redis-queue[0].ssl_port}/0" :
     local.redis_container_url
   )
-  redis_cache_azure_url                = ( var.deploy_azure_backing_services ?
+  redis_cache_azure_url = (var.deploy_azure_backing_services ?
     "rediss://:${azurerm_redis_cache.redis-cache[0].primary_access_key}@${azurerm_redis_cache.redis-cache[0].hostname}:${azurerm_redis_cache.redis-cache[0].ssl_port}/0" :
     local.redis_container_url
   )
-  secondary_worker_name                = "apply-secondary-worker-${var.app_environment}"
-  webapp_startup_command               = var.webapp_startup_command == null ? null : ["/bin/sh", "-c", var.webapp_startup_command]
-  webapp_name                          = "apply-${var.app_environment}"
-  worker_name                          = "apply-worker-${var.app_environment}"
-  clock_worker_name                    = "apply-clock-worker-${var.app_environment}"
-  vnet_name                            = "${var.cluster.cluster_resource_prefix}-vnet"
+  secondary_worker_name  = "apply-secondary-worker-${var.app_environment}"
+  webapp_startup_command = var.webapp_startup_command == null ? null : ["/bin/sh", "-c", var.webapp_startup_command]
+  webapp_name            = "apply-${var.app_environment}"
+  worker_name            = "apply-worker-${var.app_environment}"
+  clock_worker_name      = "apply-clock-worker-${var.app_environment}"
+  vnet_name              = "${var.cluster.cluster_resource_prefix}-vnet"
 
   webapp_env_variables = merge(
     var.app_environment_variables,

--- a/terraform/modules/kubernetes/variables.tf
+++ b/terraform/modules/kubernetes/variables.tf
@@ -39,11 +39,6 @@ variable "redis_sku_name" {
   default = "Standard"
 }
 
-variable "redis_enable_non_ssl_port" {
-  type    = bool
-  default = true
-}
-
 variable "redis_minimum_tls_version" {
   type    = string
   default = "1.2"

--- a/terraform/modules/kubernetes/variables.tf
+++ b/terraform/modules/kubernetes/variables.tf
@@ -89,11 +89,11 @@ locals {
   redis_service_name                   = "apply-redis-${var.app_environment}"
   redis_container_url                  = "redis://${local.redis_service_name}:6379/0"
   redis_queue_azure_url                = ( var.deploy_azure_backing_services ?
-    "redis://:${azurerm_redis_cache.redis-queue[0].primary_access_key}@${azurerm_redis_cache.redis-queue[0].hostname}:${azurerm_redis_cache.redis-queue[0].port}/0" :
+    "rediss://:${azurerm_redis_cache.redis-queue[0].primary_access_key}@${azurerm_redis_cache.redis-queue[0].hostname}:${azurerm_redis_cache.redis-queue[0].ssl_port}/0" :
     local.redis_container_url
   )
   redis_cache_azure_url                = ( var.deploy_azure_backing_services ?
-    "redis://:${azurerm_redis_cache.redis-queue[0].primary_access_key}@${azurerm_redis_cache.redis-queue[0].hostname}:${azurerm_redis_cache.redis-queue[0].port}/0" :
+    "rediss://:${azurerm_redis_cache.redis-cache[0].primary_access_key}@${azurerm_redis_cache.redis-cache[0].hostname}:${azurerm_redis_cache.redis-cache[0].ssl_port}/0" :
     local.redis_container_url
   )
   secondary_worker_name                = "apply-secondary-worker-${var.app_environment}"


### PR DESCRIPTION
## Context

The REDIS_URL and REDIS_CACHE_URL were updated to point to the same Azure Redis Cache instance. They should point to the queue and cache instances respectively.
Also we want to enforce SSL connection to redis.

## Changes proposed in this pull request

- Ensure these two values point to the correct Azure Redis Caches. Cache to cache and URL to queue.
- Disable non-SSL redis port

## Guidance to review

- Confirm the references are correct in the REDIS_URL and REDIS_CACHE_URL `app_secrets`.
- Confirm the app connects to redis

## Link to Trello card

https://trello.com/c/lfv7xZNH

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
