### PR TITLE
Update privacy policy and terms of use to reflect withdrawal data collection

### DIFF
--- a/app/views/content/service_privacy_notice.md
+++ b/app/views/content/service_privacy_notice.md
@@ -80,7 +80,7 @@ Processing applications includes:
 - getting in touch if there’s a security issue concerning your data
 - getting in touch with you to ask if you would like to participate in user research
 - getting in touch with you and providers about your applications
-- analysing application and service usage data
+- analysing application and service usage data (including the outcome of applications)
 - using information from education providers and information from the Apply service for analysis and research about initial teacher training
 
 Your data will also be shared between Apply and Get Into Teaching, which are both delivered by the Department for Education. This is to support your application journey. For example, we’ll send you relevant information and support opportunities.
@@ -193,4 +193,4 @@ Once a candidate has enrolled with a teacher training provider, we will not be a
 
 We’ll update this privacy notice when required. You should regularly review the notice.
 
-This version was last updated on 24 January 2023.
+This version was last updated on 11 April 2023.

--- a/app/views/content/service_privacy_notice_candidate.html.erb
+++ b/app/views/content/service_privacy_notice_candidate.html.erb
@@ -102,7 +102,7 @@
       <li>getting in touch if there’s a security issue concerning your data</li>
       <li>getting in touch with you to ask if you would like to participate in user research</li>
       <li>getting in touch with you and providers about your applications</li>
-      <li>analysing application and service usage data</li>
+      <li>analysing application and service usage data (including the outcome of applications)</li>
       <li>using information from education providers and information from the Apply service for analysis and research about initial teacher training</li>
     </ul>
 
@@ -308,7 +308,7 @@
 
     <p class="govuk-body">We’ll update this privacy notice when required. You should regularly review the notice.</p>
 
-    <p class="govuk-body">This version was last updated on 24 January 2023.</p>
+    <p class="govuk-body">This version was last updated on 11 April 2023.</p>
 
   </div>
 

--- a/app/views/content/terms_candidate.html.erb
+++ b/app/views/content/terms_candidate.html.erb
@@ -62,7 +62,7 @@
 
     <h3 class="govuk-heading-s">Withdrawing your application</h3>
 
-    <p class="govuk-body">You can withdraw your application at any point, even after you’ve accepted an offer.</p>
+    <p class="govuk-body">You can withdraw your application at any point, even after you’ve accepted an offer. If you withdraw, we’ll ask you why but this is optional and you do not need to tell us.</p>
 
     <p class="govuk-body">
       <%= govuk_link_to('Sign in to your account to withdraw an application', candidate_interface_sign_in_path) %>.</p>


### PR DESCRIPTION
## Context

We are moving to a world where we collect additional info on why a candidate is withdrawing their application. These changes update our policies to reflect this.

## Changes proposed in this pull request

Added wording for data usages.

## Guidance to review

Does this break any tests? Are there any other locations to update the date for 'last updated'?

## Link to Trello card

https://trello.com/c/9AM2Xvsa/1360-update-privacy-notice-for-sr4w

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
