### PR TITLE
Prevent SKE conditions being removed on the support UI

### DIFF
--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -112,6 +112,7 @@ module SupportInterface
 
     def update_conditions_service
       ::SaveOfferConditionsFromParams.new(
+        support_action: true,
         application_choice:,
         standard_conditions: standard_conditions.compact_blank,
         further_condition_attrs: further_conditions_to_save,

--- a/app/services/save_offer_conditions_from_params.rb
+++ b/app/services/save_offer_conditions_from_params.rb
@@ -1,11 +1,12 @@
 class SaveOfferConditionsFromParams
-  attr_reader :application_choice, :standard_conditions, :further_condition_attrs, :structured_conditions
+  attr_reader :application_choice, :standard_conditions, :further_condition_attrs, :structured_conditions, :support_action
 
-  def initialize(application_choice:, standard_conditions:, further_condition_attrs:, structured_conditions: [])
+  def initialize(application_choice:, standard_conditions:, further_condition_attrs:, structured_conditions: [], support_action: false)
     @application_choice = application_choice
     @standard_conditions = standard_conditions & OfferCondition::STANDARD_CONDITIONS
     @further_condition_attrs = further_condition_attrs
     @structured_conditions = structured_conditions
+    @support_action = support_action
   end
 
   def save
@@ -27,6 +28,8 @@ class SaveOfferConditionsFromParams
 private
 
   def serialize_structured_conditions
+    return if support_action
+
     # Delete all current ske conditions if there is a change of course
     @offer.ske_conditions.destroy_all if @offer.ske_conditions.any?
 

--- a/spec/services/save_offer_conditions_from_params_spec.rb
+++ b/spec/services/save_offer_conditions_from_params_spec.rb
@@ -191,5 +191,20 @@ RSpec.describe SaveOfferConditionsFromParams do
         end
       end
     end
+
+    context 'structured conditions' do
+      let(:application_choice) { create(:application_choice, :offered, offer: create(:offer, :with_ske_conditions)) }
+
+      subject(:service) do
+        described_class.new(application_choice: application_choice,
+                            standard_conditions: [],
+                            further_condition_attrs: {},
+                            support_action: true)
+      end
+
+      it 'does not remove a SKE condition' do
+        expect { service.save }.to not_change(application_choice.offer.ske_conditions, :count)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

If a support user changes conditions on an application choice, with a SKE condition, it will destroy the SKE condition. This isn't the correct behaviour.

## Changes proposed in this pull request

Prevent the `@offer.ske_conditions.destroy_all` from happening if the `SaveOfferConditionsFromParams` service is called from support

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/T3gphGqR

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
