### PR TITLE
Reflect when data collection started on withdrawal report when a user hasn't got 10 responses

### DIFF
--- a/app/views/provider_interface/reports/withdrawal_reports/show.html.erb
+++ b/app/views/provider_interface/reports/withdrawal_reports/show.html.erb
@@ -13,6 +13,9 @@
       <p class="govuk-body">
         You’ll be able to see this report once it contains data from at least <%= ProviderReports::MINIMUM_DATA_SIZE_REQUIRED %> candidates. This is to protect the privacy of candidates.
       </p>
+      <p class="govuk-body">
+        This data has only been collected from 11 April 2023.
+      </p>
     <% else %>
       <p class="govuk-body">Candidates who withdraw their application are asked to select their reasons for withdrawing. This is an optional question.</p>
       <p class="govuk-body">Candidates are asked this question when they withdraw:</p>


### PR DESCRIPTION
## Context

We received feedback from Support on this. Providers did not understand why they couldn't view the report - the reason was that data collection only started in April, not the whole cycle. We should add some copy to explain it.

I've mirrored the copy when a provider has enough withdrawals to show the report.

## Changes proposed in this pull request

Before: 
![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/35870975/6f7f7e62-de4d-4173-a332-fc93813e0a80)

After:
![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/35870975/0e75ac78-0702-4df5-8cf7-98c7b918e140)

Where this language came from (blurb when a provider has >10 withdrawals):
![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/35870975/ed7acbab-ac0b-4b8a-b42b-21be342f3f77)


## Guidance to review

Is mirroring what we say on the report when there are >10 responses the right way to go?

## Link to Trello card

https://trello.com/c/qsn05Z7j/1519-does-the-withdrawal-report-need-a-bit-more-clarifying-text-when-a-provider-doesnt-have-10-candidates-with-structured-withdrawal

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
