### PR TITLE
Render the SKE component on support

### DIFF
--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -99,7 +99,7 @@ module SupportInterface
 
       conditions_row = {
         key: 'Conditions',
-        value: render(SupportInterface::ConditionsComponent.new(conditions:)),
+        value: render(SupportInterface::ConditionsComponent.new(conditions:, application_choice:)),
       }
 
       conditions_row.merge({

--- a/app/components/support_interface/conditions_component.html.erb
+++ b/app/components/support_interface/conditions_component.html.erb
@@ -2,4 +2,15 @@
   <% conditions.each do |condition| %>
     <li><%= condition.text %></li>
   <% end %>
+
+  <div class="govuk-!-margin-top-2">
+    <% if render_ske? %>
+      <%= render(SummaryCardComponent.new(rows: ske_rows)) do %>
+        <%= render(SummaryCardHeaderComponent.new(
+          title: 'Subject knowledge enhancement course',
+          heading_level: :h2,
+        )) %>
+    <% end %>
+  <% end %>
+  </div>
 </ul>

--- a/app/components/support_interface/conditions_component.rb
+++ b/app/components/support_interface/conditions_component.rb
@@ -1,9 +1,37 @@
 module SupportInterface
   class ConditionsComponent < ViewComponent::Base
-    attr_accessor :conditions
+    attr_accessor :conditions, :application_choice
+    delegate :reason, :length, to: :ske_condition
 
-    def initialize(conditions:)
+    def initialize(conditions:, application_choice:)
       @conditions = conditions
+      @application_choice = application_choice
+    end
+
+    def ske_rows
+      [
+        { key: 'Subject', value: ske_condition.subject },
+        {
+          key: 'Length',
+          value: "#{length} weeks",
+        },
+        {
+          key: 'Reason',
+          value: ske_condition_presenter.reason,
+        },
+      ]
+    end
+
+    def ske_condition
+      application_choice.offer.ske_conditions.first
+    end
+
+    def ske_condition_presenter
+      SkeConditionPresenter.new(ske_condition, interface: :support_interface)
+    end
+
+    def render_ske?
+      (application_choice.offer? || application_choice.pending_conditions?) && application_choice.offer.ske_conditions.present?
     end
   end
 end

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -47,6 +47,10 @@ en:
       messages:
        funding_type_error: Changing %{course} from fee paying to salaried or an apprenticeship is not allowed. Please raise a dev support ticket.
        course_full_error: 'Are you sure you want to move the candidate to a course with no vacancies? Please check the box'
+    offer:
+      ske_reasons:
+        different_degree: Their degree subject was not %{degree_subject}
+        outdated_degree: Their degree subject was %{degree_subject}, but they graduated before %{graduation_cutoff_date}
   activemodel:
     errors:
       models:

--- a/spec/components/support_interface/application_choice_component_spec.rb
+++ b/spec/components/support_interface/application_choice_component_spec.rb
@@ -63,6 +63,26 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
 
       expect(result.css('.app-summary-card .govuk-summary-list__actions a')[1].text.squish).to eq 'Change conditions'
     end
+
+    context 'with a SKE condition' do
+      let(:application_choice_with_ske) { create(:application_choice, :offered, offer: create(:offer, :with_ske_conditions)) }
+
+      it 'renders the SKE component' do
+        result = render_inline(described_class.new(application_choice_with_ske))
+
+        expect(result).to have_content('Subject knowledge enhancement course')
+      end
+    end
+
+    context 'without a SKE condition' do
+      let(:application_choice_without_ske) { create(:application_choice, :offered) }
+
+      it 'does not render the SKE component' do
+        result = render_inline(described_class.new(application_choice_without_ske))
+
+        expect(result).not_to have_content('Subject knowledge enhancement course')
+      end
+    end
   end
 
   context 'Recruited' do


### PR DESCRIPTION
## Context

SKE has now launched. We need to render the component (if applicable) in the support UI.

The functionality for support to change/add a SKE will follow later.

## Changes proposed in this pull request

<img width="1202" alt="image" src="https://user-images.githubusercontent.com/47917431/226568451-c099f7da-2732-43cc-bce6-b1ae8b6dbfd2.png">


## Guidance to review

Make an offer to a candidate and add a SKE condition
View this candidate on support

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
