### PR TITLE
Add the offer accepted at date to provider export

### DIFF
--- a/app/services/provider_interface/application_data_export.rb
+++ b/app/services/provider_interface/application_data_export.rb
@@ -60,6 +60,7 @@ module ProviderInterface
           'Rejection reasons' => application.rejection_reasons,
           'Candidate ID' => application.application_form.candidate.public_id,
           'Support reference' => application.application_form.support_reference,
+          'Offer accepted date' => application.accepted_at,
         }
       end
 

--- a/spec/services/provider_interface/application_data_export_spec.rb
+++ b/spec/services/provider_interface/application_data_export_spec.rb
@@ -92,6 +92,7 @@ RSpec.describe ProviderInterface::ApplicationDataExport do
         'Rejection reasons' => ApplicationChoiceExportDecorator.new(application_choice).rejection_reasons,
         'Candidate ID' => application_choice.application_form.candidate.public_id,
         'Support reference' => application_choice.application_form.support_reference,
+        'Offer accepted date' => application_choice.accepted_at,
       }
 
       expected.each do |key, expected_value|


### PR DESCRIPTION
## Context

We've had some user requests to include the date candidates accept their offer within our application export.

## Changes proposed in this pull request

Include the offer accepted_at date

## Guidance to review

Test the export on Manage. It'll appear as the last column (intentional decision on the chance users and using specific column lookups).

## Link to Trello card

https://trello.com/c/hO730yU0/1232

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
