### PR TITLE
Add topology constraints for the webapp

### DIFF
--- a/terraform/modules/kubernetes/main.tf
+++ b/terraform/modules/kubernetes/main.tf
@@ -21,6 +21,26 @@ resource "kubernetes_deployment" "webapp" {
           "teacherservices.cloud/node_pool" = "applications"
           "kubernetes.io/os"                = "linux"
         }
+        topology_spread_constraint {
+          max_skew           = 1
+          topology_key       = "topology.kubernetes.io/zone"
+          when_unsatisfiable = "DoNotSchedule"
+          label_selector {
+            match_labels = {
+              app = local.webapp_name
+            }
+          }
+        }
+        topology_spread_constraint {
+          max_skew           = 1
+          topology_key       = "kubernetes.io/hostname"
+          when_unsatisfiable = "ScheduleAnyway"
+          label_selector {
+            match_labels = {
+              app = local.webapp_name
+            }
+          }
+        }
         container {
           name    = local.webapp_name
           image   = var.app_docker_image


### PR DESCRIPTION
## Context

In the case of an upgrade and a node is replaced, when all pods are on the same node, it causes an outage
In the case of an availability zone failures, when all pods and on nodes in the same availability zone, it causes an outage
To prevent this, we should make sure that pods are spread evenly across nodes and availability zones

## Changes proposed in this pull request

- Introduce Topology constraints to balance the pods across nodes and availability zones 

## Guidance to review

- Deploy a dev cluster 
- Deploy the review apps and scale it up to 2-4 replicas 
- Get the number of pods using ```kubectl get pods -o wide | awk '{print $7}' | sort | uniq -c ```
-  Check the distribution of the review apps across nodes and ones by using 
```kubectl get nodes -o json | jq '.items[] | "\(.metadata.labels."kubernetes.io/hostname") \(.metadata.labels."topology.kubernetes.io/zone")"' ```
- It should return something like this 
```
"aks-apps1-11315189-vmss00000d uksouth-3"
"aks-apps1-11315189-vmss00000i uksouth-2"
"aks-apps1-11315189-vmss00000k uksouth-1"
"aks-default-26612713-vmss000000 uksouth-2"
```
## Link to Trello card

https://trello.com/c/ghewRV0A/332-ensure-pods-are-spread-evenly

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
