### PR TITLE
Add adviser_status attribute to ApplicationForm

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -72,6 +72,7 @@ shared:
     - path
     - updated_at
   application_forms:
+    - adviser_status
     - becoming_a_teacher
     - becoming_a_teacher_completed
     - candidate_id

--- a/db/migrate/20230309104350_add_adviser_status_to_application_forms.rb
+++ b/db/migrate/20230309104350_add_adviser_status_to_application_forms.rb
@@ -1,0 +1,5 @@
+class AddAdviserStatusToApplicationForms < ActiveRecord::Migration[7.0]
+  def change
+    add_column :application_forms, :adviser_status, :string, null: false, default: :unassigned
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_14_083343) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_09_104350) do
   create_sequence "qualifications_public_id_seq", start: 120000
 
   # These are extensions that must be enabled in order to support this database
@@ -178,6 +178,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_14_083343) do
     t.datetime "volunteering_completed_at", precision: nil
     t.datetime "work_history_completed_at", precision: nil
     t.boolean "signed_up_for_adviser", default: false
+    t.string "adviser_status", default: "unassigned", null: false
     t.index ["candidate_id"], name: "index_application_forms_on_candidate_id"
     t.index ["submitted_at"], name: "index_application_forms_on_submitted_at"
   end


### PR DESCRIPTION
## Context

Currently we can only determine if a candidate has signed up for an adviser or not. The updated design for this journey displays a different UI to the candidate depending on their adviser status, so we are going to replace the `signed_up_for_adviser` attribute with an `adviser_status` attribute. 

## Changes proposed in this pull request

- Add adviser_status attribute to ApplicationForm

The possible values will be:

```
enum adviser_status: {
  unassigned: 'unassigned',
  waiting_to_be_assigned: 'waiting_to_be_assigned',
  assigned: 'assigned',
}
```

## Guidance to review

[Review app link](https://apply-review-8020.london.cloudapps.digital/candidate/account)

I was going to add an `inclusion` validator to the `ApplicationForm` for the enum but we don't appear to validate any of the `ApplicationForm` attributes directly, so I haven't.

Once we have updated the availability logic to use this new field we can remove the `signed_up_for_adviser` attribute.

The attribute will be populated lazily by the existing `SignUpAvailability` class and the feature isn't enabled in production so no need to backfill.

## Link to Trello card

[Trello-1258](https://trello.com/c/x0uvfL5y/1258-implement-design-tweaks-for-quickfire-tta-service)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
