### PR TITLE
Set az config to ignore warnings

### DIFF
--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -61,14 +61,14 @@ jobs:
       run: |
         STORAGE_CONN_STR="$(az keyvault secret show --name APPLY-BACKUP-STORAGE-CONNECTION-STRING --vault-name ${{ env.key_vault_name }} | jq -r .value)"
         echo "::add-mask::$STORAGE_CONN_STR"
-        echo "STORAGE_CONN_STR=$STORAGE_CONN_STR" >> $GITHUB_ENV
+        echo "AZURE_STORAGE_CONNECTION_STRING=$STORAGE_CONN_STR" >> $GITHUB_ENV
 
     - name: Upload Backup to Azure Storage
       run: |
         az config set extension.use_dynamic_install=yes_without_prompt
+        az config set core.only_show_errors=true
         az storage azcopy blob upload --container prod-db-backup \
-        --source ${BACKUP_FILE_NAME}.sql.gz \
-        --connection-string '${{ env.STORAGE_CONN_STR }}'
+        --source ${BACKUP_FILE_NAME}.sql.gz
 
     - name: Notify Slack channel on job failure
       if: failure()

--- a/.github/workflows/restore-production-snapshot.yml
+++ b/.github/workflows/restore-production-snapshot.yml
@@ -68,19 +68,18 @@ jobs:
         run: |
           STORAGE_CONN_STR="$(az keyvault secret show --name APPLY-BACKUP-STORAGE-CONNECTION-STRING --vault-name ${{ env.key_vault_name }} | jq -r .value)"
           echo "::add-mask::$STORAGE_CONN_STR"
-          echo "STORAGE_CONN_STR=$STORAGE_CONN_STR" >> $GITHUB_ENV
+          echo "AZURE_STORAGE_CONNECTION_STRING=$STORAGE_CONN_STR" >> $GITHUB_ENV
 
       - name: Get backup file name
         run: |
           az storage blob list --container ${BACKUP_CONTAINER} \
-          --connection-string '${{ env.STORAGE_CONN_STR }}' \
           --query "[? contains(name, 'apply_${BACKUP_AZURE_PREFIX}_${BACKUP_DATE}') && ends_with(name,'sql.gz')].name" | echo "BACKUP_ARCHIVE_NAME=$(jq -r .[0])" >> $GITHUB_ENV
 
       - name: Download backup
         run: |
           az config set extension.use_dynamic_install=yes_without_prompt
-          az storage azcopy blob download --container ${BACKUP_CONTAINER} --source ${BACKUP_ARCHIVE_NAME} --destination ${BACKUP_ARCHIVE_NAME} \
-          --connection-string '${{ env.STORAGE_CONN_STR }}'
+          az config set core.only_show_errors=true
+          az storage azcopy blob download --container ${BACKUP_CONTAINER} --source ${BACKUP_ARCHIVE_NAME} --destination ${BACKUP_ARCHIVE_NAME}
 
       - name: Restore backup to snapshot database
         run: gzip -d --to-stdout ${BACKUP_ARCHIVE_NAME} | cf conduit apply-postgres-snapshot -- psql

--- a/bin/download-nightly-backup
+++ b/bin/download-nightly-backup
@@ -34,13 +34,15 @@ if [[ -z "${BACKUP_DATE}" ]]; then
 fi
 
 STORAGE_CONN_STR="$(az keyvault secret show --name ${BACKUP_STORAGE_SECRET_NAME} --vault-name ${KEY_VAULT_NAME} | jq -r .value)"
+AZURE_STORAGE_CONNECTION_STRING=STORAGE_CONN_STR
 
-BACKUP_ARCHIVE_FILENAME=$(az storage blob list --connection-string ${STORAGE_CONN_STR} --container-name ${AZURE_BACKUP_STORAGE_CONTAINER_NAME} --prefix ${BACKUP_FILENAME_PREFIX}${BACKUP_DATE} --output json --query [-1].name | jq -r)
+BACKUP_ARCHIVE_FILENAME=$(az storage blob list --container-name ${AZURE_BACKUP_STORAGE_CONTAINER_NAME} --prefix ${BACKUP_FILENAME_PREFIX}${BACKUP_DATE} --output json --query [-1].name | jq -r)
 if [[ -z ${BACKUP_ARCHIVE_FILENAME} ]]; then
   echo "There are no files found matching the prefix ${BACKUP_FILENAME_PREFIX}${BACKUP_DATE} in container ${AZURE_BACKUP_STORAGE_CONTAINER_NAME}"
   exit 1
 else
   echo "Downloading ${BACKUP_ARCHIVE_FILENAME} ..."
   az config set extension.use_dynamic_install=yes_without_prompt
-  az storage azcopy blob download --connection-string ${STORAGE_CONN_STR} --container ${AZURE_BACKUP_STORAGE_CONTAINER_NAME} --source ${BACKUP_ARCHIVE_FILENAME} --destination ${BACKUP_ARCHIVE_FILENAME} --output none
+  az config set core.only_show_errors=true
+  az storage azcopy blob download --container ${AZURE_BACKUP_STORAGE_CONTAINER_NAME} --source ${BACKUP_ARCHIVE_FILENAME} --destination ${BACKUP_ARCHIVE_FILENAME} --output none
 fi


### PR DESCRIPTION
## Context

Warnings were displaying the Storage Account Connection String URL.  The warnings were being displayed as the storage extension for azcopy is still in preview. Change will prevent the connection string url from being displayed in the Github Workflow run.  

## Changes proposed in this pull request

- core.only_show_errors flag set to true for az config

## Guidance to review

Removing this line and running the workflow will display the connection string. 

## Link to Trello card

https://trello.com/c/QX7E8knD/298-secret-masking-for-azure-production-database-backup-workflow


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
