### PR TITLE
Tweaks to provider reports

### DIFF
--- a/app/services/provider_interface/diversity_data_by_provider.rb
+++ b/app/services/provider_interface/diversity_data_by_provider.rb
@@ -41,13 +41,35 @@ module ProviderInterface
         {
           header: sex.type.capitalize,
           values: [
-            application_form_data[[:applied, sex.type]] || 0,
-            application_form_data[[:offer, sex.type]] || 0,
-            application_form_data[[:recruited, sex.type]] || 0,
-            calculate_percentage(application_form_data[[:applied, sex.type]], application_form_data[[:recruited, sex.type]]),
+            applied_count_for(application_form_data, sex.type),
+            offer_count_for(application_form_data, sex.type),
+            recruited_count_for(application_form_data, sex.type),
+            calculate_percentage(
+              applied_count_for(application_form_data, sex.type),
+              recruited_count_for(application_form_data, sex.type),
+            ),
           ],
         }
       end
+    end
+
+    def applied_count_for(application_form_data, group)
+      count_for(application_form_data, :applied, group) +
+        count_for(application_form_data, :offer, group) +
+        count_for(application_form_data, :recruited, group)
+    end
+
+    def offer_count_for(application_form_data, group)
+      count_for(application_form_data, :offer, group) +
+        count_for(application_form_data, :recruited, group)
+    end
+
+    def recruited_count_for(application_form_data, group)
+      count_for(application_form_data, :recruited, group)
+    end
+
+    def count_for(application_form_data, bucket, group)
+      application_form_data[[bucket, group]] || 0
     end
 
     def disability_data

--- a/app/services/provider_interface/diversity_data_by_provider.rb
+++ b/app/services/provider_interface/diversity_data_by_provider.rb
@@ -38,38 +38,17 @@ module ProviderInterface
       sex_values << Hesa::Sex::SexStruct.new('00', 'Prefer not to say')
 
       sex_values.map do |sex|
+        applied, offer, recruited = counts_for(application_form_data, sex.type)
         {
           header: sex.type.capitalize,
           values: [
-            applied_count_for(application_form_data, sex.type),
-            offer_count_for(application_form_data, sex.type),
-            recruited_count_for(application_form_data, sex.type),
-            calculate_percentage(
-              applied_count_for(application_form_data, sex.type),
-              recruited_count_for(application_form_data, sex.type),
-            ),
+            applied,
+            offer,
+            recruited,
+            calculate_percentage(applied, recruited),
           ],
         }
       end
-    end
-
-    def applied_count_for(application_form_data, group)
-      count_for(application_form_data, :applied, group) +
-        count_for(application_form_data, :offer, group) +
-        count_for(application_form_data, :recruited, group)
-    end
-
-    def offer_count_for(application_form_data, group)
-      count_for(application_form_data, :offer, group) +
-        count_for(application_form_data, :recruited, group)
-    end
-
-    def recruited_count_for(application_form_data, group)
-      count_for(application_form_data, :recruited, group)
-    end
-
-    def count_for(application_form_data, bucket, group)
-      application_form_data[[bucket, group]] || 0
     end
 
     def disability_data
@@ -86,13 +65,14 @@ module ProviderInterface
       application_form_data = counted_groups_by('ethnic_group')
 
       EthnicGroup.all.push('Prefer not to say').map do |ethnicity|
+        applied, offer, recruited = counts_for(application_form_data, ethnicity)
         {
           header: ethnicity,
           values: [
-            application_form_data[[:applied, ethnicity]] || 0,
-            application_form_data[[:offer, ethnicity]] || 0,
-            application_form_data[[:recruited, ethnicity]] || 0,
-            calculate_percentage(application_form_data[[:applied, ethnicity]], application_form_data[[:recruited, ethnicity]]),
+            applied,
+            offer,
+            recruited,
+            calculate_percentage(applied, recruited),
           ],
         }
       end
@@ -102,14 +82,14 @@ module ProviderInterface
       application_form_data = counted_groups_by('age')
 
       AGE_GROUPS.map do |age_group|
+        applied, offer, recruited = counts_for(application_form_data, age_group)
         {
           header: age_group,
           values: [
-            application_form_data[[:applied, age_group]] || 0,
-            application_form_data[[:offer, age_group]] || 0,
-            application_form_data[[:recruited, age_group]] || 0,
-            calculate_percentage(application_form_data[[:applied, age_group]], application_form_data[[:recruited, age_group]]),
-
+            applied,
+            offer,
+            recruited,
+            calculate_percentage(applied, recruited),
           ],
         }
       end
@@ -117,16 +97,67 @@ module ProviderInterface
 
   private
 
