### PR TITLE
Fix the SKE condition Change link on check page

### DIFF
--- a/app/components/provider_interface/offer_summary_component.html.erb
+++ b/app/components/provider_interface/offer_summary_component.html.erb
@@ -12,7 +12,7 @@
         application_choice: @application_choice,
         course: @course,
         ske_condition:,
-        editable: !ske_condition.persisted?,
+        editable: true,
       ) %>
     <% end %>
   <% end %>

--- a/app/components/provider_interface/ske_conditions_component.html.erb
+++ b/app/components/provider_interface/ske_conditions_component.html.erb
@@ -5,9 +5,10 @@
   )) do %>
     <div class="app-summary-card__actions">
       <% if editable %>
-        <%= govuk_link_to 'Change', remove_condition_path %>
+        <%= govuk_link_to 'Change', change_path %>
+      <% else %>
+        <%= render ProviderInterface::ConditionStatusTagComponent.new(ske_condition) %>
       <% end %>
-      <%= render ProviderInterface::ConditionStatusTagComponent.new(ske_condition) %>
     </div>
   <% end %>
 <% end %>

--- a/app/components/provider_interface/ske_conditions_component.html.erb
+++ b/app/components/provider_interface/ske_conditions_component.html.erb
@@ -4,10 +4,9 @@
     heading_level: :h2,
   )) do %>
     <div class="app-summary-card__actions">
+      <%= render ProviderInterface::ConditionStatusTagComponent.new(ske_condition) %>
       <% if editable %>
         <%= govuk_link_to 'Remove condition', remove_condition_path %>
-      <% else %>
-        <%= render ProviderInterface::ConditionStatusTagComponent.new(ske_condition) %>
       <% end %>
     </div>
   <% end %>

--- a/app/components/provider_interface/ske_conditions_component.html.erb
+++ b/app/components/provider_interface/ske_conditions_component.html.erb
@@ -5,7 +5,7 @@
   )) do %>
     <div class="app-summary-card__actions">
       <% if editable %>
-        <%= govuk_link_to 'Change', change_path %>
+        <%= govuk_link_to 'Remove condition', remove_condition_path %>
       <% else %>
         <%= render ProviderInterface::ConditionStatusTagComponent.new(ske_condition) %>
       <% end %>

--- a/app/components/provider_interface/ske_conditions_component.rb
+++ b/app/components/provider_interface/ske_conditions_component.rb
@@ -35,21 +35,39 @@ module ProviderInterface
     end
 
     def remove_condition_path
-      edit_provider_interface_application_choice_offer_ske_requirements_path(
-        application_choice,
-      )
+      if application_choice.offer?
+        edit_provider_interface_application_choice_offer_ske_requirements_path(
+          application_choice,
+        )
+      else
+        new_provider_interface_application_choice_offer_ske_requirements_path(
+          application_choice,
+        )
+      end
     end
 
     def change_reason_path
-      edit_provider_interface_application_choice_offer_ske_reason_path(
-        application_choice,
-      )
+      if application_choice.offer?
+        edit_provider_interface_application_choice_offer_ske_reason_path(
+          application_choice,
+        )
+      else
+        new_provider_interface_application_choice_offer_ske_reason_path(
+          application_choice,
+        )
+      end
     end
 
     def change_length_path
-      edit_provider_interface_application_choice_offer_ske_length_path(
-        application_choice,
-      )
+      if application_choice.offer?
+        edit_provider_interface_application_choice_offer_ske_length_path(
+          application_choice,
+        )
+      else
+        new_provider_interface_application_choice_offer_ske_length_path(
+          application_choice,
+        )
+      end
     end
 
     def length_editable

--- a/app/components/provider_interface/ske_conditions_component.rb
+++ b/app/components/provider_interface/ske_conditions_component.rb
@@ -17,16 +17,8 @@ module ProviderInterface
     def summary_list_rows
       [
         { key: 'Subject', value: subject },
-        {
-          key: 'Length',
-          value: "#{length} weeks",
-          action: length_editable ? { visually_hidden_text: 'change ske length', href: new_provider_interface_application_choice_offer_ske_length_path(application_choice) } : {},
-        },
-        {
-          key: 'Reason',
-          value: ske_condition_presenter.reason,
-          action: editable ? { visually_hidden_text: 'change ske reason', href: new_provider_interface_application_choice_offer_ske_reason_path(application_choice) } : {},
-        },
+        { key: 'Length', value: "#{length} weeks" },
+        { key: 'Reason', value: ske_condition_presenter.reason },
       ]
     end
 
@@ -34,16 +26,10 @@ module ProviderInterface
       (ske_condition.subject.presence || @course.subjects.first&.name)
     end
 
