### PR TITLE
Fix Master's and PhD grade options

### DIFF
--- a/app/components/candidate_interface/degree_grade_component.html.erb
+++ b/app/components/candidate_interface/degree_grade_component.html.erb
@@ -3,7 +3,7 @@
   <%= form.govuk_error_summary %>
   <%= form.govuk_radio_buttons_fieldset :grade, legend: { text: legend_helper, size: 'l' }, hint: { text: t('application_form.degree.grade.international.grade_examples') } do %>
     <% if @model.uk? %>
-      <% UK_DEGREE_GRADES.each_with_index do |grade, index| %>
+      <% grades.each_with_index do |grade, index| %>
         <%= form.govuk_radio_button :grade, grade, label: { text: grade }, link_errors: index.zero? do %>
           <% if grade == 'Other' %>
               <%= render DfE::Autocomplete::View.new(

--- a/app/components/candidate_interface/degree_grade_component.html.erb
+++ b/app/components/candidate_interface/degree_grade_component.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, title_with_error_prefix(legend_helper, @model.errors.any?) %>
 <%= form_with model: @model, url: candidate_interface_degree_grade_path do |form| %>
   <%= form.govuk_error_summary %>
-  <%= form.govuk_radio_buttons_fieldset :grade, legend: { text: legend_helper, size: 'l' }, hint: { text: t('application_form.degree.grade.international.grade_examples') } do %>
+  <%= form.govuk_radio_buttons_fieldset :grade, legend: { text: legend_helper, size: 'l' } do %>
     <% if @model.uk? %>
       <% grades.each_with_index do |grade, index| %>
         <%= form.govuk_radio_button :grade, grade, label: { text: grade }, link_errors: index.zero? do %>

--- a/app/components/candidate_interface/degree_grade_component.rb
+++ b/app/components/candidate_interface/degree_grade_component.rb
@@ -11,6 +11,8 @@ class CandidateInterface::DegreeGradeComponent < ViewComponent::Base
     'Other',
   ].freeze
 
+  UK_MASTERS_DEGREE_GRADES = %w[Distinction Merit Pass Other].freeze
+
   def initialize(model:)
     @model = model
   end
@@ -33,5 +35,13 @@ class CandidateInterface::DegreeGradeComponent < ViewComponent::Base
 
   def hint_helper
     t('application_form.degree.grade.hint.not_completed') unless model.completed?
+  end
+
+  def grades
+    if model.masters?
+      UK_MASTERS_DEGREE_GRADES
+    else
+      UK_DEGREE_GRADES
+    end
   end
 end

--- a/app/components/candidate_interface/degree_review_component.rb
+++ b/app/components/candidate_interface/degree_review_component.rb
@@ -227,6 +227,8 @@ module CandidateInterface
     end
 
     def grade_row(degree)
+      return nil if doctorate?(degree)
+
       {
         key: degree.completed? ? t('application_form.degree.grade.review_label') : t('application_form.degree.grade.review_label_predicted'),
         value: degree.grade || t('application_form.degree.review.not_specified'),
@@ -280,13 +282,17 @@ module CandidateInterface
     end
 
     def append_degree(degree)
-      return DegreeWizard::DOCTORATE.downcase if formatted_degree_type(degree) == 'Doctor' || degree.qualification_level == 'doctor'
+      return DegreeWizard::DOCTORATE.downcase if doctorate?(degree)
 
       if degree.qualification_level.present?
         formatted_degree_type(degree).to_s.downcase
       else
         "#{formatted_degree_type(degree)} degree"
       end
+    end
+
+    def doctorate?(degree)
+      formatted_degree_type(degree) == 'Doctor' || degree.qualification_level == 'doctor'
     end
 
     def return_to_params

--- a/app/components/candidate_interface/degree_type_component.rb
+++ b/app/components/candidate_interface/degree_type_component.rb
@@ -21,6 +21,7 @@ class CandidateInterface::DegreeTypeComponent < ViewComponent::Base
       516a5652-c197-e711-80d8-005056ac45bb
     ],
     'Doctorate (PhD)' => %w[
+      676a5652-c197-e711-80d8-005056ac45bb
       656a5652-c197-e711-80d8-005056ac45bb
       03d6b7af-499c-49e3-96cc-e63f9beda6e5
     ],
