### PR TITLE
Guard against unsubmitted apps on diversity report

### DIFF
--- a/app/services/provider_interface/diversity_data_by_provider.rb
+++ b/app/services/provider_interface/diversity_data_by_provider.rb
@@ -153,6 +153,7 @@ module ProviderInterface
     def application_form_query
       ApplicationForm
         .joins(:application_choices)
+        .where.not(submitted_at: nil)
         .where(recruitment_cycle_year: RecruitmentCycle.current_year)
         .where('application_choices.provider_ids @> ARRAY[?]::bigint[]', provider)
         .group('application_forms.id')

--- a/spec/services/provider_interface/diversity_data_by_provider_spec.rb
+++ b/spec/services/provider_interface/diversity_data_by_provider_spec.rb
@@ -15,7 +15,7 @@ module ProviderInterface
 
     describe '#ethnicity_data' do
       it 'returns the ethnicity data for the provider' do
-        create(:application_form, recruitment_cycle_year: RecruitmentCycle.current_year, equality_and_diversity: { 'ethnic_group' => 'Mixed or multiple ethnic groups' }, application_choices: [create(:application_choice, :offered, provider_ids: [provider.id])])
+        create(:application_form, submitted_at: Time.zone.now, recruitment_cycle_year: RecruitmentCycle.current_year, equality_and_diversity: { 'ethnic_group' => 'Mixed or multiple ethnic groups' }, application_choices: [create(:application_choice, :offered, provider_ids: [provider.id])])
         expect(diversity_data_by_provider.ethnicity_data).to eq([
           {
             header: 'Asian or Asian British',
@@ -47,9 +47,9 @@ module ProviderInterface
 
     describe '#age_data' do
       it 'returns the age data for the provider' do
-        create(:application_form, recruitment_cycle_year: RecruitmentCycle.current_year, date_of_birth: Date.new(RecruitmentCycle.current_year - 25, 1, 1), application_choices: [create(:application_choice, :offered, provider_ids: [provider.id])])
-        create(:application_form, recruitment_cycle_year: RecruitmentCycle.current_year, date_of_birth: Date.new(RecruitmentCycle.current_year - 45, 1, 1), application_choices: [create(:application_choice, :recruited, provider_ids: [provider.id])])
-        create(:application_form, recruitment_cycle_year: RecruitmentCycle.current_year, date_of_birth: Date.new(RecruitmentCycle.current_year - 45, 1, 1), application_choices: [create(:application_choice, :recruited, provider_ids: [provider.id])])
+        create(:application_form, submitted_at: Time.zone.now, recruitment_cycle_year: RecruitmentCycle.current_year, date_of_birth: Date.new(RecruitmentCycle.current_year - 25, 1, 1), application_choices: [create(:application_choice, :offered, provider_ids: [provider.id])])
+        create(:application_form, submitted_at: Time.zone.now, recruitment_cycle_year: RecruitmentCycle.current_year, date_of_birth: Date.new(RecruitmentCycle.current_year - 45, 1, 1), application_choices: [create(:application_choice, :recruited, provider_ids: [provider.id])])
+        create(:application_form, submitted_at: Time.zone.now, recruitment_cycle_year: RecruitmentCycle.current_year, date_of_birth: Date.new(RecruitmentCycle.current_year - 45, 1, 1), application_choices: [create(:application_choice, :recruited, provider_ids: [provider.id])])
         expect(diversity_data_by_provider.age_data).to eq([
           {
             header: '18 to 24',
@@ -81,9 +81,9 @@ module ProviderInterface
 
     describe '#sex_data' do
       it 'returns the sex data for the provider' do
-        create(:application_form, recruitment_cycle_year: RecruitmentCycle.current_year, equality_and_diversity: { 'sex' => 'female' }, application_choices: [create(:application_choice, :offered, provider_ids: [provider.id])])
-        create(:application_form, recruitment_cycle_year: RecruitmentCycle.current_year, equality_and_diversity: { 'sex' => 'female' }, application_choices: [create(:application_choice, :recruited, provider_ids: [provider.id])])
-        create(:application_form, recruitment_cycle_year: RecruitmentCycle.current_year, equality_and_diversity: { 'sex' => 'male' }, application_choices: [create(:application_choice, provider_ids: [provider.id])])
+        create(:application_form, submitted_at: Time.zone.now, recruitment_cycle_year: RecruitmentCycle.current_year, equality_and_diversity: { 'sex' => 'female' }, application_choices: [create(:application_choice, :offered, provider_ids: [provider.id])])
+        create(:application_form, submitted_at: Time.zone.now, recruitment_cycle_year: RecruitmentCycle.current_year, equality_and_diversity: { 'sex' => 'female' }, application_choices: [create(:application_choice, :recruited, provider_ids: [provider.id])])
+        create(:application_form, submitted_at: Time.zone.now, recruitment_cycle_year: RecruitmentCycle.current_year, equality_and_diversity: { 'sex' => 'male' }, application_choices: [create(:application_choice, provider_ids: [provider.id])])
         expect(diversity_data_by_provider.sex_data).to eq([
           {
             header: 'Female',
@@ -107,10 +107,10 @@ module ProviderInterface
 
     describe '#disability_data' do
       it 'returns the disability data for the provider' do
-        create(:application_form, recruitment_cycle_year: RecruitmentCycle.current_year, equality_and_diversity: { 'disabilities' => ['Long-term illness'] }, application_choices: [create(:application_choice, :interviewing, provider_ids: [provider.id])])
-        create(:application_form, recruitment_cycle_year: RecruitmentCycle.current_year, equality_and_diversity: { 'disabilities' => ['Long-term illness', 'Mental health condition'] }, application_choices: [create(:application_choice, :interviewing, provider_ids: [provider.id])])
-        create(:application_form, recruitment_cycle_year: RecruitmentCycle.current_year, equality_and_diversity: { 'disabilities' => ['Autistic spectrum condition or another condition affecting speech, language, communication or social skills'] }, application_choices: [create(:application_choice, :accepted, provider_ids: [provider.id])])
-        create(:application_form, recruitment_cycle_year: RecruitmentCycle.current_year, equality_and_diversity: { 'disabilities' => ['Autistic spectrum condition or another condition affecting speech, language, communication or social skills'] }, application_choices: [create(:application_choice, :recruited, provider_ids: [provider.id])])
+        create(:application_form, submitted_at: Time.zone.now, recruitment_cycle_year: RecruitmentCycle.current_year, equality_and_diversity: { 'disabilities' => ['Long-term illness'] }, application_choices: [create(:application_choice, :interviewing, provider_ids: [provider.id])])
+        create(:application_form, submitted_at: Time.zone.now, recruitment_cycle_year: RecruitmentCycle.current_year, equality_and_diversity: { 'disabilities' => ['Long-term illness', 'Mental health condition'] }, application_choices: [create(:application_choice, :interviewing, provider_ids: [provider.id])])
+        create(:application_form, submitted_at: Time.zone.now, recruitment_cycle_year: RecruitmentCycle.current_year, equality_and_diversity: { 'disabilities' => ['Autistic spectrum condition or another condition affecting speech, language, communication or social skills'] }, application_choices: [create(:application_choice, :accepted, provider_ids: [provider.id])])
+        create(:application_form, submitted_at: Time.zone.now, recruitment_cycle_year: RecruitmentCycle.current_year, equality_and_diversity: { 'disabilities' => ['Autistic spectrum condition or another condition affecting speech, language, communication or social skills'] }, application_choices: [create(:application_choice, :recruited, provider_ids: [provider.id])])
         expect(diversity_data_by_provider.disability_data).to eq([
           {
             header: 'At least 1 disability or health condition declared',


### PR DESCRIPTION
## Context

It shouldn't be possible to submit an application form with `equality_and_diversity: nil`, doesn't hurt to guard against it though 🥲 