### PR TITLE
Change personal statement flows and return to application if empty

### DIFF
--- a/app/controllers/candidate_interface/personal_statement_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement_controller.rb
@@ -22,7 +22,11 @@ module CandidateInterface
       @becoming_a_teacher_form = BecomingATeacherForm.build_from_params(becoming_a_teacher_params)
 
       if @becoming_a_teacher_form.save(current_application)
-        redirect_to candidate_interface_becoming_a_teacher_show_path
+        if @becoming_a_teacher_form.blank?
+          redirect_to candidate_interface_application_form_path
+        else
+          redirect_to candidate_interface_becoming_a_teacher_show_path
+        end
       else
         track_validation_error(@becoming_a_teacher_form)
         render :new
@@ -34,7 +38,14 @@ module CandidateInterface
       @return_to = return_to_after_edit(default: candidate_interface_becoming_a_teacher_show_path)
 
       if @becoming_a_teacher_form.save(current_application)
-        redirect_to @return_to[:back_path]
+        if @becoming_a_teacher_form.blank?
+          if current_application.becoming_a_teacher_completed?
+            current_application.update!(becoming_a_teacher_completed: false)
+          end
+          redirect_to candidate_interface_application_form_path
+        else
+          redirect_to @return_to[:back_path]
+        end
       else
         track_validation_error(@becoming_a_teacher_form)
         render :edit

--- a/app/controllers/candidate_interface/personal_statement_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement_controller.rb
@@ -39,9 +39,7 @@ module CandidateInterface
 
       if @becoming_a_teacher_form.save(current_application)
         if @becoming_a_teacher_form.blank?
-          if current_application.becoming_a_teacher_completed?
-            current_application.update!(becoming_a_teacher_completed: false)
-          end
+          set_section_to_incomplete_if_completed
           redirect_to candidate_interface_application_form_path
         else
           redirect_to @return_to[:back_path]
@@ -65,6 +63,12 @@ module CandidateInterface
     end
 
   private
+
+    def set_section_to_incomplete_if_completed
+      if current_application.becoming_a_teacher_completed?
+        current_application.update!(becoming_a_teacher_completed: false)
+      end
+    end
 
     def becoming_a_teacher_params
       strip_whitespace params.require(:candidate_interface_becoming_a_teacher_form).permit(

--- a/app/controllers/candidate_interface/subject_knowledge_controller.rb
+++ b/app/controllers/candidate_interface/subject_knowledge_controller.rb
@@ -42,9 +42,7 @@ module CandidateInterface
 
       if @subject_knowledge_form.save(current_application)
         if @subject_knowledge_form.blank?
-          if current_application.subject_knowledge_completed?
-            current_application.update!(subject_knowledge_completed: false)
-          end
+          set_section_to_incomplete_if_completed
           redirect_to candidate_interface_application_form_path
         else
           redirect_to @return_to[:back_path]
@@ -69,6 +67,12 @@ module CandidateInterface
     end
 
   private
+
+    def set_section_to_incomplete_if_completed
+      if current_application.subject_knowledge_completed?
+        current_application.update!(subject_knowledge_completed: false)
+      end
+    end
 
     def subject_knowledge_params
       strip_whitespace params.require(:candidate_interface_subject_knowledge_form).permit(

--- a/app/controllers/candidate_interface/subject_knowledge_controller.rb
+++ b/app/controllers/candidate_interface/subject_knowledge_controller.rb
@@ -24,7 +24,11 @@ module CandidateInterface
       @subject_knowledge_form = SubjectKnowledgeForm.new(subject_knowledge_params)
 
       if @subject_knowledge_form.save(current_application)
-        redirect_to candidate_interface_subject_knowledge_show_path
+        if @subject_knowledge_form.blank?
+          redirect_to candidate_interface_application_form_path
+        else
+          redirect_to candidate_interface_subject_knowledge_show_path
+        end
       else
         track_validation_error(@subject_knowledge_form)
         @course_names = chosen_course_names
@@ -37,7 +41,14 @@ module CandidateInterface
       @return_to = return_to_after_edit(default: candidate_interface_subject_knowledge_show_path)
 
       if @subject_knowledge_form.save(current_application)
-        redirect_to @return_to[:back_path]
+        if @subject_knowledge_form.blank?
+          if current_application.subject_knowledge_completed?
+            current_application.update!(subject_knowledge_completed: false)
+          end
+          redirect_to candidate_interface_application_form_path
+        else
+          redirect_to @return_to[:back_path]
+        end
       else
         track_validation_error(@subject_knowledge_form)
         @course_names = chosen_course_names

--- a/app/forms/candidate_interface/becoming_a_teacher_form.rb
+++ b/app/forms/candidate_interface/becoming_a_teacher_form.rb
@@ -6,7 +6,6 @@ module CandidateInterface
 
     alias single_personal_statement? single_personal_statement
 
-    validate :presence_of_statement
     validates :becoming_a_teacher, word_count: { maximum: 1000 }, if: :single_personal_statement?
     validates :becoming_a_teacher, word_count: { maximum: 600 }, unless: :single_personal_statement?
 
@@ -17,11 +16,17 @@ module CandidateInterface
       )
     end
 
+    delegate :blank?, to: :becoming_a_teacher
+
     def self.build_from_params(params)
       new(
         single_personal_statement: params[:single_personal_statement],
         becoming_a_teacher: params[:becoming_a_teacher],
       )
+    end
+
+    def blank?
+      becoming_a_teacher.blank?
     end
 
     def save(application_form)

--- a/app/forms/candidate_interface/becoming_a_teacher_form.rb
+++ b/app/forms/candidate_interface/becoming_a_teacher_form.rb
@@ -25,9 +25,7 @@ module CandidateInterface
       )
     end
 
