### PR TITLE
Support task to send notify template

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,8 @@ gem 'govuk_design_system_formbuilder', '~> 4.0.0'
 # GOV.UK Notify
 gem 'mail-notify'
 
+gem 'notifications-ruby-client'
+
 gem 'govuk_markdown'
 
 # Linting

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -821,6 +821,7 @@ DEPENDENCIES
   launchy
   listen (>= 3.0.5, < 3.9)
   mail-notify
+  notifications-ruby-client
   oj
   okcomputer
   omniauth

--- a/app/controllers/support_interface/settings_controller.rb
+++ b/app/controllers/support_interface/settings_controller.rb
@@ -67,6 +67,9 @@ module SupportInterface
         notify_template_id,
         pdf_handle,
       )
+
+      flash[:success] = 'Email sent'
+      redirect_to support_interface_notify_template_path
     end
 
   private

--- a/app/controllers/support_interface/settings_controller.rb
+++ b/app/controllers/support_interface/settings_controller.rb
@@ -53,7 +53,47 @@ module SupportInterface
       redirect_to support_interface_mid_cycle_report_path
     end
 
+    def notify_template; end
+
+    def send_notify_template
+      notify_template_id = params.require(:template_id)
+      distribution_list = params.require(:distribution_list).read
+      pdf_handle = StringIO.new(params.require(:attachment).read)
+      client = Notifications::Client.new(ENV['GOVUK_NOTIFY_API_KEY'])
+
+      actually_email_providers!(
+        client,
+        csv_to_hashes(distribution_list),
+        notify_template_id,
+        pdf_handle,
+      )
+    end
+
   private
+
+    def actually_email_providers!(client, user_hashes, template, pdf_handle)
+      user_hashes.each do |h|
+        send_email(client, template, h['Email address'], pdf_handle)
+      end
+    end
+
+    def csv_to_hashes(csv)
+      CSV.parse(csv, headers: true).map do |row|
+        h = row.to_h
+        h.keys.zip(h.values.map(&:strip)).to_h
+      end
+    end
+
+    def send_email(client, template, address, pdf_handle)
+      pdf_handle.rewind
+      client.send_email(
+        email_address: address,
+        template_id: template,
+        personalisation: {
+          pdf_link: Notifications.prepare_upload(pdf_handle),
+        },
+      )
+    end
 
     def feature_name
       params[:feature_name].humanize

--- a/app/views/support_interface/settings/_settings_navigation.html.erb
+++ b/app/views/support_interface/settings/_settings_navigation.html.erb
@@ -7,6 +7,7 @@
   { name: 'Tasks', url: support_interface_tasks_path },
   { name: 'Support users', url: support_interface_support_users_path },
   { name: 'Mid-cycle report', url: support_interface_mid_cycle_report_path },
+  { name: 'Send notify template', url: support_interface_notify_template_path },
 ]) %>
 
 <h2 class="govuk-visually-hidden"><%= title %></h2>

--- a/app/views/support_interface/settings/notify_template.html.erb
+++ b/app/views/support_interface/settings/notify_template.html.erb
@@ -1,0 +1,14 @@
+<%= render 'settings_navigation', title: 'Send notify template' %>
+
+<h1 class="govuk-label-wrapper">
+  <label class="govuk-label govuk-label--l" for="more-detail">
+    Send a Govuk notify template with attachment
+  </label>
+</h1>
+
+<%= form_with url: support_interface_send_notify_template_path, method: :post do |f| %>
+  <%= f.govuk_text_field :template_id, label: { text: 'Notify template id' } %>
+  <%= f.govuk_file_field :distribution_list, label: { text: 'Distribution list' } %>
+  <%= f.govuk_file_field :attachment, label: { text: 'Attachment' } %>
+  <%= f.govuk_submit 'Send' %>
+<% end %>

--- a/config/routes/support.rb
+++ b/config/routes/support.rb
@@ -236,6 +236,9 @@ namespace :support_interface, path: '/support' do
     get '/mid-cycle-report', to: 'settings#mid_cycle_report', as: :mid_cycle_report
     post '/mid-cycle-report-upload', to: 'settings#mid_cycle_report_upload', as: :mid_cycle_report_upload
 
+    get '/notify-template', to: 'settings#notify_template', as: :notify_template
+    post '/send-notify-template', to: 'settings#send_notify_template', as: :send_notify_template
+
     unless HostingEnvironment.production?
       post '/cycles', to: 'settings#switch_cycle_schedule', as: :switch_cycle_schedule
     end


### PR DESCRIPTION
## Context

You can't send notify templates with attachments from the notify portal.

This will add a support task to send notify templates with a distribution list and attachment