### PR TITLE
Nudge for signups that dont start form

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -4,6 +4,7 @@ class CandidateMailer < ApplicationMailer
   layout(
     'candidate_email_with_support_footer',
     except: %i[
+      nudge_unstarted
       nudge_unsubmitted
       nudge_unsubmitted_with_incomplete_courses
       nudge_unsubmitted_with_incomplete_personal_statement
@@ -470,6 +471,15 @@ class CandidateMailer < ApplicationMailer
     email_for_candidate(
       application_form,
       subject: I18n.t!('candidate_mailer.duplicate_match.subject'),
+    )
+  end
+
+  def nudge_unstarted(application_form)
+    @application_form = application_form
+    email_for_candidate(
+      application_form,
+      subject: I18n.t!('candidate_mailer.nudge_unstarted.subject'),
+      layout: false,
     )
   end
 

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -26,6 +26,7 @@ class ApplicationForm < ApplicationRecord
 
   scope :current_cycle, -> { where(recruitment_cycle_year: RecruitmentCycle.current_year) }
   scope :unsubmitted, -> { where(submitted_at: nil) }
+  scope :unstarted, -> { where('created_at = updated_at') }
   scope :inactive_since, ->(time) { where('application_forms.updated_at < ?', time) }
   scope :with_completion, ->(completion_attributes) { where(completion_attributes.map { |attr| "#{attr} = true" }.join(' AND ')) }
   scope :has_not_received_email, lambda { |mailer, mail_template|

--- a/app/queries/get_unstarted_applications_ready_to_nudge.rb
+++ b/app/queries/get_unstarted_applications_ready_to_nudge.rb
@@ -1,0 +1,13 @@
+class GetUnstartedApplicationsReadyToNudge
+  MAILER = 'candidate_mailer'.freeze
+  MAIL_TEMPLATE = 'nudge_unstarted'.freeze
+  INACTIVE_FOR_DAYS = 14
+
+  def call
+    ApplicationForm
+      .unstarted
+      .inactive_since(INACTIVE_FOR_DAYS.days.ago)
+      .current_cycle
+      .has_not_received_email(MAILER, MAIL_TEMPLATE)
+  end
+end

--- a/app/queries/get_unstarted_applications_ready_to_nudge.rb
+++ b/app/queries/get_unstarted_applications_ready_to_nudge.rb
@@ -2,6 +2,7 @@ class GetUnstartedApplicationsReadyToNudge
   MAILER = 'candidate_mailer'.freeze
   MAIL_TEMPLATE = 'nudge_unstarted'.freeze
   INACTIVE_FOR_DAYS = 14
+  IGNORE_EARLIER_THAN = Date.new(2023, 1, 1)
 
   def call
     ApplicationForm
@@ -9,5 +10,6 @@ class GetUnstartedApplicationsReadyToNudge
       .inactive_since(INACTIVE_FOR_DAYS.days.ago)
       .current_cycle
       .has_not_received_email(MAILER, MAIL_TEMPLATE)
+      .where('created_at > ?', IGNORE_EARLIER_THAN)
   end
 end

--- a/app/views/candidate_mailer/nudge_unstarted.text.erb
+++ b/app/views/candidate_mailer/nudge_unstarted.text.erb
@@ -1,0 +1,37 @@
+<% if @application_form.first_name.present? %>
+  Dear <%= @application_form.first_name %>
+
+<% end %>
+You recently created an account to apply for teacher training, but you haven’t started your application yet.
+
+Here’s 2 things you could start thinking about to get going with your application.
+
+# Choosing a course
+
+You’ll choose the courses you want to apply for in the section of the application form called ‘Courses’. You can apply for up to 5 courses at a time.
+
+Training providers offer places on courses as people apply through the year and courses stay open until they are full.
+
+Some courses can fill up quickly, so you should apply as soon as you can if you want to start training in September 2023.
+
+Once you submit your application, you’ll get email notifications to tell you when something has changed on your application.
+
+# Writing your personal statement
+
+Training providers use the personal statement to find out more about you and your motivations for wanting to teach.
+
+Spending some time on your personal statement can really show your enthusiasm and help you stand out to training providers. 
+
+Within the application form, there is guidance to help think about what to write. You do not need to stick to it exactly, but it can help you get started.
+
+You could speak to our teacher training advisers. They were teachers and can give you free, one-to-one support with your statement:
+
+[<%= t('get_into_teaching.url_get_an_adviser_start') %>](<%= email_link_with_utm_params t('get_into_teaching.url_get_an_adviser_start'), 'nudge_unstarted', @application_form.phase %>)
+
+# Get help
+
+Call 0800 389 2500 or chat online:
+
+[<%= t('get_into_teaching.url_talk_to_us') %>](<%= email_link_with_utm_params t('get_into_teaching.url_talk_to_us'), GetUnstartedApplicationsReadyToNudge::MAIL_TEMPLATE, @application_form.phase %>)
+
+Monday to Friday, 8:30am to 5:30pm (except public holidays).

--- a/app/workers/nudge_candidates_worker.rb
+++ b/app/workers/nudge_candidates_worker.rb
@@ -20,6 +20,11 @@ class NudgeCandidatesWorker
       nil,
     ),
     Nudge.new(
+      GetUnstartedApplicationsReadyToNudge,
+      :nudge_unstarted,
+      nil,
+    ),
+    Nudge.new(
       GetIncompleteReferenceApplicationsReadyToNudge,
       :nudge_unsubmitted_with_incomplete_references,
       :reference_nudges,

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -106,6 +106,7 @@ en:
         - candidate_mailer-reference_received
         - referee_mailer-reference_confirmation_email
         - candidate_mailer-chase_reference_again
+        - candidate_mailer-nudge_unstarted
         - candidate_mailer-nudge_unsubmitted
         - candidate_mailer-nudge_unsubmitted_with_incomplete_courses
         - candidate_mailer-nudge_unsubmitted_with_incomplete_personal_statement

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -114,5 +114,7 @@ en:
         subject: ????
     nudge_unsubmitted_with_incomplete_courses:
       subject: Get help choosing a teacher training course
+    nudge_unstarted:
+      subject: Get help applying for a teacher training course
     nudge_unsubmitted_with_incomplete_personal_statement:
       subject: Get help with your personal statement

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -115,6 +115,6 @@ en:
     nudge_unsubmitted_with_incomplete_courses:
       subject: Get help choosing a teacher training course
     nudge_unstarted:
-      subject: Get help applying for a teacher training course
+      subject: Start your teacher training application
     nudge_unsubmitted_with_incomplete_personal_statement:
       subject: Get help with your personal statement

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,7 @@ en:
     url_choose_your_referees: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/how-to-apply-for-teacher-training#choose-your-references
     url_if_you_dont_have_a_degree: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/if-you-dont-have-a-degree
     url_subject_knowledge_enhancement: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement
+    url_talk_to_us: https://getintoteaching.education.gov.uk/#talk-to-us
   train_to_teach_in_england:
     url: https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration
     url_citizen_visa: https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-if-youre-a-non-uk-citizen#visa

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -849,6 +849,11 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.nudge_unsubmitted(application_form)
   end
 
+  def nudge_unstarted
+    application_form = FactoryBot.create(:application_form)
+    CandidateMailer.nudge_unstarted(application_form)
+  end
+
   def nudge_unsubmitted_with_incomplete_courses
     application_form = FactoryBot.create(:completed_application_form)
     CandidateMailer.nudge_unsubmitted_with_incomplete_courses(application_form)

--- a/spec/queries/get_unstarted_applications_ready_to_nudge_spec.rb
+++ b/spec/queries/get_unstarted_applications_ready_to_nudge_spec.rb
@@ -12,7 +12,18 @@ RSpec.describe GetUnstartedApplicationsReadyToNudge do
     expect(described_class.new.call).to include(application_form)
   end
 
-  it 'omits unstarted applications that have been started (updated since they were created)' do
+  it 'omits unstarted applications that were created before the start of 2023' do
+    application_form = create(:application_form)
+    before_2023 = Date.new(2022, 12, 31)
+    application_form.update_columns(
+      updated_at: before_2023,
+      created_at: before_2023,
+    )
+
+    expect(described_class.new.call).not_to include(application_form)
+  end
+
+  it 'omits incomplete applications that have been started (updated since they were created)' do
     application_form = create(:application_form)
     application_form.update_columns(
       updated_at: 15.days.ago,

--- a/spec/queries/get_unstarted_applications_ready_to_nudge_spec.rb
+++ b/spec/queries/get_unstarted_applications_ready_to_nudge_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe GetUnstartedApplicationsReadyToNudge do
+  it 'returns unstarted applications that have been inactive for more than 14 days' do
+    application_form = create(:application_form)
+    fifteen_days_ago = 15.days.ago
+    application_form.update_columns(
+      updated_at: fifteen_days_ago,
+      created_at: fifteen_days_ago,
+    )
+
+    expect(described_class.new.call).to include(application_form)
+  end
+
+  it 'omits unstarted applications that have been started (updated since they were created)' do
+    application_form = create(:application_form)
+    application_form.update_columns(
+      updated_at: 15.days.ago,
+      created_at: 16.days.ago,
+    )
+
+    expect(described_class.new.call).not_to include(application_form)
+  end
+
+  it 'omits unstarted applications that have been inactive for less than 14 days' do
+    application_form = create(:application_form)
+    thirteen_days_ago = 13.days.ago
+    application_form.update_columns(
+      updated_at: thirteen_days_ago,
+      created_at: thirteen_days_ago,
+    )
+
+    expect(described_class.new.call).not_to include(application_form)
+  end
+
+  it 'omits applications that were started in a previous cycle' do
+    application_form = create(
+      :application_form,
+      recruitment_cycle_year: RecruitmentCycle.previous_year,
+    )
+    fifteen_days_ago = 15.days.ago
+    application_form.update_columns(
+      updated_at: fifteen_days_ago,
+      created_at: fifteen_days_ago,
+    )
+
+    expect(described_class.new.call).to eq([])
+  end
+
+  it 'omits applications that already received this email' do
+    application_form = create(:application_form)
+    fifteen_days_ago = 15.days.ago
+    application_form.update_columns(
+      updated_at: fifteen_days_ago,
+      created_at: fifteen_days_ago,
+    )
+    create(
+      :email,
+      mailer: described_class::MAILER,
+      mail_template: described_class::MAIL_TEMPLATE,
+      application_form:,
+    )
+
+    expect(described_class.new.call).to eq([])
+  end
+end

--- a/spec/workers/nudge_candidates_worker_spec.rb
+++ b/spec/workers/nudge_candidates_worker_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe NudgeCandidatesWorker, sidekiq: true do
       email = email_for_candidate(application_form_unstarted.candidate)
 
       expect(email).to be_present
-      expect(email.subject).to include('Get help applying for a teacher training course')
+      expect(email.subject).to include('Start your teacher training application')
     end
 
     it 'sends email to candidates with an unsubmitted completed application' do


### PR DESCRIPTION
## Context

We know that (as of 26 April 2023) there are 9,517 candidates who have signed up in the ITT2023 recruitment cycle who have not started the form in Apply_1. This reflects 13.2% of all sign ups this cycle.

These people may just be looking to see what the application form is like, equally, they may not know where to start. We have an email nudge that can help.

## Changes proposed in this pull request

- Add a new nudge query class to find the applications that might be worth nudging - `GetUnstartedApplicationsReadyToNudge`
- Add new template and wire this up to the existing service class - `NudgeCandidatesWorker`

![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/450843/b6c70bd9-8b7c-4a97-926b-87cc1e7fb548)

- Include the new email in the documentation sections of the support interface.

![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/450843/4271b5d0-9f98-47fb-9c43-77f0ee4d5295)

## Guidance to review

Example query:
```
SELECT "application_forms".*
FROM "application_forms"
WHERE (created_at = updated_at)
AND (application_forms.updated_at < '2023-05-11 08:35:57.090739')
AND "application_forms"."recruitment_cycle_year" = 2023
AND (NOT EXISTS (SELECT 1 FROM "emails" WHERE (emails.application_form_id = application_forms.id) AND "emails"."mailer" = 'candidate_mailer' AND "emails"."mail_template" = 'nudge_unstarted'));
```
Does this make sense?
Is there are better way to determine whether an application is _unstarted_?


## Link to Trello card

https://trello.com/c/nSWUINNd/1457-implement-a-new-nudge-for-candidates-who-sign-up-and-do-nothing-for-14-days

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
