### PR TITLE
765 change course bugfix

### DIFF
--- a/app/components/provider_interface/application_choice_header_component.rb
+++ b/app/components/provider_interface/application_choice_header_component.rb
@@ -2,12 +2,13 @@ module ProviderInterface
   class ApplicationChoiceHeaderComponent < ViewComponent::Base
     include ViewHelper
 
-    attr_reader :application_choice, :provider_can_respond, :provider_can_set_up_interviews
+    attr_reader :application_choice, :provider_can_respond, :provider_can_set_up_interviews, :course_associated_with_user_providers
 
-    def initialize(application_choice:, provider_can_respond: false, provider_can_set_up_interviews: false)
+    def initialize(application_choice:, provider_can_respond: false, provider_can_set_up_interviews: false, course_associated_with_user_providers: true)
       @application_choice = application_choice
       @provider_can_respond = provider_can_respond
       @provider_can_set_up_interviews = provider_can_set_up_interviews
+      @course_associated_with_user_providers = course_associated_with_user_providers
     end
 
     def header_component
@@ -36,12 +37,14 @@ module ProviderInterface
       sub_navigation_items = [application_navigation_item]
 
       sub_navigation_items.push(offer_navigation_item) if offer_present?
-      sub_navigation_items.push(references_navigation_item) unless application_choice.application_unsuccessful?
-      sub_navigation_items.push(interviews_navigation_item) if interviews_present?
-      sub_navigation_items.push(notes_navigation_item)
-      sub_navigation_items.push(timeline_navigation_item)
-      sub_navigation_items.push(feedback_navigation_item) if application_choice.display_provider_feedback?
-      sub_navigation_items.push(emails_navigation_item) if HostingEnvironment.sandbox_mode?
+      if course_associated_with_user_providers.present?
+        sub_navigation_items.push(references_navigation_item) unless application_choice.application_unsuccessful?
+        sub_navigation_items.push(interviews_navigation_item) if interviews_present?
+        sub_navigation_items.push(notes_navigation_item)
+        sub_navigation_items.push(timeline_navigation_item)
+        sub_navigation_items.push(feedback_navigation_item) if application_choice.display_provider_feedback?
+        sub_navigation_items.push(emails_navigation_item) if HostingEnvironment.sandbox_mode?
+      end
 
       sub_navigation_items
     end

--- a/app/controllers/candidate_interface/offer_dashboard_controller.rb
+++ b/app/controllers/candidate_interface/offer_dashboard_controller.rb
@@ -7,8 +7,8 @@ module CandidateInterface
     def show
       @application_form = current_application
       @application_choice_with_offer = current_application.application_choices.pending_conditions.first || current_application.application_choices.recruited.first
-      @accepted_offer_provider_name = @application_choice_with_offer.provider.name
-      @accepted_offer_course_name_and_code = @application_choice_with_offer.course.name_and_code
+      @accepted_offer_provider_name = @application_choice_with_offer.current_provider.name
+      @accepted_offer_course_name_and_code = @application_choice_with_offer.current_course.name_and_code
     end
 
   private

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -3,6 +3,7 @@ module ProviderInterface
     include ClearWizardCache
 
     before_action :set_application_choice, :set_workflow_flags, except: %i[index]
