### PR TITLE
Provider interface - update SKE condition and application status

### DIFF
--- a/app/components/provider_interface/individual_condition_status_form_component.html.erb
+++ b/app/components/provider_interface/individual_condition_status_form_component.html.erb
@@ -9,7 +9,7 @@
   <h1 class="govuk-heading-l">Update status of conditions</h1>
 
   <div class="app-box govuk-!-margin-bottom-7">
-    <%= render ProviderInterface::ConditionsListComponent.new(application_choice.offer.conditions) %>
+    <%= render ProviderInterface::ConditionsListComponent.new(form_object.conditions) %>
   </div>
 
   <% form_object.conditions.each do |condition| %>

--- a/app/controllers/provider_interface/condition_statuses/checks_controller.rb
+++ b/app/controllers/provider_interface/condition_statuses/checks_controller.rb
@@ -2,12 +2,18 @@ module ProviderInterface
   module ConditionStatuses
     class ChecksController < ConditionStatusesController
       def edit
-        @form_object = ConfirmConditionsWizard.new(condition_statuses_store, { offer: @application_choice.offer })
+        @form_object = ConfirmConditionsWizard.new(
+          condition_statuses_store,
+          { offer: @application_choice.offer },
+        )
         @form_object.save_state!
       end
 
       def update
-        @form_object = ConfirmConditionsWizard.new(condition_statuses_store, attributes_for_wizard)
+        @form_object = ConfirmConditionsWizard.new(
+          condition_statuses_store,
+          attributes_for_wizard,
+        )
         @form_object.save_state!
 
         if @form_object.valid?

--- a/app/forms/provider_interface/confirm_conditions_wizard.rb
+++ b/app/forms/provider_interface/confirm_conditions_wizard.rb
@@ -7,7 +7,7 @@ module ProviderInterface
     validate :all_conditions_have_a_status_selected
 
     def conditions
-      duplicate_conditions = offer.conditions.map { |condition| duplicate_condition_with_id(condition) }
+      duplicate_conditions = offer_conditions.map { |condition| duplicate_condition_with_id(condition) }
 
       return duplicate_conditions if statuses.blank?
 
@@ -23,6 +23,14 @@ module ProviderInterface
     end
 
   private
+
+    def offer_conditions
+      if FeatureFlag.active?(:provider_ske)
+        offer.conditions
+      else
+        offer.all_conditions
+      end
+    end
 
     def duplicate_condition_with_id(condition)
       condition.dup.tap do |duplicate_condition|

--- a/app/forms/provider_interface/confirm_conditions_wizard.rb
+++ b/app/forms/provider_interface/confirm_conditions_wizard.rb
@@ -26,9 +26,9 @@ module ProviderInterface
 
     def offer_conditions
       if FeatureFlag.active?(:provider_ske)
-        offer.conditions
-      else
         offer.all_conditions
+      else
+        offer.conditions
       end
     end
 

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -2,6 +2,7 @@ class Offer < ApplicationRecord
   belongs_to :application_choice, touch: true
   has_many :conditions, -> { where(type: nil).order('created_at ASC') }, class_name: 'OfferCondition', dependent: :destroy
   has_many :ske_conditions, -> { where(type: 'SkeCondition').order('created_at ASC') }, class_name: 'SkeCondition', dependent: :destroy
+  has_many :all_conditions, -> { order('created_at ASC') }, class_name: 'OfferCondition', dependent: :destroy
 
   has_one :course_option, through: :application_choice, source: :current_course_option
 

--- a/app/models/ske_condition.rb
+++ b/app/models/ske_condition.rb
@@ -29,7 +29,7 @@ class SkeCondition < OfferCondition
 
   def initialize(attrs = {})
     attrs ||= {}
-    super({ status: :unmet }.merge(attrs))
+    super({ status: :pending }.merge(attrs))
   end
 
   def language_subject?

--- a/app/models/ske_condition.rb
+++ b/app/models/ske_condition.rb
@@ -45,6 +45,6 @@ class SkeCondition < OfferCondition
   end
 
   def text
-    subject
+    "#{subject} subject knowledge enhancement course"
   end
 end

--- a/app/models/ske_condition.rb
+++ b/app/models/ske_condition.rb
@@ -21,7 +21,7 @@ class SkeCondition < OfferCondition
   validates :length, presence: true, on: :length
   validates :reason, presence: true, on: :reason
   validates :reason, inclusion: { in: VALID_REASONS }, allow_nil: true