@@ -41,7 +42,11 @@ class CandidateInterface::DegreeTypeComponent < ViewComponent::Base
   end
 
   def name_and_abbr(degree)
-    "#{degree[:name]} (#{degree[:abbreviation]})"
+    if degree[:name] =~ /\(.*\)$/
+      degree[:name]
+    else
+      "#{degree[:name]} (#{degree[:abbreviation]})"
+    end
   end
 
   def dynamic_types

--- a/app/forms/candidate_interface/degree_wizard.rb
+++ b/app/forms/candidate_interface/degree_wizard.rb
@@ -413,6 +413,10 @@ module CandidateInterface
       degree_level.to_s.downcase
     end
 
+    def masters?
+      QUALIFICATION_LEVEL['master'] == degree_level
+    end
+
   private
 
     def hesa_institution

--- a/app/forms/candidate_interface/degree_wizard.rb
+++ b/app/forms/candidate_interface/degree_wizard.rb
@@ -97,10 +97,10 @@ module CandidateInterface
           :type
         elsif step == :university
           :completed
+        elsif (step == :completed && phd?) || step == :grade
+          :start_year
         elsif step == :completed
           :grade
-        elsif step == :grade
-          :start_year
         elsif step == :start_year
           :award_year
         elsif step == :award_year && international? && completed?
@@ -358,6 +358,7 @@ module CandidateInterface
 
     def grade_attributes
       return other_grade if grade == OTHER
+      return 'Pass' if phd?
 
       grade || other_grade
     end
@@ -415,6 +416,10 @@ module CandidateInterface
 
     def masters?
       QUALIFICATION_LEVEL['master'] == degree_level
+    end
+
+    def phd?
+      QUALIFICATION_LEVEL['doctor'] == degree_level
     end
 
   private

--- a/spec/components/candidate_interface/degree_grade_component_spec.rb
+++ b/spec/components/candidate_interface/degree_grade_component_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe CandidateInterface::DegreeGradeComponent, type: :component do
       end
 
       context 'masters degree' do
-        let(:degree_level) { CandidateInterface::DegreeWizard::QUALIFICATION_LEVEL['masters'] }
+        let(:degree_level) { CandidateInterface::DegreeWizard::QUALIFICATION_LEVEL['master'] }
 
         it 'renders grade choices for uk masters degree' do
           result = render_inline(described_class.new(model:))

--- a/spec/components/candidate_interface/degree_grade_component_spec.rb
+++ b/spec/components/candidate_interface/degree_grade_component_spec.rb
@@ -77,14 +77,29 @@ RSpec.describe CandidateInterface::DegreeGradeComponent, type: :component do
 
   describe 'rendered component' do
     context 'uk' do
-      let(:degree_params) { { uk_or_non_uk: 'uk' } }
+      let(:degree_params) { { uk_or_non_uk: 'uk', degree_level: degree_level } }
       let(:model) { CandidateInterface::DegreeWizard.new(store, degree_params) }
 
-      it 'renders grade choices for uk degree' do
-        result = render_inline(described_class.new(model:))
+      context 'undergraduate degree' do
+        let(:degree_level) { CandidateInterface::DegreeWizard::QUALIFICATION_LEVEL['bachelor'] }
 
-        expect(result.css('.govuk-radios > .govuk-radios__item').count).to eq(6)
-        expect(result.css(:label, '#govuk-label govuk-radios__label').map(&:text)).to include(*described_class::UK_DEGREE_GRADES)
+        it 'renders grade choices for uk undergraduate degree' do
+          result = render_inline(described_class.new(model:))
+
+          expect(result.css('.govuk-radios > .govuk-radios__item').count).to eq(6)
+          expect(result.css(:label, '#govuk-label govuk-radios__label').map(&:text)).to include(*described_class::UK_DEGREE_GRADES)
+        end
+      end
+
+      context 'masters degree' do
+        let(:degree_level) { CandidateInterface::DegreeWizard::QUALIFICATION_LEVEL['masters'] }
+
+        it 'renders grade choices for uk masters degree' do
+          result = render_inline(described_class.new(model:))
+
+          expect(result.css('.govuk-radios > .govuk-radios__item').count).to eq(4)
+          expect(result.css(:label, '#govuk-label govuk-radios__label').map(&:text)).to include(*described_class::UK_MASTERS_DEGREE_GRADES)
+        end
       end
     end
 

