### PR TITLE
Attempt to fix flakey SKE condition system spec

### DIFF
--- a/spec/system/provider_interface/change_existing_offer_ske_standard_flow_spec.rb
+++ b/spec/system/provider_interface/change_existing_offer_ske_standard_flow_spec.rb
@@ -114,7 +114,6 @@ RSpec.feature 'Provider changes an existing offer' do
     and_i_click_continue
     then_the_ske_standard_flow_is_not_loaded
 
-    when_i_add_a_further_condition
     then_the_correct_conditions_are_displayed
 
     and_i_click_continue


### PR DESCRIPTION

## Context

This flakey test failure has appeared in several open PRs:

```
Failed 1 out of 3 times at ./spec/system/provider_interface/change_existing_offer_ske_standard_flow_spec.rb:28: expected to find text "Be cool" in "Course details
Training provider
Barbra Bayer Institute (ZHS)
Change training provider
Course
Engineering (D1J2)
Change course details
Full time or part time
Full time
Location
Clearcourt High School 699 72658 Russel Row East Karissaport Avon WN1E 1YJ
Change location
Accredited body
North Rath Academy (02I)
Qualification
PGCE with QTS
Funding type
Apprenticeship
Conditions of offer
Add or change conditions
Disclosure and Barring Service (DBS) check Pending
A* on Maths A Level Pending
A* on Maths A Level Pending
```

I cannot reproduce locally but it looks like the
`when_i_add_a_further_condition` is overwriting a _Be cool_ condition with a duplicate _A* on Maths A Level_ condition probably due to some kind of ordering randomness.

## Changes proposed in this pull request

I've removed the second call to `when_i_add_a_further_condition` because it should be a noop (it's just overwriting a field with the value it already contains unless the order is wrong in which case it will fail the spec)

## Guidance to review

Does this make sense?

## Link to Trello card

n/a

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
