### PR TITLE
Add visually-hidden text for rejection reasons fields

### DIFF
--- a/app/models/rejection_reasons/details.rb
+++ b/app/models/rejection_reasons/details.rb
@@ -3,7 +3,7 @@ class RejectionReasons
     include ActiveModel::Model
     MAX_WORDS = 200
 
-    attr_accessor :id, :label, :text, :optional
+    attr_accessor :id, :label, :text, :optional, :visually_hidden
     validate :text_present, :word_count, unless: -> { optional }
 
     def inflate(model)

--- a/app/models/rejection_reasons/reason.rb
+++ b/app/models/rejection_reasons/reason.rb
@@ -4,7 +4,7 @@ class RejectionReasons
 
     TRANSLATION_KEY_PREFIX = 'activemodel.errors.models.provider_interface/rejections_wizard.attributes'.freeze
 
-    attr_accessor :id, :deprecated, :details, :label, :reasons, :selected_reasons
+    attr_accessor :id, :deprecated, :details, :label, :reasons, :reasons_visually_hidden, :selected_reasons
 
     validate :reasons_selected
 

--- a/app/views/provider_interface/rejections/new.html.erb
+++ b/app/views/provider_interface/rejections/new.html.erb
@@ -26,9 +26,9 @@
           <%= f.govuk_check_box :selected_reasons, reason.id, label: { text: reason.label }, link_errors: true do %>
             <% if reason.details.present? %>
               <%= f.govuk_text_area reason.details.id.to_sym,
-                  label: { text: reason.details.label, size: 's' }, max_words: RejectionReasons::Details::MAX_WORDS %>
+                  label: { text: safe_join([reason.details.label, ' ', tag.span(reason.details.visually_hidden, class: 'govuk-visually-hidden')]), size: 's' }, max_words: RejectionReasons::Details::MAX_WORDS %>
             <% elsif reason.reasons&.any? %>
-              <%= f.govuk_check_boxes_fieldset reason.selected_reasons_attr_name, legend: { text: 'Reasons', size: 's' } do %>
+              <%= f.govuk_check_boxes_fieldset reason.selected_reasons_attr_name, legend: { text: safe_join(['Reasons', ' ', tag.span(reason.reasons_visually_hidden, class: 'govuk-visually-hidden')]), size: 's' } do %>
                 <% reason.reasons.each do |nested_reason| %>
                   <%= f.govuk_check_box reason.selected_reasons_attr_name,
                     nested_reason.id,
@@ -37,7 +37,7 @@
                     <% if nested_reason.details.present? %>
                       <%= f.govuk_text_area nested_reason.details.id.to_sym,
                         label: {
-                          text: nested_reason.details.label,
+                          text: safe_join([nested_reason.details.label, ' ', tag.span(nested_reason.details.visually_hidden, class: 'govuk-visually-hidden')]),
                           size: 's',
                         },
                         max_words: RejectionReasons::Details::MAX_WORDS %>

--- a/config/rejection_reasons.yml
+++ b/config/rejection_reasons.yml
@@ -2,6 +2,7 @@
 :reasons:
 - :id: qualifications
   :label: Qualifications
+  :reasons_visually_hidden: for rejecting due to qualifications
   :reasons:
   - :id: no_maths_gcse
     :label: No maths GCSE at minimum grade 4 or C, or equivalent
@@ -16,85 +17,103 @@
     :details:
       :id: unsuitable_degree_details
       :label: Details
+      :visually_hidden: about why their qualifications do not meet course requirements
   - :id: unverified_qualifications
     :label: Could not verify qualifications
     :details:
       :id: unverified_qualifications_details
       :label: Details
+      :visually_hidden: about why you could not verify qualifications
   - :id: qualifications_other
     :label: Other
     :details:
       :id: qualifications_other_details
       :label: Details
+      :visually_hidden: of other issues with their qualifications
 - :id: personal_statement
   :label: Personal statement
+  :reasons_visually_hidden: for rejecting due to personal statement
   :reasons:
   - :id: quality_of_writing
     :label: Quality of writing
     :details:
       :id: quality_of_writing_details
       :label: Details
+      :visually_hidden: about their quality of writing
   - :id: personal_statement_other
     :label: Other
     :details:
       :id: personal_statement_other_details
       :label: Details
+      :visually_hidden: of other issues with their personal statement
 - :id: teaching_knowledge
   :label: Teaching knowledge, ability and interview performance
+  :reasons_visually_hidden: for rejecting due to teaching knowledge or interview performance
   :reasons:
   - :id: subject_knowledge
     :label: Subject knowledge
     :details:
       :id: subject_knowledge_details
       :label: Details
+      :visually_hidden: about their subject knowledge
   - :id: safeguarding_knowledge
     :label: Safeguarding knowledge
     :details:
       :id: safeguarding_knowledge_details
       :label: Details
