### PR TITLE
Cleanup offer conditions schema part 2/2

### DIFF
--- a/app/models/offer_condition.rb
+++ b/app/models/offer_condition.rb
@@ -4,8 +4,6 @@ class OfferCondition < ApplicationRecord
   belongs_to :offer, touch: true
   has_one :application_choice, through: :offer
 
-  self.ignored_columns += [:text]
-
   audited associated_with: :application_choice
 
   enum status: {

--- a/db/migrate/20230523103650_cleanup_offer_conditions.rb
+++ b/db/migrate/20230523103650_cleanup_offer_conditions.rb
@@ -1,0 +1,11 @@
+class CleanupOfferConditions < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      remove_column :offer_conditions, :text, :string
+
+      validate_check_constraint :offer_conditions, name: 'offer_conditions_type_not_null'
+      change_column_null :offer_conditions, :type, false
+      remove_check_constraint :offer_conditions, name: 'offer_conditions_type_not_null'
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_23_102018) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_23_103650) do
   create_sequence "qualifications_public_id_seq", start: 120000
 
   # These are extensions that must be enabled in order to support this database
@@ -561,14 +561,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_23_102018) do
 
   create_table "offer_conditions", force: :cascade do |t|
     t.bigint "offer_id", null: false
-    t.string "text"
     t.string "status", default: "pending", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "type"
+    t.string "type", null: false
     t.jsonb "details"
     t.index ["offer_id"], name: "index_offer_conditions_on_offer_id"
-    t.check_constraint "type IS NOT NULL", name: "offer_conditions_type_not_null"
   end
 
   create_table "offers", force: :cascade do |t|


### PR DESCRIPTION
## Context

Now that we have got rid of all unstructured conditions we can know remove the `text` column from the schema and make `type` NOT NULL.

## Changes proposed in this pull request

The changes in the PR depend on https://github.com/DFE-Digital/apply-for-teacher-training/pull/8272 which will need to be deployed first.

Migration to remove the `text` column and make `type` NOT NULL.

## Guidance to review

Is this safe?

## Link to Trello card

https://trello.com/c/ADlyFkUv/1470-migration-to-cleanup-following-structured-conditions

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
