### PR TITLE
Update prod front door config now AKS is deployed

### DIFF
--- a/terraform/custom_domains/environment_domains/workspace_variables/apply_production.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/apply_production.tfvars.json
@@ -10,8 +10,8 @@
       "cached_paths": ["/packs/*"],
       "environment_short": "pd",
       "environment_tag": "pd",
-      "origin_hostname": "apply-prod.london.cloudapps.digital",
-      "null_host_header": false,
+      "origin_hostname": "apply-production.teacherservices.cloud",
+      "null_host_header": true,
       "cnames": {
         "www": {
           "target": "d1xbatyhdsd23r.cloudfront.net",
@@ -32,8 +32,8 @@
       "cached_paths": ["/packs/*"],
       "environment_short": "pd",
       "environment_tag": "pd",
-      "origin_hostname": "apply-prod.london.cloudapps.digital",
-      "null_host_header": false,
+      "origin_hostname": "apply-production.teacherservices.cloud",
+      "null_host_header": true,
       "cnames": {
         "assets": {
           "target": "dxhwikmjcbucp.cloudfront.net",


### PR DESCRIPTION
## Context

The www2 route through front door previously pointed to the PaaS instance of the application. Now the AKS deployment in production is there, we need to ensure the front door route points to AKS.

## Changes proposed in this pull request

Update the origin for the www2 route by updating the `origin_hostname`

## Guidance to review

This change has already been applied.

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
