### PR TITLE
Allow support to amend SKE language conditions

### DIFF
--- a/app/components/support_interface/conditions_component.html.erb
+++ b/app/components/support_interface/conditions_component.html.erb
@@ -5,11 +5,13 @@
 
   <div class="govuk-!-margin-top-2">
     <% if render_ske? %>
-      <%= render(SummaryCardComponent.new(rows: ske_rows)) do %>
-        <%= render(SummaryCardHeaderComponent.new(
-          title: 'Subject knowledge enhancement course',
-          heading_level: :h2,
-        )) %>
+      <% ske_conditions.each do |ske_condition| %>
+        <%= render(SummaryCardComponent.new(rows: ske_rows(ske_condition))) do %>
+          <%= render(SummaryCardHeaderComponent.new(
+            title: 'Subject knowledge enhancement course',
+            heading_level: :h2,
+          )) %>
+      <% end %>
     <% end %>
   <% end %>
   </div>

--- a/app/components/support_interface/conditions_component.rb
+++ b/app/components/support_interface/conditions_component.rb
@@ -1,32 +1,31 @@
 module SupportInterface
   class ConditionsComponent < ViewComponent::Base
     attr_accessor :conditions, :application_choice
-    delegate :reason, :length, to: :ske_condition
 
     def initialize(conditions:, application_choice:)
       @conditions = conditions
       @application_choice = application_choice
     end
 
-    def ske_rows
+    def ske_rows(ske_condition)
       [
         { key: 'Subject', value: ske_condition.subject },
         {
           key: 'Length',
-          value: "#{length} weeks",
+          value: "#{ske_condition.length} weeks",
         },
         {
           key: 'Reason',
-          value: ske_condition_presenter.reason,
+          value: ske_condition_presenter(ske_condition).reason,
         },
       ]
     end
 
-    def ske_condition
-      application_choice.offer.ske_conditions.first
+    def ske_conditions
+      application_choice.offer.ske_conditions
     end
 
-    def ske_condition_presenter
+    def ske_condition_presenter(ske_condition)
       SkeConditionPresenter.new(ske_condition, interface: :support_interface)
     end
 

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -371,7 +371,7 @@ module ProviderInterface
     end
 
     def validate_combined_ske_length
-      if ske_conditions.many? && ske_conditions.none? { |sc| sc.length == '8' }
+      if SkeCondition.no_conditions_meet_minimum_length_criteria?(ske_conditions)
         errors.add(:base, :must_have_at_least_one_8_week_ske_course)
       end
     end

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -3,9 +3,6 @@ module ProviderInterface
     include Wizard
     include Wizard::PathHistory
 
-    MAX_SKE_LANGUAGES = 2
-    MAX_SKE_LENGTH = 36
-
     INITIAL_STEP = :select_option
     FINAL_STEPS = %i[conditions check].freeze
     CHANGE_OFFER_STEPS = %i[providers courses study_modes locations].freeze
@@ -380,8 +377,8 @@ module ProviderInterface
     end
 
     def validate_language_count
-      if ske_conditions.length > MAX_SKE_LANGUAGES
-        errors.add(:base, :too_many, count: MAX_SKE_LANGUAGES)
+      if ske_conditions.length > SkeCondition::MAX_SKE_LANGUAGES
+        errors.add(:base, :too_many, count: SkeCondition::MAX_SKE_LANGUAGES)
       end
     end
 

--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -273,7 +273,7 @@ module SupportInterface
     end
 
     def multiple_ske_conditions?
-      ske_conditions.length > 1
+      ske_conditions.many?
     end
 
     def validate_ske_conditions

--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -51,7 +51,7 @@ module SupportInterface
         standard_conditions: params['standard_conditions'] || [],
         audit_comment_ticket: params['audit_comment_ticket'],
         further_condition_attrs: params['further_conditions'] || {},
-        ske_conditions: params['ske_conditions']&.select { |_, ske_attrs| ske_attrs['ske_required'].present? } || {},
+        ske_conditions: params['ske_conditions']&.select { |_, ske_attrs| ActiveModel::Type::Boolean.new.cast(ske_attrs['ske_required']) } || {},
       }
 
       build_from_application_choice(application_choice, attrs)

--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -260,8 +260,7 @@ module SupportInterface
     end
 
     def validate_combined_ske_length