-    def blank?
-      becoming_a_teacher.blank?
-    end
+    delegate :blank?, to: :becoming_a_teacher
 
     def save(application_form)
       return false unless valid?

--- a/app/forms/candidate_interface/becoming_a_teacher_form.rb
+++ b/app/forms/candidate_interface/becoming_a_teacher_form.rb
@@ -9,6 +9,8 @@ module CandidateInterface
     validates :becoming_a_teacher, word_count: { maximum: 1000 }, if: :single_personal_statement?
     validates :becoming_a_teacher, word_count: { maximum: 600 }, unless: :single_personal_statement?
 
+    delegate :blank?, to: :becoming_a_teacher
+
     def self.build_from_application(application_form)
       new(
         single_personal_statement: application_form.single_personal_statement?,
@@ -16,16 +18,12 @@ module CandidateInterface
       )
     end
 
-    delegate :blank?, to: :becoming_a_teacher
-
     def self.build_from_params(params)
       new(
         single_personal_statement: params[:single_personal_statement],
         becoming_a_teacher: params[:becoming_a_teacher],
       )
     end
-
-    delegate :blank?, to: :becoming_a_teacher
 
     def save(application_form)
       return false unless valid?

--- a/app/forms/candidate_interface/subject_knowledge_form.rb
+++ b/app/forms/candidate_interface/subject_knowledge_form.rb
@@ -5,14 +5,15 @@ module CandidateInterface
     attr_accessor :subject_knowledge
 
     validates :subject_knowledge,
-              word_count: { maximum: 400 },
-              presence: true
+              word_count: { maximum: 400 }
 
     def self.build_from_application(application_form)
       new(
         subject_knowledge: application_form.subject_knowledge,
       )
     end
+
+    delegate :blank?, to: :subject_knowledge
 
     def save(application_form)
       return false unless valid?

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -252,13 +252,15 @@ module CandidateInterface
       application_form.becoming_a_teacher_completed
     end
 
-    def becoming_a_teacher_valid?
-      BecomingATeacherForm.build_from_application(application_form).valid?
+    def becoming_a_teacher_present?
+      BecomingATeacherForm.build_from_application(application_form).present?
     end
 
     def becoming_a_teacher_path
-      if becoming_a_teacher_valid?
+      if becoming_a_teacher_completed?
         Rails.application.routes.url_helpers.candidate_interface_becoming_a_teacher_show_path
+      elsif becoming_a_teacher_present?
+        Rails.application.routes.url_helpers.candidate_interface_edit_becoming_a_teacher_path
       else
         Rails.application.routes.url_helpers.candidate_interface_new_becoming_a_teacher_path
       end
