### PR TITLE
Increase height of personal statement textarea

### DIFF
--- a/app/views/candidate_interface/personal_statement/_form.html.erb
+++ b/app/views/candidate_interface/personal_statement/_form.html.erb
@@ -10,7 +10,7 @@
 
   <p class="govuk-body">Get support with your personal statement by speaking to our <%= govuk_link_to_with_utm_params('teacher training advisers', t('get_into_teaching.url_get_an_adviser'), utm_campaign(params), current_application.phase) %>.</p>
 
-  <%= f.govuk_text_area :becoming_a_teacher, label: { text: 'Your personal statement', size: 'm' }, rows: 20, max_words: 1000 %>
+  <%= f.govuk_text_area :becoming_a_teacher, label: { text: 'Your personal statement', size: 'm' }, rows: 25, max_words: 1000 %>
 
 <% else %>
   <h1 class="govuk-heading-l">


### PR DESCRIPTION
...from 20 rows to 25 rows.

## Context

The personal statement is up to 1000 words. Whilst users can review the statement on the following page, or resize the texture themselves in some browsers, they might not know to do this.

Increasing the height of the textarea may make it easier to review the content as it is written, for those users who do this in-browser (rather than copying and pasting from elsewhere).

| Before | After |
|--------|------|
| ![before](https://user-images.githubusercontent.com/30665/234005352-b192bcc3-6e5d-4413-b277-d8431a6b8907.png) | ![after](https://user-images.githubusercontent.com/30665/234005395-ab957153-3afa-4d05-8b93-cbb220e6b1d8.png) |