-      ske_conditions_to_validate = structured_conditions_to_save
-      if ske_conditions_to_validate.many? && ske_conditions_to_validate.none? { |sc| sc.length == '8' }
+      if SkeCondition.no_conditions_meet_minimum_length_criteria?(structured_conditions_to_save)
         errors.add(:base, :must_have_at_least_one_8_week_ske_course)
       end
     end

--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -50,7 +50,7 @@ module SupportInterface
         standard_conditions: params['standard_conditions'] || [],
         audit_comment_ticket: params['audit_comment_ticket'],
         further_condition_attrs: params['further_conditions'] || {},
-        ske_conditions: params['ske_conditions']&.select { |_, ske_attrs| ske_attrs['ske_required'] == 'true' } || {},
+        ske_conditions: params['ske_conditions']&.select { |_, ske_attrs| ske_attrs['ske_required'].present? } || {},
       }
 
       build_from_application_choice(application_choice, attrs)
@@ -109,10 +109,10 @@ module SupportInterface
       end
     end
 
-    def ske_reason_options
+    def ske_reason_options(subject:)
       [
-        CheckBoxOption.new(SkeCondition::DIFFERENT_DEGREE_REASON, different_degree_reason_label),
-        CheckBoxOption.new(SkeCondition::OUTDATED_DEGREE_REASON, outdated_degree_reason_label),
+        CheckBoxOption.new(SkeCondition::DIFFERENT_DEGREE_REASON, different_degree_reason_label(subject:)),
+        CheckBoxOption.new(SkeCondition::OUTDATED_DEGREE_REASON, outdated_degree_reason_label(subject:)),
       ]
     end
 
@@ -122,6 +122,14 @@ module SupportInterface
       else
         SkeConditionField.new(id: 0, subject: subject_name, subject_type: 'standard')
       end
+    end
+
+    def ske_condition_model_for(language, index)
+      # if ske_condition_models.present?
+      #   ske_condition_models.first
+      # else
+      SkeConditionField.new(id: index, subject: language, subject_type: 'language')
+      # end
     end
 
     def ske_course?
@@ -152,17 +160,17 @@ module SupportInterface
 
   private
 
-    def different_degree_reason_label
+    def different_degree_reason_label(subject:)
       I18n.t(
         'provider_interface.offer.ske_reasons.different_degree',
-        degree_subject: subject_name,
+        degree_subject: subject,
       )
     end
 
-    def outdated_degree_reason_label
+    def outdated_degree_reason_label(subject:)
       I18n.t(
         'provider_interface.offer.ske_reasons.outdated_degree',
-        degree_subject: subject_name,
+        degree_subject: subject,
         graduation_cutoff_date: cutoff_date.to_fs(:month_and_year),
       )
     end

--- a/app/models/ske_condition.rb
+++ b/app/models/ske_condition.rb
@@ -17,6 +17,9 @@ class SkeCondition < OfferCondition
     OUTDATED_DEGREE_REASON = 'outdated_degree'.freeze,
   ].freeze
 
+  MAX_SKE_LANGUAGES = 2
+  MAX_SKE_LENGTH = 36
+
   SKE_LENGTHS = 8.step(by: 4).take(6).freeze
 
   validates :graduation_cutoff_date, presence: true, if: :outdated_degree?

--- a/app/models/ske_condition.rb
+++ b/app/models/ske_condition.rb
@@ -38,6 +38,10 @@ class SkeCondition < OfferCondition
     super({ status: :pending }.merge(attrs))
   end
 
+  def self.no_conditions_meet_minimum_length_criteria?(ske_conditions)
+    ske_conditions.many? && ske_conditions.none? { |sc| sc.length == SKE_LENGTHS.first.to_s }
+  end
+
   def language_subject?
     subject_type == 'language'
   end

--- a/app/views/support_interface/application_choice_conditions/edit.html.erb
+++ b/app/views/support_interface/application_choice_conditions/edit.html.erb
@@ -44,7 +44,7 @@
           <% if @form.language_course? %>
             <%= f.govuk_check_boxes_fieldset :ske_languages, legend: { text: "Do you require #{@form.application_choice.application_form.full_name} to take a SKE course in any of these languages?", size: 's' }, hint: { text: 'You can select a maximum of 2', size: 's' } do %>
               <% SkeCondition::VALID_LANGUAGES.each_with_index do |language, index| %>