@@ -270,6 +272,18 @@ module CandidateInterface
 
     def subject_knowledge_completed?
       application_form.subject_knowledge_completed
+    end
+
+    def subject_knowledge_path
+      if subject_knowledge_completed?
+        Rails.application.routes.url_helpers.candidate_interface_subject_knowledge_show_path
+      else
+        Rails.application.routes.url_helpers.candidate_interface_edit_subject_knowledge_path
+      end
+    end
+
+    def subject_knowledge_present?
+      SubjectKnowledgeForm.build_from_application(application_form).present?
     end
 
     def subject_knowledge_valid?

--- a/app/views/candidate_interface/unsubmitted_application_form/_task_list.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/_task_list.html.erb
@@ -101,7 +101,7 @@
         <%= render(TaskListItemComponent.new(
           text: t('page_titles.subject_knowledge'),
           completed: application_form_presenter.subject_knowledge_completed?,
-          path: application_form_presenter.subject_knowledge_valid? ? candidate_interface_subject_knowledge_show_path : candidate_interface_edit_subject_knowledge_path,
+          path: application_form_presenter.subject_knowledge_path,
           custom_status: application_form_presenter.subject_knowledge_review_pending? ? 'Review' : nil,
           custom_color: application_form_presenter.subject_knowledge_review_pending? ? 'pink' : nil,
         )) %>

--- a/config/locales/candidate_interface/personal_statement.yml
+++ b/config/locales/candidate_interface/personal_statement.yml
@@ -25,12 +25,10 @@ en:
         candidate_interface/becoming_a_teacher_form:
           attributes:
             becoming_a_teacher:
-              blank: Tell us why you want to be a teacher
               too_many_words: Your answer must be %{count} words or less
         candidate_interface/subject_knowledge_form:
           attributes:
             subject_knowledge:
-              blank: Describe why you're suited to teach your subjects or age group
               too_many_words: Your answer must be %{count} words or less
         candidate_interface/interview_preferences_form:
           attributes:

--- a/spec/forms/candidate_interface/becoming_a_teacher_form_spec.rb
+++ b/spec/forms/candidate_interface/becoming_a_teacher_form_spec.rb
@@ -40,6 +40,18 @@ RSpec.describe CandidateInterface::BecomingATeacherForm, type: :model do
     end
   end
 
+  describe '#blank?' do
+    it 'is blank when containing only whitespace' do
+      becoming_a_teacher = described_class.new(becoming_a_teacher: ' ')
+      expect(becoming_a_teacher).to be_blank
+    end
+
+    it 'is not blank when containing some text' do
+      becoming_a_teacher = described_class.new(becoming_a_teacher: 'Test')
+      expect(becoming_a_teacher).not_to be_blank
+    end
+  end
+
   describe 'validations' do
     let(:application_form) { create(:application_form) }
 
@@ -47,7 +59,7 @@ RSpec.describe CandidateInterface::BecomingATeacherForm, type: :model do
       FeatureFlag.activate(:one_personal_statement)
     end
 
-    it { is_expected.to validate_presence_of(:becoming_a_teacher) }
+    it { is_expected.not_to validate_presence_of(:becoming_a_teacher) }
 
     context 'new single personal statement' do
       before do

--- a/spec/forms/candidate_interface/subject_knowledge_form_spec.rb
+++ b/spec/forms/candidate_interface/subject_knowledge_form_spec.rb
@@ -24,6 +24,18 @@ RSpec.describe CandidateInterface::SubjectKnowledgeForm, type: :model do
     end
   end
 
+  describe '#blank?' do
+    it 'is blank when containing only whitespace' do
+      application_form = described_class.new(subject_knowledge: ' ')
+      expect(application_form).to be_blank
+    end
+
+    it 'is not blank when containing some text' do
+      application_form = described_class.new(subject_knowledge: 'Test')
+      expect(application_form).not_to be_blank
+    end
+  end
+
   describe '#save' do
     it 'returns false if not valid' do
       subject_knowledge = described_class.new
@@ -41,7 +53,7 @@ RSpec.describe CandidateInterface::SubjectKnowledgeForm, type: :model do
   end
 
   describe 'validations' do
