### PR TITLE
API flag for deleted applications

### DIFF
--- a/app/presenters/vendor_api/application_presenter.rb
+++ b/app/presenters/vendor_api/application_presenter.rb
@@ -66,6 +66,7 @@ module VendorAPI
           further_information: application_form.further_information,
           safeguarding_issues_status: application_form.safeguarding_issues_status,
           safeguarding_issues_details_url:,
+          anonymised:,
         },
       }
     end
@@ -110,6 +111,10 @@ module VendorAPI
 
     def safeguarding_issues_details_url
       application_form.has_safeguarding_issues_to_declare? ? provider_interface_application_choice_url(application_choice, anchor: 'criminal-convictions-and-professional-misconduct') : nil
+    end
+
+    def anonymised
+      IsApplicationAnonymised.new(application_form: application_form).call
     end
 
     def reference_to_hash(reference)

--- a/app/services/is_application_anonymised.rb
+++ b/app/services/is_application_anonymised.rb
@@ -1,0 +1,11 @@
+class IsApplicationAnonymised
+  attr_reader :application_form
+
+  def initialize(application_form:)
+    @application_form = application_form
+  end
+
+  def call
+    application_form.candidate.email_address.include? 'deleted-application-'
+  end
+end

--- a/config/vendor_api/v1.0.yml
+++ b/config/vendor_api/v1.0.yml
@@ -419,6 +419,7 @@ components:
       - work_experience
       - safeguarding_issues_status
       - safeguarding_issues_details_url
+      - anonymised
       properties:
         application_url:
           type: string
@@ -548,6 +549,10 @@ components:
           description: URL to Apply system where safeguarding issues disclosed by the candidate can be access by users with permissions to view safeguarding information.
           example: https://apply-for-teacher-training.service.gov.uk/provider/applications/1#criminal-convictions-and-professional-misconduct
           nullable: true
+        anonymised:
+          type: boolean
+          description: Indicates if a candidate has been removed from the Apply service
+          example: true
     Candidate:
       type: object
       additionalProperties: false

--- a/config/vendor_api/v1.1.yml
+++ b/config/vendor_api/v1.1.yml
@@ -404,6 +404,7 @@ components:
       - work_experience
       - safeguarding_issues_status
       - safeguarding_issues_details_url
+      - anonymised
       properties:
         interviews:
           type: array

--- a/spec/presenters/vendor_api/v1.0/application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.0/application_presenter_spec.rb
@@ -218,4 +218,21 @@ RSpec.describe VendorAPI::ApplicationPresenter do
       expect(attributes[:contact_details][:country]).to eq('AE')
     end
   end
+
+  describe '#anonymised' do
+    let!(:application_choice) { create(:application_choice, :with_completed_application_form) }
+
+    context 'when the application has been deleted' do
+      it 'returns true' do
+        application_choice.application_form.candidate.update!(email_address: "deleted-application-#{application_choice.application_form.support_reference}@example.com")
+        expect(attributes[:anonymised]).to be true
+      end
+    end
+
+    context 'when the application has not been deleted' do
+      it 'returns false' do
+        expect(attributes[:anonymised]).to be false
+      end
+    end
+  end
 end

--- a/spec/services/is_application_anonymised_spec.rb
+++ b/spec/services/is_application_anonymised_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe IsApplicationAnonymised do
+  let(:application_form) { create(:completed_application_form) }
+  let(:service) { described_class.new(application_form:).call }
+
+  describe '#call' do
+    context 'when the application has been deleted' do
+      it 'returns true' do
+        application_form.candidate.update!(email_address: "deleted-application-#{application_form.support_reference}@example.com")
+        expect(service).to be true
+      end
+    end
+
+    context 'when the application has not been deleted' do
+      it 'returns false' do
+        expect(service).to be false
+      end
+    end
+  end
+end

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -233,6 +233,7 @@ RSpec.feature 'Vendor receives the application', time: CycleTimetableHelper.mid_
         further_information: '',
         safeguarding_issues_status: 'has_safeguarding_issues_to_declare',
         safeguarding_issues_details_url: Rails.application.routes.url_helpers.provider_interface_application_choice_url(@provider.application_choices.first.id, anchor: 'criminal-convictions-and-professional-misconduct'),
+        anonymised: false,
         work_experience: {
           jobs: [
             {


### PR DESCRIPTION
## Context

We have previously had feedback from Vendors around the fact that our anonymisation process can impact a Provider’s downstream process. This is because when we run the anonymisation process, we are changing many personal details, for example the email address to randomstringofnumbers@example.com. This updates the 'last_updated_at' field which means that the candidate is 'sync'-able.

When a provider then syncs with us over the API, we send them this new information, as it’s changed since their last sync. If this person has been, say, made an offer, their information will be overwritten. This means the provider will not have relevant information about someone who is going to do their course linked to a retrievable record anymore.

## Changes proposed in this pull request

- A new anonymised `boolean` field to the application form

This is set to true if the candidate has 'delete-application' in their email, which is only set if the `DeleteApplication` service is called.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/5osu8Hob

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