--- a/spec/components/candidate_interface/degree_review_component_spec.rb
+++ b/spec/components/candidate_interface/degree_review_component_spec.rb
@@ -568,6 +568,14 @@ RSpec.describe CandidateInterface::DegreeReviewComponent, type: :component do
         },
       )
     end
+
+    it 'does not render a grade' do
+      render_inline(described_class.new(application_form:))
+
+      expect(rendered_component).not_to summarise(
+        key: t('application_form.degree.grade.review_label'),
+      )
+    end
   end
 
   context 'an international degree' do

--- a/spec/components/candidate_interface/degree_type_component_spec.rb
+++ b/spec/components/candidate_interface/degree_type_component_spec.rb
@@ -76,6 +76,9 @@ RSpec.describe CandidateInterface::DegreeTypeComponent, type: :component do
               abbreviation: 'MEng',
             }],
             'Doctorate (PhD)' => [{
+              name: 'Doctor of Philosophy',
+              abbreviation: 'PhD',
+            }, {
               name: 'Doctor of Philosophy (DPhil)',
               abbreviation: 'DPhil',
             }, {

--- a/spec/forms/candidate_interface/degree_wizard_spec.rb
+++ b/spec/forms/candidate_interface/degree_wizard_spec.rb
@@ -219,10 +219,22 @@ RSpec.describe CandidateInterface::DegreeWizard do
     end
 
     context 'completed step' do
-      let(:degree_params) { { current_step: :completed } }
+      let(:degree_params) { { current_step: :completed, degree_level: degree_level } }
 
-      it 'redirects to the grades page' do
-        expect(wizard.next_step).to be(:grade)
+      context 'when degree type is not a doctorate' do
+        let(:degree_level) { CandidateInterface::DegreeWizard::QUALIFICATION_LEVEL['bachelor'] }
+
+        it 'redirects to the grades page' do
+          expect(wizard.next_step).to be(:grade)
+        end
+      end
+
+      context 'when degree type is doctorate' do
+        let(:degree_level) { CandidateInterface::DegreeWizard::QUALIFICATION_LEVEL['doctor'] }
+
+        it 'redirects to the start_year page' do
+          expect(wizard.next_step).to be(:start_year)
+        end
       end
     end
 

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_delete_and_replace_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_delete_and_replace_degrees_spec.rb
@@ -126,8 +126,6 @@ RSpec.feature 'Deleting and replacing a degree' do
     and_i_click_on_save_and_continue
     when_i_choose_whether_degree_is_completed
     and_i_click_on_save_and_continue
-    when_i_select_the_grade
-    and_i_click_on_save_and_continue
     when_i_fill_in_the_start_year
     and_i_click_on_save_and_continue
     when_i_fill_in_the_award_year

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_editing_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_editing_degrees_spec.rb
@@ -214,7 +214,7 @@ RSpec.feature 'Editing a degree' do
   end
 
   def when_i_change_my_undergraduate_degree_grade
-    choose 'Lower second-class honours (2:2)'
+    choose 'Merit'
   end
 
   def when_i_change_my_undergraduate_country_to_another_country
@@ -248,7 +248,7 @@ RSpec.feature 'Editing a degree' do
   end
 
   def then_i_can_check_my_revised_undergraduate_degree_grade
-    expect(page).to have_content 'Lower second-class honours (2:2)'
+    expect(page).to have_content 'Merit'
   end
 
   def then_i_can_check_my_revised_completion_status_and_award_year
@@ -302,7 +302,6 @@ RSpec.feature 'Editing a degree' do
 
   def then_i_can_check_my_revised_masters_undergraduate_degree
     expect(page).to have_content 'Master of Business Administration'
-    expect(page).to have_content 'MBA (Hons)'
   end
 
   def when_i_click_to_change_my_masters_undergraduate_degree_type

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_higher_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_higher_degrees_spec.rb
@@ -1,0 +1,177 @@
+require 'rails_helper'
+
+RSpec.feature 'Entering a Masters/PhD degree' do
+  include CandidateHelper
+
+  scenario 'Candidate enters their Masters and PhD degrees' do
+    given_i_am_signed_in
+    when_i_view_the_degree_section
+
+    # Add degree
+    and_i_click_add_degree
+
+    # Add country
+    then_i_can_see_the_country_page
+    when_i_choose_united_kingdom
+    and_i_click_on_save_and_continue
+
+    # Add degree level
+    then_i_can_see_the_level_page
+    when_i_choose_the_masters_level
+    and_i_click_on_save_and_continue
+
+    # Add subject
+    then_i_can_see_the_subject_page
+    when_i_fill_in_the_subject
+    and_i_click_on_save_and_continue
+
+    # Add degree type
+    then_i_can_see_the_type_page
+    when_i_choose_the_type_of_degree
+    and_i_click_on_save_and_continue
+
+    # Add university
+    then_i_can_see_the_university_page
+    when_i_fill_in_the_university
+    and_i_click_on_save_and_continue
+
+    # Add completion
+    then_i_can_see_the_completion_page
+    when_i_choose_whether_degree_is_completed
+    and_i_click_on_save_and_continue
+
+    # Add grade
+    then_i_can_see_the_grade_page_with_masters_grade_options
+    when_i_select_the_grade
+    and_i_click_on_save_and_continue
+
+    # Add start year
+    then_i_can_see_the_start_year_page
+    when_i_fill_in_the_start_year
+    and_i_click_on_save_and_continue
+
+    # Add award year
+    then_i_can_see_the_award_year_page
+    when_i_fill_in_the_award_year
+    and_i_click_on_save_and_continue
+
+    # Review
+    then_i_can_check_my_undergraduate_degree
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def when_i_view_the_degree_section
+    visit candidate_interface_application_form_path
+    when_i_click_on_degree
+  end
+
+  def when_i_click_on_degree
+    click_link 'Degree'
+  end
+
+  def and_i_click_add_degree
+    click_link 'Add a degree'
+  end
+
+  def then_i_can_see_the_country_page
+    expect(page).to have_content('Which country was the degree from?')
+  end
+
+  def when_i_choose_united_kingdom
+    choose 'United Kingdom'
+  end
+
+  def and_i_click_on_save_and_continue
+    click_button t('save_and_continue')
+  end
+
+  def when_i_click_on_save_and_continue
+    click_button t('save_and_continue')
+  end
+
+  def when_i_fill_in_the_type
+    choose 'Bachelor degree'
+  end
+
+  def then_i_can_see_the_level_page
+    expect(page).to have_content 'What type of degree is it?'
+  end
+
+  def when_i_choose_the_masters_level
+    choose 'Master’s degree'
+  end
+
+  def then_i_can_see_the_subject_page
+    expect(page).to have_content 'What subject is your degree?'
+  end
+
+  def when_i_fill_in_the_subject
+    select 'History', from: 'What subject is your degree?'
+  end
+
+  def then_i_can_see_the_type_page
+    expect(page).to have_content 'What type of master’s degree is it?'
+  end
+
+  def when_i_choose_the_type_of_degree
+    choose 'Master of Science (MSc)'
+  end
+
+  def then_i_can_see_the_university_page
+    expect(page).to have_content 'Which university awarded your degree?'
+  end
+
+  def when_i_fill_in_the_university
+    select 'University of Cambridge', from: 'candidate_interface_degree_wizard[university]'
+  end
+
+  def then_i_can_see_the_completion_page
+    expect(page).to have_content 'Have you completed your degree?'
+  end
+
+  def when_i_choose_whether_degree_is_completed
+    choose 'Yes'
+  end
+
+  def then_i_can_see_the_grade_page_with_masters_grade_options
+    expect(page).to have_content('What grade is your degree?')
+
+    expect(page).not_to have_field('First-class honours')
+    expect(page).not_to have_field('Upper second-class honours (2:1)')
+    expect(page).not_to have_field('Lower second-class honours (2:2)')
+    expect(page).not_to have_field('Third-class honours')
+
+    expect(page).to have_field('Distinction')
+    expect(page).to have_field('Merit')
+    expect(page).to have_field('Pass')
+    expect(page).to have_field('Other')
+  end
+
+  def when_i_select_the_grade
+    choose 'Merit'
+  end
+
+  def then_i_can_see_the_start_year_page
+    expect(page).to have_content('What year did you start your degree?')
+  end
+
+  def when_i_fill_in_the_start_year
+    fill_in t('page_titles.what_year_did_you_start_your_degree'), with: '2006'
+  end
+
+  def then_i_can_see_the_award_year_page
+    expect(page).to have_content('What year did you graduate?')
+  end
+
+  def when_i_fill_in_the_award_year
+    fill_in t('page_titles.what_year_did_you_graduate'), with: '2009'
+  end
+
+  def then_i_can_check_my_undergraduate_degree
+    expect(page).to have_current_path candidate_interface_degree_review_path
+    expect(page).to have_content 'History'
+  end
+end

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_masters_degree_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_masters_degree_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-RSpec.feature 'Entering a Masters/PhD degree' do
+RSpec.feature 'Entering a Masters degree' do
   include CandidateHelper
 
-  scenario 'Candidate enters their Masters and PhD degrees' do
+  scenario 'Candidate enters their Masters degree' do
     given_i_am_signed_in
     when_i_view_the_degree_section
 

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_phd_degree_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_phd_degree_spec.rb
@@ -108,7 +108,7 @@ RSpec.feature 'Entering a PhD' do
   end
 
   def when_i_choose_the_type_of_degree
-    choose 'Doctor of Philosophy (DPhil) (DPhil)'
+    choose 'Doctor of Philosophy (DPhil)'
   end
 
   def then_i_can_see_the_university_page

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_phd_degree_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_phd_degree_spec.rb
@@ -1,0 +1,150 @@
+require 'rails_helper'
+
+RSpec.feature 'Entering a PhD' do
+  include CandidateHelper
+
+  scenario 'Candidate enters their PhD' do
+    given_i_am_signed_in
+    when_i_view_the_degree_section
+
+    # Add degree
+    and_i_click_add_degree
+
+    # Add country
+    then_i_can_see_the_country_page
+    when_i_choose_united_kingdom
+    and_i_click_on_save_and_continue
+
+    # Add degree level
+    then_i_can_see_the_level_page
+    when_i_choose_the_phd_level
+    and_i_click_on_save_and_continue
+
+    # Add subject
+    then_i_can_see_the_subject_page
+    when_i_fill_in_the_subject
+    and_i_click_on_save_and_continue
+
+    # Add degree type
+    then_i_can_see_the_type_page
+    when_i_choose_the_type_of_degree
+    and_i_click_on_save_and_continue
+
+    # Add university
+    then_i_can_see_the_university_page
+    when_i_fill_in_the_university
+    and_i_click_on_save_and_continue
+
+    # Add completion
+    then_i_can_see_the_completion_page
+    when_i_choose_whether_degree_is_completed
+    and_i_click_on_save_and_continue
+
+    # Add start year
+    then_i_can_see_the_start_year_page
+    when_i_fill_in_the_start_year
+    and_i_click_on_save_and_continue
+
+    # Add award year
+    then_i_can_see_the_award_year_page
+    when_i_fill_in_the_award_year
+    and_i_click_on_save_and_continue
+
+    # Review
+    then_i_can_check_my_phd
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def when_i_view_the_degree_section
+    visit candidate_interface_application_form_path
+    when_i_click_on_degree
+  end
+
+  def when_i_click_on_degree
+    click_link 'Degree'
+  end
+
+  def and_i_click_add_degree
+    click_link 'Add a degree'
+  end
+
+  def then_i_can_see_the_country_page
+    expect(page).to have_content('Which country was the degree from?')
+  end
+
+  def when_i_choose_united_kingdom
+    choose 'United Kingdom'
+  end
+
+  def and_i_click_on_save_and_continue
+    click_button t('save_and_continue')
+  end
+
+  def when_i_click_on_save_and_continue
+    click_button t('save_and_continue')
+  end
+
+  def then_i_can_see_the_level_page
+    expect(page).to have_content 'What type of degree is it?'
+  end
+
+  def when_i_choose_the_phd_level
+    choose 'Doctorate (PhD)'
+  end
+
+  def then_i_can_see_the_subject_page
+    expect(page).to have_content 'What subject is your degree?'
+  end
+
+  def when_i_fill_in_the_subject
+    select 'History', from: 'What subject is your degree?'
+  end
+
+  def then_i_can_see_the_type_page
+    expect(page).to have_content 'What type of doctorate is it?'
+  end
+
+  def when_i_choose_the_type_of_degree
+    choose 'Doctor of Philosophy (DPhil) (DPhil)'
+  end
+
+  def then_i_can_see_the_university_page
+    expect(page).to have_content 'Which university awarded your degree?'
+  end
+
+  def when_i_fill_in_the_university
+    select 'University of Cambridge', from: 'candidate_interface_degree_wizard[university]'
+  end
+
+  def then_i_can_see_the_completion_page
+    expect(page).to have_content 'Have you completed your degree?'
+  end
+
+  def when_i_choose_whether_degree_is_completed
+    choose 'Yes'
+  end
+
+  def then_i_can_see_the_start_year_page
+    expect(page).to have_content('What year did you start your degree?')
+  end
+
+  def when_i_fill_in_the_start_year
+    fill_in t('page_titles.what_year_did_you_start_your_degree'), with: '2006'
+  end
+
+  def then_i_can_see_the_award_year_page
+    expect(page).to have_content('What year did you graduate?')
+  end
+
+  def when_i_fill_in_the_award_year
+    fill_in t('page_titles.what_year_did_you_graduate'), with: '2009'
+  end
+
+  def then_i_can_check_my_phd
+    expect(page).to have_current_path candidate_interface_degree_review_path
+    expect(page).to have_content 'History'
+  end
+end

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_qualifications_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_qualifications_spec.rb
@@ -456,7 +456,7 @@ RSpec.feature 'Candidate is redirected correctly' do
   def when_i_update_degree_grade
     when_i_click_change_degree_grade
 
-    choose 'First-class honours'
+    choose 'Distinction'
     click_button t('save_and_continue')
   end
 
@@ -574,7 +574,7 @@ RSpec.feature 'Candidate is redirected correctly' do
 
   def and_i_should_see_my_updated_degree_grade
     within('[data-qa="degree-grade"]') do
-      expect(page).to have_content('First-class honours')
+      expect(page).to have_content('Distinction')
     end
   end
 

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature 'Vendor receives the application', time: CycleTimetableHelper.mid_
       degree_type: 'Master of Science',
       degree_subject: 'Applied environmental sciences',
       university: 'Liverpool John Moores University',
-      grade: 'Lower second-class honours (2:2)',
+      grade: 'Merit',
     )
   end
 
@@ -141,8 +141,8 @@ RSpec.feature 'Vendor receives the application', time: CycleTimetableHelper.mid_
               award_year: '2009',
               awarding_body: nil,
               equivalency_details: nil,
-              grade: 'Lower second-class honours (2:2)',
-              hesa_degclss: '03',
+              grade: 'Merit',
+              hesa_degclss: '13',
               hesa_degctry: nil,
               hesa_degenddt: '2009-01-01',
               hesa_degest: '0065',


### PR DESCRIPTION
## Context

When we prompt users to enter a grade for a Master's or PhD degree we are presenting the option for Bachelors degrees. This PR corrects that by presenting Master's specific grades for Master's degrees and skipping the grade step entirely for PhDs.

## Changes proposed in this pull request

- New systems specs to cover entry of Master's and PhDs.
- Special case for Master's degrees surfaces these options:

![image](https://user-images.githubusercontent.com/450843/233596128-621eb208-2d67-49ca-bc1d-10e4a7a835da.png)


- Special case for PhDs in `DegreeWizard` to skip the grade step and set the value to `'Pass'`.

## Guidance to review

- Are the tests sufficient here?
- Are there any other cases I'm missing?

## Link to Trello card

https://trello.com/c/z5XTrOIw/875-fix-our-masters-and-phd-grade-options-that-broke-during-our-new-degree-flow

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
