### PR TITLE
Increase nginx default size

### DIFF
--- a/service_unavailable_page/web/nginx.conf
+++ b/service_unavailable_page/web/nginx.conf
@@ -16,6 +16,8 @@ http {
   keepalive_timeout 30;
   port_in_redirect off; # Ensure that redirects don't include the internal container PORT - 8080
 
+  client_max_body_size 2M;
+
   server {
     listen {{port}};
     root public;


### PR DESCRIPTION
## Context

Trying to upload a CSV on apply:
<img width="522" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/fbf11c7d-a695-4d66-8384-3ed332421e94">

Default file size is 1mb. The CSV file is 1.4mb
https://repost.aws/knowledge-center/elastic-beanstalk-nginx-configuration
