### PR TITLE
Updating the duplicate matching email to reflect the duplicate matching process

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -465,9 +465,8 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
-  def duplicate_match_email(application_form, submitted)
+  def duplicate_match_email(application_form)
     @application_form = application_form
-    @submitted = submitted
     email_for_candidate(
       application_form,
       subject: I18n.t!('candidate_mailer.duplicate_match.subject'),

--- a/app/services/support_interface/send_duplicate_match_email.rb
+++ b/app/services/support_interface/send_duplicate_match_email.rb
@@ -9,6 +9,5 @@ module SupportInterface
     def call
       CandidateMailer.duplicate_match_email(@candidate.current_application).deliver_later
     end
-
   end
 end

--- a/app/services/support_interface/send_duplicate_match_email.rb
+++ b/app/services/support_interface/send_duplicate_match_email.rb
@@ -7,7 +7,7 @@ module SupportInterface
     end
 
     def call
-      CandidateMailer.duplicate_match_email(@candidate.current_application, submitted).deliver_later
+      CandidateMailer.duplicate_match_email(@candidate.current_application).deliver_later
     end
 
   end

--- a/app/services/support_interface/send_duplicate_match_email.rb
+++ b/app/services/support_interface/send_duplicate_match_email.rb
@@ -10,8 +10,5 @@ module SupportInterface
       CandidateMailer.duplicate_match_email(@candidate.current_application, submitted).deliver_later
     end
 
-    def submitted
-      @candidate.application_forms.map(&:submitted_at).any?
-    end
   end
 end

--- a/app/views/candidate_mailer/duplicate_match_email.text.erb
+++ b/app/views/candidate_mailer/duplicate_match_email.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @application_form.first_name %>
 
-You created more than one account to apply for teacher training. Both of your accounts have been locked.
+You created more than one account to apply for teacher training. Your accounts have been locked.
 
 # Email us to unlock your account
 

--- a/app/views/candidate_mailer/duplicate_match_email.text.erb
+++ b/app/views/candidate_mailer/duplicate_match_email.text.erb
@@ -1,13 +1,7 @@
 Dear <%= @application_form.first_name %>
 
-You’ve created more than one account on Apply for teacher training.
+You created more than one account to apply for teacher training. Both of your accounts have been locked.
 
-<% if @submitted %>
-  As you have already submitted an application, the account with the unsubmitted application will be locked.
-<% else %>
-  Your access to the account you set up most recently will be removed.
-<% end %>
+# Email us to unlock your account
 
-# Get help
-
-If you think this is a mistake, reply to this email to let us know.
+Reply to this email within 5 working days and tell us which account you want to unlock.

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -100,7 +100,7 @@ en:
     find_has_opened:
       subject: Find your teacher training course now
     duplicate_match:
-      subject: Duplicate application detected
+      subject: You created more than one account to apply for teacher training
     nudge_unsubmitted:
       subject: Get last-minute advice about your teacher training application
     nudge_unsubmitted_with_incomplete_references:

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -678,7 +678,6 @@ RSpec.describe CandidateMailer do
         'details' => 'You created more than one account to apply for teacher training. Both of your accounts have been locked.',
       )
     end
-
   end
 
   describe '.nudge_unsubmitted' do

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -675,7 +675,7 @@ RSpec.describe CandidateMailer do
         'a mail with subject and content',
         'You created more than one account to apply for teacher training',
         'greeting' => 'Dear Fred',
-        'details' => 'You created more than one account to apply for teacher training. Both of your accounts have been locked.',
+        'details' => 'You created more than one account to apply for teacher training. Your accounts have been locked.',
       )
     end
   end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -667,31 +667,18 @@ RSpec.describe CandidateMailer do
   end
 
   describe '.duplicate_match_email' do
-    context 'when the candidate has submitted applications' do
+    context 'when the candidate has a duplicate account regardless of whether it is submitted or unsubmitted' do
       let(:application_form) { build_stubbed(:application_form, :minimum_info, first_name: 'Fred') }
-      let(:email) { mailer.duplicate_match_email(application_form, true) }
+      let(:email) { mailer.duplicate_match_email(application_form) }
 
       it_behaves_like(
         'a mail with subject and content',
-        'Duplicate application detected',
+        'You created more than one account to apply for teacher training',
         'greeting' => 'Dear Fred',
-        'details' => 'You’ve created more than one account on Apply for teacher training.',
-        'dynamic content' => 'As you have already submitted an application, the account with the unsubmitted application will be locked.',
+        'details' => 'You created more than one account to apply for teacher training. Both of your accounts have been locked.',
       )
     end
 
