### PR TITLE
Display guidance shown to candidates in Manage and Support views

### DIFF
--- a/app/components/shared/personal_statement_component.html.erb
+++ b/app/components/shared/personal_statement_component.html.erb
@@ -12,7 +12,7 @@
     <% end %>
   </h3>
 
-  <%= govuk_details(summary_text: 'Guidance to candidates', classes: 'govuk-!-margin-bottom-4') do %>
+  <%= govuk_details(summary_text: 'Guidance given to candidates', classes: 'govuk-!-margin-bottom-4') do %>
     <% if application_form.single_personal_statement_application? %>
       <%= render 'candidate_interface/personal_statement/guidance' %>
     <% else %>
@@ -32,7 +32,7 @@
       <% end %>
     </h3>
 
-    <%= govuk_details(summary_text: 'Guidance to candidates', classes: 'govuk-!-margin-bottom-4') do %>
+    <%= govuk_details(summary_text: 'Guidance given to candidates', classes: 'govuk-!-margin-bottom-4') do %>
       <%= render 'candidate_interface/subject_knowledge/guidance' %>
     <% end %>
 

--- a/app/components/shared/personal_statement_component.html.erb
+++ b/app/components/shared/personal_statement_component.html.erb
@@ -12,6 +12,14 @@
     <% end %>
   </h3>
 
+  <%= govuk_details(summary_text: 'Guidance to candidates', classes: 'govuk-!-margin-bottom-4') do %>
+    <% if application_form.single_personal_statement_application? %>
+      <%= render 'candidate_interface/personal_statement/guidance' %>
+    <% else %>
+      <%= render 'candidate_interface/personal_statement/guidance_old' %>
+    <% end %>
+  <% end %>
+
   <%= simple_format becoming_a_teacher, class: 'govuk-body' %>
 
   <% unless application_form.single_personal_statement_application? %>
@@ -23,6 +31,10 @@
         <% end %>
       <% end %>
     </h3>
+
+    <%= govuk_details(summary_text: 'Guidance to candidates', classes: 'govuk-!-margin-bottom-4') do %>
+      <%= render 'candidate_interface/subject_knowledge/guidance' %>
+    <% end %>
 
     <%= simple_format subject_knowledge, class: 'govuk-body' %>
 

--- a/app/views/candidate_interface/personal_statement/_form.html.erb
+++ b/app/views/candidate_interface/personal_statement/_form.html.erb
@@ -6,18 +6,7 @@
     Personal statement
   </h1>
 
-  <p class="govuk-body">You should write between 500 and 1000 words for your personal statement.</p>
-  <p class="govuk-body">Here are some examples you could write about (they are just a guide, you do not need to write about all of them):</p>
-
-  <ul class="govuk-list govuk-list--bullet">
-    <li>skills you have that are relevant to teaching</li>
-    <li>any experience of working with young people</li>
-    <li>for secondary teacher training: your interest in the subject you want to teach</li>
-    <li>your understanding of why teaching is important</li>
-    <li>your reasons for wanting to train to be a teacher</li>
-    <li>any activities you’ve done that could be relevant to teaching like first aid courses, sports coaching or volunteering</li>
-
-  </ul>
+  <%= render 'guidance' %>
 
   <p class="govuk-body">Get help with your personal statement by speaking to our <a href="https://getintoteaching.education.gov.uk/teacher-training-advisers">teacher training advisers</a>. They used to be teachers and can give you free, one-to-one support.</p>
 
@@ -30,16 +19,7 @@
 
   <p class="govuk-body">Explain why you want to be a teacher.</p>
 
-  <p class="govuk-body">You could talk about:</p>
-
-  <ul class="govuk-list govuk-list--bullet">
-    <li>what inspired you to apply</li>
-    <li>the personal qualities that would make you a good teacher</li>
-    <li>any experience you have working with children and what you learnt</li>
-    <li>your understanding of the demands and rewards of teaching</li>
-    <li>how you could contribute to a school outside of the classroom - for example, running extra-curricular activities and clubs</li>
-    <li>your thoughts on children’s wellbeing and the education system</li>
-  </ul>
+  <%= render 'guidance_old' %>
 
 <p class="govuk-body">Get help with your personal statement by speaking to our <%= govuk_link_to_with_utm_params('teacher training advisers', t('get_into_teaching.url_get_an_adviser'), utm_campaign(params), current_application.phase) %>. They were teachers and can give you free, one-to-one support.</p>
 