-                <%= f.fields_for 'ske_conditions[]', @form.ske_condition_model_for(language, index) do |fs| %>
+                <%= f.fields_for 'ske_conditions[]', @form.ske_condition_language_course_model_for(language, index) do |fs| %>
                   <%= fs.govuk_check_box :ske_required, language, label: { text: language.capitalize }, link_errors: index.zero? do %>
                     <%= fs.hidden_field :subject %>
                     <%= fs.hidden_field :subject_type %>
@@ -62,8 +62,8 @@
                 <%= fs.hidden_field :subject %>
                 <%= fs.hidden_field :subject_type %>
                 <%= fs.govuk_radio_button :ske_required, true, label: { text: 'Yes' }, link_errors: true do || %>
-                  <%= fs.govuk_collection_radio_buttons :reason, @form.ske_reason_options(subject: fs.model.subject), :value, :name, small: true, legend: { text: 'Why do they need to take a subject knowledge enhancement (SKE) course?' } %>
-                  <%= fs.govuk_collection_radio_buttons :length, @form.ske_length_options(subject: fs.model.subject), :value, :name, small: true, legend: { text: 'How long must their SKE course be?' } %>
+                  <%= fs.govuk_collection_radio_buttons :reason, @form.ske_reason_options(subject: fs.object.subject), :value, :name, small: true, legend: { text: 'Why do they need to take a subject knowledge enhancement (SKE) course?' } %>
+                  <%= fs.govuk_collection_radio_buttons :length, @form.ske_length_options, :value, :name, small: true, legend: { text: 'How long must their SKE course be?' } %>
                 <% end %>
                 <%= fs.govuk_radio_button :ske_required, false, label: { text: 'No' } %>
               <% end %>

--- a/app/views/support_interface/application_choice_conditions/edit.html.erb
+++ b/app/views/support_interface/application_choice_conditions/edit.html.erb
@@ -38,17 +38,35 @@
 
       <% end %>
 
-      <% if @form.ske_course? && !@form.language_course? %>
+      <% if @form.ske_course? %>
         <%= f.govuk_fieldset legend: { text: 'SKE conditions', size: 'm' } do %>
-          <%= f.govuk_radio_buttons_fieldset :ske_required, legend: { text: "Do you require #{@form.application_choice.application_form.full_name} to take a SKE course in #{@form.subject_name} that will be funded by the DfE?", size: 'm' } do %>
-            <%= f.fields_for 'ske_conditions[]', @form.standard_ske_condition do |fs| %>
-              <%= fs.hidden_field :subject %>
-              <%= fs.hidden_field :subject_type %>
-              <%= fs.govuk_radio_button :ske_required, true, label: { text: 'Yes' }, link_errors: true do || %>
-                <%= fs.govuk_collection_radio_buttons :reason, @form.ske_reason_options, :value, :name, small: true, legend: { text: 'Why do they need to take a subject knowledge enhancement (SKE) course?' } %>
-                <%= fs.govuk_collection_radio_buttons :length, @form.ske_length_options, :value, :name, small: true, legend: { text: 'How long must their SKE course be?' } %>
+
+          <% if @form.language_course? %>
+            <%= f.govuk_check_boxes_fieldset :ske_languages, legend: { text: "Do you require #{@form.application_choice.application_form.full_name} to take a SKE course in any of these languages?", size: 's' }, hint: { text: 'You can select a maximum of 2', size: 's' } do %>
+              <% SkeCondition::VALID_LANGUAGES.each_with_index do |language, index| %>
+                <%= f.fields_for 'ske_conditions[]', @form.ske_condition_model_for(language, index) do |fs| %>
+                  <%= fs.govuk_check_box :ske_required, language, label: { text: language.capitalize }, link_errors: index.zero? do %>
+                    <%= fs.hidden_field :subject %>
+                    <%= fs.hidden_field :subject_type %>
+                    <%= fs.govuk_collection_radio_buttons :reason, @form.ske_reason_options(subject: language), :value, :name, small: true, legend: { text: 'Why do they need to take a subject knowledge enhancement (SKE) course?' } %>
+                    <%= fs.govuk_collection_radio_buttons :length, @form.ske_length_options, :value, :name, small: true, legend: { text: 'How long must their SKE course be?' } %>
+                  <% end %>
+                <% end %>
               <% end %>
