### PR TITLE
Unchecked reference condition when change offer

### DIFF
--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -53,7 +53,7 @@ module ProviderInterface
     def self.require_references_from(offer)
       return REQUIRE_REFERENCES_CHECKED_BY_DEFAULT if reference_condition(offer)&.required.present?
 
-      '0' if reference_condition(offer).present?
+      '0' if offer.present?
     end
 
     def self.references_description_from(offer)

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -213,7 +213,8 @@ RSpec.describe ProviderInterface::OfferWizard do
   end
 
   describe '.build_from_application_choice' do
-    let(:application_choice) { create(:application_choice, :offered, offer: build(:offer, conditions:)) }
+    let(:offer) { build(:offer, conditions:) }
+    let(:application_choice) { create(:application_choice, :offered, offer:) }
     let(:conditions) do
       [
         build(:text_condition, description: 'Fitness to train to teach check'),
@@ -259,8 +260,17 @@ RSpec.describe ProviderInterface::OfferWizard do
         end
       end
 
-      context 'when blank reference condition' do
+      context 'when blank conditions' do
         let(:conditions) { [] }
+
+        it 'unchecked as default' do
+          expect(wizard).to be_valid
+          expect(wizard.require_references).to be_zero
+        end
+      end
+
+      context 'when blank offer' do
+        let(:offer) { nil }
 
         it 'checked as default' do
           expect(wizard).to be_valid


### PR DESCRIPTION
## Context

When is a blank offer, the reference condition should be ticked and when there is an offer without reference condition it should be unchecked.