### PR TITLE
Add validation for `SkeCondition#reason` values

### DIFF
--- a/app/components/provider_interface/ske_reason_component.rb
+++ b/app/components/provider_interface/ske_reason_component.rb
@@ -14,8 +14,8 @@ module ProviderInterface
 
     def options(ske_condition)
       [
-        SkeReason.new(id: :different_degree, name: first_option_label(ske_condition)),
-        SkeReason.new(id: :outdated_degree, name: second_option_label(ske_condition)),
+        SkeReason.new(id: SkeCondition::DIFFERENT_DEGREE_REASON, name: first_option_label(ske_condition)),
+        SkeReason.new(id: SkeCondition::OUTDATED_DEGREE_REASON, name: second_option_label(ske_condition)),
       ]
     end
 

--- a/app/models/ske_condition.rb
+++ b/app/models/ske_condition.rb
@@ -12,10 +12,9 @@ class SkeCondition < OfferCondition
     'ancient languages',
   ].freeze
 
-  VALID_REASONS = 
-  [
-    DIFFERENT_DEGREE_REASON = 'different_degree',
-    OUTDATED_DEGREE_REASON = 'outdated_degree',
+  VALID_REASONS = [
+    DIFFERENT_DEGREE_REASON = 'different_degree'.freeze,
+    OUTDATED_DEGREE_REASON = 'outdated_degree'.freeze,
   ].freeze
 
   validates :graduation_cutoff_date, presence: true, if: :outdated_degree?

--- a/app/models/ske_condition.rb
+++ b/app/models/ske_condition.rb
@@ -12,9 +12,16 @@ class SkeCondition < OfferCondition
     'ancient languages',
   ].freeze
 
+  VALID_REASONS = 
+  [
+    DIFFERENT_DEGREE_REASON = 'different_degree',
+    OUTDATED_DEGREE_REASON = 'outdated_degree',
+  ].freeze
+
   validates :graduation_cutoff_date, presence: true, if: :outdated_degree?
   validates :length, presence: true, on: :length
   validates :reason, presence: true, on: :reason
+  validates :reason, inclusion: { in: VALID_REASONS }, allow_nil: true
   validates :status, inclusion: { in: %w[met unmet] }
   validates :subject, inclusion: { in: VALID_LANGUAGES }, allow_blank: false, on: :subject, if: :language_subject?
   validates :subject, presence: true, on: :subject, if: :standard_subject?

--- a/app/services/data_migrations/store_enum_for_ske_reason.rb
+++ b/app/services/data_migrations/store_enum_for_ske_reason.rb
@@ -26,9 +26,9 @@ module DataMigrations
 
     def new_reason(old_reason)
       if old_reason.include?('degree subject was not')
-        'different_degree'
+        SkeCondition::DIFFERENT_DEGREE_REASON
       elsif old_reason.include?('but they graduated before')
-        'outdated_degree'
+        SkeCondition::OUTDATED_DEGREE_REASON
       else
         raise "Unknown reason: #{old_reason}"
       end

--- a/spec/components/provider_interface/ske_conditions_component_spec.rb
+++ b/spec/components/provider_interface/ske_conditions_component_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ProviderInterface::SkeConditionsComponent do
   end
 
   context 'when a language ske condition' do
-    let(:ske_condition) { build(:ske_condition, :language, length: '8', subject: 'French', reason: 'different_degree') }
+    let(:ske_condition) { build(:ske_condition, :language, length: '8', subject: 'French', reason: SkeCondition::DIFFERENT_DEGREE_REASON) }
 
     it 'renders the selected SKE values' do
       expect(result.text).to include('SubjectFrench')
@@ -26,7 +26,7 @@ RSpec.describe ProviderInterface::SkeConditionsComponent do
   end
 
   context 'when a standard ske condition' do
-    let(:ske_condition) { build(:ske_condition, length: '8', subject: 'Mathematics', reason: 'different_degree') }
+    let(:ske_condition) { build(:ske_condition, length: '8', subject: 'Mathematics', reason: SkeCondition::DIFFERENT_DEGREE_REASON) }
 
     it 'renders the subject from the course' do
       expect(result.text).to include('SubjectMathematics')

--- a/spec/factories/ske_condition.rb
+++ b/spec/factories/ske_condition.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     length { '8' }
     graduation_cutoff_date { 5.years.ago.iso8601 }
     status { 'unmet' }
-    reason { 'different_degree' }
+    reason { SkeCondition::DIFFERENT_DEGREE_REASON }
 
     trait :language do
       subject { 'French' }
@@ -15,7 +15,7 @@ FactoryBot.define do
     end
 
     trait :outdated_degree do
-      reason { 'outdated_degree' }
+      reason { SkeCondition::OUTDATED_DEGREE_REASON }
     end
   end
 end


### PR DESCRIPTION
## Context

This is a follow-up to https://github.com/DFE-Digital/apply-for-teacher-training/pull/7989

When testing changing courses with SKE conditions in the provider interface I had errors due to some bad data in `SkeCondition#reason`. This shouldn't happen in the wild but it makes sense to validate to a list of allowed values (and tidy up the hard-coded constants at the same time).

## Changes proposed in this pull request

Add an inclusion validation for `SkeCondition#reason` and tidy up a few hard-coded constants.

## Guidance to review

Does this seem sensible?

## Link to Trello card

Follow up to https://trello.com/c/ufdOHCeU/1043

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
