### PR TITLE
Update invariant check for max apps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,8 @@ gem 'postcodes_io'
 gem 'business_time'
 gem 'holidays'
 
+gem 'humanize'
+
 # Monitoring
 gem 'okcomputer'
 gem 'skylight'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -341,6 +341,7 @@ GEM
       domain_name (~> 0.5)
     http-form_data (2.3.0)
     httpclient (2.8.3)
+    humanize (2.5.1)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     io-like (0.3.1)
@@ -809,6 +810,7 @@ DEPENDENCIES
   guard-rspec
   holidays
   http
+  humanize
   json-schema
   json_api_client
   jwt


### PR DESCRIPTION
## Context

We have a daily invariant check that looks for applications that exceed our max limit. We increased our application choice limit but didn't update this check

## Changes proposed in this pull request

This invariant check will no longer use a fixed value but take the constant from our ApplicationForm model.

Tests have fixed values though – thoughts on this?