### PR TITLE
Remove IE8 styles

### DIFF
--- a/app/frontend/styles/_contents-list.scss
+++ b/app/frontend/styles/_contents-list.scss
@@ -74,16 +74,4 @@
       right: 0;
     }
   }
-
-  // Focus styles on IE8 and older include the
-  // left margin, creating an odd white box with
-  // orange border around the em dash.
-  // Use inline-block and vertical alignment to
-  // fix focus styles
-  //
-  // https://github.com/alphagov/government-frontend/pull/420#issuecomment-320632386
-  .lte-ie8 & .app-contents-list__link {
-    display: inline-block;
-    vertical-align: top;
-  }
 }

--- a/app/frontend/styles/_tab-navigation.scss
+++ b/app/frontend/styles/_tab-navigation.scss
@@ -12,11 +12,6 @@
     box-shadow: inset 0 -1px 0 $govuk-border-colour;
     width: 100%;
   }
-
-  // IE8 does not support box shadow, so use a standard border.
-  @include govuk-if-ie8 {
-    border-bottom: 1px solid $govuk-border-colour;
-  }
 }
 
 .app-tab-navigation__item {


### PR DESCRIPTION
The next main release of GOV.UK Frontend will remove support for Internet Explorer 8 (IE8), and IE8 support has long been [dropped from the service manual](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices).

The `govuk-if-ie8` SASS mixin was deprecated from [govuk-frontend v4.6.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.6.0).