### PR TITLE
Allow support to amend SKE conditions

### DIFF
--- a/app/components/provider_interface/ske_length_component.rb
+++ b/app/components/provider_interface/ske_length_component.rb
@@ -11,7 +11,7 @@ module ProviderInterface
     end
 
     def options
-      ProviderInterface::OfferWizard::SKE_LENGTHS.map do |value|
+      SkeCondition::SKE_LENGTHS.map do |value|
         SkeLength.new(value: value, label: "#{value} weeks")
       end
     end

--- a/app/controllers/support_interface/application_choice_conditions_controller.rb
+++ b/app/controllers/support_interface/application_choice_conditions_controller.rb
@@ -53,7 +53,7 @@ module SupportInterface
     def condition_params
       params
         .require(:support_interface_conditions_form)
-        .permit(:application_choice_id, :audit_comment_ticket, :confirm_make_unconditional, further_conditions: {}, standard_conditions: [])
+        .permit(:application_choice_id, :audit_comment_ticket, :confirm_make_unconditional, further_conditions: {}, standard_conditions: [], ske_conditions: {})
         .to_h
         .with_indifferent_access
     end

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -163,13 +163,13 @@ module ProviderInterface
     end
 
     def outdated_degree(application_choice, subject)
-      graduation_date = application_choice.current_course.start_date - 5.years
+      graduation_cutoff_date = application_choice.current_course.ske_graduation_cutoff_date
       subject ||= application_choice.current_course.subjects.first&.name
 
       I18n.t(
         'provider_interface.offer.ske_reasons.outdated_degree',
         degree_subject: subject,
-        graduation_cutoff_date: graduation_date.to_fs(:month_and_year),
+        graduation_cutoff_date: graduation_cutoff_date.to_fs(:month_and_year),
       )
     end
 

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -3,8 +3,6 @@ module ProviderInterface
     include Wizard
     include Wizard::PathHistory
 
-    SKE_LENGTHS = 8.step(by: 4).take(6).freeze
-
     MAX_SKE_LANGUAGES = 2
     MAX_SKE_LENGTH = 36
 

--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -96,7 +96,7 @@ module SupportInterface
     end
 
     def cutoff_date
-      application_choice.current_course.start_date - 5.years
+      (application_choice.current_course.start_date - 5.years).to_fs(:month_and_year)
     end
 
     def ske_length_options

--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -98,7 +98,7 @@ module SupportInterface
     end
 
     def cutoff_date
-      application_choice.current_course.start_date - 5.years
+      application_choice.current_course.ske_graduation_cutoff_date
     end
 
     def ske_length_options

--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -43,6 +43,7 @@ module SupportInterface
       }.merge(attrs)
 
       new(attrs).tap(&:add_slot_for_new_condition)
+
     end
 
     def self.build_from_params(application_choice, params)
@@ -102,7 +103,11 @@ module SupportInterface
     end
 
     def ske_length_options
-      SkeCondition::SKE_LENGTHS.map { |length| CheckBoxOption.new(length.to_s, "#{length} weeks") }
+      if religious_education_course?
+        [CheckBoxOption.new(SkeCondition::SKE_LENGTHS.first.to_s, "#{SkeCondition::SKE_LENGTHS.first} weeks")]
+      else
+        SkeCondition::SKE_LENGTHS.map { |length| CheckBoxOption.new(length.to_s, "#{length} weeks") }
+      end
     end
 
     def ske_reason_options

--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -48,7 +48,7 @@ module SupportInterface
         standard_conditions: params['standard_conditions'] || [],
         audit_comment_ticket: params['audit_comment_ticket'],
         further_condition_attrs: params['further_conditions'] || {},
-        ske_conditions: params['ske_conditions'] || {},
+        ske_conditions: params['ske_conditions']&.select { |_, attrs| attrs[:ske_required] == 'true' } || {},
       }
 
       build_from_application_choice(application_choice, attrs)

--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -102,7 +102,7 @@ module SupportInterface
     end
 
     def ske_length_options
-      ProviderInterface::OfferWizard::SKE_LENGTHS.map { |length| CheckBoxOption.new(length.to_s, "#{length} weeks") }
+      SkeCondition::SKE_LENGTHS.map { |length| CheckBoxOption.new(length.to_s, "#{length} weeks") }
     end
 
     def ske_reason_options

