### PR TITLE
Candidate interface Reference condition

### DIFF
--- a/app/components/candidate_interface/application_dashboard_course_choices_component.rb
+++ b/app/components/candidate_interface/application_dashboard_course_choices_component.rb
@@ -31,6 +31,7 @@ module CandidateInterface
         offer_withdrawal_reason_row(application_choice),
         interview_row(application_choice),
         ske_conditions_row(application_choice),
+        reference_conditions_row(application_choice),
         conditions_row(application_choice),
         withdraw_row(application_choice),
         respond_to_offer_row(application_choice),
@@ -102,6 +103,15 @@ module CandidateInterface
       {
         key: 'Subject knowledge enhancement course'.pluralize(ske_conditions.size),
         value: render(OfferSkeConditionsReviewComponent.new(ske_conditions:)),
+      }
+    end
+
+    def reference_conditions_row(application_choice)
+      return if (reference_condition = application_choice.offer&.reference_condition).blank?
+
+      {
+        key: 'References',
+        value: render(OfferReferenceConditionReviewComponent.new(reference_condition:)),
       }
     end
 

--- a/app/components/candidate_interface/offer_reference_condition_review_component.html.erb
+++ b/app/components/candidate_interface/offer_reference_condition_review_component.html.erb
@@ -1,0 +1,13 @@
+<% if reference_condition.description.present? %>
+  <p class="govuk-body">
+    <%= reference_condition.offer.provider.name %> said:
+  </p>
+
+  <p class="govuk-body">
+    <%= reference_condition.description %>
+  </p>
+<% else %>
+  <p class="govuk-body">
+    The provider will confirm your place once they've checked your references.
+  </p>
+<% end %>

--- a/app/components/candidate_interface/offer_reference_condition_review_component.rb
+++ b/app/components/candidate_interface/offer_reference_condition_review_component.rb
@@ -1,0 +1,9 @@
+module CandidateInterface
+  class OfferReferenceConditionReviewComponent < ViewComponent::Base
+    attr_accessor :reference_condition
+
+    def initialize(reference_condition:)
+      @reference_condition = reference_condition
+    end
+  end
+end

--- a/app/components/candidate_interface/offer_review_component.rb
+++ b/app/components/candidate_interface/offer_review_component.rb
@@ -13,6 +13,7 @@ module CandidateInterface
         (fee_row if @course_choice.current_course.fee?),
         location_row,
         (ske_conditions_row if @course_choice.offer.ske_conditions.any?),
+        (reference_condition_row if @course_choice.offer.reference_condition.present?),
         (conditions_row if @course_choice.offer.conditions.any?),
       ].compact
     end
@@ -67,6 +68,13 @@ module CandidateInterface
       {
         key: 'Subject knowledge enhancement course',
         value: ske_conditions_row_value,
+      }
+    end
+
+    def reference_condition_row
+      {
+        key: 'References',
+        value: render(OfferReferenceConditionReviewComponent.new(reference_condition: @course_choice.offer.reference_condition)),
       }
     end
 

--- a/app/components/candidate_interface/reference_condition_header_component.html.erb
+++ b/app/components/candidate_interface/reference_condition_header_component.html.erb
@@ -6,4 +6,6 @@
     </p>
   <% end %>
 <% end %>
-<p class="govuk-body">Contact <%= provider_name %> if you need help getting references.</p>
+<% if show_extra_content? %>
+  <p class="govuk-body">Contact <%= provider_name %> if you need help getting references.</p>
+<% end %>

--- a/app/components/candidate_interface/reference_condition_header_component.html.erb
+++ b/app/components/candidate_interface/reference_condition_header_component.html.erb
@@ -1,0 +1,9 @@
+<% if description.present? %>
+  <p class="govuk-body"><%= provider_name %> said:</p>
+  <%= govuk_inset_text(classes: 'govuk-!-margin-top-0') do %>
+    <p class="govuk-body">
+      <%= description %>
+    </p>
+  <% end %>
+<% end %>
+<p class="govuk-body">Contact <%= provider_name %> if you need help getting references.</p>

--- a/app/components/candidate_interface/reference_condition_header_component.rb
+++ b/app/components/candidate_interface/reference_condition_header_component.rb
@@ -1,0 +1,15 @@
+module CandidateInterface
+  class ReferenceConditionHeaderComponent < ViewComponent::Base
+    attr_accessor :reference_condition, :provider_name
+    delegate :description, :met?, to: :reference_condition, allow_nil: true
+
+    def initialize(reference_condition:, provider_name:)
+      @reference_condition = reference_condition
+      @provider_name = provider_name
+    end
+
+    def render?
+      !met?
+    end
+  end
+end

