### PR TITLE
Support interface delete application button

### DIFF
--- a/app/controllers/support_interface/application_forms/delete_application_controller.rb
+++ b/app/controllers/support_interface/application_forms/delete_application_controller.rb
@@ -4,9 +4,17 @@ module SupportInterface
       before_action :find_application_form
 
       def delete
+        @form = DeleteApplicationForm.new(application_form: @application_form)
+
+        if @form.save
+          redirect_to support_interface_application_form_path
+        else
+          render :confirm_delete
+        end
       end
 
       def confirm_delete
+        @form = DeleteApplicationForm.new(application_form: @application_form)
       end
 
     private

--- a/app/controllers/support_interface/application_forms/delete_application_controller.rb
+++ b/app/controllers/support_interface/application_forms/delete_application_controller.rb
@@ -1,0 +1,19 @@
+module SupportInterface
+  module ApplicationForms
+    class DeleteApplicationController < SupportInterfaceController
+      before_action :find_application_form
+
+      def delete
+      end
+
+      def confirm_delete
+      end
+
+    private
+
+      def find_application_form
+        @application_form = ApplicationForm.find(params[:application_form_id])
+      end
+    end
+  end
+end

--- a/app/controllers/support_interface/application_forms/delete_application_controller.rb
+++ b/app/controllers/support_interface/application_forms/delete_application_controller.rb
@@ -4,10 +4,10 @@ module SupportInterface
       before_action :find_application_form
 
       def delete
-        @form = DeleteApplicationForm.new(application_form: @application_form)
+        @form = DeleteApplicationForm.new(delete_application_params)
 
-        if @form.save
-          redirect_to support_interface_application_form_path
+        if @form.save(actor: current_support_user, application_form: @application_form)
+          redirect_to support_interface_application_form_path(@application_form.id)
         else
           render :confirm_delete
         end
@@ -18,6 +18,11 @@ module SupportInterface
       end
 
     private
+
+      def delete_application_params
+        params.require(:support_interface_application_forms_delete_application_form)
+              .permit(:accept_guidance, :audit_comment_ticket)
+      end
 
       def find_application_form
         @application_form = ApplicationForm.find(params[:application_form_id])

--- a/app/forms/support_interface/application_forms/delete_application_form.rb
+++ b/app/forms/support_interface/application_forms/delete_application_form.rb
@@ -24,6 +24,10 @@ module SupportInterface
       def application_form_id
         @application_form.id
       end
+
+      def email_address
+        @application_form.candidate.email_address
+      end
     end
   end
 end

--- a/app/forms/support_interface/application_forms/delete_application_form.rb
+++ b/app/forms/support_interface/application_forms/delete_application_form.rb
@@ -1,0 +1,27 @@
+module SupportInterface
+  module ApplicationForms
+    class DeleteApplicationForm
+      include ActiveModel::Model
+
+      attr_accessor :application_form, :accept_guidance, :audit_comment_ticket
+
+      validates :accept_guidance, presence: true
+      validates :audit_comment_ticket, presence: true
+      validates_with ZendeskUrlValidator
+
+      def initialize(application_form:)
+        @application_form = application_form
+      end
+
+      def save
+        return false unless valid?
+
+        true
+      end
+
+      def application_form_id
+        @application_form.id
+      end
+    end
+  end
+end

--- a/app/forms/support_interface/application_forms/delete_application_form.rb
+++ b/app/forms/support_interface/application_forms/delete_application_form.rb
@@ -9,14 +9,16 @@ module SupportInterface
       validates :audit_comment_ticket, presence: true
       validates_with ZendeskUrlValidator
 
-      def initialize(application_form:)
+      def save(actor:, application_form:)
         @application_form = application_form
-      end
 
-      def save
         return false unless valid?
 
-        true
+        DeleteApplication.new(
+          actor:,
+          application_form:,
+          zendesk_url: audit_comment_ticket,
+        ).call!
       end
 
       def application_form_id