-    it { is_expected.to validate_presence_of(:subject_knowledge) }
+    it { is_expected.not_to validate_presence_of(:subject_knowledge) }
 
     valid_text = Faker::Lorem.sentence(word_count: 400)
     invalid_text = Faker::Lorem.sentence(word_count: 401)

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -546,22 +546,6 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
     end
   end
 
-  describe '#becoming_a_teacher_valid?' do
-    it 'returns true if the becoming a teacher section is valid' do
-      application_form = build(:completed_application_form, becoming_a_teacher_completed: false)
-      presenter = described_class.new(application_form)
-
-      expect(presenter).to be_becoming_a_teacher_valid
-    end
-
-    it 'returns false if the becoming a teacher section is invalid' do
-      application_form = build(:application_form, becoming_a_teacher_completed: false)
-      presenter = described_class.new(application_form)
-
-      expect(presenter).not_to be_becoming_a_teacher_valid
-    end
-  end
-
   describe '#subject_knowledge_completed?' do
     it 'returns true if the interview prefrences section is completed' do
       application_form = build(:application_form, subject_knowledge_completed: true)
@@ -587,7 +571,9 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
     end
 
     it 'returns false if the subject knowledge section is invalid' do
-      application_form = build(:application_form, subject_knowledge_completed: false)
+      invalid_text = Faker::Lorem.sentence(word_count: 401)
+      application_form = build(:application_form, subject_knowledge_completed: false, subject_knowledge: invalid_text)
+
       presenter = described_class.new(application_form)
 
       expect(presenter).not_to be_subject_knowledge_valid

--- a/spec/system/candidate_interface/entering_details/candidate_becoming_a_teacher_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_becoming_a_teacher_spec.rb
@@ -9,10 +9,10 @@ RSpec.feature 'Entering "Why do you want to be a teacher?"' do
 
     when_i_click_on_becoming_a_teacher
     and_i_submit_the_form
-    then_i_should_see_validation_errors
-    and_a_validation_error_is_logged_for_becoming_a_teacher
+    then_i_should_return_to_the_application
 
-    when_i_fill_in_an_answer
+    when_i_click_on_becoming_a_teacher
+    and_i_fill_in_an_answer
     and_i_submit_the_form
     then_i_can_check_my_answers
 
@@ -42,10 +42,6 @@ RSpec.feature 'Entering "Why do you want to be a teacher?"' do
     click_link t('page_titles.becoming_a_teacher')
   end
 
-  def then_i_should_see_validation_errors
-    expect(page).to have_content t('activemodel.errors.models.candidate_interface/becoming_a_teacher_form.attributes.becoming_a_teacher.blank')
-  end
-
   def and_a_validation_error_is_logged_for_becoming_a_teacher
     validation_error = ValidationError.last
     expect(validation_error).to be_present
@@ -60,7 +56,7 @@ RSpec.feature 'Entering "Why do you want to be a teacher?"' do
     fill_in t('becoming_a_teacher.label', scope:), with: 'Hello world'
   end
 
-  def when_i_fill_in_an_answer
+  def and_i_fill_in_an_answer
     scope = 'application_form.personal_statement'
     fill_in t('becoming_a_teacher.label', scope:), with: 'Hello world'
   end
@@ -72,6 +68,10 @@ RSpec.feature 'Entering "Why do you want to be a teacher?"' do
 
   def and_i_submit_the_form
     click_button t('continue')
+  end
+
+  def then_i_should_return_to_the_application
+    expect(page).to have_content('Your application')
   end
 
   def when_i_click_to_change_my_answer

--- a/spec/system/candidate_interface/entering_details/candidate_entering_subject_knowledge_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_subject_knowledge_spec.rb
@@ -12,9 +12,10 @@ RSpec.feature 'Entering subject knowledge' do
 
     when_i_click_on_subject_knowledge
     and_i_submit_the_form
-    then_i_should_see_validation_errors
+    then_i_should_return_to_the_application
 
-    when_i_fill_in_an_answer
+    when_i_click_on_subject_knowledge
+    and_i_fill_in_an_answer
     and_i_submit_the_form
     then_i_can_check_my_answers
 