--- a/app/components/candidate_interface/reference_condition_header_component.rb
+++ b/app/components/candidate_interface/reference_condition_header_component.rb
@@ -1,15 +1,20 @@
 module CandidateInterface
   class ReferenceConditionHeaderComponent < ViewComponent::Base
-    attr_accessor :reference_condition, :provider_name
+    attr_accessor :reference_condition, :provider_name, :show_extra_content
     delegate :description, :met?, to: :reference_condition, allow_nil: true
 
-    def initialize(reference_condition:, provider_name:)
+    def initialize(reference_condition:, provider_name:, show_extra_content: true)
       @reference_condition = reference_condition
       @provider_name = provider_name
+      @show_extra_content = show_extra_content
     end
 
     def render?
       !met?
+    end
+
+    def show_extra_content?
+      @show_extra_content.present?
     end
   end
 end

--- a/app/components/candidate_interface/references_component.html.erb
+++ b/app/components/candidate_interface/references_component.html.erb
@@ -1,21 +1,29 @@
-<ol class="app-task-list govuk-!-margin-bottom-2">
-  <% references.each do |reference| %>
-    <li class="app-task-list__item">
-      <div class="app-task-list__content">
-        <% if reference_condition_met? %>
-          <strong class="govuk-task-list__status--black">
-            Received by training provider
-          </strong>
-        <% else %>
-          <%= render CandidateInterface::ReferenceStatusesComponent.new(reference: reference) %>
-        <% end %>
-        <div class="app-task-list__task-name">
-          <%= govuk_link_to reference.name, candidate_interface_application_offer_dashboard_reference_path(reference.id) %>
-          <% unless reference_condition_met? %>
-            <%= render(CandidateInterface::ReferenceStatusLineComponent.new(reference)) %>
-          <% end %>
-        </div>
+<% if reference_condition_met? %>
+  <dl class="govuk-summary-list">
+    <% references.each do |reference| %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= govuk_link_to(reference.name, candidate_interface_application_offer_dashboard_reference_path(reference.id)) %>
+        </dt>
+        <dd class="govuk-summary-list__actions">
+          <strong>Received by training provider</strong>
+        </dd>
       </div>
-    </li>
-  <% end %>
-</ol>
+    <% end %>
+  </dl>
+  <%= render SummaryListComponent.new(rows:) %>
+<% else %>
+  <ol class="app-task-list govuk-!-margin-bottom-2">
+    <% references.each do |reference| %>
+      <li class="app-task-list__item">
+        <div class="app-task-list__content">
+          <%= render CandidateInterface::ReferenceStatusesComponent.new(reference: reference) %>
+          <div class="app-task-list__task-name">
+            <%= govuk_link_to reference.name, candidate_interface_application_offer_dashboard_reference_path(reference.id) %>
+              <%= render(CandidateInterface::ReferenceStatusLineComponent.new(reference)) %>
+          </div>
+        </div>
+      </li>
+    <% end %>
+  </ol>
+<% end %>

--- a/app/components/candidate_interface/references_component.html.erb
+++ b/app/components/candidate_interface/references_component.html.erb
@@ -1,16 +1,4 @@
 <% if reference_condition_met? %>
-  <dl class="govuk-summary-list">
-    <% references.each do |reference| %>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= govuk_link_to(reference.name, candidate_interface_application_offer_dashboard_reference_path(reference.id)) %>
-        </dt>
-        <dd class="govuk-summary-list__actions">
-          <strong>Received by training provider</strong>
-        </dd>
-      </div>
-    <% end %>
-  </dl>
   <%= render SummaryListComponent.new(rows:) %>
 <% else %>
   <ol class="app-task-list govuk-!-margin-bottom-2">

--- a/app/components/candidate_interface/references_component.html.erb
+++ b/app/components/candidate_interface/references_component.html.erb
@@ -2,10 +2,18 @@
   <% references.each do |reference| %>
     <li class="app-task-list__item">
       <div class="app-task-list__content">
