### PR TITLE
Remove referee guidance: "include facts, not your opinion"

### DIFF
--- a/app/components/referee_interface/feedback_hints_component.html.erb
+++ b/app/components/referee_interface/feedback_hints_component.html.erb
@@ -1,5 +1,3 @@
-<p class="govuk-body">Your reference should contain facts, not your opinion.</p>
-
 <p class="govuk-body">You could include:</p>
 
 <ul class="govuk-list govuk-list--bullet">

--- a/spec/system/referee_interface/referee_can_submit_a_reference_after_revisiting_signin_link_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_after_revisiting_signin_link_spec.rb
@@ -75,7 +75,6 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
   end
 
   def then_i_see_the_reference_comment_page
-    expect(page).to have_content('Your reference should contain facts, not your opinion.')
     expect(page).to have_content('when they worked with you')
     expect(page).to have_content('their role and responsibilities')
   end

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
@@ -213,7 +213,6 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
   end
 
   def then_i_see_the_reference_comment_page
-    expect(page).to have_content('Your reference should contain facts, not your opinion.')
     expect(page).to have_content('when their course started and ended')
     expect(page).to have_content('their academic record')
   end


### PR DESCRIPTION
We’ve decided to remove the line, as it was causing referees to give very short factual references, which some providers interpret as including safeguarding concerns by omission.