### PR TITLE
Fix logic around GCSE status for adviser sign up

### DIFF
--- a/app/workers/adviser_sign_up_worker.rb
+++ b/app/workers/adviser_sign_up_worker.rb
@@ -63,12 +63,24 @@ private
   end
 
   def pass_gcse_maths_and_english?
-    !!(application_form.maths_gcse&.pass_gcse? && application_form.english_gcse&.pass_gcse?)
+    pass_gcse_maths? && pass_gcse_english?
+  end
+
+  def pass_gcse_maths?
+    !!application_form.maths_gcse&.pass_gcse?
+  end
+
+  def pass_gcse_english?
+    !!application_form.english_gcse&.pass_gcse?
   end
 
   def retaking_gcse_maths_and_english?
-    !!(application_form.maths_gcse&.currently_completing_qualification? &&
-      application_form.english_gcse&.currently_completing_qualification?)
+    return false if pass_gcse_maths_and_english?
+
+    retaking_maths = application_form.maths_gcse&.currently_completing_qualification?
+    retaking_english = application_form.english_gcse&.currently_completing_qualification?
+
+    !!((pass_gcse_maths? || retaking_maths) && (pass_gcse_english? || retaking_english))
   end
 
   def pass_gcse_science?

--- a/spec/workers/adviser_sign_up_worker_spec.rb
+++ b/spec/workers/adviser_sign_up_worker_spec.rb
@@ -121,16 +121,60 @@ RSpec.describe AdviserSignUpWorker do
       end
 
       it 'sends yes for planning_to_retake_gcse_maths_and_english_id if they are completing both Maths and English GCSEs' do
-        application_form.maths_gcse.update(currently_completing_qualification: true)
-        application_form.english_gcse.update(currently_completing_qualification: true)
+        application_form.maths_gcse.update(grade: 'Z', currently_completing_qualification: true)
+        application_form.english_gcse.update(grade: 'Z', currently_completing_qualification: true)
 
-        expect_sign_up(planning_to_retake_gcse_maths_and_english_id: constants.fetch(:gcse, true))
+        expect_sign_up(
+          has_gcse_maths_and_english_id: constants.fetch(:gcse, false),
+          planning_to_retake_gcse_maths_and_english_id: constants.fetch(:gcse, true),
+        )
+      end
+
+      it 'sends yes for planning_to_retake_gcse_maths_and_english_id if they are have passed their Maths GCSE and are completing their English GCSE' do
+        application_form.english_gcse.update(grade: 'Z', currently_completing_qualification: true)
+
+        expect_sign_up(
+          has_gcse_maths_and_english_id: constants.fetch(:gcse, false),
+          planning_to_retake_gcse_maths_and_english_id: constants.fetch(:gcse, true),
+        )
+      end
+
+      it 'sends yes for planning_to_retake_gcse_maths_and_english_id if they are have passed their English GCSE and are completing their Maths GCSE' do
+        application_form.maths_gcse.update(grade: 'Z', currently_completing_qualification: true)
+
+        expect_sign_up(
+          has_gcse_maths_and_english_id: constants.fetch(:gcse, false),
+          planning_to_retake_gcse_maths_and_english_id: constants.fetch(:gcse, true),
+        )
+      end
+
+      it 'sends no for planning_to_retake_gcse_maths_and_english_id if they are completing their Maths GCSE and have not passed their English GCSE' do
+        application_form.maths_gcse.update(grade: 'Z', currently_completing_qualification: true)
+        application_form.english_gcse.update(grade: 'Z')
+
+        expect_sign_up(
+          has_gcse_maths_and_english_id: constants.fetch(:gcse, false),
+          planning_to_retake_gcse_maths_and_english_id: constants.fetch(:gcse, false),
+        )
+      end
+
+      it 'sends no for planning_to_retake_gcse_maths_and_english_id if they are completing their English GCSE and have not passed their Maths GCSE' do
+        application_form.english_gcse.update(grade: 'Z', currently_completing_qualification: true)
+        application_form.maths_gcse.update(grade: 'Z')
+
+        expect_sign_up(
+          has_gcse_maths_and_english_id: constants.fetch(:gcse, false),
+          planning_to_retake_gcse_maths_and_english_id: constants.fetch(:gcse, false),
+        )
       end
 
       it 'sends yes for planning_to_retake_gcse_science_id if they are completing their Science GCSE' do
-        application_form.science_gcse.update(currently_completing_qualification: true)
+        application_form.science_gcse.update(grade: 'Z', currently_completing_qualification: true)
 
-        expect_sign_up(planning_to_retake_gcse_science_id: constants.fetch(:gcse, true))
+        expect_sign_up(
+          has_gcse_science_id: constants.fetch(:gcse, false),
+          planning_to_retake_gcse_science_id: constants.fetch(:gcse, true),
+        )
       end
     end
   end


### PR DESCRIPTION
## Context

When checking to see if a candidate is eligible for an adviser we ensure that they either have or are retaking GCSE Maths and English. When we come to submit the sign up payload to the API, however, it becomes more complicated as the API/CRM combines the Maths and English status into single fields.

This has caused an edge case issue whereby a candidate may, for example, have a Maths GCSE and be retaking their English GCSE. As it stands, this would result in `false` being passed to both the `has_gcse_maths_and_english_id` and `planning_to_retake_gcse_maths_and_english_id` attributes, resulting in a 400 bad request response from the API.

We can handle this scenario a number of ways and - after discussing with the CRM team - we have decided that if the candidate has one GCSE and is retaking the other we should send `false` for `has_gcse_maths_and_english_id` and `true` for `planning_on_retaking_gcse_maths_and_english_id`.

## Changes proposed in this pull request

- Fix logic around GCSE status for adviser sign up

## Guidance to review

Sign up as a new candidate and fill out the application form to be eligible for an adviser (using UK candidate criteria). Set Maths GCSE to a pass and English GCSE to be currently completing. Submit the adviser sign up form and check it went through successfully.

Resolves [this sentry error](https://dfe-teacher-services.sentry.io/issues/4003660497/?project=1765973&referrer=slack).

[Link to review app](https://apply-review-8130.london.cloudapps.digital/)

## Link to Trello card

[Trello-4437](https://trello.com/c/c71PZDJH/4437-investigate-sentry-error-from-apply-adviser-sign-up)

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
