### PR TITLE
Update reference condition on Manage

### DIFF
--- a/app/components/provider_interface/offer_summary_component.html.erb
+++ b/app/components/provider_interface/offer_summary_component.html.erb
@@ -4,7 +4,9 @@
 
   <h2 class="govuk-heading-m">Conditions of offer</h2>
 
-  <p class="govuk-body">Candidates are required to receive 2 references.</p>
+  <% unless FeatureFlag.active?(:structured_reference_condition) %>
+    <p class="govuk-body">Candidates are required to receive 2 references.</p>
+  <% end %>
 
   <% if ske_conditions.present? %>
     <% ske_conditions.each do |ske_condition| %>

--- a/app/controllers/provider_interface/offers_controller.rb
+++ b/app/controllers/provider_interface/offers_controller.rb
@@ -15,6 +15,10 @@ module ProviderInterface
         decision: :change_offer,
       )
       @wizard.save_state!
+      @conditions = [
+        @application_choice.offer&.conditions,
+        @application_choice.offer&.reference_condition,
+      ].compact.flatten
 
       return unless @provider_user_can_make_decisions
 

--- a/app/controllers/provider_interface/offers_controller.rb
+++ b/app/controllers/provider_interface/offers_controller.rb
@@ -60,10 +60,11 @@ module ProviderInterface
       @wizard = OfferWizard.new(offer_store)
       if @wizard.valid?(:save)
         begin
-          ChangeOffer.new(actor: current_provider_user,
-                          application_choice: @application_choice,
-                          course_option: @wizard.course_option,
-                          update_conditions_service:).save!
+          change_offer = ChangeOffer.new(actor: current_provider_user,
+                                         application_choice: @application_choice,
+                                         course_option: @wizard.course_option,
+                                         update_conditions_service:)
+          change_offer.save!
           @wizard.clear_state!
           flash[:success] = t('.success')
         rescue IdenticalOfferError

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -43,9 +43,25 @@ module ProviderInterface
         standard_conditions: standard_conditions_from(application_choice.offer),
         further_condition_attrs: further_condition_attrs_from(application_choice.offer),
         ske_conditions: ske_conditions_from(application_choice.offer),
+        require_references: require_references_from(application_choice.offer),
+        references_description: references_description_from(application_choice.offer),
       }.merge(options)
 
       new(state_store, attrs)
+    end
+
+    def self.require_references_from(offer)
+      return REQUIRE_REFERENCES_CHECKED_BY_DEFAULT if reference_condition(offer)&.required.present?
+
+      '0'
+    end
+
+    def self.references_description_from(offer)
+      reference_condition(offer)&.description
+    end
+
+    def self.reference_condition(offer)
+      offer&.reference_condition
     end
 
     def require_references

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -2,6 +2,7 @@ class Offer < ApplicationRecord
   belongs_to :application_choice, touch: true
   has_many :conditions, -> { where(type: nil).order('created_at ASC') }, class_name: 'OfferCondition', dependent: :destroy
   has_many :ske_conditions, -> { where(type: 'SkeCondition').order('created_at ASC') }, class_name: 'SkeCondition', dependent: :destroy
+  has_one :reference_condition, -> { where(type: 'ReferenceCondition').order('created_at ASC') }, class_name: 'ReferenceCondition', dependent: :destroy
   has_many :all_conditions, -> { order('created_at ASC') }, class_name: 'OfferCondition', dependent: :destroy
 
   has_one :course_option, through: :application_choice, source: :current_course_option

--- a/app/models/reference_condition.rb
+++ b/app/models/reference_condition.rb
@@ -8,6 +8,6 @@ class ReferenceCondition < OfferCondition
   end
 
   def text
-    'Suitable references'
+    'References'
   end
 end

--- a/app/services/change_offer.rb
+++ b/app/services/change_offer.rb
@@ -50,7 +50,7 @@ private
       application_choice:,
       course_option:,
       conditions: update_conditions_service.conditions,
