### PR TITLE
Introduce dependency for webapp to be created before the workers

### DIFF
--- a/terraform/modules/kubernetes/main.tf
+++ b/terraform/modules/kubernetes/main.tf
@@ -231,6 +231,7 @@ resource "kubernetes_deployment" "main_worker" {
       }
     }
   }
+  depends_on = [kubernetes_deployment.webapp]
 }
 
 resource "kubernetes_deployment" "secondary_worker" {
@@ -301,6 +302,7 @@ resource "kubernetes_deployment" "secondary_worker" {
       }
     }
   }
+  depends_on = [kubernetes_deployment.webapp]
 }
 
 resource "kubernetes_deployment" "clock_worker" {
@@ -371,4 +373,5 @@ resource "kubernetes_deployment" "clock_worker" {
       }
     }
   }
+  depends_on = [kubernetes_deployment.webapp]
 }


### PR DESCRIPTION
## Context

There is a large number of this Sentry error: ActiveRecord::NoDatabaseError
It only happens with review apps. We suspect that when the workers start, there is no database and sidekiq complains. The database is created by the db:prepare command on the webapp and may take some time to create.

To work around this issue, we should precreate the database before the workers start.

## Changes proposed in this pull request

Introduce dependency to deploy webapp before the workers are deployed

## Guidance to review

- Make sure the review apps are destroyed as the change below will not be picked up by terraform as an infra change
- Deploy to dev cluster and make sure the WebApp gets created before the main worker 
```
module.kubernetes.kubernetes_config_map.app_config: Creating...
module.kubernetes.kubernetes_service.webapp: Creating...
module.kubernetes.kubernetes_service.redis[0]: Creating...
module.kubernetes.kubernetes_service.postgres[0]: Creating...
module.kubernetes.kubernetes_deployment.redis[0]: Creating...
module.kubernetes.kubernetes_config_map.app_config: Creation complete after 0s [id=development/apply-config-review-1234-63f3864de5fa49e6f3fa903dd50425c837689f55]
module.kubernetes.kubernetes_service.redis[0]: Creation complete after 0s [id=development/apply-redis-review-1234]
module.kubernetes.kubernetes_service.postgres[0]: Creation complete after 0s [id=development/apply-postgres-review-1234]
module.kubernetes.kubernetes_service.webapp: Creation complete after 0s [id=development/apply-review-1234]
module.kubernetes.kubernetes_ingress_v1.webapp: Creating...
module.kubernetes.kubernetes_deployment.redis[0]: Creation complete after 4s [id=development/apply-redis-review-1234]
module.kubernetes.kubernetes_secret.app_secrets: Creating...
module.statuscake.time_sleep.wait_10_seconds: Creating...
module.statuscake.time_sleep.wait_10_seconds: Creation complete after 0s [id=2023-05-04T11:49:16Z]
module.kubernetes.kubernetes_deployment.postgres[0]: Creating...
module.kubernetes.kubernetes_secret.app_secrets: Creation complete after 0s [id=development/apply-secrets-review-1234-8e83de0b2fcbdfe71ed329184949e7e5038aefcf]
module.kubernetes.kubernetes_deployment.webapp: Creating...
module.kubernetes.kubernetes_ingress_v1.webapp: Creation complete after 8s [id=development/apply-review-1234]
module.kubernetes.kubernetes_deployment.postgres[0]: Creation complete after 2s [id=development/apply-postgres-review-1234]
module.kubernetes.kubernetes_deployment.webapp: Still creating... [10s elapsed]
module.kubernetes.kubernetes_deployment.webapp: Still creating... [20s elapsed]
module.kubernetes.kubernetes_deployment.webapp: Still creating... [30s elapsed]
module.kubernetes.kubernetes_deployment.webapp: Creation complete after 36s [id=development/apply-review-1234]
module.kubernetes.kubernetes_deployment.clock_worker: Creating...
module.kubernetes.kubernetes_deployment.secondary_worker: Creating...
module.kubernetes.kubernetes_deployment.main_worker: Creating...
module.kubernetes.kubernetes_deployment.secondary_worker: Still creating... [10s elapsed]
module.kubernetes.kubernetes_deployment.main_worker: Still creating... [10s elapsed]
module.kubernetes.kubernetes_deployment.clock_worker: Still creating... [10s elapsed]
module.kubernetes.kubernetes_deployment.main_worker: Creation complete after 16s [id=development/apply-worker-review-1234]
module.kubernetes.kubernetes_deployment.secondary_worker: Creation complete after 16s [id=development/apply-secondary-worker-review-1234]
module.kubernetes.kubernetes_deployment.clock_worker: Creation complete after 16s [id=development/apply-clock-worker-review-1234]
```

## Link to Trello card

(https://trello.com/c/tg0H19wK/257-apply-create-database-before-review-app-workers-start)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
