### PR TITLE
Spike: ApplicationChoice personal statement

### DIFF
--- a/app/controllers/candidate_interface/course_choices/course_selection_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/course_selection_controller.rb
@@ -45,9 +45,13 @@ module CandidateInterface
             course_choice_id: params[:course_choice_id],
           )
         elsif @pick_course.single_site?
-          course_option = @pick_course.available_course_options.first
-          AddOrUpdateCourseChoice.new(
-            course_option_id: course_option.id,
+          redirect_to candidate_interface_course_choices_personal_statement_path(
+            @pick_course.provider_id,
+            @pick_course.course_id,
+            @pick_course.available_study_modes_with_vacancies.first,
+            course_choice_id: params[:course_choice_id],
+          )
+          course_option = @pick_course.available_course_options.first AddOrUpdateCourseChoice.new( course_option_id: course_option.id,
             application_form: current_application,
             controller: self,
             id_of_course_choice_to_replace: params[:course_choice_id],

--- a/app/controllers/candidate_interface/course_choices/personal_statement_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/personal_statement_controller.rb
@@ -1,19 +1,29 @@
 module CandidateInterface
   module CourseChoices
     class PersonalStatementController < BaseController
-      def new; end
+      def new
+        @personal_statement_form = PersonalStatementForm.new
+      end
 
       def edit; end
 
       def create
-          course_option = @pick_course.available_course_options.first 
-          AddOrUpdateCourseChoice.new( 
-            course_option_id: course_option.id,
-            application_form: current_application,
-            personal_statement: personal_statement,
-            controller: self,
-            id_of_course_choice_to_replace: params[:course_choice_id],
-          ).call
+        @personal_statement_form = PersonalStatementForm.new(
+          personal_statement: params[:candidate_interface_personal_statement_form][:personal_statement],
+          provider_id: params[:provider_id],
+          course_id: params[:course_id],
+          study_mode: params[:study_mode],
+          site_id: params[:site_id],
+        )
+
+        course_option = @personal_statement_form.available_course_options.first
+        AddOrUpdateCourseChoice.new(
+          course_option_id: course_option.id,
+          application_form: current_application,
+          personal_statement: @personal_statement_form.personal_statement,
+          controller: self,
+          id_of_course_choice_to_replace: params[:course_choice_id],
+        ).call
       end
 
       def update; end

--- a/app/controllers/candidate_interface/course_choices/personal_statement_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/personal_statement_controller.rb
@@ -5,7 +5,16 @@ module CandidateInterface
 
       def edit; end
 
-      def create; end
+      def create
+          course_option = @pick_course.available_course_options.first 
+          AddOrUpdateCourseChoice.new( 
+            course_option_id: course_option.id,
+            application_form: current_application,
+            personal_statement: personal_statement,
+            controller: self,
+            id_of_course_choice_to_replace: params[:course_choice_id],
+          ).call
+      end
 
       def update; end
     end

--- a/app/controllers/candidate_interface/course_choices/personal_statement_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/personal_statement_controller.rb
@@ -1,0 +1,13 @@
+module CandidateInterface
+  module CourseChoices
+    class PersonalStatementController < BaseController
+      def new; end
+
+      def edit; end
+
+      def create; end
+
+      def update; end
+    end
+  end
+end

--- a/app/controllers/candidate_interface/course_choices/site_selection_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/site_selection_controller.rb
@@ -34,14 +34,10 @@ module CandidateInterface
 
         render :new and return unless @pick_site.valid?
 
-        AddOrUpdateCourseChoice
-          .new(
-            course_option_id:,
-            application_form: current_application,
-            controller: self,
-            id_of_course_choice_to_replace: params[:course_choice_id],
-          )
-          .call
+        redirect_to candidate_interface_course_choices_personal_statement_path(
+          site_id: @pick_site.course_option.site_id,
+          course_choice_id: params[:course_choice_id],
+        )
       end
 
       def update

--- a/app/controllers/candidate_interface/course_choices/study_mode_selection_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/study_mode_selection_controller.rb
@@ -34,12 +34,12 @@ module CandidateInterface
         render :new and return unless @pick_study_mode.valid?
 
         if @pick_study_mode.single_site_course?
-          AddOrUpdateCourseChoice.new(
-            course_option_id: @pick_study_mode.first_site_id,
-            application_form: current_application,
-            controller: self,
-            id_of_course_choice_to_replace: params[:course_choice_id],
-          ).call
+          redirect_to candidate_interface_course_choices_personal_statement_path(
+            @pick_study_mode.provider_id,
+            @pick_study_mode.course_id,
+            @pick_study_mode.study_mode,
+            course_choice_id: params[:course_choice_id],
+          )
         else
           redirect_to candidate_interface_course_choices_site_path(
             @pick_study_mode.provider_id,

--- a/app/forms/candidate_interface/personal_statement_form.rb
+++ b/app/forms/candidate_interface/personal_statement_form.rb
@@ -1,0 +1,11 @@
+module CandidateInterface
+  class PersonalStatementForm
+    include ActiveModel::Model
+
+    attr_accessor :personal_statement, :provider_id, :course_id, :study_mode, :site_id
+
+    def available_course_options
+      Course.find(course_id).course_options.available
+    end
+  end
+end

--- a/app/forms/candidate_interface/pick_site_form.rb
+++ b/app/forms/candidate_interface/pick_site_form.rb
@@ -2,7 +2,7 @@ module CandidateInterface
   class PickSiteForm
     include ActiveModel::Model
 
-    attr_accessor :application_form, :course_option_id
+    attr_accessor :application_form, :course_option_id, :personal_statement
     validates :course_option_id, presence: true
     validate :number_of_choices, on: :save
 
@@ -18,7 +18,7 @@ module CandidateInterface
     def save
       return unless valid?(:save)
 
-      application_form.application_choices.new.configure_initial_course_choice!(course_option, personal_statement)
+      application_form.application_choices.new.configure_initial_course_choice!(course_option, personal_statement:)
     end
 
     def update(application_choice)

--- a/app/forms/candidate_interface/pick_site_form.rb
+++ b/app/forms/candidate_interface/pick_site_form.rb
@@ -18,7 +18,7 @@ module CandidateInterface
     def save
       return unless valid?(:save)
 
-      application_form.application_choices.new.configure_initial_course_choice!(course_option)
+      application_form.application_choices.new.configure_initial_course_choice!(course_option, personal_statement)
     end
 
     def update(application_choice)
@@ -27,11 +27,12 @@ module CandidateInterface
       application_choice.configure_initial_course_choice!(course_option)
     end
 
-  private
 
     def course_option
       @course_option ||= CourseOption.find(course_option_id)
     end
+
+  private
 
     def number_of_choices
       return if application_form.can_add_more_choices?

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -211,9 +211,10 @@ class ApplicationChoice < ApplicationRecord
     )
   end
 
-  def configure_initial_course_choice!(course_option)
+  def configure_initial_course_choice!(course_option, personal_statement: nil)
     self.original_course_option = course_option
     self.course_option = course_option
+    self.personal_statement = personal_statement
 
     update_course_option_and_associated_fields!(
       course_option,

--- a/app/services/candidate_interface/add_or_update_course_choice.rb
+++ b/app/services/candidate_interface/add_or_update_course_choice.rb
@@ -1,10 +1,11 @@
 module CandidateInterface
   class AddOrUpdateCourseChoice
-    attr_reader :course_option_id, :application_form, :controller, :id_of_course_choice_to_replace
+    attr_reader :course_option_id, :application_form, :personal_statement, :controller, :id_of_course_choice_to_replace
 
-    def initialize(course_option_id:, application_form:, controller:, return_to: nil, id_of_course_choice_to_replace: nil)
+    def initialize(course_option_id:,application_form:, personal_statement: nil, controller:, return_to: nil, id_of_course_choice_to_replace: nil)
       @course_option_id = course_option_id
       @application_form = application_form
+      @personal_statement = personal_statement
       @controller = controller
       @id_of_course_choice_to_replace = id_of_course_choice_to_replace
       @return_to = return_to
@@ -55,6 +56,7 @@ module CandidateInterface
       pick_site_form = PickSiteForm.new(
         application_form:,
         course_option_id:,
+        personal_statement:,
       )
 
       if pick_site_form.save

--- a/app/views/candidate_interface/course_choices/personal_statement/new.html.erb
+++ b/app/views/candidate_interface/course_choices/personal_statement/new.html.erb
@@ -1,0 +1,37 @@
+<main class="govuk-main-wrapper " id="main-content" role="main">
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Personal statement</h1>
+
+      <p class="govuk-body">You should write between 500 and 1000 words for your personal statement.</p>
+      <p class="govuk-body">Here are some examples you could write about (they are just a guide, you do not need to write about all of them):</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>skills you have that are relevant to teaching</li>
+        <li>any experience of working with young people</li>
+        <li>your interest in SUBJECT HERE </li>
+
+        <li>your understanding of why teaching is important</li>
+        <li>your reasons for wanting to train to be a teacher</li>
+        <li>any activities you’ve done that could be relevant to teaching like first aid courses, sports coaching or volunteering</li>
+      </ul>
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-label--m govuk-!-margin-top-6" for="personal-statement">
+          Your personal statement
+        </label>
+
+        <%= govuk_text_area :personal_statement, label: { text: 'Your personal statement', size: 'm' }, rows: 25, max_words: 1000 %>
+
+    </div>
+
+    <button class="govuk-button" data-module="govuk-button">
+      Save and continue
+    </button>
+
+    <%= govuk_submit t('continue') %>
+    </form>
+  </div>
+  </div>
+
+</main>

--- a/app/views/candidate_interface/course_choices/personal_statement/new.html.erb
+++ b/app/views/candidate_interface/course_choices/personal_statement/new.html.erb
@@ -2,36 +2,34 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">Personal statement</h1>
+      <%= form_with(
+            model: @personal_statement_form,
+            url: candidate_interface_course_choices_personal_statement_path(
+              params[:provider_id], params[:course_id], params[:study_mode], course_choice_id: @course_choice_id
+            ),
+          ) do |f| %>
 
-      <p class="govuk-body">You should write between 500 and 1000 words for your personal statement.</p>
-      <p class="govuk-body">Here are some examples you could write about (they are just a guide, you do not need to write about all of them):</p>
+        <h1 class="govuk-heading-l">Personal statement</h1>
 
-      <ul class="govuk-list govuk-list--bullet">
-        <li>skills you have that are relevant to teaching</li>
-        <li>any experience of working with young people</li>
-        <li>your interest in SUBJECT HERE </li>
+        <p class="govuk-body">You should write between 500 and 1000 words for your personal statement.</p>
+        <p class="govuk-body">Here are some examples you could write about (they are just a guide, you do not need to write about all of them):</p>
 
-        <li>your understanding of why teaching is important</li>
-        <li>your reasons for wanting to train to be a teacher</li>
-        <li>any activities you’ve done that could be relevant to teaching like first aid courses, sports coaching or volunteering</li>
-      </ul>
-      <div class="govuk-form-group">
-        <label class="govuk-label govuk-label--m govuk-!-margin-top-6" for="personal-statement">
-          Your personal statement
-        </label>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>skills you have that are relevant to teaching</li>
+          <li>any experience of working with young people</li>
+          <li>your interest in SUBJECT HERE </li>
 
-        <%= govuk_text_area :personal_statement, label: { text: 'Your personal statement', size: 'm' }, rows: 25, max_words: 1000 %>
+          <li>your understanding of why teaching is important</li>
+          <li>your reasons for wanting to train to be a teacher</li>
+          <li>any activities you’ve done that could be relevant to teaching like first aid courses, sports coaching or volunteering</li>
+        </ul>
+        <div class="govuk-form-group">
+          <%= f.govuk_text_area :personal_statement, label: { text: 'Your personal statement', size: 'm' }, rows: 25, max_words: 1000 %>
+        </div>
 
+        <%= f.govuk_submit t('continue') %>
+      <% end %>
     </div>
-
-    <button class="govuk-button" data-module="govuk-button">
-      Save and continue
-    </button>
-
-    <%= govuk_submit t('continue') %>
-    </form>
-  </div>
   </div>
 
 </main>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -45,6 +45,7 @@ shared:
     - withdrawn_at
     - withdrawn_or_declined_for_candidate_by_provider
     - structured_withdrawal_reasons
+    - personal_statement
   application_experiences:
     - application_form_id
     - commitment

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -363,10 +363,10 @@ namespace :candidate_interface, path: '/candidate' do
       get '/provider/:provider_id/courses/:course_id/:study_mode/edit' => 'course_choices/site_selection#edit', as: :edit_course_choices_site
       patch '/provider/:provider_id/courses/:course_id/:study_mode/edit' => 'course_choices/site_selection#update'
 
-      get '/provider/:provider_id/courses/:course_id/:personal_statement' => 'course_choices/personal_statement#new', as: :course_choices_site
-      post '/provider/:provider_id/courses/:course_id/:personal_statement' => 'course_choices/personal_statement#create'
-      get '/provider/:provider_id/courses/:course_id/:personal_statement/edit' => 'course_choices/personal_statement#edit', as: :edit_course_choices_site
-      patch '/provider/:provider_id/courses/:course_id/:personal_statement/edit' => 'course_choices/personal_statement#update'
+      get '/provider/:provider_id/courses/:course_id/:study_mode/:site_id/personal_statement' => 'course_choices/personal_statement#new', as: :course_choices_personal_statement
+      post '/provider/:provider_id/courses/:course_id/:study_mode/:site_id/personal_statement' => 'course_choices/personal_statement#create'
+      get '/provider/:provider_id/courses/:course_id/:study_mode/:site_id/personal_statement/edit' => 'course_choices/personal_statement#edit', as: :edit_course_choices_personal_statement
+      patch '/provider/:provider_id/courses/:course_id/:study_mode/:site_id/personal_statement/edit' => 'course_choices/personal_statement#update'
 
 
       get '/another' => 'course_choices/add_another_course#ask', as: :course_choices_add_another_course

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -363,6 +363,12 @@ namespace :candidate_interface, path: '/candidate' do
       get '/provider/:provider_id/courses/:course_id/:study_mode/edit' => 'course_choices/site_selection#edit', as: :edit_course_choices_site
       patch '/provider/:provider_id/courses/:course_id/:study_mode/edit' => 'course_choices/site_selection#update'
 
+      get '/provider/:provider_id/courses/:course_id/:personal_statement' => 'course_choices/personal_statement#new', as: :course_choices_site
+      post '/provider/:provider_id/courses/:course_id/:personal_statement' => 'course_choices/personal_statement#create'
+      get '/provider/:provider_id/courses/:course_id/:personal_statement/edit' => 'course_choices/personal_statement#edit', as: :edit_course_choices_site
+      patch '/provider/:provider_id/courses/:course_id/:personal_statement/edit' => 'course_choices/personal_statement#update'
+
+
       get '/another' => 'course_choices/add_another_course#ask', as: :course_choices_add_another_course
       post '/another' => 'course_choices/add_another_course#decide', as: :course_choices_add_another_course_selection
 

--- a/db/migrate/20230425101236_add_personal_statement_to_application_choice.rb
+++ b/db/migrate/20230425101236_add_personal_statement_to_application_choice.rb
@@ -1,0 +1,5 @@
+class AddPersonalStatementToApplicationChoice < ActiveRecord::Migration[7.0]
+  def change
+    add_column :application_choices, :personal_statement, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_13_153953) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_25_101236) do
   create_sequence "qualifications_public_id_seq", start: 120000
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
+  enable_extension "plpgsql"
   enable_extension "unaccent"
 
   create_table "application_choices", force: :cascade do |t|
@@ -54,6 +55,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_13_153953) do
     t.bigint "original_course_option_id"
     t.datetime "course_changed_at"
     t.text "structured_withdrawal_reasons", default: [], array: true