-      ske_conditions: update_conditions_service.try(:structured_conditions),
+      structured_conditions: update_conditions_service.try(:structured_conditions),
     )
   end
 end

--- a/app/services/make_offer.rb
+++ b/app/services/make_offer.rb
@@ -55,7 +55,7 @@ private
       application_choice:,
       course_option:,
       conditions: update_conditions_service.conditions,
-      ske_conditions: update_conditions_service.try(:structured_conditions),
+      structured_conditions: update_conditions_service.try(:structured_conditions),
     )
   end
 end

--- a/app/services/offer_validations.rb
+++ b/app/services/offer_validations.rb
@@ -6,7 +6,7 @@ class OfferValidations
   MAX_CONDITION_1_LENGTH = 2000
   MAX_CONDITION_LENGTH = 255
 
-  attr_accessor :application_choice, :course_option, :conditions, :ske_conditions
+  attr_accessor :application_choice, :course_option, :conditions, :structured_conditions
 
   validates :course_option, presence: true
   validate :conditions_count, if: :conditions
@@ -36,9 +36,24 @@ class OfferValidations
 
     if application_choice.current_course_option == course_option &&
        application_choice.offer.conditions_text.sort == conditions.sort &&
-       existing_ske_condition_details == new_ske_condition_details
+       existing_ske_condition_details == new_ske_condition_details &&
+       existing_reference_condition == new_reference_condition
       raise IdenticalOfferError
     end
+  end
+
+  def existing_reference_condition
+    condition = application_choice.offer&.reference_condition
+
+    return if condition.blank?
+
+    condition.details.symbolize_keys.slice(:required, :description)
+  end
+
+  def new_reference_condition
+    return if reference_condition.blank?
+
+    reference_condition.details.symbolize_keys.slice(:required, :description)
   end
 
   def existing_ske_condition_details
@@ -46,7 +61,7 @@ class OfferValidations
   end
 
   def new_ske_condition_details
-    (ske_conditions || []).map { |condition| condition.details.symbolize_keys.slice(:length, :reason, :subject) }.sort_by { |hash| hash[:name] }
+    ske_conditions.map { |condition| condition.details.symbolize_keys.slice(:length, :reason, :subject) }.sort_by { |hash| hash[:name] }
   end
 
   def ratifying_provider_changed?
@@ -70,6 +85,18 @@ class OfferValidations
   end
 
 private
+
+  def ske_conditions
+    Array(structured_conditions).select do |structured_condition|
+      structured_condition.is_a?(SkeCondition)
+    end
+  end
+
+  def reference_condition
+    Array(structured_conditions).find do |structured_condition|
+      structured_condition.is_a?(ReferenceCondition)
+    end
+  end
 
   def any_accepted_offers?
     (application_choice.self_and_siblings - [application_choice]).map(&:status).map(&:to_sym).intersect?(ApplicationStateChange::ACCEPTED_STATES)

--- a/app/services/save_offer_conditions_from_params.rb
+++ b/app/services/save_offer_conditions_from_params.rb
@@ -30,8 +30,9 @@ private
   def serialize_structured_conditions
     return if support_action
 
-    # Delete all current ske conditions if there is a change of course
+    # Delete all current structured conditions if there is a change of course
     @offer.ske_conditions.destroy_all if @offer.ske_conditions.any?
+    @offer.reference_condition.destroy if @offer.reference_condition.present?
 
     return if structured_conditions.blank?
 

--- a/app/views/provider_interface/offer/conditions/_form.html.erb
+++ b/app/views/provider_interface/offer/conditions/_form.html.erb
@@ -16,7 +16,7 @@
 
       <% if FeatureFlag.active?(:structured_reference_condition) %>
         <%= f.govuk_check_boxes_fieldset :structured_reference_condition, legend: { text: 'References', size: 'm' }, multiple: false do %>
