### PR TITLE
Filter sensitive data on Sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -3,7 +3,15 @@ Sentry.init do |config|
   config.release = ENV['SHA']
   filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
 
-  config.before_send = lambda do |event, _hint|
+  config.before_send = lambda do |event, hint|
+    if hint[:exception].is_a?(ActiveRecord::RecordNotUnique)
+      # rubocop:disable Style/HashEachMethods
+      event.exception.values.each do |single_exception|
+        single_exception.value.gsub!(/^DETAIL:.*$/, '[PG DETAIL FILTERED]')
+      end
+      # rubocop:enable Style/HashEachMethods
+    end
+
     filter.filter(event.to_hash)
   end
 


### PR DESCRIPTION
## Context

When the record is not unique Postgres raises the exception and it goes to Sentry like this:

```
  PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "index_provider_users_on_email_address"
DETAIL:  Key (email_address)=(someuser@somedomain.uk.com) already exists.
```

We want to avoid that so this change filter the detail from the exception

## The result

As a test, you can see filtered here: https://dfe-teacher-services.sentry.io/issues/4046612784/?project=1765973&query=is%3Aunresolved&referrer=issue-stream&stream_index=0