+    t.text "personal_statement"
     t.index ["application_form_id", "course_option_id"], name: "index_course_option_to_application_form_id", unique: true
     t.index ["application_form_id"], name: "index_application_choices_on_application_form_id"
     t.index ["course_option_id"], name: "index_application_choices_on_course_option_id"


### PR DESCRIPTION
## SPIKE 🦧🦧🦧🦧🦧🦧🦧🦧🦧

@stevehook and I had a spike to see how easy it would be to add a personal statement section to the candidate course selection journey. This would appear as the last page.

We still need to discuss the following scenarios: 
- allowing candidates to copy over existing personal statements
- allowing candidates to return to, and complete, the personal statement at a later date

It also uncovered that the `CourseChoices` controllers probably needs a fairly significant refactor but has otherwise proved it's technically feasible. 

In terms of approaching it for when we come to actually build it, these are the following steps we recommend:
- Migration to add `personal_statement` to the `ApplicationChoice`
- Begin writing to both `ApplicationChoice.personal_statement` and `ApplicationForm.personal_statement(becoming_a_teacher)`
- Backfill `ApplicationChoice.personal_statement`
- Refactor the `CourseChoices` functionality
- Build the new personal statement section behind a feature flag, so we write to it but the candidate never sees it until we activate it (new cycle)