### PR TITLE
Add production to scheduled database workflows

### DIFF
--- a/.github/workflows/backup-and-restore.yml
+++ b/.github/workflows/backup-and-restore.yml
@@ -34,7 +34,7 @@ jobs:
           slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
 
       - name: Backup and Restore action for ${{ inputs.environment }} to AKS prod cluster
-        if: inputs.environment == 'sandbox' || inputs.environment == 'prod'
+        if: inputs.environment == 'sandbox' || inputs.environment == 'production'
         id: backup_and_restore_env_prod
         uses: ./.github/actions/backup_and_restore/
         with:

--- a/.github/workflows/scheduled-aks-db-restore.yml
+++ b/.github/workflows/scheduled-aks-db-restore.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [staging, sandbox]
+        environment: [staging, sandbox, production]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -29,7 +29,7 @@ jobs:
           slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
 
       - name: Backup and Restore action for ${{ matrix.environment }} to AKS prod cluster
-        if: matrix.environment == 'sandbox' || matrix.environment == 'prod'
+        if: matrix.environment == 'sandbox' || matrix.environment == 'production'
         id: backup_and_restore_env_prod
         uses: ./.github/actions/backup_and_restore/
         with:

--- a/terraform/aks/workspace_variables/production_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/production_aks.tfvars.json
@@ -21,6 +21,5 @@
   "clock_worker_replicas": 0,
   "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
   "postgres_enable_high_availability": true,
-  "webapp_startup_command": "bundle exec rails db:prepare && bundle exec rails server -b 0.0.0.0",
   "pdb_min_available": "50%"
 }


### PR DESCRIPTION
## Context

We need a way to keep the AKS production in sync with PaaS production. This change adds the production environment to the workflow schedule.

We need to ensure the workers and clock stay at zero.

## Changes proposed in this pull request

Add production to the workflows that restore data from PaaS to AKS

## Guidance to review

## Link to Trello card

https://trello.com/c/DawQm5fF

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
