### PR TITLE
Fix flakey provider change course test

### DIFF
--- a/spec/system/provider_interface/provider_exits_journey_when_changing_a_course_before_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_exits_journey_when_changing_a_course_before_an_offer_spec.rb
@@ -73,7 +73,7 @@ RSpec.feature 'Provider exits journey when changing a course' do
   end
 
   def and_i_click_on_change_the_course
-    within(all('.govuk-summary-list__row').find { |e| e.text.include?('Course') }) do
+    within(all('.govuk-summary-list__row dt').find { |e| e.text == 'Course' }.find(:xpath, '..')) do
       click_on 'Change'
     end
   end


### PR DESCRIPTION
## Context

This test failed intermittently because the matcher `within(all('.govuk-summary-list__row').find { |e| e.text == 'Course' })` sometimes finds the wrong summary table row. It happens because Faker sometimes includes the name _Course_ in some other field. If we focus on the wrong row then we don't find the _Change_ link.

![image](https://user-images.githubusercontent.com/450843/228504699-89020c02-98dd-4635-92ad-5d8f2306a38a.png)

## Changes proposed in this pull request

This change just makes the match a little more precise so we don't pick the wrong row.

## Guidance to review

Is there a more elegant capybara finder for this?

## Link to Trello card

n/a

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
