### PR TITLE
Making content on the withdrawal report more clear to explain withdrawals are from a set list

### DIFF
--- a/app/views/provider_interface/reports/withdrawal_reports/show.html.erb
+++ b/app/views/provider_interface/reports/withdrawal_reports/show.html.erb
@@ -14,7 +14,7 @@
         You’ll be able to see this report once it contains data from at least <%= ProviderReports::MINIMUM_DATA_SIZE_REQUIRED %> candidates. This is to protect the privacy of candidates.
       </p>
       <p class="govuk-body">
-        This data has only been collected from 11 April 2023.
+        The report shows data from candidates who withdrew their application and selected their reason from a set list. This is an optional question. Data for this report has only been collected from 11 April 2023.
       </p>
     <% else %>
       <p class="govuk-body">Candidates who withdraw their application are asked to select their reasons for withdrawing. This is an optional question.</p>


### PR DESCRIPTION
## Context

When providers have less than 10 withdrawals, we need to explain that the report only shows candidates who have chosen their reason from a set list and the data has only been collected since April.

We previously made this change on another PR, but have now added more clarity.
Previous PR: https://github.com/DFE-Digital/apply-for-teacher-training/pull/8281

## Changes proposed in this pull request

Changed content on the page is the provider can't see the report.

**Content now reads:**

You’ll be able to see this report once it contains data from at least 10 candidates. This is to protect the privacy of candidates.

The report shows data from candidates who withdrew their application and selected their reason from a set list. This is an optional question. Data for this report has only been collected from 11 April 2023.

### Before:

<img width="690" alt="Screenshot 2023-05-26 at 12 52 56" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/68232608/d1ba740f-9557-4f87-9240-7aeb205216ab">

### After

<img width="732" alt="Screenshot 2023-05-26 at 12 53 24" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/68232608/3b74e426-c512-486e-8cf1-0bbe1523cd70">



## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
