### PR TITLE
[88] Cache rails assets on AKS

### DIFF
--- a/terraform/custom_domains/environment_domains/.terraform.lock.hcl
+++ b/terraform/custom_domains/environment_domains/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   constraints = "3.43.0"
   hashes = [
     "h1:Oc/do6RovvNcKddQglsUeX1gWDeA1F7Fet+ajqWYb8M=",
+    "h1:zf15PjCXucKHP9MhpB1EgXKqqUWh/NJf7Hf1PoQChUE=",
     "zh:1a6d3553a8b9c85193d8334e8678aae305d14ec1d69b0d45799c322145d41475",
     "zh:1cb9ecd6531060c8f52d4f70863754ef18d3c297dee2aa173ce6dbd6f3c62621",
     "zh:21effe14cf1f5bace7aa172198ee2aa6ffc78324e4648af9b8df8b29995fa711",

--- a/terraform/custom_domains/environment_domains/main.tf
+++ b/terraform/custom_domains/environment_domains/main.tf
@@ -1,7 +1,7 @@
 # Used to create domains to be managed by front door.
 module "domains" {
   for_each              = var.hosted_zone
-  source                = "git::https://github.com/DFE-Digital/terraform-modules.git//domains/environment_domains?ref=0.5.2"
+  source                = "git::https://github.com/DFE-Digital/terraform-modules.git//domains/environment_domains?ref=0.5.3"
   zone                  = each.key
   front_door_name       = each.value.front_door_name
   resource_group_name   = each.value.resource_group_name
@@ -9,7 +9,8 @@ module "domains" {
   environment           = each.value.environment_short
   host_name             = each.value.origin_hostname
   multiple_hosted_zones = var.multiple_hosted_zones
-  null_host_header      = each.value.null_host_header
+  null_host_header      = try(each.value.null_host_header, null)
+  cached_paths          = try(each.value.cached_paths, null)
 }
 
 # Takes values from hosted_zone.domain_name.cnames (or txt_records, a-records). Use for domains which are not associated with front door.

--- a/terraform/custom_domains/environment_domains/workspace_variables/apply_pentest.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/apply_pentest.tfvars.json
@@ -5,6 +5,7 @@
       "front_door_name": "s189p01-apply-edu-domains-fd",
       "resource_group_name": "s189p01-applydomains-rg",
       "domains": ["pen"],
+      "cached_paths": ["/packs/*"],
       "environment_short": "pt",
       "environment_tag": "pt",
       "origin_hostname": "apply-pen.london.cloudapps.digital",
@@ -26,6 +27,7 @@
       "domains": [
         "pen"
       ],
+      "cached_paths": ["/packs/*"],
       "environment_short": "pt",
       "environment_tag": "pt",
       "origin_hostname": "apply-pen.london.cloudapps.digital",

--- a/terraform/custom_domains/environment_domains/workspace_variables/apply_production.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/apply_production.tfvars.json
@@ -7,6 +7,7 @@
       "domains": [
         "www2"
       ],
+      "cached_paths": ["/packs/*"],
       "environment_short": "pd",
       "environment_tag": "pd",
       "origin_hostname": "apply-prod.london.cloudapps.digital",
@@ -28,6 +29,7 @@
       "domains": [
         "www2"
       ],
+      "cached_paths": ["/packs/*"],
       "environment_short": "pd",
       "environment_tag": "pd",
       "origin_hostname": "apply-prod.london.cloudapps.digital",

--- a/terraform/custom_domains/environment_domains/workspace_variables/apply_qa.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/apply_qa.tfvars.json
@@ -7,6 +7,7 @@
       "domains": [
         "qa2"
       ],
+      "cached_paths": ["/packs/*"],
       "environment_short": "qa",
       "environment_tag": "qa",
       "origin_hostname": "apply-qa.test.teacherservices.cloud",
@@ -28,6 +29,7 @@
       "domains": [
         "qa2"
       ],
+      "cached_paths": ["/packs/*"],
       "environment_short": "qa",
       "environment_tag": "qa",
       "origin_hostname": "apply-qa.test.teacherservices.cloud",

--- a/terraform/custom_domains/environment_domains/workspace_variables/apply_sandbox.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/apply_sandbox.tfvars.json
@@ -7,6 +7,7 @@
       "domains": [
         "sandbox2"
       ],
+      "cached_paths": ["/packs/*"],
       "environment_short": "sbx",
       "environment_tag": "sbx",
       "origin_hostname": "apply-sandbox.teacherservices.cloud",
@@ -28,6 +29,7 @@
       "domains": [
         "sandbox2"
       ],
+      "cached_paths": ["/packs/*"],
       "environment_short": "sbx",
       "environment_tag": "sbx",
       "origin_hostname": "apply-sandbox.teacherservices.cloud",

--- a/terraform/custom_domains/environment_domains/workspace_variables/apply_staging.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/apply_staging.tfvars.json
@@ -7,6 +7,7 @@
       "domains": [
         "staging2"
       ],
+      "cached_paths": ["/packs/*"],
       "environment_short": "stg",
       "environment_tag": "stg",
       "origin_hostname": "apply-staging.test.teacherservices.cloud",
@@ -28,6 +29,7 @@
       "domains": [
         "staging2"
       ],
+      "cached_paths": ["/packs/*"],
       "environment_short": "stg",
       "environment_tag": "stg",
       "origin_hostname": "apply-staging.test.teacherservices.cloud",


### PR DESCRIPTION
## Context
Cache assets in the front door CDN when the app runs on AKS. As opposed to caching them in the cloudfront CDN when it runs on paas.

Depends on https://github.com/DFE-Digital/terraform-modules/pull/9

## Changes proposed in this pull request
Cache all requests with the `/packs/*` path

## Guidance to review
Apply to qa2. Observe requests for assets are not all passed to the ap

## Before merging
When https://github.com/DFE-Digital/terraform-modules/pull/9 is merged, update the module version in https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/terraform/custom_domains/environment_domains/main.tf#L4

## Link to Trello card
https://trello.com/c/jpKQdwQS

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