--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -43,7 +43,6 @@ module SupportInterface
       }.merge(attrs)
 
       new(attrs).tap(&:add_slot_for_new_condition)
-
     end
 
     def self.build_from_params(application_choice, params)
@@ -95,7 +94,7 @@ module SupportInterface
     end
 
     def subject
-      application_choice.course_option&.course&.subjects&.first
+      application_choice.current_course&.subjects&.first
     end
 
     def cutoff_date

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -22,6 +22,7 @@ class Course < ApplicationRecord
   after_update :touch_application_choices_and_forms, if: :in_current_recruitment_cycle?
 
   CODE_LENGTH = 4
+  SKE_GRADUATION_CUTOFF_THRESHOLD = 5.years
 
   # This enum is copied verbatim from Find to maintain consistency
   enum level: {
@@ -176,6 +177,10 @@ class Course < ApplicationRecord
       open_on_apply: true,
       opened_on_apply_at: Time.zone.now,
     )
+  end
+
+  def ske_graduation_cutoff_date
+    start_date - SKE_GRADUATION_CUTOFF_THRESHOLD
   end
 
 private

--- a/app/models/ske_condition.rb
+++ b/app/models/ske_condition.rb
@@ -54,14 +54,12 @@ class SkeCondition < OfferCondition
   def length_for_ske_courses
     return if length.blank?
 
-    if religious_education_course?
-      if length != SKE_LENGTHS.first.to_s
-        errors.add(
-          :length,
-          :invalid_length,
-          allowed_values: SkeCondition::SKE_LENGTHS.first,
-        )
-      end
+    if religious_education_course? && length != SKE_LENGTHS.first.to_s
+      errors.add(
+        :length,
+        :invalid_length,
+        allowed_values: SkeCondition::SKE_LENGTHS.first,
+      )
     elsif SKE_LENGTHS.exclude?(length.to_i)
       errors.add(
         :length,

--- a/app/models/ske_condition.rb
+++ b/app/models/ske_condition.rb
@@ -17,6 +17,8 @@ class SkeCondition < OfferCondition
     OUTDATED_DEGREE_REASON = 'outdated_degree'.freeze,
   ].freeze
 
+  SKE_LENGTHS = 8.step(by: 4).take(6).freeze
+
   validates :graduation_cutoff_date, presence: true, if: :outdated_degree?
   validates :length, presence: true, on: :length
   validates :reason, presence: true, on: :reason

--- a/app/models/ske_condition.rb
+++ b/app/models/ske_condition.rb
@@ -26,6 +26,7 @@ class SkeCondition < OfferCondition
   validates :status, inclusion: { in: %w[pending met unmet] }
   validates :subject, inclusion: { in: VALID_LANGUAGES }, allow_blank: false, on: :subject, if: :language_subject?
   validates :subject, presence: true, on: :subject, if: :standard_subject?
+  validate :length_for_religious_education_courses
 
   attr_accessor :required
 
@@ -48,5 +49,23 @@ class SkeCondition < OfferCondition
 
   def text
     "#{subject} subject knowledge enhancement course"
+  end
+
+  def length_for_religious_education_courses
+    if religious_education_course?
+      if length != SKE_LENGTHS.first.to_s
+        errors.add(:length, :invalid_standard_length)
+      end
+    elsif SKE_LENGTHS.contains?(length.to_i)
+      errors.add(:length, :invalid_length_for_religious_education)
+    end
+  end
+
+  def religious_education_course?
+    subject&.code&.in?(Subject::SKE_RE_COURSES)
+  end
+
+  def subject
+    offer.course_option&.course&.subjects&.first || offer.course.subjects.first
   end
 end

--- a/app/views/provider_interface/offer/ske_lengths/_form.html.erb
+++ b/app/views/provider_interface/offer/ske_lengths/_form.html.erb
@@ -6,9 +6,9 @@
     <% if @wizard.ske_conditions.many? %>
       <h1 class="govuk-heading-l"><%= t('.ske_language_length_many_title') %></h1>
       <p class="govuk-hint">
