### PR TITLE
Attempt to fix provider reports vs. missing E&D data

### DIFF
--- a/app/services/provider_interface/diversity_data_by_provider.rb
+++ b/app/services/provider_interface/diversity_data_by_provider.rb
@@ -163,7 +163,7 @@ module ProviderInterface
     def count_for_disabilities_and_status(data, status, disability = nil)
       data.select do |selected_disabilities|
         application_status, selected_disabilities = selected_disabilities
-        application_status == status && (disability.nil? ? selected_disabilities.any? : selected_disabilities.include?(disability))
+        application_status == status && (disability.nil? ? selected_disabilities&.any? : selected_disabilities&.include?(disability))
       end.values.sum || 0
     end
 
@@ -176,7 +176,7 @@ module ProviderInterface
         if attribute == 'age'
           [status_bucket_for(application_form), age_group_for(application_form.date_of_birth)]
         else
-          [status_bucket_for(application_form), application_form.equality_and_diversity[attribute]]
+          [status_bucket_for(application_form), Hash(application_form.equality_and_diversity)[attribute]]
         end
       end.transform_values(&:count)
     end

--- a/spec/services/provider_interface/diversity_data_by_provider_spec.rb
+++ b/spec/services/provider_interface/diversity_data_by_provider_spec.rb
@@ -162,6 +162,69 @@ module ProviderInterface
           },
         ])
       end
+
+      it 'returns handles missing equality and disability data' do
+        create(
+          :application_form,
+          submitted_at: Time.zone.now,
+          recruitment_cycle_year: RecruitmentCycle.current_year,
+          equality_and_diversity: nil,
+          application_choices: [
+            create(:application_choice, :interviewing, provider_ids: [provider.id]),
+          ],
+        )
+
+        expect(diversity_data_by_provider.disability_data).to eq([
+          {
+            header: 'At least 1 disability or health condition declared',
+            values: [0, 0, 0, '-'],
+          },
+          {
+            header: 'Autistic spectrum condition or another condition affecting speech, language, communication or social skills',
+            values: [0, 0, 0, '-'],
+          },
+          {
+            header: 'Blindness or a visual impairment not corrected by glasses',
+            values: [0, 0, 0, '-'],
+          },
+          {
+            header: 'Condition affecting motor, cognitive, social and emotional skills, speech or language since childhood',
+            values: [0, 0, 0, '-'],
+          },
+          {
+            header: 'Deafness or a serious hearing impairment',
+            values: [0, 0, 0, '-'],
+          },
+          {
+            header: 'Dyslexia, dyspraxia or attention deficit hyperactivity disorder (ADHD) or another learning difference',
+            values: [0, 0, 0, '-'],
+          },
+          {
+            header: 'Long-term illness',
+            values: [0, 0, 0, '-'],
+          },
+          {
+            header: 'Mental health condition',
+            values: [0, 0, 0, '-'],
+          },
+          {
+            header: 'Physical disability or mobility issue',
+            values: [0, 0, 0, '-'],
+          },
+          {
+            header: 'Another disability, health condition or impairment affecting daily life',
+            values: [0, 0, 0, '-'],
+          },
+          {
+            header: 'I do not have any of these disabilities or health conditions',
+            values: [0, 0, 0, '-'],
+          },
+          {
+            header: 'Prefer not to say',
+            values: [0, 0, 0, '-'],
+          },
+        ])
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

https://dfe-teacher-services.sentry.io/issues/4168806406/?project=1765973&referrer=slack

This runtime error is happening because there are some (deleted) applications that have a non-null submitted_at and null equality_and_diversity values.

e.g. https://www.apply-for-teacher-training.service.gov.uk/support/applications/146029

## Changes proposed in this pull request

We need to defensively code these out of the results that we process for these reports.

## Guidance to review

- Does it make more sense to try to filter these out in the database query? (When I initially tried this it broke a lot of tests).

## Link to Trello card

https://trello.com/c/DvtbBvvl/1475-provider-reports-failing-with-deleted-applications-that-have-no-ed-data

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
