### PR TITLE
Bugfix: reduce line length for prose text

### DIFF
--- a/app/views/provider_interface/reports/diversity_reports/show.html.erb
+++ b/app/views/provider_interface/reports/diversity_reports/show.html.erb
@@ -21,30 +21,37 @@
       <p class="govuk-body">
         <%= govuk_link_to 'Export data (ZIP)', provider_interface_reports_provider_diversity_report_path(provider_id: @provider, format: :zip) %>
       </p>
-      <h2 class="govuk-heading-m">Sex</h3>
+      <h2 class="govuk-heading-m">Sex</h2>
       <%= render ProviderInterface::ReportTableComponent.new(headers: ['Sex', *ProviderInterface::DiversityDataByProvider::REPORT_HEADERS],
                                                              rows: @diversity_report_sex_data,
                                                              show_footer: true,
                                                              exclude_from_footer: ['Percentage recruited'],
                                                              bold_row_headers: false) %>
-
-      <h2 class="govuk-heading-m">Disability and health conditions</h3>
+    </div>
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h2 class="govuk-heading-m">Disability and health conditions</h2>
       <p class="govuk-body">This question is separate from asking candidates if they need additional support with their application or while they train.</p>
       <p class="govuk-body">Candidates can select multiple disabilities or health conditions, so the numbers may not match the totals.</p>
+    </div>
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <%= render ProviderInterface::ReportTableComponent.new(headers: ['Disability or health condition', *ProviderInterface::DiversityDataByProvider::REPORT_HEADERS],
                                                              rows: @diversity_report_disability_data,
                                                              show_footer: true,
                                                              exclude_from_footer: ['Percentage recruited'],
                                                              bold_row_headers: false) %>
 
-      <h2 class="govuk-heading-m">Ethnicity</h3>
+      <h2 class="govuk-heading-m">Ethnicity</h2>
       <%= render ProviderInterface::ReportTableComponent.new(headers: ['Ethnic group', *ProviderInterface::DiversityDataByProvider::REPORT_HEADERS],
                                                              rows: @diversity_report_ethnicity_data,
                                                              show_footer: true,
                                                              exclude_from_footer: ['Percentage recruited'],
                                                              bold_row_headers: false) %>
 
-      <h2 class="govuk-heading-m">Age</h3>
+      <h2 class="govuk-heading-m">Age</h2>
       <%= render ProviderInterface::ReportTableComponent.new(headers: ['Age group', *ProviderInterface::DiversityDataByProvider::REPORT_HEADERS],
                                                              rows: @diversity_report_age_data,
                                                              show_footer: true,


### PR DESCRIPTION
We should avoid full-width prose text, as it's harder to read. This brings the max width down to 2/3rds, matching the prose content on the rest of the page.

(Also fix mismatched header tags)

## Screenshots

### Before

<img width="1025" alt="Screenshot 2023-05-25 at 13 19 49" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/30665/2e05b215-ffed-4085-862b-56f4daa64bf9">

### After

<img width="1042" alt="Screenshot 2023-05-25 at 13 17 52" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/30665/3c9a2794-66e3-4734-93ea-e1ea1b12969e">