-  validates :status, inclusion: { in: %w[met unmet] }
+  validates :status, inclusion: { in: %w[pending met unmet] }
   validates :subject, inclusion: { in: VALID_LANGUAGES }, allow_blank: false, on: :subject, if: :language_subject?
   validates :subject, presence: true, on: :subject, if: :standard_subject?
 
@@ -42,5 +42,9 @@ class SkeCondition < OfferCondition
 
   def outdated_degree?
     reason == 'outdated_degree'
+  end
+
+  def text
+    subject
   end
 end

--- a/app/services/provider_interface/save_condition_statuses.rb
+++ b/app/services/provider_interface/save_condition_statuses.rb
@@ -50,7 +50,7 @@ module ProviderInterface
 
     def save_conditions
       statuses_form_object.conditions.each do |condition|
-        condition_to_update = application_choice.offer.conditions.find(condition.id)
+        condition_to_update = application_choice.offer.all_conditions.find(condition.id)
         detect_changed_statuses(condition_to_update, condition.status)
         condition_to_update.update!(status: condition.status)
       end

--- a/spec/factories/ske_condition.rb
+++ b/spec/factories/ske_condition.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     subject_type { 'standard' }
     length { '8' }
     graduation_cutoff_date { 5.years.ago.iso8601 }
-    status { 'unmet' }
+    status { 'pending' }
     reason { SkeCondition::DIFFERENT_DEGREE_REASON }
 
     trait :language do

--- a/spec/forms/provider_interface/confirm_conditions_wizard_spec.rb
+++ b/spec/forms/provider_interface/confirm_conditions_wizard_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ProviderInterface::ConfirmConditionsWizard do
     context 'when built from an offer' do
       it 'returns the conditions of the offer without SKE conditions' do
         expect(wizard.conditions).to eq(conditions)
-        expect(wizard.conditions).not_to include { |condition| condition.is_a?(SkeCondition) }
+        expect(wizard.conditions).not_to(include { |condition| condition.is_a?(SkeCondition) })
       end
     end
 
@@ -47,7 +47,7 @@ RSpec.describe ProviderInterface::ConfirmConditionsWizard do
 
       it 'returns the conditions of the offer including SKE conditions' do
         expect(wizard.conditions).to eq(conditions)
-        expect(wizard.conditions).to include { |condition| condition.is_a?(SkeCondition) }
+        expect(wizard.conditions).to(include { |condition| condition.is_a?(SkeCondition) })
       end
     end
 

--- a/spec/forms/provider_interface/confirm_conditions_wizard_spec.rb
+++ b/spec/forms/provider_interface/confirm_conditions_wizard_spec.rb
@@ -2,7 +2,16 @@ require 'rails_helper'
 
 RSpec.describe ProviderInterface::ConfirmConditionsWizard do
   let(:store) { instance_double(WizardStateStores::RedisStore) }
-  let(:offer) { create(:offer, conditions: [create(:offer_condition, status: :met), create(:offer_condition)]) }
+  let(:offer) {
+    create(
+      :offer,
+      conditions: [
+        create(:offer_condition, status: :met),
+        create(:offer_condition),
+        create(:ske_condition),
+      ],
+    )
+  }
   let(:conditions) { offer.conditions }
   let(:statuses) { nil }
 
@@ -27,8 +36,18 @@ RSpec.describe ProviderInterface::ConfirmConditionsWizard do
 
   describe '#conditions' do
     context 'when built from an offer' do
-      it 'returns the conditions of the offer' do
+      it 'returns the conditions of the offer without SKE conditions' do
         expect(wizard.conditions).to eq(conditions)
+        expect(wizard.conditions).not_to include { |condition| condition.is_a?(SkeCondition) }
+      end
+    end
+
+    context 'when built from an offer with provider_ske feature flag active' do
+      before { FeatureFlag.activate(:provider_ske) }
+
+      it 'returns the conditions of the offer including SKE conditions' do
+        expect(wizard.conditions).to eq(conditions)
+        expect(wizard.conditions).to include { |condition| condition.is_a?(SkeCondition) }
       end
     end
 

--- a/spec/models/ske_condition_spec.rb
+++ b/spec/models/ske_condition_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe SkeCondition do
+  describe '#text' do
+    it 'returns the subject in a human readable title' do
+      build(:ske_condition)
+
+      expect(build(:ske_condition).text).to eq('Mathematics subject knowledge enhancement course')
+    end
+  end
+end

