### PR TITLE
Change postgres snapshot database configuration deployment condition

### DIFF
--- a/terraform/modules/kubernetes/azure_postgres.tf
+++ b/terraform/modules/kubernetes/azure_postgres.tf
@@ -82,7 +82,7 @@ resource "azurerm_postgresql_flexible_server_configuration" "max-connections" {
 }
 
 resource "azurerm_postgresql_flexible_server_configuration" "postgres-snapshot-extensions" {
-  count = var.deploy_azure_backing_services ? 1 : 0
+  count = var.deploy_snapshot_database ? 1 : 0
 
   name      = "azure.extensions"
   server_id = azurerm_postgresql_flexible_server.postgres-snapshot-server[0].id


### PR DESCRIPTION
## Context

Configuration only needs to be deployed if snapshot database is being deployed

The snapshot Postgres database extensions configuration only needs to be deployed if snapshot database is being deployed

## Changes proposed in this pull request

Conditional variable for snapshots extension config resource creation changed to ```deploy_snapshot_database ```
## Guidance to review

error ```azurerm_postgresql_flexible_server.postgres-snapshot-server is empty tuple``` should vanish


## Link to Trello card
https://trello.com/c/0SFPAg3o/228-apply-create-snapshot-database

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