--- a/app/views/support_interface/application_forms/delete_application/confirm_delete.html.erb
+++ b/app/views/support_interface/application_forms/delete_application/confirm_delete.html.erb
@@ -1,0 +1,35 @@
+<% content_for :browser_title, title_with_error_prefix('Are you sure you want to delete all the personal information associated with this application?', @application_form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(application_form_id: params[:application_form_id]), 'Back to application') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+      model: @application_form,
+      url: support_interface_delete_application_form_path(application_form_id: params[:application_form_id]),
+      method: :patch,
+    ) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">Are you sure you want to delete all the personal information associated with this application?</h1>
+
+      <p class="govuk-body">This operation cannot be undone.</p>
+      <p class="govuk-body">You can only delete unsubmitted applications.</p>
+
+      <%= f.govuk_text_field(
+        :audit_comment_ticket,
+        label: {
+          text: t('support_interface.audit_comment_ticket.label'),
+          size: 'm',
+        },
+        rows: 1,
+        hint: { text: t('support_interface.audit_comment_ticket.hint') },
+      ) %>
+
+      <%= f.govuk_check_boxes_fieldset :accept_guidance, legend: nil do %>
+        <%= f.govuk_check_box :accept_guidance, true, multiple: false, label: { text: 'I have read the guidance' }, link_errors: true %>
+      <% end %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/application_forms/delete_application/confirm_delete.html.erb
+++ b/app/views/support_interface/application_forms/delete_application/confirm_delete.html.erb
@@ -4,9 +4,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(
-      model: @application_form,
-      url: support_interface_delete_application_form_path(application_form_id: params[:application_form_id]),
-      method: :patch,
+      model: @form,
+      url: support_interface_delete_application_form_path(application_form_id: @form.application_form_id),
+      method: :delete,
     ) do |f| %>
       <%= f.govuk_error_summary %>
 

--- a/app/views/support_interface/application_forms/delete_application/confirm_delete.html.erb
+++ b/app/views/support_interface/application_forms/delete_application/confirm_delete.html.erb
@@ -10,7 +10,7 @@
     ) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-l">Are you sure you want to delete all the personal information associated with this application?</h1>
+      <h1 class="govuk-heading-l">Are you sure you want to delete all the personal information for <%= @form.email_address %>?</h1>
 
       <p class="govuk-body">This operation cannot be undone.</p>
       <p class="govuk-body">You can only delete unsubmitted applications.</p>

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -12,7 +12,7 @@
   <% end %>
 
   <% unless @application_form.submitted? %>
-    <%= govuk_button_to 'Delete all application data', support_interface_confirm_delete_application_form_path(@application_form.candidate), secondary: true, method: :get %>
+    <%= govuk_button_to 'Delete all application data', support_interface_confirm_delete_application_form_path(@application_form.id), secondary: true, method: :get %>
   <% end %>
 </div>
 

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -10,6 +10,10 @@
   <% else %>
     <%= govuk_button_to 'Exclude this candidate from service performance data', support_interface_hide_candidate_path(@application_form.candidate, from_application_form_id: @application_form.id), secondary: true %>
   <% end %>
+
+  <% unless @application_form.submitted? %>
+    <%= govuk_button_to 'Delete all application data', support_interface_confirm_delete_application_form_path(@application_form.candidate), secondary: true, method: :get %>
+  <% end %>
 </div>
 
 <%= render SupportInterface::PersonalInformationComponent.new(application_form: @application_form) %>

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -298,6 +298,13 @@ en:
             audit_comment_ticket:
               blank: Enter a Zendesk ticket URL
               invalid: Enter a valid Zendesk ticket URL
+        support_interface/application_forms/delete_application_form:
+          attributes:
+            accept_guidance:
+              blank: Select that you have read the guidance
+            audit_comment_ticket:
+              blank: Enter a Zendesk ticket URL
+              invalid: Enter a valid Zendesk ticket URL
         support_interface/remove_access_form:
           attributes:
             accept_guidance:

--- a/config/routes/support.rb
+++ b/config/routes/support.rb
@@ -81,6 +81,9 @@ namespace :support_interface, path: '/support' do
 
     get '/revert-to-pending-conditions/:application_choice_id' => 'application_forms/application_choices#confirm_revert_to_pending_conditions', as: :application_form_application_choice_revert_to_pending_conditions
     patch '/revert-to-pending-conditions/:application_choice_id' => 'application_forms/application_choices#revert_to_pending_conditions'
+
+    get '/confirm-delete-application' => 'application_forms/delete_application#confirm_delete', as: :confirm_delete_application_form
+    delete '/delete-application' => 'application_forms/delete_application#delete', as: :delete_application_form
   end
 
   get '/duplicate-matches' => 'duplicate_matches#index', as: :duplicate_matches

--- a/spec/forms/support_interface/application_forms/delete_application_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/delete_application_form_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ApplicationForms::ChangeCourseChoiceForm, type: :model, with_audited: true do
+  include CourseOptionHelpers
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:accept_guidance) }
+    it { is_expected.to validate_presence_of(:audit_comment_ticket) }
+
+    context 'for an invalid zendesk link' do
+      invalid_link = 'nonsense'
+      it { is_expected.not_to allow_value(invalid_link).for(:audit_comment_ticket) }
+    end
+
+    context 'for an valid zendesk link' do
+      valid_link = 'www.becomingateacher.zendesk.com/agent/tickets/example'
+      it { is_expected.to allow_value(valid_link).for(:audit_comment_ticket) }
+    end
+  end
+
+  describe '#save!' do
+    context 'if the application has already been submitted' do
+      it 'raises an error' do
+      end
+    end
+
+    context 'if the application has not been submitted' do
+      it 'deletes the application' do
+      end
+    end
+  end
+end

--- a/spec/forms/support_interface/application_forms/delete_application_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/delete_application_form_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe SupportInterface::ApplicationForms::ChangeCourseChoiceForm, type: :model, with_audited: true do
+RSpec.describe SupportInterface::ApplicationForms::DeleteApplicationForm, type: :model, with_audited: true do
   include CourseOptionHelpers
 
   describe 'validations' do
@@ -18,14 +18,33 @@ RSpec.describe SupportInterface::ApplicationForms::ChangeCourseChoiceForm, type:
     end
   end
 
-  describe '#save!' do
+  describe '#save' do
     context 'if the application has already been submitted' do
+      let(:application_form) { create(:application_form, :completed, submitted_application_choices_count: 1) }
+      let(:actor) { create(:support_user) }
+
       it 'raises an error' do
+        form = described_class.new(
+          accept_guidance: true,
+          audit_comment_ticket: 'https://becomingateacher.zendesk.com/agent/tickets/12345',
+        )
+        expect { form.save(actor:, application_form:) }.to raise_error(RuntimeError)
+        expect(application_form.reload.date_of_birth).to be_present
       end
     end
 
     context 'if the application has not been submitted' do
+      let(:application_form) { create(:application_form, :minimum_info) }
+      let(:actor) { create(:support_user) }
+
       it 'deletes the application' do
+        form = described_class.new(
+          accept_guidance: true,
+          audit_comment_ticket: 'https://becomingateacher.zendesk.com/agent/tickets/12345',
+        )
+        form.save(actor:, application_form:)
+        expect(application_form.reload.first_name).not_to be_present
+        expect(application_form.date_of_birth).not_to be_present
       end
     end
   end

--- a/spec/system/support_interface/delete_application_spec.rb
+++ b/spec/system/support_interface/delete_application_spec.rb
@@ -8,7 +8,8 @@ RSpec.feature 'Delete a candidate application (by anonymising all of their data)
     and_there_is_an_unsubmitted_application
 
     when_i_visit_the_application_page
-    then_i_see_a_delete_application_link
+    then_i_see_personal_information_about_the_candidate
+    and_i_see_a_delete_application_link
 
     when_i_click_delete_application
     then_i_see_a_confirmation_page_prompting_for_an_audit_comment
@@ -16,9 +17,9 @@ RSpec.feature 'Delete a candidate application (by anonymising all of their data)
     when_i_click_continue
     then_i_see_a_validation_error
 
