### PR TITLE
Add patch schedule for Azure Redis

### DIFF
--- a/terraform/modules/kubernetes/azure_redis.tf
+++ b/terraform/modules/kubernetes/azure_redis.tf
@@ -20,6 +20,11 @@ resource "azurerm_redis_cache" "redis-cache" {
     update = "30m"
   }
 
+  patch_schedule {
+    day_of_week = "Sunday"
+    start_hour_utc = 01
+  }
+
   lifecycle {
     ignore_changes = [
       tags
@@ -73,6 +78,11 @@ resource "azurerm_redis_cache" "redis-queue" {
   timeouts {
     create = "30m"
     update = "30m"
+  }
+
+  patch_schedule {
+    day_of_week = "Sunday"
+    start_hour_utc = 01
   }
 
   lifecycle {


### PR DESCRIPTION
## Context

Azure redis instances don't have a patch schedule set, which means patching can occur anytime.
Patching triggers a redis failover which can impact existing connections.

This PR adds a patch schedule to restrict patching to a time when there is low usage.
Intention is to set to:
    day_of_week = "Sunday"
    start_hour_utc = 01
    maintenance window defaults to 5 hours, which is the minimum allowed.

Only Redis server updates are made during the scheduled maintenance window. The maintenance window doesn't apply to Azure updates or updates to the host operating system.

## Changes proposed in this pull request

Update azure_redis terraform

## Guidance to review

- confirm patch window acceptable
- make env deploy-plan
- tested patch window add/modify didn't affect running instance

## Link to Trello card

https://trello.com/c/AhLkf2BG/327-apply-set-patch-schedule-for-redis

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
