### PR TITLE
Remove reference to 5 day limit to revert rejection

### DIFF
--- a/app/views/support_interface/application_forms/application_choices/confirm_revert_rejection.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/confirm_revert_rejection.html.erb
@@ -14,7 +14,6 @@
 
       <p class="govuk-body">A rejection can only be reverted if:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>it was rejected within 5 working days of the request to revert</li>
         <li>the candidate has not accepted any other offers</li>
       </ul>
       <p class="govuk-body">In order to revert the rejection you must first contact the provider to confirm that they agree to this.</p>

--- a/app/views/support_interface/application_forms/application_choices/confirm_revert_rejection.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/confirm_revert_rejection.html.erb
@@ -12,10 +12,7 @@
 
       <h1 class="govuk-heading-l">Are you sure you want to revert this rejection?</h1>
 
-      <p class="govuk-body">A rejection can only be reverted if:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>the candidate has not accepted any other offers</li>
-      </ul>
+      <p class="govuk-body">A rejection can only be reverted if the candidate has not accepted any other offers.</p>
       <p class="govuk-body">In order to revert the rejection you must first contact the provider to confirm that they agree to this.</p>
       <p class="govuk-body">Once the rejection has been reverted, please email the candidate to let them know.</p>
 

--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -141,21 +141,13 @@ The default state for an `OfferCondition` object is `pending`.
 ### Reverting an application choice to pending conditions
 
 If an application choice status is `recruited`, `conditions_not_met` or `offr_deferred` it can be reverted to `pending_conditions` using the support UI.
+
 ### Revert a rejection
 
 Providers may need to revert a rejection so that they can offer a different course or if it was done in error.
 
-If less than five working days have passed since the application has been submitted, then the rejection can be reverted via the
-Support UI when viewing the application choice.
-
-If more than five working days have passed, the rejection can be reverted as follows:
-
-```ruby
-application_choice = ApplicationChoice.find(id)
-zendesk_ticket = 'https://becomingateacher.zendesk.com/agent/tickets/...'
-SupportInterface::RevertRejection.new(application_choice:, zendesk_ticket:).save!
-
-```
+The rejection can be reverted via the Support UI when viewing the application
+choice.
 
 If a candidate has had a course rejected in error but wishes to replace their course option with another offered by a _different_ provider,
 then following reverting the rejection via the Support UI, you will need to [withdraw the course option via the console](#change-providercourse),

--- a/spec/system/support_interface/revert_rejection_over_5_days_ago_spec.rb
+++ b/spec/system/support_interface/revert_rejection_over_5_days_ago_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+RSpec.feature 'Revert an accidental rejection' do
+  include DfESignInHelpers
+
+  scenario 'Revert a rejected application and return it to the `awaiting_provider_decision` status', with_audited: true do
+    given_i_am_a_support_user
+    and_there_is_a_rejected_application
+
+    when_i_visit_the_application_page
+    then_i_see_a_revert_rejection_link
+
+    when_i_click_revert_rejection
+    then_i_see_a_confirmation_page_prompting_for_an_audit_comment
+
+    when_i_click_continue
+    then_i_see_a_validation_error
+
+    when_i_add_an_audit_comment_and_click_continue
+    then_i_see_the_application_page
+    and_the_application_is_now_awaiting_provider_decision
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_is_a_rejected_application
+    application_form = create(
+      :application_form,
+      submitted_at: 60.days.ago,
+    )
+    @application_choice = create(
+      :application_choice,
+      :awaiting_provider_decision,
+      application_form:,
+    )
+    @application_choice.update!(status: :rejected, rejected_at: 60.days.ago)
+  end
+
+  def when_i_visit_the_application_page
+    visit support_interface_application_form_path(@application_choice.application_form_id)
+  end
+
+  def then_i_see_a_revert_rejection_link
+    expect(page).to have_link('Revert rejection')
+  end
+
+  def when_i_click_revert_rejection
+    click_link('Revert rejection')
+  end
+
+  def then_i_see_a_confirmation_page_prompting_for_an_audit_comment
+    expect(page).to have_current_path(
+      support_interface_application_form_revert_rejection_path(
+        application_form_id: @application_choice.application_form_id,
+        application_choice_id: @application_choice.id,
+      ),
+    )
+    expect(page).to have_content('Are you sure you want to revert this rejection?')
+  end
+
+  def when_i_click_continue
+    click_on 'Continue'
+  end
+
+  def then_i_see_a_validation_error
+    expect(page).to have_current_path(
+      support_interface_application_form_revert_rejection_path(
+        application_form_id: @application_choice.application_form_id,
+        application_choice_id: @application_choice.id,
+      ),
+    )
+    expect(page).to have_content('Enter a Zendesk ticket URL')
+    expect(page).to have_content('Select that you have read the guidance')
+  end
+
+  def when_i_add_an_audit_comment_and_click_continue
+    fill_in 'Zendesk ticket URL', with: 'https://becomingateacher.zendesk.com/agent/tickets/123'
+    check 'I have read the guidance'
+    click_on 'Continue'
+  end
+
+  def then_i_see_the_application_page
+    expect(page).to have_current_path(support_interface_application_form_path(@application_choice.application_form_id))
+  end
+
+  def and_the_application_is_now_awaiting_provider_decision
+    expect(@application_choice.reload.awaiting_provider_decision?).to be true
+  end
+end


### PR DESCRIPTION
## Context

We no longer enforce the condition that rejections must be reverted within 5 days.

## Changes proposed in this pull request

Before:
![image](https://user-images.githubusercontent.com/450843/231384415-8828ab8f-dc8f-4904-91e9-f7606abaeced.png)

After:
![image](https://user-images.githubusercontent.com/450843/231384640-04217b41-a149-451f-93da-b86a662d7c9e.png)

Also adds system spec to exercise a > 5 day rejection.

## Guidance to review

Does this make sense?

## Link to Trello card

https://trello.com/c/avSia89o/869-give-support-users-more-buttons

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