-        One language course must be <%= ProviderInterface::OfferWizard::SKE_LENGTHS.min %> weeks.
-        The other course can be between <%= ProviderInterface::OfferWizard::SKE_LENGTHS.min %>
-        and <%= ProviderInterface::OfferWizard::SKE_LENGTHS.max %> weeks.
+        One language course must be <%= SkeCondition::SKE_LENGTHS.min %> weeks.
+        The other course can be between <%= SkeCondition::SKE_LENGTHS.min %>
+        and <%= SkeCondition::SKE_LENGTHS.max %> weeks.
       </p>
     <% end %>
 

--- a/app/views/support_interface/application_choice_conditions/edit.html.erb
+++ b/app/views/support_interface/application_choice_conditions/edit.html.erb
@@ -41,8 +41,9 @@
       <%= f.govuk_fieldset legend: { text: 'SKE conditions', size: 'm' } do %>
 
         <%= f.govuk_radio_buttons_fieldset :ske_required, legend: { text: "Do you require #{@form.application_choice.application_form.full_name} to take a SKE course in #{@form.subject_name} that will be funded by the DfE?", size: 'm' } do %>
-          <%= f.fields_for 'ske_conditions[]', OpenStruct.new(id: 0, subject: @form.subject_name) do |fs| %>
+          <%= f.fields_for 'ske_conditions[]', @form.standard_ske_condition do |fs| %>
             <%= fs.hidden_field :subject %>
+            <%= fs.hidden_field :subject_type %>
             <%= fs.govuk_radio_button :ske_required, true, label: { text: 'Yes' }, link_errors: true do || %>
               <%= fs.govuk_collection_radio_buttons :reason, @form.ske_reason_options, :value, :name, small: true, legend: { text: 'Why do they need to take a subject knowledge enhancement (SKE) course?' } %>
               <%= fs.govuk_collection_radio_buttons :length, @form.ske_length_options, :value, :name, small: true, legend: { text: 'How long must their SKE course be?' } %>

--- a/app/views/support_interface/application_choice_conditions/edit.html.erb
+++ b/app/views/support_interface/application_choice_conditions/edit.html.erb
@@ -38,20 +38,20 @@
 
       <% end %>
 
-      <%= f.govuk_fieldset legend: { text: 'SKE conditions', size: 'm' } do %>
-
-        <%= f.govuk_radio_buttons_fieldset :ske_required, legend: { text: "Do you require #{@form.application_choice.application_form.full_name} to take a SKE course in #{@form.subject_name} that will be funded by the DfE?", size: 'm' } do %>
-          <%= f.fields_for 'ske_conditions[]', @form.standard_ske_condition do |fs| %>
-            <%= fs.hidden_field :subject %>
-            <%= fs.hidden_field :subject_type %>
-            <%= fs.govuk_radio_button :ske_required, true, label: { text: 'Yes' }, link_errors: true do || %>
-              <%= fs.govuk_collection_radio_buttons :reason, @form.ske_reason_options, :value, :name, small: true, legend: { text: 'Why do they need to take a subject knowledge enhancement (SKE) course?' } %>
-              <%= fs.govuk_collection_radio_buttons :length, @form.ske_length_options, :value, :name, small: true, legend: { text: 'How long must their SKE course be?' } %>
+      <% if @form.ske_course? && !@form.language_course? %>
+        <%= f.govuk_fieldset legend: { text: 'SKE conditions', size: 'm' } do %>
+          <%= f.govuk_radio_buttons_fieldset :ske_required, legend: { text: "Do you require #{@form.application_choice.application_form.full_name} to take a SKE course in #{@form.subject_name} that will be funded by the DfE?", size: 'm' } do %>
+            <%= f.fields_for 'ske_conditions[]', @form.standard_ske_condition do |fs| %>
+              <%= fs.hidden_field :subject %>
+              <%= fs.hidden_field :subject_type %>
+              <%= fs.govuk_radio_button :ske_required, true, label: { text: 'Yes' }, link_errors: true do || %>
+                <%= fs.govuk_collection_radio_buttons :reason, @form.ske_reason_options, :value, :name, small: true, legend: { text: 'Why do they need to take a subject knowledge enhancement (SKE) course?' } %>
+                <%= fs.govuk_collection_radio_buttons :length, @form.ske_length_options, :value, :name, small: true, legend: { text: 'How long must their SKE course be?' } %>
+              <% end %>
+              <%= fs.govuk_radio_button :ske_required, false, label: { text: 'No' } %>
             <% end %>