-              <%= fs.govuk_radio_button :ske_required, false, label: { text: 'No' } %>
+              <%= f.govuk_radio_divider %>
+              <%= f.govuk_check_box :ske_languages, 'no', label: { text: 'No, a SKE course is not required' }, exclusive: true %>
+            <% end %>
+          <% else %>
+            <%= f.govuk_radio_buttons_fieldset :ske_required, legend: { text: "Do you require #{@form.application_choice.application_form.full_name} to take a SKE course in #{@form.subject_name} that will be funded by the DfE?", size: 'm' } do %>
+              <%= f.fields_for 'ske_conditions[]', @form.standard_ske_condition do |fs| %>
+                <%= fs.hidden_field :subject %>
+                <%= fs.hidden_field :subject_type %>
+                <%= fs.govuk_radio_button :ske_required, true, label: { text: 'Yes' }, link_errors: true do || %>
+                  <%= fs.govuk_collection_radio_buttons :reason, @form.ske_reason_options(subject: fs.model.subject), :value, :name, small: true, legend: { text: 'Why do they need to take a subject knowledge enhancement (SKE) course?' } %>
+                  <%= fs.govuk_collection_radio_buttons :length, @form.ske_length_options(subject: fs.model.subject), :value, :name, small: true, legend: { text: 'How long must their SKE course be?' } %>
+                <% end %>
+                <%= fs.govuk_radio_button :ske_required, false, label: { text: 'No' } %>
+              <% end %>
             <% end %>
           <% end %>
         <% end %>

--- a/app/views/support_interface/application_choice_conditions/edit.html.erb
+++ b/app/views/support_interface/application_choice_conditions/edit.html.erb
@@ -42,7 +42,7 @@
         <%= f.govuk_fieldset legend: { text: 'SKE conditions', size: 'm' } do %>
 
           <% if @form.language_course? %>
-            <%= f.govuk_check_boxes_fieldset :ske_languages, legend: { text: "Do you require #{@form.application_choice.application_form.full_name} to take a SKE course in any of these languages?", size: 's' }, hint: { text: 'You can select a maximum of 2', size: 's' } do %>
+            <%= f.govuk_check_boxes_fieldset :ske_languages, legend: { text: "Do you require #{@form.application_choice.application_form.full_name} to take a SKE course in any of these languages?", size: 's' }, hint: { text: "You can select a maximum of #{SkeCondition::MAX_SKE_LANGUAGES}", size: 's' } do %>
               <% SkeCondition::VALID_LANGUAGES.each_with_index do |language, index| %>
                 <%= f.fields_for 'ske_conditions[]', @form.ske_condition_language_course_model_for(language, index) do |fs| %>
                   <%= fs.govuk_check_box :ske_required, language, label: { text: language.capitalize }, link_errors: index.zero? do %>

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -111,6 +111,9 @@ en:
           attributes:
             base:
               exceeded_max_conditions: 'You can only have %{count} conditions or fewer'
+              must_have_at_least_one_8_week_ske_course: Select one language course that’s 8 weeks, the other course can be between 8 and 28 weeks
+              no_and_languages_selected: Select a language, or select ‘No, a SKE course is not required’
+              too_many: Select no more than %{count} languages
             audit_comment_ticket:
               blank: Enter a Zendesk ticket URL
               invalid: Enter a valid Zendesk ticket URL

