### PR TITLE
Don't break page if GCSE doesn't have a grade

### DIFF
--- a/app/components/shared/gcse_qualification_cards_component.html.erb
+++ b/app/components/shared/gcse_qualification_cards_component.html.erb
@@ -74,7 +74,13 @@
                   </dd>
                 <% end %>
               <% else %>
-                <% raise 'Neither `grade` nor `constituent_grades` found' %>
+                <div class="govuk-warning-text">
+                  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                  <strong class="govuk-warning-text__text">
+                    <span class="govuk-warning-text__assistive"></span>
+                    There is no grade recorded for this qualification.
+                  </strong>
+                </div>
               <% end %>
 
               <% if qualification.failed_required_gcse? %>

--- a/app/components/shared/gcse_qualification_cards_component.html.erb
+++ b/app/components/shared/gcse_qualification_cards_component.html.erb
@@ -74,13 +74,7 @@
                   </dd>
                 <% end %>
               <% else %>
-                <div class="govuk-warning-text">
-                  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                  <strong class="govuk-warning-text__text">
-                    <span class="govuk-warning-text__assistive"></span>
-                    There is no grade recorded for this qualification.
-                  </strong>
-                </div>
+                    <dd class="app-qualification__value">Not added</dd>
               <% end %>
 
               <% if qualification.failed_required_gcse? %>


### PR DESCRIPTION
## Context

Currently it's not possible for a provider or support user to view an application with a GCSE that doesn't have a grade or constituent_grades; they see a 500 error.

## Changes proposed in this pull request

Instead of erroring, fail gracefully-ish with a warning message.

## Guidance to review

- Update an application to have a science GCSE with `grade: nil, constituent_grades: nil`
- Attempt to access that application in the support console
- Let the good times roll

## Link to Trello card

https://trello.com/c/NBDcyF3b/1204-it-shouldnt-be-possible-for-candidates-to-enter-a-gcse-science-without-grade-or-constituent-grades

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
