### PR TITLE
Basic monitoring for aks apps

### DIFF
--- a/docs/aks-alerting.md
+++ b/docs/aks-alerting.md
@@ -1,0 +1,69 @@
+# AKS alerting configuration
+
+## Purpose
+
+This document describes the alerting configuration for AKS
+
+## Backend Service Alerting
+
+Postgres and Redis monitoring is configured within the environment terraform
+
+If enabled it will monitor and alert via email on the following
+- postgres memory, cpu and storage used
+- redis memory used
+
+### To enable backing service alerting
+
+1. Update tvfars.json
+
+In terraform/aks/workspace_variables/${env}.tfvars.json, set
+
+"enable_alerting": true
+
+2. If required, add alert threshold overrides to terraform/aks/workspace_variables/${env}.tfvars.json
+
+Defaults below:
+
+pg_memory_threshold        default = 75
+
+pg_cpu_threshold           default = 60
+
+pg_storage_threshold       default = 75
+
+redis_memory_threshold     default = 60
+
+3. Set email alert group
+
+Add ALERT_EMAILGROUP to the infra keyvault secret for that environment
+
+Note that alerting will only be configured if Azure backing services are being used
+
+i.e. "deploy_azure_backing_services": true
+
+## CDN/Frontdoor Alerting
+
+CDN/Frontdoor monitoring is configured within the custom_domain terraform
+
+If enabled it will monitor and alert via email on the following
+- high request latency
+- high 5xx request rate
+
+### To enable CDN alerting
+
+1. Update tvfars.json
+
+In terraform/custom_domains/environment_domains/workspace_variables/apply-${env}.tfvars.json, set
+
+"alert_domains": ["apply-for-teacher-training.service.gov.uk"]
+
+2. If required, add alert threshold overrides to terraform/custom_domains/environment_domains/workspace_variables/apply-${env}.tfvars.json
+
+Defaults below:
+
+latency_threshold"         default = 1500
+
+percent_5xx_threshold      default = 10
+
+3. Set email alert group
+
+Add ALERT_EMAILGROUP to the infra keyvault secret for that environment

--- a/docs/aks-alerting.md
+++ b/docs/aks-alerting.md
@@ -6,7 +6,7 @@ This document describes the alerting configuration for AKS
 
 ## Backend Service Alerting
 
-Postgres and Redis monitoring is configured within the environment terraform
+Postgres and Redis monitoring is configured within the aks terraform
 
 If enabled it will monitor and alert via email on the following
 - postgres memory, cpu and storage used
@@ -14,35 +14,32 @@ If enabled it will monitor and alert via email on the following
 
 ### To enable backing service alerting
 
-1. Update tvfars.json
+1. Create an alert action group manually for each subscription
 
-In terraform/aks/workspace_variables/${env}.tfvars.json, set
+Current config is 1 ag per subscription per app.
+So for apply this is
+- s189d01-att-dev-ag in rg s189d01-att-rv-rg
+- s189t01-att-test-ag in rg s189t01-att-qa-rg
+- s189p01-att-production-ag in rg s189p01-att-pd-rg
 
-"enable_alerting": true
+2. Update tvfars.json
 
-2. If required, add alert threshold overrides to terraform/aks/workspace_variables/${env}.tfvars.json
+In each terraform/aks/workspace_variables/${env}.tfvars.json, set
+- "enable_alerting": true
+- "pg_actiongroup_name": "actiongroup_name from step 1",
+- "pg_actiongroup_rg": "actiongroup_rg from step 1",
 
-Defaults below:
+3. If required, add alert threshold overrides to terraform/aks/workspace_variables/${env}.tfvars.json
 
-pg_memory_threshold        default = 75
-
-pg_cpu_threshold           default = 60
-
-pg_storage_threshold       default = 75
-
-redis_memory_threshold     default = 60
-
-3. Set email alert group
-
-Add ALERT_EMAILGROUP to the infra keyvault secret for that environment
-
-Note that alerting will only be configured if Azure backing services are being used
-
-i.e. "deploy_azure_backing_services": true
+Defaults:
+- pg_memory_threshold        default = 75
+- pg_cpu_threshold           default = 60
+- pg_storage_threshold       default = 75
+- redis_memory_threshold     default = 60
 
 ## CDN/Frontdoor Alerting
 
