### PR TITLE
Replace provider feedback form link with email link

### DIFF
--- a/app/lib/provider_interface.rb
+++ b/app/lib/provider_interface.rb
@@ -1,3 +1,3 @@
 module ProviderInterface
-  FEEDBACK_LINK = 'https://docs.google.com/forms/d/e/1FAIpQLSeJfcE9cITcICGIbwnBn-xYGT24bn_Us_AUYVuA2GtJOZmIoA/viewform?usp=sf_link'.freeze
+  FEEDBACK_LINK = 'mailto:becomingateacher@digital.education.gov.uk'.freeze
 end


### PR DESCRIPTION
The Google form will no longer work once we have transitioned away from GSuite.

https://trello.com/c/QvJ0kTOh/1334-replace-provider-feedback-form-with-email-link