### PR TITLE
Telling providers not to share reference contents with candidates

### DIFF
--- a/app/views/provider_mailer/reference_received.text.erb
+++ b/app/views/provider_mailer/reference_received.text.erb
@@ -6,4 +6,6 @@ View the references for this application:
 
 <%= @link %>
 
+You must not share the contents of any references with <%= @candidate_name %>.
+
 <% content_for :additional_footer_content do %><%= render 'notification_preferences' %><% end %>


### PR DESCRIPTION
## Context

We had a complaint from a referee who said that what they had written about a candidate had been shared with the candidate. It turns out the training provider had read what the referee wrote to the candidate.

Currently we do not say anywhere to providers that they should not share references with candidates.

## Changes proposed in this pull request

Added a line to the 'refrence received' email for providers to say they must not share reference content with candidates
Added a line to the reference page for providers to say they must not share reference content

## Link to Trello card

https://trello.com/c/6ldsRgMc/1290-look-at-adding-content-to-emails-and-service-to-tell-providers-not-to-share-reference-info-with-candidates

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
