### PR TITLE
Update maintenance banner to render on candidate side

### DIFF
--- a/config/locales/service_information_banner.yml
+++ b/config/locales/service_information_banner.yml
@@ -3,10 +3,10 @@ en:
     provider:
       sandbox_header: The sandbox will be unavailable on Tuesday 25 May from 8am to 9am
       sandbox_body: This will affect both the web service and the API. You may lose work if you are using the sandbox when it becomes unavailable.
-      header: The Manage service will be unavailable on Wednesday 26 May from 8am to 9am
+      header: The Manage service will be unavailable on Wednesday 19 April from 8pm to 10:30pm
       body: This will affect both the web service and the API. You may lose work if you are using Manage when it becomes unavailable.
     candidate:
       sandbox_header: The sandbox will be unavailable on Tuesday 25 May from 8am to 9am
       sandbox_body: You may lose work if you are using the sandbox when it becomes unavailable.
-      header: This service will be unavailable on Wednesday 26 May from 8am to 9am
+      header: This service will be unavailable on Wednesday 19 April from 8pm to 10:30pm
       body: You may lose work if you are using this service when it becomes unavailable.


### PR DESCRIPTION
## Context

We are going to migrate our prod env to Azure later today. We can warn candidates and providers ahead of time using a feature flag, which we should do.

## Changes proposed in this pull request

Amend the copy in the content on our service banner.

## Guidance to review

Does this work? What does the sandbox_header variable mean for us activating the flag?

## Link to Trello card

N/A

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
