### PR TITLE
Correct adviser status constants

### DIFF
--- a/config/adviser/constants.yml
+++ b/config/adviser/constants.yml
@@ -32,5 +32,5 @@ countries:
 adviser_status:
   unassigned: 222_750_000
   waiting_to_be_assigned: 222_750_001
-  assigned: 222_750_003
-  previously_assigned: 222_750_004
+  assigned: 222_750_002
+  previously_assigned: 222_750_003


### PR DESCRIPTION
## Context

The statuses had a typo; I had missed out `02` which is for assigned and `03` should be previously assigned.

## Changes proposed in this pull request

- Correct adviser status constants

## Guidance to review

I'm reviewing this with Ian on the CRM team at the moment which is how we spotted it.

## Link to Trello card

N/A

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
