### PR TITLE
Add delete reference button to support UI

### DIFF
--- a/app/components/support_interface/reference_with_feedback_component.html.erb
+++ b/app/components/support_interface/reference_with_feedback_component.html.erb
@@ -1,13 +1,24 @@
 <div data-qa="reference">
   <%= render SummaryCardComponent.new(rows: rows, editable: true) do %>
     <%= render(SummaryCardHeaderComponent.new(title: title, heading_level: 3)) do %>
-      <% if @editable && reference.feedback_refused? %>
-        <div class='app-summary-card__actions'>
-          <%= govuk_link_to support_interface_reinstate_reference_path(reference) do %>
-          Undo refusal<span class="govuk-visually-hidden"> for <%= reference.name %></span>
+      <div class="app-summary-card__actions">
+        <ul class="app-summary-card__actions-list">
+          <% if @editable && true %>
+            <li class="app-summary-card__actions-list-item">
+              <%= govuk_link_to support_interface_destroy_reference_path(reference) do %>
+                <%= t('application_form.references.delete_reference.action') %>
+              <% end %>
+            </li>
+            <% if @editable && reference.feedback_refused? %>
+              <li class="app-summary-card__actions-list-item">
+                <%= govuk_link_to support_interface_reinstate_reference_path(reference) do %>
+                Undo refusal<span class="govuk-visually-hidden"> for <%= reference.name %></span>
+                <% end %>
+              </li>
+            <% end %>
           <% end %>
-        </div>
-      <% end %>
+        </ul>
+      </div>
     <% end %>
   <% end %>
 </div>

--- a/app/controllers/support_interface/references_controller.rb
+++ b/app/controllers/support_interface/references_controller.rb
@@ -20,10 +20,18 @@ module SupportInterface
       redirect_to referee_interface_refuse_feedback_path(token: @reference.refresh_feedback_token!)
     end
 
-    def destroy; end
+    def destroy
+      @form = SupportInterface::ApplicationForms::DeleteReferenceForm.new(reference: @reference)
+    end
 
     def confirm_destroy
-      # TODO:
+      @form = SupportInterface::ApplicationForms::DeleteReferenceForm.new(delete_reference_params)
+      if @form.save(actor: current_support_user, reference: @reference)
+        flash[:success] = 'Reference deleted'
+        redirect_to support_interface_application_form_path(@reference.application_form)
+      else
+        render :destroy
+      end
     end
 
   private
@@ -34,9 +42,13 @@ module SupportInterface
 
     def redirect_to_application_form_path_unless_feedback_requested_and_test_environment
       unless @reference.feedback_requested? && HostingEnvironment.test_environment?
-        redirect_to support_interface_application_form_path(reference.application_form) and
-          return
+        redirect_to support_interface_application_form_path(reference.application_form) and return
       end
+    end
+
+    def delete_reference_params
+      params.require(:support_interface_application_forms_delete_reference_form)
+            .permit(:accept_guidance, :audit_comment_ticket)
     end
   end
 end

--- a/app/controllers/support_interface/references_controller.rb
+++ b/app/controllers/support_interface/references_controller.rb
@@ -20,6 +20,12 @@ module SupportInterface
       redirect_to referee_interface_refuse_feedback_path(token: @reference.refresh_feedback_token!)
     end
 
+    def destroy; end
+
+    def confirm_destroy
+      # TODO:
+    end
+
   private
 
     def build_reference

--- a/app/forms/support_interface/application_forms/delete_reference_form.rb
+++ b/app/forms/support_interface/application_forms/delete_reference_form.rb
@@ -1,0 +1,25 @@
+module SupportInterface
+  module ApplicationForms
+    class DeleteReferenceForm
+      include ActiveModel::Model
+
+      attr_accessor :reference, :accept_guidance, :audit_comment_ticket
+
+      validates :accept_guidance, presence: true
+      validates :audit_comment_ticket, presence: true
+      validates_with ZendeskUrlValidator
+
+      def save(actor:, reference:)
+        @reference = reference
+
+        return false unless valid?
+
+        SupportInterface::DeleteReference.new.call!(
+          actor:,
+          reference:,
+          zendesk_url: audit_comment_ticket,
+        )
+      end
+    end
+  end
+end

--- a/app/services/support_interface/delete_reference.rb
+++ b/app/services/support_interface/delete_reference.rb
@@ -1,0 +1,14 @@
+module SupportInterface
+  class DeleteReference
+    include ImpersonationAuditHelper
+
+    def call!(actor:, reference:, zendesk_url: audit_comment_ticket)
+      audit(actor) do
+        ActiveRecord::Base.transaction do
+          reference.audit_comment = "Data deletion request: #{zendesk_url}"
+          reference.destroy!
+        end
+      end
+    end
+  end
+end