-    context 'when the candidate has not submitted any applications' do
-      let(:application_form) { build_stubbed(:application_form, first_name: 'Fred') }
-      let(:email) { mailer.duplicate_match_email(application_form, false) }
-
-      it_behaves_like(
-        'a mail with subject and content',
-        'Duplicate application detected',
-        'greeting' => 'Dear Fred',
-        'details' => 'You’ve created more than one account on Apply for teacher training.',
-        'dynamic content' => 'Your access to the account you set up most recently will be removed.',
-      )
-    end
   end
 
   describe '.nudge_unsubmitted' do

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -806,9 +806,8 @@ class CandidateMailerPreview < ActionMailer::Preview
 
   def duplicate_match_email
     application_form = FactoryBot.build(:application_form, first_name: 'Tester', submitted_at: Time.zone.now)
-    submitted = true
 
-    CandidateMailer.duplicate_match_email(application_form, submitted)
+    CandidateMailer.duplicate_match_email(application_form)
   end
 
   def find_has_opened_no_name

--- a/spec/services/support_interface/send_duplicate_match_email_spec.rb
+++ b/spec/services/support_interface/send_duplicate_match_email_spec.rb
@@ -32,4 +32,3 @@ RSpec.describe SupportInterface::SendDuplicateMatchEmail do
       end
     end
   end
-end

--- a/spec/services/support_interface/send_duplicate_match_email_spec.rb
+++ b/spec/services/support_interface/send_duplicate_match_email_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe SupportInterface::SendDuplicateMatchEmail do
     end
   end
 
-    context 'when a candidate does not have any submitted applications' do
-      before do
-        create(:application_choice, :application_not_sent, candidate:)
-      end
+  context 'when a candidate does not have any submitted applications' do
+    before do
+      create(:application_choice, :application_not_sent, candidate:)
     end
   end
+end

--- a/spec/services/support_interface/send_duplicate_match_email_spec.rb
+++ b/spec/services/support_interface/send_duplicate_match_email_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe SupportInterface::SendDuplicateMatchEmail do
       expect(CandidateMailer).to have_received(:duplicate_match_email).once
     end
   end
-end
 
     context 'when a candidate does not have any submitted applications' do
       before do

--- a/spec/services/support_interface/send_duplicate_match_email_spec.rb
+++ b/spec/services/support_interface/send_duplicate_match_email_spec.rb
@@ -25,10 +25,5 @@ RSpec.describe SupportInterface::SendDuplicateMatchEmail do
       before do
         create(:application_choice, :application_not_sent, candidate:)
       end
-
-      it 'returns false' do
-        submitted = described_class.new(candidate).submitted
-        expect(submitted).to be(false)
-      end
     end
   end

--- a/spec/services/support_interface/send_duplicate_match_email_spec.rb
+++ b/spec/services/support_interface/send_duplicate_match_email_spec.rb
@@ -20,18 +20,7 @@ RSpec.describe SupportInterface::SendDuplicateMatchEmail do
       expect(CandidateMailer).to have_received(:duplicate_match_email).once
     end
   end
-
-  describe '#submitted' do
-    context 'when a candidate has a submitted application' do
-      before do
-        create(:application_choice, :awaiting_provider_decision, :with_completed_application_form, status: 'rejected', candidate:)
-      end
-
-      it 'returns true' do
-        submitted = described_class.new(candidate).submitted
-        expect(submitted).to be(true)
-      end
-    end
+end
 
     context 'when a candidate does not have any submitted applications' do
       before do

--- a/spec/services/support_interface/send_duplicate_match_email_spec.rb
+++ b/spec/services/support_interface/send_duplicate_match_email_spec.rb
@@ -20,10 +20,4 @@ RSpec.describe SupportInterface::SendDuplicateMatchEmail do
       expect(CandidateMailer).to have_received(:duplicate_match_email).once
     end
   end
-
-  context 'when a candidate does not have any submitted applications' do
-    before do
-      create(:application_choice, :application_not_sent, candidate:)
-    end
-  end
 end


### PR DESCRIPTION
## Context

We currently have 2 duplicate matching emails that are sent (from one template) that are dependent on the candidate's state. However, these don't accurately reflect the process we follow for duplicate matching. Instead of blocking any 1 account like the emails say, we block both accounts and email the candidate to ask which one they want to keep.

This content reflects that new reality.

I've attempted to amend the 2 tests into 1 test given the state of submission doesn't matter any more.

## Changes proposed in this pull request

Changing the duplicate matching email template into something that works in all cases. 

Removing tests that are no longer used.

## Guidance to review

Does this duplicate matching email send in all cases? i.e. 
2 x unsubmitted ✅ 
1 x unsubmitted, 1 x submitted ✅ 
2 x submitted ✅ 

## Link to Trello card

https://trello.com/c/SHksFKgw/1097-duplicate-matches-review-email-templates

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
