### PR TITLE
Fix issue with incorrect Withdrawals report link

### DIFF
--- a/app/views/provider_interface/reports/index.html.erb
+++ b/app/views/provider_interface/reports/index.html.erb
@@ -38,7 +38,7 @@
               <%= govuk_link_to t('page_titles.provider.diversity_report'), provider_interface_reports_provider_diversity_report_path(provider_id: provider) %>
             </li>
             <li>
-              <%= govuk_link_to t('page_titles.provider.withdrawal_report'), provider_interface_reports_provider_withdrawal_report_path(provider_id: @providers.first) %>
+              <%= govuk_link_to t('page_titles.provider.withdrawal_report'), provider_interface_reports_provider_withdrawal_report_path(provider_id: provider) %>
             </li>
           <% end %>
         </ul>

--- a/spec/system/provider_interface/provider_reports_page_spec.rb
+++ b/spec/system/provider_interface/provider_reports_page_spec.rb
@@ -18,6 +18,10 @@ RSpec.feature 'Provider reports page' do
 
     when_i_visit_the_reports_page
     then_i_should_see_links_for_all_the_provider_status_application_records
+
+    when_the_provider_reports_feature_flag_is_active
+    when_i_visit_the_reports_page
+    then_i_should_see_new_links_for_all_the_provider_reports
   end
 
   def given_i_am_a_provider_user_with_permissions_to_see_applications_for_my_provider
@@ -65,6 +69,19 @@ RSpec.feature 'Provider reports page' do
     @provider_user.providers.each do |provider|
       expect(page).to have_content(provider.name)
       expect(page).to have_link('Status of active applications', href: provider_interface_reports_provider_status_of_active_applications_path(provider_id: provider))
+    end
+  end
+
+  def when_the_provider_reports_feature_flag_is_active
+    FeatureFlag.activate(:provider_reports)
+  end
+
+  def then_i_should_see_new_links_for_all_the_provider_reports
+    @provider_user.providers.each do |provider|
+      expect(page).to have_content(provider.name)
+      expect(page).to have_link('Status of active applications', href: provider_interface_reports_provider_status_of_active_applications_path(provider_id: provider))
+      expect(page).to have_link('Sex, disability, ethnicity and age of candidates', href: provider_interface_reports_provider_diversity_report_path(provider_id: provider))
+      expect(page).to have_link('Withdrawals', href: provider_interface_reports_provider_withdrawal_report_path(provider_id: provider))
     end
   end
 end


### PR DESCRIPTION


## Context

There is a bug in the view template for the new provider_reports section that renders the withdrawals report link for the first provider repeatedly (rather than looping over all providers).

## Changes proposed in this pull request

Fixes the bug and extends the existing provider reports system spec to cover the bug.


## Guidance to review

- Are there are any other issues here?
- Is the test sufficient?

## Link to Trello card

n/a

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
