### PR TITLE
Change adviser sign up design/behaviour

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,11 +30,11 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: b4183f7116116c388eb1d5d77ce79c1a5e8c493b
+  revision: a7a90dcad3504755cde124a7e180cdc9e6211c2d
   specs:
-    get_into_teaching_api_client (3.1.0)
+    get_into_teaching_api_client (3.2.0)
       faraday (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (3.1.0)
+    get_into_teaching_api_client_faraday (3.2.0)
       activesupport
       faraday
       faraday-encoding

--- a/app/controllers/candidate_interface/adviser_sign_ups_controller.rb
+++ b/app/controllers/candidate_interface/adviser_sign_ups_controller.rb
@@ -35,7 +35,7 @@ module CandidateInterface
     def adviser_sign_up_params
       params
         .fetch(:adviser_sign_up, {})
-        .permit(:preferred_teaching_subject)
+        .permit(:preferred_teaching_subject_id)
     end
 
     def render_404_unless_available

--- a/app/services/adviser/constants.rb
+++ b/app/services/adviser/constants.rb
@@ -1,0 +1,14 @@
+class Adviser::Constants
+  CONSTANTS_PATH = 'config/adviser/constants.yml'.freeze
+
+  class << self
+    extend Forwardable
+    def_delegator :constants, :dig, :fetch
+
+  private
+
+    def constants
+      @constants ||= YAML.load_file(CONSTANTS_PATH).with_indifferent_access
+    end
+  end
+end

--- a/app/services/adviser/teaching_subjects.rb
+++ b/app/services/adviser/teaching_subjects.rb
@@ -1,32 +1,33 @@
 class Adviser::TeachingSubjects
-  SUBJECTS_IDS_TO_EXCLUDE = [
-    '6b793433-cd1f-e911-a979-000d3a20838a', # Art
-    'a62655a1-2afa-e811-a981-000d3a276620', # Media studies
-    'bc68e0c1-7212-e911-a974-000d3a206976', # No preference
-    'bc2655a1-2afa-e811-a981-000d3a276620', # Other
-    'ae2655a1-2afa-e811-a981-000d3a276620', # Physics with maths
-    'ba2655a1-2afa-e811-a981-000d3a276620', # Vocational health
-  ].freeze
-
-  PRIMARY_SUBJECT_ID = 'b02655a1-2afa-e811-a981-000d3a276620'.freeze
-
   def all
     @all ||= secondary + [primary]
   end
 
   def secondary
     @secondary_teaching_subjects ||= teaching_subjects.reject do |subject|
-      subject.id.in?(SUBJECTS_IDS_TO_EXCLUDE) || subject.id == PRIMARY_SUBJECT_ID
+      subject.id.in?(subject_ids_to_exclude) || subject.id == primary_subject_id
     end
   end
 
   def primary
-    @primary_teaching_subject ||= teaching_subjects.find { |subject| subject.id == PRIMARY_SUBJECT_ID }
+    @primary_teaching_subject ||= teaching_subjects.find { |subject| subject.id == primary_subject_id }
   end
 
 private
 
   def teaching_subjects
     @teaching_subjects ||= GetIntoTeachingApiClient::LookupItemsApi.new.get_teaching_subjects
+  end
+
+  def subject_ids_to_exclude
+    constants.fetch(:teaching_subjects, :excluded).values
+  end
+
+  def primary_subject_id
+    constants.fetch(:teaching_subjects, :primary)
+  end
+
+  def constants
+    Adviser::Constants
   end
 end

--- a/app/services/adviser/teaching_subjects.rb
+++ b/app/services/adviser/teaching_subjects.rb
@@ -1,5 +1,5 @@
 class Adviser::TeachingSubjects
-  SUBJECTS_TO_EXCLUDE = [
+  SUBJECTS_IDS_TO_EXCLUDE = [
     '6b793433-cd1f-e911-a979-000d3a20838a', # Art
     'a62655a1-2afa-e811-a981-000d3a276620', # Media studies
     'bc68e0c1-7212-e911-a974-000d3a206976', # No preference
@@ -16,7 +16,7 @@ class Adviser::TeachingSubjects
 
   def secondary
     @secondary_teaching_subjects ||= teaching_subjects.reject do |subject|
-      subject.id.in?(SUBJECTS_TO_EXCLUDE) || subject.id == PRIMARY_SUBJECT_ID
+      subject.id.in?(SUBJECTS_IDS_TO_EXCLUDE) || subject.id == PRIMARY_SUBJECT_ID
     end
   end
 

--- a/app/services/adviser/teaching_subjects.rb
+++ b/app/services/adviser/teaching_subjects.rb
@@ -1,0 +1,32 @@
+class Adviser::TeachingSubjects
+  SUBJECTS_TO_EXCLUDE = [
+    '6b793433-cd1f-e911-a979-000d3a20838a', # Art
+    'a62655a1-2afa-e811-a981-000d3a276620', # Media studies
+    'bc68e0c1-7212-e911-a974-000d3a206976', # No preference
+    'bc2655a1-2afa-e811-a981-000d3a276620', # Other
+    'ae2655a1-2afa-e811-a981-000d3a276620', # Physics with maths
+    'ba2655a1-2afa-e811-a981-000d3a276620', # Vocational health
+  ].freeze
+
+  PRIMARY_SUBJECT_ID = 'b02655a1-2afa-e811-a981-000d3a276620'.freeze
+
+  def all
+    @all ||= secondary + [primary]
+  end
+
+  def secondary
+    @secondary_teaching_subjects ||= teaching_subjects.reject do |subject|
+      subject.id.in?(SUBJECTS_TO_EXCLUDE) || subject.id == PRIMARY_SUBJECT_ID
+    end
+  end
+
+  def primary
+    @primary_teaching_subject ||= teaching_subjects.find { |subject| subject.id == PRIMARY_SUBJECT_ID }
+  end
+
+private
+
+  def teaching_subjects
+    @teaching_subjects ||= GetIntoTeachingApiClient::LookupItemsApi.new.get_teaching_subjects
+  end
+end

--- a/app/views/candidate_interface/adviser_sign_ups/new.html.erb
+++ b/app/views/candidate_interface/adviser_sign_ups/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.new_adviser_sign_up'), @adviser_sign_up.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, t('application_form.adviser_sign_up.back')) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -8,20 +8,27 @@
 
       <h1 class="govuk-heading-l"><%= t('application_form.adviser_sign_up.heading') %></h1>
 
-      <p class="govuk-body">
-       <%= t('application_form.adviser_sign_up.introduction') %>
-      </p>
+      <p class="govuk-body"><%= t('application_form.adviser_sign_up.introduction') %></p>
 
-      <%= render DfE::Autocomplete::View.new(
-        f,
-        attribute_name: :preferred_teaching_subject,
-        form_field: f.govuk_select(
-          :preferred_teaching_subject,
-          options_for_select(dfe_autocomplete_options(lookup_item_options(@adviser_sign_up.teaching_subjects)), f.object.preferred_teaching_subject),
-          label: { text: t('application_form.adviser_sign_up.preferred_teaching_subject.label'), tag: 'h2', size: 'm' },
-          hint: { text: t('application_form.adviser_sign_up.preferred_teaching_subject.hint') },
-        ),
-      ) %>
+      <ul class="govuk-list govuk-list--bullet">
+        <li><%= t('application_form.adviser_sign_up.bullets').first %></li>
+        <li><%= t('application_form.adviser_sign_up.bullets').second %></li>
+        <li><%= t('application_form.adviser_sign_up.bullets').third %></li>
+      </ul>
+
+      <%= f.govuk_radio_buttons_fieldset(:preferred_teaching_subject_id, legend: { size: 'm' }) do %>
+        <%= f.govuk_radio_button :preferred_teaching_subject_id, @adviser_sign_up.teaching_subject_primary.id,
+          label: { text: @adviser_sign_up.teaching_subject_primary.value },
+          link_errors: true %>
+        <%= f.govuk_radio_divider 'or' %>
+        <% @adviser_sign_up.teaching_subject_secondary.each do |subject| %>
+          <%= f.govuk_radio_button :preferred_teaching_subject_id, subject.id, label: { text: subject.value } %>
+        <% end %>
+      <% end %>
+
+      <p class="govuk-body">
+        <%= t('application_form.adviser_sign_up.disclaimer') %>
+      </p>
 
       <%= f.govuk_submit t('application_form.adviser_sign_up.submit_text') %>
     <% end %>

--- a/app/views/candidate_interface/shared/_support.html.erb
+++ b/app/views/candidate_interface/shared/_support.html.erb
@@ -1,4 +1,6 @@
 <aside class="app-related" role="complementary">
+  <%= render 'adviser_call_to_action', adviser_sign_up: @adviser_sign_up %>
+
   <h2 class="govuk-heading-s govuk-!-margin-bottom-2" id="support-title"><%= t('layout.support.title') %></h2>
 
   <ul class="govuk-list govuk-!-font-size-16">

--- a/app/views/candidate_interface/unsubmitted_application_form/_adviser_call_to_action.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/_adviser_call_to_action.html.erb
@@ -1,8 +1,28 @@
 <% if adviser_sign_up.available? %>
-  <section class="govuk-!-margin-bottom-8">
-    <div class="govuk-inset-text">
-      <p class="govuk-body">A <%= govuk_link_to('teacher training adviser', 'https://getintoteaching.education.gov.uk/teacher-training-advisers', target: :blank) %> can help you with this section.</p>
-      <%= govuk_link_to(t('application_form.adviser_sign_up.call_to_action'), new_candidate_interface_adviser_sign_up_path, class: 'govuk-button') %>
-    </div>
-  </section>
+  <h2 class="govuk-heading-s govuk-!-margin-bottom-2" id="support-title">
+    <%= t('application_form.adviser_sign_up.call_to_action.available.heading') %>
+  </h2>
+  <p class="govuk-body-s govuk-!-margin-bottom-2">
+    <%= t('application_form.adviser_sign_up.call_to_action.available.text') %>
+  </p>
+  <p class="govuk-body-s">
+    <%= govuk_link_to(
+      t('application_form.adviser_sign_up.call_to_action.available.button_text'),
+      new_candidate_interface_adviser_sign_up_path,
+    ) %>
+  </p>
+<% elsif adviser_sign_up.waiting_to_be_assigned_to_an_adviser? %>
+  <h2 class="govuk-heading-s govuk-!-margin-bottom-2" id="support-title">
+    <%= t('application_form.adviser_sign_up.call_to_action.waiting_to_be_assigned.heading') %>
+  </h2>
+  <p class="govuk-body-s">
+    <%= t('application_form.adviser_sign_up.call_to_action.waiting_to_be_assigned.text') %>
+  </p>
+<% elsif adviser_sign_up.already_assigned_to_an_adviser? %>
+  <h2 class="govuk-heading-s govuk-!-margin-bottom-2" id="support-title">
+    <%= t('application_form.adviser_sign_up.call_to_action.already_assigned.heading') %>
+  </h2>
+  <p class="govuk-body-s govuk-!-margin-bottom-2">
+    <%= t('application_form.adviser_sign_up.call_to_action.already_assigned.text') %>
+  </p>
 <% end %>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -11,8 +11,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'adviser_call_to_action', adviser_sign_up: @adviser_sign_up %>
-
     <section class="govuk-!-margin-bottom-8">
       <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.personal_details') %></h2>
       <ol class="app-task-list">

--- a/config/adviser/constants.yml
+++ b/config/adviser/constants.yml
@@ -1,0 +1,36 @@
+teaching_subjects:
+  primary: b02655a1-2afa-e811-a981-000d3a276620
+  excluded:
+    media_studies: a62655a1-2afa-e811-a981-000d3a276620
+    art: 6b793433-cd1f-e911-a979-000d3a20838a
+    no_preference: bc68e0c1-7212-e911-a974-000d3a206976
+    other: bc2655a1-2afa-e811-a981-000d3a276620
+    physics_with_maths: ae2655a1-2afa-e811-a981-000d3a276620
+    vocational_health: ba2655a1-2afa-e811-a981-000d3a276620
+channels:
+  apply: 222_750_049
+degree_status:
+  graduated: 222_750_000
+  studying: 222_750_001
+uk_degree_grades:
+  "First-class honours": 222_750_001
+  "Upper second-class honours (2:1)": 222_750_002
+  "Lower second-class honours (2:2)": 222_750_003
+degree_types:
+  domestic: 222_750_000
+  international: 222_750_005
+types:
+ interested_in_teacher_training: 222_750_000
+gcse:
+  true: 222_750_000
+  false: 222_750_001
+education_phases:
+  primary: 222_750_000
+  secondary: 222_750_001
+countries:
+  unknown: 76f5c2e6-74f9-e811-a97a-000d3a2760f2
+adviser_status:
+  unassigned: 222_750_000
+  waiting_to_be_assigned: 222_750_001
+  assigned: 222_750_003
+  previously_assigned: 222_750_004

--- a/config/locales/candidate_interface/adviser_sign_up.yml
+++ b/config/locales/candidate_interface/adviser_sign_up.yml
@@ -1,15 +1,35 @@
 en:
+  helpers:
+    legend:
+      adviser_sign_up:
+        preferred_teaching_subject_id: What are you interested in teaching?
+    hint:
+      adviser_sign_up:
+        preferred_teaching_subject_id: We're asking this so that a dedicated adviser can be assigned to you.
   application_form:
     adviser_sign_up:
-      heading: Sign up for a Teacher Training Adviser
+      back: Back to application
+      heading: Get a teacher training adviser
       introduction: |-
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas arcu mauris, lobortis ut ipsum eu,
-        ultricies blandit dolor. Cras malesuada, elit quis vulputate semper, ipsum dolor tempus arcu, nec
-        facilisis dolor libero at sapien.
-      submit_text: Sign up
-      call_to_action: Sign up for a TTA
+        Our advisers can answer your questions about how to put together the best application you can. They can help you with:
+      bullets:
+        - writing your personal statement
+        - understanding your different training options
+        - preparing for interviews
+      disclaimer: |-
+        If you continue, we'll share your personal details and the status of your application with a dedicated adviser.
+        We will not share your personal statement, qualifications or work history with them.
+      submit_text: Continue
       flash:
-        success: A Teacher Training Adviser will be in touch to help you with your application.
-      preferred_teaching_subject:
-        label: Which subject are you interested in teaching?
-        hint: Select 'Primary' if you are interested in teaching at a Primary School.
+        success: An adviser will contact you by email within 5 working days.
+      call_to_action:
+        available:
+          heading: Get a teacher training adviser
+          text: Our advisers have years of teaching experience and can give you free, one-to-one help with your application.
+          button_text: Get an adviser
+        waiting_to_be_assigned:
+          heading: Get a teacher training adviser
+          text: An adviser will contact you by email.
+        already_assigned:
+          heading: Speak to your teacher training adviser
+          text: Your adviser can give you free, one-to-one help with your application.

--- a/config/locales/candidate_interface/adviser_sign_up.yml
+++ b/config/locales/candidate_interface/adviser_sign_up.yml
@@ -11,7 +11,7 @@ en:
       back: Back to application
       heading: Get a teacher training adviser
       introduction: |-
-        Our advisers can answer your questions about how to put together the best application you can. They can help you with:
+        Our advisers were experienced teachers and can answer all your questions about how to put together the best application. They'll help you with:
       bullets:
         - writing your personal statement
         - understanding your different training options

--- a/config/locales/candidate_interface/adviser_sign_up.yml
+++ b/config/locales/candidate_interface/adviser_sign_up.yml
@@ -5,19 +5,19 @@ en:
         preferred_teaching_subject_id: What are you interested in teaching?
     hint:
       adviser_sign_up:
-        preferred_teaching_subject_id: We're asking this so that a dedicated adviser can be assigned to you.
+        preferred_teaching_subject_id: We’re asking this so that a dedicated adviser can be assigned to you.
   application_form:
     adviser_sign_up:
       back: Back to application
       heading: Get a teacher training adviser
       introduction: |-
-        Our advisers were experienced teachers and can answer all your questions about how to put together the best application. They'll help you with:
+        Our advisers were experienced teachers and can answer all your questions about how to put together the best application. They’ll help you with:
       bullets:
         - writing your personal statement
         - understanding your different training options
         - preparing for interviews
       disclaimer: |-
-        If you continue, we'll share your personal details and the status of your application with a dedicated adviser.
+        If you continue, we’ll share your personal details and the status of your application with a dedicated adviser.
         We will not share your personal statement, qualifications or work history with them.
       submit_text: Continue
       flash:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -441,7 +441,7 @@ en:
         adviser/sign_up:
           attributes:
             preferred_teaching_subject_id:
-              inclusion: You must select a subject from the list
+              inclusion: Select a subject you’re interested in teaching
 
   activerecord:
     attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,7 +98,7 @@ en:
       edit: Edit your personal information
       review: Check your personal information
     nationalities: What is your nationality?
-    new_adviser_sign_up: Sign up for a Teacher Training Adviser
+    new_adviser_sign_up: Get a teacher training adviser
     languages: Is English your main language?
     immigration_right_to_work: Right to work or study in the UK
     immigration_status: What is your immigration status?
@@ -440,7 +440,7 @@ en:
               already_signed_up: You have already signed up for a Teacher Training Adviser
         adviser/sign_up:
           attributes:
-            preferred_teaching_subject:
+            preferred_teaching_subject_id:
               inclusion: You must select a subject from the list
 
   activerecord:

--- a/spec/models/adviser/sign_up_spec.rb
+++ b/spec/models/adviser/sign_up_spec.rb
@@ -15,20 +15,14 @@ RSpec.describe Adviser::SignUp do
   subject(:sign_up) do
     described_class.new(
       application_form,
-      preferred_teaching_subject: preferred_teaching_subject&.value,
+      preferred_teaching_subject_id: preferred_teaching_subject&.id,
     )
   end
 
   describe 'validations' do
-    let(:valid_subjects) { [preferred_teaching_subject.value] }
+    let(:valid_subjects) { Adviser::TeachingSubjects.new.all.map(&:id) }
 
-    it { is_expected.to validate_inclusion_of(:preferred_teaching_subject).in_array(valid_subjects) }
-  end
-
-  describe '#teaching_subjects' do
-    it 'returns teaching subjects' do
-      expect(sign_up.teaching_subjects).to contain_exactly(preferred_teaching_subject)
-    end
+    it { is_expected.to validate_inclusion_of(:preferred_teaching_subject_id).in_array(valid_subjects) }
   end
 
   describe '#save' do

--- a/spec/services/adviser/constants_spec.rb
+++ b/spec/services/adviser/constants_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe Adviser::Constants do
+  describe '#fetch' do
+    it 'returns the constant value' do
+      expect(described_class.fetch('teaching_subjects', 'primary')).to eq('b02655a1-2afa-e811-a981-000d3a276620')
+      expect(described_class.fetch('uk_degree_grades')).to include('First-class honours' => 222_750_001)
+    end
+
+    it 'supports symbol keys' do
+      expect(described_class.fetch(:teaching_subjects, 'primary')).to eq('b02655a1-2afa-e811-a981-000d3a276620')
+    end
+
+    it 'supports boolean keys' do
+      expect(described_class.fetch(:gcse, true)).to eq(222_750_000)
+      expect(described_class.fetch(:gcse, false)).to eq(222_750_001)
+    end
+
+    it 'returns nil if the key is not found' do
+      expect(described_class.fetch(:unknown, :key)).to be_nil
+    end
+
+    it 'caches the YAML file' do
+      allow(YAML).to receive(:load_file).with(described_class::CONSTANTS_PATH).and_call_original
+
+      described_class.fetch('teaching_subjects')
+      described_class.fetch('uk_degree_grades')
+
+      expect(YAML).to have_received(:load_file).at_most(:once)
+    end
+  end
+end

--- a/spec/services/adviser/sign_up_availability_spec.rb
+++ b/spec/services/adviser/sign_up_availability_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Adviser::SignUpAvailability do
   let(:in_memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
   let(:application_form) { create(:completed_application_form, :with_domestic_adviser_qualifications) }
   let(:candidate_matchback_double) { instance_double(Adviser::CandidateMatchback, matchback: nil) }
+  let(:constants) { Adviser::Constants }
 
   subject(:availability) { described_class.new(application_form) }
 
@@ -105,7 +106,7 @@ RSpec.describe Adviser::SignUpAvailability do
     end
 
     context 'when the candidate is found in the GiT API' do
-      let(:assignment_status_id) { described_class::ADVISER_STATUS.key(ApplicationForm.adviser_statuses[:assigned]) }
+      let(:assignment_status_id) { constants.fetch(:adviser_status, :assigned) }
 
       before do
         api_model = GetIntoTeachingApiClient::TeacherTrainingAdviserSignUp.new(
@@ -123,19 +124,19 @@ RSpec.describe Adviser::SignUpAvailability do
       end
 
       context 'when the candidate is waiting to be assigned an adviser' do
-        let(:assignment_status_id) { described_class::ADVISER_STATUS.key(ApplicationForm.adviser_statuses[:waiting_to_be_assigned]) }
+        let(:assignment_status_id) { constants.fetch(:adviser_status, :waiting_to_be_assigned) }
 
         it { expect { check_availability }.to change(application_form, :adviser_status).to(ApplicationForm.adviser_statuses[:waiting_to_be_assigned]) }
       end
 
       context 'when the candidate has not been assigned an adviser' do
-        let(:assignment_status_id) { described_class::ADVISER_STATUS.key(ApplicationForm.adviser_statuses[:unassigned]) }
+        let(:assignment_status_id) { constants.fetch(:adviser_status, :unassigned) }
 
         it { expect { check_availability }.to change(application_form, :adviser_status).to(ApplicationForm.adviser_statuses[:unassigned]) }
       end
 
       context 'when the candidate has been previously assigned to an adviser' do
-        let(:assignment_status_id) { described_class::ADVISER_STATUS.key(ApplicationForm.adviser_statuses[:previously_assigned]) }
+        let(:assignment_status_id) { constants.fetch(:adviser_status, :previously_assigned) }
 
         it { expect { check_availability }.to change(application_form, :adviser_status).to(ApplicationForm.adviser_statuses[:previously_assigned]) }
       end
@@ -157,7 +158,7 @@ RSpec.describe Adviser::SignUpAvailability do
   end
 
   def stub_matchback_with_adviser_status(status)
-    assignment_status_id = described_class::ADVISER_STATUS.key(ApplicationForm.adviser_statuses[status])
+    assignment_status_id = constants.fetch(:adviser_status, status)
     matchback_candidate = GetIntoTeachingApiClient::TeacherTrainingAdviserSignUp.new(assignment_status_id:)
     allow(candidate_matchback_double).to receive(:matchback) { matchback_candidate }
   end

--- a/spec/services/adviser/teaching_subjects_spec.rb
+++ b/spec/services/adviser/teaching_subjects_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Adviser::TeachingSubjects do
+  include_context 'get into teaching api stubbed endpoints'
+
+  subject(:teaching_subjects) { described_class.new }
+
+  describe '#all' do
+    it 'returns the primary teaching subject and secondary teaching subjects' do
+      expect(teaching_subjects.all).to contain_exactly(primary_teaching_subject, preferred_teaching_subject)
+    end
+  end
+
+  describe '#secondary' do
+    it 'returns secondary teaching subjects' do
+      expect(teaching_subjects.secondary).to contain_exactly(preferred_teaching_subject)
+    end
+
+    it 'excludes unwanted teaching subjects' do
+      expect(teaching_subjects.secondary).not_to include(excluded_teaching_subject)
+    end
+
+    it 'excludes the primary teaching subject' do
+      expect(teaching_subjects.secondary).not_to include(primary_teaching_subject)
+    end
+  end
+
+  describe '#primary' do
+    it 'returns the primary teaching subject' do
+      expect(teaching_subjects.primary).to eq(primary_teaching_subject)
+    end
+  end
+end

--- a/spec/support/shared_examples/get_into_teaching_api_stubbed_endpoints.rb
+++ b/spec/support/shared_examples/get_into_teaching_api_stubbed_endpoints.rb
@@ -19,6 +19,6 @@ RSpec.shared_context 'get into teaching api stubbed endpoints' do
   let(:privacy_policy) { GetIntoTeachingApiClient::PrivacyPolicy.new(id: SecureRandom.uuid, text: 'Privacy policy') }
   let(:country) { GetIntoTeachingApiClient::Country.new(id: SecureRandom.uuid, iso_code: 'GB') }
   let(:preferred_teaching_subject) { GetIntoTeachingApiClient::TeachingSubject.new(id: SecureRandom.uuid, value: 'Maths') }
-  let(:primary_teaching_subject) { GetIntoTeachingApiClient::TeachingSubject.new(id: Adviser::TeachingSubjects::PRIMARY_SUBJECT_ID, value: 'Primary') }
-  let(:excluded_teaching_subject) { GetIntoTeachingApiClient::TeachingSubject.new(id: Adviser::TeachingSubjects::SUBJECTS_IDS_TO_EXCLUDE.sample, value: 'Excluded') }
+  let(:primary_teaching_subject) { GetIntoTeachingApiClient::TeachingSubject.new(id: Adviser::Constants.fetch(:teaching_subjects, :primary), value: 'Primary') }
+  let(:excluded_teaching_subject) { GetIntoTeachingApiClient::TeachingSubject.new(id: Adviser::Constants.fetch(:teaching_subjects, :excluded).values.sample, value: 'Excluded') }
 end

--- a/spec/support/shared_examples/get_into_teaching_api_stubbed_endpoints.rb
+++ b/spec/support/shared_examples/get_into_teaching_api_stubbed_endpoints.rb
@@ -1,8 +1,7 @@
 RSpec.shared_context 'get into teaching api stubbed endpoints' do
   before do
-    lookup_items_api_double = instance_double(GetIntoTeachingApiClient::LookupItemsApi)
     allow(GetIntoTeachingApiClient::LookupItemsApi).to receive(:new).and_return(lookup_items_api_double)
-    allow(lookup_items_api_double).to receive(:get_teaching_subjects) { [preferred_teaching_subject].compact }
+    allow(lookup_items_api_double).to receive(:get_teaching_subjects) { [preferred_teaching_subject, primary_teaching_subject, excluded_teaching_subject].compact }
     allow(lookup_items_api_double).to receive(:get_countries) { [country].compact }
 
     pick_list_items_api_double = instance_double(GetIntoTeachingApiClient::PickListItemsApi)
@@ -14,9 +13,12 @@ RSpec.shared_context 'get into teaching api stubbed endpoints' do
     allow(privacy_policies_api_double).to receive(:get_latest_privacy_policy) { privacy_policy }
   end
 
+  let(:lookup_items_api_double) { instance_double(GetIntoTeachingApiClient::LookupItemsApi) }
   let(:this_year) { GetIntoTeachingApiClient::PickListItem.new(id: 1, value: Time.zone.today.year.to_s) }
   let(:next_year) { GetIntoTeachingApiClient::PickListItem.new(id: 2, value: 1.year.from_now.year.to_s) }
   let(:privacy_policy) { GetIntoTeachingApiClient::PrivacyPolicy.new(id: SecureRandom.uuid, text: 'Privacy policy') }
   let(:country) { GetIntoTeachingApiClient::Country.new(id: SecureRandom.uuid, iso_code: 'GB') }
   let(:preferred_teaching_subject) { GetIntoTeachingApiClient::TeachingSubject.new(id: SecureRandom.uuid, value: 'Maths') }
+  let(:primary_teaching_subject) { GetIntoTeachingApiClient::TeachingSubject.new(id: Adviser::TeachingSubjects::PRIMARY_SUBJECT_ID, value: 'Primary') }
+  let(:excluded_teaching_subject) { GetIntoTeachingApiClient::TeachingSubject.new(id: Adviser::TeachingSubjects::SUBJECTS_IDS_TO_EXCLUDE.sample, value: 'Excluded') }
 end

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_becomes_eligible_for_adviser_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_becomes_eligible_for_adviser_spec.rb
@@ -61,7 +61,7 @@ RSpec.feature 'Candidate becomes eligible for an adviser' do
   end
 
   def then_i_should_see_the_adviser_cta
-    expect(page).to have_link(t('application_form.adviser_sign_up.call_to_action'))
+    expect(page).to have_link(t('application_form.adviser_sign_up.call_to_action.available.button_text'))
   end
 
   def and_the_adviser_offering_should_be_tracked
@@ -73,6 +73,6 @@ RSpec.feature 'Candidate becomes eligible for an adviser' do
   end
 
   def then_i_should_not_see_the_adviser_cta
-    expect(page).not_to have_link(t('application_form.adviser_sign_up.call_to_action'))
+    expect(page).not_to have_link(t('application_form.adviser_sign_up.call_to_action.available.button_text'))
   end
 end

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_signs_up_for_an_adviser_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_signs_up_for_an_adviser_spec.rb
@@ -23,15 +23,11 @@ RSpec.feature 'Candidate signs up for an adviser', js: true do
     then_i_should_see_validation_errors_for_preferred_teaching_subject
     and_the_validation_error_should_be_tracked
 
-    when_i_fill_in_preferred_teaching_subject('unknown subject')
-    when_i_click_the_sign_up_button
-    then_i_should_see_validation_errors_for_preferred_teaching_subject
-
-    when_i_fill_in_preferred_teaching_subject(preferred_teaching_subject.value)
+    when_i_select_a_preferred_teaching_subject(preferred_teaching_subject.value)
     when_i_click_the_sign_up_button
     then_i_should_be_redirected_to_the_application_form_page
     and_i_should_see_the_success_message
-    and_i_should_not_see_the_adviser_cta
+    and_the_adviser_cta_be_replaced_with_the_waiting_to_be_assigned_message
     and_an_adviser_sign_up_job_should_be_enqueued
     and_the_sign_up_should_be_tracked
   end
@@ -79,7 +75,7 @@ RSpec.feature 'Candidate signs up for an adviser', js: true do
   end
 
   def when_i_click_on_the_adviser_cta
-    click_link t('application_form.adviser_sign_up.call_to_action')
+    click_link t('application_form.adviser_sign_up.call_to_action.available.button_text')
   end
 
   def then_i_should_be_on_the_adviser_sign_up_page
@@ -92,7 +88,7 @@ RSpec.feature 'Candidate signs up for an adviser', js: true do
 
   def then_i_should_see_validation_errors_for_preferred_teaching_subject
     expect(page).to have_content(
-      t('activemodel.errors.models.adviser/sign_up.attributes.preferred_teaching_subject.inclusion'),
+      t('activemodel.errors.models.adviser/sign_up.attributes.preferred_teaching_subject_id.inclusion'),
     )
   end
 
@@ -104,10 +100,8 @@ RSpec.feature 'Candidate signs up for an adviser', js: true do
     })
   end
 
-  def when_i_fill_in_preferred_teaching_subject(subject)
-    fill_in 'Which subject are you interested in teaching?', with: subject
-    # Triggering the autocomplete
-    find('input[name="adviser_sign_up[preferred_teaching_subject_raw]"]').native.send_keys(:return)
+  def when_i_select_a_preferred_teaching_subject(subject)
+    find('label', text: subject).click
   end
 
   def then_i_should_be_redirected_to_the_application_form_page
@@ -123,8 +117,9 @@ RSpec.feature 'Candidate signs up for an adviser', js: true do
       .with(@application_form.id, preferred_teaching_subject.id).once
   end
 
-  def and_i_should_not_see_the_adviser_cta
-    expect(page).not_to have_link(t('application_form.adviser_sign_up.call_to_action'))
+  def and_the_adviser_cta_be_replaced_with_the_waiting_to_be_assigned_message
+    expect(page).not_to have_link(t('application_form.adviser_sign_up.call_to_action.available.button_text'))
+    expect(page).to have_text(t('application_form.adviser_sign_up.call_to_action.waiting_to_be_assigned.text'))
   end
 
   def and_the_sign_up_should_be_tracked


### PR DESCRIPTION
## Context

This updates the content and design of the way that candidates can get a teacher training adviser through Apply.

We’ve changed the question about the subject to be more generic so that it also applies to Primary. The answers now use radios instead of an autocomplete, with Primary as the first option, separated by an "or". Some hint text explains why this question is being asked.

The call to action also changes depending on the adviser status of the candidate. The states are:

- Sign up unavailable and not currently assigned/waiting for an adviser (show nothing)
- Sign up available (show CTA button)
- Waiting to be assigned (state immediately after sign up)
- Adviser assigned (prompt them to contact their adviser)

## Changes proposed in this pull request

- Update GiT API client
- Add TeachingSubjects class
- Expand SignUpAvailability to check adviser status
- Update adviser sign up UI

## Guidance to review

[Link to review app](https://apply-review-8029.london.cloudapps.digital/)

Closes #8004

| Available | Waiting to be assigned | Assigned | Success | Sign up page |
| ----------- | ----------- | ----------- | ----------- | ----------- |
| <img width="1162" alt="Screenshot 2023-03-13 at 17 04 57" src="https://user-images.githubusercontent.com/29867726/224773941-1b6b7602-6ec5-4ff6-b6c3-8623735bc593.png">      | <img width="1162" alt="Screenshot 2023-03-13 at 17 04 27" src="https://user-images.githubusercontent.com/29867726/224773790-3801b41c-2a9e-45c6-82a6-ad278e89d753.png">       |  <img width="1162" alt="Screenshot 2023-03-13 at 17 05 38" src="https://user-images.githubusercontent.com/29867726/224774053-4fa9bb02-a136-40ea-9de3-9d2ab5978b0d.png">       |  <img width="1162" alt="Screenshot 2023-03-13 at 17 07 00" src="https://user-images.githubusercontent.com/29867726/224774369-5001c1fe-f1df-4671-9b30-aa01ecd37360.png">       | ![screencapture-localhost-3000-candidate-application-adviser-sign-ups-new-2023-03-13-17_09_46](https://user-images.githubusercontent.com/29867726/224775061-517fbf7f-eb54-4bfa-a599-faa8cd2eb565.png)   |

## Link to Trello card

[Trello-1258](https://trello.com/c/x0uvfL5y/1258-implement-design-tweaks-for-quickfire-tta-service)

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
