### PR TITLE
Ske change course

### DIFF
--- a/app/components/provider_interface/offer_summary_component.html.erb
+++ b/app/components/provider_interface/offer_summary_component.html.erb
@@ -8,7 +8,12 @@
 
   <% if FeatureFlag.active?(:provider_ske) && @ske_required %>
     <% ske_conditions.each do |ske_condition| %>
-      <%= render ProviderInterface::SkeConditionsComponent.new(application_choice: @application_choice, course: @course, ske_condition:, editable: !ske_condition.persisted?) %>
+      <%= render ProviderInterface::SkeConditionsComponent.new(
+        application_choice: @application_choice,
+        course: @course,
+        ske_condition:,
+        editable: !ske_condition.persisted?,
+      ) %>
     <% end %>
   <% end %>
 

--- a/app/components/provider_interface/offer_summary_component.html.erb
+++ b/app/components/provider_interface/offer_summary_component.html.erb
@@ -6,9 +6,9 @@
 
   <p class="govuk-body">Candidates are required to receive 2 references.</p>
 
-  <% if FeatureFlag.active?(:provider_ske) %>
+  <% if FeatureFlag.active?(:provider_ske) && @ske_required %>
     <% ske_conditions.each do |ske_condition| %>
-      <%= render ProviderInterface::SkeConditionsComponent.new(application_choice: @application_choice, ske_condition:, editable: !ske_condition.persisted?) %>
+      <%= render ProviderInterface::SkeConditionsComponent.new(application_choice: @application_choice, course: @course, ske_condition:, editable: !ske_condition.persisted?) %>
     <% end %>
   <% end %>
 

--- a/app/components/provider_interface/offer_summary_component.html.erb
+++ b/app/components/provider_interface/offer_summary_component.html.erb
@@ -6,7 +6,7 @@
 
   <p class="govuk-body">Candidates are required to receive 2 references.</p>
 
-  <% if FeatureFlag.active?(:provider_ske) && @ske_required %>
+  <% if FeatureFlag.active?(:provider_ske) && ske_conditions.present? %>
     <% ske_conditions.each do |ske_condition| %>
       <%= render ProviderInterface::SkeConditionsComponent.new(
         application_choice: @application_choice,

--- a/app/components/provider_interface/offer_summary_component.rb
+++ b/app/components/provider_interface/offer_summary_component.rb
@@ -3,7 +3,7 @@ module ProviderInterface
     include ViewHelper
     include QualificationValueHelper
 
-    attr_accessor :application_choice, :course, :course_option, :conditions, :available_providers, :available_courses, :available_course_options, :border, :editable, :show_conditions_link, :ske_conditions, :ske_required
+    attr_accessor :application_choice, :course, :course_option, :conditions, :available_providers, :available_courses, :available_course_options, :border, :editable, :show_conditions_link, :ske_conditions
 
     def initialize(application_choice:, course:, course_option:, conditions:, available_providers: [], available_courses: [], available_course_options: [], border: true, editable: true, show_conditions_link: false, ske_conditions: [])
       @application_choice = application_choice
@@ -17,7 +17,6 @@ module ProviderInterface
       @editable = editable
       @show_conditions_link = show_conditions_link
       @ske_conditions = ske_conditions
-      @ske_required = ske_conditions.present?
     end
 
     def rows

--- a/app/components/provider_interface/offer_summary_component.rb
+++ b/app/components/provider_interface/offer_summary_component.rb
@@ -3,7 +3,7 @@ module ProviderInterface
     include ViewHelper
     include QualificationValueHelper
 
-    attr_accessor :application_choice, :course, :course_option, :conditions, :available_providers, :available_courses, :available_course_options, :border, :editable, :show_conditions_link, :ske_conditions
+    attr_accessor :application_choice, :course, :course_option, :conditions, :available_providers, :available_courses, :available_course_options, :border, :editable, :show_conditions_link, :ske_conditions, :ske_required
 
     def initialize(application_choice:, course:, course_option:, conditions:, available_providers: [], available_courses: [], available_course_options: [], border: true, editable: true, show_conditions_link: false, ske_conditions: [])
       @application_choice = application_choice
@@ -17,6 +17,7 @@ module ProviderInterface
       @editable = editable
       @show_conditions_link = show_conditions_link
       @ske_conditions = ske_conditions
+      @ske_required = ske_conditions.present?
     end
 
     def rows

--- a/app/components/provider_interface/ske_conditions_component.rb
+++ b/app/components/provider_interface/ske_conditions_component.rb
@@ -31,7 +31,7 @@ module ProviderInterface
     end
 
     def subject
-      (ske_condition.language.presence || @course.subjects.first&.name)
+      (ske_condition.subject.presence || @course.subjects.first&.name)
     end
 
     def remove_condition_path

--- a/app/components/provider_interface/ske_conditions_component.rb
+++ b/app/components/provider_interface/ske_conditions_component.rb
@@ -1,10 +1,11 @@
 module ProviderInterface
   class SkeConditionsComponent < ViewComponent::Base
-    attr_reader :application_choice, :ske_condition, :editable, :ske_condition_presenter
-    delegate :subject, :reason, :length, to: :ske_condition
+    attr_reader :application_choice, :course, :ske_condition, :editable, :ske_condition_presenter
+    delegate :reason, :length, to: :ske_condition
 
-    def initialize(application_choice:, ske_condition:, editable:)
+    def initialize(application_choice:, course:, ske_condition:, editable:)
       @application_choice = application_choice
+      @course = course
       @editable = editable
       @ske_condition = ske_condition
       @ske_condition_presenter = SkeConditionPresenter.new(
@@ -27,6 +28,10 @@ module ProviderInterface
           action: editable ? { visually_hidden_text: 'change ske reason', href: new_provider_interface_application_choice_offer_ske_reason_path(application_choice) } : {},
         },
       ]
+    end
+
+    def subject
+      (ske_condition.language.presence || @course.subjects.first&.name)
     end
 
     def remove_condition_path

--- a/app/components/provider_interface/ske_length_component.rb
+++ b/app/components/provider_interface/ske_length_component.rb
@@ -21,8 +21,8 @@ module ProviderInterface
         {
           legend: {
             text: t(
-              'provider_interface.offer.ske_lengths.new.title_language',
-              language: ske_condition.subject,
+              'provider_interface.offer.ske_lengths.form.title_language',
+              language: ske_condition.language,
             ),
           },
         }

--- a/app/components/provider_interface/ske_length_component.rb
+++ b/app/components/provider_interface/ske_length_component.rb
@@ -22,7 +22,7 @@ module ProviderInterface
           legend: {
             text: t(
               'provider_interface.offer.ske_lengths.form.title_language',
-              language: ske_condition.language,
+              language: ske_condition.subject,
             ),
           },
         }

--- a/app/components/provider_interface/ske_length_component.rb
+++ b/app/components/provider_interface/ske_length_component.rb
@@ -11,7 +11,7 @@ module ProviderInterface
     end
 
     def options
-      ProviderInterface::OfferWizard::SKE_LENGTH.map do |value|
+      ProviderInterface::OfferWizard::SKE_LENGTHS.map do |value|
         SkeLength.new(value: value, label: "#{value} weeks")
       end
     end

--- a/app/components/provider_interface/ske_reason_component.rb
+++ b/app/components/provider_interface/ske_reason_component.rb
@@ -24,8 +24,8 @@ module ProviderInterface
         {
           legend: {
             text: t(
-              'provider_interface.offer.ske_reasons.new.title_language',
-              language: ske_condition.subject,
+              'provider_interface.offer.ske_reasons.form.title_language',
+              language: ske_condition.language,
             ),
           },
         }
@@ -38,15 +38,15 @@ module ProviderInterface
 
     def first_option_label(ske_condition)
       I18n.t(
-        'provider_interface.offer.ske_reasons.different_degree',
-        degree_subject: ske_condition.subject.capitalize,
+        'provider_interface.offer.ske_reasons.form.different_degree',
+        degree_subject: subject.capitalize,
       )
     end
 
     def second_option_label(ske_condition)
       I18n.t(
-        'provider_interface.offer.ske_reasons.outdated_degree',
-        degree_subject: ske_condition.subject.capitalize,
+        'provider_interface.offer.ske_reasons.form.outdated_degree',
+        degree_subject: subject.capitalize,
         graduation_cutoff_date: SkeConditionPresenter.new(ske_condition).cutoff_date,
       )
     end

--- a/app/components/provider_interface/ske_reason_component.rb
+++ b/app/components/provider_interface/ske_reason_component.rb
@@ -25,7 +25,7 @@ module ProviderInterface
           legend: {
             text: t(
               'provider_interface.offer.ske_reasons.form.title_language',
-              language: ske_condition.language,
+              language: ske_condition.subject,
             ),
           },
         }
@@ -38,15 +38,15 @@ module ProviderInterface
 
     def first_option_label(ske_condition)
       I18n.t(
-        'provider_interface.offer.ske_reasons.form.different_degree',
-        degree_subject: subject.capitalize,
+        'provider_interface.offer.ske_reasons.different_degree',
+        degree_subject: ske_condition.subject.capitalize,
       )
     end
 
     def second_option_label(ske_condition)
       I18n.t(
-        'provider_interface.offer.ske_reasons.form.outdated_degree',
-        degree_subject: subject.capitalize,
+        'provider_interface.offer.ske_reasons.outdated_degree',
+        degree_subject: ske_condition.subject.capitalize,
         graduation_cutoff_date: SkeConditionPresenter.new(ske_condition).cutoff_date,
       )
     end