--- a/spec/system/provider_interface/provider_marks_conditions_as_met_with_ske_disabled_spec.rb
+++ b/spec/system/provider_interface/provider_marks_conditions_as_met_with_ske_disabled_spec.rb
@@ -7,20 +7,18 @@ RSpec.feature 'Confirm conditions met' do
 
   scenario 'Provider user confirms offer conditions have been met by the candidate' do
     given_i_am_a_provider_user_with_dfe_sign_in
+    and_the_ske_feature_flag_is_inactive
     and_i_am_an_authorised_provider_user
     and_i_can_access_the_provider_interface
-    and_the_ske_feature_flag_is_active
 
     when_i_navigate_to_an_offer_accepted_by_the_candidate
     and_i_navigate_to_the_offer_tab
     then_i_should_see_change_offer_text
 
     when_i_click_on_confirm_conditions
-    then_i_should_see_a_summary_of_the_standard_conditions
-    then_i_should_see_a_summary_of_the_ske_condition
+    then_i_should_see_a_summary_of_the_conditions
 
-    when_i_select_they_have_met_all_the_standard_conditions
-    when_i_select_they_have_met_the_ske_conditions
+    when_i_select_they_have_met_all_the_conditions
     and_confirm_my_selection_in_the_next_page
 
     then_i_get_feedback_that_my_action_succeeded
@@ -35,8 +33,8 @@ RSpec.feature 'Confirm conditions met' do
     provider_exists_in_dfe_sign_in
   end
 
-  def and_the_ske_feature_flag_is_active
-    FeatureFlag.activate(:provider_ske)
+  def and_the_ske_feature_flag_is_inactive
+    FeatureFlag.deactivate(:provider_ske)
   end
 
   def and_i_am_an_authorised_provider_user
@@ -59,11 +57,10 @@ RSpec.feature 'Confirm conditions met' do
       last_name: 'Smith',
     )
     @conditions = create_list(:offer_condition, 3)
-    @ske_condition = create(:ske_condition, status: 'pending')
     @application_choice = create(
       :application_choice,
       :accepted,
-      offer: create(:offer, conditions: @conditions + [@ske_condition]),
+      offer: create(:offer, conditions: @conditions),
       current_course_option: course_option,
       application_form: @application_form,
     )
@@ -82,7 +79,7 @@ RSpec.feature 'Confirm conditions met' do
     click_on 'Update status of conditions'
   end
 
-  def then_i_should_see_a_summary_of_the_standard_conditions
+  def then_i_should_see_a_summary_of_the_conditions
     within '.app-box' do
       @conditions.each do |condition|
         expect(page).to have_content(condition.text)
@@ -90,23 +87,11 @@ RSpec.feature 'Confirm conditions met' do
     end
   end
 
-  def then_i_should_see_a_summary_of_the_ske_condition
-    within '.app-box' do
-      expect(page).to have_content(@ske_condition.subject)
-    end
-  end
-
-  def when_i_select_they_have_met_all_the_standard_conditions
+  def when_i_select_they_have_met_all_the_conditions
     @conditions.each do |condition|
       within_fieldset(condition.text) do
         choose 'Met'
       end
-    end
-  end
-
-  def when_i_select_they_have_met_the_ske_conditions
-    within_fieldset(@ske_condition.text) do
-      choose 'Met'
     end
 
     click_on t('continue')


### PR DESCRIPTION
## Context

We need to define the flow of the condition status for SKE in correlation to the application status.

## Changes proposed in this pull request

If the `provider_ske` feature flag is active and there are SKE conditions attached to an offer they should appear in the status panel and form of the _Update status of conditions_ page.

![image](https://user-images.githubusercontent.com/450843/225064361-084d56a4-0787-4b0b-9e96-7d0e1a5518b4.png)

This is what the check page, which appears after you click the _Continue_ button above, looks like now (no deliberate changes here):

![image](https://user-images.githubusercontent.com/450843/225064458-a0fe3b47-519d-4fd9-bc2c-6d181a65088a.png)


Question:

At the moment the provider sees this on the _Offer_ tab of the main application page (after the above flow):

![image](https://user-images.githubusercontent.com/450843/225278472-e3235f75-200a-4781-8294-db7d59dee9d6.png)

How do we want this to appear? (This could be handled in a separate PR). It seems we need the full details (course duration etc. as well as the title) but we are missing a flag to say that the condition is _met_. Would the following simple change work?

![image](https://user-images.githubusercontent.com/450843/225303089-0fb63cb7-b0d4-4cd7-9ad3-3f9ad0eccf02.png)


## Guidance to review

Per commit

## Link to Trello card

https://trello.com/c/zVDquTX4/1088-%E2%9B%B7%EF%B8%8F-ske-condition-status-application-status

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