+      :visually_hidden: about their safeguarding knowledge
   - :id: teaching_method_knowledge
     :label: Teaching method knowledge
     :details:
       :id: teaching_method_knowledge_details
       :label: Details
+      :visually_hidden: about their teaching method knowledge
   - :id: teaching_role_knowledge
     :label: Teaching role knowledge
     :details:
       :id: teaching_role_knowledge_details
       :label: Details
+      :visually_hidden: about their teaching role knowledge
   - :id: teaching_demonstration
     :label: Teaching demonstration
     :details:
       :id: teaching_demonstration_details
       :label: Details
+      :visually_hidden: about their teaching demonstration
   - :id: teaching_knowledge_other
     :label: Other
     :details:
       :id: teaching_knowledge_other_details
       :label: Details
+      :visually_hidden: of other issues with their teaching knowledge, ability or interview performance
 - :id: communication_and_scheduling
   :label: Communication, interview attendance and scheduling
+  :reasons_visually_hidden: for rejecting due to communication, interview attendance or scheduling
   :reasons:
   - :id: did_not_reply
     :label: Did not reply to messages
     :details:
       :id: did_not_reply_details
       :label: Details
+      :visually_hidden: of how they did not reply to messages
   - :id: did_not_attend_interview
     :label: Did not attend interview
     :details:
       :id: did_not_attend_interview_details
       :label: Details
+      :visually_hidden: of how they did not attend interview
   - :id: could_not_arrange_interview
     :label: Could not arrange interview
     :details:
       :id: could_not_arrange_interview_details
       :label: Details
+      :visually_hidden: about not being able to arrange an interview
   - :id: communication_and_scheduling_other
     :label: Other
     :details:
       :id: communication_and_scheduling_other_details
       :label: Details
+      :visually_hidden: of other issues with communication, interview attendance or scheduling
 - :id: references
   :deprecated: true
   :label: References
@@ -106,19 +125,23 @@
   :details:
     :id: safeguarding_details
     :label: Details
+    :visually_hidden: about safeguarding
 - :id: visa_sponsorship
   :label: Visa sponsorship
   :details:
     :id: visa_sponsorship_details
     :label: Details
+    :visually_hidden: about visa sponsorship
 - :id: course_full
   :label: Course full
   :details:
     :id: course_full_details
     :label: Details (optional)
     :optional: true
+    :visually_hidden: about the course being full
 - :id: other
   :label: Other
   :details:
     :id: other_details
     :label: Details
+    :visually_hidden: of other reasons

--- a/config/rejection_reasons.yml
+++ b/config/rejection_reasons.yml
@@ -39,7 +39,7 @@
     :details:
       :id: quality_of_writing_details
       :label: Details
-      :visually_hidden: about their quality of writing
+      :visually_hidden: about their quality of writing in their personal statement
   - :id: personal_statement_other
     :label: Other
     :details:
@@ -55,31 +55,31 @@
     :details:
       :id: subject_knowledge_details
       :label: Details
-      :visually_hidden: about their subject knowledge
+      :visually_hidden: about issues with their subject knowledge
   - :id: safeguarding_knowledge
     :label: Safeguarding knowledge
     :details:
       :id: safeguarding_knowledge_details
       :label: Details
-      :visually_hidden: about their safeguarding knowledge
+      :visually_hidden: about issues with their safeguarding knowledge
   - :id: teaching_method_knowledge
     :label: Teaching method knowledge
     :details:
       :id: teaching_method_knowledge_details
       :label: Details
-      :visually_hidden: about their teaching method knowledge
+      :visually_hidden: about issues with their teaching method knowledge
   - :id: teaching_role_knowledge
     :label: Teaching role knowledge
     :details:
       :id: teaching_role_knowledge_details
       :label: Details
-      :visually_hidden: about their teaching role knowledge
+      :visually_hidden: about issues with their teaching role knowledge
   - :id: teaching_demonstration
     :label: Teaching demonstration
     :details:
       :id: teaching_demonstration_details
       :label: Details
-      :visually_hidden: about their teaching demonstration
+      :visually_hidden: about issues with their teaching demonstration
   - :id: teaching_knowledge_other
     :label: Other
     :details:
@@ -101,7 +101,7 @@
     :details:
       :id: did_not_attend_interview_details
       :label: Details
-      :visually_hidden: of how they did not attend interview
+      :visually_hidden: of how they did not attend interviews
   - :id: could_not_arrange_interview
     :label: Could not arrange interview
     :details:
@@ -144,4 +144,4 @@
   :details:
     :id: other_details
     :label: Details
-    :visually_hidden: of other reasons
+    :visually_hidden: of other reasons for rejection