--- a/spec/system/support_interface/change_offer_language_ske_conditions_spec.rb
+++ b/spec/system/support_interface/change_offer_language_ske_conditions_spec.rb
@@ -1,0 +1,134 @@
+require 'rails_helper'
+
+RSpec.feature 'Add course to submitted application' do
+  include DfESignInHelpers
+
+  scenario 'Support user adds course to submitted application' do
+    given_i_am_a_support_user
+    and_the_provider_ske_feature_flag_is_active
+    and_there_is_an_offered_application_in_the_system
+    and_the_language_course_subject_requires_ske
+    and_i_visit_the_support_page
+
+    when_i_click_on_the_application
+    then_i_should_see_the_current_conditions
+
+    when_i_click_on_change_conditions
+    then_i_see_the_condition_edit_form_with_a_warning
+
+    when_i_add_two_new_ske_conditions_and_click_update_conditions_with_a_support_ticket_url
+    then_i_see_the_new_ske_conditions
+
+    # when_i_click_on_change_conditions
+    # and_i_change_the_length_of_the_ske_condition
+    # then_i_see_the_updated_ske_condition
+
+    # when_i_click_on_change_conditions
+    # and_i_delete_the_ske_condition
+    # then_i_see_that_the_ske_condition_has_been_removed
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_the_provider_ske_feature_flag_is_active
+    FeatureFlag.activate(:provider_ske)
+  end
+
+  def and_there_is_an_offered_application_in_the_system
+    candidate = create(:candidate, email_address: 'candy@example.com')
+
+    Audited.audit_class.as_user(candidate) do
+      @application_form = create(
+        :completed_application_form,
+        first_name: 'Candy',
+        last_name: 'Dayte',
+        candidate:,
+      )
+
+      conditions = [build(:offer_condition, text: 'Be cool', status: 'met')]
+      @application_choice = create(
+        :application_choice,
+        :offered,
+        :accepted,
+        offer: build(:offer, conditions:),
+        application_form: @application_form,
+      )
+    end
+  end
+
+  def and_the_language_course_subject_requires_ske
+    @application_choice.course_option.course.subjects.delete_all
+    @application_choice.course_option.course.subjects << build(
+      :subject, code: '15', name: 'Modern Languages'
+    )
+  end
+
+  def and_i_visit_the_support_page
+    visit support_interface_path
+  end
+
+  def when_i_click_on_the_application
+    click_on 'Candy Dayte'
+  end
+
+  def then_i_should_see_the_current_conditions
+    expect(page).to have_content("Conditions\nBe cool")
+  end
+
+  def when_i_click_on_change_conditions
+    click_on 'Change conditions'
+  end
+
+  def then_i_see_the_condition_edit_form_with_a_warning
+    expect(page).to have_current_path(
+      support_interface_update_application_choice_conditions_path(@application_choice),
+    )
+  end
+
+  def when_i_add_two_new_ske_conditions_and_click_update_conditions_with_a_support_ticket_url
+    fill_in 'Zendesk ticket URL', with: 'becomingateacher.zendesk.com/agent/tickets/12345'
+    check('French')
+    within('#support-interface-conditions-form-ske-conditions-0-ske-required-french-conditional') do
+      choose('Their degree subject was not French')
+      choose('8 weeks')
+    end
+    check('German')
+    within('#support-interface-conditions-form-ske-conditions-2-ske-required-german-conditional') do
+      choose('Their degree subject was not German')
+      choose('12 weeks')
+    end
+    click_on 'Update conditions'
+  end
+
+  def then_i_see_the_new_ske_conditions
+    expect(page).to have_content('Subject knowledge enhancement course')
+    expect(page).to have_content("Length\n8 weeks")
+    expect(page).to have_content("Reason\nTheir degree subject was not German")
+  end
+
+#   def and_i_change_the_length_of_the_ske_condition
+#     fill_in 'Zendesk ticket URL', with: 'becomingateacher.zendesk.com/agent/tickets/12345'
+#     choose('Yes')
+#     choose('Their degree subject was not Biology')
+#     choose('20 weeks')
+#     click_on 'Update conditions'
+#   end
+
+#   def then_i_see_the_updated_ske_condition
+#     expect(page).to have_content('Subject knowledge enhancement course')
+#     expect(page).to have_content("Length\n20 weeks")
+#     expect(page).to have_content("Reason\nTheir degree subject was not Biology")
+#   end
+
+#   def and_i_delete_the_ske_condition
+#     fill_in 'Zendesk ticket URL', with: 'becomingateacher.zendesk.com/agent/tickets/12345'
+#     choose('No')
+#     click_on 'Update conditions'
+#   end
+
+#   def then_i_see_that_the_ske_condition_has_been_removed
+#     expect(page).not_to have_content('Subject knowledge enhancement course')
+#   end
+end

--- a/spec/system/support_interface/change_offer_language_ske_conditions_spec.rb
+++ b/spec/system/support_interface/change_offer_language_ske_conditions_spec.rb
@@ -23,9 +23,9 @@ RSpec.feature 'Add course to submitted application' do
     and_i_change_the_length_of_the_ske_condition
     then_i_see_the_updated_ske_condition
 
-    # when_i_click_on_change_conditions
-    # and_i_delete_the_ske_condition
-    # then_i_see_that_the_ske_condition_has_been_removed
+    when_i_click_on_change_conditions
+    and_i_delete_the_ske_condition
+    then_i_see_that_the_ske_condition_has_been_removed
   end
 
   def given_i_am_a_support_user

