### PR TITLE
Show providers a preview of the rejection email

### DIFF
--- a/app/forms/provider_interface/rejections_wizard.rb
+++ b/app/forms/provider_interface/rejections_wizard.rb
@@ -72,9 +72,5 @@ module ProviderInterface
 
       reason.reasons.select { |nr| attrs[reason.selected_reasons_attr_name].exclude?(nr.id) }
     end
-
-    def flattened_reasons
-      to_model.selected_reasons.flat_map { |reason| reason.selected_reasons || reason }
-    end
   end
 end

--- a/app/forms/provider_interface/rejections_wizard.rb
+++ b/app/forms/provider_interface/rejections_wizard.rb
@@ -72,5 +72,9 @@ module ProviderInterface
 
       reason.reasons.select { |nr| attrs[reason.selected_reasons_attr_name].exclude?(nr.id) }
     end
+
+    def flattened_reasons
+      to_model.selected_reasons.flat_map { |reason| reason.selected_reasons || reason }
+    end
   end
 end

--- a/app/frontend/styles/provider/_all.scss
+++ b/app/frontend/styles/provider/_all.scss
@@ -14,3 +14,4 @@
 @import "search";
 @import "timeline";
 @import "user-card";
+@import "email-preview";

--- a/app/frontend/styles/provider/_email-preview.scss
+++ b/app/frontend/styles/provider/_email-preview.scss
@@ -1,0 +1,8 @@
+.app-email-preview {
+  margin-top: govuk-spacing(4);
+  margin-bottom: govuk-spacing(6);
+  padding: govuk-spacing(4);
+  border-width: $govuk-border-width;
+  border-style: solid;
+  border-color: $govuk-border-colour;
+}

--- a/app/views/provider_interface/rejections/check.html.erb
+++ b/app/views/provider_interface/rejections/check.html.erb
@@ -13,19 +13,10 @@
         <h1 class="govuk-heading-l">Check details and reject application</h1>
       <% end %>
 
-      <%= render RejectionReasons::RejectionReasonsComponent.new(
-        application_choice: @application_choice,
-        reasons: @wizard.to_model,
-        editable: true,
-      ) %>
-
       <% if @interview_cancellation_presenter.render? %>
         <p class="govuk-body"><%= @interview_cancellation_presenter.text %></p>
       <% end %>
 
-      <% if rbd_application_with_no_feedback? %>
-        <%= f.govuk_submit 'Give feedback' %>
-      <% else %>
         <p class="govuk-body">The candidate will be sent this email:</p>
         <div class="app-email-preview">
           <p class="govuk-body">Dear <%= @application_choice.application_form.first_name %>,</p>
@@ -37,22 +28,42 @@
           <p class="govuk-body">They’ve given the following feedback to explain their decision:</p>
 
           <div class="govuk-inset-text">
-            <% @wizard.flattened_reasons.each do |reason| %>
-              <% next if reason.nil? %>
-              <% if reason.details.present? %>
-                <% if reason.details.text.empty? %>
-                  <p class="govuk-body"><%= reason.label %></p>
+            <% @wizard.to_model.selected_reasons.as_json.each do |reason| %>
+              <h1 class="govuk-heading-m"><%= reason[:label] %></h1>
+              <% if reason[:selected_reasons].nil? %>
+                <p class="govuk-body"><%= reason[:text] %></p>
+                <% if reason[:details].present? %>
+                  <% if reason[:details].text.empty? %>
+                    <p class="govuk-body"><%= reason[:label] %></p>
+                  <% else %>
+                    <p class="govuk-body"><%= reason[:label] %>:</p>
+                    <p class="govuk-body"><%= reason[:details].text %></p>
+                  <% end %>
                 <% else %>
-                  <p class="govuk-body"><%= reason.label %>:</p>
-                  <p class="govuk-body"><%= reason.details.text %></p>
+                  <p class="govuk-body"><%= reason[:label] %></p>
                 <% end %>
               <% else %>