-            <%= fs.govuk_radio_button :ske_required, false, label: { text: 'No' } %>
           <% end %>
         <% end %>
-
       <% end %>
 
       <%= f.govuk_submit 'Update conditions' %>

--- a/app/views/support_interface/application_choice_conditions/edit.html.erb
+++ b/app/views/support_interface/application_choice_conditions/edit.html.erb
@@ -38,6 +38,21 @@
 
       <% end %>
 
+      <%= f.govuk_fieldset legend: { text: 'SKE conditions', size: 'm' } do %>
+
+        <%= f.govuk_radio_buttons_fieldset :ske_required, legend: { text: "Do you require #{@form.application_choice.application_form.full_name} to take a SKE course in #{@form.subject_name} that will be funded by the DfE?", size: 'm' } do %>
+          <%= f.fields_for 'ske_conditions[]', OpenStruct.new(id: 0, subject: @form.subject_name) do |fs| %>
+            <%= fs.hidden_field :subject %>
+            <%= fs.govuk_radio_button :ske_required, true, label: { text: 'Yes' }, link_errors: true do || %>
+              <%= fs.govuk_collection_radio_buttons :reason, @form.ske_reason_options, :value, :name, small: true, legend: { text: 'Why do they need to take a subject knowledge enhancement (SKE) course?' } %>
+              <%= fs.govuk_collection_radio_buttons :length, @form.ske_length_options, :value, :name, small: true, legend: { text: 'How long must their SKE course be?' } %>
+            <% end %>
+            <%= fs.govuk_radio_button :ske_required, false, label: { text: 'No' } %>
+          <% end %>
+        <% end %>
+
+      <% end %>
+
       <%= f.govuk_submit 'Update conditions' %>
 
       <p class="govuk-body">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -512,6 +512,11 @@ en:
               too_long: "The note must be %{count} characters or fewer"
             user:
               blank: Missing user
+        ske_condition:
+          attributes:
+            length:
+              invalid_standard_length: "SKE courses must be %{SkeCondition::SKE_LENGTHS.to_sentence(last_word_connector: ' or ')} weeks long. Religious education courses must be 8 weeks long."
+              invalid_length_for_religious_education: "Religious education courses must be %{SkeCondition::SKE_LENGTHS.first} weeks long."
 
   errors:
     messages:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -515,8 +515,7 @@ en:
         ske_condition:
           attributes:
             length:
-              invalid_standard_length: "SKE courses must be %{SkeCondition::SKE_LENGTHS.to_sentence(last_word_connector: ' or ')} weeks long. Religious education courses must be 8 weeks long."
-              invalid_length_for_religious_education: "Religious education courses must be %{SkeCondition::SKE_LENGTHS.first} weeks long."
+              invalid_length: "SKE courses must be %{allowed_values} weeks long."
 
   errors:
     messages:

--- a/spec/factories/ske_condition.rb
+++ b/spec/factories/ske_condition.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :ske_condition, parent: :offer_condition, class: 'SkeCondition' do
+    offer
+
     text { nil }
 
     subject { 'Mathematics' }

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -12,5 +12,10 @@ FactoryBot.define do
       sequence(:name) { |n| "French #{n}" }
       code { '15' }
     end
+
+    trait :religious_education do
+      sequence(:name) { |n| "Religious education #{n}}" }
+      code { 'V6' }
+    end
   end
 end

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ProviderInterface::OfferWizard do
   let(:subject_type) { 'language' }
   let(:graduation_cutoff_date) { Time.zone.now.iso8601 }
   let(:ske_conditions) do
-    subjects.map { |subject| SkeCondition.new(subject:, subject_type:, graduation_cutoff_date:) }
+    subjects.map { |subject| SkeCondition.new(subject:, subject_type:, graduation_cutoff_date:, length: '8') }
   end
   let(:further_condition_1) { '' }
   let(:further_condition_2) { '' }