-    def remove_condition_path
-      new_provider_interface_application_choice_offer_ske_requirements_path(application_choice)
-    end
-
-    def length_editable
-      editable && !religious_education_course?
-    end
-
-    def religious_education_course?
-      @application_choice.current_course.subjects.first&.code&.in?(Subject::SKE_RE_COURSES)
+    def change_path
+      edit_provider_interface_application_choice_offer_ske_requirements_path(
+        application_choice,
+      )
     end
   end
 end

--- a/app/components/provider_interface/ske_conditions_component.rb
+++ b/app/components/provider_interface/ske_conditions_component.rb
@@ -17,8 +17,16 @@ module ProviderInterface
     def summary_list_rows
       [
         { key: 'Subject', value: subject },
-        { key: 'Length', value: "#{length} weeks" },
-        { key: 'Reason', value: ske_condition_presenter.reason },
+        {
+          key: 'Length',
+          value: "#{length} weeks",
+          action: length_editable ? { visually_hidden_text: 'change ske length', href: change_length_path } : {},
+        },
+        {
+          key: 'Reason',
+          value: ske_condition_presenter.reason,
+          action: editable ? { visually_hidden_text: 'change ske reason', href: change_reason_path } : {},
+        },
       ]
     end
 
@@ -26,10 +34,30 @@ module ProviderInterface
       (ske_condition.subject.presence || @course.subjects.first&.name)
     end
 
-    def change_path
+    def remove_condition_path
       edit_provider_interface_application_choice_offer_ske_requirements_path(
         application_choice,
       )
+    end
+
+    def change_reason_path
+      edit_provider_interface_application_choice_offer_ske_reason_path(
+        application_choice,
+      )
+    end
+
+    def change_length_path
+      edit_provider_interface_application_choice_offer_ske_length_path(
+        application_choice,
+      )
+    end
+
+    def length_editable
+      editable && !religious_education_course?
+    end
+
+    def religious_education_course?
+      @application_choice.current_course.subjects.first&.code&.in?(Subject::SKE_RE_COURSES)
     end
   end
 end

--- a/app/services/change_offer.rb
+++ b/app/services/change_offer.rb
@@ -46,8 +46,11 @@ private
   end
 
   def offer
-    @offer ||= OfferValidations.new(application_choice:,
-                                    course_option:,
-                                    conditions: update_conditions_service.conditions)
+    @offer ||= OfferValidations.new(
+      application_choice:,
+      course_option:,
+      conditions: update_conditions_service.conditions,
+      ske_conditions: update_conditions_service.structured_conditions,
+    )
   end
 end

--- a/app/services/change_offer.rb
+++ b/app/services/change_offer.rb
@@ -50,7 +50,7 @@ private
       application_choice:,
       course_option:,
       conditions: update_conditions_service.conditions,
-      ske_conditions: update_conditions_service.structured_conditions,
+      ske_conditions: update_conditions_service.try(:structured_conditions),
     )
   end
 end

--- a/app/services/make_offer.rb
+++ b/app/services/make_offer.rb
@@ -51,8 +51,11 @@ private
   end
 
   def offer
-    @offer ||= OfferValidations.new(application_choice:,
-                                    course_option:,
-                                    conditions: update_conditions_service.conditions)
+    @offer ||= OfferValidations.new(
+      application_choice:,
+      course_option:,
+      conditions: update_conditions_service.conditions,
+      ske_conditions: update_conditions_service.structured_conditions,
+    )
   end
 end

--- a/app/services/make_offer.rb
+++ b/app/services/make_offer.rb
@@ -55,7 +55,7 @@ private
       application_choice:,
       course_option:,
       conditions: update_conditions_service.conditions,
-      ske_conditions: update_conditions_service.structured_conditions,
+      ske_conditions: update_conditions_service.try(:structured_conditions),
     )
   end
 end

--- a/app/services/offer_validations.rb
+++ b/app/services/offer_validations.rb
@@ -6,7 +6,7 @@ class OfferValidations
   MAX_CONDITION_1_LENGTH = 2000
   MAX_CONDITION_LENGTH = 255
 
-  attr_accessor :application_choice, :course_option, :conditions
+  attr_accessor :application_choice, :course_option, :conditions, :ske_conditions
 
   validates :course_option, presence: true
   validate :conditions_count, if: :conditions
@@ -34,9 +34,19 @@ class OfferValidations
   def identical_to_existing_offer?
     return unless application_choice.offer?
 
-    if application_choice.current_course_option == course_option && application_choice.offer.conditions_text.sort == conditions.sort
+    if application_choice.current_course_option == course_option &&
+       application_choice.offer.conditions_text.sort == conditions.sort &&
+       existing_ske_condition_details == new_ske_condition_details
       raise IdenticalOfferError
     end
