### PR TITLE
Add status tag to `SkeConditionsComponent`

### DIFF
--- a/app/components/provider_interface/ske_conditions_component.html.erb
+++ b/app/components/provider_interface/ske_conditions_component.html.erb
@@ -3,10 +3,11 @@
     title: 'Subject knowledge enhancement course',
     heading_level: :h2,
   )) do %>
-    <% if editable %>
-      <div class="app-summary-card__actions">
+    <div class="app-summary-card__actions">
+      <% if editable %>
         <%= govuk_link_to 'Change', remove_condition_path %>
-      </div>
-    <% end %>
+      <% end %>
+      <%= render ProviderInterface::ConditionStatusTagComponent.new(ske_condition) %>
+    </div>
   <% end %>
 <% end %>

--- a/spec/components/provider_interface/ske_conditions_component_spec.rb
+++ b/spec/components/provider_interface/ske_conditions_component_spec.rb
@@ -16,22 +16,30 @@ RSpec.describe ProviderInterface::SkeConditionsComponent do
   end
 
   context 'when a language ske condition' do
-    let(:ske_condition) { build(:ske_condition, :language, length: '8', subject: 'French', reason: SkeCondition::DIFFERENT_DEGREE_REASON) }
+    let(:ske_condition) { build(:ske_condition, :language, length: '8', subject: 'French', reason: SkeCondition::DIFFERENT_DEGREE_REASON, status: :met) }
 
     it 'renders the selected SKE values' do
       expect(result.text).to include('SubjectFrench')
       expect(result.text).to include('Length8 weeks')
       expect(result.text).to include('ReasonTheir degree subject was not French')
     end
+
+    it 'renders the condition status' do
+      expect(result.text).to include('Met')
+    end
   end
 
   context 'when a standard ske condition' do
-    let(:ske_condition) { build(:ske_condition, length: '8', subject: 'Mathematics', reason: SkeCondition::DIFFERENT_DEGREE_REASON) }
+    let(:ske_condition) { build(:ske_condition, length: '8', subject: 'Mathematics', reason: SkeCondition::DIFFERENT_DEGREE_REASON, status: :pending) }
 
     it 'renders the subject from the course' do
       expect(result.text).to include('SubjectMathematics')
       expect(result.text).to include('Length8 weeks')
       expect(result.text).to include('ReasonTheir degree subject was not Mathematics')
+    end
+
+    it 'renders the condition status' do
+      expect(result.text).to include('Pending')
     end
   end
 end


### PR DESCRIPTION
## Context

It should be possible for a provider to see at a glance whether a SKE condition is pending, met or unmet (just as it is with standard conditions).

## Changes proposed in this pull request

The status tag is just added to the title row of the SKE condition summary card:

![image](https://user-images.githubusercontent.com/450843/226299038-8826bdfa-b5d6-44b7-9f0c-ae802cb3a960.png)

## Guidance to review


## Link to Trello card

[<!-- http://trello.com/123-example-card -->
](https://trello.com/c/WJNHAHEP/1291-do-we-need-to-indicate-the-status-of-eg-met-ske-conditions-on-the-main-provider-offer-view)

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
