### PR TITLE
Add vertical borders to the provider mid-cycle report

### DIFF
--- a/app/frontend/styles/_table.scss
+++ b/app/frontend/styles/_table.scss
@@ -12,3 +12,16 @@
     border-bottom: 0;
   }
 }
+
+.app_table__header--border-right,
+.app_table__cell--border-right {
+  border-right: 1px solid $govuk-border-colour;
+}
+
+
+.app-table__row--no-bottom-border {
+  .govuk-table__cell,
+  .govuk-table__header {
+    border-bottom: 0;
+  }
+}

--- a/app/views/provider_interface/reports/mid_cycle_reports/_table.html.erb
+++ b/app/views/provider_interface/reports/mid_cycle_reports/_table.html.erb
@@ -3,15 +3,15 @@
     <table class="govuk-table govuk-!-margin-bottom-9">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row app-table__row--no-bottom-border">
-          <th scope="col" class="govuk-table__header govuk-!-border-bottom-0" colspan="0"></th>
-          <th scope="colgroup" class="govuk-table__header govuk-!-border-bottom-0 govuk-table__header--numeric" colspan="3"> <%= provider_name %> </th>
-          <th scope="colgroup" class="govuk-table__header govuk-!-border-bottom-0 govuk-table__header--numeric" colspan="3">All providers</th>
+          <th scope="col" class="govuk-table__header app_table__header--border-right" colspan="0"></th>
+          <th scope="colgroup" class="govuk-table__header  govuk-table__header--numeric  app_table__header--border-right" colspan="3"> <%= provider_name %> </th>
+          <th scope="colgroup" class="govuk-table__header  govuk-table__header--numeric" colspan="3">All providers</th>
         </tr>
         <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header"><%= subject_table ? 'Subject' : 'Level' %></th>
+          <th scope="col" class="govuk-table__header app_table__header--border-right"><%= subject_table ? 'Subject' : 'Level' %></th>
           <th scope="col" class="govuk-table__header govuk-table__header--numeric govuk-!-font-weight-regular">This cycle</th>
           <th scope="col" class="govuk-table__header govuk-table__header--numeric govuk-!-font-weight-regular">Last cycle</th>
-          <th scope="col" class="govuk-table__header govuk-table__header--numeric govuk-!-font-weight-regular">Change</th>
+          <th scope="col" class="govuk-table__header govuk-table__header--numeric govuk-!-font-weight-regular app_table__header--border-right">Change</th>
           <th scope="col" class="govuk-table__header govuk-table__header--numeric govuk-!-font-weight-regular">This cycle</th>
           <th scope="col" class="govuk-table__header govuk-table__header--numeric govuk-!-font-weight-regular">Last cycle</th>
           <th scope="col" class="govuk-table__header govuk-table__header--numeric govuk-!-font-weight-regular">Change</th>
@@ -26,12 +26,12 @@
           <% next if row[first_column].delete(',').to_i.zero? && row[second_column].delete(',').to_i.zero? %>
 
           <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header govuk-!-font-weight-regular <%= row['level'] == 'top' ? '' : 'govuk-!-padding-left-2' %>">
+            <th scope="row" class="govuk-table__header govuk-!-font-weight-regular app_table__cell--border-right <%= row['level'] == 'top' ? '' : 'govuk-!-padding-left-2' %>">
               <%= row['tad_subject'] %>
             </th>
             <td class="govuk-table__cell govuk-table__cell--numeric"><%= row[first_column] %></td>
             <td class="govuk-table__cell govuk-table__cell--numeric"><%= row[second_column] %></td>
-            <td class="govuk-table__cell govuk-table__cell--numeric"><%= row[third_column] %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric app_table__cell--border-right"><%= row[third_column] %></td>
             <td class="govuk-table__cell govuk-table__cell--numeric"><%= national_model.find { |national_row| national_row['tad_subject'] == row['tad_subject'] }[first_column] %></td>
             <td class="govuk-table__cell govuk-table__cell--numeric"><%= national_model.find { |national_row| national_row['tad_subject'] == row['tad_subject'] }[second_column] %></td>
             <td class="govuk-table__cell govuk-table__cell--numeric"><%= national_model.find { |national_row| national_row['tad_subject'] == row['tad_subject'] }[third_column] %></td>
@@ -41,10 +41,10 @@
       <% if include_total %>
         <tfoot>
           <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header">Total</th>
+            <th scope="row" class="govuk-table__header app_table__header--border-right">Total</th>
             <td scope="row" class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold"><%= number_with_delimiter(provider_model.select { |row| row['level'] == 'top' }.map { |row| row[first_column]&.delete(',').to_i }.sum, delimiter: ',') %></td>
             <td scope="row" class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold"><%= number_with_delimiter(provider_model.select { |row| row['level'] == 'top' }.map { |row| row[second_column]&.delete(',').to_i }.sum, delimiter: ',') %></td>
-            <td scope="row" class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold">
+            <td scope="row" class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold app_table__cell--border-right">
               <% first_total = provider_model.select { |row| row['level'] == 'top' }.map { |row| row[first_column]&.delete(',').to_i }.sum %>
               <% second_total = provider_model.select { |row| row['level'] == 'top' }.map { |row| row[second_column]&.delete(',').to_i }.sum %>
               <% percentage_change = second_total.to_f.zero? ? 0 : (first_total - second_total).to_f / second_total * 100 %>


### PR DESCRIPTION
## Context

The provider-level mid-cycle report uses 6 columns in 2 groups of 3.

To make this a bit clearer, this PR adds vertical lines between the groups.

## Screenshots

### Before

<img width="1012" alt="Screenshot 2023-05-19 at 18 10 16" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/30665/c7ba99fb-08f8-4790-93eb-d18bed1c8c3f">

### After

<img width="1011" alt="Screenshot 2023-05-19 at 18 09 13" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/30665/7cac2f74-82ce-4807-8575-36801c10aa6b">