+  end
+
+  def existing_ske_condition_details
+    application_choice.offer.ske_conditions.map { |condition| condition.details.symbolize_keys.slice(:length, :reason, :subject) }.sort
+  end
+
+  def new_ske_condition_details
+    (ske_conditions || []).map { |condition| condition.details.symbolize_keys.slice(:length, :reason, :subject) }.sort
   end
 
   def ratifying_provider_changed?

--- a/spec/components/provider_interface/ske_conditions_component_spec.rb
+++ b/spec/components/provider_interface/ske_conditions_component_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe ProviderInterface::SkeConditionsComponent do
       let(:editable) { true }
 
       it 'renders a Change link' do
-        expect(result.css('header.app-summary-card__header a').text).to eq('Change')
+        expect(result.css('header.app-summary-card__header a').text).to eq('Remove condition')
       end
     end
   end
@@ -54,7 +54,7 @@ RSpec.describe ProviderInterface::SkeConditionsComponent do
       let(:editable) { true }
 
       it 'renders a Change link' do
-        expect(result.css('header.app-summary-card__header a').text).to eq('Change')
+        expect(result.css('header.app-summary-card__header a').text).to eq('Remove condition')
       end
     end
   end

--- a/spec/components/provider_interface/ske_conditions_component_spec.rb
+++ b/spec/components/provider_interface/ske_conditions_component_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ProviderInterface::SkeConditionsComponent do
   let(:application_choice) { create(:application_choice) }
   let(:course) { create(:course) }