--- a/app/controllers/provider_interface/offer/courses_controller.rb
+++ b/app/controllers/provider_interface/offer/courses_controller.rb
@@ -48,7 +48,7 @@ module ProviderInterface
     private
 
       def course_params
-        params.require(:provider_interface_offer_wizard).permit(:course_id)
+        params.require(:provider_interface_offer_wizard).permit(:course_id, :course_option_id)
       end
 
       def attributes_for_wizard

--- a/app/controllers/provider_interface/offer/courses_controller.rb
+++ b/app/controllers/provider_interface/offer/courses_controller.rb
@@ -52,7 +52,10 @@ module ProviderInterface
       end
 
       def attributes_for_wizard
-        course_params.to_h.merge!(current_step: 'courses')
+        course_params.to_h.merge!(
+          current_step: 'courses',
+          ske_conditions: [],
+        )
       end
     end
   end

--- a/app/controllers/provider_interface/offer/ske_requirements_controller.rb
+++ b/app/controllers/provider_interface/offer/ske_requirements_controller.rb
@@ -13,6 +13,18 @@ module ProviderInterface
         end
       end
 
+      def update
+        super do |wizard|
+          wizard.ske_conditions = build_ske_conditions
+
+          if no_options_selected?
+            wizard.errors.add(:base, :blank)
+          elsif no_and_languages_selected?
+            wizard.errors.add(:base, :no_and_languages_selected)
+          end
+        end
+      end
+
     private
 
       def ske_flow_params

--- a/app/controllers/provider_interface/offer/ske_requirements_controller.rb
+++ b/app/controllers/provider_interface/offer/ske_requirements_controller.rb
@@ -49,7 +49,7 @@ module ProviderInterface
             [
               SkeCondition.new(
                 graduation_cutoff_date:,
-                subject: @application_choice.current_course.subjects.first.name,
+                subject: @wizard.subject_name,
                 subject_type: 'standard',
               ),
             ]

--- a/app/controllers/provider_interface/offers_controller.rb
+++ b/app/controllers/provider_interface/offers_controller.rb
@@ -128,7 +128,7 @@ module ProviderInterface
         application_choice: @application_choice,
         standard_conditions: @wizard.standard_conditions,
         further_condition_attrs: @wizard.further_condition_attrs,
-        structured_conditions: @wizard.structured_conditions,
+        structured_conditions: @wizard.structured_conditions || @application_choice.offer.ske_conditions,
       )
     end
 

--- a/app/controllers/provider_interface/ske_controller.rb
+++ b/app/controllers/provider_interface/ske_controller.rb
@@ -7,6 +7,11 @@ module ProviderInterface
       @wizard.save_state!
     end
 
+    def edit
+      @wizard = OfferWizard.new(offer_store, decision: :change_offer, current_step: ske_flow_step)
+      @wizard.save_state!
+    end
+
     def create
       @wizard = OfferWizard.new(offer_store, decision: :make_offer, current_step: ske_flow_step)
 
@@ -17,6 +22,22 @@ module ProviderInterface
         @wizard.save_state!
 
         redirect_to [:new, :provider_interface, @application_choice, :offer, @wizard.next_step]
+      else
+        track_validation_error(@wizard)
+        render 'new'
+      end
+    end
+
+    def update
+      @wizard = OfferWizard.new(offer_store, decision: :change_offer, current_step: ske_flow_step)
+
+      yield @wizard if block_given?
+      @wizard.assign_attributes(ske_flow_params)
+
+      if @wizard.errors.empty? && @wizard.valid_for_current_step?
+        @wizard.save_state!
+
+        redirect_to [:edit, :provider_interface, @application_choice, :offer, @wizard.next_step]
       else
         track_validation_error(@wizard)
         render 'new'

--- a/app/controllers/provider_interface/ske_controller.rb
+++ b/app/controllers/provider_interface/ske_controller.rb
@@ -40,7 +40,7 @@ module ProviderInterface
         redirect_to [:edit, :provider_interface, @application_choice, :offer, @wizard.next_step]
       else
         track_validation_error(@wizard)
-        render 'new'
+        render 'edit'
       end
     end
 

--- a/app/controllers/support_interface/application_forms/courses_controller.rb
+++ b/app/controllers/support_interface/application_forms/courses_controller.rb
@@ -53,7 +53,7 @@ module SupportInterface
         @change_course_choice = ChangeCourseChoiceForm.new(change_course_choice_params)
 
         begin
-          if @change_course_choice.save(params[:application_choice_id])
+          if @change_course_choice.save(application_choice_id)
             flash[:success] = 'Course successfully changed'
             redirect_to support_interface_application_form_path(application_form_id)
           else
@@ -93,6 +93,10 @@ module SupportInterface
 
       def application_form_id
         params[:application_form_id]
+      end
+
+      def application_choice_id
+        params[:application_choice_id]
       end
 
       def course_code

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -3,7 +3,7 @@ module ProviderInterface
     include Wizard
     include Wizard::PathHistory
 
-    SKE_LENGTH = 8.step(by: 4).take(6).freeze
+    SKE_LENGTHS = 8.step(by: 4).take(6).freeze
 
     MAX_SKE_LANGUAGES = 2
     MAX_SKE_LENGTH = 36

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -158,6 +158,17 @@ module ProviderInterface
         available_study_modes.length > 1 || available_course_options.length > 1
     end
 
+    def outdated_degree(application_choice, subject)
+      graduation_date = application_choice.current_course.start_date - 5.years
+      subject ||= application_choice.current_course.subjects.first&.name
+
+      I18n.t(
+        'provider_interface.offer.ske_reasons.form.outdated_degree',
+        degree_subject: subject,
+        graduation_date: graduation_date.to_fs(:month_and_year),
+      )
+    end
+
     def structured_conditions
       return [] unless FeatureFlag.active?(:provider_ske)
 

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -164,9 +164,7 @@ module ProviderInterface
       ske_conditions
     end
 
-    def subject_name
-      subject.name
-    end
+    delegate :name, to: :subject, prefix: true
 
   private
 

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -82,6 +82,11 @@ module ProviderInterface
     end
 
     def ske_conditions=(conditions)
+      if conditions.nil?
+        @ske_conditions = nil
+        return
+      end
+
       @ske_conditions = if conditions.first.is_a?(SkeCondition)
                           conditions
                         else
@@ -164,9 +169,9 @@ module ProviderInterface
       subject ||= application_choice.current_course.subjects.first&.name
 
       I18n.t(
-        'provider_interface.offer.ske_reasons.form.outdated_degree',
+        'provider_interface.offer.ske_reasons.outdated_degree',
         degree_subject: subject,
-        graduation_date: graduation_date.to_fs(:month_and_year),
+        graduation_cutoff_date: graduation_date.to_fs(:month_and_year),
       )
     end
 
@@ -210,7 +215,7 @@ module ProviderInterface
     private_class_method :further_condition_attrs_from
 
     def self.ske_conditions_from(offer)
-      offer.ske_conditions.to_a
+      offer&.ske_conditions&.to_a
     end
 
     private_class_method :ske_conditions_from
@@ -344,7 +349,6 @@ module ProviderInterface
         validate_ske_conditions(:subject)
         validate_language_count if language_course?
       end
-
 
       validate_ske_conditions(:reason) if at_or_past(:ske_reason)
 

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -304,7 +304,7 @@ module ProviderInterface
       case decision.to_sym
       when :change_offer
         if ske_required?
-          [INITIAL_STEP] + CHANGE_OFFER_STEPS + SKE_STEPS + FINAL_STEPS
+          [INITIAL_STEP, CHANGE_OFFER_STEPS, SKE_STEPS, FINAL_STEPS].flatten
         else
           [INITIAL_STEP] + CHANGE_OFFER_STEPS + FINAL_STEPS
         end

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -59,7 +59,7 @@ module ProviderInterface
     end
 
     def course_option
-      CourseOption.find(course_option_id)
+      CourseOption.find_by(id: course_option_id)
     end
 
     def ske_conditions_attributes=(attributes)
@@ -164,10 +164,14 @@ module ProviderInterface
       ske_conditions
     end
 
+    def subject_name
+      subject.name
+    end
+
   private
 
     def subject
-      course_option.course.subjects.first
+      course_option&.course&.subjects&.first || course.subjects.first
     end
 
     def subject_mapping
@@ -283,7 +287,11 @@ module ProviderInterface
     def steps
       case decision.to_sym
       when :change_offer
-        [INITIAL_STEP] + CHANGE_OFFER_STEPS + FINAL_STEPS
+        if ske_required?
+          [INITIAL_STEP] + CHANGE_OFFER_STEPS + SKE_STEPS + FINAL_STEPS
+        else
+          [INITIAL_STEP] + CHANGE_OFFER_STEPS + FINAL_STEPS
+        end
       when :make_offer
         if ske_required?
           [INITIAL_STEP] + SKE_STEPS + FINAL_STEPS

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -45,6 +45,7 @@ module ProviderInterface
         decision: :default,
         standard_conditions: standard_conditions_from(application_choice.offer),
         further_condition_attrs: further_condition_attrs_from(application_choice.offer),
