### PR TITLE
Simplify the error messages for personal statement sections

### DIFF
--- a/config/locales/candidate_interface/personal_statement.yml
+++ b/config/locales/candidate_interface/personal_statement.yml
@@ -24,12 +24,12 @@ en:
           attributes:
             becoming_a_teacher:
               blank: Tell us why you want to be a teacher
-              too_many_words: Tell us why you want to be a teacher must be %{count} words or fewer
+              too_many_words: Your answer must be %{count} words or fewer
         candidate_interface/subject_knowledge_form:
           attributes:
             subject_knowledge:
               blank: Describe why you're suited to teach your subjects or age group
-              too_many_words: Your description about your suitability to teach your subjects or age group must be %{count} words or fewer
+              too_many_words: Your answer must be %{count} words or fewer
         candidate_interface/interview_preferences_form:
           attributes:
             any_preferences:

--- a/config/locales/candidate_interface/personal_statement.yml
+++ b/config/locales/candidate_interface/personal_statement.yml
@@ -24,12 +24,12 @@ en:
           attributes:
             becoming_a_teacher:
               blank: Tell us why you want to be a teacher
-              too_many_words: Your answer must be %{count} words or fewer
+              too_many_words: Your answer must be %{count} words or less
         candidate_interface/subject_knowledge_form:
           attributes:
             subject_knowledge:
               blank: Describe why you're suited to teach your subjects or age group
-              too_many_words: Your answer must be %{count} words or fewer
+              too_many_words: Your answer must be %{count} words or less
         candidate_interface/interview_preferences_form:
           attributes:
             any_preferences:


### PR DESCRIPTION
These sections have quite long and cumbersome error messages if the content is above the word count. This simplifies and shortens them.

## Screenshots

| Before | After |
| ----- | ----- |
| <img width="754" alt="Screenshot 2023-03-09 at 15 44 16" src="https://user-images.githubusercontent.com/30665/224080539-b7047b2d-4269-4045-b667-5b82318869e5.png"> | <img width="720" alt="Screenshot 2023-03-09 at 15 59 36" src="https://user-images.githubusercontent.com/30665/224081106-9c51763e-bf8d-4fad-a642-b430d3b6da39.png"> |
|  <img width="742" alt="Screenshot 2023-03-09 at 15 46 16" src="https://user-images.githubusercontent.com/30665/224080658-d0221ade-df2d-40ce-8f8b-6ccccdf9b617.png"> |   <img width="732" alt="Screenshot 2023-03-09 at 15 59 15" src="https://user-images.githubusercontent.com/30665/224081185-048d195e-3aeb-43a3-b3e0-235600084696.png"> |
