### PR TITLE
Remove references to legacy referee google form

### DIFF
--- a/app/mailers/referee_mailer.rb
+++ b/app/mailers/referee_mailer.rb
@@ -71,25 +71,4 @@ class RefereeMailer < ApplicationMailer
       application_form_id: reference.application_form_id,
     )
   end
-
-private
-
-  # rubocop:disable  Style/StringConcatenation
-  def google_form_url_for(candidate_name, reference)
-    # `to_query` replaces spaces with `+`, but a Google Form with a prefilled parameter
-    # shows a `+` in the actual form, eg "Jane Doe" becomes "Jane+Doe", so we need to
-    # switch them to %20 without stripping out a possible `+` in an email address
-    t('referee_mailer.reference_request.google_form_url') +
-      '?' +
-      {
-        t('referee_mailer.reference_request.email_entry') => reference.email_address,
-        t('referee_mailer.reference_request.reference_id_entry') => reference.id,
-      }.to_query +
-      '&' +
-      {
-        t('referee_mailer.reference_request.candidate_name_entry') => candidate_name,
-        t('referee_mailer.reference_request.referee_name_entry') => reference.name,
-      }.to_query.gsub('+', '%20')
-  end
-  # rubocop:enable  Style/StringConcatenation
 end

--- a/config/locales/emails/referee_mailer.yml
+++ b/config/locales/emails/referee_mailer.yml
@@ -7,7 +7,6 @@ en:
       character: activities you’ve done together
     reference_request:
       subject: Teacher training reference needed for %{candidate_name}
-      google_form_url: https://docs.google.com/forms/d/e/1FAIpQLSeLHV9XVqckn8XUjyAS3n7dzKU5OF-BLm5dYn51JcT6qa9pGg/viewform
       email_entry: entry.409316871
       reference_id_entry: entry.1515340886
       candidate_name_entry: entry.1696393181


### PR DESCRIPTION
This is no longer used.