### PR TITLE
Support: Add visa sponsorship info to course details page

### DIFF
--- a/app/components/support_interface/course_details_component.rb
+++ b/app/components/support_interface/course_details_component.rb
@@ -63,6 +63,14 @@ module SupportInterface
           value: course.financial_support || 'None',
         },
         {
+          key: 'Can sponsor student visas?',
+          value: course.can_sponsor_student_visa? ? 'Yes' : 'No',
+        },
+        {
+          key: 'Can sponsor skilled worker visas?',
+          value: course.can_sponsor_skilled_worker_visa? ? 'Yes' : 'No',
+        },
+        {
           key: 'Course in previous cycle',
           value: course.in_previous_cycle ? govuk_link_to(course.in_previous_cycle.year_name_and_code, support_interface_course_path(course.in_previous_cycle)) : 'None',
         },


### PR DESCRIPTION
## Context

We [recently](https://github.com/DFE-Digital/apply-for-teacher-training/pull/8139) started syncing visa sponsorship at a `Course` level. It would be good to see this in the Support interface.

## Changes proposed in this pull request

Add "Can sponsor student visas?" and "Can sponsor skilled worker visas?" fields to Support interface course details page.

## Link to Trello card

https://trello.com/c/Yt55k8yM/1373-add-visa-sponsorship-for-courses-in-support-interface

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