-  let(:editable) { true }
+  let(:editable) { false }
   let(:result) do
     render_inline(
       described_class.new(
@@ -27,6 +27,14 @@ RSpec.describe ProviderInterface::SkeConditionsComponent do
     it 'renders the condition status' do
       expect(result.text).to include('Met')
     end
+
+    context 'when the SKE condition is editable' do
+      let(:editable) { true }
+
+      it 'renders a Change link' do
+        expect(result.css('header.app-summary-card__header a').text).to eq('Change')
+      end
+    end
   end
 
   context 'when a standard ske condition' do
@@ -40,6 +48,14 @@ RSpec.describe ProviderInterface::SkeConditionsComponent do
 
     it 'renders the condition status' do
       expect(result.text).to include('Pending')
+    end
+
+    context 'when the SKE condition is editable' do
+      let(:editable) { true }
+
+      it 'renders a Change link' do
+        expect(result.css('header.app-summary-card__header a').text).to eq('Change')
+      end
     end
   end
 end

--- a/spec/services/offer_validations_spec.rb
+++ b/spec/services/offer_validations_spec.rb
@@ -62,6 +62,21 @@ RSpec.describe OfferValidations, type: :model do
           expect { offer.valid? }.to raise_error(IdenticalOfferError)
         end
       end
+
+      context 'when the offer details differ only by SKE condition' do
+        let(:application_choice) { build_stubbed(:application_choice, :offered) }
+        let(:course_option) { application_choice.course_option }
+        let(:conditions) { application_choice.offer.conditions_text }
+        let(:ske_conditions) { [build(:ske_condition)] }
+        let(:new_ske_conditions) { [build(:ske_condition, length: '12')] }
+
+        subject(:offer) { described_class.new(application_choice:, course_option:, conditions:, ske_conditions: new_ske_conditions) }
+
+        it 'raises an IdenticalOfferError' do
+          allow(application_choice.offer).to receive(:ske_conditions).and_return(ske_conditions)
+          expect { offer.valid? }.not_to raise_error(IdenticalOfferError)
+        end
+      end
     end
 
     describe '#ratifying_provider_changed?' do

--- a/spec/system/provider_interface/change_existing_offer_ske_standard_flow_spec.rb
+++ b/spec/system/provider_interface/change_existing_offer_ske_standard_flow_spec.rb
@@ -212,7 +212,7 @@ RSpec.feature 'Provider changes an existing offer' do
 
   def when_i_choose_to_edit_the_ske_condition
     within(all('.app-summary-card__header')[0]) do
-      click_on 'Change'
+      click_on 'Remove condition'
     end
   end
 

--- a/spec/system/provider_interface/change_existing_offer_ske_standard_flow_spec.rb
+++ b/spec/system/provider_interface/change_existing_offer_ske_standard_flow_spec.rb
@@ -79,20 +79,32 @@ RSpec.feature 'Provider changes an existing offer' do
     and_the_ske_conditions_should_be_displayed
     and_i_can_confirm_the_changed_offer_details
 
+    when_i_choose_to_edit_the_ske_condition
+    and_i_select_ske_is_required
+    and_i_click_continue
+    and_i_add_a_ske_reason
+    and_i_click_continue
+    and_i_answer_the_ske_length_differently
+    and_i_click_continue
+    and_i_click_continue
+    then_the_review_page_is_loaded
+    and_the_modified_ske_conditions_should_be_displayed
+    and_i_can_confirm_the_changed_offer_details
+
     when_i_send_the_offer
     then_i_see_that_the_offer_was_successfully_updated
-    and_the_ske_conditions_should_be_displayed
+    and_the_modified_ske_conditions_should_be_displayed
 
     # Toggle the standard conditions and save
     when_i_choose_to_change_the_conditions
     and_i_click_continue
     then_the_review_page_is_loaded
-    and_the_ske_conditions_should_be_displayed
+    and_the_modified_ske_conditions_should_be_displayed
 
     when_i_send_the_offer
     then_i_see_that_the_offer_was_successfully_updated
     and_i_can_see_the_new_offer_condition
-    and_the_ske_conditions_should_be_displayed
+    and_the_modified_ske_conditions_should_be_displayed
 
     # Change provider and course to a subject that does NOT permit SKE conditions
     when_i_choose_to_change_the_course
@@ -198,6 +210,12 @@ RSpec.feature 'Provider changes an existing offer' do
     end
   end
 
+  def when_i_choose_to_edit_the_ske_condition
+    within(all('.app-summary-card__header')[0]) do
+      click_on 'Change'
+    end
+  end
+
   def then_i_am_taken_to_the_change_provider_page
     expect(page).to have_content('Training provider')
   end
@@ -246,6 +264,7 @@ RSpec.feature 'Provider changes an existing offer' do
   def when_i_select_ske_is_required
     choose 'Yes'
   end
+  alias_method :and_i_select_ske_is_required, :when_i_select_ske_is_required
 
   def then_the_ske_reason_page_is_loaded
     expect(page).to have_current_path("/provider/applications/#{application_choice.id}/offer/ske-reason/edit", ignore_query: true)
@@ -254,6 +273,7 @@ RSpec.feature 'Provider changes an existing offer' do
   def when_i_add_a_ske_reason
     choose t('provider_interface.offer.ske_reasons.different_degree', degree_subject: @ske_subject.name)
   end
+  alias_method :and_i_add_a_ske_reason, :when_i_add_a_ske_reason
 
   def then_the_ske_length_page_is_loaded
     expect(page).to have_current_path("/provider/applications/#{application_choice.id}/offer/ske-length/edit", ignore_query: true)
@@ -263,10 +283,21 @@ RSpec.feature 'Provider changes an existing offer' do
     choose '8 weeks'
   end
 
+  def and_i_answer_the_ske_length_differently
+    choose '12 weeks'
+  end
+
   def and_the_ske_conditions_should_be_displayed
     expect(page).to have_content('Subject knowledge enhancement course')
     expect(page).to have_content("Subject\n#{@ske_subject.name}")
     expect(page).to have_content("Length\n8 weeks")
+    expect(page).to have_content("Reason\nTheir degree subject was not #{@ske_subject.name}")
+  end
+
+  def and_the_modified_ske_conditions_should_be_displayed
+    expect(page).to have_content('Subject knowledge enhancement course')
+    expect(page).to have_content("Subject\n#{@ske_subject.name}")
+    expect(page).to have_content("Length\n12 weeks")
     expect(page).to have_content("Reason\nTheir degree subject was not #{@ske_subject.name}")
   end
 


### PR DESCRIPTION
## Context

When you add a SKE condition you are given the option to change the length, reason or the whole thing just prior to sending the offer (/provider/applications/:id/offer/check/edit). These links don’t work (they redirect to the application show page and you lose your changes). Corresponding links don’t appear on the review page.

There are some questions below about UX...

## Changes proposed in this pull request

Before:

These links did not work...
![image](https://user-images.githubusercontent.com/450843/226903362-e9188aba-bdb8-4f18-a877-88afc7653d2d.png)

After:
This link now takes you back to the first of the SKE condition pages in the wizard...
![image](https://user-images.githubusercontent.com/450843/226903873-f66cb1c8-248f-48dd-92f8-9a330413c6f6.png)

Note that the _Change_ links on the individual SKE conditions have been removed.


Question:
To me this is the minimum needed to fix the original issue (broken links) but it leaves us with two 'change' links for conditions and these look a bit inconsistent. Should we consolidate these into a single link somewhere or does it make sense to leave as is (because SKE and standard conditions are different kinds of thing really)?


## Guidance to review



## Link to Trello card

[<!-- http://trello.com/123-example-card -->](https://trello.com/c/9HrSXCar/1278-some-of-the-change-links-for-a-pending-ske-condition-are-not-implemented-yet)

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
