### PR TITLE
Remove data request form

### DIFF
--- a/app/views/support_interface/data_exports/directory.html.erb
+++ b/app/views/support_interface/data_exports/directory.html.erb
@@ -24,19 +24,4 @@
       </ul>
     </aside>
   </div>
-
-  <div class="govuk-grid-column-one-third govuk-!-margin-top-5">
-    <aside class="app-card" role="complementary">
-      <h3 class="govuk-heading-s govuk-!-margin-bottom-2">Can’t find what you’re looking for?</h3>
-      <p class="govuk-body">
-        You can request data by completing this
-        <%= govuk_link_to(
-            'google form',
-            'https://docs.google.com/forms/d/e/1FAIpQLSd-J_cFOgmy2TjhFo_cA0kqDoHT8NlcQvH13U2z-AMlR6JoEA/viewform',
-            target: '_blank',
-            rel: 'noopener',
-          ) %>.
-      </p>
-    </aside>
-  </div>
 </div>


### PR DESCRIPTION
This removes the data request form from the internal support interface. We think this is little-used, and has largely been replaced by other internal processes.

The google form will no longer work once we transition away from GSuite.

<img width="495" alt="Screenshot 2023-03-24 at 14 25 34" src="https://user-images.githubusercontent.com/30665/227552929-7765aedd-5252-4db8-89d6-07658c346dc6.png">
