### PR TITLE
Support page to allow mid-cycle reports to be uploaded

### DIFF
--- a/app/controllers/support_interface/settings_controller.rb
+++ b/app/controllers/support_interface/settings_controller.rb
@@ -36,6 +36,23 @@ module SupportInterface
       redirect_to support_interface_cycles_path
     end
 
+    def mid_cycle_report; end
+
+    def mid_cycle_report_upload
+      publication_date = Date.new(
+        *params.slice('publication_date(1i)', 'publication_date(2i)', 'publication_date(3i)').values.map(&:to_i),
+      )
+
+      provider_csv = CSV.parse(params.require(:provider_data), headers: true)
+      Publications::ProviderMidCycleReport.ingest(provider_csv, publication_date)
+
+      national_csv = CSV.parse(params.require(:national_data), headers: true)
+      Publications::NationalMidCycleReport.ingest(national_csv, publication_date)
+
+      flash[:success] = 'Mid cycle reports uploaded'
+      redirect_to support_interface_mid_cycle_report_path
+    end
+
   private
 
     def feature_name

--- a/app/views/support_interface/settings/_settings_navigation.html.erb
+++ b/app/views/support_interface/settings/_settings_navigation.html.erb
@@ -6,6 +6,7 @@
   { name: 'Recruitment cycles', url: support_interface_cycles_path },
   { name: 'Tasks', url: support_interface_tasks_path },
   { name: 'Support users', url: support_interface_support_users_path },
+  { name: 'Mid-cycle report', url: support_interface_mid_cycle_report_path },
 ]) %>
 
 <h2 class="govuk-visually-hidden"><%= title %></h2>

--- a/app/views/support_interface/settings/mid_cycle_report.html.erb
+++ b/app/views/support_interface/settings/mid_cycle_report.html.erb
@@ -1,0 +1,14 @@
+<%= render 'settings_navigation', title: 'Mid-cycle report' %>
+
+<h1 class="govuk-label-wrapper">
+  <label class="govuk-label govuk-label--l" for="more-detail">
+    Copy and paste mid-cycle reports (CSV)
+  </label>
+</h1>
+
+<%= form_with url: support_interface_mid_cycle_report_upload_path, method: :post do |f| %>
+  <%= f.govuk_date_field :publication_date, omit_day: false, legend: { text: 'Publication date' } %>
+  <%= f.govuk_text_area :national_data, label: { text: 'National level' }, rows: 20 %>
+  <%= f.govuk_text_area :provider_data, label: { text: 'Provider level' }, rows: 20 %>
+  <%= f.govuk_submit 'Upload' %>
+<% end %>

--- a/config/routes/support.rb
+++ b/config/routes/support.rb
@@ -233,6 +233,9 @@ namespace :support_interface, path: '/support' do
 
     get '/cycles', to: 'settings#cycles', as: :cycles
 
+    get '/mid-cycle-report', to: 'settings#mid_cycle_report', as: :mid_cycle_report
+    post '/mid-cycle-report-upload', to: 'settings#mid_cycle_report_upload', as: :mid_cycle_report_upload
+
     unless HostingEnvironment.production?
       post '/cycles', to: 'settings#switch_cycle_schedule', as: :switch_cycle_schedule
     end


### PR DESCRIPTION
## Context

We need to upload CSV data to populate the mid cycle reports.

## Changes proposed in this pull request

Add page in Support console that allows mid cycle reports (national and provider level) to be copy-pasted.

## Guidance to review

Navigate to `/support/settings/mid-cycle-report`, upload some valid data, and see if it's been uploaded successfully.

<img width="731" alt="CleanShot 2023-05-18 at 16 28 30@2x" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/168365/e02552f5-6076-43cf-8fea-09302137c0a5">

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
