### PR TITLE
Fix Sentry error in manage for check interviews page

### DIFF
--- a/app/controllers/provider_interface/interviews/checks_controller.rb
+++ b/app/controllers/provider_interface/interviews/checks_controller.rb
@@ -4,6 +4,8 @@ module ProviderInterface
       def new
         @wizard = InterviewWizard.new(interview_store, **interview_form_context_params.merge(current_step: 'check', action:))
         @wizard.save_state!
+
+        redirect_to new_provider_interface_application_choice_interview_path if @wizard.provider.blank?
       end
 
       def edit

--- a/spec/requests/provider_interface/interviews/checks_controller_spec.rb
+++ b/spec/requests/provider_interface/interviews/checks_controller_spec.rb
@@ -16,6 +16,32 @@ RSpec.describe ProviderInterface::Interviews::ChecksController do
     user_exists_in_dfe_sign_in(email_address: provider_user.email_address)
   end
 
+  describe 'when bypass the new check interview page for accredited providers' do
+    let(:course) do
+      build(
+        :course,
+        :with_accredited_provider,
+        :with_provider_relationship_permissions,
+        :open_on_apply,
+        provider:,
+      )
+    end
+    let!(:application_choice) do
+      create(
+        :application_choice,
+        :awaiting_provider_decision,
+        application_form:,
+        course_option:,
+      )
+    end
+
+    it 'redirects to the new interview page' do
+      get new_provider_interface_application_choice_interviews_check_path(application_choice)
+
+      expect(response).to redirect_to(new_provider_interface_application_choice_interview_path(application_choice))
+    end
+  end
+
   describe 'going back when the interview store has been cleared' do
     let!(:application_choice) do
       create(:application_choice, :awaiting_provider_decision, application_form:, course_option:)

--- a/spec/requests/provider_interface/interviews/checks_controller_spec.rb
+++ b/spec/requests/provider_interface/interviews/checks_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ProviderInterface::Interviews::ChecksController do
         provider:,
       )
     end
-    let!(:application_choice) do
+    let(:application_choice) do
       create(
         :application_choice,
         :awaiting_provider_decision,


### PR DESCRIPTION
## Context

When the user goes to the /interviews/new hit continue, comes back and return to the interview page the provider id is nil and the /interviews/check required the @wizard.provider to be present.

So the solution is never to render the /interviews/check if @wizard.provider is blank and redirect to the right page that sets it.
