### PR TITLE
Fix test failure triggered by daylight savings

### DIFF
--- a/spec/services/reference_actions_policy_spec.rb
+++ b/spec/services/reference_actions_policy_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe ReferenceActionsPolicy do
       expect(policy(reference).can_send_reminder?).to be true
     end
 
-    it 'is true when state is feedback_requested and last reminder was sent 2 days ago' do
-      reference = build(:reference, :feedback_requested, reminder_sent_at: (2.days + 1.minute).ago)
+    it 'is true when state is feedback_requested and last reminder was sent over 2 days ago' do
+      reference = build(:reference, :feedback_requested, reminder_sent_at: (48.hours + 1.minute).ago)
       expect(policy(reference).can_send_reminder?).to be true
     end
 


### PR DESCRIPTION
## Context

Builds are failing due to a DST related mismatch in a test.

## Changes proposed in this pull request

We are comparing `2.days.ago` (test) with `48.hours.ago` (code under test) and the are off by an hour if we cross a DST threshold (which we do next weekend. This PR just changes to `48.hours.ago` in the test.

## Guidance to review



## Link to Trello card

n/a

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