--- a/spec/models/rejection_reasons/reason_spec.rb
+++ b/spec/models/rejection_reasons/reason_spec.rb
@@ -18,10 +18,12 @@ RSpec.describe RejectionReasons::Reason do
       instance = described_class.new(
         id: 'aaa',
         label: 'AAA',
+        reasons_visually_hidden: 'about AAA',
         reasons: [{ id: 'r1', label: 'R1' }, { id: 'r2', label: 'R2', details: { id: 'd1', label: 'D1' } }],
       )
       expect(instance.reasons.size).to eq(2)
       expect(instance.reasons.map(&:class).uniq).to eq([described_class])
+      expect(instance.reasons_visually_hidden).to eq('about AAA')
       expect(instance.reasons.first.id).to eq('r1')
       expect(instance.reasons.first.label).to eq('R1')
       expect(instance.reasons.last.id).to eq('r2')

--- a/spec/system/provider_interface/reject_an_application_spec.rb
+++ b/spec/system/provider_interface/reject_an_application_spec.rb
@@ -60,21 +60,29 @@ RSpec.describe 'Reject an application' do
   end
 
   def and_i_give_reasons_why_i_am_rejecting_the_application
-    check 'rejection-reasons-selected-reasons-qualifications-field'
-    check 'rejection-reasons-qualifications-selected-reasons-no-maths-gcse-field'
-    check 'rejection-reasons-qualifications-selected-reasons-unverified-qualifications-field'
-    fill_in 'rejection-reasons-unverified-qualifications-details-field', with: 'We can find no evidence of your GCSEs'
+    check 'Qualifications'
 
-    check 'rejection-reasons-selected-reasons-personal-statement-field'
-    check 'rejection-reasons-personal-statement-selected-reasons-quality-of-writing-field'
-    fill_in 'rejection-reasons-quality-of-writing-details-field', with: 'We do not accept applications written in morse code'
-    check 'rejection-reasons-personal-statement-selected-reasons-personal-statement-other-field'
-    fill_in 'rejection-reasons-personal-statement-other-details-field', with: 'This was wayyyyy too personal'
+    within_fieldset 'Reasons for rejecting due to qualifications' do
+      check 'No maths GCSE at minimum grade 4 or C, or equivalent'
 
-    check 'rejection-reasons-selected-reasons-course-full-field'
-    fill_in 'rejection-reasons-course-full-details-field', with: 'Other courses exist'
+      check 'Could not verify qualifications'
+      fill_in 'Details about why you could not verify qualifications', with: 'We can find no evidence of your GCSEs'
+    end
+
+    check 'Personal statement'
+
+    within_fieldset 'Reasons for rejecting due to personal statement' do
+      check 'Quality of writing'
+      fill_in 'Details about their quality of writing', with: 'We do not accept applications written in morse code'
+      check 'Other'
+      fill_in 'Details of other issues with their personal statement', with: 'This was wayyyyy too personal'
+    end
+
+    check 'Course full'
+    fill_in 'Details (optional) about the course being full', with: 'Other courses exist'
+
     check 'rejection-reasons-selected-reasons-other-field'
-    fill_in 'rejection-reasons-other-details-field', with: 'There are so many other reasons why your application was rejected...'
+    fill_in 'Details of other reasons', with: 'There are so many other reasons why your application was rejected...'
   end
 
   def and_i_check_the_reasons_for_rejection


### PR DESCRIPTION
This adds visually-hiddden text to the otherwise-identical labels and legends within the rejections reasons interface, so that screen reader users can differentiate them when they are announced out of context.

## Details of the issues

### Non-unique legends

On the reasons for rejection page, there is a list of checkboxes, most of which when clicked reveal a nested set of checkboxes with the heading "Reasons" (implemented as a legend):

<img width="851" alt="Screenshot 2023-05-11 at 16 16 39" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/30665/05df1733-41be-403a-9ae7-d99688d48c8b">

Because these legends all have the same text, this may be confusing or difficult for users of screen-reading software, which can announce these legends out of the context of the previous checkbox label.

To resolve this, visually-hidden text can be added to the legends, so that they contain "Reasons [about why their qualifications do not meet course requirements]".

### Non-unique textarea labels

When the nested checkboxes are checked, most of them reveal a textarea labelled "Details":

<img width="863" alt="Screenshot 2023-05-11 at 16 25 35" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/30665/309ab7e1-f2ff-4bfc-9867-4caa03cc9808">

Because these legends all have the same text, this may be confusing or difficult for users of screen-reading software or dictation software to enter text.

To resolve this, visually-hidden text can be added to the labels, so that they contain "Details [about why you could not verify qualifications]".


🗂️ [Trello card](https://trello.com/c/sFGCwJeI/1438-sr4r-add-visually-hidden-text-to-form-elements)