-    # when_i_add_an_audit_comment_and_click_continue
-    # then_i_see_the_application_page
-    # and_the_application_is_now_deleted
+    when_i_add_an_audit_comment_and_click_continue
+    then_i_see_the_application_page
+    and_the_application_is_now_deleted
   end
 
   def given_i_am_a_support_user
@@ -38,7 +39,16 @@ RSpec.feature 'Delete a candidate application (by anonymising all of their data)
     visit support_interface_application_form_path(@application_form.id)
   end
 
-  def then_i_see_a_delete_application_link
+  def then_i_see_personal_information_about_the_candidate
+    @candidate_first_name = @application_form.first_name
+    @candidate_last_name = @application_form.last_name
+    @candidate_dob = @application_form.date_of_birth.to_fs(:govuk_date)
+    expect(page).to have_content(@candidate_first_name)
+    expect(page).to have_content(@candidate_last_name)
+    expect(page).to have_content(@candidate_dob)
+  end
+
+  def and_i_see_a_delete_application_link
     expect(page).to have_button('Delete all application data')
   end
 
@@ -75,10 +85,12 @@ RSpec.feature 'Delete a candidate application (by anonymising all of their data)
   end
 
   def then_i_see_the_application_page
-    expect(page).to have_current_path(support_interface_application_form_path(@application_choice.application_form_id))
+    expect(page).to have_current_path(support_interface_application_form_path(@application_form.id))
   end
 
   def and_the_application_is_now_deleted
-    
+    expect(page).not_to have_content(@candidate_first_name)
+    expect(page).not_to have_content(@candidate_last_name)
+    expect(page).not_to have_content(@candidate_dob)
   end
 end

--- a/spec/system/support_interface/delete_application_spec.rb
+++ b/spec/system/support_interface/delete_application_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.feature 'Delete a candidate application (by anonymising all of their data)' do
+  include DfESignInHelpers
+
+  scenario 'Delete a candidate application', with_audited: true do
+    given_i_am_a_support_user
+    and_there_is_an_unsubmitted_application
+
+    when_i_visit_the_application_page
+    then_i_see_a_delete_application_link
+
+    when_i_click_delete_application
+    then_i_see_a_confirmation_page_prompting_for_an_audit_comment
+
+    # when_i_click_continue
+    # then_i_see_a_validation_error
+
+    # when_i_add_an_audit_comment_and_click_continue
+    # then_i_see_the_application_page
+    # and_the_application_is_now_deleted
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_is_an_unsubmitted_application
+    @application_form = create(
+      :application_form,
+      :completed,
+      application_choices_count: 3,
+      submitted_at: nil,
+    )
+  end
+
+  def when_i_visit_the_application_page
+    visit support_interface_application_form_path(@application_form.id)
+  end
+
+  def then_i_see_a_delete_application_link
+    expect(page).to have_button('Delete all application data')
+  end
+
+  def when_i_click_delete_application
+    click_button('Delete all application data')
+  end
+
+  def then_i_see_a_confirmation_page_prompting_for_an_audit_comment
+    expect(page).to have_current_path(
+      support_interface_confirm_delete_application_form_path(
+        application_form_id: @application_form.id,
+      ),
+    )
+    expect(page).to have_content('Are you sure you want to delete all the personal information associated with this application?')
+    expect(page).to have_content('This operation cannot be undone.')
+  end
+
+  def when_i_click_continue
+    click_on 'Continue'
+  end
+
+  def then_i_see_a_validation_error
+    expect(page).to have_current_path(
+      support_interface_application_form_application_choice_revert_to_pending_conditions_path(
+        application_form_id: @application_choice.application_form_id,
+        application_choice_id: @application_choice.id,
+      ),
+    )
+    expect(page).to have_content('Enter a Zendesk ticket URL')
+    expect(page).to have_content('Select that you have read the guidance')
+  end
+
+  def when_i_add_an_audit_comment_and_click_continue
+    fill_in 'Zendesk ticket URL', with: 'https://becomingateacher.zendesk.com/agent/tickets/123'
+    check 'I have read the guidance'
+    click_on 'Continue'
+  end
+
+  def then_i_see_the_application_page
+    expect(page).to have_current_path(support_interface_application_form_path(@application_choice.application_form_id))
+  end
+
+  def and_the_application_is_now_deleted
+    pending 'assert that nobody can see the candidates details any longer'
+  end
+end

