### PR TITLE
Update candidate navbar styling

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,10 +1,12 @@
 <% case try(:current_namespace) %>
 <% when 'candidate_interface' %>
   <%= render(HeaderComponent.new(
-    classes: "app-header--#{HostingEnvironment.environment_name}",
-    service_name: service_name,
+    classes: "app-header--#{HostingEnvironment.environment_name} app-header--full-border app-header--wide-logo",
+    product_name: service_name,
+    homepage_url: service_link,
     service_link: service_link,
     navigation_items: NavigationItems.for_candidate_interface(try(:current_candidate), controller),
+    navigation_classes: 'govuk-header__navigation--end',
   )) %>
   <%= render PhaseBannerComponent.new %>
 <% when 'support_interface' %>


### PR DESCRIPTION
## Context

The candidate interface is the only place on the service where we have different navbar styling. This brings it inline with support/provider interface

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="992" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/73c00523-92e9-4386-8463-30a70da7d9ad">|<img width="1005" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/04cc8299-0598-4e47-8e05-be4833692cda">|
