### PR TITLE
Vendor API changes for SKE conditions

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -16,4 +16,8 @@ class Offer < ApplicationRecord
   def conditions_text
     conditions.pluck(:text)
   end
+
+  def all_conditions_text
+    all_conditions.map(&:text)
+  end
 end

--- a/app/presenters/concerns/decisions_api_data.rb
+++ b/app/presenters/concerns/decisions_api_data.rb
@@ -40,10 +40,16 @@ module DecisionsAPIData
     return nil if application_choice.offer.nil?
 
     {
-      conditions: application_choice.offer.conditions_text,
+      conditions: conditions_text,
       offer_made_at: application_choice.offered_at,
       offer_accepted_at: application_choice.accepted_at,
       offer_declined_at: application_choice.declined_at,
     }.merge(current_course)
+  end
+
+private
+
+  def conditions_text
+    FeatureFlag.active?(:provider_ske) ? application_choice.offer.all_conditions_text : application_choice.offer.conditions_text
   end
 end

--- a/spec/factories/offer.rb
+++ b/spec/factories/offer.rb
@@ -9,7 +9,12 @@ FactoryBot.define do
     end
 
     trait :with_ske_conditions do
-      conditions { [association(:ske_condition, offer: instance)] }
+      conditions {
+        [
+          build(:offer_condition),
+          build(:ske_condition),
+        ]
+      }
     end
   end
 

--- a/spec/presenters/concerns/decisions_api_data_spec.rb
+++ b/spec/presenters/concerns/decisions_api_data_spec.rb
@@ -103,13 +103,22 @@ RSpec.describe DecisionsAPIData do
         create(:application_choice, :with_completed_application_form, :offered)
       end
 
-      before do
-        FeatureFlag.activate(:provider_ske)
-        create(:ske_condition, offer: application_choice.offer)
+      before { create(:ske_condition, offer: application_choice.offer) }
+
+      context 'with `provider_ske` feature flag on' do
+        before { FeatureFlag.activate(:provider_ske) }
+
+        it 'includes the SKE condition as well as standard conditions' do
+          expect(presenter.offer[:conditions]).to include('Mathematics subject knowledge enhancement course')
+        end
       end
 
-      it 'includes the SKE condition as well as standard conditions' do
-        expect(presenter.offer[:conditions]).to include('Mathematics subject knowledge enhancement course')
+      context 'with `provider_ske` feature flag off' do
+        before { FeatureFlag.deactivate(:provider_ske) }
+
+        it 'includes the SKE condition as well as standard conditions' do
+          expect(presenter.offer[:conditions]).not_to include('Mathematics subject knowledge enhancement course')
+        end
       end
     end
 

--- a/spec/presenters/concerns/decisions_api_data_spec.rb
+++ b/spec/presenters/concerns/decisions_api_data_spec.rb
@@ -98,6 +98,21 @@ RSpec.describe DecisionsAPIData do
       end
     end
 
+    context 'when there is an offer with SKE conditions' do
+      let(:application_choice) do
+        create(:application_choice, :with_completed_application_form, :offered)
+      end
+
+      before do
+        FeatureFlag.activate(:provider_ske)
+        create(:ske_condition, offer: application_choice.offer)
+      end
+
+      it 'includes the SKE condition as well as standard conditions' do
+        expect(presenter.offer[:conditions]).to include('Mathematics subject knowledge enhancement course')
+      end
+    end
+
     context 'when there is an accepted offer' do
       let(:application_choice) { create(:application_choice, :with_completed_application_form, :accepted) }
 


### PR DESCRIPTION
## Context

Currently offer conditions are returned via the Vendor API as an array of strings. We just serialise the condition `text` which maps to a database column of the same name for regular conditions and to the `subject` for SKE conditions.

We want to make sure that providers have access to the condition text for all conditions (when the `provider_ske` feature flag is active).

## Changes proposed in this pull request

Override `DecisionsAPIData` presenter module to include SKE conditions iff the `provider_ske` feature flag is active.

## Guidance to review

We've taken a conservative approach to this change (limiting the scope of the changes to low-level methods that may be used for features outside the Vendor API). This leaves certain other features (e.g. candidate emails) without SKE conditions.

## Link to Trello card

[<!-- http://trello.com/123-example-card -->](https://trello.com/c/Wh38X6nQ/1039-%E2%9B%B7%EF%B8%8F-skeish-api-conditions)

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