--- a/spec/forms/support_interface/conditions_form_spec.rb
+++ b/spec/forms/support_interface/conditions_form_spec.rb
@@ -354,4 +354,24 @@ RSpec.describe SupportInterface::ConditionsForm do
       expect(form.further_condition_attrs.values.map { |hash| hash['text'] }).to eq(['FC1', 'FC2', 'FC3', 'FC4', 'FC5', ''])
     end
   end
+
+  describe '#ske_length_options' do
+    before do
+      @application_choice = create(:application_choice, :offered, offer: build(:offer))
+      @form = described_class.build_from_application_choice(@application_choice)
+    end
+
+    it 'returns a CheckBoxOption for each possible length' do
+      expect(@form.ske_length_options.size).to eq(6)
+    end
+
+    it 'returns a single CheckBoxOption for religious education courses' do
+      @application_choice.course_option.course.subjects.delete_all
+      @application_choice.course_option.course.subjects << build(
+        :subject, code: 'V6',
+        name: 'Religious instruction'
+      )
+      expect(@form.ske_length_options.size).to eq(1)
+    end
+  end
 end

--- a/spec/forms/support_interface/conditions_form_spec.rb
+++ b/spec/forms/support_interface/conditions_form_spec.rb
@@ -188,14 +188,15 @@ RSpec.describe SupportInterface::ConditionsForm do
         'standard_conditions' => [
           'Fitness to train to teach check',
         ],
-        'ske_conditions' => [
-          {
+        'ske_conditions' => {
+          '0' => {
+            'ske_required' => 'true',
             'length' => '8',
             'reason' => 'different_degree',
             'subject' => 'Chemistry',
             'subject_type' => 'standard',
           },
-        ],
+        },
         'audit_comment_ticket' => 'https://becomingateacher.zendesk.com/agent/tickets/12345',
       )
       form.save
@@ -229,14 +230,15 @@ RSpec.describe SupportInterface::ConditionsForm do
         'standard_conditions' => [
           'Fitness to train to teach check',
         ],
-        'ske_conditions' => [
-          {
+        'ske_conditions' => {
+          '0' => {
+            'ske_required' => 'true',
             'length' => '8',
             'reason' => 'different_degree',
             'subject' => 'Chemistry',
             'subject_type' => 'standard',
           },
-        ],
+        },
         'audit_comment_ticket' => 'https://becomingateacher.zendesk.com/agent/tickets/12345',
       )
       form.save
@@ -264,7 +266,7 @@ RSpec.describe SupportInterface::ConditionsForm do
         'standard_conditions' => [
           'Fitness to train to teach check',
         ],
-        'ske_conditions' => [],
+        'ske_conditions' => {},
         'audit_comment_ticket' => 'https://becomingateacher.zendesk.com/agent/tickets/12345',
       )
       form.save

--- a/spec/forms/support_interface/conditions_form_spec.rb
+++ b/spec/forms/support_interface/conditions_form_spec.rb
@@ -368,8 +368,9 @@ RSpec.describe SupportInterface::ConditionsForm do
     it 'returns a single CheckBoxOption for religious education courses' do
       @application_choice.course_option.course.subjects.delete_all
       @application_choice.course_option.course.subjects << build(
-        :subject, code: 'V6',
-        name: 'Religious instruction'
+        :subject,
+        code: 'V6',
+        name: 'Religious instruction',
       )
       expect(@form.ske_length_options.size).to eq(1)
     end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -157,4 +157,12 @@ RSpec.describe Course do
       end
     end
   end
+
+  describe '#ske_graduation_cutoff_date' do
+    let(:course) { build(:course, start_date: Date.new(2023, 1, 1)) }
+
+    it 'returns correct date' do
+      expect(course.ske_graduation_cutoff_date).to eq(Date.new(2018, 1, 1))
+    end
+  end
 end

--- a/spec/models/ske_condition_spec.rb
+++ b/spec/models/ske_condition_spec.rb
@@ -8,4 +8,25 @@ RSpec.describe SkeCondition do
       expect(build(:ske_condition).text).to eq('Mathematics subject knowledge enhancement course')
     end
   end
