### PR TITLE
Only show SKE status for accepted offers

### DIFF
--- a/app/components/provider_interface/offer_summary_component.html.erb
+++ b/app/components/provider_interface/offer_summary_component.html.erb
@@ -12,7 +12,7 @@
         application_choice: @application_choice,
         course: @course,
         ske_condition:,
-        editable: true,
+        editable: !@application_choice.accepted_choice?,
       ) %>
     <% end %>
   <% end %>

--- a/app/components/provider_interface/ske_conditions_component.html.erb
+++ b/app/components/provider_interface/ske_conditions_component.html.erb
@@ -4,7 +4,9 @@
     heading_level: :h2,
   )) do %>
     <div class="app-summary-card__actions">
-      <%= render ProviderInterface::ConditionStatusTagComponent.new(ske_condition) %>
+      <% if offer_accepted? %>
+        <%= render ProviderInterface::ConditionStatusTagComponent.new(ske_condition) %>
+      <% end %>
       <% if editable %>
         <%= govuk_link_to 'Remove condition', remove_condition_path %>
       <% end %>

--- a/app/components/provider_interface/ske_conditions_component.rb
+++ b/app/components/provider_interface/ske_conditions_component.rb
@@ -77,5 +77,9 @@ module ProviderInterface
     def religious_education_course?
       @application_choice.current_course.subjects.first&.code&.in?(Subject::SKE_RE_COURSES)
     end
+
+    def offer_accepted?
+      @application_choice.accepted_choice?
+    end
   end
 end

--- a/spec/components/provider_interface/ske_conditions_component_spec.rb
+++ b/spec/components/provider_interface/ske_conditions_component_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe ProviderInterface::SkeConditionsComponent do
       expect(result.text).to include('ReasonTheir degree subject was not French')
     end
 
-    it 'renders the condition status' do
-      expect(result.text).to include('Met')
+    it 'does not render the condition status' do
+      expect(result.text).not_to include('Met')
     end
 
     context 'when the SKE condition is editable' do
@@ -33,6 +33,14 @@ RSpec.describe ProviderInterface::SkeConditionsComponent do
 
       it 'renders a Change link' do
         expect(result.css('header.app-summary-card__header a').text).to eq('Remove condition')
+      end
+    end
+
+    context 'when the candidate accepted the offer' do
+      before { application_choice.status = :pending_conditions }
+
+      it 'does renders the condition status' do
+        expect(result.text).to include('Met')
       end
     end
   end
@@ -46,8 +54,8 @@ RSpec.describe ProviderInterface::SkeConditionsComponent do
       expect(result.text).to include('ReasonTheir degree subject was not Mathematics')
     end
 
-    it 'renders the condition status' do
-      expect(result.text).to include('Pending')
+    it 'does not render the condition status' do
+      expect(result.text).not_to include('Pending')
     end
 
     context 'when the SKE condition is editable' do
@@ -55,6 +63,14 @@ RSpec.describe ProviderInterface::SkeConditionsComponent do
 
       it 'renders a Change link' do
         expect(result.css('header.app-summary-card__header a').text).to eq('Remove condition')
+      end
+    end
+
+    context 'when the candidate accepted the offer' do
+      before { application_choice.status = :pending_conditions }
+
+      it 'does renders the condition status' do
+        expect(result.text).to include('Pending')
       end
     end
   end


### PR DESCRIPTION
## Context

This is a tiny follow-up to https://github.com/DFE-Digital/apply-for-teacher-training/pull/8062 that simply hides the SKE status tag (visible on the check and review offer pages) until the candidate has accepted the offer.

## Changes proposed in this pull request

Hide tag unless `ApplicationChoice` is in one of the 'accepted' statuses.

Before acceptance:

![image](https://user-images.githubusercontent.com/450843/228176048-c1257ff7-52da-4e4e-99f1-4415caa5106f.png)

After acceptance:

![image](https://user-images.githubusercontent.com/450843/228178832-6a8e78c4-5739-47d8-92c8-9a4bae7339c0.png)


## Guidance to review


## Link to Trello card

Original card: https://trello.com/c/9HrSXCar/1278-some-of-the-change-links-for-a-pending-ske-condition-are-not-implemented-yet

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