+        ske_conditions: ske_conditions_from(application_choice.offer),
       }.merge(options)
 
       new(state_store, attrs)
@@ -208,6 +209,12 @@ module ProviderInterface
 
     private_class_method :further_condition_attrs_from
 
+    def self.ske_conditions_from(offer)
+      offer.ske_conditions.to_a
+    end
+
+    private_class_method :ske_conditions_from
+
     def course_option_details
       OfferedCourseOptionDetailsCheck.new(provider_id:,
                                           course_id:,
@@ -337,6 +344,7 @@ module ProviderInterface
         validate_ske_conditions(:subject)
         validate_language_count if language_course?
       end
+
 
       validate_ske_conditions(:reason) if at_or_past(:ske_reason)
 

--- a/app/forms/support_interface/application_forms/change_course_choice_form.rb
+++ b/app/forms/support_interface/application_forms/change_course_choice_form.rb
@@ -55,7 +55,7 @@ module SupportInterface
       end
 
       def remove_ske_conditions!
-        application_choice_with_offer.ske_conditions.destroy_all
+        RemoveSkeConditionsFromOffer.new(offer: application_choice_with_offer).call
       end
     end
   end

--- a/app/forms/support_interface/application_forms/change_course_choice_form.rb
+++ b/app/forms/support_interface/application_forms/change_course_choice_form.rb
@@ -15,8 +15,8 @@ module SupportInterface
 
         return false unless valid?
 
-        if ske_course?
-          remove_ske_condition
+        if offer_has_ske_conditions?
+          remove_ske_conditions!
         end
 
         SupportInterface::ChangeApplicationChoiceCourseOption.new(
@@ -50,11 +50,11 @@ module SupportInterface
         ApplicationChoice.find(application_choice).offer
       end
 
-      def ske_course?
+      def offer_has_ske_conditions?
         application_choice_with_offer&.ske_conditions.present?
       end
 
-      def remove_ske_condition
+      def remove_ske_conditions!
         application_choice_with_offer.ske_conditions.destroy_all
       end
     end

--- a/app/forms/support_interface/application_forms/change_course_choice_form.rb
+++ b/app/forms/support_interface/application_forms/change_course_choice_form.rb
@@ -3,16 +3,21 @@ module SupportInterface
     class ChangeCourseChoiceForm
       include ActiveModel::Model
 
-      attr_accessor :application_choice_id, :provider_code, :course_code, :study_mode, :site_code, :accept_guidance, :audit_comment_ticket, :confirm_course_change, :checkbox_rendered
+      attr_accessor :application_choice_id, :application_choice, :provider_code, :course_code, :study_mode, :site_code, :accept_guidance, :audit_comment_ticket, :confirm_course_change, :checkbox_rendered
 
       validates :provider_code, :course_code, :study_mode, :site_code, :accept_guidance, :audit_comment_ticket, presence: true
       validates :confirm_course_change, presence: true, if: :checkbox_rendered?
       validates_with ZendeskUrlValidator
 
       def save(application_choice)
+        @application_choice = application_choice
         self.accept_guidance = ActiveModel::Type::Boolean.new.cast(accept_guidance)
 
         return false unless valid?
+
+        if ske_course?
+          remove_ske_condition
+        end
 
         SupportInterface::ChangeApplicationChoiceCourseOption.new(
           application_choice_id: application_choice,
@@ -39,6 +44,18 @@ module SupportInterface
 
       def checkbox_rendered?
         checkbox_rendered == 'true'
+      end
+
+      def application_choice_with_offer
+        ApplicationChoice.find(application_choice).offer
+      end
+
+      def ske_course?
+        application_choice_with_offer&.ske_conditions.present?
+      end
+
+      def remove_ske_condition
+        application_choice_with_offer.ske_conditions.destroy_all
       end
     end
   end

--- a/app/services/remove_ske_conditions_from_offer.rb
+++ b/app/services/remove_ske_conditions_from_offer.rb
@@ -1,0 +1,11 @@
+class RemoveSkeConditionsFromOffer
+  attr_reader :offer
+
+  def initialize(offer:)
+    @offer = offer
+  end
+
+  def call
+    offer.ske_conditions.destroy_all
+  end
+end

--- a/app/services/save_offer_conditions_from_params.rb
+++ b/app/services/save_offer_conditions_from_params.rb
@@ -29,6 +29,9 @@ private
   def serialize_structured_conditions
     return if structured_conditions.blank?
 
+    # Delete all current ske conditions if there is a change of course
+    @offer.ske_conditions.destroy_all if @offer.ske_conditions.any? && structured_conditions.any? { |structured_condition| structured_condition.type == 'SkeCondition' }
+
     structured_conditions.each do |structured_condition|
       structured_condition.offer = @offer
       structured_condition.save!

--- a/app/services/save_offer_conditions_from_params.rb
+++ b/app/services/save_offer_conditions_from_params.rb
@@ -30,12 +30,16 @@ private
     return if structured_conditions.blank?
 
     # Delete all current ske conditions if there is a change of course
-    @offer.ske_conditions.destroy_all if @offer.ske_conditions.any? && structured_conditions.any? { |structured_condition| structured_condition.type == 'SkeCondition' }
+    @offer.ske_conditions.destroy_all if ske_conditions?
 
     structured_conditions.each do |structured_condition|
       structured_condition.offer = @offer
       structured_condition.save!
     end
+  end
+
+  def ske_conditions?
+    @offer.ske_conditions.any?
   end
 
   def serialize_standard_conditions

--- a/app/services/save_offer_conditions_from_params.rb
+++ b/app/services/save_offer_conditions_from_params.rb
@@ -27,19 +27,15 @@ class SaveOfferConditionsFromParams
 private
 
   def serialize_structured_conditions
-    return if structured_conditions.blank?
-
     # Delete all current ske conditions if there is a change of course
-    @offer.ske_conditions.destroy_all if ske_conditions?
+    @offer.ske_conditions.destroy_all if @offer.ske_conditions.any?
+
+    return if structured_conditions.blank?
 
     structured_conditions.each do |structured_condition|
       structured_condition.offer = @offer
       structured_condition.save!
     end
-  end
-
-  def ske_conditions?
-    @offer.ske_conditions.any?
   end
 
   def serialize_standard_conditions

--- a/app/views/provider_interface/offer/checks/edit.html.erb
+++ b/app/views/provider_interface/offer/checks/edit.html.erb
@@ -16,7 +16,8 @@
                                                                        course: @wizard.course_option.course,
                                                                        available_providers: @providers,
                                                                        available_courses: @courses,
-                                                                       available_course_options: @course_options) %>
+                                                                       available_course_options: @course_options,
+                                                                       ske_conditions: @wizard.ske_conditions) %>
 
       <%= f.govuk_submit t('.submit') %>
 

--- a/app/views/provider_interface/offer/checks/new.html.erb
+++ b/app/views/provider_interface/offer/checks/new.html.erb
@@ -18,7 +18,7 @@
                                                               available_courses: @courses,
                                                               available_course_options: @course_options,
                                                               show_conditions_link: true,
-                                                              ske_conditions: @wizard.ske_conditions,) %>
+                                                              ske_conditions: @wizard.ske_conditions) %>
 
       <% if @interview_cancellation_presenter.render? %>
         <p class="govuk-body"><%= @interview_cancellation_presenter.text %></p>

--- a/app/views/provider_interface/offer/checks/new.html.erb
+++ b/app/views/provider_interface/offer/checks/new.html.erb
@@ -18,7 +18,7 @@
                                                               available_courses: @courses,
                                                               available_course_options: @course_options,
                                                               show_conditions_link: true,
-                                                              ske_conditions: @wizard.ske_conditions) %>
+                                                              ske_conditions: @wizard.ske_conditions,) %>
 
       <% if @interview_cancellation_presenter.render? %>
         <p class="govuk-body"><%= @interview_cancellation_presenter.text %></p>

--- a/app/views/provider_interface/offer/ske_lengths/_form.html.erb
+++ b/app/views/provider_interface/offer/ske_lengths/_form.html.erb
@@ -1,0 +1,17 @@
+<%= form_with model: @wizard, url: provider_interface_application_choice_offer_ske_length_path(@application_choice), method: method do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <span class="govuk-caption-l"><%= t('caption.make_offer', name: @application_choice.application_form.full_name) %></span>
+  <% if language_ske? %>
+    <% if @wizard.ske_conditions.many? %>
+      <h1 class="govuk-heading-l"><%= t('.ske_language_length_many_title') %></h1>
+      <p class="govuk-hint">One language course must be 8 weeks. The other course can be between 8 and 28 weeks.</p>
+    <% end %>
+
+    <%= render ProviderInterface::SkeLengthComponent.new(form: f, offer_wizard: f.object, radio_options: { legend: { text: t('.title'), size: 'l' } }) %>
+  <% else %>
+    <%= render ProviderInterface::SkeLengthComponent.new(form: f, offer_wizard: f.object, radio_options: { legend: { text: t('.title'), size: 'l' } }) %>
+  <% end %>
+
+  <%= f.govuk_submit t('continue') %>
+<% end %>

