### PR TITLE
Initialize VendorAPI application presenters with full version number

### DIFF
--- a/app/controllers/concerns/vendor_api/application_data_concerns.rb
+++ b/app/controllers/concerns/vendor_api/application_data_concerns.rb
@@ -27,7 +27,7 @@ module VendorAPI
     end
 
     def exclude_deferrals
-      full_api_version_number.eql?(VendorAPI::VERSION_1_0)
+      version_number.eql?(VendorAPI::VERSION_1_0)
     end
 
     def include_properties

--- a/app/controllers/concerns/versioning.rb
+++ b/app/controllers/concerns/versioning.rb
@@ -9,10 +9,7 @@ private
   end
 
   def version_number
-    @version_number = extract_version(version_param)
-  end
-
-  def full_api_version_number
-    "#{major_version_number(version_number)}.#{minor_version_number(version_number)}"
+    extracted_from_param = extract_version(version_param)
+    @version_number = "#{major_version_number(extracted_from_param)}.#{minor_version_number(extracted_from_param)}"
   end
 end

--- a/spec/requests/vendor_api/versioning_spec.rb
+++ b/spec/requests/vendor_api/versioning_spec.rb
@@ -105,6 +105,22 @@ RSpec.describe 'Versioning' do
           expect(response).to have_http_status(:ok)
           expect(parsed_response['data'].size).to eq(1)
         end
+
+        it 'deriving latest minor version when not specified' do
+          single_application_presenter_class = VendorAPI::SingleApplicationPresenter
+          single_application_presenter = instance_double(single_application_presenter_class, serialized_json: [])
+
+          allow(single_application_presenter_class).to receive(:new).and_return(single_application_presenter)
+
+          stub_const(
+            'VendorAPI::VERSIONS',
+            { '1.0' => [], '1.1' => [], '1.2' => [VendorAPI::Changes::RetrieveSingleApplication] },
+          )
+          get_api_request "/api/v1/applications/#{application_choice.id}"
+
+          expect(response).to have_http_status(:ok)
+          expect(single_application_presenter_class).to have_received(:new).with('1.2', application_choice)
+        end
       end
 
       context 'when the full version is specified' do


### PR DESCRIPTION
## Context

Currently, when API users specify `v1`, the application doesn't include 1.3-only properties.

## Changes proposed in this pull request

Update vendor API versioning logic such that application presenters are initialized with the full version number rather than just what's specified in the URL. So if the user only specifies major version number, initialize presenters with the latest minor version (1.3 rather than 1).

## Question

Can we think of a sensible way to test this?

## Link to Trello card

https://trello.com/c/n6ejT1K2/1284-investigate-sandbox-api-versioning-issue

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