--- a/app/views/support_interface/references/destroy.html.erb
+++ b/app/views/support_interface/references/destroy.html.erb
@@ -1,0 +1,43 @@
+<% content_for :browser_title, 'Delete reference' %>
+<% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(@reference.application_form)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      Are you sure you want to delete the reference from <%= @reference.name %>?
+    </h1>
+
+    <p class="govuk-body">
+      This operation cannot be undone.
+    </p>
+
+    <%= render(SummaryCardComponent.new(rows: [
+    {
+      key: 'Reference name',
+      value: @reference.name,
+    },
+    {
+      key: 'Reference email address',
+      value: @reference.email_address,
+    },
+    ])) %>
+
+    <%= form_with model: @reference, url: support_interface_destroy_reference_path(@reference), method: :post do |f| %>
+      <%= f.govuk_text_field(
+        :audit_comment_ticket,
+        label: {
+          text: t('support_interface.audit_comment_ticket.label'),
+          size: 'm',
+        },
+        rows: 1,
+        hint: { text: t('support_interface.audit_comment_ticket.hint') },
+      ) %>
+
+      <%= f.govuk_check_boxes_fieldset :accept_guidance, legend: nil do %>
+        <%= f.govuk_check_box :accept_guidance, true, multiple: false, label: { text: 'I have read the guidance' }, link_errors: true %>
+      <% end %>
+
+      <%= f.govuk_submit 'Permanently delete reference' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/references/destroy.html.erb
+++ b/app/views/support_interface/references/destroy.html.erb
@@ -22,8 +22,12 @@
     },
     ])) %>
 