--- a/app/views/candidate_interface/personal_statement/_guidance.html.erb
+++ b/app/views/candidate_interface/personal_statement/_guidance.html.erb
@@ -1,0 +1,11 @@
+<p class="govuk-body">You should write between 500 and 1000 words for your personal statement.</p>
+<p class="govuk-body">Here are some examples you could write about (they are just a guide, you do not need to write about all of them):</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>skills you have that are relevant to teaching</li>
+  <li>any experience of working with young people</li>
+  <li>for secondary teacher training: your interest in the subject you want to teach</li>
+  <li>your understanding of why teaching is important</li>
+  <li>your reasons for wanting to train to be a teacher</li>
+  <li>any activities you’ve done that could be relevant to teaching like first aid courses, sports coaching or volunteering</li>
+</ul>

--- a/app/views/candidate_interface/personal_statement/_guidance_old.html.erb
+++ b/app/views/candidate_interface/personal_statement/_guidance_old.html.erb
@@ -1,0 +1,10 @@
+<p class="govuk-body">You could talk about:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>what inspired you to apply</li>
+  <li>the personal qualities that would make you a good teacher</li>
+  <li>any experience you have working with children and what you learnt</li>
+  <li>your understanding of the demands and rewards of teaching</li>
+  <li>how you could contribute to a school outside of the classroom - for example, running extra-curricular activities and clubs</li>
+  <li>your thoughts on children’s wellbeing and the education system</li>
+</ul>

--- a/app/views/candidate_interface/subject_knowledge/_form.html.erb
+++ b/app/views/candidate_interface/subject_knowledge/_form.html.erb
@@ -3,20 +3,7 @@
   <%= t('page_titles.subject_knowledge') %>
 </h1>
 
-<p class="govuk-body">If you’re applying for secondary teacher training, describe your knowledge of the subjects you’d like to teach.</p>
-
-<p class="govuk-body">If you’re applying for primary teacher training, say why you’d like to teach this age group.</p>
-
-<p class="govuk-body">If you’re applying for a primary course with a subject specialism, or you're particularly interested in certain primary subjects, you can also talk about that.</p>
-
-<p class="govuk-body">You could talk about your:</p>
-<ul class="govuk-list govuk-list--bullet">
-  <li>work experience</li>
-  <li>degree and degree modules</li>
-  <li>qualifications, such as A levels</li>
-  <li>skills, interests or achievements</li>
-  <li>understanding of the national curriculum</li>
-</ul>
+<%= render 'guidance' %>
 
 <p class="govuk-body">Get help with your personal statement by speaking to our <%= govuk_link_to_with_utm_params 'teacher training advisers', t('get_into_teaching.url_get_an_adviser_start'), utm_campaign(params), @current_application.phase %>. They were teachers and can give you free, one-to-one support.</p>
 

--- a/app/views/candidate_interface/subject_knowledge/_guidance.html.erb
+++ b/app/views/candidate_interface/subject_knowledge/_guidance.html.erb
@@ -1,0 +1,14 @@
+<p class="govuk-body">If you’re applying for secondary teacher training, describe your knowledge of the subjects you’d like to teach.</p>
+
+<p class="govuk-body">If you’re applying for primary teacher training, say why you’d like to teach this age group.</p>
+
+<p class="govuk-body">If you’re applying for a primary course with a subject specialism, or you're particularly interested in certain primary subjects, you can also talk about that.</p>
+
+<p class="govuk-body">You could talk about your:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>work experience</li>
+  <li>degree and degree modules</li>
+  <li>qualifications, such as A levels</li>
+  <li>skills, interests or achievements</li>
+  <li>understanding of the national curriculum</li>
+</ul>


### PR DESCRIPTION
## Context

We will shortly change the personal statement to just be a single section instead of 2. Alongside this, we have rewritten the guidance for the new single personal statement section.

As this will affect in some way what candidates write, we think it will be helpful to let providers see what the guidance shown to candidates was, at the time they wrote it.

We are adding this guidance using the "details" component, so that it can be hidden by default but shown if needed.

🗂️ [Trello card](https://trello.com/c/Z6MANXzJ/1296-add-personal-statement-guidance-to-manage-view-of-application)

## Review questions

* I've moved the guidance to a partial, rather than copying-and-pasting it and risking them diverging - is this ok, or is there a better patten?
* Does this need any tests?
* Also affects the support view, but I think that’s ok? (Maybe it's useful for support staff too?)

## Screenshots

### Manage view of applications written using 2 personal statement sections

Closed:

<img width="973" alt="Screenshot 2023-03-22 at 13 46 54" src="https://user-images.githubusercontent.com/30665/226927265-53634956-cd72-4c49-9435-f52d9eba7bad.png">

Open:

<img width="1058" alt="Screenshot 2023-03-22 at 13 54 43" src="https://user-images.githubusercontent.com/30665/226927640-3db0f37d-c058-4668-aa06-0df04f88e66c.png">

### Manage view of applications written using single personal statement

<img width="1062" alt="Screenshot 2023-03-22 at 13 54 19" src="https://user-images.githubusercontent.com/30665/226927692-ee8d0207-f324-4178-8a87-566d4aea0deb.png">