--- a/app/views/provider_interface/offer/ske_lengths/_form.html.erb
+++ b/app/views/provider_interface/offer/ske_lengths/_form.html.erb
@@ -5,7 +5,11 @@
   <% if language_ske? %>
     <% if @wizard.ske_conditions.many? %>
       <h1 class="govuk-heading-l"><%= t('.ske_language_length_many_title') %></h1>
-      <p class="govuk-hint">One language course must be 8 weeks. The other course can be between 8 and 28 weeks.</p>
+      <p class="govuk-hint">
+        One language course must be <%= ProviderInterface::OfferWizard::SKE_LENGTHS.min %> weeks.
+        The other course can be between <%= ProviderInterface::OfferWizard::SKE_LENGTHS.min %>
+        and <%= ProviderInterface::OfferWizard::SKE_LENGTHS.max %> weeks.
+      </p>
     <% end %>
 
     <%= render ProviderInterface::SkeLengthComponent.new(form: f, offer_wizard: f.object, radio_options: { legend: { text: t('.title'), size: 'l' } }) %>

--- a/app/views/provider_interface/offer/ske_lengths/edit.html.erb
+++ b/app/views/provider_interface/offer/ske_lengths/edit.html.erb
@@ -1,0 +1,24 @@
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, :edit, back: true)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @wizard, url: provider_interface_application_choice_offer_ske_length_path(@application_choice), method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <span class="govuk-caption-l"><%= t('caption.make_offer', name: @application_choice.application_form.full_name) %></span>
+      <% if language_ske? %>
+        <% if @wizard.ske_conditions.many? %>
+          <h1 class="govuk-heading-l"><%= t('.ske_language_length_many_title') %></h1>
+          <p class="govuk-hint">One language course must be 8 weeks. The other course can be between 8 and 28 weeks.</p>
+        <% end %>
+
+        <%= render ProviderInterface::SkeLengthComponent.new(form: f, offer_wizard: f.object, radio_options: { legend: { text: t('.title'), size: 'l' } }) %>
+      <% else %>
+        <%= render ProviderInterface::SkeLengthComponent.new(form: f, offer_wizard: f.object, radio_options: { legend: { text: t('.title'), size: 'l' } }) %>
+      <% end %>
+
+      <%= f.govuk_submit t('continue') %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/provider_interface/offer/ske_lengths/edit.html.erb
+++ b/app/views/provider_interface/offer/ske_lengths/edit.html.erb
@@ -1,24 +1,8 @@
-<% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix(t('provider_interface.offer.ske_lengths.form.title'), @wizard.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, :edit, back: true)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @wizard, url: provider_interface_application_choice_offer_ske_length_path(@application_choice), method: :patch do |f| %>
-      <%= f.govuk_error_summary %>
-
-      <span class="govuk-caption-l"><%= t('caption.make_offer', name: @application_choice.application_form.full_name) %></span>
-      <% if language_ske? %>
-        <% if @wizard.ske_conditions.many? %>
-          <h1 class="govuk-heading-l"><%= t('.ske_language_length_many_title') %></h1>
-          <p class="govuk-hint">One language course must be 8 weeks. The other course can be between 8 and 28 weeks.</p>
-        <% end %>
-
-        <%= render ProviderInterface::SkeLengthComponent.new(form: f, offer_wizard: f.object, radio_options: { legend: { text: t('.title'), size: 'l' } }) %>
-      <% else %>
-        <%= render ProviderInterface::SkeLengthComponent.new(form: f, offer_wizard: f.object, radio_options: { legend: { text: t('.title'), size: 'l' } }) %>
-      <% end %>
-
-      <%= f.govuk_submit t('continue') %>
-    <% end %>
+    <%= render 'form', method: :patch %>
   </div>
 </div>

--- a/app/views/provider_interface/offer/ske_lengths/new.html.erb
+++ b/app/views/provider_interface/offer/ske_lengths/new.html.erb
@@ -1,24 +1,8 @@
-<% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix(t('provider_interface.offer.ske_lengths.form.title'), @wizard.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, :new, back: true)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @wizard, url: provider_interface_application_choice_offer_ske_length_path(@application_choice), method: :post do |f| %>
-      <%= f.govuk_error_summary %>
-
-      <span class="govuk-caption-l"><%= t('caption.make_offer', name: @application_choice.application_form.full_name) %></span>
-      <% if language_ske? %>
-        <% if @wizard.ske_conditions.many? %>
-          <h1 class="govuk-heading-l"><%= t('.ske_language_length_many_title') %></h1>
-          <p class="govuk-hint">One language course must be 8 weeks. The other course can be between 8 and 28 weeks.</p>
-        <% end %>
-
-        <%= render ProviderInterface::SkeLengthComponent.new(form: f, offer_wizard: f.object, radio_options: { legend: { text: t('.title'), size: 'l' } }) %>
-      <% else %>
-        <%= render ProviderInterface::SkeLengthComponent.new(form: f, offer_wizard: f.object, radio_options: { legend: { text: t('.title'), size: 'l' } }) %>
-      <% end %>
-
-      <%= f.govuk_submit t('continue') %>
-    <% end %>
+    <%= render 'form', method: :post %>
   </div>
 </div>

--- a/app/views/provider_interface/offer/ske_reasons/_form.html.erb
+++ b/app/views/provider_interface/offer/ske_reasons/_form.html.erb
@@ -1,0 +1,16 @@
+<%= form_with model: @wizard, url: provider_interface_application_choice_offer_ske_reason_path(@application_choice), method: method do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <span class="govuk-caption-l"><%= t('caption.make_offer', name: @application_choice.application_form.full_name) %></span>
+  <% if language_ske? %>
+    <% if @wizard.ske_conditions.many? %>
+      <h1 class="govuk-heading-l"><%= t('.title_many') %></h1>
+      <p class="govuk-hint"><%= t('.hint_many') %></p>
+    <% end %>
+
+    <%= render ProviderInterface::SkeReasonComponent.new(application_choice: @application_choice, offer_wizard: f.object, form: f, radio_options: @wizard.ske_conditions.one? ? { legend: { text: t('.title'), size: 'l' }, hint: { text: t('.hint') } } : {}) %>
+  <% else %>
+    <%= render ProviderInterface::SkeReasonComponent.new(application_choice: @application_choice, offer_wizard: f.object, form: f, radio_options: { legend: { text: t('.title'), size: 'l' }, hint: { text: t('.hint') } }) %>
+  <% end %>
+  <%= f.govuk_submit t('continue') %>
+<% end %>

--- a/app/views/provider_interface/offer/ske_reasons/edit.html.erb
+++ b/app/views/provider_interface/offer/ske_reasons/edit.html.erb
@@ -1,23 +1,8 @@
-<% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix(t('provider_interface.offer.ske_reasons.form.title'), @wizard.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, :edit, back: true)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @wizard, url: provider_interface_application_choice_offer_ske_reason_path(@application_choice), method: :patch do |f| %>
-      <%= f.govuk_error_summary %>
-
-      <span class="govuk-caption-l"><%= t('caption.make_offer', name: @application_choice.application_form.full_name) %></span>
-      <% if language_ske? %>
-        <% if @wizard.ske_conditions.many? %>
-          <h1 class="govuk-heading-l"><%= t('.title_many') %></h1>
-          <p class="govuk-hint"><%= t('.hint_many') %></p>
-        <% end %>
-
-        <%= render ProviderInterface::SkeReasonComponent.new(application_choice: @application_choice, offer_wizard: f.object, form: f, radio_options: @wizard.ske_conditions.one? ? { legend: { text: t('.title'), size: 'l' }, hint: { text: t('.hint') } } : {}) %>
-      <% else %>
-        <%= render ProviderInterface::SkeReasonComponent.new(application_choice: @application_choice, offer_wizard: f.object, form: f, radio_options: { legend: { text: t('.title'), size: 'l' }, hint: { text: t('.hint') } }) %>
-      <% end %>
-      <%= f.govuk_submit t('continue') %>
-    <% end %>
+    <%= render 'form', method: :patch %>
   </div>
 </div>

