### PR TITLE
Remove redundant environment_tag

### DIFF
--- a/terraform/custom_domains/environment_domains/workspace_variables/apply_pentest.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/apply_pentest.tfvars.json
@@ -4,10 +4,13 @@
     "apply-for-teacher-training.education.gov.uk": {
       "front_door_name": "s189p01-apply-edu-domains-fd",
       "resource_group_name": "s189p01-applydomains-rg",
-      "domains": ["pen"],
-      "cached_paths": ["/packs/*"],
+      "domains": [
+        "pen"
+      ],
+      "cached_paths": [
+        "/packs/*"
+      ],
       "environment_short": "pt",
-      "environment_tag": "pt",
       "origin_hostname": "apply-pen.london.cloudapps.digital",
       "null_host_header": true,
       "cnames": {
@@ -27,9 +30,10 @@
       "domains": [
         "pen"
       ],
-      "cached_paths": ["/packs/*"],
+      "cached_paths": [
+        "/packs/*"
+      ],
       "environment_short": "pt",
-      "environment_tag": "pt",
       "origin_hostname": "apply-pen.london.cloudapps.digital",
       "null_host_header": true,
       "cnames": {

--- a/terraform/custom_domains/environment_domains/workspace_variables/apply_production.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/apply_production.tfvars.json
@@ -11,9 +11,10 @@
       "domains": [
         "www"
       ],
-      "cached_paths": ["/packs/*"],
+      "cached_paths": [
+        "/packs/*"
+      ],
       "environment_short": "pd",
-      "environment_tag": "pd",
       "origin_hostname": "apply-production.teacherservices.cloud",
       "null_host_header": true,
       "cnames": {
@@ -29,9 +30,10 @@
       "domains": [
         "www"
       ],
-      "cached_paths": ["/packs/*"],
+      "cached_paths": [
+        "/packs/*"
+      ],
       "environment_short": "pd",
-      "environment_tag": "pd",
       "origin_hostname": "apply-production.teacherservices.cloud",
       "null_host_header": true,
       "cnames": {

--- a/terraform/custom_domains/environment_domains/workspace_variables/apply_ptqa.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/apply_ptqa.tfvars.json
@@ -7,9 +7,10 @@
       "domains": [
         "ptqa"
       ],
-      "cached_paths": ["/packs/*"],
+      "cached_paths": [
+        "/packs/*"
+      ],
       "environment_short": "ptq",
-      "environment_tag": "ptq",
       "origin_hostname": "apply-review-ptqa.platform-test.teacherservices.cloud",
       "null_host_header": true
     },
@@ -19,9 +20,10 @@
       "domains": [
         "ptqa"
       ],
-      "cached_paths": ["/packs/*"],
+      "cached_paths": [
+        "/packs/*"
+      ],
       "environment_short": "ptq",
-      "environment_tag": "ptq",
       "origin_hostname": "apply-review-ptqa.platform-test.teacherservices.cloud",
       "null_host_header": true
     }

--- a/terraform/custom_domains/environment_domains/workspace_variables/apply_ptstaging.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/apply_ptstaging.tfvars.json
@@ -7,9 +7,10 @@
       "domains": [
         "ptstaging"
       ],
-      "cached_paths": ["/packs/*"],
+      "cached_paths": [
+        "/packs/*"
+      ],
       "environment_short": "pts",
-      "environment_tag": "pts",
       "origin_hostname": "apply-review-ptstaging.platform-test.teacherservices.cloud",
       "null_host_header": true
     },
@@ -19,9 +20,10 @@
       "domains": [
         "ptstaging"
       ],
-      "cached_paths": ["/packs/*"],
+      "cached_paths": [
+        "/packs/*"
+      ],
       "environment_short": "pts",
-      "environment_tag": "pts",
       "origin_hostname": "apply-review-ptstaging.platform-test.teacherservices.cloud",
       "null_host_header": true
     }

--- a/terraform/custom_domains/environment_domains/workspace_variables/apply_qa.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/apply_qa.tfvars.json
@@ -10,9 +10,10 @@
       "domains": [
         "qa"
       ],
-      "cached_paths": ["/packs/*"],
+      "cached_paths": [
+        "/packs/*"
+      ],
       "environment_short": "qa",
-      "environment_tag": "qa",
       "origin_hostname": "apply-qa.test.teacherservices.cloud",
       "null_host_header": true,
       "cnames": {
@@ -28,9 +29,10 @@
       "domains": [
         "qa"
       ],
-      "cached_paths": ["/packs/*"],
+      "cached_paths": [
+        "/packs/*"
+      ],
       "environment_short": "qa",
-      "environment_tag": "qa",
       "origin_hostname": "apply-qa.test.teacherservices.cloud",
       "null_host_header": true,
       "cnames": {

--- a/terraform/custom_domains/environment_domains/workspace_variables/apply_sandbox.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/apply_sandbox.tfvars.json
@@ -10,9 +10,10 @@
       "domains": [
         "sandbox"
       ],
-      "cached_paths": ["/packs/*"],
+      "cached_paths": [
+        "/packs/*"
+      ],
       "environment_short": "sbx",
-      "environment_tag": "sbx",
       "origin_hostname": "apply-sandbox.teacherservices.cloud",
       "null_host_header": true,
       "cnames": {
@@ -28,9 +29,10 @@
       "domains": [
         "sandbox"
       ],
-      "cached_paths": ["/packs/*"],
+      "cached_paths": [
+        "/packs/*"
+      ],
       "environment_short": "sbx",
-      "environment_tag": "sbx",
       "origin_hostname": "apply-sandbox.teacherservices.cloud",
       "null_host_header": true,
       "cnames": {

--- a/terraform/custom_domains/environment_domains/workspace_variables/apply_staging.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/apply_staging.tfvars.json
@@ -12,9 +12,10 @@
       "domains": [
         "staging"
       ],
-      "cached_paths": ["/packs/*"],
+      "cached_paths": [
+        "/packs/*"
+      ],
       "environment_short": "stg",
-      "environment_tag": "stg",
       "origin_hostname": "apply-staging.test.teacherservices.cloud",
       "null_host_header": true,
       "cnames": {
@@ -30,9 +31,10 @@
       "domains": [
         "staging"
       ],
-      "cached_paths": ["/packs/*"],
+      "cached_paths": [
+        "/packs/*"
+      ],
       "environment_short": "stg",
-      "environment_tag": "stg",
       "origin_hostname": "apply-staging.test.teacherservices.cloud",
       "null_host_header": true,
       "cnames": {


### PR DESCRIPTION
## Context

environment_tag has been identified as a property which isn't being used. We should remove it to ensure that we keep our config tidy with relevant values

## Changes proposed in this pull request

Remove environment_tag property

## Guidance to review

Ran the following (`make apply ENV domains-plan`) for each deployed environment to confirm there are no changes.

## Link to Trello card

https://trello.com/c/1yEerHJZ

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
