### PR TITLE
Remove guidance

### DIFF
--- a/app/views/provider_interface/application_data_export/new.html.erb
+++ b/app/views/provider_interface/application_data_export/new.html.erb
@@ -37,10 +37,6 @@
         <%= f.govuk_collection_check_boxes :provider_ids, @application_data_export_form.providers_that_actor_belongs_to.order('name ASC'), ->(p) { p.id.to_s }, :name, legend: { text: 'Organisation', size: 'm' } %>
       <% end %>
 
-      <div class="govuk-inset-text">
-        Sex, disability and ethnicity information will be marked as confidential if you do not have permission to view it, or if the candidate has not accepted your offer.
-      </div>
-
       <%= f.govuk_submit 'Export application data (CSV)' %>
 
       <p class="govuk-body">

--- a/spec/system/provider_interface/provider_reports_page_spec.rb
+++ b/spec/system/provider_interface/provider_reports_page_spec.rb
@@ -59,7 +59,6 @@ RSpec.feature 'Provider reports page' do
   def then_i_should_be_on_the_data_export_page
     expect(page).to have_current_path(provider_interface_new_application_data_export_path)
     expect(page).to have_content('Export application data (CSV)')
-    expect(page).to have_content('Sex, disability and ethnicity information will be marked as confidential')
   end
 
   def then_i_should_see_links_for_all_the_provider_status_application_records


### PR DESCRIPTION
## Context

We added this guidance but it appears we never added any diversity data.

We did discuss pointing to the new (incoming) diversity report, but this will appear on the page before this one, so I think ok just to remove this guidance for now?

_Old guidance lingers,
Unneeded on the page now,
Clearer path ahead._

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="719" alt="image" src="https://user-images.githubusercontent.com/47917431/235679481-15e9f04f-5043-4216-b883-e74ed440a3ea.png">|<img width="560" alt="image" src="https://user-images.githubusercontent.com/47917431/235679418-939e5a66-e35b-431c-ac88-e75509a9c2ac.png">|

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/raEWaBVf/

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
