### PR TITLE
Prevent deletion of references from earlier applications

### DIFF
--- a/app/components/candidate_interface/references_review_component.html.erb
+++ b/app/components/candidate_interface/references_review_component.html.erb
@@ -5,13 +5,13 @@
 <% references.each_with_index do |reference, index| %>
   <%= render(SummaryCardComponent.new(
     rows: reference_rows(reference),
-    editable: editable,
+    editable: editable && reference_editable?(reference),
     ignore_editable: ignore_editable_for,
   )) do %>
     <%= render(SummaryCardHeaderComponent.new(title: reference.name, heading_level: @heading_level)) do %>
       <div class="app-summary-card__actions">
         <ul class="app-summary-card__actions-list">
-          <% if editable && can_destroy?(reference) %>
+          <% if editable && reference_editable?(reference) %>
             <li class="app-summary-card__actions-list-item">
               <%= govuk_link_to confirm_destroy_path(reference) do %>
                 <%= t('application_form.references.delete_reference.action') %>

--- a/app/components/candidate_interface/references_review_component.html.erb
+++ b/app/components/candidate_interface/references_review_component.html.erb
@@ -11,7 +11,7 @@
     <%= render(SummaryCardHeaderComponent.new(title: reference.name, heading_level: @heading_level)) do %>
       <div class="app-summary-card__actions">
         <ul class="app-summary-card__actions-list">
-          <% if editable %>
+          <% if editable && can_destroy?(reference) %>
             <li class="app-summary-card__actions-list-item">
               <%= govuk_link_to confirm_destroy_path(reference) do %>
                 <%= t('application_form.references.delete_reference.action') %>

--- a/app/components/candidate_interface/references_review_component.rb
+++ b/app/components/candidate_interface/references_review_component.rb
@@ -196,7 +196,7 @@ module CandidateInterface
       end
     end
 
-    def can_destroy?(reference)
+    def reference_editable?(reference)
       !reference.duplicate?
     end
 

--- a/app/components/candidate_interface/references_review_component.rb
+++ b/app/components/candidate_interface/references_review_component.rb
@@ -196,6 +196,10 @@ module CandidateInterface
       end
     end
 
+    def can_destroy?(reference)
+      !reference.duplicate?
+    end
+
     def confirm_destroy_path(reference)
       candidate_interface_confirm_destroy_new_reference_path(reference)
     end

--- a/app/services/delete_reference.rb
+++ b/app/services/delete_reference.rb
@@ -1,6 +1,7 @@
 class DeleteReference
   def call(reference:)
     raise 'Application has been sent to providers' if reference.application_form.submitted?
+    raise 'Reference cannot be deleted because it is from a previous application' if reference.duplicate?
 
     if reference.selected
       reference.application_form.update!(references_completed: false)

--- a/spec/components/candidate_interface/references_review_component_spec.rb
+++ b/spec/components/candidate_interface/references_review_component_spec.rb
@@ -109,7 +109,21 @@ RSpec.describe CandidateInterface::ReferencesReviewComponent, type: :component d
       expect(result.text).to include reference_two.email_address
     end
 
+    it 'renders the delete link' do
+      reference = create(:reference, application_form:)
+
+      result = render_inline(described_class.new(references: [reference], application_form:))
+      expect(result.css("a[href='#{delete_reference_path(reference)}']")).to be_present
+    end
+
     context 'when a reference is carried over' do
+      it 'does not render the delete link' do
+        reference = create(:reference, application_form:, duplicate: true)
+
+        result = render_inline(described_class.new(references: [reference], application_form:))
+        expect(result.css("a[href='#{delete_reference_path(reference)}']")).not_to be_present
+      end
+
       context 'when the state is feedback_provided' do
         it 'renders a status row' do
           reference = create(:reference, :feedback_provided, application_form:)
@@ -131,5 +145,9 @@ RSpec.describe CandidateInterface::ReferencesReviewComponent, type: :component d
         end
       end
     end
+  end
+
+  def delete_reference_path(reference)
+    Rails.application.routes.url_helpers.candidate_interface_confirm_destroy_new_reference_path(reference)
   end
 end

--- a/spec/services/delete_reference_spec.rb
+++ b/spec/services/delete_reference_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe DeleteReference do
       expect { described_class.new.call(reference:) }.to raise_error('Application has been sent to providers')
     end
 
+    it 'raises error if reference is a duplicate from a prior application' do
+      application_form = create(:application_form)
+      reference_to_delete = create(:reference, :feedback_provided, application_form:, duplicate: true)
+      expect { described_class.new.call(reference: reference_to_delete) }.to raise_error('Reference cannot be deleted because it is from a previous application')
+    end
+
     it 'deletes the reference' do
       application_form = create(:application_form)
       reference_to_delete = create(:reference, :feedback_provided, application_form:)


### PR DESCRIPTION
## Context

Candidates should not be able to purge references associated with earlier failed applications.

## Changes proposed in this pull request

Before:

![image](https://user-images.githubusercontent.com/450843/233410695-dcf2b3b9-2ac1-4045-aa67-76e1c7238df5.png)

After:

![image](https://user-images.githubusercontent.com/450843/233410549-80a62eb4-eda3-42fc-a96a-4df77523814a.png)

There are two changes behind the scenes here:
- The `CandidateInterface::ReferencesReviewComponent` doesn't render the `Delete` link for references that have been duplicated from a prior application (carried over or apply again within the same recruitment cycle).
- The `DeleteReference` service will throw an exception if it's called for a reference that has been duplicated. (This shouldn't ever happen through the normal UI).

## Guidance to review

- Is it reasonable to rely on `Reference#duplicate?` to determine whether we should allow deletion or not?

## Link to Trello card

https://trello.com/c/m2FeKlSp/1395-delete-the-delete-reference-button-in-certain-circumstances

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
