### PR TITLE
Migrate staging env to AKS

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -524,32 +524,6 @@ jobs:
           exclude: 'govuk-components,govuk_design_system_formbuilder,govuk-frontend'
           merge-method: merge
 
-  deploy-before-production:
-    name: Parallel deployment before production
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    environment:
-      name: ${{ matrix.environment }}
-      url: ${{ steps.deploy_app_before_production.outputs.deploy-url }}
-    needs: [lint, test]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        environment: [staging]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Deploy App to ${{ matrix.environment }}
-        id: deploy_app_before_production
-        uses: ./.github/actions/deploy/
-        with:
-          arm-access-key: ${{ secrets.ARM_ACCESS_KEY }}
-          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          environment: ${{ matrix.environment }}
-          sha: ${{ github.sha }}
-          slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
-
   deploy-aks-before-production:
     name: Parallel deployment before production v2
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -558,7 +532,6 @@ jobs:
       url: ${{ steps.deploy_app_before_production_v2.outputs.deploy-url }}
     needs: [lint, test]
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -583,7 +556,7 @@ jobs:
     environment:
       name: production
       url: ${{ steps.deploy_app.outputs.deploy-url }}
-    needs: [deploy-before-production,deploy-aks-before-production]
+    needs: [deploy-aks-before-production]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,6 @@ on:
         required: true
         type: choice
         options:
-        - staging
         - production
         - sandbox
         - loadtest

--- a/.github/workflows/scheduled-aks-db-restore.yml
+++ b/.github/workflows/scheduled-aks-db-restore.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [staging, sandbox, production]
+        environment: [sandbox, production]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/terraform/aks/workspace_variables/staging_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/staging_aks.tfvars.json
@@ -5,10 +5,7 @@
   "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-STAGING",
   "cluster": "test",
   "namespace": "bat-staging",
-  "gov_uk_host_names": [
-    "staging2.apply-for-teacher-training.service.gov.uk",
-    "staging2.apply-for-teacher-training.education.gov.uk"
-  ],
+  "gov_uk_host_names": ["staging.apply-for-teacher-training.service.gov.uk","staging.apply-for-teacher-training.education.gov.uk"],
   "webapp_memory_max": "1024Mi",
   "worker_memory_max": "1024Mi",
   "secondary_worker_memory_max": "1024Mi",
@@ -24,7 +21,7 @@
   "statuscake_alerts": {
     "apply-staging": {
       "website_name": "Apply-Teacher-Training-AKS-Staging",
-      "website_url": "https://staging2.apply-for-teacher-training.service.gov.uk/integrations/monitoring/all",
+      "website_url": "https://staging.apply-for-teacher-training.service.gov.uk/integrations/monitoring/all",
       "check_rate": 30,
       "contact_group": [
         282783
@@ -32,7 +29,7 @@
     },
     "apply-staging-check": {
       "website_name": "Apply-Teacher-Training-Check-AKS-Staging",
-      "website_url": "https://staging2.apply-for-teacher-training.service.gov.uk/check",
+      "website_url": "https://staging.apply-for-teacher-training.service.gov.uk/check",
       "check_rate": 30,
       "contact_group": [
         282783

--- a/terraform/custom_domains/environment_domains/workspace_variables/apply_staging.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/apply_staging.tfvars.json
@@ -10,7 +10,7 @@
       "front_door_name": "s189p01-apply-edu-domains-fd",
       "resource_group_name": "s189p01-applydomains-rg",
       "domains": [
-        "staging2"
+        "staging"
       ],
       "cached_paths": ["/packs/*"],
       "environment_short": "stg",
@@ -18,10 +18,6 @@
       "origin_hostname": "apply-staging.test.teacherservices.cloud",
       "null_host_header": true,
       "cnames": {
-        "staging": {
-          "target": "d2hsy40vkk0kkh.cloudfront.net",
-          "ttl": 300
-        },
         "_1d4b1f5476af8d39d1661df9e6d7e63e.staging": {
           "target": "_5a3f2a4df63ba5e370e6036e7757f323.bbfvkzsszw.acm-validations.aws",
           "ttl": 86400
@@ -32,7 +28,7 @@
       "front_door_name": "s189p01-apply-svc-domains-fd",
       "resource_group_name": "s189p01-applydomains-rg",
       "domains": [
-        "staging2"
+        "staging"
       ],
       "cached_paths": ["/packs/*"],
       "environment_short": "stg",
@@ -40,17 +36,9 @@
       "origin_hostname": "apply-staging.test.teacherservices.cloud",
       "null_host_header": true,
       "cnames": {
-        "staging-assets": {
-          "target": "d325g8v033lilj.cloudfront.net",
-          "ttl": 300
-        },
         "_829232a7a8d7b8feb96f04e168b309a3.staging-assets": {
           "target": "_cb8025b2433e4e200440af49798b0811.gwpjclltnz.acm-validations.aws",
           "ttl": 86400
-        },
-        "staging": {
-          "target": "d2hsy40vkk0kkh.cloudfront.net",
-          "ttl": 300
         },
         "_5b4d5b584c2120b1a977ec93d64580b0.staging": {
           "target": "_6c257c0fff3b6426ce3e75937fc7c077.bbfvkzsszw.acm-validations.aws",


### PR DESCRIPTION
## Context

Migrate Staging from PaaS to AKS

## Changes proposed in this pull request

- DNS and frontdoor changes
- aks env changed from staging2 to staging
- paas staging env removed from workflow 

## Guidance to review

make apply staging domains-plan
make staging_aks deploy-plan PASSCODE=1 IMAGE_TAG=xxxxx 

## Link to Trello card

https://trello.com/c/SAzkjfGF/132-apply-migrate-staging-environment

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