-          <%= f.govuk_check_box :require_references, 1, 0, label: { text: 'Suitable references' }, multiple: false do %>
+          <%= f.govuk_check_box :require_references, 1, 0, label: { text: 'References' }, multiple: false do %>
             <%= f.govuk_text_area :references_description, label: { text: 'Details (optional)' }, hint: { text: 'For example, if you require a reference from their current school employer' } %>
           <% end %>
         <% end %>

--- a/app/views/provider_interface/offers/show.html.erb
+++ b/app/views/provider_interface/offers/show.html.erb
@@ -31,7 +31,7 @@
       <%= render ProviderInterface::CompletedOfferSummaryComponent.new(
             application_choice: @application_choice,
             course_option: @application_choice.current_course_option,
-            conditions: @application_choice.offer.conditions,
+            conditions: @conditions,
             course: @application_choice.current_course,
             available_providers: @providers,
             available_courses: @courses,
@@ -43,7 +43,7 @@
       <%= render ProviderInterface::ReadOnlyCompletedOfferSummaryComponent.new(
         application_choice: @application_choice,
         course_option: @application_choice.current_course_option,
-        conditions: @application_choice.offer.conditions,
+        conditions: @conditions,
         course: @application_choice.current_course,
         available_providers: [],
         available_courses: [],

--- a/spec/models/reference_condition_spec.rb
+++ b/spec/models/reference_condition_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ReferenceCondition do
 
   describe '#text' do
     it 'returns humanised text' do
-      expect(reference_condition.text).to eq('Suitable references')
+      expect(reference_condition.text).to eq('References')
     end
   end
 end

--- a/spec/services/offer_validations_spec.rb
+++ b/spec/services/offer_validations_spec.rb
@@ -63,6 +63,21 @@ RSpec.describe OfferValidations, type: :model do
         end
       end
 
+      context 'when the offer details differ only by reference condition' do
+        let(:application_choice) { build_stubbed(:application_choice, :offered) }
+        let(:course_option) { application_choice.course_option }
+        let(:conditions) { application_choice.offer.conditions_text }
+        let(:reference_condition) { build(:reference_condition) }
+        let(:new_reference_condition) { build(:reference_condition, required: false) }
+
+        subject(:offer) { described_class.new(application_choice:, course_option:, conditions:, structured_conditions: [new_reference_condition]) }
+
+        it 'does not raise an IdenticalOfferError' do
+          allow(application_choice.offer).to receive(:reference_condition).and_return(reference_condition)
+          expect { offer.valid? }.not_to raise_error(IdenticalOfferError)
+        end
+      end
+
       context 'when the offer details differ only by SKE condition' do
         let(:application_choice) { build_stubbed(:application_choice, :offered) }
         let(:course_option) { application_choice.course_option }
@@ -70,9 +85,9 @@ RSpec.describe OfferValidations, type: :model do
         let(:ske_conditions) { [build(:ske_condition)] }
         let(:new_ske_conditions) { [build(:ske_condition, length: '8'), build(:ske_condition, length: '12')] }
 
-        subject(:offer) { described_class.new(application_choice:, course_option:, conditions:, ske_conditions: new_ske_conditions) }
+        subject(:offer) { described_class.new(application_choice:, course_option:, conditions:, structured_conditions: new_ske_conditions) }
 
-        it 'raises an IdenticalOfferError' do
+        it 'does not raise an IdenticalOfferError' do
           allow(application_choice.offer).to receive(:ske_conditions).and_return(ske_conditions)
           expect { offer.valid? }.not_to raise_error(IdenticalOfferError)
         end

--- a/spec/system/provider_interface/make_offer_structured_conditions_spec.rb
+++ b/spec/system/provider_interface/make_offer_structured_conditions_spec.rb
@@ -80,7 +80,11 @@ RSpec.feature 'Provider makes an offer' do
 
     when_i_send_the_offer
     then_i_see_that_the_offer_was_successfuly_made
-    and_i_the_structured_conditions_are_created
+    and_the_structured_conditions_are_created
+    and_when_i_click_to_add_or_change_conditions
+    and_i_change_the_reference_condition_description
+    when_i_resend_the_offer
+    then_the_structured_conditions_are_updated
   end
 
   def given_i_am_a_provider_user
@@ -281,15 +285,40 @@ RSpec.feature 'Provider makes an offer' do
     end
   end
 
-  def and_i_the_structured_conditions_are_created
+  def and_the_structured_conditions_are_created
     expect(reference_condition).not_to be_nil
     expect(reference_condition.required).to be(true)
     expect(reference_condition.description).to eq('The candidate needs to provide a reference from their current school employer')
+    expect(page).to have_content('Suitable references')
+    expect(page).to have_content('The candidate needs to provide a reference from their current school employer')
   end
 
   def reference_condition
-    application_choice.offer.all_conditions.find do |condition|
+    application_choice.offer.reload.all_conditions.find do |condition|
       condition.is_a?(ReferenceCondition)
     end
+  end
+
+  def and_when_i_click_to_add_or_change_conditions
+    click_on 'Add or change conditions'
+  end
+
+  def and_i_change_the_reference_condition_description
+    expect(page.find('input[@name="provider_interface_offer_wizard[require_references]"]')).to be_checked
+    fill_in 'Details (optional)', with: 'The candidate needs to provide 4 references'
+  end
+
+  def when_i_resend_the_offer
+    click_button 'Continue'
+    click_button 'Send new offer'
+  end
+
+  def then_the_structured_conditions_are_updated
+    reference_condition.reload
+    expect(reference_condition).not_to be_nil
+    expect(reference_condition.required).to be(true)
+    expect(reference_condition.description).to eq('The candidate needs to provide 4 references')
+    expect(page).to have_content('Suitable references')
+    expect(page).to have_content('The candidate needs to provide 4 references')
   end
 end

--- a/spec/system/provider_interface/make_offer_structured_conditions_spec.rb
+++ b/spec/system/provider_interface/make_offer_structured_conditions_spec.rb
@@ -135,7 +135,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def and_the_reference_condition_is_checked_with_details
-    check 'Suitable references'
+    check 'References'
     fill_in 'Details (optional)', with: 'The candidate needs to provide a reference from their current school employer'
   end
 
@@ -162,7 +162,7 @@ RSpec.feature 'Provider makes an offer' do
   def and_i_can_confirm_my_answers
     within('.app-offer-panel') do
       expect(page).to have_content('A* on Maths A Level')
-      expect(page).to have_content('Suitable references')
+      expect(page).to have_content('References')
       expect(page).to have_content('The candidate needs to provide a reference from their current school employer')
     end
   end
@@ -289,7 +289,7 @@ RSpec.feature 'Provider makes an offer' do
     expect(reference_condition).not_to be_nil
     expect(reference_condition.required).to be(true)
     expect(reference_condition.description).to eq('The candidate needs to provide a reference from their current school employer')
-    expect(page).to have_content('Suitable references')
+    expect(page).to have_content('References')
     expect(page).to have_content('The candidate needs to provide a reference from their current school employer')
   end
 
@@ -318,7 +318,7 @@ RSpec.feature 'Provider makes an offer' do
     expect(reference_condition).not_to be_nil
     expect(reference_condition.required).to be(true)
     expect(reference_condition.description).to eq('The candidate needs to provide 4 references')
-    expect(page).to have_content('Suitable references')
+    expect(page).to have_content('References')
     expect(page).to have_content('The candidate needs to provide 4 references')
   end
 end


### PR DESCRIPTION
## Context

This PR adds the possibility of changing an offer conditions by:

1. Unchecking the reference conditions (and be destroyed! - Cast it into the fire! Destroy it!)
2. Or updating the optional field to another content.

Also the conditions are displayed into the offer page.