### PR TITLE
Support functionality: Change award year and grade for other qualifications

### DIFF
--- a/app/components/shared/qualification_row_component.html.erb
+++ b/app/components/shared/qualification_row_component.html.erb
@@ -11,13 +11,17 @@
   <td class="govuk-table__cell">
     <%= qualification.award_year %>
     <% if editable %>
-      Change
+      <%= govuk_link_to support_interface_application_form_edit_other_qualification_award_year_path(qualification_id: qualification.id) do %>
+        Change
+      <% end %>
     <% end %>
   </td>
   <td class="govuk-table__cell">
     <%= render QualificationGradeComponent.new(qualification: qualification) %>
     <% if editable %>
-      Change
+      <%= govuk_link_to support_interface_application_form_edit_other_qualification_grade_path(qualification_id: qualification.id) do %>
+        Change
+      <% end %>
     <% end %>
   </td>
 </tr>

--- a/app/components/shared/qualification_row_component.html.erb
+++ b/app/components/shared/qualification_row_component.html.erb
@@ -8,6 +8,16 @@
   <td class="govuk-table__cell">
     <%= country %>
   </td>
-  <td class="govuk-table__cell"><%= qualification.award_year %></td>
-  <td class="govuk-table__cell"><%= render QualificationGradeComponent.new(qualification: qualification) %></td>
+  <td class="govuk-table__cell">
+    <%= qualification.award_year %>
+    <% if editable %>
+      Change
+    <% end %>
+  </td>
+  <td class="govuk-table__cell">
+    <%= render QualificationGradeComponent.new(qualification: qualification) %>
+    <% if editable %>
+      Change
+    <% end %>
+  </td>
 </tr>

--- a/app/components/shared/qualification_row_component.html.erb
+++ b/app/components/shared/qualification_row_component.html.erb
@@ -12,7 +12,7 @@
     <%= qualification.award_year %>
     <% if editable %>
       <%= govuk_link_to support_interface_application_form_edit_other_qualification_award_year_path(qualification_id: qualification.id) do %>
-        Change
+        Change <span class="govuk-visually-hidden">award year</span>
       <% end %>
     <% end %>
   </td>
@@ -20,7 +20,7 @@
     <%= render QualificationGradeComponent.new(qualification: qualification) %>
     <% if editable %>
       <%= govuk_link_to support_interface_application_form_edit_other_qualification_grade_path(qualification_id: qualification.id) do %>
-        Change
+        Change <span class="govuk-visually-hidden">grade</span>
       <% end %>
     <% end %>
   </td>

--- a/app/components/shared/qualification_row_component.rb
+++ b/app/components/shared/qualification_row_component.rb
@@ -1,9 +1,10 @@
 # NOTE: This component is used by both provider and support UIs
 class QualificationRowComponent < ViewComponent::Base
-  attr_reader :qualification
+  attr_reader :qualification, :editable
 
-  def initialize(qualification:)
+  def initialize(qualification:, editable: false)
     @qualification = qualification
+    @editable = editable
   end
 
   def country

--- a/app/components/shared/qualifications_component.html.erb
+++ b/app/components/shared/qualifications_component.html.erb
@@ -8,6 +8,6 @@
     editable: editable?,
   ) %>
   <%= render GcseQualificationCardsComponent.new(application_form, editable: editable?) %>
-  <%= render QualificationsTableComponent.new(qualifications: application_form.application_qualifications.other, header: 'A levels and other qualifications', subheader: 'Details of A levels and other qualifications') %>
+  <%= render QualificationsTableComponent.new(qualifications: application_form.application_qualifications.other, header: 'A levels and other qualifications', subheader: 'Details of A levels and other qualifications', editable: editable?) %>
   <%= render EflQualificationCardComponent.new(application_form) %>
 </section>

--- a/app/components/shared/qualifications_table_component.html.erb
+++ b/app/components/shared/qualifications_table_component.html.erb
@@ -13,7 +13,7 @@
     </thead>
     <tbody class="govuk-table__body">
       <% qualifications.each do |qualification| %>
-        <%= render QualificationRowComponent.new(qualification: qualification) %>
+        <%= render QualificationRowComponent.new(qualification: qualification, editable: editable) %>
       <% end %>
     </tbody>
   </table>