+    before_action :redirect_if_application_changed_provider, only: %i[timeline]
 
     def index
       @filter = ProviderApplicationsFilter.new(

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -2,8 +2,7 @@ module ProviderInterface
   class ApplicationChoicesController < ProviderInterfaceController
     include ClearWizardCache
 
-    before_action :set_application_choice, except: %i[index]
-    before_action :set_workflow_flags, except: %i[index]
+    before_action :set_application_choice, :set_workflow_flags, except: %i[index]
 
     def index
       @filter = ProviderApplicationsFilter.new(
@@ -73,7 +72,7 @@ module ProviderInterface
     end
 
     def application_withdrawable?
-      @provider_can_respond && ApplicationStateChange::UNSUCCESSFUL_STATES.exclude?(@application_choice.status.to_sym)
+      @provider_user_can_make_decisions && ApplicationStateChange::UNSUCCESSFUL_STATES.exclude?(@application_choice.status.to_sym)
     end
     helper_method :application_withdrawable?
 
@@ -100,22 +99,6 @@ module ProviderInterface
         user: current_provider_user,
         current_course: @application_choice.current_course,
       )
-    end
-
-    def set_workflow_flags
-      @provider_can_respond = auth.can_make_decisions?(
-        application_choice: @application_choice,
-        course_option_id: @application_choice.current_course_option.id,
-      )
-      @provider_can_set_up_interviews = auth.can_set_up_interviews?(
-        application_choice: @application_choice,
-        course_option: @application_choice.current_course_option,
-      )
-      @offer_present = ApplicationStateChange::OFFERED_STATES.include?(@application_choice.status.to_sym)
-    end
-
-    def auth
-      ProviderAuthorisation.new(actor: current_provider_user)
     end
 
     def state_store_key

--- a/app/controllers/provider_interface/interviews_controller.rb
+++ b/app/controllers/provider_interface/interviews_controller.rb
@@ -2,7 +2,7 @@ module ProviderInterface
   class InterviewsController < ProviderInterfaceController
     include ClearWizardCache
 
-    before_action :set_application_choice
+    before_action :set_application_choice, :set_workflow_flags
     before_action :requires_set_up_interviews_permission, except: %i[index]
     before_action :confirm_application_is_in_decision_pending_state, except: %i[index]
     before_action :confirm_interview_is_not_in_the_past, only: %i[edit update destroy]
@@ -14,13 +14,7 @@ module ProviderInterface
       application_at_interviewable_stage = ApplicationStateChange::INTERVIEWABLE_STATES.include?(
         @application_choice.status.to_sym,
       )
-      @provider_can_make_decisions =
-        current_provider_user.authorisation.can_make_decisions?(application_choice: @application_choice,
-                                                                course_option: @application_choice.current_course_option)
-      provider_can_set_up_interviews =
-        current_provider_user.authorisation.can_set_up_interviews?(application_choice: @application_choice,
-                                                                   course_option: @application_choice.current_course_option)
-      @interviews_can_be_created_and_edited = application_at_interviewable_stage && provider_can_set_up_interviews
+      @interviews_can_be_created_and_edited = application_at_interviewable_stage && @provider_user_can_set_up_interviews
 
       redirect_to provider_interface_application_choice_path if @application_choice.interviews.none?
     end

--- a/app/controllers/provider_interface/notes_controller.rb
+++ b/app/controllers/provider_interface/notes_controller.rb
@@ -1,6 +1,6 @@
 module ProviderInterface
   class NotesController < ProviderInterfaceController
-    before_action :set_application_choice, :set_workflow_flags
+    before_action :set_application_choice, :set_workflow_flags, :redirect_if_application_changed_provider
 
     def index
       @notes = @application_choice.notes.order('created_at DESC')

--- a/app/controllers/provider_interface/notes_controller.rb
+++ b/app/controllers/provider_interface/notes_controller.rb
@@ -1,18 +1,8 @@
 module ProviderInterface
   class NotesController < ProviderInterfaceController
-    before_action :set_application_choice
+    before_action :set_application_choice, :set_workflow_flags
 
     def index
-      @provider_can_respond = current_provider_user.authorisation.can_make_decisions?(
-        application_choice: @application_choice,
-        course_option: @application_choice.current_course_option,
-      )
-
-      @provider_can_set_up_interviews = current_provider_user.authorisation.can_set_up_interviews?(
-        application_choice: @application_choice,
-        course_option: @application_choice.current_course_option,
-      )
-
       @notes = @application_choice.notes.order('created_at DESC')
     end
 

--- a/app/controllers/provider_interface/offers_controller.rb
+++ b/app/controllers/provider_interface/offers_controller.rb
@@ -1,6 +1,6 @@
 module ProviderInterface
   class OffersController < ProviderInterfaceController
-    before_action :set_application_choice
+    before_action :set_application_choice, :set_workflow_flags
     before_action :confirm_application_is_in_decision_pending_state, except: %i[edit update show]
     before_action :confirm_application_is_in_offered_state, only: %i[show]
     before_action :confirm_application_can_have_offer_changed, only: %i[edit update]
@@ -16,7 +16,7 @@ module ProviderInterface
       )
       @wizard.save_state!
 
-      return unless provider_user_can_make_decisions
+      return unless @provider_user_can_make_decisions
 
       @providers = available_providers
       @courses = available_courses(@application_choice.current_course.provider.id)
