### PR TITLE
Increase timeout for konduit restores

### DIFF
--- a/.github/actions/backup_and_restore/action.yml
+++ b/.github/actions/backup_and_restore/action.yml
@@ -38,8 +38,8 @@ runs:
     - name: Setup cf cli
       uses: DFE-Digital/github-actions/setup-cf-cli@master
       with:
-        CF_USERNAME:   ${{ steps.get-secrets.outputs.CF_USER }}
-        CF_PASSWORD:   ${{ steps.get-secrets.outputs.CF_PASSWORD }}
+        CF_USERNAME: ${{ steps.get-secrets.outputs.CF_USER }}
+        CF_PASSWORD: ${{ steps.get-secrets.outputs.CF_PASSWORD }}
         CF_SPACE_NAME: ${{ env.paas_space_name }}
         INSTALL_CONDUIT: true
 
@@ -57,9 +57,9 @@ runs:
         cf logout
         az logout
 
-#
-# Now restore to the equivalent AKS env database
-#
+    #
+    # Now restore to the equivalent AKS env database
+    #
 
     - name: Set KV environment variables for AKS
       shell: bash
@@ -95,7 +95,7 @@ runs:
     - name: Install kubectl
       uses: azure/setup-kubectl@v3
       with:
-        version: 'v1.26.1' # default is latest stable
+        version: "v1.26.1" # default is latest stable
 
     - name: K8 setup
       shell: bash
@@ -106,7 +106,7 @@ runs:
     - name: Restore backup to aks env database
       shell: bash
       run: |
-        bin/konduit.sh -i ${{ env.backup_file_name }} -c ${{ env.app_name }} -- psql
+        bin/konduit.sh -i ${{ env.backup_file_name }} -c -t 7200 ${{ env.app_name }} -- psql
 
     - name: Remove PaaS specific event triggers
       shell: bash


### PR DESCRIPTION
## Context

The default konduit time is 3600 seconds. Sometimes the restore takes just a little longer. 

## Changes proposed in this pull request

Set it to 7200 seconds to ensure it completes.

## Guidance to review

`bin/konduit.sh -i file-name -c -t 7200 app-name -- psql`

## Link to Trello card

https://trello.com/c/DawQm5fF

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
