### PR TITLE
Remove sentry message over the limit field truncation

### DIFF
--- a/app/presenters/concerns/field_truncation.rb
+++ b/app/presenters/concerns/field_truncation.rb
@@ -8,7 +8,6 @@ private
     return field_value if field_value.nil?
     return field_value if field_value.length <= limit
 
-    Sentry.capture_message("#{field_name} truncated for application with id #{application_choice.id} as length exceeded #{limit} chars")
     field_value.truncate(limit, omission: OMISSION_TEXT)
   end
 

--- a/spec/presenters/concerns/candidate_api_data_spec.rb
+++ b/spec/presenters/concerns/candidate_api_data_spec.rb
@@ -109,15 +109,6 @@ RSpec.describe CandidateAPIData do
         it 'returns a value within the field limit' do
           expect(presenter.candidate[:uk_residency_status].length).to be(limit)
         end
-
-        it 'raises a sentry error' do
-          allow(Sentry).to receive(:capture_message)
-
-          presenter.candidate[:uk_residency_status]
-
-          expect(Sentry).to have_received(:capture_message)
-            .with("#{described_class::UK_RESIDENCY_STATUS_FIELD} truncated for application with id #{application_choice.id} as length exceeded #{limit} chars")
-        end
       end
 
       context 'when the right to work or study details is nil' do

--- a/spec/presenters/concerns/decisions_api_data_spec.rb
+++ b/spec/presenters/concerns/decisions_api_data_spec.rb
@@ -52,8 +52,6 @@ RSpec.describe DecisionsAPIData do
 
       presenter.rejection
 
-      expect(Sentry).to have_received(:capture_message).with("Rejection.properties.reason truncated for application with id #{application_choice.id} as length exceeded 65535 chars")
-
       expect(presenter.rejection[:reason].length).to be(65535)
       expect(presenter.rejection[:reason]).to end_with(described_class::OMISSION_TEXT)
       expect(presenter.rejection[:date]).to eq(rejected_at.iso8601)

--- a/spec/presenters/concerns/work_experience_api_data_spec.rb
+++ b/spec/presenters/concerns/work_experience_api_data_spec.rb
@@ -48,11 +48,7 @@ RSpec.describe WorkExperienceAPIData do
       let(:breaks) { [] }
 
       it 'returns the work_history_breaks attribute of an application' do
-        allow(Sentry).to receive(:capture_message)
-
         presenter.work_history_break_explanation
-
-        expect(Sentry).to have_received(:capture_message).with("WorkExperiences.properties.work_history_break_explanation truncated for application with id #{application_choice.id} as length exceeded 10240 chars")
 
         expect(presenter.work_history_break_explanation).to end_with(described_class::OMISSION_TEXT)
         expect(presenter.work_history_break_explanation.length).to be(10240)


### PR DESCRIPTION
## Context

It is already known that we will maintain the truncation behavior so this message becomes redundant, so it was decided to simply remove it.
