### PR TITLE
Data migration to update support users' email addresses (#1420)

### DIFF
--- a/app/services/data_migrations/modify_digital_email_addresses.rb
+++ b/app/services/data_migrations/modify_digital_email_addresses.rb
@@ -1,0 +1,16 @@
+module DataMigrations
+  class ModifyDigitalEmailAddresses
+    TIMESTAMP = 20230427174430
+    MANUAL_RUN = false
+
+    def change
+      SupportUser.where("email_address LIKE '%@digital.education.gov.uk'").each do |support_user|
+        new_email = support_user.email_address.gsub(
+          '@digital.education.gov.uk',
+          '@education.gov.uk',
+        )
+        support_user.update(email_address: new_email)
+      end
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::ModifyDigitalEmailAddresses',
   'DataMigrations::StoreEnumForSkeReason',
   'DataMigrations::SetMissingSectionCompletedAtTimestamps',
   'DataMigrations::PopulateSectionCompletedAts',

--- a/spec/services/data_migrations/modify_digital_email_addresses_spec.rb
+++ b/spec/services/data_migrations/modify_digital_email_addresses_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::ModifyDigitalEmailAddresses do
+  let!(:support_users) do
+    [
+      create(:support_user, email_address: 'kuldip@digital.education.gov.uk'),
+      create(:support_user, email_address: 'sanjeema@digital.education.gov.uk'),
+      create(:support_user, email_address: 'prakash@education.gov.uk'),
+    ]
+  end
+
+  it "updates support users' @digital email addresses to their @education equivalents" do
+    described_class.new.change
+
+    expect(support_users.map(&:reload).map(&:email_address)).to eq([
+      'kuldip@education.gov.uk',
+      'sanjeema@education.gov.uk',
+      'prakash@education.gov.uk',
+    ])
+  end
+end


### PR DESCRIPTION
## Context

We no longer have `@digital.education.gov.uk` email addresses. These will have changed in DSE sign-in to their `@education.gov.uk` equivalents, but this isn't automatically reflected in Apply Support.

## Changes proposed in this pull request

Data migration to update all `@digital.education.gov.uk` email addresses to `@education.gov.uk`.

## Guidance to review

Whatchu think

## Link to Trello card

https://trello.com/c/kJhfXV3l/1420-update-support-users-to-reflect-their-new-email-addresses-replace-digitaleducation-with-education

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