--- a/app/views/provider_interface/offer/ske_reasons/edit.html.erb
+++ b/app/views/provider_interface/offer/ske_reasons/edit.html.erb
@@ -1,0 +1,23 @@
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, :edit, back: true)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @wizard, url: provider_interface_application_choice_offer_ske_reason_path(@application_choice), method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <span class="govuk-caption-l"><%= t('caption.make_offer', name: @application_choice.application_form.full_name) %></span>
+      <% if language_ske? %>
+        <% if @wizard.ske_conditions.many? %>
+          <h1 class="govuk-heading-l"><%= t('.title_many') %></h1>
+          <p class="govuk-hint"><%= t('.hint_many') %></p>
+        <% end %>
+
+        <%= render ProviderInterface::SkeReasonComponent.new(application_choice: @application_choice, offer_wizard: f.object, form: f, radio_options: @wizard.ske_conditions.one? ? { legend: { text: t('.title'), size: 'l' }, hint: { text: t('.hint') } } : {}) %>
+      <% else %>
+        <%= render ProviderInterface::SkeReasonComponent.new(application_choice: @application_choice, offer_wizard: f.object, form: f, radio_options: { legend: { text: t('.title'), size: 'l' }, hint: { text: t('.hint') } }) %>
+      <% end %>
+      <%= f.govuk_submit t('continue') %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/provider_interface/offer/ske_reasons/new.html.erb
+++ b/app/views/provider_interface/offer/ske_reasons/new.html.erb
@@ -1,23 +1,8 @@
-<% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix(t('provider_interface.offer.ske_reasons.form.title'), @wizard.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, :new, back: true)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @wizard, url: provider_interface_application_choice_offer_ske_reason_path(@application_choice), method: :post do |f| %>
-      <%= f.govuk_error_summary %>
-
-      <span class="govuk-caption-l"><%= t('caption.make_offer', name: @application_choice.application_form.full_name) %></span>
-      <% if language_ske? %>
-        <% if @wizard.ske_conditions.many? %>
-          <h1 class="govuk-heading-l"><%= t('.title_many') %></h1>
-          <p class="govuk-hint"><%= t('.hint_many') %></p>
-        <% end %>
-
-        <%= render ProviderInterface::SkeReasonComponent.new(application_choice: @application_choice, offer_wizard: f.object, form: f, radio_options: @wizard.ske_conditions.one? ? { legend: { text: t('.title'), size: 'l' }, hint: { text: t('.hint') } } : {}) %>
-      <% else %>
-        <%= render ProviderInterface::SkeReasonComponent.new(application_choice: @application_choice, offer_wizard: f.object, form: f, radio_options: { legend: { text: t('.title'), size: 'l' }, hint: { text: t('.hint') } }) %>
-      <% end %>
-      <%= f.govuk_submit t('continue') %>
-    <% end %>
+    <%= render 'form', method: :post %>
   </div>
 </div>

--- a/app/views/provider_interface/offer/ske_requirements/_form.html.erb
+++ b/app/views/provider_interface/offer/ske_requirements/_form.html.erb
@@ -1,0 +1,36 @@
+<%= form_with model: @wizard, url: provider_interface_application_choice_offer_ske_requirements_path(@application_choice), method: method do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <span class="govuk-caption-l"><%= t('caption.make_offer', name: @application_choice.application_form.full_name) %></span>
+  <h1 class="govuk-heading-l"><%= t('.title') %></h1>
+
+  <% if language_ske? || physics_ske? %>
+    <p class="govuk-body">
+      The Department for Education (DfE) will pay candidates to take up to 2 language SKE courses if they need one,
+      so long as they have a 2:2 degree or higher, or are expected to get this when they graduate.
+    </p>
+  <% else %>
+    <p class="govuk-body">The Department for Education (DfE) will pay candidates to take a SKE course if they need one, so long as they:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>have a 2:2 degree or higher, or are expected to get this when they graduate</li>
+      <li>are eligible for student finance (home fee status)</li>
+    </ul>
+  <% end %>
+
+  <% if language_ske? %>
+    <%= f.govuk_check_boxes_fieldset :ske_languages, legend: { text: "Do you require #{@application_choice.application_form.full_name} to take a SKE course in any of these languages?", size: 's' }, hint: { text: 'You can select a maximum of 2', size: 's' } do %>
+      <% SkeCondition::VALID_LANGUAGES.each_with_index do |language, index| %>
+        <%= f.govuk_check_box :ske_languages, language, label: { text: language.capitalize }, link_errors: index.zero? %>
+      <% end %>
+      <%= f.govuk_radio_divider %>
+      <%= f.govuk_check_box :ske_languages, 'no', label: { text: 'No, a SKE course is not required' }, exclusive: true %>
+    <% end %>
+  <% else %>
+    <%= f.govuk_radio_buttons_fieldset :ske_required, legend: { text: "Do you require #{@application_choice.application_form.full_name} to take a SKE course in #{@wizard.subject_name} that will be funded by the DfE?", size: 'm' } do %>
+      <%= f.govuk_radio_button :ske_required, true, label: { text: 'Yes' }, link_errors: true %>
+      <%= f.govuk_radio_button :ske_required, false, label: { text: 'No' } %>
+    <% end %>
+  <% end %>
+
+  <%= f.govuk_submit t('continue') %>
+<% end %>

--- a/app/views/provider_interface/offer/ske_requirements/edit.html.erb
+++ b/app/views/provider_interface/offer/ske_requirements/edit.html.erb
@@ -1,0 +1,43 @@
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, :edit, back: true)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @wizard, url: provider_interface_application_choice_offer_ske_requirements_path(@application_choice), method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <span class="govuk-caption-l"><%= t('caption.make_offer', name: @application_choice.application_form.full_name) %></span>
+      <h1 class="govuk-heading-l"><%= t('.title') %></h1>
+
+      <% if language_ske? || physics_ske? %>
+        <p class="govuk-body">
+          The Department for Education (DfE) will pay candidates to take up to 2 language SKE courses if they need one,
+          so long as they have a 2:2 degree or higher, or are expected to get this when they graduate.
+        </p>
+      <% else %>
+        <p class="govuk-body">The Department for Education (DfE) will pay candidates to take a SKE course if they need one, so long as they:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>have a 2:2 degree or higher, or are expected to get this when they graduate</li>
+          <li>are eligible for student finance (home fee status)</li>
+        </ul>
+      <% end %>
+
+      <% if language_ske? %>
+        <%= f.govuk_check_boxes_fieldset :ske_languages, legend: { text: "Do you require #{@application_choice.application_form.full_name} to take a SKE course in any of these languages?", size: 's' }, hint: { text: 'You can select a maximum of 2', size: 's' } do %>
+          <% SkeCondition::VALID_LANGUAGES.each_with_index do |language, index| %>
+            <%= f.govuk_check_box :ske_languages, language, label: { text: language.capitalize }, link_errors: index.zero? %>
+          <% end %>
+          <%= f.govuk_radio_divider %>
+          <%= f.govuk_check_box :ske_languages, 'no', label: { text: 'No, a SKE course is not required' }, exclusive: true %>
+        <% end %>
+      <% else %>
+        <%= f.govuk_radio_buttons_fieldset :ske_required, legend: { text: "Do you require #{@application_choice.application_form.full_name} to take a SKE course in #{@wizard.subject_name} that will be funded by the DfE?", size: 'm' } do %>
+          <%= f.govuk_radio_button :ske_required, true, label: { text: 'Yes' }, link_errors: true %>
+          <%= f.govuk_radio_button :ske_required, false, label: { text: 'No' } %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_submit t('continue') %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/provider_interface/offer/ske_requirements/edit.html.erb
+++ b/app/views/provider_interface/offer/ske_requirements/edit.html.erb
@@ -1,43 +1,8 @@
-<% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix(t('provider_interface.offer.ske_requirements.form.title'), @wizard.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, :edit, back: true)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @wizard, url: provider_interface_application_choice_offer_ske_requirements_path(@application_choice), method: :patch do |f| %>
-      <%= f.govuk_error_summary %>
-
-      <span class="govuk-caption-l"><%= t('caption.make_offer', name: @application_choice.application_form.full_name) %></span>
-      <h1 class="govuk-heading-l"><%= t('.title') %></h1>
-
-      <% if language_ske? || physics_ske? %>
-        <p class="govuk-body">
-          The Department for Education (DfE) will pay candidates to take up to 2 language SKE courses if they need one,
-          so long as they have a 2:2 degree or higher, or are expected to get this when they graduate.
-        </p>
-      <% else %>
-        <p class="govuk-body">The Department for Education (DfE) will pay candidates to take a SKE course if they need one, so long as they:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>have a 2:2 degree or higher, or are expected to get this when they graduate</li>
-          <li>are eligible for student finance (home fee status)</li>
-        </ul>
-      <% end %>
-
-      <% if language_ske? %>
-        <%= f.govuk_check_boxes_fieldset :ske_languages, legend: { text: "Do you require #{@application_choice.application_form.full_name} to take a SKE course in any of these languages?", size: 's' }, hint: { text: 'You can select a maximum of 2', size: 's' } do %>
-          <% SkeCondition::VALID_LANGUAGES.each_with_index do |language, index| %>
-            <%= f.govuk_check_box :ske_languages, language, label: { text: language.capitalize }, link_errors: index.zero? %>
-          <% end %>
-          <%= f.govuk_radio_divider %>
-          <%= f.govuk_check_box :ske_languages, 'no', label: { text: 'No, a SKE course is not required' }, exclusive: true %>
-        <% end %>
-      <% else %>
-        <%= f.govuk_radio_buttons_fieldset :ske_required, legend: { text: "Do you require #{@application_choice.application_form.full_name} to take a SKE course in #{@wizard.subject_name} that will be funded by the DfE?", size: 'm' } do %>
-          <%= f.govuk_radio_button :ske_required, true, label: { text: 'Yes' }, link_errors: true %>
-          <%= f.govuk_radio_button :ske_required, false, label: { text: 'No' } %>
-        <% end %>
-      <% end %>
-
-      <%= f.govuk_submit t('continue') %>
-    <% end %>
+    <%= render 'form', method: :patch %>
   </div>
 </div>