+    def counts_for(data, group)
+      [
+        applied_count_for(data, group),
+        offer_count_for(data, group),
+        recruited_count_for(data, group),
+      ]
+    end
+
+    def applied_count_for(data, group)
+      count_for(data, :applied, group) +
+        count_for(data, :offer, group) +
+        count_for(data, :recruited, group)
+    end
+
+    def offer_count_for(data, group)
+      count_for(data, :offer, group) +
+        count_for(data, :recruited, group)
+    end
+
+    def recruited_count_for(data, group)
+      count_for(data, :recruited, group)
+    end
+
+    def count_for(data, bucket, group)
+      data[[bucket, group]] || 0
+    end
+
     def disability_info(data, disability = nil)
+      applied, offer, recruited = disability_counts_for(data, disability)
       {
         header: disability.nil? ? 'At least 1 disability or health condition declared' : disability,
         values: [
-          count_for_disabilities_and_status(data, :applied, disability),
-          count_for_disabilities_and_status(data, :offer, disability),
-          count_for_disabilities_and_status(data, :recruited, disability),
-          calculate_percentage(count_for_disabilities_and_status(data, :applied, disability), count_for_disabilities_and_status(data, :recruited, disability)),
+          applied,
+          offer,
+          recruited,
+          calculate_percentage(applied, recruited),
         ],
       }
+    end
+
+    def disability_counts_for(data, group)
+      [
+        applied_disability_count_for(data, group),
+        offer_disability_count_for(data, group),
+        recruited_disability_count_for(data, group),
+      ]
+    end
+
+    def applied_disability_count_for(data, group)
+      count_for_disabilities_and_status(data, :applied, group) +
+        count_for_disabilities_and_status(data, :offer, group) +
+        count_for_disabilities_and_status(data, :recruited, group)
+    end
+
+    def offer_disability_count_for(data, group)
+      count_for_disabilities_and_status(data, :offer, group) +
+        count_for_disabilities_and_status(data, :recruited, group)
+    end
+
+    def recruited_disability_count_for(data, group)
+      count_for_disabilities_and_status(data, :recruited, group)
     end
 
     def count_for_disabilities_and_status(data, status, disability = nil)

--- a/spec/services/provider_interface/diversity_data_by_provider_spec.rb
+++ b/spec/services/provider_interface/diversity_data_by_provider_spec.rb
@@ -87,7 +87,7 @@ module ProviderInterface
         expect(diversity_data_by_provider.sex_data).to eq([
           {
             header: 'Female',
-            values: [0, 1, 1, '-'],
+            values: [2, 2, 1, '50%'],
           },
           {
             header: 'Male',

--- a/spec/services/provider_interface/diversity_data_by_provider_spec.rb
+++ b/spec/services/provider_interface/diversity_data_by_provider_spec.rb
@@ -27,7 +27,7 @@ module ProviderInterface
           },
           {
             header: 'Mixed or multiple ethnic groups',
-            values: [0, 1, 0, '-'],
+            values: [1, 1, 0, '0%'],
           },
           {
             header: 'White',
@@ -57,7 +57,7 @@ module ProviderInterface
           },
           {
             header: '25 to 34',
-            values: [0, 1, 0, '-'],
+            values: [1, 1, 0, '0%'],
           },
           {
             header: '35 to 44',
@@ -65,7 +65,7 @@ module ProviderInterface
           },
           {
             header: '45 to 54',
-            values: [0, 0, 2, '-'],
+            values: [2, 2, 2, '100%'],
           },
           {
             header: '55 to 64',
@@ -114,11 +114,11 @@ module ProviderInterface
         expect(diversity_data_by_provider.disability_data).to eq([
           {
             header: 'At least 1 disability or health condition declared',
-            values: [2, 1, 1, '50%'],
+            values: [4, 2, 1, '25%'],
           },
           {
             header: 'Autistic spectrum condition or another condition affecting speech, language, communication or social skills',
-            values: [0, 1, 1, '-'],
+            values: [2, 2, 1, '50%'],
           },
           {
             header: 'Blindness or a visual impairment not corrected by glasses',


### PR DESCRIPTION
## Context

These reports have recently been added:

- Equality and diversity report
- Withdrawal reasons report

Following testing we need to make a small change to the Applied column on the _Equality and diversity report_. This should include all candidates that have applied in the past regardless of their current state, e.g. it should include Recruited candidates.

## Changes proposed in this pull request

Use cumulative totals for the applied > offer > recruited columns. Update specs.

Before:
![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/450843/a36d8b21-c460-4e91-a873-88ab865fac2d)


After:
![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/450843/a880c05f-9f0c-4aa4-9917-0728c73f3262)



## Guidance to review

- Does this make sense?
- Could the code be streamlined?

## Link to Trello card

https://trello.com/c/FQy53c9J/1472-tweaks-to-new-provider-reports

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
