### PR TITLE
Include emails table in analytics event debug

### DIFF
--- a/config/analytics_event_debug.yml
+++ b/config/analytics_event_debug.yml
@@ -2,4 +2,4 @@ shared:
   event_filters:
     -
       event_type: (create|update|delete)_entity
-      entity_table_name: course_options
+      entity_table_name: course_options|emails


### PR DESCRIPTION
## Context

The analytics team are having problems with missing CRUD events from Apply.

## Changes proposed in this pull request

Add `emails` to the analytics event debug to help track down the missing events.

## Link to Trello card

https://trello.com/c/xAO3T6LJ/1371-add-emails-to-analytics

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