--- a/app/views/provider_interface/offer/ske_requirements/new.html.erb
+++ b/app/views/provider_interface/offer/ske_requirements/new.html.erb
@@ -1,43 +1,8 @@
-<% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix(t('provider_interface.offer.ske_requirements.form.title'), @wizard.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(offer_path_for(@application_choice, @wizard.previous_step, :new, back: true)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @wizard, url: provider_interface_application_choice_offer_ske_requirements_path(@application_choice), method: :post do |f| %>
-      <%= f.govuk_error_summary %>
-
-      <span class="govuk-caption-l"><%= t('caption.make_offer', name: @application_choice.application_form.full_name) %></span>
-      <h1 class="govuk-heading-l"><%= t('.title') %></h1>
-
-      <% if language_ske? || physics_ske? %>
-        <p class="govuk-body">
-          The Department for Education (DfE) will pay candidates to take up to 2 language SKE courses if they need one,
-          so long as they have a 2:2 degree or higher, or are expected to get this when they graduate.
-        </p>
-      <% else %>
-        <p class="govuk-body">The Department for Education (DfE) will pay candidates to take a SKE course if they need one, so long as they:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>have a 2:2 degree or higher, or are expected to get this when they graduate</li>
-          <li>are eligible for student finance (home fee status)</li>
-        </ul>
-      <% end %>
-
-      <% if language_ske? %>
-        <%= f.govuk_check_boxes_fieldset :ske_languages, legend: { text: "Do you require #{@application_choice.application_form.full_name} to take a SKE course in any of these languages?", size: 's' }, hint: { text: 'You can select a maximum of 2', size: 's' } do %>
-          <% SkeCondition::VALID_LANGUAGES.each_with_index do |language, index| %>
-            <%= f.govuk_check_box :ske_languages, language, label: { text: language.capitalize }, link_errors: index.zero? %>
-          <% end %>
-          <%= f.govuk_radio_divider %>
-          <%= f.govuk_check_box :ske_languages, 'no', label: { text: 'No, a SKE course is not required' }, exclusive: true %>
-        <% end %>
-      <% else %>
-        <%= f.govuk_radio_buttons_fieldset :ske_required, legend: { text: "Do you require #{@application_choice.application_form.full_name} to take a SKE course in #{@wizard.subject_name} that will be funded by the DfE?", size: 'm' } do %>
-          <%= f.govuk_radio_button :ske_required, true, label: { text: 'Yes' }, link_errors: true %>
-          <%= f.govuk_radio_button :ske_required, false, label: { text: 'No' } %>
-        <% end %>
-      <% end %>
-
-      <%= f.govuk_submit t('continue') %>
-    <% end %>
+    <%= render 'form', method: :post %>
   </div>
 </div>

--- a/app/views/provider_interface/offer/ske_requirements/new.html.erb
+++ b/app/views/provider_interface/offer/ske_requirements/new.html.erb
@@ -31,7 +31,7 @@
           <%= f.govuk_check_box :ske_languages, 'no', label: { text: 'No, a SKE course is not required' }, exclusive: true %>
         <% end %>
       <% else %>
-        <%= f.govuk_radio_buttons_fieldset :ske_required, legend: { text: "Do you require #{@application_choice.application_form.full_name} to take a SKE course in #{@application_choice.current_course.subjects.first&.name} that will be funded by the DfE?", size: 'm' } do %>
+        <%= f.govuk_radio_buttons_fieldset :ske_required, legend: { text: "Do you require #{@application_choice.application_form.full_name} to take a SKE course in #{@wizard.subject_name} that will be funded by the DfE?", size: 'm' } do %>
           <%= f.govuk_radio_button :ske_required, true, label: { text: 'Yes' }, link_errors: true %>
           <%= f.govuk_radio_button :ske_required, false, label: { text: 'No' } %>
         <% end %>

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -11,6 +11,8 @@ en:
       ske_requirements:
         new:
           title: Subject knowledge enhancement (SKE) courses
+        edit:
+          title: Subject knowledge enhancement (SKE) courses
       ske_reasons:
         different_degree: Their degree subject was not %{degree_subject}
         outdated_degree: Their degree subject was %{degree_subject}, but they graduated before %{graduation_cutoff_date}
@@ -20,8 +22,20 @@ en:
           hint_many: Your answers will be shown to the candidate.
           title_many: Reasons for needing to take a subject knowledge enhancement course
           title_language: Why do they need to take a course in %{language}?
+        edit:
+          title: Why do they need to take a subject knowledge enhancement (SKE) course?
+          hint: We’ll show your answer to the candidate.
+          hint_many: Your answers will be shown to the candidate.
+          different_degree: Their degree subject was not %{degree_subject}
+          outdated_degree: Their degree subject was %{degree_subject}, but they graduated before %{graduation_date}
+          title_many: Reasons for needing to take a subject knowledge enhancement course
+          title_language: Why do they need to take a course in %{language}?
       ske_lengths:
         new:
+          title: How long must their SKE course be?
+          ske_language_length_many_title: Subject knowledge enhancement (SKE) course requirements
+          title_language: How long must their SKE course in %{language} be?
+        edit:
           title: How long must their SKE course be?
           ske_language_length_many_title: Subject knowledge enhancement (SKE) course requirements
           title_language: How long must their SKE course in %{language} be?

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -9,33 +9,19 @@ en:
         select: Decision
     offer:
       ske_requirements:
-        new:
-          title: Subject knowledge enhancement (SKE) courses
-        edit:
+        form:
           title: Subject knowledge enhancement (SKE) courses
       ske_reasons:
         different_degree: Their degree subject was not %{degree_subject}
         outdated_degree: Their degree subject was %{degree_subject}, but they graduated before %{graduation_cutoff_date}
-        new:
+        form:
           title: Why do they need to take a subject knowledge enhancement (SKE) course?
           hint: We’ll show your answer to the candidate.
           hint_many: Your answers will be shown to the candidate.
-          title_many: Reasons for needing to take a subject knowledge enhancement course
-          title_language: Why do they need to take a course in %{language}?
-        edit:
-          title: Why do they need to take a subject knowledge enhancement (SKE) course?
-          hint: We’ll show your answer to the candidate.
-          hint_many: Your answers will be shown to the candidate.
-          different_degree: Their degree subject was not %{degree_subject}
-          outdated_degree: Their degree subject was %{degree_subject}, but they graduated before %{graduation_date}
           title_many: Reasons for needing to take a subject knowledge enhancement course
           title_language: Why do they need to take a course in %{language}?
       ske_lengths:
-        new:
-          title: How long must their SKE course be?
-          ske_language_length_many_title: Subject knowledge enhancement (SKE) course requirements
-          title_language: How long must their SKE course in %{language} be?
-        edit:
+        form:
           title: How long must their SKE course be?
           ske_language_length_many_title: Subject knowledge enhancement (SKE) course requirements
           title_language: How long must their SKE course in %{language} be?

--- a/config/routes/provider.rb
+++ b/config/routes/provider.rb
@@ -74,9 +74,9 @@ namespace :provider_interface, path: '/provider' do
       resource :locations, only: %i[new create edit update]
       resource :conditions, only: %i[new create edit update]
       resource :check, only: %i[new edit]
-      resource :ske_requirements, only: %i[new create], path: 'ske-requirements'
-      resource :ske_reason, only: %i[new create], path: 'ske-reason'
-      resource :ske_length, only: %i[new create], path: 'ske-length'
+      resource :ske_requirements, only: %i[new create update edit], path: 'ske-requirements'
+      resource :ske_reason, only: %i[new create update edit], path: 'ske-reason'
+      resource :ske_length, only: %i[new create update edit], path: 'ske-length'
     end
 
     namespace :courses, as: :application_choice_course do

--- a/spec/components/provider_interface/ske_conditions_component_spec.rb
+++ b/spec/components/provider_interface/ske_conditions_component_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ProviderInterface::SkeConditionsComponent do
     let(:ske_condition) { build(:ske_condition, length: '8', subject: 'Mathematics', reason: 'different_degree') }
 
     it 'renders the subject from the course' do
-      expect(result.text).to include("Subject#{course.subjects.first.name}")
+      expect(result.text).to include('SubjectMathematics')
       expect(result.text).to include('Length8 weeks')
       expect(result.text).to include('ReasonTheir degree subject was not Mathematics')
     end

--- a/spec/components/provider_interface/ske_conditions_component_spec.rb
+++ b/spec/components/provider_interface/ske_conditions_component_spec.rb
@@ -2,13 +2,15 @@ require 'rails_helper'
 
 RSpec.describe ProviderInterface::SkeConditionsComponent do
   let(:application_choice) { create(:application_choice) }
+  let(:course) { create(:course) }
   let(:editable) { true }
   let(:result) do
     render_inline(
       described_class.new(
         application_choice:,
+        course:,
         ske_condition:,
-        editable: editable,
+        editable:,
       ),
     )
   end
@@ -27,7 +29,7 @@ RSpec.describe ProviderInterface::SkeConditionsComponent do
     let(:ske_condition) { build(:ske_condition, length: '8', subject: 'Mathematics', reason: 'different_degree') }
 
     it 'renders the subject from the course' do
-      expect(result.text).to include('SubjectMathematics')
+      expect(result.text).to include("Subject#{course.subjects.first.name}")
       expect(result.text).to include('Length8 weeks')
       expect(result.text).to include('ReasonTheir degree subject was not Mathematics')
     end

--- a/spec/factories/ske_condition.rb
+++ b/spec/factories/ske_condition.rb
@@ -5,9 +5,14 @@ FactoryBot.define do
     subject { 'Mathematics' }
     subject_type { 'standard' }
     length { '8' }
-    reason { 'different_degree' }
     graduation_cutoff_date { 5.years.ago.iso8601 }
     status { 'unmet' }
+    reason do
+      I18n.t(
+        'provider_interface.offer.ske_reasons.form.different_degree',
+        degree_subject: (language || 'Mathematics').capitalize,
+      )
+    end
 
     trait :language do
       subject { 'French' }

--- a/spec/factories/ske_condition.rb
+++ b/spec/factories/ske_condition.rb
@@ -7,12 +7,7 @@ FactoryBot.define do
     length { '8' }
     graduation_cutoff_date { 5.years.ago.iso8601 }
     status { 'unmet' }
-    reason do
-      I18n.t(
-        'provider_interface.offer.ske_reasons.form.different_degree',
-        degree_subject: (language || 'Mathematics').capitalize,
-      )
-    end
+    reason { 'different_degree' }
 
     trait :language do
       subject { 'French' }

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -487,8 +487,25 @@ RSpec.describe ProviderInterface::OfferWizard do
       context 'when current_step is :locations' do
         let(:current_step) { :locations }
 
-        it 'returns :conditions' do
-          expect(wizard.next_step).to eq(:conditions)
+        before do
+          FeatureFlag.activate(:provider_ske)
+        end
+
+        context 'when ske is not required' do
+          it 'returns :conditions' do
+            expect(wizard.next_step).to eq(:conditions)
+          end
+        end
+
+        context 'when ske is required' do
+          before do
+            wizard.course_option.course.subjects.delete_all
+            wizard.course_option.course.subjects << build(:subject, code: 'C1', name: 'biology')
+          end
+
+          it 'returns :ske_requirements' do
+            expect(wizard.next_step).to eq(:ske_requirements)
+          end
         end
       end
 

--- a/spec/system/provider_interface/change_existing_offer_ske_standard_flow_spec.rb
+++ b/spec/system/provider_interface/change_existing_offer_ske_standard_flow_spec.rb
@@ -196,7 +196,7 @@ RSpec.feature 'Provider changes an existing offer' do
   end
 
   def when_i_add_a_ske_reason
-    choose t('provider_interface.offer.ske_reasons.new.different_degree', degree_subject: @ske_subject.name)
+    choose t('provider_interface.offer.ske_reasons.form.different_degree', degree_subject: @ske_subject.name)
   end
 
   def then_the_ske_length_page_is_loaded

--- a/spec/system/provider_interface/change_existing_offer_ske_standard_flow_spec.rb
+++ b/spec/system/provider_interface/change_existing_offer_ske_standard_flow_spec.rb
@@ -38,6 +38,7 @@ RSpec.feature 'Provider changes an existing offer' do
     and_i_click_on_the_offer_tab
     then_i_see_the_offer_details
 
+    # Change provider and course to a subject that permits SKE conditions
     when_i_choose_to_change_the_provider
     then_i_am_taken_to_the_change_provider_page
 
@@ -80,14 +81,18 @@ RSpec.feature 'Provider changes an existing offer' do
 
     when_i_send_the_offer
     then_i_see_that_the_offer_was_successfully_updated
+    and_the_ske_conditions_should_be_displayed
 
+    # Toggle the standard conditions and save
     when_i_choose_to_change_the_conditions
     and_i_click_continue
-
     then_the_review_page_is_loaded
-    when_i_send_the_offer
+    and_the_ske_conditions_should_be_displayed
 
+    when_i_send_the_offer
     then_i_see_that_the_offer_was_successfully_updated
+    and_i_can_see_the_new_offer_condition
+    and_the_ske_conditions_should_be_displayed
   end
 
   def given_i_am_a_provider_user
@@ -259,6 +264,11 @@ RSpec.feature 'Provider changes an existing offer' do
     click_on 'Send new offer'
   end
 
+  def and_i_can_see_the_new_offer_condition
+    expect(page).not_to have_content('Fitness to train to teach check')
+    expect(page).to have_content('Disclosure and Barring Service (DBS) check')
+  end
+
   def then_i_see_that_the_offer_was_successfully_updated
     within('.govuk-notification-banner--success') do
       expect(page).to have_content('New offer sent')
@@ -267,5 +277,7 @@ RSpec.feature 'Provider changes an existing offer' do
 
   def when_i_choose_to_change_the_conditions
     click_on 'Add or change conditions'
+    uncheck 'Fitness to train to teach check'
+    check 'Disclosure and Barring Service (DBS) check'
   end
 end

--- a/spec/system/provider_interface/change_existing_offer_ske_standard_flow_spec.rb
+++ b/spec/system/provider_interface/change_existing_offer_ske_standard_flow_spec.rb
@@ -252,7 +252,7 @@ RSpec.feature 'Provider changes an existing offer' do
   end
 
   def when_i_add_a_ske_reason
-    choose t('provider_interface.offer.ske_reasons.form.different_degree', degree_subject: @ske_subject.name)
+    choose t('provider_interface.offer.ske_reasons.different_degree', degree_subject: @ske_subject.name)
   end
 
   def then_the_ske_length_page_is_loaded

--- a/spec/system/provider_interface/change_existing_offer_ske_standard_flow_spec.rb
+++ b/spec/system/provider_interface/change_existing_offer_ske_standard_flow_spec.rb
@@ -1,0 +1,271 @@
+require 'rails_helper'
+
+RSpec.feature 'Provider changes an existing offer' do
+  include DfESignInHelpers
+  include ProviderUserPermissionsHelper
+  include OfferStepsHelper
+
+  let(:provider_user) { create(:provider_user, :with_dfe_sign_in) }
+  let(:provider) { provider_user.providers.first }
+  let(:ratifying_provider) { create(:provider) }
+  let(:application_form) { build(:application_form, :minimum_info) }
+  let(:conditions) do
+    [build(:offer_condition, text: 'Fitness to train to teach check'),
+     build(:offer_condition, text: 'Be cool')]
+  end
+  let!(:application_choice) do
+    create(:application_choice,
+           :offered,
+           offer: build(:offer, conditions:),
+           application_form:,
+           current_course_option: course_option)
+  end
+  let(:course) do
+    build(:course, :full_time, provider:, accredited_provider: ratifying_provider)
+  end
+  let(:course_option) { build(:course_option, course:) }
+
+  scenario 'Changing an offer which has already been made' do
+    given_i_am_a_provider_user
+    and_i_am_permitted_to_make_decisions_for_my_provider
+    and_i_sign_in_to_the_provider_interface
+    and_provider_ske_feature_flag_is_enabled
+
+    given_the_provider_user_can_offer_multiple_provider_courses
+
+    when_i_visit_the_provider_interface
+    and_i_click_an_application_choice_with_an_offer
+    and_i_click_on_the_offer_tab
+    then_i_see_the_offer_details
+
+    when_i_choose_to_change_the_provider
+    then_i_am_taken_to_the_change_provider_page
+
+    when_i_select_a_different_provider
+    and_i_click_continue
+
+    when_i_select_a_different_course
+    and_i_click_continue
+    then_no_study_mode_is_pre_selected
+
+    when_i_select_a_study_mode
+    and_i_click_continue
+
+    when_i_select_a_new_location
+    and_i_click_continue
+    then_the_ske_standard_flow_is_loaded
+
+    when_i_select_ske_is_required
+    and_i_click_continue
+    then_the_ske_reason_page_is_loaded
+
+    when_i_add_a_ske_reason
+    and_i_click_continue
+    then_the_ske_length_page_is_loaded
+
+    when_i_answer_the_ske_length
+    and_i_click_continue
+    then_the_conditions_page_is_loaded
+    and_the_conditions_of_the_original_offer_are_filled_in
+
+    when_i_add_a_further_condition
+    and_i_add_another_and_then_remove_a_further_condition
+    then_the_correct_conditions_are_displayed
+
+    and_i_click_continue
+
+    then_the_review_page_is_loaded
+    and_the_ske_conditions_should_be_displayed
+    and_i_can_confirm_the_changed_offer_details
+
+    when_i_send_the_offer
+    then_i_see_that_the_offer_was_successfully_updated
+
+    when_i_choose_to_change_the_conditions
+    and_i_click_continue
+
+    then_the_review_page_is_loaded
+    when_i_send_the_offer
+
+    then_i_see_that_the_offer_was_successfully_updated
+  end
+
+  def given_i_am_a_provider_user
+    user_exists_in_dfe_sign_in(email_address: provider_user.email_address)
+  end
+
+  def and_i_am_permitted_to_make_decisions_for_my_provider
+    permit_make_decisions!
+  end
+
+  def and_i_sign_in_to_the_provider_interface
+    provider_signs_in_using_dfe_sign_in
+  end
+
+  def given_the_provider_user_can_offer_multiple_provider_courses
+    @selected_provider = create(:provider)
+    create(:provider_permissions, provider: @selected_provider, provider_user:, make_decisions: true)
+    @ske_subject = create(:subject, code: 'C1', name: 'Biology')
+    courses = create_list(:course, 2, subjects: [@ske_subject], study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: ratifying_provider)
+    @selected_course = courses.sample
+
+    course_options = [create(:course_option, :part_time, course: @selected_course),
+                      create(:course_option, :full_time, course: @selected_course),
+                      create(:course_option, :full_time, course: @selected_course),
+                      create(:course_option, :part_time, course: @selected_course)]
+
+    create(
+      :provider_relationship_permissions,
+      training_provider: provider,
+      ratifying_provider:,
+      ratifying_provider_can_make_decisions: true,
+    )
+
+    create(
+      :provider_relationship_permissions,
+      training_provider: @selected_provider,
+      ratifying_provider:,
+      ratifying_provider_can_make_decisions: true,
+    )
+
+    @selected_course_option = course_options.sample
+  end
+
+  def when_i_visit_the_provider_interface
+    visit provider_interface_applications_path
+  end
+
+  def and_i_click_an_application_choice_with_an_offer
+    click_on application_choice.application_form.full_name
+  end
+
+  def and_i_click_on_the_offer_tab
+    click_on 'Offer'
+  end
+
+  def then_i_see_the_offer_details
+    expect(page).to have_content('Course details')
+    expect(page).to have_content('Conditions of offer')
+  end
+
+  def when_i_choose_to_change_the_provider
+    within(all('.govuk-summary-list__row')[0]) do
+      click_on 'Change'
+    end
+  end
+
+  def then_i_am_taken_to_the_change_provider_page
+    expect(page).to have_content('Training provider')
+  end
+
+  def when_i_select_a_different_provider
+    choose @selected_provider.name_and_code
+  end
+
+  def and_i_click_continue
+    click_on t('continue')
+  end
+
+  def when_i_select_a_different_course
+    choose @selected_course.name_and_code
+  end
+
+  def then_no_study_mode_is_pre_selected
+    expect(find_field('Full time')).not_to be_checked
+    expect(find_field('Part time')).not_to be_checked
+  end
+
+  def when_i_select_a_study_mode
+    choose @selected_course_option.study_mode.humanize
+  end
+
+  def when_i_select_a_new_location
+    choose @selected_course_option.site_name
+  end
+
+  def then_the_ske_standard_flow_is_loaded
+    expect(page).to have_current_path("/provider/applications/#{application_choice.id}/offer/ske-requirements/edit", ignore_query: true)
+  end
+
+  def when_i_select_ske_is_required
+    choose 'Yes'
+  end
+
+  def then_the_ske_reason_page_is_loaded
+    expect(page).to have_current_path("/provider/applications/#{application_choice.id}/offer/ske-reason/edit", ignore_query: true)
+  end
+
+  def when_i_add_a_ske_reason
+    choose t('provider_interface.offer.ske_reasons.new.different_degree', degree_subject: @ske_subject.name)
+  end
+
+  def then_the_ske_length_page_is_loaded
+    expect(page).to have_current_path("/provider/applications/#{application_choice.id}/offer/ske-length/edit", ignore_query: true)
+  end
+
+  def when_i_answer_the_ske_length
+    choose '8 weeks'
+  end
+
+  def and_the_ske_conditions_should_be_displayed
+    expect(page).to have_content('Subject knowledge enhancement course')
+    expect(page).to have_content("Subject\n#{@ske_subject.name}")
+    expect(page).to have_content("Length\n8 weeks")
+    expect(page).to have_content("Reason\nTheir degree subject was not #{@ske_subject.name}")
+  end
+
+  def then_the_conditions_page_is_loaded
+    expect(page).to have_content('Conditions of offer')
+  end
+
+  def and_the_conditions_of_the_original_offer_are_filled_in
+    expect(find("input[value='Fitness to train to teach check']")).to be_checked
+    expect(page).to have_field('Condition 1', with: 'Be cool')
+  end
+
+  def when_i_add_a_further_condition
+    click_on 'Add another condition'
+    fill_in('provider_interface_offer_wizard[further_conditions][1][text]', with: 'A* on Maths A Level')
+  end
+
+  def and_i_add_another_and_then_remove_a_further_condition
+    click_on 'Add another condition'
+    fill_in('provider_interface_offer_wizard[further_conditions][2][text]', with: 'Go to the cinema')
+    click_on 'Remove condition 3'
+  end
+
+  def then_the_correct_conditions_are_displayed
+    expect(page).to have_field('Condition 2', with: 'A* on Maths A Level')
+    expect(page).not_to have_field('Condition 3', with: 'Go to the cinema')
+  end
+
+  def then_the_review_page_is_loaded
+    expect(page).to have_content('Check and send new offer')
+  end
+
+  def and_i_can_confirm_the_changed_offer_details
+    within('.app-offer-panel') do
+      expect(page).to have_content(@selected_provider.name_and_code)
+      expect(page).to have_content(@selected_course.name_and_code)
+      expect(page).to have_content(@selected_course_option.study_mode.humanize)
+      expect(page).to have_content(@selected_course_option.site.name_and_address(' '))
+      expect(page).to have_content('Fitness to train to teach check')
+      expect(page).to have_content('Be cool')
+      expect(page).to have_content('A* on Maths A Level')
+    end
+  end
+
+  def when_i_send_the_offer
+    click_on 'Send new offer'
+  end
+
+  def then_i_see_that_the_offer_was_successfully_updated
+    within('.govuk-notification-banner--success') do
+      expect(page).to have_content('New offer sent')
+    end
+  end
+
+  def when_i_choose_to_change_the_conditions
+    click_on 'Add or change conditions'
+  end
+end

--- a/spec/system/provider_interface/make_offer_ske_standard_flow_feature_flag_enabled_spec.rb
+++ b/spec/system/provider_interface/make_offer_ske_standard_flow_feature_flag_enabled_spec.rb
@@ -30,6 +30,7 @@ RSpec.feature 'Provider makes an offer with SKE enabled in standard courses' do
     and_provider_ske_feature_flag_is_enabled
 
     given_the_provider_has_multiple_courses
+    and_the_other_courses_subject_does_not_require_ske
     given_the_provider_user_can_offer_multiple_provider_courses
 
     when_i_visit_the_provider_interface
@@ -107,7 +108,6 @@ RSpec.feature 'Provider makes an offer with SKE enabled in standard courses' do
     and_i_can_confirm_the_new_course_selection
     and_i_can_confirm_the_new_study_mode_selection
     and_i_can_confirm_the_new_location_selection
-    and_the_ske_conditions_should_be_displayed
 
     when_i_send_the_offer
     then_i_see_that_the_offer_was_successfuly_made
@@ -117,6 +117,13 @@ RSpec.feature 'Provider makes an offer with SKE enabled in standard courses' do
     application_choice.course_option.course.subjects.delete_all
     application_choice.course_option.course.subjects << build(
       :subject, code: 'C1', name: 'Biology'
+    )
+  end
+
+  def and_the_other_courses_subject_does_not_require_ske
+    @provider_available_course.subjects.delete_all
+    @provider_available_course.subjects << build(
+      :subject, code: 'W1', name: 'Art and design'
     )
   end
 
@@ -177,13 +184,6 @@ RSpec.feature 'Provider makes an offer with SKE enabled in standard courses' do
 
   def when_i_answer_the_ske_length
     choose '8 weeks'
-  end
-
-  def and_the_ske_conditions_should_be_displayed
-    expect(page).to have_content('Subject knowledge enhancement course')
-    expect(page).to have_content("Subject\n#{subject_name}")
-    expect(page).to have_content("Length\n8 weeks")
-    expect(page).to have_content("Reason\nTheir degree subject was not #{subject_name}")
   end
 
   def subject_name


### PR DESCRIPTION
## Context

Providers have the ability to change an offer after making it. They can also change the course options whilst in the process of making an offer. We need to account for the following scenarios:
- Changing from a SKE eligible course to a non-SKE eligible course
- Changing from a non-SKE eligible course to a SKE eligible course

For these scenarios we've decided to take an approach of removing any SKE conditions associated with the offer and getting the user to rebuild it (if applicable).

We also need to handle the scenario of a support user changing an offer course. For this we've decided to just remove any associated SKE conditions. There will be follow up work to provide functionality for the support user to reinstate/add a SKE condition – for now this will have to be done by a dev in the console.

## Changes proposed in this pull request

- In the wizard a path has been added for `:change_offer`
- introduce `edit` and `update` actions and the corresponding views into the SKE flow
- reset SKE conditions if appropriate within the wizard on changing a course
- `ChangeCourseChoiceForm` now checks an offer for SKE conditions and will remove if found.

## Guidance to review

Journeys to test for:
- Making an offer
- Changing an existing SKE eligible offer to a non-SKE eligible course
- Changing an existing non-SKE eligible offer to a SKE eligible course
- Making a SKE eligible offer and then changing to a non-SKE eligible course before the offer is sent
- Making a non-SKE eligible offer and then changing to a SKE eligible course before the offer is sent
- Support user changing a SKE eligible offer in the console

## Link to Trello card

https://trello.com/c/ufdOHCeU/1043

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
