### PR TITLE
Add code to support pod disruption budget

### DIFF
--- a/terraform/aks/terraform.tf
+++ b/terraform/aks/terraform.tf
@@ -28,9 +28,10 @@ module "kubernetes" {
   redis_family                        = var.redis_family
   redis_sku_name                      = var.redis_sku_name
   gov_uk_host_names                   = var.gov_uk_host_names
-  pg_actiongroup_name                  = var.pg_actiongroup_name
-  pg_actiongroup_rg                    = var.pg_actiongroup_rg
+  pg_actiongroup_name                 = var.pg_actiongroup_name
+  pg_actiongroup_rg                   = var.pg_actiongroup_rg
   enable_alerting                     = var.enable_alerting
+  pdb_min_available                   = var.pdb_min_available
 }
 
 module "statuscake" {

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -92,6 +92,7 @@ variable "postgres_enable_high_availability" { default = false }
 variable "redis_capacity" { default = 1 }
 variable "redis_family" { default = "C" }
 variable "redis_sku_name" { default = "Standard" }
+variable "pdb_min_available" { default = null }
 
 locals {
   app_name_suffix = var.app_name_suffix != null ? var.app_name_suffix : var.paas_app_environment
@@ -104,7 +105,7 @@ locals {
   app_env_values_from_yaml = try(yamldecode(file("${path.module}/workspace-variables/${var.paas_app_environment}_app_env.yml")), {})
 
   review_url_vars = {
-    "CUSTOM_HOSTNAME" = "apply-${local.app_name_suffix}.test.teacherservices.cloud"
+    "CUSTOM_HOSTNAME"  = "apply-${local.app_name_suffix}.test.teacherservices.cloud"
     "AUTHORISED_HOSTS" = "apply-${local.app_name_suffix}.test.teacherservices.cloud"
   }
 

--- a/terraform/aks/workspace_variables/production_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/production_aks.tfvars.json
@@ -7,7 +7,10 @@
   "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-PRODUCTION",
   "cluster": "production",
   "namespace": "bat-production",
-  "gov_uk_host_names": ["www2.apply-for-teacher-training.service.gov.uk","www2.apply-for-teacher-training.education.gov.uk"],
+  "gov_uk_host_names": [
+    "www2.apply-for-teacher-training.service.gov.uk",
+    "www2.apply-for-teacher-training.education.gov.uk"
+  ],
   "webapp_memory_max": "6144Mi",
   "worker_memory_max": "4096Mi",
   "secondary_worker_memory_max": "4096Mi",
@@ -18,5 +21,6 @@
   "clock_worker_replicas": 0,
   "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
   "postgres_enable_high_availability": true,
-  "webapp_startup_command": "bundle exec rails db:prepare && bundle exec rails server -b 0.0.0.0"
+  "webapp_startup_command": "bundle exec rails db:prepare && bundle exec rails server -b 0.0.0.0",
+  "pdb_min_available": "50%"
 }

--- a/terraform/aks/workspace_variables/qa_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/qa_aks.tfvars.json
@@ -7,7 +7,10 @@
   "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-QA",
   "cluster": "test",
   "namespace": "bat-qa",
-  "gov_uk_host_names": ["qa.apply-for-teacher-training.service.gov.uk","qa.apply-for-teacher-training.education.gov.uk"],
+  "gov_uk_host_names": [
+    "qa.apply-for-teacher-training.service.gov.uk",
+    "qa.apply-for-teacher-training.education.gov.uk"
+  ],
   "webapp_memory_max": "1024Mi",
   "worker_memory_max": "1024Mi",
   "secondary_worker_memory_max": "1024Mi",

--- a/terraform/aks/workspace_variables/sandbox_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/sandbox_aks.tfvars.json
@@ -7,7 +7,10 @@
   "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-SANDBOX",
   "cluster": "production",
   "namespace": "bat-production",
-  "gov_uk_host_names": ["sandbox2.apply-for-teacher-training.service.gov.uk","sandbox2.apply-for-teacher-training.education.gov.uk"],
+  "gov_uk_host_names": [
+    "sandbox2.apply-for-teacher-training.service.gov.uk",
+    "sandbox2.apply-for-teacher-training.education.gov.uk"
+  ],
   "webapp_memory_max": "1024Mi",
   "worker_memory_max": "1024Mi",
   "secondary_worker_memory_max": "1024Mi",
@@ -20,5 +23,6 @@
   "postgres_enable_high_availability": true,
   "enable_alerting": true,
   "pg_actiongroup_name": "s189p01-att-production-ag",
-  "pg_actiongroup_rg": "s189p01-att-pd-rg"
+  "pg_actiongroup_rg": "s189p01-att-pd-rg",
+  "pdb_min_available": "50%"
 }

--- a/terraform/aks/workspace_variables/staging_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/staging_aks.tfvars.json
@@ -7,7 +7,10 @@
   "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-STAGING",
   "cluster": "test",
   "namespace": "bat-staging",
-  "gov_uk_host_names": ["staging2.apply-for-teacher-training.service.gov.uk","staging2.apply-for-teacher-training.education.gov.uk"],
+  "gov_uk_host_names": [
+    "staging2.apply-for-teacher-training.service.gov.uk",
+    "staging2.apply-for-teacher-training.education.gov.uk"
+  ],
   "webapp_memory_max": "1024Mi",
   "worker_memory_max": "1024Mi",
   "secondary_worker_memory_max": "1024Mi",

--- a/terraform/modules/kubernetes/availability.tf
+++ b/terraform/modules/kubernetes/availability.tf
@@ -1,0 +1,16 @@
+resource "kubernetes_pod_disruption_budget_v1" "pdb" {
+  count = var.pdb_min_available != null ? 1 : 0
+
+  metadata {
+    name      = "${local.webapp_name}-pdb"
+    namespace = var.namespace
+  }
+  spec {
+    min_available = var.pdb_min_available
+    selector {
+      match_labels = {
+        app = local.webapp_name
+      }
+    }
+  }
+}

--- a/terraform/modules/kubernetes/variables.tf
+++ b/terraform/modules/kubernetes/variables.tf
@@ -81,6 +81,10 @@ variable "pg_storage_threshold" {
 variable "redis_memory_threshold" {
   default = 60
 }
+variable "pdb_min_available" {
+  type    = string
+  default = null
+}
 
 locals {
   app_config_name                      = "apply-config-${var.app_environment}"


### PR DESCRIPTION
## Context

When we make changes to the AKS cluster that involves moving or evicting workloads we need to ensure that enough instances of existing workloads remain available to service requests. This can be achieved by using pod disruption budgets (PDB). More details about these: https://learn.microsoft.com/en-us/azure/aks/operator-best-practices-scheduler.

## Changes proposed in this pull request

Add the ability to specify either the min available property of a pod disruption budget using the tfvars file. This allows each environment to potentially have a different PDB. The PDB is matched by the label `app`.

## Guidance to review

- Checkout the branch
- Add the following to the tfvars file:
```
  "webapp_replicas": 8,
  "pdb_min_available": "50%"
```
- Run `make review_aks deploy PR_NUMBER=8044 PASSCODE=1 IMAGE_TAG=a0ca7e21599f7a9ae2d8e2a550258a8bffd1887f` and apply the PDB and instance increase.
- From the teacher-services-cloud GitHub project run `make test get-cluster-credentials`
- Run `kubectl get pdb -A`
- You should see the new PDB created

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