+
+  describe 'validation' do
+    before { @ske_condition = create(:ske_condition) }
+
+    it 'is invalid when SKE length is not in list of permissible values' do
+      @ske_condition.length = '13'
+      expect(@ske_condition.valid?).to be(false)
+    end
+
+    context 'with a religious education course' do
+      before do
+        @ske_condition.offer.course.subjects.delete_all
+        @ske_condition.offer.course.subjects << build(:subject, :religious_education)
+      end
+
+      it 'is invalid when SKE length is not 8 weeks' do
+        @ske_condition.length = '12'
+        expect(@ske_condition.valid?).to be(false)
+      end
+    end
+  end
 end

--- a/spec/system/support_interface/change_offer_ske_conditions_spec.rb
+++ b/spec/system/support_interface/change_offer_ske_conditions_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Add course to submitted application' do
 
   scenario 'Support user adds course to submitted application' do
     given_i_am_a_support_user
+    and_the_provider_ske_feature_flag_is_active
     and_there_is_an_offered_application_in_the_system
     and_the_course_subject_requires_ske
     and_i_visit_the_support_page
@@ -32,6 +33,10 @@ RSpec.feature 'Add course to submitted application' do
 
   def given_i_am_a_support_user
     sign_in_as_support_user
+  end
+
+  def and_the_provider_ske_feature_flag_is_active
+    FeatureFlag.activate(:provider_ske)
   end
 
   def and_there_is_an_offered_application_in_the_system

--- a/spec/system/support_interface/change_offer_ske_conditions_spec.rb
+++ b/spec/system/support_interface/change_offer_ske_conditions_spec.rb
@@ -1,0 +1,112 @@
+require 'rails_helper'
+
+RSpec.feature 'Add course to submitted application' do
+  include DfESignInHelpers
+
+  scenario 'Support user adds course to submitted application' do
+    given_i_am_a_support_user
+    and_there_is_an_offered_application_in_the_system
+    and_the_course_subject_requires_ske
+    and_i_visit_the_support_page
+
+    when_i_click_on_the_application
+    then_i_should_see_the_current_conditions
+
+    when_i_click_on_change_conditions
+    then_i_see_the_condition_edit_form_with_a_warning
+
+    when_i_add_a_new_ske_condition_and_click_update_conditions_without_a_support_ticket_url
+    then_i_see_a_validation_error
+
+    when_i_add_a_new_ske_condition_and_click_update_conditions_with_a_support_ticket_url
+    then_i_see_the_new_ske_condition_as_well_as_the_original_ones
+
+    # when_i_click_on_change_conditions
+    # and_i_remove_all_conditions_and_click_update_conditions
+    # then_i_see_a_confirmation_page_about_candidate_being_recruited
+
+    # when_i_click_yes_im_sure
+    # then_i_see_that_the_candidate_has_been_recruited_and_conditions_have_been_removed
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_is_an_offered_application_in_the_system
+    candidate = create(:candidate, email_address: 'candy@example.com')
+
+    Audited.audit_class.as_user(candidate) do
+      @application_form = create(
+        :completed_application_form,
+        first_name: 'Candy',
+        last_name: 'Dayte',
+        candidate:,
+      )
+
+      conditions = [build(:offer_condition, text: 'Be cool', status: 'met')]
+      @application_choice = create(
+        :application_choice,
+        :offered,
+        :accepted,
+        offer: build(:offer, conditions:),
+        application_form: @application_form,
+      )
+    end
+  end
+
+  def and_the_course_subject_requires_ske
+    @application_choice.course_option.course.subjects.delete_all
+    @application_choice.course_option.course.subjects << build(
+      :subject, code: 'C1', name: 'Biology'
+    )
+  end
+
+  def and_i_visit_the_support_page
+    visit support_interface_path
+  end
+
+  def when_i_click_on_the_application
+    click_on 'Candy Dayte'
+  end
+
+  def then_i_should_see_the_current_conditions
+    expect(page).to have_content("Conditions\nBe cool")
+  end
+
+  def when_i_click_on_change_conditions
+    click_on 'Change conditions'
+  end
+
+  def then_i_see_the_condition_edit_form_with_a_warning
+    expect(page).to have_current_path(
+      support_interface_update_application_choice_conditions_path(@application_choice),
+    )
+  end
+
+  def when_i_add_a_new_ske_condition_and_click_update_conditions_without_a_support_ticket_url
+    choose('Yes')
+    choose('Their degree subject was not Biology')
+    choose('8 weeks')
+    click_on 'Update conditions'
+  end
+
+  def then_i_see_a_validation_error
+    expect(page).to have_current_path(support_interface_update_application_choice_conditions_path(@application_choice))
+    expect(page).to have_content('Enter a Zendesk ticket URL')
+  end
+
+  def when_i_add_a_new_ske_condition_and_click_update_conditions_with_a_support_ticket_url
+    fill_in 'Zendesk ticket URL', with: 'becomingateacher.zendesk.com/agent/tickets/12345'
+    choose('Yes')
+    choose('Their degree subject was not Biology')
+    choose('8 weeks')
+    click_on 'Update conditions'
+  end
+
+  def then_i_see_the_new_ske_condition_as_well_as_the_original_ones
+    expect(page).to have_content('Subject knowledge enhancement course')
+    expect(page).to have_content("Length\n8 weeks")
+    expect(page).to have_content("Reason\nTheir degree subject was not Biology")
+  end
+end