@@ -129,15 +129,6 @@ module ProviderInterface
         standard_conditions: @wizard.standard_conditions,
         further_condition_attrs: @wizard.further_condition_attrs,
         structured_conditions: @wizard.structured_conditions || @application_choice.offer&.ske_conditions || [],
-      )
-    end
-
-    helper_method :provider_user_can_make_decisions
-
-    def provider_user_can_make_decisions
-      @provider_can_make_decisions = current_provider_user.authorisation.can_make_decisions?(
-        application_choice: @application_choice,
-        course_option_id: @application_choice.current_course_option.id,
       )
     end
   end

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -154,5 +154,22 @@ module ProviderInterface
         application_support_url: support_interface_application_form_url(@application_choice.application_form),
       }
     end
+
+    def set_workflow_flags
+      @provider_user_can_make_decisions = provider_authorisation.can_make_decisions?(
+        application_choice: @application_choice,
+        course_option: @application_choice.current_course_option,
+      )
+      @provider_user_can_set_up_interviews = provider_authorisation.can_set_up_interviews?(
+        application_choice: @application_choice,
+        course_option: @application_choice.current_course_option,
+      )
+      @course_associated_with_user_providers = provider_authorisation.course_associated_with_user_providers?(course: @application_choice.current_course)
+      @offer_present = ApplicationStateChange::OFFERED_STATES.include?(@application_choice.status.to_sym)
+    end
+
+    def provider_authorisation
+      ProviderAuthorisation.new(actor: current_provider_user)
+    end
   end
 end

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -171,5 +171,9 @@ module ProviderInterface
     def provider_authorisation
       ProviderAuthorisation.new(actor: current_provider_user)
     end
+
+    def redirect_if_application_changed_provider
+      redirect_to provider_interface_application_choice_path(application_choice_id: @application_choice.id) unless @course_associated_with_user_providers
+    end
   end
 end

--- a/app/controllers/provider_interface/references_controller.rb
+++ b/app/controllers/provider_interface/references_controller.rb
@@ -1,6 +1,6 @@
 module ProviderInterface
   class ReferencesController < ProviderInterfaceController
-    before_action :set_application_choice, :redirect_if_unsuccessful, :set_references, :set_workflow_flags
+    before_action :set_application_choice, :redirect_if_unsuccessful, :set_references, :set_workflow_flags, :redirect_if_application_changed_provider
 
   private
 

--- a/app/controllers/provider_interface/references_controller.rb
+++ b/app/controllers/provider_interface/references_controller.rb
@@ -1,17 +1,6 @@
 module ProviderInterface
   class ReferencesController < ProviderInterfaceController
-    before_action :set_application_choice, :redirect_if_unsuccessful, :set_references
-
-    def index
-      @provider_can_make_decisions =
-        current_provider_user.authorisation.can_make_decisions?(application_choice: @application_choice,
-                                                                course_option: @application_choice.current_course_option)
-
-      @provider_can_set_up_interviews = current_provider_user.authorisation.can_set_up_interviews?(
-        application_choice: @application_choice,
-        course_option: @application_choice.current_course_option,
-      )
-    end
+    before_action :set_application_choice, :redirect_if_unsuccessful, :set_references, :set_workflow_flags
 
   private
 

--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -136,6 +136,14 @@ class ProviderAuthorisation
   class NotAuthorisedError < StandardError; end
   class RelationshipNotPresent < StandardError; end
 
+  def course_associated_with_user_providers?(course:)
+    return true if @actor.is_a?(SupportUser)
+
+    [course.provider, course.accredited_provider].compact.any? do |provider|
+      @actor.providers.include?(provider)
+    end
+  end
+
 private
 
   def relationship_for(course:)
@@ -211,14 +219,6 @@ private
     return true if @actor.is_a?(SupportUser)
 
     GetApplicationChoicesForProviders.call(providers: @actor.providers, includes: [course_option: :course]).include?(application_choice)
-  end
-
-  def course_associated_with_user_providers?(course:)
-    return true if @actor.is_a?(SupportUser)
-
-    [course.provider, course.accredited_provider].compact.any? do |provider|
-      @actor.providers.include?(provider)
-    end
   end
 
   def add_error(permission, error)

--- a/app/views/provider_interface/application_choices/emails.html.erb
+++ b/app/views/provider_interface/application_choices/emails.html.erb
@@ -8,7 +8,11 @@
   }) %>
 <% end %>
 