--- a/spec/system/support_interface/change_offer_language_ske_conditions_spec.rb
+++ b/spec/system/support_interface/change_offer_language_ske_conditions_spec.rb
@@ -19,9 +19,9 @@ RSpec.feature 'Add course to submitted application' do
     when_i_add_two_new_ske_conditions_and_click_update_conditions_with_a_support_ticket_url
     then_i_see_the_new_ske_conditions
 
-    # when_i_click_on_change_conditions
-    # and_i_change_the_length_of_the_ske_condition
-    # then_i_see_the_updated_ske_condition
+    when_i_click_on_change_conditions
+    and_i_change_the_length_of_the_ske_condition
+    then_i_see_the_updated_ske_condition
 
     # when_i_click_on_change_conditions
     # and_i_delete_the_ske_condition
@@ -108,27 +108,36 @@ RSpec.feature 'Add course to submitted application' do
     expect(page).to have_content("Reason\nTheir degree subject was not German")
   end
 
-#   def and_i_change_the_length_of_the_ske_condition
-#     fill_in 'Zendesk ticket URL', with: 'becomingateacher.zendesk.com/agent/tickets/12345'
-#     choose('Yes')
-#     choose('Their degree subject was not Biology')
-#     choose('20 weeks')
-#     click_on 'Update conditions'
-#   end
+  def and_i_change_the_length_of_the_ske_condition
+    fill_in 'Zendesk ticket URL', with: 'becomingateacher.zendesk.com/agent/tickets/12345'
+    check('French')
+    within('#support-interface-conditions-form-ske-conditions-0-ske-required-french-conditional') do
+      choose('Their degree subject was not French')
+      choose('8 weeks')
+    end
+    check('German')
+    within('#support-interface-conditions-form-ske-conditions-2-ske-required-german-conditional') do
+      choose('Their degree subject was not German')
+      choose('16 weeks')
+    end
+    click_on 'Update conditions'
+  end
 
-#   def then_i_see_the_updated_ske_condition
-#     expect(page).to have_content('Subject knowledge enhancement course')
-#     expect(page).to have_content("Length\n20 weeks")
-#     expect(page).to have_content("Reason\nTheir degree subject was not Biology")
-#   end
+  def then_i_see_the_updated_ske_condition
+    expect(page).to have_content('Subject knowledge enhancement course')
+    expect(page).to have_content("Length\n16 weeks")
+    expect(page).to have_content("Reason\nTheir degree subject was not German")
+  end
 
-#   def and_i_delete_the_ske_condition
-#     fill_in 'Zendesk ticket URL', with: 'becomingateacher.zendesk.com/agent/tickets/12345'
-#     choose('No')
-#     click_on 'Update conditions'
-#   end
+  def and_i_delete_the_ske_condition
+    fill_in 'Zendesk ticket URL', with: 'becomingateacher.zendesk.com/agent/tickets/12345'
+    uncheck('French')
+    uncheck('German')
+    check('No, a SKE course is not required')
+    click_on 'Update conditions'
+  end
 
-#   def then_i_see_that_the_ske_condition_has_been_removed
-#     expect(page).not_to have_content('Subject knowledge enhancement course')
-#   end
+  def then_i_see_that_the_ske_condition_has_been_removed
+    expect(page).not_to have_content('Subject knowledge enhancement course')
+  end
 end


### PR DESCRIPTION
## Context

Follow up to https://github.com/DFE-Digital/apply-for-teacher-training/pull/8110 that adds support for multiple SKE conditions (that are allowed for modern language courses)

## Changes proposed in this pull request

For a language course we present SKE conditions as a list of check boxes, one for each language:

![image](https://user-images.githubusercontent.com/450843/231156421-32692c0f-727e-4127-94d8-195287488680.png)

Multiple SKE conditions are now displayed on the main application form:

![image](https://user-images.githubusercontent.com/450843/231156856-deea91ef-c809-4e3d-860a-55cf220b1194.png)


## Guidance to review

Does the UI make sense?
Is there a more elegant way to do the data exchange in `ConditionsForm`?

## Link to Trello card

https://trello.com/c/LMTxUp45/1272-allow-support-to-add-amend-a-ske-condition

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
