### PR TITLE
Use free-text grades for non Bachelors/Masters degrees

### DIFF
--- a/app/components/candidate_interface/degree_grade_component.html.erb
+++ b/app/components/candidate_interface/degree_grade_component.html.erb
@@ -2,7 +2,7 @@
 <%= form_with model: @model, url: candidate_interface_degree_grade_path do |form| %>
   <%= form.govuk_error_summary %>
   <%= form.govuk_radio_buttons_fieldset :grade, legend: { text: legend_helper, size: 'l' } do %>
-    <% if @model.uk? %>
+    <% if @model.uk? && specific_grade_options? %>
       <% grades.each_with_index do |grade, index| %>
         <%= form.govuk_radio_button :grade, grade, label: { text: grade }, link_errors: index.zero? do %>
           <% if grade == 'Other' %>

--- a/app/components/candidate_interface/degree_grade_component.rb
+++ b/app/components/candidate_interface/degree_grade_component.rb
@@ -2,7 +2,7 @@ class CandidateInterface::DegreeGradeComponent < ViewComponent::Base
   include ViewHelper
   attr_reader :model
 
-  UK_DEGREE_GRADES = [
+  UK_BACHELORS_DEGREE_GRADES = [
     'First-class honours',
     'Upper second-class honours (2:1)',
     'Lower second-class honours (2:2)',
@@ -37,11 +37,15 @@ class CandidateInterface::DegreeGradeComponent < ViewComponent::Base
     t('application_form.degree.grade.hint.not_completed') unless model.completed?
   end
 
+  def specific_grade_options?
+    model.masters? || model.bachelors?
+  end
+
   def grades
     if model.masters?
       UK_MASTERS_DEGREE_GRADES
     else
-      UK_DEGREE_GRADES
+      UK_BACHELORS_DEGREE_GRADES
     end
   end
 end

--- a/app/components/candidate_interface/degree_grade_component.rb
+++ b/app/components/candidate_interface/degree_grade_component.rb
@@ -18,8 +18,10 @@ class CandidateInterface::DegreeGradeComponent < ViewComponent::Base
   end
 
   def legend_helper
-    if model.uk?
+    if model.uk? && model.has_specified_grades?
       t('application_form.degree.grade.legend.uk', complete: (model.completed? ? 'is your degree' : 'do you expect to get').to_s)
+    elsif model.uk? && !model.has_specified_grades?
+      t('application_form.degree.grade.legend.uk_with_optional_grade', complete: (model.completed? ? 'Did' : 'Will').to_s)
     else
       t('application_form.degree.grade.legend.non_uk', complete: (model.completed? ? 'Did' : 'Will').to_s)
     end

--- a/app/components/candidate_interface/degree_grade_component.rb
+++ b/app/components/candidate_interface/degree_grade_component.rb
@@ -18,9 +18,9 @@ class CandidateInterface::DegreeGradeComponent < ViewComponent::Base
   end
 
   def legend_helper
-    if model.uk? && model.has_specified_grades?
+    if model.uk? && model.specified_grades?
       t('application_form.degree.grade.legend.uk', complete: (model.completed? ? 'is your degree' : 'do you expect to get').to_s)
-    elsif model.uk? && !model.has_specified_grades?
+    elsif model.uk? && !model.specified_grades?
       t('application_form.degree.grade.legend.uk_with_optional_grade', complete: (model.completed? ? 'Did' : 'Will').to_s)
     else
       t('application_form.degree.grade.legend.non_uk', complete: (model.completed? ? 'Did' : 'Will').to_s)

--- a/app/forms/candidate_interface/degree_wizard.rb
+++ b/app/forms/candidate_interface/degree_wizard.rb
@@ -424,6 +424,10 @@ module CandidateInterface
       degree_level.to_s.downcase
     end
 
+    def bachelors?
+      QUALIFICATION_LEVEL['bachelor'] == degree_level
+    end
+
     def masters?
       QUALIFICATION_LEVEL['master'] == degree_level
     end
@@ -606,7 +610,7 @@ module CandidateInterface
     def self.map_to_uk_grade?(application_qualification)
       return if application_qualification.grade.nil?
 
-      CandidateInterface::DegreeGradeComponent::UK_DEGREE_GRADES.find { |uk_grade| uk_grade.include?(application_qualification.grade) }.present?
+      CandidateInterface::DegreeGradeComponent::UK_BACHELORS_DEGREE_GRADES.find { |uk_grade| uk_grade.include?(application_qualification.grade) }.present?
     end
 
     private_class_method :map_to_uk_grade?

--- a/app/forms/candidate_interface/degree_wizard.rb
+++ b/app/forms/candidate_interface/degree_wizard.rb
@@ -56,7 +56,7 @@ module CandidateInterface
     validates :university, presence: true, on: :university
     validates :completed, presence: true, on: :completed
     validates :grade, presence: true, on: :grade
-    validates :other_grade, presence: true, length: { maximum: 255 }, if: :grade_choices, on: :grade
+    validates :other_grade, presence: true, length: { maximum: 255 }, if: :use_other_grade?, on: :grade
     validates :start_year, year: true, presence: true, on: :start_year
     validates :award_year, year: true, presence: true, on: :award_year
     validates :have_enic_reference, presence: true, if: :international?, on: :enic
@@ -367,7 +367,7 @@ module CandidateInterface
     end
 
     def grade_attributes
-      return other_grade if grade == OTHER
+      return other_grade if use_other_grade?
       return 'Pass' if phd?
 
       grade || other_grade
@@ -401,7 +401,7 @@ module CandidateInterface
       other_type.present?
     end
 
-    def grade_choices
+    def use_other_grade?
       grade == OTHER || grade == YES
     end
 

--- a/app/forms/candidate_interface/degree_wizard.rb
+++ b/app/forms/candidate_interface/degree_wizard.rb
@@ -436,6 +436,10 @@ module CandidateInterface
       QUALIFICATION_LEVEL['doctor'] == degree_level
     end
 
+    def has_specified_grades?
+      masters? || bachelors?
+    end
+
   private
 
     def hesa_institution

--- a/app/forms/candidate_interface/degree_wizard.rb
+++ b/app/forms/candidate_interface/degree_wizard.rb
@@ -55,7 +55,16 @@ module CandidateInterface
     validates :other_type, presence: true, length: { maximum: 255 }, if: %i[uk? other_type_selected], on: :type
     validates :university, presence: true, on: :university
     validates :completed, presence: true, on: :completed
-    validates :grade, presence: true, on: :grade
+    validate(on: :grade) do |wizard|
+      wizard.grade.blank?
+      message =
+        if wizard.specified_grades?
+          I18n.t('activemodel.errors.models.candidate_interface/degree_wizard.attributes.grade.blank')
+        else
+          I18n.t('activemodel.errors.models.candidate_interface/degree_wizard.attributes.do_you_have_a_grade.blank')
+        end
+      wizard.errors.add(:grade, message) if wizard.grade.blank?
+    end
     validates :other_grade, presence: true, length: { maximum: 255 }, if: :use_other_grade?, on: :grade
     validates :start_year, year: true, presence: true, on: :start_year
     validates :award_year, year: true, presence: true, on: :award_year
@@ -436,7 +445,7 @@ module CandidateInterface
       QUALIFICATION_LEVEL['doctor'] == degree_level
     end
 
-    def has_specified_grades?
+    def specified_grades?
       masters? || bachelors?
     end
 

--- a/config/locales/candidate_interface/degree.yml
+++ b/config/locales/candidate_interface/degree.yml
@@ -35,6 +35,7 @@ en:
       grade:
         legend:
           uk: What grade %{complete}?
+          uk_with_optional_grade: "%{complete} this qualification give a grade?"
           non_uk: "%{complete} your degree give a grade?"
         label:
           completed: What grade did you get?

--- a/config/locales/candidate_interface/degree.yml
+++ b/config/locales/candidate_interface/degree.yml
@@ -126,6 +126,8 @@ en:
               blank: Enter the institution where you studied
             grade:
               blank: Select your degree grade
+            do_you_have_a_grade:
+              blank: Select if your qualification gives a grade
             other_grade:
               blank: Enter your degree grade
               too_long: Your degree grade must be %{count} characters or fewer

--- a/spec/components/candidate_interface/degree_grade_component_spec.rb
+++ b/spec/components/candidate_interface/degree_grade_component_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe CandidateInterface::DegreeGradeComponent, type: :component do
           result = render_inline(described_class.new(model:))
 
           expect(result.css('.govuk-radios > .govuk-radios__item').count).to eq(6)
-          expect(result.css(:label, '#govuk-label govuk-radios__label').map(&:text)).to include(*described_class::UK_DEGREE_GRADES)
+          expect(result.css(:label, '#govuk-label govuk-radios__label').map(&:text)).to include(*described_class::UK_BACHELORS_DEGREE_GRADES)
         end
       end
 

--- a/spec/components/candidate_interface/degree_grade_component_spec.rb
+++ b/spec/components/candidate_interface/degree_grade_component_spec.rb
@@ -7,18 +7,56 @@ RSpec.describe CandidateInterface::DegreeGradeComponent, type: :component do
 
   describe '#legend_helper' do
     context 'when uk_or_non_uk is uk' do
-      it 'degree is completed' do
-        degree_params = { uk_or_non_uk: 'uk', completed: 'Yes' }
-        model = CandidateInterface::DegreeWizard.new(store, degree_params)
+      context 'when degree type has specific grades' do
+        it 'degree is completed' do
+          degree_params = {
+            uk_or_non_uk: 'uk',
+            completed: 'Yes',
+            degree_level: 'Bachelor degree',
+            type: 'Bachelor of Engineering',
+          }
+          model = CandidateInterface::DegreeWizard.new(store, degree_params)
 
-        expect(described_class.new(model:).legend_helper).to eq('What grade is your degree?')
+          expect(described_class.new(model:).legend_helper).to eq('What grade is your degree?')
+        end
+
+        it 'degree is not completed' do
+          degree_params = {
+            uk_or_non_uk: 'uk',
+            completed: 'No',
+            degree_level: 'Bachelor degree',
+            type: 'Bachelor of Engineering',
+          }
+          model = CandidateInterface::DegreeWizard.new(store, degree_params)
+
+          expect(described_class.new(model:).legend_helper).to eq('What grade do you expect to get?')
+        end
       end
 
-      it 'degree is not completed' do
-        degree_params = { uk_or_non_uk: 'uk', completed: 'No' }
-        model = CandidateInterface::DegreeWizard.new(store, degree_params)
+      context 'when degree type has optional free-text grade' do
+        it 'degree is completed' do
+          degree_params = {
+            uk_or_non_uk: 'uk',
+            completed: 'Yes',
+            degree_level: 'Foundation degree',
+            type: 'Foundation of Sciences',
+          }
+          model = CandidateInterface::DegreeWizard.new(store, degree_params)
 
-        expect(described_class.new(model:).legend_helper).to eq('What grade do you expect to get?')
+          expect(described_class.new(model:).legend_helper).to eq('Did this qualification give a grade?')
+        end
+
+        it 'degree is not completed' do
+          degree_params = {
+            uk_or_non_uk: 'uk',
+            completed: 'No',
+            degree_level: 'Foundation degree',
+            type: 'Foundation of Sciences',
+          }
+          model = CandidateInterface::DegreeWizard.new(store, degree_params)
+
+          expect(described_class.new(model:).legend_helper).to eq('Will this qualification give a grade?')
+        end
       end
     end
 

--- a/spec/forms/candidate_interface/degree_wizard_spec.rb
+++ b/spec/forms/candidate_interface/degree_wizard_spec.rb
@@ -427,10 +427,18 @@ RSpec.describe CandidateInterface::DegreeWizard do
 
       it { is_expected.to validate_presence_of(:degree_level).on(:degree_level) }
       it { is_expected.to validate_presence_of(:equivalent_level).on(:degree_level) }
-      it { is_expected.to validate_presence_of(:grade).on(:grade) }
       it { is_expected.to validate_presence_of(:other_grade).on(:grade) }
       it { is_expected.to validate_length_of(:other_grade).is_at_most(255).on(:grade) }
       it { is_expected.to validate_presence_of(:type).on(:type) }
+    end
+
+    context 'grade is missing for UK degree with specified grade options' do
+      let(:degree_params) { { uk_or_non_uk: 'uk', grade: nil, degree_level: 'Bachelor degree', type: 'Bachelor of Arts' } }
+
+      it 'is invalid' do
+        wizard.valid?(:grade)
+        expect(wizard.errors.full_messages).to eq(['Grade Select your degree grade'])
+      end
     end
 
     context 'other type' do

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -356,7 +356,12 @@ module CandidateHelper
     choose 'Yes'
     click_button t('save_and_continue')
 
-    choose grade
+    if has_selector?("input[type='radio'][value='#{grade}']")
+      choose grade
+    else
+      choose 'Yes'
+      fill_in 'What grade did you get?', with: grade
+    end
     click_button t('save_and_continue')
 
     fill_in t('page_titles.what_year_did_you_start_your_degree'), with: '2006'


### PR DESCRIPTION
## Context

It doesn't make sense to give Bachelor's degree options for e.g. Level 6 Diploma qualifications.

## Changes proposed in this pull request

Use the following input style for other degree type grades:

When you've completed the qualification:
![image](https://user-images.githubusercontent.com/450843/235137063-c4daf27f-b7a5-4f81-8217-1e55deede15b.png)

When you're still studying:
![image](https://user-images.githubusercontent.com/450843/235137205-d22532f7-d50c-4526-89f7-e637c826506f.png)

## Guidance to review



## Link to Trello card

https://trello.com/c/0caBkB7I/1413-fix-level-6-diploma-and-other-degree-type-grades

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