--- a/app/components/shared/qualifications_table_component.rb
+++ b/app/components/shared/qualifications_table_component.rb
@@ -1,11 +1,12 @@
 # NOTE: This component is used by both provider and support UIs
 class QualificationsTableComponent < ViewComponent::Base
-  attr_reader :qualifications, :header, :subheader
+  attr_reader :qualifications, :header, :subheader, :editable
 
-  def initialize(qualifications:, header:, subheader:)
+  def initialize(qualifications:, header:, subheader:, editable: false)
     @qualifications = qualifications
     @header = header
     @subheader = subheader
+    @editable = editable
   end
 
   def add_other_qualifications_q_a

--- a/app/controllers/support_interface/application_forms/other_qualifications_controller.rb
+++ b/app/controllers/support_interface/application_forms/other_qualifications_controller.rb
@@ -1,0 +1,61 @@
+module SupportInterface
+  module ApplicationForms
+    class OtherQualificationsController < SupportInterfaceController
+      def edit_award_year
+        @qualification_award_year_form = EditOtherQualificationAwardYearForm.new(
+          ApplicationQualification.find(params[:qualification_id]),
+        )
+      end
+
+      def update_award_year
+        @qualification_award_year_form = EditOtherQualificationAwardYearForm.new(
+          ApplicationQualification.find(params[:qualification_id]),
+        )
+
+        @qualification_award_year_form.assign_attributes(edit_award_year_params)
+        if @qualification_award_year_form.valid?
+          @qualification_award_year_form.save!
+          flash[:success] = 'Qualification award year updated'
+          redirect_to support_interface_application_form_path(@qualification_award_year_form.application_form)
+        else
+          render :edit_award_year
+        end
+      end
+
+      def edit_grade
+        @qualification_grade_form = EditOtherQualificationGradeForm.new(
+          ApplicationQualification.find(params[:qualification_id]),
+        )
+      end
+
+      def update_grade
+        @qualification_grade_form = EditOtherQualificationGradeForm.new(
+          ApplicationQualification.find(params[:qualification_id]),
+        )
+
+        @qualification_grade_form.assign_attributes(edit_grade_params)
+        if @qualification_grade_form.valid?
+          @qualification_grade_form.save!
+          flash[:success] = 'Qualification grade updated'
+          redirect_to support_interface_application_form_path(@qualification_grade_form.application_form)
+        else
+          render :edit_grade
+        end
+      end
+
+    private
+
+      def edit_award_year_params
+        params.require(
+          :support_interface_application_forms_edit_other_qualification_award_year_form,
+        ).permit(:award_year, :audit_comment)
+      end
+
+      def edit_grade_params
+        params.require(
+          :support_interface_application_forms_edit_other_qualification_grade_form,
+        ).permit(:grade, :audit_comment)
+      end
+    end
+  end
+end

--- a/app/forms/support_interface/application_forms/edit_other_qualification_award_year_form.rb
+++ b/app/forms/support_interface/application_forms/edit_other_qualification_award_year_form.rb
@@ -1,0 +1,33 @@
+module SupportInterface
+  module ApplicationForms
+    class EditOtherQualificationAwardYearForm
+      include ActiveModel::Model
+      include DateValidationHelper
+
+      attr_reader :qualification
+      attr_accessor :award_year, :audit_comment
+
+      validates :award_year, presence: true, year: { future: true }
+      validates :audit_comment, presence: true
+      validates_with ZendeskUrlValidator
+
+      delegate :application_form, :subject, to: :qualification
+
+      def initialize(qualification)
+        @qualification = qualification
+
+        super(
+          award_year: @qualification.award_year,
+        )
+      end
+
+      def save!
+        @qualification.update!(
+          award_year:,
+          audit_comment:,
+        )
+        qualification
+      end
+    end
+  end
+end

