### PR TITLE
Remove compatability-mode styles

### DIFF
--- a/app/frontend/styles/support/_button.scss
+++ b/app/frontend/styles/support/_button.scss
@@ -17,17 +17,6 @@ $app-button-tertiary-button-text-colour: govuk-colour("white");
     color: $app-button-tertiary-button-text-colour;
   }
 
-  // alphagov/govuk_template includes a specific a:link:focus selector
-  // designed to make unvisited links a slightly darker blue when focussed, so
-  // we need to override the text colour for that combination of selectors so
-  // so that unvisited links styled as buttons do not end up with dark blue
-  // text when focussed.
-  @include govuk-compatibility(govuk_template) {
-    &:link:focus {
-      color: $app-button-tertiary-button-text-colour;
-    }
-  }
-
   &:hover {
     background-color: $app-button-tertiary-button-hover-colour;
 


### PR DESCRIPTION
These styles throw a warning:

> WARNING: govuk-compatibility is deprecated. From version 5.0, GOV.UK Frontend will not support compatibility mode. To silence this warning, update $govuk-suppressed-warnings with key: "compatibility-helper"

...I think they can be safely removed now?