### PR TITLE
Content tweak: change 'Offer' to 'Offered'

### DIFF
--- a/app/services/provider_interface/diversity_data_by_provider.rb
+++ b/app/services/provider_interface/diversity_data_by_provider.rb
@@ -11,7 +11,7 @@ module ProviderInterface
 
     REPORT_HEADERS = [
       'Applied',
-      'Offer',
+      'Offered',
       'Recruited',
       'Percentage recruited',
     ].freeze


### PR DESCRIPTION
The column header words should be consistently in past tense.

Thanks to @simonwhatley for spotting and reporting.

## Screenshots

### Before

<img width="1012" alt="Screenshot 2023-05-25 at 13 23 11" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/30665/4e2a8be3-5c47-41e4-9aab-979431933d56">

### After

<img width="1027" alt="Screenshot 2023-05-25 at 13 22 29" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/30665/de07b576-b197-43c4-b22a-035deabe47e4">
