### PR TITLE
Add word count and increase box size on reference giving flow

### DIFF
--- a/app/views/referee_interface/reference/feedback.html.erb
+++ b/app/views/referee_interface/reference/feedback.html.erb
@@ -16,7 +16,7 @@
 
       <%= render(RefereeInterface::FeedbackHintsComponent.new(reference: @reference_form.reference)) %>
 
-      <%= f.govuk_text_area :feedback, label: { text: t('referee.feedback.label'), size: 'm' }, max_words: 500, rows: 12 %>
+      <%= f.govuk_text_area :feedback, label: { text: t('referee.feedback.label'), size: 'm' }, max_words: 500, rows: 10 %>
 
       <%= f.govuk_submit t('save_and_continue') %>
     <% end %>

--- a/app/views/referee_interface/reference/feedback.html.erb
+++ b/app/views/referee_interface/reference/feedback.html.erb
@@ -16,7 +16,7 @@
 
       <%= render(RefereeInterface::FeedbackHintsComponent.new(reference: @reference_form.reference)) %>
 
-      <%= f.govuk_text_area :feedback, label: { text: t('referee.feedback.label'), size: 'm' }, max_words: 500, threshold: 50, rows: 6 %>
+      <%= f.govuk_text_area :feedback, label: { text: t('referee.feedback.label'), size: 'm' }, max_words: 500, rows: 12 %>
 
       <%= f.govuk_submit t('save_and_continue') %>
     <% end %>


### PR DESCRIPTION
## Context

We have been identifying options to help improve the reference giving flow, this is one low effort measure that may have an impact.

## Changes proposed in this pull request

Ensure word counter shows at all times. Increase size of the input box.



| Before     | After |
|----------|--------|
| <img width="1800" alt="image" src="https://user-images.githubusercontent.com/35870975/231822951-8daf8b7d-8e7e-4fd7-8c67-ad411fdf5e85.png"> | ![image](https://user-images.githubusercontent.com/35870975/231821634-988d1f21-e48f-494e-83d2-770bb6c8b7ca.png) | 

## Guidance to review

Does it work?

## Link to Trello card

https://trello.com/c/0UaoIOgr/1311-decide-and-draft-updated-copy-on-our-referee-ie-reference-giving-flow-to-encourage-a-more-complete-safeguarding-reference

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