--- a/spec/system/support_interface/change_offer_ske_conditions_spec.rb
+++ b/spec/system/support_interface/change_offer_ske_conditions_spec.rb
@@ -19,14 +19,15 @@ RSpec.feature 'Add course to submitted application' do
     then_i_see_a_validation_error
 
     when_i_add_a_new_ske_condition_and_click_update_conditions_with_a_support_ticket_url
-    then_i_see_the_new_ske_condition_as_well_as_the_original_ones
+    then_i_see_the_new_ske_condition
 
-    # when_i_click_on_change_conditions
-    # and_i_remove_all_conditions_and_click_update_conditions
-    # then_i_see_a_confirmation_page_about_candidate_being_recruited
+    when_i_click_on_change_conditions
+    and_i_change_the_length_of_the_ske_condition
+    then_i_see_the_updated_ske_condition
 
-    # when_i_click_yes_im_sure
-    # then_i_see_that_the_candidate_has_been_recruited_and_conditions_have_been_removed
+    when_i_click_on_change_conditions
+    and_i_delete_the_ske_condition
+    then_i_see_that_the_ske_condition_has_been_removed
   end
 
   def given_i_am_a_support_user
@@ -104,9 +105,33 @@ RSpec.feature 'Add course to submitted application' do
     click_on 'Update conditions'
   end
 
-  def then_i_see_the_new_ske_condition_as_well_as_the_original_ones
+  def then_i_see_the_new_ske_condition
     expect(page).to have_content('Subject knowledge enhancement course')
     expect(page).to have_content("Length\n8 weeks")
     expect(page).to have_content("Reason\nTheir degree subject was not Biology")
+  end
+
+  def and_i_change_the_length_of_the_ske_condition
+    fill_in 'Zendesk ticket URL', with: 'becomingateacher.zendesk.com/agent/tickets/12345'
+    choose('Yes')
+    choose('Their degree subject was not Biology')
+    choose('20 weeks')
+    click_on 'Update conditions'
+  end
+
+  def then_i_see_the_updated_ske_condition
+    expect(page).to have_content('Subject knowledge enhancement course')
+    expect(page).to have_content("Length\n20 weeks")
+    expect(page).to have_content("Reason\nTheir degree subject was not Biology")
+  end
+
+  def and_i_delete_the_ske_condition
+    fill_in 'Zendesk ticket URL', with: 'becomingateacher.zendesk.com/agent/tickets/12345'
+    choose('No')
+    click_on 'Update conditions'
+  end
+
+  def then_i_see_that_the_ske_condition_has_been_removed
+    expect(page).not_to have_content('Subject knowledge enhancement course')
   end
 end


### PR DESCRIPTION
## Context

Support staff should be able to create/amend/delete SKE conditions just as they can other kinds of offer condition in the support interface.

## Changes proposed in this pull request

Extend the existing offer condition form to include SKE conditions (not a wizard). For now this only works for 'standard' SKE courses, not language courses (they'll be in a follow-up PR).

![image](https://user-images.githubusercontent.com/450843/228818504-d255b5f7-4e6e-491e-b76e-c6d845d08d15.png)

## Guidance to review

Main concern here is that we don't mess up other conditions as part of this change. i.e. no unintended side-effects.

## Link to Trello card

https://trello.com/c/LMTxUp45/1272-allow-support-to-add-amend-a-ske-condition

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
