### PR TITLE
228 apply create snapshot database

### DIFF
--- a/.github/workflows/restore-production-snapshot-aks..yml
+++ b/.github/workflows/restore-production-snapshot-aks..yml
@@ -1,0 +1,90 @@
+name: Restore AKS Snapshot Database
+#Restores Snapshot Database apply-postgres-snapshot instance from nightly backup
+
+on:
+  workflow_dispatch:
+    inputs:
+      date-to-restore-from:
+        description: The date of the backup to use in the restore in yyyy-MM-dd format
+        required: true
+      environment:
+        description: GitHub environment to run the restore in
+        type: choice
+        default: qa
+        options:
+          - qa
+          - production
+
+jobs:
+  backup:
+    name: Restore Snapshot Database (${{ github.event.inputs.environment }})
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.event.inputs.environment }}_aks
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set KV environment variables
+        run: |
+          tf_vars_file=terraform/aks/workspace_variables/${{ github.event.inputs.environment }}.tfvars.json
+          CLUSTER=$(jq -r '.cluster' ${tf_vars_file})
+          echo "APP_NAME=$(jq -r '.paas_app_environment' ${tf_vars_file})" >> $GITHUB_ENV
+
+          case ${CLUSTER} in
+            test)
+              echo "CLUSTER_RG=s189t01-tsc-ts-rg" >> $GITHUB_ENV
+              echo "CLUSTER_NAME=s189t01-tsc-test-aks" >> $GITHUB_ENV
+              ;;
+            production)
+              echo "CLUSTER_RG=s189p01-tsc-pd-rg" >> $GITHUB_ENV
+              echo "CLUSTER_NAME=s189p01-tsc-production-aks" >> $GITHUB_ENV
+              ;;
+            *)
+              echo "unknown cluster"
+              ;;
+          esac
+
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Setup postgres client
+        uses: DFE-Digital/github-actions/install-postgres-client@master
+
+      - name: Validate date-to-restore-from input
+        run: if [[ ${{ github.event.inputs.date-to-restore-from }} =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then echo "BACKUP_DATE=${BASH_REMATCH[0]}" >> $GITHUB_ENV; else exit 1; fi
+
+      - name: Set Azure prefix and backup container name
+        run: |
+          BACKUP_AZURE_PREFIX=${{ github.event.inputs.environment }}
+          echo "BACKUP_AZURE_PREFIX=${BACKUP_AZURE_PREFIX}" >> $GITHUB_ENV
+          echo "BACKUP_CONTAINER=${BACKUP_AZURE_PREFIX}-db-backup" >> $GITHUB_ENV
+
+      - name: Set Connection String
+        run: |
+          STORAGE_CONN_STR=$(az storage account show-connection-string -g  $STORAGE_ACCOUNT_RG -n $STORAGE_ACCOUNT_NAME --query 'connectionString')
+          echo "::add-mask::$STORAGE_CONN_STR"
+          echo "AZURE_STORAGE_CONNECTION_STRING=$STORAGE_CONN_STR" >> $GITHUB_ENV
+
+      - name: Get backup file name
+        run: |
+          az storage blob list --container ${BACKUP_CONTAINER} \
+          --query "[? contains(name, 'apply_${BACKUP_AZURE_PREFIX}_${BACKUP_DATE}') && ends_with(name,'sql.gz')].name" | echo "BACKUP_ARCHIVE_NAME=$(jq -r .[0])" >> $GITHUB_ENV
+
+      - name: Download backup
+        run: |
+          az config set extension.use_dynamic_install=yes_without_prompt
+          az config set core.only_show_errors=true
+          az storage azcopy blob download --container ${BACKUP_CONTAINER} --source ${BACKUP_ARCHIVE_NAME} --destination ${BACKUP_ARCHIVE_NAME}
+
+      - name: K8 setup
+        shell: bash
+        run: |
+          az aks get-credentials -g ${CLUSTER_RG} -n ${CLUSTER_NAME}
+          make install-konduit
+
+      - name: Restore backup to aks env database
+        shell: bash
+        run: |
+          bin/konduit.sh -i ${BACKUP_ARCHIVE_NAME} -c -t 7200 ${APP_NAME} -- psql

--- a/terraform/aks/terraform.tf
+++ b/terraform/aks/terraform.tf
@@ -35,6 +35,7 @@ module "kubernetes" {
   postgres_version                    = var.postgres_version
   config_short                        = var.config_short
   service_short                       = var.service_short
+  deploy_snapshot_database            = var.deploy_snapshot_database
 }
 
 module "statuscake" {

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -11,6 +11,8 @@ variable "paas_postgres_snapshot_service_plan" { default = "small-11" }
 
 variable "paas_snapshot_databases_to_deploy" { default = 0 }
 
+variable "deploy_snapshot_database" { default = false}
+
 variable "paas_clock_app_memory" { default = 512 }
 
 variable "paas_worker_app_memory" { default = 512 }

--- a/terraform/aks/workspace_variables/production_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/production_aks.tfvars.json
@@ -19,6 +19,8 @@
   "secondary_worker_replicas": 0,
   "clock_worker_replicas": 0,
   "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
+  "postgres_flexible_snapshot_server_sku": "B_Standard_B1ms",
+  "deploy_snapshot_database": true,
   "postgres_enable_high_availability": true,
   "pdb_min_available": "50%",
   "statuscake_alerts": {

--- a/terraform/modules/kubernetes/azure_postgres.tf
+++ b/terraform/modules/kubernetes/azure_postgres.tf
@@ -30,6 +30,40 @@ resource "azurerm_postgresql_flexible_server" "postgres-server" {
     ]
   }
 }
+resource "azurerm_postgresql_flexible_server" "postgres-snapshot-server" {
+  count = var.deploy_snapshot_database ? 1 : 0
+
+  name                   = local.postgres_snapshot_server_name
+  location               = data.azurerm_resource_group.app-resource-group.location
+  resource_group_name    = data.azurerm_resource_group.app-resource-group.name
+  version                = var.postgres_version
+  administrator_login    = var.postgres_admin_username
+  administrator_password = var.postgres_admin_password
+  create_mode            = "Default"
+  storage_mb             = var.postgres_flexible_server_storage_mb
+  sku_name               = var.postgres_snapshot_flexible_server_sku
+  delegated_subnet_id    = data.azurerm_subnet.postgres-subnet[0].id
+  private_dns_zone_id    = data.azurerm_private_dns_zone.postgres-dns[0].id
+  lifecycle {
+    ignore_changes = [
+      tags,
+      # Allow Azure to manage deployment zone. Ignore changes.
+      zone,
+      # Required for import because of https://github.com/hashicorp/terraform-provider-azurerm/issues/15586
+      create_mode
+    ]
+  }
+}
+
+resource "azurerm_postgresql_flexible_server_database" "snapshot-db" {
+  count = var.deploy_snapshot_database ? 1 : 0
+  # add option to not create database
+
+  name      = local.postgres_snapshot_service_name
+  server_id = azurerm_postgresql_flexible_server.postgres-snapshot-server[0].id
+  collation = "en_US.utf8"
+  charset   = "utf8"
+}
 
 resource "azurerm_postgresql_flexible_server_configuration" "postgres-extensions" {
   count = var.deploy_azure_backing_services ? 1 : 0
@@ -45,6 +79,14 @@ resource "azurerm_postgresql_flexible_server_configuration" "max-connections" {
   name      = "max_connections"
   server_id = azurerm_postgresql_flexible_server.postgres-server[0].id
   value     = 856 # Maximum on GP_Standard_D2ds_v4. See: https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-limits#maximum-connections
+}
+
+resource "azurerm_postgresql_flexible_server_configuration" "postgres-snapshot-extensions" {
+  count = var.deploy_azure_backing_services ? 1 : 0
+
+  name      = "azure.extensions"
+  server_id = azurerm_postgresql_flexible_server.postgres-snapshot-server[0].id
+  value     = "PG_BUFFERCACHE,PG_STAT_STATEMENTS,PGCRYPTO,UNACCENT"
 }
 
 resource "azurerm_storage_account" "database_backup" {

--- a/terraform/modules/kubernetes/variables.tf
+++ b/terraform/modules/kubernetes/variables.tf
@@ -20,6 +20,10 @@ variable "postgres_flexible_server_sku" {
   type    = string
   default = "B_Standard_B1ms"
 }
+variable "postgres_snapshot_flexible_server_sku" {
+  type    = string
+  default = "B_Standard_B1ms"
+}
 variable "postgres_flexible_server_storage_mb" {
   type    = number
   default = 32768
@@ -94,6 +98,7 @@ variable "pdb_min_available" {
 
 variable "config_short" {}
 variable "service_short" {}
+variable "deploy_snapshot_database" { default = false}
 
 locals {
   app_config_name                      = "apply-config-${var.app_environment}"
@@ -105,6 +110,8 @@ locals {
   postgres_dns_zone                    = var.cluster.dns_zone_prefix != null ? "${var.cluster.dns_zone_prefix}.internal.postgres.database.azure.com" : "production.internal.postgres.database.azure.com"
   postgres_server_name                 = "${var.azure_resource_prefix}-${var.service_short}-${var.app_environment}-psql"
   postgres_service_name                = "apply-postgres-${var.app_environment}"
+  postgres_snapshot_server_name        = "${var.azure_resource_prefix}-${var.service_short}-${var.app_environment}-snapshot-psql"
+  postgres_snapshot_service_name       = "apply-postgres-${var.app_environment}-snapshot"
   redis_dns_zone                       = "privatelink.redis.cache.windows.net"
   redis_cache_name                     = "${var.azure_resource_prefix}-${var.service_short}-${var.app_environment}-redis-cache"
   redis_cache_private_endpoint_name    = "${var.azure_resource_prefix}-${var.service_short}-${var.app_environment}-redis-cache-pe"


### PR DESCRIPTION
## Context

Production deployment needs to create a snapshot database to restore. This change will migrate PAAS to azure as we will now use Azure Postgres SQL Database for the snapshot database.

## Changes proposed in this pull request

New Azure Postgres SQL server created on snapshot database toggle variable:
  - This server will not have high availability. 
  - Production snapshot will use SKU of B_Standard_B1ms which will also be the default for snapshot databases till we can confirm whether we need to change this based on further usage.

New Azure Postgres SQL server Database created on snapshot database toggle variable 


## Guidance to review

Can set snapshot_databases_to_deploy variable to true in a more test environment like development and deploy to see if snapshot Database gets created.

## Link to Trello card
https://trello.com/c/0SFPAg3o/228-apply-create-snapshot-database

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
