### PR TITLE
Enable unaccent pg extension

### DIFF
--- a/db/migrate/20230328103309_enable_unaccent.rb
+++ b/db/migrate/20230328103309_enable_unaccent.rb
@@ -1,0 +1,5 @@
+class EnableUnaccent < ActiveRecord::Migration[7.0]
+  def change
+    enable_extension 'unaccent' unless extension_enabled?('unaccent')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_13_100534) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_28_103309) do
   create_sequence "qualifications_public_id_seq", start: 120000
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
+  enable_extension "unaccent"
 
   create_table "application_choices", force: :cascade do |t|
     t.bigint "application_form_id", null: false


### PR DESCRIPTION
## Context

Need to capture accented names in the duplicate matcher – need a postgresql extension to help!