-<%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(application_choice: @application_choice, provider_can_respond: @provider_can_respond) %>
+<%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(
+  application_choice: @application_choice,
+  provider_can_respond: @provider_user_can_make_decisions,
+  course_associated_with_user_providers: @course_associated_with_user_providers,
+) %>
 
 <table class="govuk-table">
   <thead class="govuk-table__head">

--- a/app/views/provider_interface/application_choices/feedback.html.erb
+++ b/app/views/provider_interface/application_choices/feedback.html.erb
@@ -1,5 +1,9 @@
 <% content_for :browser_title, "#{@application_choice.application_form.full_name} – #{@application_choice.course.name_and_code} - Feedback" %>
 
-<%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(application_choice: @application_choice, provider_can_respond: @provider_can_respond) %>
+<%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(
+  application_choice: @application_choice,
+  provider_can_respond: @provider_user_can_make_decisions,
+  course_associated_with_user_providers: @course_associated_with_user_providers,
+) %>
 
 <%= render ProviderInterface::ApplicationFeedbackComponent.new(application_choice: @application_choice) %>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -2,8 +2,9 @@
 
 <%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(
   application_choice: @application_choice,
-  provider_can_respond: @provider_can_respond,
-  provider_can_set_up_interviews: @provider_can_set_up_interviews,
+  provider_can_respond: @provider_user_can_make_decisions,
+  provider_can_set_up_interviews: @provider_user_can_set_up_interviews,
+  course_associated_with_user_providers: @course_associated_with_user_providers,
 ) %>
 
 <%= render ProviderInterface::StatusBoxComponent.new(application_choice: @application_choice, options: @status_box_options) unless @offer_present || @application_choice.rejected? %>
@@ -47,7 +48,7 @@
   </div>
 <% end %>
 