-    <%= form_with model: @reference, url: support_interface_destroy_reference_path(@reference), method: :post do |f| %>
-      <%= f.govuk_text_field(
+    <%= form_with(
+      model: @form,
+      url: support_interface_destroy_reference_path(@form.reference),
+      method: :post,
+    ) do |form_builder| %>
+      <%= form_builder.govuk_text_field(
         :audit_comment_ticket,
         label: {
           text: t('support_interface.audit_comment_ticket.label'),
@@ -33,11 +37,11 @@
         hint: { text: t('support_interface.audit_comment_ticket.hint') },
       ) %>
 
-      <%= f.govuk_check_boxes_fieldset :accept_guidance, legend: nil do %>
-        <%= f.govuk_check_box :accept_guidance, true, multiple: false, label: { text: 'I have read the guidance' }, link_errors: true %>
+      <%= form_builder.govuk_check_boxes_fieldset :accept_guidance, legend: nil do %>
+        <%= form_builder.govuk_check_box :accept_guidance, true, multiple: false, label: { text: 'I have read the guidance' }, link_errors: true %>
       <% end %>
 
-      <%= f.govuk_submit 'Permanently delete reference' %>
+      <%= form_builder.govuk_submit 'Permanently delete reference' %>
     <% end %>
   </div>
 </div>

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -305,6 +305,13 @@ en:
             audit_comment_ticket:
               blank: Enter a Zendesk ticket URL
               invalid: Enter a valid Zendesk ticket URL
+        support_interface/application_forms/delete_reference_form:
+          attributes:
+            accept_guidance:
+              blank: Select that you have read the guidance
+            audit_comment_ticket:
+              blank: Enter a Zendesk ticket URL
+              invalid: Enter a valid Zendesk ticket URL
         support_interface/remove_access_form:
           attributes:
             accept_guidance:

--- a/config/routes/support.rb
+++ b/config/routes/support.rb
@@ -113,6 +113,8 @@ namespace :support_interface, path: '/support' do
     post '/cancel' => 'references#confirm_cancel'
     get '/reinstate' => 'references#reinstate', as: :reinstate_reference
     post '/reinstate' => 'references#confirm_reinstate'
+    get '/destroy' => 'references#destroy', as: :destroy_reference
+    post '/destroy' => 'references#confirm_destroy'
     get '/impersonate-and-give' => 'references#impersonate_and_give', as: :impersonate_referee_and_give_reference
     get 'impersonate-and-decline' => 'references#impersonate_and_decline', as: :impersonate_referee_and_decline_reference
   end

--- a/spec/system/support_interface/delete_application_spec.rb
+++ b/spec/system/support_interface/delete_application_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'Delete a candidate application (by anonymising all of their data)' do
   include DfESignInHelpers
+  include CandidateHelper
 
   scenario 'Delete a candidate application', with_audited: true do
     given_i_am_a_support_user
@@ -44,8 +45,12 @@ RSpec.feature 'Delete a candidate application (by anonymising all of their data)
     @candidate_last_name = @application_form.last_name
     @candidate_dob = @application_form.date_of_birth.to_fs(:govuk_date)
     @candidate_email = @application_form.candidate.email_address
-    expect(page).to have_content(@candidate_first_name)
-    expect(page).to have_content(@candidate_last_name)
+    within_summary_row 'First name' do
+      expect(page).to have_content(@candidate_first_name)
+    end
+    within_summary_row 'Last name' do
+      expect(page).to have_content(@candidate_last_name)
+    end
     expect(page).to have_content(@candidate_dob)
   end
 
@@ -90,9 +95,15 @@ RSpec.feature 'Delete a candidate application (by anonymising all of their data)
   end
 
   def and_the_application_is_now_deleted
-    expect(page).not_to have_content(@candidate_first_name)
-    expect(page).not_to have_content(@candidate_last_name)
-    expect(page).not_to have_content(@candidate_dob)
     expect(page).not_to have_content(@candidate_email)
+    within_summary_row 'First name' do
+      expect(page).not_to have_content(@candidate_first_name)
+    end
+    within_summary_row 'Last name' do
+      expect(page).not_to have_content(@candidate_last_name)
+    end
+    within_summary_row 'Date of birth' do
+      expect(page).not_to have_content(@candidate_dob)
+    end
   end
 end

--- a/spec/system/support_interface/delete_reference_spec.rb
+++ b/spec/system/support_interface/delete_reference_spec.rb
@@ -1,0 +1,122 @@
+require 'rails_helper'
+
+RSpec.feature 'Deleting references' do
+  include DfESignInHelpers
+  include CandidateHelper
+
+  it 'Support user deletes a reference', with_audited: true do
+    given_i_am_a_support_user
+    and_an_application_exists_with_reference
+
+    when_i_visit_the_application_page
+    and_i_click_the_delete_link_next_to_reference
+    then_i_should_see_a_confirmation_form
+
+    # when_i_submit_the_update_form
+    # then_i_should_see_blank_audit_comment_error_message
+
+    # when_i_complete_the_details_form
+    # and_i_submit_the_update_form
+    # then_i_should_see_a_flash_message
+    # and_i_should_see_the_new_details
+    # and_i_should_see_my_details_comment_in_the_audit_log
+
+    # when_i_visit_the_application_page
+    # and_i_click_the_change_link_next_to_feedback
+    # then_i_should_see_the_feedback_form
+
+    # when_i_submit_the_update_form
+    # then_i_should_see_relevant_blank_error_messages
+
+    # when_i_complete_the_feedback_form
+    # and_i_submit_the_update_form
+    # then_i_should_see_a_flash_message
+    # and_i_should_see_the_new_feedback
+    # and_i_should_see_my_feedback_comment_in_the_audit_log
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_an_application_exists_with_reference
+    @form = create(:application_form, :with_completed_references)
+    @reference = create(:reference, :feedback_requested, name: 'Dumbledore', email_address: 'a.dumbledore@hogwarts.ac.uk', relationship: 'Headmaster', application_form: @form)
+  end
+
+  def when_i_visit_the_application_page
+    visit support_interface_application_form_path(@form)
+  end
+
+  def and_i_click_the_delete_link_next_to_reference
+    within_summary_card('Dumbledore') do
+      click_link 'Delete'
+    end
+  end
+
+  def then_i_should_see_a_confirmation_form
+    expect(page).to have_content('Are you sure you want to delete the reference from Dumbledore?')
+  end
+
+  # def when_i_submit_the_update_form
+  #   click_button 'Update'
+  # end
+  # alias_method :and_i_submit_the_update_form, :when_i_submit_the_update_form
+
+  # def then_i_should_see_blank_audit_comment_error_message
+  #   expect(page).to have_content t('activemodel.errors.models.support_interface/application_forms/edit_reference_details_form.attributes.audit_comment.blank')
+  # end
+
+  # def when_i_complete_the_details_form
+  #   fill_in 'support_interface_application_forms_edit_reference_details_form[name]', with: 'McGonagall'
+  #   fill_in 'support_interface_application_forms_edit_reference_details_form[email_address]', with: 'm.mcgonagall@hogwarts.ac.uk'
+  #   fill_in 'support_interface_application_forms_edit_reference_details_form[relationship]', with: 'Head of House'
+  #   fill_in 'support_interface_application_forms_edit_reference_details_form[audit_comment]', with: 'Updated as part of Zen Desk ticket #12345'
+  # end
+
+  # def then_i_should_see_a_flash_message
+  #   expect(page).to have_content 'Reference updated'
+  # end
+
+  # def and_i_should_see_the_new_details
+  #   expect(page).to have_content 'McGonagall'
+  #   expect(page).to have_content 'm.mcgonagall@hogwarts.ac.uk'
+  #   expect(page).to have_content 'Head of House'
+  # end
+
+  # def and_i_should_see_my_details_comment_in_the_audit_log
+  #   click_on 'History'
+  #   expect(page).to have_content 'Updated as part of Zen Desk ticket #12345'
+  # end
+
+  # def and_i_click_the_change_link_next_to_feedback
+  #   within_summary_card('McGonagall') do
+  #     click_link 'Add reference'
+  #   end
+  # end
+
+  # def then_i_should_see_the_feedback_form
+  #   expect(page).to have_content('Edit reference feedback')
+  # end
+
+  # def then_i_should_see_relevant_blank_error_messages
+  #   expect(page).to have_content t('activemodel.errors.models.support_interface/application_forms/edit_reference_feedback_form.attributes.feedback.blank')
+  #   expect(page).to have_content t('activemodel.errors.models.support_interface/application_forms/edit_reference_feedback_form.attributes.audit_comment.blank')
+  #   expect(page).to have_content t('activemodel.errors.models.support_interface/application_forms/edit_reference_feedback_form.attributes.send_emails.blank')
+  # end
+
+  # def when_i_complete_the_feedback_form
+  #   fill_in 'support_interface_application_forms_edit_reference_feedback_form[feedback]', with: 'Harry is a good egg'
+  #   fill_in 'support_interface_application_forms_edit_reference_feedback_form[audit_comment]', with: 'Updated as part of Zen Desk ticket #12346'
+  #   choose 'Yes'
+  # end
+
+  # def and_i_should_see_the_new_feedback
+  #   expect(page).to have_content 'Harry is a good egg'
+  # end
+
+  # def and_i_should_see_my_feedback_comment_in_the_audit_log
+  #   click_on 'History'
+  #   expect(page).to have_content 'Updated as part of Zen Desk ticket #12346'
+  # end
+end

--- a/spec/system/support_interface/delete_reference_spec.rb
+++ b/spec/system/support_interface/delete_reference_spec.rb
@@ -12,27 +12,14 @@ RSpec.feature 'Deleting references' do
     and_i_click_the_delete_link_next_to_reference
     then_i_should_see_a_confirmation_form
 
-    # when_i_submit_the_update_form
-    # then_i_should_see_blank_audit_comment_error_message
+    when_i_submit_the_confirmation_form
+    then_i_should_see_blank_zendesk_url_error_message
 
-    # when_i_complete_the_details_form
-    # and_i_submit_the_update_form
-    # then_i_should_see_a_flash_message
-    # and_i_should_see_the_new_details
-    # and_i_should_see_my_details_comment_in_the_audit_log
-
-    # when_i_visit_the_application_page
-    # and_i_click_the_change_link_next_to_feedback
-    # then_i_should_see_the_feedback_form
-
-    # when_i_submit_the_update_form
-    # then_i_should_see_relevant_blank_error_messages
-
-    # when_i_complete_the_feedback_form
-    # and_i_submit_the_update_form
-    # then_i_should_see_a_flash_message
-    # and_i_should_see_the_new_feedback
-    # and_i_should_see_my_feedback_comment_in_the_audit_log
+    when_i_complete_the_confirmation_form
+    when_i_submit_the_confirmation_form
+    then_i_should_see_a_flash_message
+    and_i_should_not_see_the_deleted_reference_details
+    and_i_should_see_my_zendesk_ticket_in_the_audit_log
   end
 
   def given_i_am_a_support_user
@@ -58,65 +45,30 @@ RSpec.feature 'Deleting references' do
     expect(page).to have_content('Are you sure you want to delete the reference from Dumbledore?')
   end
 
-  # def when_i_submit_the_update_form
-  #   click_button 'Update'
-  # end
-  # alias_method :and_i_submit_the_update_form, :when_i_submit_the_update_form
+  def when_i_submit_the_confirmation_form
+    click_button 'Permanently delete reference'
+  end
 
-  # def then_i_should_see_blank_audit_comment_error_message
-  #   expect(page).to have_content t('activemodel.errors.models.support_interface/application_forms/edit_reference_details_form.attributes.audit_comment.blank')
-  # end
+  def then_i_should_see_blank_zendesk_url_error_message
+    expect(page).to have_content('Enter a Zendesk ticket URL')
+  end
 
-  # def when_i_complete_the_details_form
-  #   fill_in 'support_interface_application_forms_edit_reference_details_form[name]', with: 'McGonagall'
-  #   fill_in 'support_interface_application_forms_edit_reference_details_form[email_address]', with: 'm.mcgonagall@hogwarts.ac.uk'
-  #   fill_in 'support_interface_application_forms_edit_reference_details_form[relationship]', with: 'Head of House'
-  #   fill_in 'support_interface_application_forms_edit_reference_details_form[audit_comment]', with: 'Updated as part of Zen Desk ticket #12345'
-  # end
+  def when_i_complete_the_confirmation_form
+    fill_in 'Zendesk ticket URL', with: 'https://becomingateacher.zendesk.com/agent/tickets/12345'
+    check 'I have read the guidance'
+  end
 
-  # def then_i_should_see_a_flash_message
-  #   expect(page).to have_content 'Reference updated'
-  # end
+  def then_i_should_see_a_flash_message
+    expect(page).to have_content 'Reference deleted'
+  end
 
-  # def and_i_should_see_the_new_details
-  #   expect(page).to have_content 'McGonagall'
-  #   expect(page).to have_content 'm.mcgonagall@hogwarts.ac.uk'
-  #   expect(page).to have_content 'Head of House'
-  # end
+  def and_i_should_not_see_the_deleted_reference_details
+    expect(page).not_to have_content 'Dumbledore'
+  end
 
-  # def and_i_should_see_my_details_comment_in_the_audit_log
-  #   click_on 'History'
-  #   expect(page).to have_content 'Updated as part of Zen Desk ticket #12345'
-  # end
-
-  # def and_i_click_the_change_link_next_to_feedback
-  #   within_summary_card('McGonagall') do
-  #     click_link 'Add reference'
-  #   end
-  # end
-
-  # def then_i_should_see_the_feedback_form
-  #   expect(page).to have_content('Edit reference feedback')
-  # end
-
-  # def then_i_should_see_relevant_blank_error_messages
-  #   expect(page).to have_content t('activemodel.errors.models.support_interface/application_forms/edit_reference_feedback_form.attributes.feedback.blank')
-  #   expect(page).to have_content t('activemodel.errors.models.support_interface/application_forms/edit_reference_feedback_form.attributes.audit_comment.blank')
-  #   expect(page).to have_content t('activemodel.errors.models.support_interface/application_forms/edit_reference_feedback_form.attributes.send_emails.blank')
-  # end
-
-  # def when_i_complete_the_feedback_form
-  #   fill_in 'support_interface_application_forms_edit_reference_feedback_form[feedback]', with: 'Harry is a good egg'
-  #   fill_in 'support_interface_application_forms_edit_reference_feedback_form[audit_comment]', with: 'Updated as part of Zen Desk ticket #12346'
-  #   choose 'Yes'
-  # end
-
-  # def and_i_should_see_the_new_feedback
-  #   expect(page).to have_content 'Harry is a good egg'
-  # end
-
-  # def and_i_should_see_my_feedback_comment_in_the_audit_log
-  #   click_on 'History'
-  #   expect(page).to have_content 'Updated as part of Zen Desk ticket #12346'
-  # end
+  def and_i_should_see_my_zendesk_ticket_in_the_audit_log
+    click_on 'History'
+    expect(page).to have_content 'Destroy Application Reference'
+    expect(page).to have_content 'https://becomingateacher.zendesk.com/agent/tickets/12345'
+  end
 end


### PR DESCRIPTION
## Context

We've recently made it impossible for candidates to delete references under certain circumstances. To mitigate this we have added the capability to do so in the support interface so that in genuine cases candidates can still have a reference removed via support.

## Changes proposed in this pull request

- Adds a Delete link to the reference panel in the Support interface.
- That link opens a confirmation form:

![image](https://user-images.githubusercontent.com/450843/235726067-3ad5e295-311e-4ce2-a6a1-65b8418f82c3.png)


## Guidance to review

- Are the tests sufficient?

## Link to Trello card

https://trello.com/c/T2is8q1O/1422-add-delete-reference-button-to-support-interface

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
