### PR TITLE
Update number of choices in monthly report

### DIFF
--- a/app/views/publications/monthly_statistics/show.html.erb
+++ b/app/views/publications/monthly_statistics/show.html.erb
@@ -133,7 +133,7 @@
 
     <h2 class="govuk-heading-l" id="by-candidate-status">2. Candidate status</h2>
 
-    <p class="govuk-body">When applying for the first time in a recruitment cycle, candidates can make up to 3 applications
+    <p class="govuk-body">When applying for the first time in a recruitment cycle, candidates can make up to <%= max_course_choices %> applications
       at the same time.</p>
     <p class="govuk-body">The “first application” column in the first table below counts only the status of a candidate’s most
        “advanced” application, if they had more than one application in progress at the same time.</p>


### PR DESCRIPTION
Looks like we forgot to update "3 choices" in one location in the monthly report. 🤦 

This uses the `<%= max_course_choices %>` helper, as in the other locations in the report, so that the number is updated dynamically.