### PR TITLE
Tune front door alert thresholds

### DIFF
--- a/docs/aks-alerting.md
+++ b/docs/aks-alerting.md
@@ -63,5 +63,5 @@ In each terraform/custom_domains/environment_domains/workspace_variables/apply-$
 3. If required, add alert threshold overrides to terraform/custom_domains/environment_domains/workspace_variables/apply-${env}.tfvars.json
 
 Defaults:
-- latency_threshold"         default = 1000
-- percent_5xx_threshold      default = 10
+- latency_threshold          default = 1500
+- percent_5xx_threshold      default = 15

--- a/terraform/custom_domains/environment_domains/variables.tf
+++ b/terraform/custom_domains/environment_domains/variables.tf
@@ -13,8 +13,8 @@ variable "enable_alerting" { default = false }
 variable "pg_actiongroup_name" { default = null }
 variable "pg_actiongroup_rg" { default = null }
 variable "latency_threshold" {
-  default = 1000
+  default = 1500
 }
 variable "percent_5xx_threshold" {
-  default = 10
+  default = 15
 }

--- a/terraform/custom_domains/environment_domains/workspace_variables/apply_staging.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/apply_staging.tfvars.json
@@ -3,6 +3,8 @@
   "enable_alerting": true,
   "pg_actiongroup_name": "s189p01-att-production-ag",
   "pg_actiongroup_rg": "s189p01-att-pd-rg",
+  "latency_threshold": 2000,
+  "percent_5xx_threshold": 20,
   "hosted_zone": {
     "apply-for-teacher-training.education.gov.uk": {
       "front_door_name": "s189p01-apply-edu-domains-fd",


### PR DESCRIPTION
## Context

Tune the front door monitoring alert defaults
- latency from 1000 -> 1500 (1.5s)
- 5xx failures from 10 -> 15 (percent)

Override defaults for staging
- latency -> 2000 (2s)
- 5xx failures -> 20 (percent)

## Changes proposed in this pull request

Update terraform defaults

## Guidance to review

Already deployed as it's a manual deployment
- make apply env domains-plan
- check alerts in azure
- monitor alert emails

## Link to Trello card

n/a

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
