### PR TITLE
Remove 'other' as a selectable reason from R4R

### DIFF
--- a/config/rejection_reason_codes.yml
+++ b/config/rejection_reason_codes.yml
@@ -51,10 +51,3 @@ R08:
     :id: course_full_details
     :label: Details
     :text: We are unable to offer you a place on the chosen course because it is fully subscribed.
-R09:
-  :id: other
-  :label: Other
-  :details:
-    :id: other_details
-    :label: Details
-    :text: We were unable to offer you a place on the chosen course. Please contact us for details.

--- a/config/rejection_reasons.yml
+++ b/config/rejection_reasons.yml
@@ -117,8 +117,3 @@
     :id: course_full_details
     :label: Details (optional)
     :optional: true
-- :id: other
-  :label: Other
-  :details:
-    :id: other_details
-    :label: Details

--- a/spec/forms/provider_interface/rejections_wizard_spec.rb
+++ b/spec/forms/provider_interface/rejections_wizard_spec.rb
@@ -75,7 +75,6 @@ RSpec.describe ProviderInterface::RejectionsWizard do
         personal_statement_selected_reasons: %w[quality_of_writing],
         qualifications_other_details: 'There was no record of any of your qualifications.',
         quality_of_writing_details: 'We cannot accept applications written in Old Norse.',
-        other_details: 'There were a few other reasons why we rejected your application...',
       }
     end
 
@@ -96,7 +95,6 @@ RSpec.describe ProviderInterface::RejectionsWizard do
         personal_statement_selected_reasons: %w[quality_of_writing],
         qualifications_other_details: 'There was no record of any of your qualifications.',
         quality_of_writing_details: 'We cannot accept applications written in Old Norse.',
-        other_details: 'There were a few other reasons why we rejected your application...',
       }
     end
 
@@ -109,7 +107,6 @@ RSpec.describe ProviderInterface::RejectionsWizard do
       expect(wizard.qualifications_other_details).to be_nil
       expect(wizard.personal_statement_selected_reasons).to be_empty
       expect(wizard.quality_of_writing_details).to be_nil
-      expect(wizard.other_details).to eq('There were a few other reasons why we rejected your application...')
     end
   end
 end

--- a/spec/models/vendor_api/rejection_reasons_spec.rb
+++ b/spec/models/vendor_api/rejection_reasons_spec.rb
@@ -27,15 +27,15 @@ RSpec.describe VendorAPI::RejectionReasons do
     it 'populates selected reasons from codes' do
       instance = described_class.new([
         { code: 'R01', details: 'No relevant qualifications' },
-        { code: 'R09', details: 'Some other stuff' },
+        { code: 'R08', details: 'Course is full' },
       ])
 
       expect(instance.selected_reasons.first).to be_a(RejectionReasons::Reason)
       expect(instance.selected_reasons.first.label).to eq('Qualifications')
       expect(instance.selected_reasons.first.details.text).to eq('No relevant qualifications')
       expect(instance.selected_reasons.last).to be_a(RejectionReasons::Reason)
-      expect(instance.selected_reasons.last.label).to eq('Other')
-      expect(instance.selected_reasons.last.details.text).to eq('Some other stuff')
+      expect(instance.selected_reasons.last.label).to eq('Course full')
+      expect(instance.selected_reasons.last.details.text).to eq('Course is full')
     end
   end
 

--- a/spec/requests/vendor_api/v1.2/post_reject_by_codes_spec.rb
+++ b/spec/requests/vendor_api/v1.2/post_reject_by_codes_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject-by-codes'
             details: 'Does not meet minimum GCSE requirements.',
           },
           {
-            code: 'R09',
-            details: 'Wearing clown shoes to the interview was odd.',
+            code: 'R08',
+            details: 'This course is now full.',
           },
         ],
       }
@@ -32,7 +32,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject-by-codes'
       expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse', '1.2', draft: false)
       expect(parsed_response['data']['attributes']['status']).to eq 'rejected'
       expect(parsed_response['data']['attributes']['rejection']).to match a_hash_including(
-        'reason' => "Qualifications:\nDoes not meet minimum GCSE requirements.\n\nOther:\nWearing clown shoes to the interview was odd.",
+        'reason' => "Qualifications:\nDoes not meet minimum GCSE requirements.\n\nCourse full:\nThis course is now full.",
       )
       expect(application_choice.reload.structured_rejection_reasons).to eq(
         'selected_reasons' => [
@@ -45,11 +45,11 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject-by-codes'
             },
           },
           {
-            'id' => 'other',
-            'label' => 'Other',
+            'id' => 'course_full',
+            'label' => 'Course full',
             'details' => {
-              'id' => 'other_details',
-              'text' => 'Wearing clown shoes to the interview was odd.',
+              'id' => 'course_full_details',
+              'text' => 'This course is now full.',
             },
           },
         ],