-CDN/Frontdoor monitoring is configured within the custom_domain terraform
+CDN/Frontdoor monitoring is configured within the custom_domains terraform
 
 If enabled it will monitor and alert via email on the following
 - high request latency
@@ -50,20 +47,21 @@ If enabled it will monitor and alert via email on the following
 
 ### To enable CDN alerting
 
-1. Update tvfars.json
+1. Create an alert action group manually for the prod subscription (if one doesn't already exist from the backing service)
 
-In terraform/custom_domains/environment_domains/workspace_variables/apply-${env}.tfvars.json, set
+CDN/fd is only configured in the prod subscription.
+So for apply this is
+- s189p01-att-production-ag in rg s189p01-att-pd-rg
 
-"alert_domains": ["apply-for-teacher-training.service.gov.uk"]
+2. Update tvfars.json
 
-2. If required, add alert threshold overrides to terraform/custom_domains/environment_domains/workspace_variables/apply-${env}.tfvars.json
+In each terraform/custom_domains/environment_domains/workspace_variables/apply-${env}.tfvars.json, set
+- "enable_alerting":
+- "pg_actiongroup_name": "actiongroup_name from step 1",
+- "pg_actiongroup_rg": "actiongroup_rg from step 1",
 
-Defaults below:
+3. If required, add alert threshold overrides to terraform/custom_domains/environment_domains/workspace_variables/apply-${env}.tfvars.json
 
-latency_threshold"         default = 1500
-
-percent_5xx_threshold      default = 10
-
-3. Set email alert group
-
-Add ALERT_EMAILGROUP to the infra keyvault secret for that environment
+Defaults:
+- latency_threshold"         default = 1000
+- percent_5xx_threshold      default = 10

--- a/terraform/aks/terraform.tf
+++ b/terraform/aks/terraform.tf
@@ -10,7 +10,7 @@ module "kubernetes" {
   namespace                           = var.namespace
   postgres_admin_password             = local.infra_secrets.POSTGRES_ADMIN_PASSWORD
   postgres_admin_username             = local.infra_secrets.POSTGRES_ADMIN_USERNAME
-  resource_group_name                 = var.app_resource_group_name
+  resource_group_name                 = var.key_vault_resource_group
   resource_prefix                     = var.azure_resource_prefix
   webapp_startup_command              = var.webapp_startup_command
   webapp_memory_max                   = var.webapp_memory_max
@@ -28,6 +28,8 @@ module "kubernetes" {
   redis_family                        = var.redis_family
   redis_sku_name                      = var.redis_sku_name
   gov_uk_host_names                   = var.gov_uk_host_names
+  alert_emailgroup                    = local.infra_secrets.ALERT_EMAILGROUP
+  enable_alerting                     = var.enable_alerting
 }
 
 module "statuscake" {

--- a/terraform/aks/terraform.tf
+++ b/terraform/aks/terraform.tf
@@ -10,7 +10,7 @@ module "kubernetes" {
   namespace                           = var.namespace
   postgres_admin_password             = local.infra_secrets.POSTGRES_ADMIN_PASSWORD
   postgres_admin_username             = local.infra_secrets.POSTGRES_ADMIN_USERNAME
-  resource_group_name                 = var.key_vault_resource_group
+  resource_group_name                 = var.app_resource_group_name
   resource_prefix                     = var.azure_resource_prefix
   webapp_startup_command              = var.webapp_startup_command
   webapp_memory_max                   = var.webapp_memory_max
@@ -28,7 +28,8 @@ module "kubernetes" {
   redis_family                        = var.redis_family
   redis_sku_name                      = var.redis_sku_name
   gov_uk_host_names                   = var.gov_uk_host_names
-  alert_emailgroup                    = local.infra_secrets.ALERT_EMAILGROUP
+  pg_actiongroup_name                  = var.pg_actiongroup_name
+  pg_actiongroup_rg                    = var.pg_actiongroup_rg
   enable_alerting                     = var.enable_alerting
 }
 

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -75,6 +75,8 @@ variable "azure_resource_prefix" {}
 variable "app_resource_group_name" { default = null }
 
 variable "enable_alerting" { default = false }
+variable "pg_actiongroup_name" { default = false }
+variable "pg_actiongroup_rg" { default = false }
 
 variable "webapp_memory_max" { default = "1Gi" }
 variable "worker_memory_max" { default = "1Gi" }

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -74,6 +74,8 @@ variable "azure_resource_prefix" {}
 
 variable "app_resource_group_name" { default = null }
 
+variable "enable_alerting" { default = false }
+
 variable "webapp_memory_max" { default = "1Gi" }
 variable "worker_memory_max" { default = "1Gi" }
 variable "secondary_worker_memory_max" { default = "1Gi" }

--- a/terraform/aks/workspace_variables/qa_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/qa_aks.tfvars.json
@@ -17,6 +17,8 @@
   "secondary_worker_replicas": 1,
   "clock_worker_replicas": 1,
   "enable_alerting": true,
+  "pg_actiongroup_name": "s189t01-att-test-ag",
+  "pg_actiongroup_rg": "s189t01-att-qa-rg",
   "statuscake_alerts": {
     "apply-aks-qa": {
       "website_name": "Apply-Teacher-Training-AKS-QA",

--- a/terraform/aks/workspace_variables/qa_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/qa_aks.tfvars.json
@@ -16,6 +16,7 @@
   "worker_replicas": 1,
   "secondary_worker_replicas": 1,
   "clock_worker_replicas": 1,
+  "enable_alerting": true,
   "statuscake_alerts": {
     "apply-aks-qa": {
       "website_name": "Apply-Teacher-Training-AKS-QA",

--- a/terraform/aks/workspace_variables/sandbox_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/sandbox_aks.tfvars.json
@@ -18,5 +18,7 @@
   "clock_worker_replicas": 0,
   "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
   "postgres_enable_high_availability": true,
-  "enable_alerting": true
+  "enable_alerting": true,
+  "pg_actiongroup_name": "s189p01-att-production-ag",
+  "pg_actiongroup_rg": "s189p01-att-pd-rg"
 }

--- a/terraform/aks/workspace_variables/sandbox_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/sandbox_aks.tfvars.json
@@ -17,5 +17,6 @@
   "secondary_worker_replicas": 1,
   "clock_worker_replicas": 0,
   "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
-  "postgres_enable_high_availability": true
+  "postgres_enable_high_availability": true,
+  "enable_alerting": true
 }

--- a/terraform/aks/workspace_variables/staging_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/staging_aks.tfvars.json
@@ -16,6 +16,7 @@
   "worker_replicas": 1,
   "secondary_worker_replicas": 1,
   "clock_worker_replicas": 1,
+  "enable_alerting": true,
   "statuscake_alerts": {
     "apply-staging": {
       "website_name": "Apply-Teacher-Training-AKS-Staging",

--- a/terraform/aks/workspace_variables/staging_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/staging_aks.tfvars.json
@@ -17,6 +17,8 @@
   "secondary_worker_replicas": 1,
   "clock_worker_replicas": 1,
   "enable_alerting": true,
+  "pg_actiongroup_name": "s189t01-att-test-ag",
+  "pg_actiongroup_rg": "s189t01-att-qa-rg",
   "statuscake_alerts": {
     "apply-staging": {
       "website_name": "Apply-Teacher-Training-AKS-Staging",

--- a/terraform/custom_domains/environment_domains/monitoring.tf
+++ b/terraform/custom_domains/environment_domains/monitoring.tf
@@ -1,0 +1,104 @@
+data "azurerm_key_vault" "key_vault" {
+  name                = "s189p01-att-sbx-kv"
+  resource_group_name = "s189p01-att-sbx-rg"
+}
+
+data "azurerm_key_vault_secret" "infra_secrets" {
+  key_vault_id = data.azurerm_key_vault.key_vault.id
+  name         = "BAT-INFRA-SECRETS-SANDBOX"
+}
+
+resource "azurerm_monitor_action_group" "main" {
+  count = var.alert_domains != null ? 1 : 0
+
+  name                = "apply-cdn-${var.hosted_zone[var.alert_domains[0]].environment_short}-ag"
+  resource_group_name = var.hosted_zone[var.alert_domains[0]].resource_group_name
+  short_name          = "apply-${var.hosted_zone[var.alert_domains[0]].environment_short}"
+
+  email_receiver {
+    name          = "apply-${var.hosted_zone[var.alert_domains[0]].environment_short}-email-receiver"
+    email_address = local.alert_emailgroup
+  }
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+}
+
+data "azurerm_cdn_frontdoor_profile" "svc_domain" {
+  for_each            = toset(var.alert_domains)
+
+  name                = var.hosted_zone[each.value].front_door_name
+  resource_group_name = var.hosted_zone[each.value].resource_group_name
+}
+
+# Default is to evaluate alerts every 1 minute,
+# aggregated over the last 5 minutes
+
+resource "azurerm_monitor_metric_alert" "fd_total_latency" {
+  for_each            = toset(var.alert_domains)
+
+  name                = "${var.hosted_zone[each.value].front_door_name}-metricalert-latency"
+  resource_group_name = var.hosted_zone[each.value].resource_group_name
+  scopes              = [data.azurerm_cdn_frontdoor_profile.svc_domain[each.value].id]
+  description         = "Action will be triggered when avg latency is greater than 1500ms"
+
+  criteria {
+    metric_namespace = "Microsoft.Cdn/profiles"
+    metric_name      = "TotalLatency"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = var.latency_threshold
+
+    dimension {
+      name     = "Endpoint"
+      operator = "StartsWith"
+      values   = [var.hosted_zone[each.value].domains[0]]
+    }
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.main[0].id
+  }
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+}
+
+resource "azurerm_monitor_metric_alert" "fd_percent_5xx" {
+  for_each            = toset(var.alert_domains)
+
+  name                = "${var.hosted_zone[each.value].front_door_name}-metricalert-5xx"
+  resource_group_name = var.hosted_zone[each.value].resource_group_name
+  scopes              = [data.azurerm_cdn_frontdoor_profile.svc_domain[each.value].id]
+  description         = "Action will be triggered when 5xx failures greater than 10%"
+
+  criteria {
+    metric_namespace = "Microsoft.Cdn/profiles"
+    metric_name      = "Percentage5XX"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = var.percent_5xx_threshold
+
+    dimension {
+      name     = "Endpoint"
+      operator = "StartsWith"
+      values   = [var.hosted_zone[each.value].domains[0]]
+    }
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.main[0].id
+  }
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+}

--- a/terraform/custom_domains/environment_domains/terraform.tf
+++ b/terraform/custom_domains/environment_domains/terraform.tf
@@ -15,8 +15,4 @@ provider "azurerm" {
   features {}
 
   skip_provider_registration = true
-  subscription_id            = try(local.azure_credentials.subscriptionId, null)
-  client_id                  = try(local.azure_credentials.clientId, null)
-  client_secret              = try(local.azure_credentials.clientSecret, null)
-  tenant_id                  = try(local.azure_credentials.tenantId, null)
 }

--- a/terraform/custom_domains/environment_domains/terraform.tf
+++ b/terraform/custom_domains/environment_domains/terraform.tf
@@ -15,4 +15,8 @@ provider "azurerm" {
   features {}
 
   skip_provider_registration = true
+  subscription_id            = try(local.azure_credentials.subscriptionId, null)
+  client_id                  = try(local.azure_credentials.clientId, null)
+  client_secret              = try(local.azure_credentials.clientSecret, null)
+  tenant_id                  = try(local.azure_credentials.tenantId, null)
 }

--- a/terraform/custom_domains/environment_domains/variables.tf
+++ b/terraform/custom_domains/environment_domains/variables.tf
@@ -9,17 +9,12 @@ variable "multiple_hosted_zones" {
 }
 
 # Variables for Azure alerts
-variable "alert_domains" { default = null }
+variable "enable_alerting" { default = false }
+variable "pg_actiongroup_name" { default = null }
+variable "pg_actiongroup_rg" { default = null }
 variable "latency_threshold" {
-  default = 1500
+  default = 1000
 }
 variable "percent_5xx_threshold" {
   default = 10
-}
-
-variable "azure_credentials" { default = null }
-locals {
-  azure_credentials = try(jsondecode(var.azure_credentials), null)
-  infra_secrets     = yamldecode(data.azurerm_key_vault_secret.infra_secrets.value)
-  alert_emailgroup  = local.infra_secrets.ALERT_EMAILGROUP
 }

--- a/terraform/custom_domains/environment_domains/variables.tf
+++ b/terraform/custom_domains/environment_domains/variables.tf
@@ -7,3 +7,19 @@ variable "multiple_hosted_zones" {
   type = bool
   default = false
 }
+
+# Variables for Azure alerts
+variable "alert_domains" { default = null }
+variable "latency_threshold" {
+  default = 1500
+}
+variable "percent_5xx_threshold" {
+  default = 10
+}
+
+variable "azure_credentials" { default = null }
+locals {
+  azure_credentials = try(jsondecode(var.azure_credentials), null)
+  infra_secrets     = yamldecode(data.azurerm_key_vault_secret.infra_secrets.value)
+  alert_emailgroup  = local.infra_secrets.ALERT_EMAILGROUP
+}

--- a/terraform/custom_domains/environment_domains/workspace_variables/apply_production.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/apply_production.tfvars.json
@@ -1,5 +1,9 @@
 {
   "multiple_hosted_zones": true,
+  "enable_alerting": true,
+  "pg_actiongroup_name": "s189p01-att-production-ag",
+  "pg_actiongroup_rg": "s189p01-att-pd-rg",
+  "latency_threshold": 5000,
   "hosted_zone": {
     "apply-for-teacher-training.education.gov.uk": {
       "front_door_name": "s189p01-apply-edu-domains-fd",

--- a/terraform/custom_domains/environment_domains/workspace_variables/apply_qa.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/apply_qa.tfvars.json
@@ -1,5 +1,6 @@
 {
   "multiple_hosted_zones": true,
+  "alert_domains": ["apply-for-teacher-training.service.gov.uk"],
   "hosted_zone": {
     "apply-for-teacher-training.education.gov.uk": {
       "front_door_name": "s189p01-apply-edu-domains-fd",

--- a/terraform/custom_domains/environment_domains/workspace_variables/apply_qa.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/apply_qa.tfvars.json
@@ -1,6 +1,8 @@
 {
   "multiple_hosted_zones": true,
-  "alert_domains": ["apply-for-teacher-training.service.gov.uk"],
+  "enable_alerting": true,
+  "pg_actiongroup_name": "s189p01-att-production-ag",
+  "pg_actiongroup_rg": "s189p01-att-pd-rg",
   "hosted_zone": {
     "apply-for-teacher-training.education.gov.uk": {
       "front_door_name": "s189p01-apply-edu-domains-fd",

--- a/terraform/custom_domains/environment_domains/workspace_variables/apply_sandbox.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/apply_sandbox.tfvars.json
@@ -1,5 +1,6 @@
 {
   "multiple_hosted_zones": true,
+  "alert_domains": ["apply-for-teacher-training.service.gov.uk"],
   "hosted_zone": {
     "apply-for-teacher-training.education.gov.uk": {
       "front_door_name": "s189p01-apply-edu-domains-fd",

--- a/terraform/custom_domains/environment_domains/workspace_variables/apply_sandbox.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/apply_sandbox.tfvars.json
@@ -1,6 +1,8 @@
 {
   "multiple_hosted_zones": true,
-  "alert_domains": ["apply-for-teacher-training.service.gov.uk"],
+  "enable_alerting": true,
+  "pg_actiongroup_name": "s189p01-att-production-ag",
+  "pg_actiongroup_rg": "s189p01-att-pd-rg",
   "hosted_zone": {
     "apply-for-teacher-training.education.gov.uk": {
       "front_door_name": "s189p01-apply-edu-domains-fd",

--- a/terraform/custom_domains/environment_domains/workspace_variables/apply_staging.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/apply_staging.tfvars.json
@@ -1,5 +1,6 @@
 {
   "multiple_hosted_zones": true,
+  "alert_domains": ["apply-for-teacher-training.service.gov.uk"],
   "hosted_zone": {
     "apply-for-teacher-training.education.gov.uk": {
       "front_door_name": "s189p01-apply-edu-domains-fd",

--- a/terraform/custom_domains/environment_domains/workspace_variables/apply_staging.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/apply_staging.tfvars.json
@@ -1,6 +1,8 @@
 {
   "multiple_hosted_zones": true,
-  "alert_domains": ["apply-for-teacher-training.service.gov.uk"],
+  "enable_alerting": true,
+  "pg_actiongroup_name": "s189p01-att-production-ag",
+  "pg_actiongroup_rg": "s189p01-att-pd-rg",
   "hosted_zone": {
     "apply-for-teacher-training.education.gov.uk": {
       "front_door_name": "s189p01-apply-edu-domains-fd",

--- a/terraform/modules/kubernetes/monitoring.tf
+++ b/terraform/modules/kubernetes/monitoring.tf
@@ -1,0 +1,129 @@
+resource "azurerm_monitor_action_group" "main" {
+  count = var.enable_alerting ? 1 : 0
+
+  name                = "${local.webapp_name}-ag"
+  resource_group_name = var.resource_group_name
+  short_name          = "${var.app_environment}"
+
+  email_receiver {
+    name          = "${local.webapp_name}-email-receiver"
+    email_address = var.alert_emailgroup
+  }
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+}
+
+# Default is to evaluate alerts every 1 minute,
+# aggregated over the last 5 minutes
+
+resource "azurerm_monitor_metric_alert" "postgres_memory" {
+  count = var.enable_alerting ? (var.deploy_azure_backing_services ? 1 : 0 ) : 0
+
+  name                = "${azurerm_postgresql_flexible_server.postgres-server[0].name}-metricalert-memory"
+  resource_group_name = data.azurerm_resource_group.backing-service-resource-group[0].name
+  scopes              = [azurerm_postgresql_flexible_server.postgres-server[0].id]
+  description         = "Action will be triggered when memory use is greater than 75%"
+
+  criteria {
+    metric_namespace = "Microsoft.DBforPostgreSQL/flexibleServers"
+    metric_name      = "memory_percent"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = var.pg_memory_threshold
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.main[0].id
+  }
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+}
+
+resource "azurerm_monitor_metric_alert" "postgres_cpu" {
+  count = var.enable_alerting ? (var.deploy_azure_backing_services ? 1 : 0 ) : 0
+
+  name                = "${azurerm_postgresql_flexible_server.postgres-server[0].name}-metricalert-cpu"
+  resource_group_name = data.azurerm_resource_group.backing-service-resource-group[0].name
+  scopes              = [azurerm_postgresql_flexible_server.postgres-server[0].id]
+  description         = "Action will be triggered when cpu use is greater than 60%"
+
+  criteria {
+    metric_namespace = "Microsoft.DBforPostgreSQL/flexibleServers"
+    metric_name      = "cpu_percent"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = var.pg_cpu_threshold
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.main[0].id
+  }
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+}
+
+resource "azurerm_monitor_metric_alert" "postgres_storage" {
+  count = var.enable_alerting ? (var.deploy_azure_backing_services ? 1 : 0 ) : 0
+
+  name                = "${azurerm_postgresql_flexible_server.postgres-server[0].name}-metricalert-storage"
+  resource_group_name = data.azurerm_resource_group.backing-service-resource-group[0].name
+  scopes              = [azurerm_postgresql_flexible_server.postgres-server[0].id]
+  description         = "Action will be triggered when storage use is greater than 75%"
+
+  criteria {
+    metric_namespace = "Microsoft.DBforPostgreSQL/flexibleServers"
+    metric_name      = "storage_percent"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = var.pg_storage_threshold
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.main[0].id
+  }
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+}
+
+resource "azurerm_monitor_metric_alert" "redis_memory" {
+  count = var.enable_alerting ? (var.deploy_azure_backing_services ? 1 : 0 ) : 0
+
+  name                = "${azurerm_redis_cache.redis-queue[0].name}-metricalert-memory"
+  resource_group_name = data.azurerm_resource_group.backing-service-resource-group[0].name
+  scopes              = [azurerm_redis_cache.redis-queue[0].id]
+  description         = "Action will be triggered when memory use is greater than 60%"
+
+  criteria {
+    metric_namespace = "Microsoft.Cache/redis"
+    metric_name      = "allusedmemorypercentage"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = var.redis_memory_threshold
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.main[0].id
+  }
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+}

--- a/terraform/modules/kubernetes/monitoring.tf
+++ b/terraform/modules/kubernetes/monitoring.tf
@@ -1,20 +1,8 @@
-resource "azurerm_monitor_action_group" "main" {
+data "azurerm_monitor_action_group" "main" {
   count = var.enable_alerting ? 1 : 0
 
-  name                = "${local.webapp_name}-ag"
-  resource_group_name = var.resource_group_name
-  short_name          = "${var.app_environment}"
-
-  email_receiver {
-    name          = "${local.webapp_name}-email-receiver"
-    email_address = var.alert_emailgroup
-  }
-
-  lifecycle {
-    ignore_changes = [
-      tags
-    ]
-  }
+  name                = var.pg_actiongroup_name
+  resource_group_name = var.pg_actiongroup_rg
 }
 
 # Default is to evaluate alerts every 1 minute,
@@ -23,7 +11,7 @@ resource "azurerm_monitor_action_group" "main" {
 resource "azurerm_monitor_metric_alert" "postgres_memory" {
   count = var.enable_alerting ? (var.deploy_azure_backing_services ? 1 : 0 ) : 0
 
-  name                = "${azurerm_postgresql_flexible_server.postgres-server[0].name}-metricalert-memory"
+  name                = "${azurerm_postgresql_flexible_server.postgres-server[0].name}-memory"
   resource_group_name = data.azurerm_resource_group.backing-service-resource-group[0].name
   scopes              = [azurerm_postgresql_flexible_server.postgres-server[0].id]
   description         = "Action will be triggered when memory use is greater than 75%"
@@ -37,7 +25,7 @@ resource "azurerm_monitor_metric_alert" "postgres_memory" {
   }
 
   action {
-    action_group_id = azurerm_monitor_action_group.main[0].id
+    action_group_id = data.azurerm_monitor_action_group.main[0].id
   }
 
   lifecycle {
@@ -50,7 +38,7 @@ resource "azurerm_monitor_metric_alert" "postgres_memory" {
 resource "azurerm_monitor_metric_alert" "postgres_cpu" {
   count = var.enable_alerting ? (var.deploy_azure_backing_services ? 1 : 0 ) : 0
 
-  name                = "${azurerm_postgresql_flexible_server.postgres-server[0].name}-metricalert-cpu"
+  name                = "${azurerm_postgresql_flexible_server.postgres-server[0].name}-cpu"
   resource_group_name = data.azurerm_resource_group.backing-service-resource-group[0].name
   scopes              = [azurerm_postgresql_flexible_server.postgres-server[0].id]
   description         = "Action will be triggered when cpu use is greater than 60%"
@@ -64,7 +52,7 @@ resource "azurerm_monitor_metric_alert" "postgres_cpu" {
   }
 
   action {
-    action_group_id = azurerm_monitor_action_group.main[0].id
+    action_group_id = data.azurerm_monitor_action_group.main[0].id
   }
 
   lifecycle {
@@ -77,7 +65,7 @@ resource "azurerm_monitor_metric_alert" "postgres_cpu" {
 resource "azurerm_monitor_metric_alert" "postgres_storage" {
   count = var.enable_alerting ? (var.deploy_azure_backing_services ? 1 : 0 ) : 0
 
-  name                = "${azurerm_postgresql_flexible_server.postgres-server[0].name}-metricalert-storage"
+  name                = "${azurerm_postgresql_flexible_server.postgres-server[0].name}-storage"
   resource_group_name = data.azurerm_resource_group.backing-service-resource-group[0].name
   scopes              = [azurerm_postgresql_flexible_server.postgres-server[0].id]
   description         = "Action will be triggered when storage use is greater than 75%"
@@ -91,7 +79,7 @@ resource "azurerm_monitor_metric_alert" "postgres_storage" {
   }
 
   action {
-    action_group_id = azurerm_monitor_action_group.main[0].id
+    action_group_id = data.azurerm_monitor_action_group.main[0].id
   }
 
   lifecycle {
@@ -104,7 +92,7 @@ resource "azurerm_monitor_metric_alert" "postgres_storage" {
 resource "azurerm_monitor_metric_alert" "redis_memory" {
   count = var.enable_alerting ? (var.deploy_azure_backing_services ? 1 : 0 ) : 0
 
-  name                = "${azurerm_redis_cache.redis-queue[0].name}-metricalert-memory"
+  name                = "${azurerm_redis_cache.redis-queue[0].name}-memory"
   resource_group_name = data.azurerm_resource_group.backing-service-resource-group[0].name
   scopes              = [azurerm_redis_cache.redis-queue[0].id]
   description         = "Action will be triggered when memory use is greater than 60%"
@@ -118,7 +106,7 @@ resource "azurerm_monitor_metric_alert" "redis_memory" {
   }
 
   action {
-    action_group_id = azurerm_monitor_action_group.main[0].id
+    action_group_id = data.azurerm_monitor_action_group.main[0].id
   }
 
   lifecycle {

--- a/terraform/modules/kubernetes/variables.tf
+++ b/terraform/modules/kubernetes/variables.tf
@@ -65,6 +65,22 @@ variable "gov_uk_host_names" {
   type    = list(any)
 }
 
+# Variables for Azure alerts
+variable "alert_emailgroup" {}
+variable "enable_alerting" {}
+variable "pg_memory_threshold" {
+  default = 75
+}
+variable "pg_cpu_threshold" {
+  default = 60
+}
+variable "pg_storage_threshold" {
+  default = 75
+}
+variable "redis_memory_threshold" {
+  default = 60
+}
+
 locals {
   app_config_name                      = "apply-config-${var.app_environment}"
   app_resource_group_name              = "${var.resource_prefix}-${var.app_environment}-rg"

--- a/terraform/modules/kubernetes/variables.tf
+++ b/terraform/modules/kubernetes/variables.tf
@@ -66,8 +66,9 @@ variable "gov_uk_host_names" {
 }
 
 # Variables for Azure alerts
-variable "alert_emailgroup" {}
 variable "enable_alerting" {}
+variable "pg_actiongroup_name" {}
+variable "pg_actiongroup_rg" {}
 variable "pg_memory_threshold" {
   default = 75
 }


### PR DESCRIPTION
## Context

Add some basic monitoring until we get prometheus/grafana up and running

Create Azure monitoring alerts which will email the alert_emailgroup when triggered
- postgres memory, cpu and storage used
- redis memory used
- high request latency
- high 5xx request rate

## Changes proposed in this pull request

Add terraform config

## Guidance to review

Currently deployed for the review-8888 app in dev cluster5, 
although the cdn alerts are only an example, as the real cdn is in the production subscription.

While you could add postgres/redis alerts for any env that is using azure backing services,
cdn alerting is available for all envs, but is configured in the prod subscription as that is where fd is configured.

## Link to Trello card

https://trello.com/c/eRbGhIRF/84-basic-monitoring

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
