### PR TITLE
Fix the review_url_vars variable

### DIFF
--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -106,10 +106,10 @@ locals {
 
   app_env_values_from_yaml = try(yamldecode(file("${path.module}/workspace-variables/${var.paas_app_environment}_app_env.yml")), {})
 
-  review_url_vars = {
+  review_url_vars = var.app_name_suffix != null ? {
     "CUSTOM_HOSTNAME"  = "apply-${local.app_name_suffix}.${local.cluster[var.cluster].dns_zone_prefix}.teacherservices.cloud"
     "AUTHORISED_HOSTS" = "apply-${local.app_name_suffix}.${local.cluster[var.cluster].dns_zone_prefix}.teacherservices.cloud"
-  }
+  } : {}
 
   app_env_values = merge(
     local.app_env_values_from_yaml,


### PR DESCRIPTION
## Context

Fix the review_url_vars that was broken in https://github.com/DFE-Digital/apply-for-teacher-training/pull/8091
It's only used in review apps, but tries to set in all envs

## Changes proposed in this pull request

Update aks terraform variables

## Guidance to review

deploy-plan all aks envs

## Link to Trello card

n/a

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
