### PR TITLE
Add postgres maintenance window for prod envs

### DIFF
--- a/terraform/aks/terraform.tf
+++ b/terraform/aks/terraform.tf
@@ -36,6 +36,7 @@ module "kubernetes" {
   config_short                        = var.config_short
   service_short                       = var.service_short
   deploy_snapshot_database            = var.deploy_snapshot_database
+  azure_maintenance_window            = var.azure_maintenance_window
 }
 
 module "statuscake" {

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -93,6 +93,7 @@ variable "redis_sku_name" { default = "Standard" }
 variable "pdb_min_available" { default = null }
 variable "config_short" {}
 variable "service_short" {}
+variable "azure_maintenance_window" { default = null }
 
 locals {
   app_name_suffix = var.app_name_suffix != null ? var.app_name_suffix : var.paas_app_environment

--- a/terraform/aks/workspace_variables/production_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/production_aks.tfvars.json
@@ -26,6 +26,11 @@
   "enable_alerting": true,
   "pg_actiongroup_name": "s189p01-att-production-ag",
   "pg_actiongroup_rg": "s189p01-att-pd-rg",
+  "azure_maintenance_window": {
+    "day_of_week": 0,
+    "start_hour": 3,
+    "start_minute": 0
+  },
   "statuscake_alerts": {
     "apply-production": {
       "website_name": "Apply-Teacher-Training-AKS-Production",

--- a/terraform/aks/workspace_variables/sandbox_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/sandbox_aks.tfvars.json
@@ -24,6 +24,11 @@
   "pg_actiongroup_name": "s189p01-att-production-ag",
   "pg_actiongroup_rg": "s189p01-att-pd-rg",
   "pdb_min_available": "50%",
+  "azure_maintenance_window": {
+    "day_of_week": 0,
+    "start_hour": 2,
+    "start_minute": 0
+  },
   "statuscake_alerts": {
     "apply-sandbox": {
       "website_name": "Apply-Teacher-Training-AKS-Sandbox",

--- a/terraform/modules/kubernetes/azure_postgres.tf
+++ b/terraform/modules/kubernetes/azure_postgres.tf
@@ -18,6 +18,16 @@ resource "azurerm_postgresql_flexible_server" "postgres-server" {
       mode = "ZoneRedundant"
     }
   }
+
+  dynamic "maintenance_window" {
+    for_each = var.azure_maintenance_window != null ? [var.azure_maintenance_window] : []
+    content {
+      day_of_week  = maintenance_window.value.day_of_week
+      start_hour   = maintenance_window.value.start_hour
+      start_minute = maintenance_window.value.start_minute
+    }
+  }
+
   lifecycle {
     ignore_changes = [
       tags,

--- a/terraform/modules/kubernetes/variables.tf
+++ b/terraform/modules/kubernetes/variables.tf
@@ -99,6 +99,7 @@ variable "pdb_min_available" {
 variable "config_short" {}
 variable "service_short" {}
 variable "deploy_snapshot_database" { default = false}
+variable "azure_maintenance_window" {}
 
 locals {
   app_config_name                      = "apply-config-${var.app_environment}"


### PR DESCRIPTION
## Context

Azure postgres instances don't have a maintenance window set, which means maintenance can occur anytime between 11pm and 7am daily.
Maintenance can cause a db restart or failover, with some downtime depending on ha settings.

This PR adds a maintenance window to restrict maintenance to a time when there is low usage for production environments.
Intention is to set to:

    day_of_week = 0 (Sunday)
    start_hour = 2 (sandbox) or 3 (prod)
    start_minute = 0
    the maintenance window is set to 1 hour

"As part of rolling out changes, we apply the updates to the servers configured with system-managed schedule first followed by servers with custom schedule after a minimum gap of 7-days within a given region."
- non prod envs will use a system managed schedule (between 11pm and 7am daily)

"Normally there are at least 30 days between successful scheduled maintenance events for a server.
However, in case of a critical emergency update such as a severe vulnerability, the notification window could be shorter than five days or be omitted. The critical update may be applied to your server even if a successful scheduled maintenance was performed in the last 30 days."

## Changes proposed in this pull request

terraform updates

## Guidance to review

- confirm patch window acceptable
- make env deploy-plan
- tested maintenance window add/modify didn't affect running instance

## Link to Trello card

https://trello.com/c/iy1syxPK/330-apply-and-postgres-patch-window

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
