### PR TITLE
DNM: Reorder provider navigation bar

### DIFF
--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -54,11 +54,13 @@ class NavigationItems
         items << NavigationItem.new('Applications', provider_interface_applications_path, active?(current_controller, %w[application_choices decisions offer_changes notes interviews offers feedback conditions reconfirm_deferred_offers]), [])
         items << NavigationItem.new('Interview schedule', provider_interface_interview_schedule_path, active?(current_controller, %w[interview_schedules]), [])
 
+
+
+        items << NavigationItem.new('Reports', provider_interface_reports_path, active?(current_controller, %w[reports application_data_export hesa_export]))
+
         if FeatureFlag.active?(:provider_activity_log)
           items << NavigationItem.new('Activity log', provider_interface_activity_log_path, active?(current_controller, %w[activity_log]), [])
         end
-
-        items << NavigationItem.new('Reports', provider_interface_reports_path, active?(current_controller, %w[reports application_data_export hesa_export]), 'app-primary-navigation__item--align-right')
       end
 
       items


### PR DESCRIPTION
⚠️  **This shouldn’t go live until the 2 new reports are launched.** ⚠️ 

Intention here is to draw more attention to the new reports (equality questions and reasons for withdrawal), and to tidy up the nav bar (there’s no need for one item to be right-aligned).

The Activity log is moved to be the last item, as we suspect this is the least-used feature of the service (mainly there for auditing purposes).

## Before

<img width="1036" alt="Screenshot 2023-04-21 at 16 21 27" src="https://user-images.githubusercontent.com/30665/233674386-1a2346b7-290a-433d-ad3a-9c0b47493f25.png">

## After

<img width="1044" alt="Screenshot 2023-04-21 at 16 21 15" src="https://user-images.githubusercontent.com/30665/233674412-483161df-1bbb-4fa5-902a-04eb55176758.png">

