### PR TITLE
[349] Deploy postgres and redis containers to the app nodepool

### DIFF
--- a/terraform/modules/kubernetes/aks_postgres.tf
+++ b/terraform/modules/kubernetes/aks_postgres.tf
@@ -20,7 +20,8 @@ resource "kubernetes_deployment" "postgres" {
       }
       spec {
         node_selector = {
-          "kubernetes.io/os" : "linux"
+          "teacherservices.cloud/node_pool" = "applications"
+          "kubernetes.io/os"                = "linux"
         }
         container {
           name  = local.postgres_service_name

--- a/terraform/modules/kubernetes/aks_redis.tf
+++ b/terraform/modules/kubernetes/aks_redis.tf
@@ -20,7 +20,8 @@ resource "kubernetes_deployment" "redis" {
       }
       spec {
         node_selector = {
-          "kubernetes.io/os" : "linux"
+          "teacherservices.cloud/node_pool" = "applications"
+          "kubernetes.io/os"                = "linux"
         }
         container {
           name  = local.redis_service_name


### PR DESCRIPTION
## Context
Postgres and redis review containers didn’t have a node selector to force them to be scheduled on the applications node pool so they were sometimes deployed to the default one. This is reserved for the system.

## Changes proposed in this pull request
Pin containers to the applications node pool

## Guidance to review
Run `kubectl -n bat-qa get pods -o wide` and check the node pool

## Link to Trello card
https://trello.com/c/VQwLiRfF