--- a/app/forms/support_interface/application_forms/edit_other_qualification_grade_form.rb
+++ b/app/forms/support_interface/application_forms/edit_other_qualification_grade_form.rb
@@ -1,0 +1,38 @@
+module SupportInterface
+  module ApplicationForms
+    class EditOtherQualificationGradeForm
+      include ActiveModel::Model
+
+      attr_reader :qualification
+      attr_accessor :grade, :audit_comment
+
+      validates :grade, presence: true
+      validates :audit_comment, presence: true
+      validates_with ZendeskUrlValidator
+      validate :grade_format_is_valid
+
+      delegate :application_form, :subject, to: :qualification
+
+      def initialize(qualification)
+        @qualification = qualification
+
+        super(
+          grade: @qualification.grade
+        )
+      end
+
+      def save!
+        @qualification.update!(
+          grade:,
+          audit_comment:,
+        )
+      end
+
+    private
+
+      def grade_format_is_valid
+        errors.add(:grade, :invalid) unless grade.in?(A_LEVEL_GRADES) || grade.in?(AS_LEVEL_GRADES) || grade.in?(ALL_GCSE_GRADES)
+      end
+    end
+  end
+end

--- a/app/views/support_interface/application_forms/other_qualifications/edit_award_year.html.erb
+++ b/app/views/support_interface/application_forms/other_qualifications/edit_award_year.html.erb
@@ -1,0 +1,18 @@
+<% content_for :browser_title, title_with_error_prefix('Edit qualification award year', @qualification_award_year_form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(@qualification_award_year_form.application_form)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @qualification_award_year_form, url: support_interface_application_form_update_other_qualification_award_year_path do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_fieldset legend: { text: "Edit #{@qualification_award_year_form.subject.capitalize} qualification details", size: 'l' } do %>
+        <%= f.govuk_text_field :award_year, label: { text: 'Award year', size: 'm' } %>
+      <% end %>
+
+        <%= f.govuk_text_field :audit_comment, label: { text: t('support_interface.audit_comment_ticket.label'), size: 'm' }, hint: { text: t('support_interface.audit_comment_ticket.hint') } %>
+
+      <%= f.govuk_submit 'Update details' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/application_forms/other_qualifications/edit_grade.html.erb
+++ b/app/views/support_interface/application_forms/other_qualifications/edit_grade.html.erb
@@ -1,0 +1,17 @@
+<% content_for :browser_title, title_with_error_prefix('Edit qualification grade', @qualification_grade_form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(@qualification_grade_form.application_form)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @qualification_grade_form, url: support_interface_application_form_update_other_qualification_grade_path do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_fieldset legend: { text: "Edit #{@qualification_grade_form.subject.capitalize} qualification details", size: 'l' } do %>
+        <%= f.govuk_text_field :grade, label: { text: 'Grade', size: 'm' } %>
+      <% end %>
+
+        <%= f.govuk_text_field :audit_comment, label: { text: t('support_interface.audit_comment_ticket.label'), size: 'm' }, hint: { text: t('support_interface.audit_comment_ticket.hint') } %>
+
+      <%= f.govuk_submit 'Update details' %>
+    <% end %>
+  </div>

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -208,6 +208,22 @@ en:
               blank: Enter the grade
             audit_comment:
               blank: Enter a Zendesk ticket URL
+        support_interface/application_forms/edit_other_qualification_award_year_form:
+          attributes:
+            award_year:
+              blank: Award year cannot be blank
+              wrong_length: Year must include 4 numbers 
+              invalid: test
+            audit_comment:
+              blank: Enter a Zendesk ticket URL
+        support_interface/application_forms/edit_other_qualification_grade_form:
+          attributes:
+            grade:
+              blank: Enter the grade
+            audit_comment:
+              blank: Enter a Zendesk ticket URL
+            grade:
+              invalid: Enter a valid grade
         support_interface/application_forms/edit_degree_form:
           attributes:
             award_year:

--- a/config/routes/support.rb
+++ b/config/routes/support.rb
@@ -27,6 +27,12 @@ namespace :support_interface, path: '/support' do
     get '/gcses-grade/:gcse_id' => 'application_forms/gcses#edit_grade', as: :application_form_edit_gcse_grade
     post '/gcses-grade/:gcse_id' => 'application_forms/gcses#update_grade', as: :application_form_update_gcse_grade
 
+    get '/other-qualification-award-year/:qualification_id' => 'application_forms/other_qualifications#edit_award_year', as: :application_form_edit_other_qualification_award_year
+    post '/other-qualification-award-year/:qualification_id' => 'application_forms/other_qualifications#update_award_year', as: :application_form_update_other_qualification_award_year
+
+    get '/other-qualification-grade/:qualification_id' => 'application_forms/other_qualifications#edit_grade', as: :application_form_edit_other_qualification_grade
+    post '/other-qualification-grade/:qualification_id' => 'application_forms/other_qualifications#update_grade', as: :application_form_update_other_qualification_grade
+
     get '/degrees/:degree_id' => 'application_forms/degrees#edit', as: :application_form_edit_degree
     post '/degrees/:degree_id' => 'application_forms/degrees#update', as: :application_form_update_degree
 

--- a/spec/forms/support_interface/application_forms/edit_other_qualification_award_year_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/edit_other_qualification_award_year_form_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ApplicationForms::EditOtherQualificationAwardYearForm, type: :model, with_audited: true do
+  describe '#save' do
+    let(:zendesk_ticket) { 'www.becomingateacher.zendesk.com/agent/tickets/example' }
+    let(:qualification) { create(:other_qualification) }
+    let(:form) { described_class.new(qualification) }
+
+    it 'returns false if the award year is in the future' do
+      invalid_award_year = Time.zone.now.year + 4
+
+      form.assign_attributes(award_year: invalid_award_year, audit_comment: zendesk_ticket)
+
+      expect(form).not_to be_valid
+    end
+
+    it 'returns false if no award year is provided' do
+      form.assign_attributes(award_year: nil, audit_comment: zendesk_ticket)
+
+      expect(form).not_to be_valid
+    end
+
+    it 'updates the qualification if valid' do
+      valid_award_year = Time.zone.now.year
+
+      form.assign_attributes(award_year: valid_award_year, audit_comment: zendesk_ticket)
+
+      form.save!
+
+      expect(form).to be_valid
+      expect(qualification.award_year).to eq valid_award_year.to_s
+      expect(qualification.audits.last.comment).to include(zendesk_ticket)
+    end
+  end
+end

--- a/spec/forms/support_interface/application_forms/edit_other_qualification_grade_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/edit_other_qualification_grade_form_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ApplicationForms::EditOtherQualificationGradeForm, type: :model, with_audited: true do
+  describe '#save' do
+    let(:zendesk_ticket) { 'www.becomingateacher.zendesk.com/agent/tickets/example' }
+    let(:qualification) { create(:other_qualification) }
+    let(:form) { described_class.new(qualification) }
+
+    it 'returns false if the grade is not valid' do
+      invalid_grade = 'nonsense'
+
+      form.assign_attributes(grade: invalid_grade, audit_comment: zendesk_ticket)
+
+      expect(form).not_to be_valid
+    end
+
+    it 'returns false if no grade is provided' do
+      form.assign_attributes(grade: nil, audit_comment: zendesk_ticket)
+
+      expect(form).not_to be_valid
+    end
+
+    it 'updates the qualification if valid' do
+      valid_grade = 'A'
+
+      form.assign_attributes(grade: valid_grade, audit_comment: zendesk_ticket)
+
+      form.save!
+
+      expect(form).to be_valid
+      expect(qualification.grade).to eq valid_grade
+      expect(qualification.audits.last.comment).to include(zendesk_ticket)
+    end
+  end
+end

--- a/spec/system/support_interface/editing_other_qualification_spec.rb
+++ b/spec/system/support_interface/editing_other_qualification_spec.rb
@@ -1,0 +1,129 @@
+require 'rails_helper'
+
+RSpec.feature 'Editing other qualification' do
+  include DfESignInHelpers
+
+  scenario 'Support user edits award year and grade', with_audited: true do
+    given_i_am_a_support_user
+    and_an_application_exists
+
+    when_i_visit_the_application_page
+    and_i_click_the_change_link_next_to_the_first_qualification
+    then_i_should_see_a_prepopulated_form_for_award_year
+
+    when_i_provide_an_invalid_award_year
+    and_i_submit_the_form
+    then_i_see_an_error_message
+
+    when_i_update_the_form
+    and_i_submit_the_form
+    then_i_should_see_a_flash_message
+    and_i_should_see_the_new_details
+    and_i_should_see_my_details_comment_in_the_audit_log
+
+    when_i_click_the_change_grade_link_next_to_the_first_qualification
+    then_i_should_see_a_prepopulated_form_for_grade
+
+    when_i_provide_an_invalid_grade
+    and_i_submit_the_form
+    then_i_am_told_to_enter_a_valid_grade
+
+    when_i_enter_a_valid_grade
+    and_i_submit_the_form
+    then_i_should_see_a_flash_message_telling_me_the_grade_has_been_updated
+    and_i_should_see_the_new_grade
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_an_application_exists
+    @form = create(:completed_application_form)
+    create(:other_qualification, subject: 'Forensic Science', award_year: 1.year.ago, application_form: @form, grade: 'C')
+  end
+
+  def when_i_visit_the_application_page
+    visit support_interface_application_form_path(@form)
+  end
+
+  def and_i_click_the_change_link_next_to_the_first_qualification
+    within('[data-qa="qualifications-table-a-levels-and-other-qualifications"]') do
+      click_link 'Change award year'
+    end
+  end
+
+  def then_i_should_see_a_prepopulated_form_for_award_year
+    expect(page).to have_content('Edit Forensic science qualification details')
+    expect(page).to have_selector("input[value='#{1.year.ago}']")
+  end
+
+  def when_i_provide_an_invalid_award_year
+    fill_in 'Award year', with: '201'
+    fill_in 'Zendesk ticket URL', with: 'https://becomingateacher.zendesk.com/agent/tickets/12345'
+  end
+
+  def then_i_see_an_error_message
+    expect(page).to have_content 'Enter a real award year'
+  end
+
+  def when_i_update_the_form
+    fill_in 'Award year', with: Time.zone.now.year
+    fill_in 'Zendesk ticket URL', with: 'https://becomingateacher.zendesk.com/agent/tickets/12345'
+  end
+
+  def and_i_submit_the_form
+    click_button 'Update'
+  end
+
+  def then_i_should_see_a_flash_message
+    expect(page).to have_content 'Qualification award year updated'
+  end
+
+  def and_i_should_see_the_new_details
+    within('[data-qa="qualifications-table-a-levels-and-other-qualifications"]') do
+      expect(page).to have_content Time.zone.now.year
+    end
+  end
+
+  def and_i_should_see_my_details_comment_in_the_audit_log
+    click_link 'History'
+    expect(page).to have_content 'https://becomingateacher.zendesk.com/agent/tickets/12345'
+  end
+
+  def when_i_click_the_change_grade_link_next_to_the_first_qualification
+    visit support_interface_application_form_path(@form)
+    within('[data-qa="qualifications-table-a-levels-and-other-qualifications"]') do
+      click_link 'Change grade'
+    end
+  end
+
+  def then_i_should_see_a_prepopulated_form_for_grade
+    expect(page).to have_content('Edit Forensic science qualification details')
+    expect(page).to have_selector("input[value='C']")
+  end
+
+  def when_i_provide_an_invalid_grade
+    fill_in 'Grade', with: 'hello'
+    fill_in 'Zendesk ticket URL', with: 'https://becomingateacher.zendesk.com/agent/tickets/12345'
+  end
+
+  def then_i_am_told_to_enter_a_valid_grade
+    expect(page).to have_content 'Enter a valid grade'
+  end
+
+  def when_i_enter_a_valid_grade
+    fill_in 'Grade', with: 'A'
+    fill_in 'Zendesk ticket URL', with: 'https://becomingateacher.zendesk.com/agent/tickets/12345'
+  end
+
+  def then_i_should_see_a_flash_message_telling_me_the_grade_has_been_updated
+    expect(page).to have_content 'Qualification grade updated'
+  end
+
+  def and_i_should_see_the_new_grade
+    within('[data-qa="qualifications-table-a-levels-and-other-qualifications"]') do
+      expect(page).to have_content 'A'
+    end
+  end
+end


### PR DESCRIPTION
## Context

Further support functionality – allow them to change the grade and award year for other qualifications

## Changes proposed in this pull request

<img width="1165" alt="image" src="https://user-images.githubusercontent.com/47917431/228206078-985e3443-1e2d-4d08-b211-385fede60560.png">

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/i378zJbr

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