-<% if @provider_can_respond && ApplicationStateChange::DECISION_PENDING_STATUSES.include?(@application_choice.status.to_sym) %>
+<% if @provider_user_can_make_decisions && ApplicationStateChange::DECISION_PENDING_STATUSES.include?(@application_choice.status.to_sym) %>
   <%= render ProviderInterface::ChangeCourseDetailsComponent.new(
     application_choice: @application_choice,
     course_option: @application_choice.course_option,

--- a/app/views/provider_interface/application_choices/timeline.html.erb
+++ b/app/views/provider_interface/application_choices/timeline.html.erb
@@ -2,8 +2,9 @@
 
 <%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(
   application_choice: @application_choice,
-  provider_can_respond: @provider_can_respond,
-  provider_can_set_up_interviews: @provider_can_set_up_interviews,
+  provider_can_respond: @provider_user_can_make_decisions,
+  provider_can_set_up_interviews: @provider_user_can_set_up_interviews,
+  course_associated_with_user_providers: @course_associated_with_user_providers,
 ) %>
 
 <%= render ProviderInterface::ApplicationTimelineComponent.new(application_choice: @application_choice) %>

--- a/app/views/provider_interface/interviews/index.html.erb
+++ b/app/views/provider_interface/interviews/index.html.erb
@@ -1,6 +1,10 @@
 <% content_for :browser_title, "#{@application_choice.application_form.full_name} – #{@application_choice.course.name_and_code} - Interviews" %>
 
-<%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(application_choice: @application_choice, provider_can_respond: @provider_can_make_decisions) %>
+<%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(
+  application_choice: @application_choice,
+  provider_can_respond: @provider_user_can_make_decisions,
+  course_associated_with_user_providers: @course_associated_with_user_providers,
+) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/provider_interface/notes/index.html.erb
+++ b/app/views/provider_interface/notes/index.html.erb
@@ -2,8 +2,9 @@
 
 <%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(
   application_choice: @application_choice,
-  provider_can_respond: @provider_can_respond,
-  provider_can_set_up_interviews: @provider_can_set_up_interviews,
+  provider_can_respond: @provider_user_can_make_decisions,
+  provider_can_set_up_interviews: @provider_user_can_set_up_interviews,
+  course_associated_with_user_providers: @course_associated_with_user_providers,
 ) %>
 <h1 class="govuk-heading-l">Notes</h1>
 

--- a/app/views/provider_interface/offer/checks/edit.html.erb
+++ b/app/views/provider_interface/offer/checks/edit.html.erb
@@ -10,14 +10,16 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= f.govuk_error_summary %>
-      <%= render ProviderInterface::CompletedOfferSummaryComponent.new(application_choice: @application_choice,
-                                                                       course_option: @wizard.course_option,
-                                                                       conditions: @wizard.conditions_to_render,
-                                                                       course: @wizard.course_option.course,
-                                                                       available_providers: @providers,
-                                                                       available_courses: @courses,
-                                                                       available_course_options: @course_options,
-                                                                       ske_conditions: @wizard.ske_conditions) %>
+      <%= render ProviderInterface::CompletedOfferSummaryComponent.new(
+         application_choice: @application_choice,
+         course_option: @wizard.course_option,
+         conditions: @wizard.conditions_to_render,
+         course: @wizard.course_option.course,
+         available_providers: @providers,
+         available_courses: @courses,
+         available_course_options: @course_options,
+         ske_conditions: @wizard.ske_conditions,
+       ) %>
 
       <%= f.govuk_submit t('.submit') %>
 

--- a/app/views/provider_interface/offers/show.html.erb
+++ b/app/views/provider_interface/offers/show.html.erb
@@ -1,4 +1,8 @@
-<%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(application_choice: @application_choice, provider_can_respond: provider_user_can_make_decisions) %>
+<%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(
+  application_choice: @application_choice,
+  provider_can_respond: @provider_user_can_make_decisions,
+  course_associated_with_user_providers: @course_associated_with_user_providers,
+) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Offer</h2>
@@ -11,7 +15,7 @@
       </div>
     <% end %>
 
-    <% if provider_user_can_make_decisions %>
+    <% if @provider_user_can_make_decisions %>
       <p class="govuk-body govuk-!-margin-bottom-7">
         <% if %i[pending_conditions recruited].include?(@application_choice.status.to_sym) %>
           <%= govuk_link_to 'Defer offer', provider_interface_application_choice_new_defer_offer_path(@application_choice) %>
@@ -23,7 +27,7 @@
       </p>
     <% end %>
 
-    <% if provider_user_can_make_decisions && @application_choice.offer? %>
+    <% if @provider_user_can_make_decisions && @application_choice.offer? %>
       <%= render ProviderInterface::CompletedOfferSummaryComponent.new(
             application_choice: @application_choice,
             course_option: @application_choice.current_course_option,
@@ -45,7 +49,7 @@
         available_courses: [],
         available_course_options: [],
         border: false,
-        editable: provider_user_can_make_decisions,
+        editable: @provider_user_can_make_decisions,
         ske_conditions: @application_choice.offer.ske_conditions,
       ) %>
     <% end %>

--- a/app/views/provider_interface/references/index.html.erb
+++ b/app/views/provider_interface/references/index.html.erb
@@ -1,6 +1,11 @@
 <% content_for :browser_title, "#{@application_choice.application_form.full_name} – #{@application_choice.course.name_and_code} - References" %>
 
-<%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(application_choice: @application_choice, provider_can_respond: @provider_can_make_decisions, provider_can_set_up_interviews: @provider_can_set_up_interviews) %>
+<%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(
+  application_choice: @application_choice,
+  provider_can_respond: @provider_user_can_make_decisions,
+  provider_can_set_up_interviews: @provider_user_can_set_up_interviews,
+  course_associated_with_user_providers: @course_associated_with_user_providers,
+) %>
 <h1 class="govuk-heading-l">References</h1>
 
 <p class="govuk-body govuk-!-display-none-print">

--- a/spec/requests/provider_interface/viewing_changed_provider_application_spec.rb
+++ b/spec/requests/provider_interface/viewing_changed_provider_application_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe 'Viewing application which were changed to different providers' do
+  let!(:provider_user) { create(:provider_user, :with_provider, dfe_sign_in_uid: 'DFE_SIGN_IN_UID') }
+  let(:provider) { provider_user.providers.first }
+
+  before do
+    allow(DfESignInUser).to receive(:load_from_session)
+      .and_return(
+        DfESignInUser.new(
+          email_address: provider_user.email_address,
+          dfe_sign_in_uid: provider_user.dfe_sign_in_uid,
+          first_name: provider_user.first_name,
+          last_name: provider_user.last_name,
+        ),
+      )
+  end
+
+  describe 'GET references, notes and timeline tab when viewing a changed app' do
+    it 'restrict access and redirects to the application tab' do
+      old_provider = provider
+      new_provider = create(:provider, code: 'YYY')
+      old_course = create(:course, provider: old_provider)
+      new_course = create(:course, provider: new_provider)
+      old_course_option = create(:course_option, course: old_course)
+      new_course_option = create(:course_option, course: new_course)
+
+      application_choice = create(
+        :application_choice,
+        :offered,
+        course_option: old_course_option,
+        current_course_option: new_course_option,
+      )
+      application_choice_id = application_choice.id
+
+      [
+        provider_interface_application_choice_references_path(application_choice_id:),
+        provider_interface_application_choice_notes_path(application_choice_id:),
+        provider_interface_application_choice_timeline_path(application_choice_id:),
+      ].each do |path|
+        get path
+        expect(response).to redirect_to(
+          provider_interface_application_choice_path(application_choice_id: application_choice.id),
+        )
+      end
+    end
+  end
+end

--- a/spec/system/provider_interface/see_application_after_change_to_a_different_provider_spec.rb
+++ b/spec/system/provider_interface/see_application_after_change_to_a_different_provider_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.feature 'An application was changed to another provider' do
+  include CourseOptionHelpers
+  include DfESignInHelpers
+
+  scenario 'And the old provider can only see part of their application' do
+    given_an_application_which_has_changed_provider
+    and_i_am_a_provider_user_authenticated_with_dfe_sign_in
+
+    when_i_belong_to_the_original_provider
+    and_i_visit_the_provider_interface
+    and_i_sign_in_to_the_provider_interface
+    then_i_can_see_the_application
+
+    and_i_visit_the_provider_interface
+    then_i_can_see_the_application
+
+    when_i_click_on_the_individual_application
+    then_i_can_see_only_the_application_and_offer_tabs
+
+    when_i_click_on_the_offer_tab
+    then_i_can_see_only_the_application_and_offer_tabs
+  end
+
+  def given_an_application_which_has_changed_provider
+    @old_provider = create(:provider, code: 'XXX')
+    @new_provider = create(:provider, code: 'YYY')
+    old_course = create(:course, provider: @old_provider)
+    new_course = create(:course, provider: @new_provider)
+    old_course_option = create(:course_option, course: old_course)
+    new_course_option = create(:course_option, course: new_course)
+
+    @application_choice = create(
+      :application_choice,
+      :offered,
+      course_option: old_course_option,
+      current_course_option: new_course_option,
+    )
+  end
+
+  def and_i_am_a_provider_user_authenticated_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+    provider_signs_in_using_dfe_sign_in
+  end
+
+  def when_i_belong_to_the_original_provider
+    @provider_user = provider_user_exists_in_apply_database
+    @provider_user.providers << @old_provider
+  end
+
+  def and_i_visit_the_provider_interface
+    visit provider_interface_applications_path
+  end
+
+  def then_i_can_see_the_application
+    expect(page).to have_content @application_choice.application_form.full_name
+  end
+
+  def when_i_click_on_the_individual_application
+    click_on @application_choice.application_form.full_name
+  end
+
+  def then_i_can_see_only_the_application_and_offer_tabs
+    expect(navigation_tabs).to eq(%w[Application Offer])
+  end
+
+  def when_i_click_on_the_offer_tab
+    click_on 'Offer'
+  end
+
+  def navigation_tabs
+    page.first('.app-tab-navigation').text.split
+  end
+end

--- a/spec/system/provider_interface/see_application_after_change_to_a_different_provider_spec.rb
+++ b/spec/system/provider_interface/see_application_after_change_to_a_different_provider_spec.rb
@@ -14,8 +14,6 @@ RSpec.feature 'An application was changed to another provider' do
     then_i_can_see_the_application
 
     and_i_visit_the_provider_interface
-    then_i_can_see_the_application
-
     when_i_click_on_the_individual_application
     then_i_can_see_only_the_application_and_offer_tabs
 


### PR DESCRIPTION
## Context

This fixes the bug described below by not showing tabs on provider interface and by correcting the course and provider name showing in the candidate interface.

## How to reproduce the bug

1. Candidate applies to a course lets say at Aspire Education, is offered a place and then candidate accepts
2. Change application to course to a new provider in support, Teach West London, when candidate is in pending conditions
The bugs:
3. Candidate is visible to both old and new provider in provider interface
4. On the candidate side, the post offer dashboard only shows the course he applied to, not the one he was changed to