--- a/spec/system/provider_interface/provider_gives_feedback_for_rejected_by_default_spec.rb
+++ b/spec/system/provider_interface/provider_gives_feedback_for_rejected_by_default_spec.rb
@@ -68,8 +68,6 @@ RSpec.describe 'Reject an application' do
     fill_in 'rejection-reasons-personal-statement-other-details-field', with: 'This was wayyyyy too personal'
 
     check 'rejection-reasons-selected-reasons-course-full-field'
-    check 'rejection-reasons-selected-reasons-other-field'
-    fill_in 'rejection-reasons-other-details-field', with: 'There are so many other reasons why your application was rejected...'
   end
 
   def and_i_check_the_feedback_given
@@ -104,16 +102,6 @@ RSpec.describe 'Reject an application' do
       'Course full',
       'Course full',
     ])
-
-    expect(email[15..17]).to eq([
-      'Other',
-      'Other:',
-      'There are so many other reasons why your application was rejected...',
-    ])
-
-    expect(email.last).to eq(
-      "Contact #{@application_choice.current_course_option.provider.name} if you would like to talk about their feedback.",
-    )
 
     expect(page).to have_button('Give feedback')
   end
@@ -154,8 +142,5 @@ RSpec.describe 'Reject an application' do
 
     expect(page).to have_content('Course full')
     expect(page).to have_content('The course is full')
-
-    expect(page).to have_content('Other')
-    expect(page).to have_content('There are so many other reasons why your application was rejected...')
   end
 end

--- a/spec/system/provider_interface/reject_an_application_cancels_upcoming_interviews_spec.rb
+++ b/spec/system/provider_interface/reject_an_application_cancels_upcoming_interviews_spec.rb
@@ -62,8 +62,6 @@ RSpec.describe 'Reject an application with interviews' do
     fill_in 'rejection-reasons-personal-statement-other-details-field', with: 'This was wayyyyy too personal'
 
     check 'rejection-reasons-selected-reasons-course-full-field'
-    check 'rejection-reasons-selected-reasons-other-field'
-    fill_in 'rejection-reasons-other-details-field', with: 'There are so many other reasons why your application was rejected...'
 
     click_on t('continue')
   end

--- a/spec/system/provider_interface/reject_an_application_spec.rb
+++ b/spec/system/provider_interface/reject_an_application_spec.rb
@@ -73,8 +73,6 @@ RSpec.describe 'Reject an application' do
 
     check 'rejection-reasons-selected-reasons-course-full-field'
     fill_in 'rejection-reasons-course-full-details-field', with: 'Other courses exist'
-    check 'rejection-reasons-selected-reasons-other-field'
-    fill_in 'rejection-reasons-other-details-field', with: 'There are so many other reasons why your application was rejected...'
   end
 
   def and_i_check_the_reasons_for_rejection
@@ -110,16 +108,6 @@ RSpec.describe 'Reject an application' do
       'Course full:',
       'Other courses exist',
     ])
-
-    expect(email[16..18]).to eq([
-      'Other',
-      'Other:',
-      'There are so many other reasons why your application was rejected...',
-    ])
-
-    expect(email.last).to eq(
-      "Contact #{@application_choice.current_course_option.provider.name} if you would like to talk about their feedback.",
-    )
 
     expect(page).to have_button('Reject application')
   end
@@ -158,8 +146,5 @@ RSpec.describe 'Reject an application' do
 
     expect(page).to have_content('Course full')
     expect(page).to have_content('Other courses exist')
-
-    expect(page).to have_content('Other')
-    expect(page).to have_content('There are so many other reasons why your application was rejected...')
   end
 end

--- a/spec/system/wizard_cache_cleared_spec.rb
+++ b/spec/system/wizard_cache_cleared_spec.rb
@@ -132,8 +132,6 @@ RSpec.describe 'Clearing the wizard cache' do
     fill_in 'rejection-reasons-personal-statement-other-details-field', with: 'This was wayyyyy too personal'
 
     check 'rejection-reasons-selected-reasons-course-full-field'
-    check 'rejection-reasons-selected-reasons-other-field'
-    fill_in 'rejection-reasons-other-details-field', with: 'There are so many other reasons why your application was rejected...'
 
     click_on t('continue')
   end


### PR DESCRIPTION
## Context

A lot of users are selecting 'other' as a reason for rejecting a candidate. This makes the data a challenge to analyse as we end up with a lot of free text values. 

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="610" alt="image" src="https://user-images.githubusercontent.com/47917431/224720465-d5d31ae6-83fa-4847-bf90-e58878252e69.png">|<img width="608" alt="image" src="https://user-images.githubusercontent.com/47917431/224719883-b3fb281e-3d33-4420-8595-3da2a1c86bba.png">|

## Guidance to review

Go through the rejection flow. It doesn't exist.

Check the exports – these should work ok.

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
