### PR TITLE
Fix bug in validators for SKE conditions

### DIFF
--- a/app/services/offer_validations.rb
+++ b/app/services/offer_validations.rb
@@ -46,7 +46,7 @@ class OfferValidations
   end
 
   def new_ske_condition_details
-    (ske_conditions || []).map { |condition| condition.details.symbolize_keys.slice(:length, :reason, :subject) }.sort { |hash1, hash2| hash1[:name] <=> hash2[:name] }
+    (ske_conditions || []).map { |condition| condition.details.symbolize_keys.slice(:length, :reason, :subject) }.sort_by { |hash| hash[:name] }
   end
 
   def ratifying_provider_changed?

--- a/app/services/offer_validations.rb
+++ b/app/services/offer_validations.rb
@@ -42,11 +42,11 @@ class OfferValidations
   end
 
   def existing_ske_condition_details
-    application_choice.offer.ske_conditions.map { |condition| condition.details.symbolize_keys.slice(:length, :reason, :subject) }.sort
+    application_choice.offer.ske_conditions.map { |condition| condition.details.symbolize_keys.slice(:length, :reason, :subject) }.sort { |hash1, hash2| hash1[:name] <=> hash2[:name] }
   end
 
   def new_ske_condition_details
-    (ske_conditions || []).map { |condition| condition.details.symbolize_keys.slice(:length, :reason, :subject) }.sort
+    (ske_conditions || []).map { |condition| condition.details.symbolize_keys.slice(:length, :reason, :subject) }.sort { |hash1, hash2| hash1[:name] <=> hash2[:name] }
   end
 
   def ratifying_provider_changed?

--- a/spec/services/offer_validations_spec.rb
+++ b/spec/services/offer_validations_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe OfferValidations, type: :model do
         let(:course_option) { application_choice.course_option }
         let(:conditions) { application_choice.offer.conditions_text }
         let(:ske_conditions) { [build(:ske_condition)] }
-        let(:new_ske_conditions) { [build(:ske_condition, length: '12')] }
+        let(:new_ske_conditions) { [build(:ske_condition, length: '8'), build(:ske_condition, length: '12')] }
 
         subject(:offer) { described_class.new(application_choice:, course_option:, conditions:, ske_conditions: new_ske_conditions) }
 


### PR DESCRIPTION
## Context

I spotted this when testing another PR. It was introduced with SKE conditions, specifically in the validation rules we apply when modifying the conditions.

## Changes proposed in this pull request

Calling `sort` on an array of `Hash`es causes an `sort': comparison of Hash with Hash failed (ArgumentError)` exception. So we have to define exactly how we sort the SKE conditions - by name seems sensible.

## Guidance to review

Does this seem reasonable?

## Link to Trello card

n/a

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
