### PR TITLE
Ignore accents in matching names

### DIFF
--- a/app/queries/get_duplicate_matches.rb
+++ b/app/queries/get_duplicate_matches.rb
@@ -10,15 +10,15 @@ class GetDuplicateMatches
           submitted_at
         FROM application_forms application_details
         JOIN(
-          SELECT TRIM(UPPER(application_forms.last_name)) last_name, application_forms.date_of_birth, COALESCE(REPLACE(UPPER(application_forms.postcode), ' ', ''), '') postcode
+          SELECT TRIM(UPPER(unaccent(application_forms.last_name))) last_name, application_forms.date_of_birth, COALESCE(REPLACE(UPPER(application_forms.postcode), ' ', ''), '') postcode
           FROM application_forms
           WHERE application_forms.previous_application_form_id IS NULL
-          GROUP BY TRIM(UPPER(application_forms.last_name)), application_forms.date_of_birth, COALESCE(REPLACE(UPPER(application_forms.postcode), ' ', ''), '')
+          GROUP BY TRIM(UPPER(unaccent(application_forms.last_name))), application_forms.date_of_birth, COALESCE(REPLACE(UPPER(application_forms.postcode), ' ', ''), '')
           HAVING (count(*) > 1)
         ) duplicate_attributes
         ON COALESCE(REPLACE(UPPER(application_details.postcode), ' ', ''), '') = duplicate_attributes.postcode
         AND application_details.date_of_birth = duplicate_attributes.date_of_birth
-        AND TRIM(UPPER(application_details.last_name)) = duplicate_attributes.last_name
+        AND TRIM(UPPER(unaccent(application_details.last_name))) = duplicate_attributes.last_name
         JOIN(
           SELECT TRIM(UPPER(application_forms.last_name)) last_name, application_forms.date_of_birth, COALESCE(REPLACE(UPPER(application_forms.postcode), ' ', ''), '') postcode
           FROM application_forms

--- a/spec/queries/get_duplicate_matches_spec.rb
+++ b/spec/queries/get_duplicate_matches_spec.rb
@@ -58,6 +58,24 @@ RSpec.describe GetDuplicateMatches do
       end
     end
 
+    context 'matches a name using an accent' do
+      let(:last_names) { returned_array_of_hashes.map { |element| element['last_name'] } }
+
+      before do
+        application_form(candidate_1, last_name: 'Fernández')
+        application_form(candidate_2, last_name: 'Fernandez')
+      end
+
+      it 'returns an array of hashes with the correct keys' do
+        expect(returned_array_of_hashes.count).to eq(2)
+      end
+
+      it 'returns all duplicates' do
+        expect(last_names).to include('Fernández')
+        expect(last_names).to include('Fernandez')
+      end
+    end
+
     context 'matches a postcode with or without a space' do
       let(:postcodes) { returned_array_of_hashes.map { |element| element['postcode'] } }
 


### PR DESCRIPTION
## Context

Candidates can get around our duplicate matcher by including an accent in their name.

## Changes proposed in this pull request

<img width="1211" alt="image" src="https://user-images.githubusercontent.com/47917431/227956988-ddabef81-a9be-4905-87c5-bfd7110c315a.png">

## Guidance to review

Maybe a better way of doing this?

## Link to Trello card

https://trello.com/c/rW1846yG

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
