### PR TITLE
Temp update host header value for sbox/prod

### DIFF
--- a/terraform/custom_domains/environment_domains/workspace_variables/apply_production.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/apply_production.tfvars.json
@@ -10,7 +10,7 @@
       "environment_short": "pd",
       "environment_tag": "pd",
       "origin_hostname": "apply-prod.london.cloudapps.digital",
-      "null_host_header": true,
+      "null_host_header": false,
       "cnames": {
         "www": {
           "target": "d1xbatyhdsd23r.cloudfront.net",
@@ -31,7 +31,7 @@
       "environment_short": "pd",
       "environment_tag": "pd",
       "origin_hostname": "apply-prod.london.cloudapps.digital",
-      "null_host_header": true,
+      "null_host_header": false,
       "cnames": {
         "assets": {
           "target": "dxhwikmjcbucp.cloudfront.net",

--- a/terraform/custom_domains/environment_domains/workspace_variables/apply_sandbox.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/apply_sandbox.tfvars.json
@@ -10,7 +10,7 @@
       "environment_short": "sbox",
       "environment_tag": "sbox",
       "origin_hostname": "apply-sandbox.london.cloudapps.digital",
-      "null_host_header": true,
+      "null_host_header": false,
       "cnames": {
         "sandbox": {
           "target": "d1xbatyhdsd23r.cloudfront.net",
@@ -31,7 +31,7 @@
       "environment_short": "sbx",
       "environment_tag": "sbx",
       "origin_hostname": "apply-sandbox.london.cloudapps.digital",
-      "null_host_header": true,
+      "null_host_header": false,
       "cnames": {
         "sandbox-assets": {
           "target": "dxhwikmjcbucp.cloudfront.net",


### PR DESCRIPTION
## Context

New values needs to be false until the environment is moved to AKS through front door

## Changes proposed in this pull request

Update the null_host_header value to false so we can run the Terraform without error and it works with GOV.UK PaaS. Switch back to true when implementing with AKS and updating origin_hostname.

## Guidance to review

Confirm no typos. Tested against sandbox already

## Link to Trello card

https://trello.com/c/1yEerHJZ

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