-                <p class="govuk-body"><%= reason.label %></p>
+                <% reason[:selected_reasons].each do |reason| %>
+                  <% if reason.details.present? %>
+                    <% if reason.details.text.empty? %>
+                      <p class="govuk-body"><%= reason.label %></p>
+                    <% else %>
+                      <p class="govuk-body"><%= reason.label %>:</p>
+                      <p class="govuk-body"><%= reason.details.text %></p>
+                    <% end %>
+                  <% else %>
+                    <p class="govuk-body"><%= reason.label %></p>
+                  <% end %>
+                <% end %>
               <% end %>
             <% end %>
           </div>
           <p class="govuk-body"> Contact <%= @application_choice.current_course_option.course.provider.name %> if you would like to talk about their feedback.</p>
         </div>
+
+      <% if rbd_application_with_no_feedback? %>
+        <%= f.govuk_submit 'Give feedback' %>
+      <% else %>
         <%= f.govuk_submit 'Reject application' %>
       <% end %>
     <% end %>

--- a/app/views/provider_interface/rejections/check.html.erb
+++ b/app/views/provider_interface/rejections/check.html.erb
@@ -23,17 +23,36 @@
         <p class="govuk-body"><%= @interview_cancellation_presenter.text %></p>
       <% end %>
 
-      <div class="govuk-warning-text">
-        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-        <strong class="govuk-warning-text__text">
-          <span class="govuk-warning-text__assistive"></span>
-          The candidate will be sent an email to tell them why you rejected their application.
-        </strong>
-      </div>
-
       <% if rbd_application_with_no_feedback? %>
         <%= f.govuk_submit 'Give feedback' %>
       <% else %>
+        <p class="govuk-body">The candidate will be sent this email:</p>
+        <div class="app-email-preview">
+          <p class="govuk-body">Dear <%= @application_choice.application_form.first_name %>,</p>
+
+          <p class="govuk-body">Thank you for your application to study <%= @application_choice.current_course_option.course.name_and_code %> at <%= @application_choice.current_course_option.course.provider.name %>.</p>
+
+          <p class="govuk-body">On this occasion, the provider is not offering you a place on this course.</p>
+
+          <p class="govuk-body">They’ve given the following feedback to explain their decision:</p>
+
+          <div class="govuk-inset-text">
+            <% @wizard.flattened_reasons.each do |reason| %>
+              <% next if reason.nil? %>
+              <% if reason.details.present? %>
+                <% if reason.details.text.empty? %>
+                  <p class="govuk-body"><%= reason.label %></p>
+                <% else %>
+                  <p class="govuk-body"><%= reason.label %>:</p>
+                  <p class="govuk-body"><%= reason.details.text %></p>
+                <% end %>
+              <% else %>
+                <p class="govuk-body"><%= reason.label %></p>
+              <% end %>
+            <% end %>
+          </div>
+          <p class="govuk-body"> Contact <%= @application_choice.current_course_option.course.provider.name %> if you would like to talk about their feedback.</p>
+        </div>
         <%= f.govuk_submit 'Reject application' %>
       <% end %>
     <% end %>

--- a/spec/system/provider_interface/provider_gives_feedback_for_rejected_by_default_spec.rb
+++ b/spec/system/provider_interface/provider_gives_feedback_for_rejected_by_default_spec.rb
@@ -73,40 +73,47 @@ RSpec.describe 'Reject an application' do
   end
 
   def and_i_check_the_feedback_given
-    expect(page).to have_link('Back', href: new_provider_interface_rejection_path(@application_choice))
-
     expect(page).to have_content('Check details and give feedback')
+    expect(page).to have_content('The candidate will be sent this email:')
 
-    rows = page.all('.govuk-summary-list__row')
+    email = page.all('.app-email-preview').first.text.split("\n")
 
