### PR TITLE
Upgrade postgres databases to 14

### DIFF
--- a/terraform/aks/terraform.tf
+++ b/terraform/aks/terraform.tf
@@ -32,6 +32,7 @@ module "kubernetes" {
   pg_actiongroup_rg                   = var.pg_actiongroup_rg
   enable_alerting                     = var.enable_alerting
   pdb_min_available                   = var.pdb_min_available
+  postgres_version                    = var.postgres_version
 }
 
 module "statuscake" {

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -34,6 +34,8 @@ variable "key_vault_infra_secret_name" {}
 
 variable "key_vault_app_secret_name" {}
 
+variable "postgres_version" { default = "11" }
+
 variable "gov_uk_host_names" {
   default = []
   type    = list(any)

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -34,7 +34,7 @@ variable "key_vault_infra_secret_name" {}
 
 variable "key_vault_app_secret_name" {}
 
-variable "postgres_version" { default = "11" }
+variable "postgres_version" { default = "14" }
 
 variable "gov_uk_host_names" {
   default = []

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -34,7 +34,7 @@ variable "key_vault_infra_secret_name" {}
 
 variable "key_vault_app_secret_name" {}
 
-variable "postgres_version" { default = "14" }
+variable "postgres_version" { default = "11" }
 
 variable "gov_uk_host_names" {
   default = []

--- a/terraform/aks/workspace_variables/qa_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/qa_aks.tfvars.json
@@ -22,6 +22,7 @@
   "enable_alerting": true,
   "pg_actiongroup_name": "s189t01-att-test-ag",
   "pg_actiongroup_rg": "s189t01-att-qa-rg",
+  "postgres_version": "14",
   "statuscake_alerts": {
     "apply-aks-qa": {
       "website_name": "Apply-Teacher-Training-AKS-QA",

--- a/terraform/modules/kubernetes/azure-resources.tf
+++ b/terraform/modules/kubernetes/azure-resources.tf
@@ -4,7 +4,7 @@ resource "azurerm_postgresql_flexible_server" "postgres-server" {
   name                   = local.postgres_server_name
   location               = data.azurerm_resource_group.backing-service-resource-group[0].location
   resource_group_name    = data.azurerm_resource_group.backing-service-resource-group[0].name
-  version                = 11
+  version                = var.postgres_version
   administrator_login    = var.postgres_admin_username
   administrator_password = var.postgres_admin_password
   create_mode            = "Default"

--- a/terraform/modules/kubernetes/postgres.tf
+++ b/terraform/modules/kubernetes/postgres.tf
@@ -24,7 +24,7 @@ resource "kubernetes_deployment" "postgres" {
         }
         container {
           name  = local.postgres_service_name
-          image = "postgres:14-alpine"
+          image = "postgres:${var.postgres_version}-alpine"
           resources {
             requests = {
               cpu    = var.cluster.cpu_min

--- a/terraform/modules/kubernetes/postgres.tf
+++ b/terraform/modules/kubernetes/postgres.tf
@@ -24,7 +24,7 @@ resource "kubernetes_deployment" "postgres" {
         }
         container {
           name  = local.postgres_service_name
-          image = "postgres:11-alpine"
+          image = "postgres:14-alpine"
           resources {
             requests = {
               cpu    = var.cluster.cpu_min

--- a/terraform/modules/kubernetes/variables.tf
+++ b/terraform/modules/kubernetes/variables.tf
@@ -10,7 +10,7 @@ variable "cluster" {}
 variable "deploy_azure_backing_services" {}
 variable "webapp_startup_command" {}
 variable "resource_prefix" {}
-variable "postgres_version" { default = "11" }
+variable "postgres_version" {}
 variable "postgres_admin_password" { sensitive = true }
 variable "postgres_admin_username" {}
 variable "postgres_enable_high_availability" {

--- a/terraform/modules/kubernetes/variables.tf
+++ b/terraform/modules/kubernetes/variables.tf
@@ -10,6 +10,7 @@ variable "cluster" {}
 variable "deploy_azure_backing_services" {}
 variable "webapp_startup_command" {}
 variable "resource_prefix" {}
+variable "postgres_version" { default = "11" }
 variable "postgres_admin_password" { sensitive = true }
 variable "postgres_admin_username" {}
 variable "postgres_enable_high_availability" {


### PR DESCRIPTION
## Context

To upgrade the postgres database to version 14

## Changes proposed in this pull request

- Introduced variable to set the version number 
- Set the default to 14

## Guidance to review

- make qa_aks deploy-plan PASSCODE=1234

## Link to Trello card

https://trello.com/c/JH27e84R/275-upgrade-postgres-databases-to-14

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