@@ -60,7 +61,7 @@ RSpec.feature 'Entering subject knowledge' do
     click_change_link('evidence of subject knowledge')
   end
 
-  def when_i_fill_in_an_answer
+  def and_i_fill_in_an_answer
     scope = 'application_form.personal_statement'
     fill_in t('subject_knowledge.label', scope:), with: 'Hello world'
   end
@@ -106,5 +107,9 @@ RSpec.feature 'Entering subject knowledge' do
 
   def and_that_the_section_is_completed
     expect(page).to have_css('#your-suitability-to-teach-a-subject-or-age-group-badge-id', text: 'Completed')
+  end
+
+  def then_i_should_return_to_the_application
+    expect(page).to have_content('Your application')
   end
 end

--- a/spec/system/candidate_interface/entering_details/candidate_personal_statement_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_personal_statement_spec.rb
@@ -14,7 +14,12 @@ RSpec.feature 'Entering "Personal statement"' do
 
     when_i_click_on_personal_statement
     and_i_submit_the_form
-    then_i_should_see_validation_errors
+    then_i_should_return_to_the_application
+
+    when_i_click_on_personal_statement
+    and_i_fill_in_more_than_1000_words
+    and_i_submit_the_form
+    then_i_should_see_a_validation_error
     and_a_validation_error_is_logged_for_becoming_a_teacher
 
     when_i_fill_in_an_answer
@@ -51,8 +56,8 @@ RSpec.feature 'Entering "Personal statement"' do
     click_link 'Your personal statement'
   end
 
-  def then_i_should_see_validation_errors
-    expect(page).to have_content 'Write your personal statement'
+  def then_i_should_see_a_validation_error
+    expect(page).to have_content 'Your answer must be 1000 words or less'
   end
 
   def and_a_validation_error_is_logged_for_becoming_a_teacher
@@ -66,6 +71,10 @@ RSpec.feature 'Entering "Personal statement"' do
 
   def and_i_fill_in_some_details_but_omit_some_required_details
     fill_in 'Your personal statement', with: 'Hello world'
+  end
+
+  def and_i_fill_in_more_than_1000_words
+    fill_in 'Your personal statement', with: ('test ' * 1_001)
   end
 
   def when_i_fill_in_an_answer
@@ -104,5 +113,9 @@ RSpec.feature 'Entering "Personal statement"' do
 
   def and_that_the_section_is_completed
     expect(page).to have_css('#your-personal-statement-badge-id', text: 'Completed')
+  end
+
+  def then_i_should_return_to_the_application
+    expect(page).to have_content('Your application')
   end
 end


### PR DESCRIPTION
This updates the flow around the personal statement (and subject knowledge) so that:

* If the "Continue" button is pressed and the personal statement is blank, the user is returned to the main application task list instead of seeing an error. If the section was previously marked as completed, it is reset to incomplete.
* The main application task list page links to the "edit" screen instead of the "review" screen if the personal statement hasn't yet been marked as completed.

🗂️ [Trello card](https://trello.com/c/F9yTFTCu/1159-if-personal-statement-is-submitted-as-blank-return-user-to-the-application-task-list-with-the-section-still-marked-as-incomplete)
➡️ Related: [Allow personal statement to be saved even if over word limit](https://github.com/DFE-Digital/apply-for-teacher-training/pull/8021)

## Context

From analysing error messages shown to users, it is clear that one of the most common errors is users pressing the "Continue" button without having written anything into the personal statement field.

We assume that this is because they wanted to take a look at what was required for this section, and to see the guidance, but weren’t yet ready to actually write it.  They may not have realised that they need to use the back link, and so instead press the "Continue" button.

The second change (linking to edit screen if not yet completed) is just a minor one - to save users from having to click the "Change" link from the review screen.

## Alternative options

We could instead add a "Cancel" link next to the "Continue" button. However this would duplicate the "Back" link, which may be confusing. It also introduces a small but critical risk that users accidentally click this link instead of the Continue button, and lose the content they’ve written.

We could still show an error if a user had previously saved some content in the personal statement. This might reduce the risk of them accidentally blanking their personal statement. However this risk feels quite low, and there might be legitimate reasons why a user would want to remove their previous content and reset to a blank state?