### PR TITLE
Sync courses visa sponsorship with Publish API

### DIFF
--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -66,6 +66,8 @@ module TeacherTrainingPublicAPI
       course.applications_open_from = course_from_api.applications_open_from
       course.recruitment_cycle_year = recruitment_cycle_year
       course.exposed_in_find = course_from_api.findable
+      course.can_sponsor_skilled_worker_visa = course_from_api.can_sponsor_skilled_worker_visa
+      course.can_sponsor_student_visa = course_from_api.can_sponsor_student_visa
       course.funding_type = course_from_api.funding_type
       course.program_type = course_from_api.program_type
       course.age_range = age_range_in_years(course_from_api)

--- a/spec/examples/teacher_training_api/course_list_response.json
+++ b/spec/examples/teacher_training_api/course_list_response.json
@@ -21,6 +21,8 @@
           {
           }
         ],
+        "can_sponsor_skilled_worker_visa": true,
+        "can_sponsor_student_visa": true,
         "changed_at": "2019-06-13T10:44:31Z",
         "code": "3GTY",
         "uuid": "906c6f3c-b2d6-46e1-8bf7-3fbd13d3ea06",

--- a/spec/examples/teacher_training_api/course_single_response.json
+++ b/spec/examples/teacher_training_api/course_single_response.json
@@ -20,6 +20,8 @@
         {
         }
       ],
+      "can_sponsor_skilled_worker_visa": true,
+      "can_sponsor_student_visa": true,
       "changed_at": "2019-06-13T10:44:31Z",
       "code": "3GTY",
       "degree_grade": "two_two",

--- a/spec/system/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_courses_spec.rb
@@ -32,41 +32,47 @@ RSpec.feature 'Sync courses', sidekiq: true do
     )
     stub_teacher_training_api_courses(
       provider_code: 'ABC',
-      specified_attributes: [{
-        code: 'ABC1',
-        name: 'Primary',
-        level: 'primary',
-        study_mode: 'full_time',
-        summary: 'PGCE with QTS full time',
-        start_date: 'September 2021',
-        course_length: 'OneYear',
-        findable: true,
-        funding_type: 'fee',
-        program_type: 'school_direct_training_programme',
-        age_maximum: 11,
-        age_minimum: 3,
-        state: 'published',
-        qualifications: %w[qts pgce],
-        accredited_body_code: '',
-        uuid: @course_uuid,
-      },
-                             {
-                               code: 'ABC2',
-                               name: 'Primary',
-                               level: 'primary',
-                               study_mode: 'full_time',
-                               summary: 'PGCE with QTS full time',
-                               start_date: 'September 2021',
-                               course_length: 'OneYear',
-                               findable: true,
-                               funding_type: 'fee',
-                               program_type: 'school_direct_training_programme',
-                               age_maximum: 11,
-                               age_minimum: 3,
-                               state: 'published',
-                               qualifications: %w[qts pgce],
-                               accredited_body_code: 'DEF',
-                             }],
+      specified_attributes: [
+        {
+          code: 'ABC1',
+          name: 'Primary',
+          level: 'primary',
+          study_mode: 'full_time',
+          summary: 'PGCE with QTS full time',
+          start_date: 'September 2021',
+          course_length: 'OneYear',
+          findable: true,
+          funding_type: 'fee',
+          program_type: 'school_direct_training_programme',
+          age_maximum: 11,
+          age_minimum: 3,
+          state: 'published',
+          qualifications: %w[qts pgce],
+          accredited_body_code: '',
+          uuid: @course_uuid,
+          can_sponsor_skilled_worker_visa: false,
+          can_sponsor_student_visa: false,
+        },
+        {
+          code: 'ABC2',
+          name: 'Primary',
+          level: 'primary',
+          study_mode: 'full_time',
+          summary: 'PGCE with QTS full time',
+          start_date: 'September 2021',
+          course_length: 'OneYear',
+          findable: true,
+          funding_type: 'fee',
+          program_type: 'school_direct_training_programme',
+          age_maximum: 11,
+          age_minimum: 3,
+          state: 'published',
+          qualifications: %w[qts pgce],
+          accredited_body_code: 'DEF',
+          can_sponsor_skilled_worker_visa: true,
+          can_sponsor_student_visa: true,
+        },
+      ],
     )
     stub_teacher_training_api_sites(
       provider_code: 'ABC',
@@ -93,7 +99,10 @@ RSpec.feature 'Sync courses', sidekiq: true do
   end
 
   def then_it_creates_one_course
-    expect(Course.find_by(code: 'ABC2')).not_to be_nil
+    course = Course.find_by(code: 'ABC2')
+    expect(course).not_to be_nil
+    expect(course.can_sponsor_skilled_worker_visa).to be true
+    expect(course.can_sponsor_student_visa).to be true
   end
 
   def and_it_creates_a_corresponding_provider_relationship
@@ -107,6 +116,8 @@ RSpec.feature 'Sync courses', sidekiq: true do
     expect(course.name).to eql('Primary')
     expect(course.age_range).to eql('3 to 11')
     expect(course.withdrawn).to be false
+    expect(course.can_sponsor_skilled_worker_visa).to be false
+    expect(course.can_sponsor_student_visa).to be false
   end
 
   def and_it_sets_the_last_synced_timestamp


### PR DESCRIPTION
## Context

Add the attributes to our DB when we sync courses from Publish API.

There will be a following PR that I will open to use in the candidate interface. First, we need to merge, and sync the columns (automatically every x minutes) then we can use the attributes.