### PR TITLE
Fix degree wizard back link for PhDs

### DIFF
--- a/app/forms/candidate_interface/degree_wizard.rb
+++ b/app/forms/candidate_interface/degree_wizard.rb
@@ -202,6 +202,14 @@ module CandidateInterface
       end
     end
 
+    def start_year_back_link
+      if @wizard.reviewing_and_unchanged_country?
+        @wizard.back_to_review
+      else
+        candidate_interface_degree_grade_path
+      end
+    end
+
     def award_year_back_link
       if reviewing_and_from_wizard_page
         Rails.application.routes.url_helpers.candidate_interface_degree_completed_path

--- a/app/forms/candidate_interface/degree_wizard.rb
+++ b/app/forms/candidate_interface/degree_wizard.rb
@@ -203,10 +203,12 @@ module CandidateInterface
     end
 
     def start_year_back_link
-      if @wizard.reviewing_and_unchanged_country?
-        @wizard.back_to_review
+      if reviewing_and_unchanged_country?
+        back_to_review
+      elsif phd?
+        Rails.application.routes.url_helpers.candidate_interface_degree_completed_path
       else
-        candidate_interface_degree_grade_path
+        Rails.application.routes.url_helpers.candidate_interface_degree_grade_path
       end
     end
 

--- a/app/views/candidate_interface/degrees/degree/new_start_year.html.erb
+++ b/app/views/candidate_interface/degrees/degree/new_start_year.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
   <% content_for :title, title_with_error_prefix(t('page_titles.what_year_did_you_start_your_degree'), @wizard.errors.any?) %>
-  <% content_for :before_content, govuk_back_link_to(@wizard.reviewing_and_unchanged_country? ? @wizard.back_to_review : candidate_interface_degree_grade_path) %>
+  <% content_for :before_content, govuk_back_link_to(@wizard.start_year_back_link) %>
   <%= form_with model: @wizard, url: candidate_interface_degree_start_year_path do |f| %>
     <%= f.govuk_error_summary %>
     <%= f.govuk_text_field :start_year, label: { text: t('page_titles.what_year_did_you_start_your_degree'), size: 'l' }, hint: { text: 'For example, 1999' }, width: 4 %>

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_phd_degree_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_phd_degree_spec.rb
@@ -42,6 +42,11 @@ RSpec.feature 'Entering a PhD' do
 
     # Add start year
     then_i_can_see_the_start_year_page
+    when_i_click_the_back_link
+    then_i_can_see_the_completion_page
+    and_i_click_on_save_and_continue
+
+    then_i_can_see_the_start_year_page
     when_i_fill_in_the_start_year
     and_i_click_on_save_and_continue
 
@@ -129,6 +134,10 @@ RSpec.feature 'Entering a PhD' do
 
   def then_i_can_see_the_start_year_page
     expect(page).to have_content('What year did you start your degree?')
+  end
+
+  def when_i_click_the_back_link
+    click_on 'Back'
   end
 
   def when_i_fill_in_the_start_year


### PR DESCRIPTION
## Context

This is a follow up to https://github.com/DFE-Digital/apply-for-teacher-training/pull/8167.

This PR changes the flow of the `DegreeWizard` so that the grade page is skipped when entering the details for a PhD because they don't have grades. However it didn't properly handle the back link on the 'start date' page (the one that follows the grade page normally).

## Changes proposed in this pull request

Alter the logic for the back link on the 'start date' page to skip back to the 'completed' page iff the degree is a PhD.

## Guidance to review

- Are there any other ways to break this feature?
- Are the tests adequate?

## Link to Trello card

https://trello.com/c/z5XTrOIw/875-fix-our-masters-and-phd-grade-options-that-broke-during-our-new-degree-flow

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
