### PR TITLE
Update the candidate API current version

### DIFF
--- a/app/lib/candidate_api_specification.rb
+++ b/app/lib/candidate_api_specification.rb
@@ -1,5 +1,5 @@
 class CandidateAPISpecification
-  CURRENT_VERSION = 'v1.1'.freeze
+  CURRENT_VERSION = 'v1.2'.freeze
   VERSIONS = ['v1.1', 'v1.2'].freeze
 
   def self.as_yaml(version = CURRENT_VERSION)

--- a/spec/requests/candidate_api/get_candidates_v1_1_spec.rb
+++ b/spec/requests/candidate_api/get_candidates_v1_1_spec.rb
@@ -1,10 +1,12 @@
 require 'rails_helper'
 
-RSpec.describe 'GET /candidate-api/candidates' do
+RSpec.describe 'GET /candidate-api/v1.1/candidates' do
   include CandidateAPISpecHelper
 
-  it_behaves_like 'an API endpoint requiring a date param', '/candidate-api/candidates', 'updated_since', ServiceAPIUser.candidate_user.create_magic_link_token!
-  it_behaves_like 'a candidate API endpoint', '/candidate-api/candidates', 'updated_since', 'v1.1'
+  let(:root_path) { '/candidate-api/v1.1/candidates' }
+
+  it_behaves_like 'an API endpoint requiring a date param', '/candidate-api/v1.1/candidates', 'updated_since', ServiceAPIUser.candidate_user.create_magic_link_token!
+  it_behaves_like 'a candidate API endpoint', '/candidate-api/v1.1/candidates', 'updated_since', 'v1.1'
 
   it 'returns applications ordered by created_at timestamp' do
     allow(ApplicationFormStateInferrer).to receive(:new).and_return(instance_double(ApplicationFormStateInferrer, state: :unsubmitted_not_started_form))
@@ -16,7 +18,7 @@ RSpec.describe 'GET /candidate-api/candidates' do
     TestSuiteTimeMachine.advance
     application_forms << create(:completed_application_form, candidate:)
 
-    get_api_request "/candidate-api/candidates?updated_since=#{CGI.escape(1.day.ago.iso8601)}", token: candidate_api_token
+    get_api_request "/candidate-api/v1.1/candidates?updated_since=#{CGI.escape(1.day.ago.iso8601)}", token: candidate_api_token
 
     response_data = parsed_response.dig('data', 0, 'attributes', 'application_forms')
 


### PR DESCRIPTION
## Context

https://www.apply-for-teacher-training.service.gov.uk/candidate-api currently returns v1.1, so you need to know to add v1.2 to the URL to get the latest documentation.

## Changes proposed in this pull request

Change the current version to `1.2`

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/X9jeaRYV

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