-    expect(rows[0].text.split("\n")).to eq([
+    expect(email[0..3]).to eq([
+      "Dear #{@application_choice.application_form.first_name},",
+      "Thank you for your application to study #{@application_choice.current_course_option.course.name_and_code} at #{@application_choice.current_course_option.provider.name}.",
+      'On this occasion, the provider is not offering you a place on this course.',
+      'They’ve given the following feedback to explain their decision:',
+    ])
+
+    expect(email[4..7]).to eq([
       'Qualifications',
       'No maths GCSE at minimum grade 4 or C, or equivalent',
       'Could not verify qualifications:',
       'We can find no evidence of your GCSEs',
-      'Change',
     ])
 
-    expect(rows[1].text.split("\n")).to eq([
+    expect(email[8..12]).to eq([
       'Personal statement',
       'Quality of writing:',
       'We do not accept applications written in morse code',
       'Other:',
       'This was wayyyyy too personal',
-      'Change',
     ])
 
-    expect(rows[2].text.split("\n")).to eq([
+    expect(email[13..14]).to eq([
       'Course full',
-      'The course is full.',
-      'Change',
+      'Course full',
     ])
 
-    expect(rows[3].text.split("\n")).to eq([
+    expect(email[15..17]).to eq([
       'Other',
+      'Other:',
       'There are so many other reasons why your application was rejected...',
-      'Change',
     ])
+
+    expect(email.last).to eq(
+      "Contact #{@application_choice.current_course_option.provider.name} if you would like to talk about their feedback.",
+    )
 
     expect(page).to have_button('Give feedback')
   end

--- a/spec/system/provider_interface/reject_an_application_spec.rb
+++ b/spec/system/provider_interface/reject_an_application_spec.rb
@@ -21,15 +21,8 @@ RSpec.describe 'Reject an application' do
     and_i_click_back
     then_i_can_see_the_rejection_reasons_form
 
-    and_i_click_continue
-    and_i_click_change
-    then_i_can_see_the_rejection_reasons_form
-
-    and_i_click_continue
-    and_i_check_the_reasons_for_rejection
-    then_i_can_see_the_email_preview
-
-    when_i_reject_the_application
+    when_i_click_continue
+    and_i_reject_the_application
     then_i_can_see_the_rejected_application_feedback
   end
 
@@ -86,37 +79,47 @@ RSpec.describe 'Reject an application' do
 
   def and_i_check_the_reasons_for_rejection
     expect(page).to have_content('Check details and reject application')
+    expect(page).to have_content('The candidate will be sent this email:')
 
-    rows = page.all('.govuk-summary-list__row')
+    email = page.all('.app-email-preview').first.text.split("\n")
 
-    expect(rows[0].text.split("\n")).to eq([
+    expect(email[0..3]).to eq([
+      "Dear #{@application_choice.application_form.first_name},",
+      "Thank you for your application to study #{@application_choice.current_course_option.course.name_and_code} at #{@application_choice.current_course_option.provider.name}.",
+      'On this occasion, the provider is not offering you a place on this course.',
+      'They’ve given the following feedback to explain their decision:',
+    ])
+
+    expect(email[4..7]).to eq([
       'Qualifications',
       'No maths GCSE at minimum grade 4 or C, or equivalent',
       'Could not verify qualifications:',
       'We can find no evidence of your GCSEs',
-      'Change',
     ])
 
-    expect(rows[1].text.split("\n")).to eq([
+    expect(email[8..12]).to eq([
       'Personal statement',
       'Quality of writing:',
       'We do not accept applications written in morse code',
       'Other:',
       'This was wayyyyy too personal',
-      'Change',
     ])
 
-    expect(rows[2].text.split("\n")).to eq([
+    expect(email[13..15]).to eq([
       'Course full',
+      'Course full:',
       'Other courses exist',
-      'Change',
     ])
 
-    expect(rows[3].text.split("\n")).to eq([
+    expect(email[16..18]).to eq([
       'Other',
+      'Other:',
       'There are so many other reasons why your application was rejected...',
-      'Change',
     ])
+
+    expect(email.last).to eq(
+      "Contact #{@application_choice.current_course_option.provider.name} if you would like to talk about their feedback.",
+    )
 
     expect(page).to have_button('Reject application')
   end
@@ -124,6 +127,8 @@ RSpec.describe 'Reject an application' do
   def and_i_click_continue
     click_on 'Continue'
   end
+
+  alias_method :when_i_click_continue, :and_i_click_continue
 
   def and_i_click_back
     click_on 'Back'
@@ -133,11 +138,7 @@ RSpec.describe 'Reject an application' do
     expect(page).to have_current_path(new_provider_interface_rejection_path(@application_choice))
   end
 
-  def and_i_click_change
-    first(:link, 'Change').click
-  end
-
-  def when_i_reject_the_application
+  def and_i_reject_the_application
     click_on 'Reject application'
   end
 
@@ -160,13 +161,5 @@ RSpec.describe 'Reject an application' do
 
     expect(page).to have_content('Other')
     expect(page).to have_content('There are so many other reasons why your application was rejected...')
-  end
-
-  def then_i_can_see_the_email_preview
-    expect(page).to have_content("Dear #{@application_choice.application_form.first_name},")
-    expect(page).to have_content("Thank you for your application to study #{@application_choice.current_course_option.course.name_and_code} at #{@application_choice.current_course_option.course.provider.name}")
-    expect(page).to have_content('On this occasion, the provider is not offering you a place on this course.')
-    expect(page).to have_content('They’ve given the following feedback to explain their decision:')
-    expect(page).to have_content("Contact #{@application_choice.current_course_option.course.provider.name} if you would like to talk about their feedback.")
   end
 end

--- a/spec/system/provider_interface/reject_an_application_spec.rb
+++ b/spec/system/provider_interface/reject_an_application_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe 'Reject an application' do
 
     and_i_click_continue
     and_i_check_the_reasons_for_rejection
+    then_i_can_see_the_email_preview
 
     when_i_reject_the_application
     then_i_can_see_the_rejected_application_feedback
@@ -46,7 +47,7 @@ RSpec.describe 'Reject an application' do
 
   def and_my_organisation_has_received_an_application
     course_option = course_option_for_provider_code(provider_code: 'ABC')
-    @application_choice = create(:application_choice, :awaiting_provider_decision, course_option:)
+    @application_choice = create(:application_choice, :with_completed_application_form, :awaiting_provider_decision, course_option:)
   end
 
   def when_i_choose_to_reject_an_application
@@ -159,5 +160,13 @@ RSpec.describe 'Reject an application' do
 
     expect(page).to have_content('Other')
     expect(page).to have_content('There are so many other reasons why your application was rejected...')
+  end
+
+  def then_i_can_see_the_email_preview
+    expect(page).to have_content("Dear #{@application_choice.application_form.first_name},")
+    expect(page).to have_content("Thank you for your application to study #{@application_choice.current_course_option.course.name_and_code} at #{@application_choice.current_course_option.course.provider.name}")
+    expect(page).to have_content('On this occasion, the provider is not offering you a place on this course.')
+    expect(page).to have_content('They’ve given the following feedback to explain their decision:')
+    expect(page).to have_content("Contact #{@application_choice.current_course_option.course.provider.name} if you would like to talk about their feedback.")
   end
 end


### PR DESCRIPTION
## Context

We recently did some user research on a new rejection journey for providers. We're not going to implement the full journey at this point, but something that tested well was the rejection email preview that candidates receive.

## Changes proposed in this pull request

This PR implements just the email preview.

<img width="585" alt="image" src="https://user-images.githubusercontent.com/47917431/224086309-b9a0c5f8-0a0f-465f-8934-c62fc7151686.png">


## Guidance to review

Followed design from the [prototype](https://manage-applications-beta.herokuapp.com) albeit the rest of the page is different.

Haven't given much thought to the rest of the layout so looking for suggestions there.