### PR TITLE
Correction to dfe-analytics Gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -144,7 +144,7 @@ gem 'colorize'
 gem 'rack-mini-profiler', require: ['prepend_net_http_patch']
 
 # BigQuery
-gem 'dfe-analytics', github: 'DFE-Digital/dfe-analytics', tag: 'v1.9.0'
+gem 'dfe-analytics', github: 'DFE-Digital/dfe-analytics', tag: 'v1.8.1'
 
 group :development do
   gem 'listen', '>= 3.0.5', '< 3.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/DFE-Digital/dfe-analytics.git
-  revision: fb72ceb04923ed28313c1c0ab053b95dccd772d0
-  tag: v1.9.0
+  revision: 528b82c6f694d3c23b3b23882a20124a20e1c756
+  tag: v1.8.1
   specs:
-    dfe-analytics (1.9.0)
+    dfe-analytics (1.8.1)
       google-cloud-bigquery (~> 1.38)
       request_store_rails (~> 2)
 


### PR DESCRIPTION
## Context

It seems dependabot got ahead of the current version of the `dfe-analytics` gem. 1.8.1 is the current version.

## Changes proposed in this pull request

Fix Gemfile.

## Guidance to review

Does `bundle install` work now?

## Link to Trello card

n/a

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
