### PR TITLE
Fix IP address issue on AKS QA and beyond

### DIFF
--- a/app/controllers/dfe_sign_in_controller.rb
+++ b/app/controllers/dfe_sign_in_controller.rb
@@ -68,7 +68,7 @@ private
       @local_user,
       device: {
         user_agent: request.user_agent,
-        ip_address: request.remote_ip,
+        ip_address: user_ip_address,
       },
     ).deliver_later
   end
@@ -119,5 +119,12 @@ private
 
   def target_path_is_support_path
     @target_path&.match(/^#{support_interface_path}/)
+  end
+
+  def user_ip_address
+    # If we are on AKS we need to use the x-real-ip header instead
+    # of the remote ip as X-FORWARDED-FOR constains the ip and proxies
+    # Rails is picking the proxy from last to first on remote_ip calls.
+    request.headers['x-real-ip'] || request.remote_ip
   end
 end

--- a/app/controllers/dfe_sign_in_controller.rb
+++ b/app/controllers/dfe_sign_in_controller.rb
@@ -123,8 +123,8 @@ private
 
   def user_ip_address
     # If we are on AKS we need to use the x-real-ip header instead
-    # of the remote ip as X-FORWARDED-FOR constains the ip and proxies
-    # Rails is picking the proxy from last to first on remote_ip calls.
-    request.headers['x-real-ip'] || request.remote_ip
+    # of the remote ip as X-FORWARDED-FOR contains the ip and proxies
+    # and Rails is picking the proxy from last to first on remote_ip calls.
+    request.headers['x-real-ip'].presence || request.remote_ip
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -151,9 +151,16 @@ Rails.application.configure do
 
   config.middleware.insert_before ActionDispatch::RemoteIp, FixAzureXForwardedForMiddleware
 
-  # Add AWS IP addresses to trusted proxy list
-  config.action_dispatch.trusted_proxies = [
-    ActionDispatch::RemoteIp::TRUSTED_PROXIES,
-    AWSIpRanges.cloudfront_ips.map { |proxy| IPAddr.new(proxy) },
-  ].flatten
+  # Don't add AWS IP ranges on AKS.
+  if ENV['KUBERNETES_SERVICE_HOST'].present?
+    config.action_dispatch.trusted_proxies = [
+      ActionDispatch::RemoteIp::TRUSTED_PROXIES,
+    ]
+  else
+    # Add AWS IP addresses to trusted proxy list
+    config.action_dispatch.trusted_proxies = [
+      ActionDispatch::RemoteIp::TRUSTED_PROXIES,
+      AWSIpRanges.cloudfront_ips.map { |proxy| IPAddr.new(proxy) },
+    ].flatten
+  end
 end


### PR DESCRIPTION
## Context

On AKS Rails is picking up the proxies instead of the real original ip so this PR adds the possibility to use the x-real-ip header  first and the remote ip second. 

*As PaaS don't have the x-real-ip set* **nothing** will change in PaaS production only on AKS.

Additionally, I added a check to not make AWS request when the app starts to boot if we are on AKS.