-        <%= render CandidateInterface::ReferenceStatusesComponent.new(reference: reference) %>
+        <% if reference_condition_met? %>
+          <strong class="govuk-task-list__status--black">
+            Received by training provider
+          </strong>
+        <% else %>
+          <%= render CandidateInterface::ReferenceStatusesComponent.new(reference: reference) %>
+        <% end %>
         <div class="app-task-list__task-name">
           <%= govuk_link_to reference.name, candidate_interface_application_offer_dashboard_reference_path(reference.id) %>
-          <%= render(CandidateInterface::ReferenceStatusLineComponent.new(reference)) %>
+          <% unless reference_condition_met? %>
+            <%= render(CandidateInterface::ReferenceStatusLineComponent.new(reference)) %>
+          <% end %>
         </div>
       </div>
     </li>

--- a/app/components/candidate_interface/references_component.html.erb
+++ b/app/components/candidate_interface/references_component.html.erb
@@ -1,17 +1,23 @@
-<% if reference_condition_met? %>
-  <%= render SummaryListComponent.new(rows:) %>
-<% else %>
-  <ol class="app-task-list govuk-!-margin-bottom-2">
-    <% references.each do |reference| %>
-      <li class="app-task-list__item">
-        <div class="app-task-list__content">
+<ol class="app-task-list govuk-!-margin-bottom-2">
+  <% references.each do |reference| %>
+    <li class="app-task-list__item">
+      <div class="app-task-list__content">
+        <% if reference_condition_met? %>
+          <%= govuk_tag(
+              text: t('candidate_new_reference_status.feedback_provided'),
+              colour: t('candidate_new_reference_colours.feedback_provided'),
+            ) %>
+        <% else %>
           <%= render CandidateInterface::ReferenceStatusesComponent.new(reference: reference) %>
-          <div class="app-task-list__task-name">
-            <%= govuk_link_to reference.name, candidate_interface_application_offer_dashboard_reference_path(reference.id) %>
-              <%= render(CandidateInterface::ReferenceStatusLineComponent.new(reference)) %>
-          </div>
+        <% end %>
+        <div class="app-task-list__task-name">
+          <%= govuk_link_to reference.name, candidate_interface_application_offer_dashboard_reference_path(reference.id) %>
+
+          <% unless reference_condition_met? %>
+            <%= render(CandidateInterface::ReferenceStatusLineComponent.new(reference)) %>
+          <% end %>
         </div>
-      </li>
-    <% end %>
-  </ol>
-<% end %>
+      </div>
+    </li>
+  <% end %>
+</ol>

--- a/app/components/candidate_interface/references_component.rb
+++ b/app/components/candidate_interface/references_component.rb
@@ -14,5 +14,14 @@ module CandidateInterface
     def references
       application_form.application_references.creation_order
     end
+
+    def rows
+      references.map do |reference|
+        {
+          key: govuk_link_to(reference.name, candidate_interface_application_offer_dashboard_reference_path(reference.id)),
+          value: tag.strong('Received by training provider'),
+        }
+      end
+    end
   end
 end

--- a/app/components/candidate_interface/references_component.rb
+++ b/app/components/candidate_interface/references_component.rb
@@ -2,10 +2,13 @@ module CandidateInterface
   class ReferencesComponent < ViewComponent::Base
     include ViewHelper
 
-    attr_reader :application_form
+    attr_reader :application_form, :reference_condition
 
-    def initialize(application_form:)
+    delegate :met?, to: :reference_condition, allow_nil: true, prefix: true
+
+    def initialize(application_form:, reference_condition:)
       @application_form = application_form
+      @reference_condition = reference_condition
     end
 
     def references

--- a/app/views/candidate_interface/decisions/accept_offer.html.erb
+++ b/app/views/candidate_interface/decisions/accept_offer.html.erb
@@ -14,6 +14,8 @@
           <%= t('decisions.accept_offer.references_description') %>
         </p>
 
+        <%= render CandidateInterface::ReferenceConditionHeaderComponent.new(reference_condition: @application_choice.offer.reference_condition, provider_name: @application_choice.current_provider.name, show_extra_content: false) %>
+
         <p class="govuk-body">
           <%= t('decisions.accept_offer.change_reference_details') %>
         </p>

--- a/app/views/candidate_interface/offer_dashboard/show.html.erb
+++ b/app/views/candidate_interface/offer_dashboard/show.html.erb
@@ -13,7 +13,9 @@
     <h2 class="govuk-heading-m">References</h2>
     <%= render CandidateInterface::ReferenceConditionHeaderComponent.new(reference_condition: @application_choice_with_offer.offer.reference_condition, provider_name: @accepted_offer_provider_name) %>
     <%= render CandidateInterface::ReferencesComponent.new(application_form: @application_form) %>
