### PR TITLE
Matched content about teacher training advisers on both personal statement questions

### DIFF
--- a/app/views/candidate_interface/personal_statement/_form.html.erb
+++ b/app/views/candidate_interface/personal_statement/_form.html.erb
@@ -17,9 +17,7 @@
   <li>your thoughts on children’s wellbeing and the education system</li>
 </ul>
 
-<%= govuk_inset_text do %>
-  <p class="govuk-body">A <%= govuk_link_to_with_utm_params('teacher training adviser', t('get_into_teaching.url_get_an_adviser'), utm_campaign(params), current_application.phase) %> can help you with this section.</p>
-<% end %>
+<p class="govuk-body">Get help with your personal statement by speaking to our <%= govuk_link_to_with_utm_params('teacher training adviser', t('get_into_teaching.url_get_an_adviser'), utm_campaign(params), current_application.phase) %>. They were teachers and can give you free, one-to-one support.</p>
 
 <%= f.govuk_text_area :becoming_a_teacher, label: { text: t('application_form.personal_statement.becoming_a_teacher.label'), size: 'm' }, rows: 20, max_words: 600 %>
 <%= f.govuk_submit t('continue') %>

--- a/app/views/candidate_interface/subject_knowledge/_form.html.erb
+++ b/app/views/candidate_interface/subject_knowledge/_form.html.erb
@@ -18,7 +18,7 @@
   <li>understanding of the national curriculum</li>
 </ul>
 
-<p class="govuk-body">If you need help, you can speak to our <%= govuk_link_to_with_utm_params 'teacher training advisers', t('get_into_teaching.url_get_an_adviser_start'), utm_campaign(params), @current_application.phase %>. Our advisers were teachers and they can give you free, one-to-one support with your personal statement.</p>
+<p class="govuk-body">Get help with your personal statement by speaking to our <%= govuk_link_to_with_utm_params 'teacher training advisers', t('get_into_teaching.url_get_an_adviser_start'), utm_campaign(params), @current_application.phase %>. They were teachers and can give you free, one-to-one support.</p>
 
 <%= f.govuk_text_area :subject_knowledge, label: { text: t('application_form.personal_statement.subject_knowledge.label'), size: 'm' }, rows: 20, max_words: 400 %>
 <%= f.govuk_submit t('continue') %>


### PR DESCRIPTION
## Context

Noticed the content on each personal statement question was not consistent. Made changes to both to be more succinct and be the same across both.

## Changes proposed in this pull request

- removed inset text from the 'Why you want to be a teacher' question
- made the teacher training adviser content shorter across both personal statement questions

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
