### PR TITLE
Add visa sponsorship message when course can sponsor visa

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -251,6 +251,7 @@ module CandidateInterface
     def visa_details_row(application_choice)
       return if (immigration_right_to_work?(application_choice) ||
                 application_predates_visa_sponsorship_information?(application_choice)) ||
+                course_can_sponsor_visa?(application_choice) ||
                 provider_can_sponsor_visa?(application_choice)
 
       {
@@ -266,6 +267,15 @@ module CandidateInterface
 
     def application_predates_visa_sponsorship_information?(application_choice)
       application_choice.application_form.recruitment_cycle_year < 2022
+    end
+
+    def course_can_sponsor_visa?(application_choice)
+      (
+        application_choice.course.salary? && application_choice.course.can_sponsor_skilled_worker_visa?
+      ) ||
+        (
+          !application_choice.course.salary? && application_choice.course.can_sponsor_student_visa?
+        )
     end
 
     def provider_can_sponsor_visa?(application_choice)

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -251,8 +251,7 @@ module CandidateInterface
     def visa_details_row(application_choice)
       return if (immigration_right_to_work?(application_choice) ||
                 application_predates_visa_sponsorship_information?(application_choice)) ||
-                course_can_sponsor_visa?(application_choice) ||
-                provider_can_sponsor_visa?(application_choice)
+                course_can_sponsor_visa?(application_choice)
 
       {
         key: 'Visa sponsorship',
@@ -276,16 +275,6 @@ module CandidateInterface
         (
           !application_choice.course.salary? && application_choice.course.can_sponsor_student_visa?
         )
-    end
-
-    def provider_can_sponsor_visa?(application_choice)
-      (
-        application_choice.course.salary? &&
-          application_choice.provider.can_sponsor_skilled_worker_visa?
-      ) || (
-        !application_choice.course.salary? &&
-          application_choice.provider.can_sponsor_student_visa?
-      )
     end
 
     def status_row(application_choice)

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -642,38 +642,6 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true
       end
     end
 
-    context 'when the candidate does not have the right to work and the provider can sponsor a student visa' do
-      it 'does NOT render a Visa sponsorship row' do
-        provider = create(
-          :provider,
-          can_sponsor_student_visa: true,
-        )
-
-        course_option = create(
-          :course_option,
-          course: create(
-            :course,
-            funding_type: 'fee',
-            provider:,
-          ),
-        )
-
-        application_form = create(
-          :completed_application_form,
-          first_nationality: 'Indian',
-          right_to_work_or_study: 'no',
-          recruitment_cycle_year: 2022,
-          application_choices: [create(
-            :application_choice,
-            course_option:,
-          )],
-        )
-
-        result = render_inline(described_class.new(application_form:))
-        expect(result.css('.govuk-summary-list__key').text).not_to include('Visa sponsorship')
-      end
-    end
-
     context 'when the candidate does not have the right to work and the course can NOT sponsor a student visa' do
       it 'renders a Visa sponsorship row' do
         provider = create(:provider)
@@ -682,38 +650,6 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true
           course: create(
             :course,
             can_sponsor_student_visa: false,
-            funding_type: 'fee',
-            provider:,
-          ),
-        )
-
-        application_form = create(
-          :completed_application_form,
-          first_nationality: 'Indian',
-          right_to_work_or_study: 'no',
-          recruitment_cycle_year: 2022,
-          application_choices: [create(
-            :application_choice,
-            course_option:,
-          )],
-        )
-
-        result = render_inline(described_class.new(application_form:))
-        expect(result.css('.govuk-summary-list__key').text).to include('Visa sponsorship')
-      end
-    end
-
-    context 'when the candidate does not have the right to work and the provider can NOT sponsor a student visa' do
-      it 'renders a Visa sponsorship row' do
-        provider = create(
-          :provider,
-          can_sponsor_student_visa: false,
-        )
-
-        course_option = create(
-          :course_option,
-          course: create(
-            :course,
             funding_type: 'fee',
             provider:,
           ),
@@ -761,70 +697,6 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true
 
         result = render_inline(described_class.new(application_form:))
         expect(result.css('.govuk-summary-list__key').text).to include('Visa sponsorship')
-      end
-    end
-
-    context 'when the candidate does not have the right to work and the provider can NOT sponsor a skilled worker visa on a salaried course' do
-      it 'renders a Visa sponsorship row' do
-        provider = create(
-          :provider,
-          can_sponsor_skilled_worker_visa: false,
-        )
-
-        course_option = create(
-          :course_option,
-          course: create(
-            :course,
-            funding_type: 'salary',
-            provider:,
-          ),
-        )
-
-        application_form = create(
-          :completed_application_form,
-          first_nationality: 'Indian',
-          right_to_work_or_study: 'no',
-          recruitment_cycle_year: 2022,
-          application_choices: [create(
-            :application_choice,
-            course_option:,
-          )],
-        )
-
-        result = render_inline(described_class.new(application_form:))
-        expect(result.css('.govuk-summary-list__key').text).to include('Visa sponsorship')
-      end
-    end
-
-    context 'when the candidate does not have the right to work and the provider can sponsor a skilled worker visa on a salaried course' do
-      it 'renders a Visa sponsorship row' do
-        provider = create(
-          :provider,
-          can_sponsor_skilled_worker_visa: true,
-        )
-
-        course_option = create(
-          :course_option,
-          course: create(
-            :course,
-            funding_type: 'salary',
-            provider:,
-          ),
-        )
-
-        application_form = create(
-          :completed_application_form,
-          first_nationality: 'Indian',
-          right_to_work_or_study: 'no',
-          recruitment_cycle_year: 2022,
-          application_choices: [create(
-            :application_choice,
-            course_option:,
-          )],
-        )
-
-        result = render_inline(described_class.new(application_form:))
-        expect(result.css('.govuk-summary-list__key').text).not_to include('Visa sponsorship')
       end
     end
 

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -612,6 +612,36 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true
       end
     end
 
+    context 'when the candidate does not have the right to work and the course can sponsor a student visa' do
+      it 'does NOT render a Visa sponsorship row' do
+        provider = create(:provider)
+
+        course_option = create(
+          :course_option,
+          course: create(
+            :course,
+            funding_type: 'fee',
+            can_sponsor_student_visa: true,
+            provider:,
+          ),
+        )
+
+        application_form = create(
+          :completed_application_form,
+          first_nationality: 'Indian',
+          right_to_work_or_study: 'no',
+          recruitment_cycle_year: 2022,
+          application_choices: [create(
+            :application_choice,
+            course_option:,
+          )],
+        )
+
+        result = render_inline(described_class.new(application_form:))
+        expect(result.css('.govuk-summary-list__key').text).not_to include('Visa sponsorship')
+      end
+    end
+
     context 'when the candidate does not have the right to work and the provider can sponsor a student visa' do
       it 'does NOT render a Visa sponsorship row' do
         provider = create(
@@ -644,6 +674,35 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true
       end
     end
 
+    context 'when the candidate does not have the right to work and the course can NOT sponsor a student visa' do
+      it 'renders a Visa sponsorship row' do
+        provider = create(:provider)
+        course_option = create(
+          :course_option,
+          course: create(
+            :course,
+            can_sponsor_student_visa: false,
+            funding_type: 'fee',
+            provider:,
+          ),
+        )
+
+        application_form = create(
+          :completed_application_form,
+          first_nationality: 'Indian',
+          right_to_work_or_study: 'no',
+          recruitment_cycle_year: 2022,
+          application_choices: [create(
+            :application_choice,
+            course_option:,
+          )],
+        )
+
+        result = render_inline(described_class.new(application_form:))
+        expect(result.css('.govuk-summary-list__key').text).to include('Visa sponsorship')
+      end
+    end
+
     context 'when the candidate does not have the right to work and the provider can NOT sponsor a student visa' do
       it 'renders a Visa sponsorship row' do
         provider = create(
@@ -656,6 +715,35 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true
           course: create(
             :course,
             funding_type: 'fee',
+            provider:,
+          ),
+        )
+
+        application_form = create(
+          :completed_application_form,
+          first_nationality: 'Indian',
+          right_to_work_or_study: 'no',
+          recruitment_cycle_year: 2022,
+          application_choices: [create(
+            :application_choice,
+            course_option:,
+          )],
+        )
+
+        result = render_inline(described_class.new(application_form:))
+        expect(result.css('.govuk-summary-list__key').text).to include('Visa sponsorship')
+      end
+    end
+
+    context 'when the candidate does not have the right to work and the course can NOT sponsor a skilled worker visa on a salaried course' do
+      it 'renders a Visa sponsorship row' do
+        provider = create(:provider)
+        course_option = create(
+          :course_option,
+          course: create(
+            :course,
+            can_sponsor_skilled_worker_visa: false,
+            funding_type: 'salary',
             provider:,
           ),
         )
@@ -706,37 +794,66 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, mid_cycle: true
         result = render_inline(described_class.new(application_form:))
         expect(result.css('.govuk-summary-list__key').text).to include('Visa sponsorship')
       end
+    end
 
-      context 'when the candidate does not have the right to work and the provider can sponsor a skilled worker visa on a salaried course' do
-        it 'renders a Visa sponsorship row' do
-          provider = create(
-            :provider,
+    context 'when the candidate does not have the right to work and the provider can sponsor a skilled worker visa on a salaried course' do
+      it 'renders a Visa sponsorship row' do
+        provider = create(
+          :provider,
+          can_sponsor_skilled_worker_visa: true,
+        )
+
+        course_option = create(
+          :course_option,
+          course: create(
+            :course,
+            funding_type: 'salary',
+            provider:,
+          ),
+        )
+
+        application_form = create(
+          :completed_application_form,
+          first_nationality: 'Indian',
+          right_to_work_or_study: 'no',
+          recruitment_cycle_year: 2022,
+          application_choices: [create(
+            :application_choice,
+            course_option:,
+          )],
+        )
+
+        result = render_inline(described_class.new(application_form:))
+        expect(result.css('.govuk-summary-list__key').text).not_to include('Visa sponsorship')
+      end
+    end
+
+    context 'when the candidate does not have the right to work and the course can sponsor a skilled worker visa on a salaried course' do
+      it 'renders a Visa sponsorship row' do
+        provider = create(:provider)
+        course_option = create(
+          :course_option,
+          course: create(
+            :course,
             can_sponsor_skilled_worker_visa: true,
-          )
+            funding_type: 'salary',
+            provider:,
+          ),
+        )
 
-          course_option = create(
-            :course_option,
-            course: create(
-              :course,
-              funding_type: 'salary',
-              provider:,
-            ),
-          )
+        application_form = create(
+          :completed_application_form,
+          first_nationality: 'Indian',
+          right_to_work_or_study: 'no',
+          recruitment_cycle_year: 2022,
+          application_choices: [create(
+            :application_choice,
+            course_option:,
+          )],
+        )
 
-          application_form = create(
-            :completed_application_form,
-            first_nationality: 'Indian',
-            right_to_work_or_study: 'no',
-            recruitment_cycle_year: 2022,
-            application_choices: [create(
-              :application_choice,
-              course_option:,
-            )],
-          )
-
-          result = render_inline(described_class.new(application_form:))
-          expect(result.css('.govuk-summary-list__key').text).not_to include('Visa sponsorship')
-        end
+        result = render_inline(described_class.new(application_form:))
+        expect(result.css('.govuk-summary-list__key').text).not_to include('Visa sponsorship')
       end
     end
 

--- a/spec/factories/course.rb
+++ b/spec/factories/course.rb
@@ -15,6 +15,9 @@ FactoryBot.define do
     withdrawn { false }
     program_type { 'scitt_programme' }
 
+    can_sponsor_skilled_worker_visa { false }
+    can_sponsor_student_visa { false }
+
     funding_type { %w[fee salary apprenticeship].sample }
     course_subjects { [association(:course_subject, course: instance)] }
 


### PR DESCRIPTION
## Context

Now that we sync with Publish we can use the attributes from the course in the candidate interface.

We should now not display the visa sponsorship message if the course can sponsor visa for students and skilled workers.