-    <%= govuk_button_link_to 'Request another reference', candidate_interface_request_reference_references_start_path, secondary: true %>
+    <% unless @application_choice_with_offer.offer.reference_condition&.met? %>
+      <%= govuk_button_link_to 'Request another reference', candidate_interface_request_reference_references_start_path, secondary: true %>
+    <% end %>
 
     <% if (ske_conditions = @application_choice_with_offer.offer.ske_conditions).any? %>
       <h2 class="govuk-heading-m">Subject knowledge enhancement course</h2>

--- a/app/views/candidate_interface/offer_dashboard/show.html.erb
+++ b/app/views/candidate_interface/offer_dashboard/show.html.erb
@@ -11,7 +11,7 @@
     <% end %>
 
     <h2 class="govuk-heading-m">References</h2>
-    <p class="govuk-body">Contact <%= @accepted_offer_provider_name %> if you need help getting references.</p>
+    <%= render CandidateInterface::ReferenceConditionHeaderComponent.new(reference_condition: @application_choice_with_offer.offer.reference_condition, provider_name: @accepted_offer_provider_name) %>
     <%= render CandidateInterface::ReferencesComponent.new(application_form: @application_form) %>
     <%= govuk_button_link_to 'Request another reference', candidate_interface_request_reference_references_start_path, secondary: true %>
 

--- a/app/views/candidate_interface/offer_dashboard/show.html.erb
+++ b/app/views/candidate_interface/offer_dashboard/show.html.erb
@@ -12,7 +12,7 @@
 
     <h2 class="govuk-heading-m">References</h2>
     <%= render CandidateInterface::ReferenceConditionHeaderComponent.new(reference_condition: @application_choice_with_offer.offer.reference_condition, provider_name: @accepted_offer_provider_name) %>
-    <%= render CandidateInterface::ReferencesComponent.new(application_form: @application_form) %>
+    <%= render CandidateInterface::ReferencesComponent.new(application_form: @application_form, reference_condition: @application_choice_with_offer.offer.reference_condition) %>
     <% unless @application_choice_with_offer.offer.reference_condition&.met? %>
       <%= govuk_button_link_to 'Request another reference', candidate_interface_request_reference_references_start_path, secondary: true %>
     <% end %>

--- a/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
+++ b/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
@@ -322,8 +322,11 @@ RSpec.describe CandidateInterface::ApplicationDashboardCourseChoicesComponent, t
     let(:offer) { create(:offer, conditions: [build(:reference_condition, description: nil)]) }
 
     it 'renders the references section with a default content' do
-      render_inline(described_class.new(application_form:, editable: false, show_status: true))
-      expect(rendered_component).to summarise(key: 'References', value: "The provider will confirm your place once they've checked your references.")
+      render_inline(
+        described_class.new(application_form:, editable: false, show_status: true),
+      ) do |rendered_component|
+        expect(rendered_component).to summarise(key: 'References', value: "The provider will confirm your place once they've checked your references.")
+      end
     end
   end
 
@@ -333,8 +336,11 @@ RSpec.describe CandidateInterface::ApplicationDashboardCourseChoicesComponent, t
     let(:offer) { create(:offer, conditions: [build(:reference_condition, description: 'You need to provide 6 references')]) }
 
     it 'renders the references section with a description' do
-      render_inline(described_class.new(application_form:, editable: false, show_status: true))
-      expect(rendered_component).to summarise(key: 'References', value: "#{offer.provider.name} said: You need to provide 6 references")
+      render_inline(
+        described_class.new(application_form:, editable: false, show_status: true),
+      ) do |rendered_component|
+        expect(rendered_component).to summarise(key: 'References', value: "#{offer.provider.name} said: You need to provide 6 references")
+      end
     end
   end
 

--- a/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
+++ b/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
@@ -316,6 +316,28 @@ RSpec.describe CandidateInterface::ApplicationDashboardCourseChoicesComponent, t
     end
   end
 
