### PR TITLE
Attempt to fix flakey `ProviderAgreement` model test

### DIFF
--- a/spec/models/provider_agreement_spec.rb
+++ b/spec/models/provider_agreement_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ProviderAgreement do
   describe '#for_provider' do
     it 'returns agreements scoped to a provider' do
       data_sharing_agreement = create(:provider_agreement, agreement_type: :data_sharing_agreement)
-      other_provider = create(:provider, :unsigned, code: 'ZZZ', name: 'Other')
+      other_provider = create(:provider, :unsigned, name: 'Other')
       create(:provider_agreement, provider: other_provider)
       expect(described_class.count).to eq(2)
       expect(described_class.for_provider(data_sharing_agreement.provider).count).to eq(1)


### PR DESCRIPTION


## Context

This occasionally gives a database `duplicate key value violates unique constraint \"index_providers_on_code\"`.

## Changes proposed in this pull request

I'm assuming this happens because we have a hard-coded `ZZZ` `code` that could conflict with a Faker generated `code`. The factory already generates unique codes via Faker by default so there doesn't seem to be any need for the hard-coded value.

## Guidance to review

n/a

## Link to Trello card

n/a

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