--- a/spec/system/support_interface/delete_application_spec.rb
+++ b/spec/system/support_interface/delete_application_spec.rb
@@ -43,6 +43,7 @@ RSpec.feature 'Delete a candidate application (by anonymising all of their data)
     @candidate_first_name = @application_form.first_name
     @candidate_last_name = @application_form.last_name
     @candidate_dob = @application_form.date_of_birth.to_fs(:govuk_date)
+    @candidate_email = @application_form.candidate.email_address
     expect(page).to have_content(@candidate_first_name)
     expect(page).to have_content(@candidate_last_name)
     expect(page).to have_content(@candidate_dob)
@@ -62,7 +63,7 @@ RSpec.feature 'Delete a candidate application (by anonymising all of their data)
         application_form_id: @application_form.id,
       ),
     )
-    expect(page).to have_content('Are you sure you want to delete all the personal information associated with this application?')
+    expect(page).to have_content("Are you sure you want to delete all the personal information for #{@candidate_email}")
     expect(page).to have_content('This operation cannot be undone.')
   end
 
@@ -92,5 +93,6 @@ RSpec.feature 'Delete a candidate application (by anonymising all of their data)
     expect(page).not_to have_content(@candidate_first_name)
     expect(page).not_to have_content(@candidate_last_name)
     expect(page).not_to have_content(@candidate_dob)
+    expect(page).not_to have_content(@candidate_email)
   end
 end

--- a/spec/system/support_interface/delete_application_spec.rb
+++ b/spec/system/support_interface/delete_application_spec.rb
@@ -13,8 +13,8 @@ RSpec.feature 'Delete a candidate application (by anonymising all of their data)
     when_i_click_delete_application
     then_i_see_a_confirmation_page_prompting_for_an_audit_comment
 
-    # when_i_click_continue
-    # then_i_see_a_validation_error
+    when_i_click_continue
+    then_i_see_a_validation_error
 
     # when_i_add_an_audit_comment_and_click_continue
     # then_i_see_the_application_page
@@ -62,10 +62,7 @@ RSpec.feature 'Delete a candidate application (by anonymising all of their data)
 
   def then_i_see_a_validation_error
     expect(page).to have_current_path(
-      support_interface_application_form_application_choice_revert_to_pending_conditions_path(
-        application_form_id: @application_choice.application_form_id,
-        application_choice_id: @application_choice.id,
-      ),
+      support_interface_delete_application_form_path(application_form_id: @application_form.id),
     )
     expect(page).to have_content('Enter a Zendesk ticket URL')
     expect(page).to have_content('Select that you have read the guidance')
@@ -82,6 +79,6 @@ RSpec.feature 'Delete a candidate application (by anonymising all of their data)
   end
 
   def and_the_application_is_now_deleted
-    pending 'assert that nobody can see the candidates details any longer'
+    
   end
 end


### PR DESCRIPTION
## Context

When support receive a request to remove a candidate's data from the Apply system support staff need to ask a developer to do this manually. This PR introduces a feature to the support interface that will allow support to do this themselves.

## Changes proposed in this pull request

- Adds a button to the candidate show page:

![image](https://user-images.githubusercontent.com/450843/232708235-380d518f-9753-4a36-ac53-481871146b40.png)

- Confirmation form with prompts for ZenDesk ticket:

![image](https://user-images.githubusercontent.com/450843/232777634-daa3bc3c-8325-454c-a8a8-e11574b5a1a5.png)


## Guidance to review

- Do we need any further safeguards around this feature?
- Do we need any more content/guidance on the confirmation form?

## Link to Trello card

[<!-- http://trello.com/123-example-card -->](https://trello.com/c/avSia89o/869-give-support-users-more-buttons)

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