+  context 'when there is an offer with reference condition without description' do
+    let(:application_form) { application_choice.application_form }
+    let(:application_choice) { create(:application_choice, :offered, offer:) }
+    let(:offer) { create(:offer, conditions: [build(:reference_condition, description: nil)]) }
+
+    it 'renders the references section with a default content' do
+      render_inline(described_class.new(application_form:, editable: false, show_status: true))
+      expect(rendered_component).to summarise(key: 'References', value: "The provider will confirm your place once they've checked your references.")
+    end
+  end
+
+  context 'when there is an offer with reference condition with description' do
+    let(:application_form) { application_choice.application_form }
+    let(:application_choice) { create(:application_choice, :offered, offer:) }
+    let(:offer) { create(:offer, conditions: [build(:reference_condition, description: 'You need to provide 6 references')]) }
+
+    it 'renders the references section with a description' do
+      render_inline(described_class.new(application_form:, editable: false, show_status: true))
+      expect(rendered_component).to summarise(key: 'References', value: "#{offer.provider.name} said: You need to provide 6 references")
+    end
+  end
+
   def create_application_form_with_course_choices(statuses:)
     application_form = create(:application_form)
 

--- a/spec/components/candidate_interface/offer_review_component_spec.rb
+++ b/spec/components/candidate_interface/offer_review_component_spec.rb
@@ -19,6 +19,23 @@ RSpec.describe CandidateInterface::OfferReviewComponent do
 
     expect(result.css('.govuk-summary-list__key').text).to include('Provider')
     expect(result.css('.govuk-summary-list__value').text).to include(course_option.course.provider.name)
+    expect(result).not_to include('References')
+  end
+
+  context 'when reference condition' do
+    let(:conditions) do
+      [
+        build(:offer_condition, text: 'Fitness to train to teach check'),
+        build(:offer_condition, text: 'Be cool'),
+        build(:reference_condition, description: nil),
+      ]
+    end
+
+    it 'renders references section' do
+      render_inline(described_class.new(course_choice: application_choice))
+
+      expect(rendered_component).to summarise(key: 'References', value: "The provider will confirm your place once they've checked your references.")
+    end
   end
 
   context 'when Find is open' do

--- a/spec/components/candidate_interface/offer_review_component_spec.rb
+++ b/spec/components/candidate_interface/offer_review_component_spec.rb
@@ -25,16 +25,16 @@ RSpec.describe CandidateInterface::OfferReviewComponent do
   context 'when reference condition' do
     let(:conditions) do
       [
-        build(:offer_condition, text: 'Fitness to train to teach check'),
-        build(:offer_condition, text: 'Be cool'),
+        build(:text_condition, text: 'Fitness to train to teach check'),
+        build(:text_condition, text: 'Be cool'),
         build(:reference_condition, description: nil),
       ]
     end
 
     it 'renders references section' do
-      render_inline(described_class.new(course_choice: application_choice))
-
-      expect(rendered_component).to summarise(key: 'References', value: "The provider will confirm your place once they've checked your references.")
+      render_inline(described_class.new(course_choice: application_choice)) do |rendered_component|
+        expect(rendered_component).to summarise(key: 'References', value: "The provider will confirm your place once they've checked your references.")
+      end
     end
   end
 

--- a/spec/components/candidate_interface/reference_condition_header_component_spec.rb
+++ b/spec/components/candidate_interface/reference_condition_header_component_spec.rb
@@ -22,10 +22,12 @@ RSpec.describe CandidateInterface::ReferenceConditionHeaderComponent, type: :com
   end
 
   context 'when reference condition with description' do
-    let(:reference_condition) { build(:reference_condition, description: 'Provider many references') }
+    subject(:content) { result.text.strip.split.join(' ') }
+
+    let(:reference_condition) { build(:reference_condition, description: 'Provide many references') }
 
     it 'renders condition description' do
-      expect(result.text.strip).to eq("Uni said:\n  \n    \n      Provider many references\n    \n  Contact Uni if you need help getting references.")
+      expect(content).to eq('Uni said: Provide many references Contact Uni if you need help getting references.')
     end
   end
 

