### PR TITLE
[101] Introduce liveness and startup probe into the workers

### DIFF
--- a/terraform/modules/kubernetes/main.tf
+++ b/terraform/modules/kubernetes/main.tf
@@ -19,7 +19,7 @@ resource "kubernetes_deployment" "webapp" {
       spec {
         node_selector = {
           "kubernetes.azure.com/agentpool" = "applications"
-          "kubernetes.io/os" = "linux"
+          "kubernetes.io/os"               = "linux"
         }
         container {
           name    = local.webapp_name
@@ -187,14 +187,26 @@ resource "kubernetes_deployment" "main_worker" {
       spec {
         node_selector = {
           "kubernetes.azure.com/agentpool" = "applications"
-          "kubernetes.io/os" = "linux"
+          "kubernetes.io/os"               = "linux"
         }
         container {
           name    = local.worker_name
           image   = var.app_docker_image
           command = ["bundle"]
           args    = ["exec", "sidekiq", "-c", "5", "-C", "config/sidekiq-main.yml"]
-
+          liveness_probe {
+            exec {
+              command = ["pgrep", "-f", "sidekiq"]
+            }
+            period_seconds = 10
+          }
+          startup_probe {
+            exec {
+              command = ["pgrep", "-f", "sidekiq"]
+            }
+            initial_delay_seconds = 5
+            period_seconds        = 10
+          }
           env_from {
             config_map_ref {
               name = kubernetes_config_map.app_config.metadata.0.name
@@ -245,14 +257,26 @@ resource "kubernetes_deployment" "secondary_worker" {
       spec {
         node_selector = {
           "kubernetes.azure.com/agentpool" = "applications"
-          "kubernetes.io/os" = "linux"
+          "kubernetes.io/os"               = "linux"
         }
         container {
           name    = local.secondary_worker_name
           image   = var.app_docker_image
           command = ["bundle"]
           args    = ["exec", "sidekiq", "-c", "5", "-C", "config/sidekiq-secondary.yml"]
-
+          liveness_probe {
+            exec {
+              command = ["pgrep", "-f", "sidekiq"]
+            }
+            period_seconds = 10
+          }
+          startup_probe {
+            exec {
+              command = ["pgrep", "-f", "sidekiq"]
+            }
+            initial_delay_seconds = 5
+            period_seconds        = 10
+          }
           env_from {
             config_map_ref {
               name = kubernetes_config_map.app_config.metadata.0.name
@@ -303,14 +327,26 @@ resource "kubernetes_deployment" "clock_worker" {
       spec {
         node_selector = {
           "kubernetes.azure.com/agentpool" = "applications"
-          "kubernetes.io/os" = "linux"
+          "kubernetes.io/os"               = "linux"
         }
         container {
           name    = local.clock_worker_name
           image   = var.app_docker_image
           command = ["bundle"]
           args    = ["exec", "clockwork", "config/clock.rb"]
-
+          liveness_probe {
+            exec {
+              command = ["pgrep", "-f", "clockwork"]
+            }
+            period_seconds = 10
+          }
+          startup_probe {
+            exec {
+              command = ["pgrep", "-f", "clockwork"]
+            }
+            initial_delay_seconds = 5
+            period_seconds        = 10
+          }
           env_from {
             config_map_ref {
               name = kubernetes_config_map.app_config.metadata.0.name


### PR DESCRIPTION
## Context

This change is to introduce liveness probes into each worker 

## Changes proposed in this pull request

Changes made are in the terraform main.tf file below the container section. Added Liveness probes to
1 main_worker
2 secondary_worker
3 clockwork_worker

## Guidance to review

1. Deploy aks cluster
2. use ```kubectl exec -ti apply-worker-review-1234-5fd97b9698-hcpjz -n development -- sh``` to sh into your pod
3. replace apply-worker-review-1234-5fd97b9698-hcpjz with your own pod deployment
4. run pgrep -f sidekiq
5. if it returns 1 test is successful 

## Link to Trello card

[<!-- http://trello.com/123-example-card -->](https://trello.com/c/mmX7RZLU/101-define-healthcheck-for-background-workers)


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