--- a/spec/components/candidate_interface/reference_condition_header_component_spec.rb
+++ b/spec/components/candidate_interface/reference_condition_header_component_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::ReferenceConditionHeaderComponent, type: :component do
+  let(:result) do
+    render_inline(described_class.new(reference_condition:, provider_name: 'Uni'))
+  end
+
+  context 'when no reference condition' do
+    let(:reference_condition) { nil }
+
+    it 'renders default message' do
+      expect(result.text).to eq("Contact Uni if you need help getting references.\n")
+    end
+  end
+
+  context 'when reference condition without description' do
+    let(:reference_condition) { build(:reference_condition, description: nil) }
+
+    it 'renders default message' do
+      expect(result.text).to eq("Contact Uni if you need help getting references.\n")
+    end
+  end
+
+  context 'when reference condition with description' do
+    let(:reference_condition) { build(:reference_condition, description: 'Provider many references') }
+
+    it 'renders condition description' do
+      expect(result.text).to eq("  Uni said:\n  \n    \n      Provider many references\n    \nContact Uni if you need help getting references.\n")
+    end
+  end
+
+  context 'when reference condition is met' do
+    let(:reference_condition) { build(:reference_condition, status: :met) }
+
+    it 'renders condition description' do
+      expect(result.text).to be_empty
+    end
+  end
+end

--- a/spec/components/candidate_interface/reference_condition_header_component_spec.rb
+++ b/spec/components/candidate_interface/reference_condition_header_component_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CandidateInterface::ReferenceConditionHeaderComponent, type: :com
     let(:reference_condition) { nil }
 
     it 'renders default message' do
-      expect(result.text).to eq("Contact Uni if you need help getting references.\n")
+      expect(result.text.strip).to eq('Contact Uni if you need help getting references.')
     end
   end
 
@@ -17,7 +17,7 @@ RSpec.describe CandidateInterface::ReferenceConditionHeaderComponent, type: :com
     let(:reference_condition) { build(:reference_condition, description: nil) }
 
     it 'renders default message' do
-      expect(result.text).to eq("Contact Uni if you need help getting references.\n")
+      expect(result.text.strip).to eq('Contact Uni if you need help getting references.')
     end
   end
 
@@ -25,7 +25,7 @@ RSpec.describe CandidateInterface::ReferenceConditionHeaderComponent, type: :com
     let(:reference_condition) { build(:reference_condition, description: 'Provider many references') }
 
     it 'renders condition description' do
-      expect(result.text).to eq("  Uni said:\n  \n    \n      Provider many references\n    \nContact Uni if you need help getting references.\n")
+      expect(result.text.strip).to eq("Uni said:\n  \n    \n      Provider many references\n    \n  Contact Uni if you need help getting references.")
     end
   end
 

--- a/spec/components/candidate_interface/references_component_spec.rb
+++ b/spec/components/candidate_interface/references_component_spec.rb
@@ -2,11 +2,31 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::ReferencesComponent, type: :component do
   let(:url_helpers) { Rails.application.routes.url_helpers }
+  let(:reference_condition) { nil }
+  let(:application_form) { create(:application_form, application_references: [reference]) }
+  let(:reference) { create(:reference, feedback_status: 'feedback_requested', requested_at: 2.seconds.ago) }
+  let(:result) { render_inline(described_class.new(application_form:, reference_condition:)) }
+
+  context 'when reference condition' do
+    context 'when is met' do
+      let(:reference_condition) { create(:reference_condition, status: :met) }
+
+      it 'renders the correct status' do
+        expect(result.text).to include 'Received by training provider'
+      end
+    end
+
+    context 'when is pending' do
+      let(:reference_condition) { create(:reference_condition, status: :pending) }
+
+      it 'renders the correct status' do
+        expect(result.css('.govuk-tag').text).to include 'Requested'
+      end
+    end
+  end
 
   context 'when feedback provided' do
     let(:reference) { create(:reference, feedback_status: 'feedback_provided') }
-    let(:application_form) { create(:application_form, application_references: [reference]) }
-    let(:result) { render_inline(described_class.new(application_form:)) }
 
     it 'renders the correct reference link' do
       expect(result.css('.govuk-link')[0].attributes['href'].value).to eq(url_helpers.candidate_interface_application_offer_dashboard_reference_path(reference.id))

--- a/spec/factories/offer.rb
+++ b/spec/factories/offer.rb
@@ -8,6 +8,12 @@ FactoryBot.define do
       conditions { [association(:text_condition, :unmet, offer: instance)] }
     end
 
+    trait :with_reference_condition do
+      conditions {
+        [build(:reference_condition)]
+      }
+    end
+
     trait :with_ske_conditions do
       conditions {
         [


### PR DESCRIPTION
## Context

Once “references” is a structured reference condition, we need to consider how this will be used in the candidate interface.

Touchpoints:

1. Offer card and Offer details page
2. Accepting an offer and confirming references
3. Post-offer dashboard - showing details text, removing ability to request new references when condition is met.

