### PR TITLE
Fix false positive tests

### DIFF
--- a/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
+++ b/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe CandidateInterface::ApplicationDashboardCourseChoicesComponent, t
       )
       expect(rendered_component).to summarise(
         key: 'Conditions',
-        value: 'Contact the provider to find out more about any conditions.They’ll confirm your place once you’ve met any conditions and they’ve checked your references.',
+        value: 'Contact the provider to find out more about any conditions. They’ll confirm your place once you’ve met any conditions and they’ve checked your references.',
       )
     end
 

--- a/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
+++ b/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
@@ -100,12 +100,11 @@ RSpec.describe CandidateInterface::ApplicationDashboardCourseChoicesComponent, t
       end
 
       it 'renders component with the status as rejected and displays the reason' do
-        render_inline(
+        rendered_component = render_inline(
           described_class.new(application_form:, editable: false, show_status: true),
-        ) do |rendered_component|
-          expect(rendered_component).to summarise(key: 'Status', value: 'Unsuccessful')
-          expect(rendered_component).to summarise(key: 'Feedback', value: 'Course full')
-        end
+        )
+        expect(rendered_component).to summarise(key: 'Status', value: 'Unsuccessful')
+        expect(rendered_component).to summarise(key: 'Feedback', value: 'Course full')
       end
     end
   end
@@ -122,22 +121,23 @@ RSpec.describe CandidateInterface::ApplicationDashboardCourseChoicesComponent, t
     end
 
     it 'renders component with the status as Offer withdrawn and displays the reason' do
-      render_inline(
+      rendered_component = render_inline(
         described_class.new(application_form:, editable: false, show_status: true),
-      ) do |rendered_component|
-        expect(rendered_component).to summarise(key: 'Status', value: 'Offer withdrawn')
-        expect(rendered_component).to summarise(key: 'Reason for offer withdrawal', value: 'Course full')
-      end
+      )
+      expect(rendered_component).to summarise(key: 'Status', value: 'Offer withdrawn')
+      expect(rendered_component).to summarise(key: 'Reason for offer withdrawal', value: 'Course full')
     end
 
     it 'does not render the reason if an offer is subsequently made' do
       application_choice.offer!
 
-      render_inline(
+      rendered_component = render_inline(
         described_class.new(application_form:, editable: false, show_status: true),
-      ) do |rendered_component|
-        expect(rendered_component).not_to summarise(key: 'Reason for offer withdrawal', value: 'Course full')
-      end
+      )
+      expect(rendered_component).not_to summarise(
+        key: 'Reason for offer withdrawal',
+        value: 'Course full',
+      )
     end
   end
 
@@ -145,11 +145,11 @@ RSpec.describe CandidateInterface::ApplicationDashboardCourseChoicesComponent, t
     let(:application_form) { create_application_form_with_course_choices(statuses: %w[awaiting_provider_decision]) }
 
     it 'renders component with the status as awaiting decision' do
-      render_inline(
+      rendered_component = render_inline(
         described_class.new(application_form:, editable: false, show_status: true),
-      ) do |rendered_component|
-        expect(rendered_component).to summarise(key: 'Status', value: 'Awaiting decision')
-      end
+      )
+
+      expect(rendered_component).to summarise(key: 'Status', value: 'Awaiting decision')
     end
 
     it 'renders component with a withdraw link' do
@@ -167,22 +167,33 @@ RSpec.describe CandidateInterface::ApplicationDashboardCourseChoicesComponent, t
       application_choice = application_form.application_choices.first
       create(:offer, application_choice:, conditions:)
 
-      render_inline(
+      rendered_component = render_inline(
         described_class.new(application_form:, editable: false, show_status: true),
-      ) do |rendered_component|
-        expect(rendered_component).to summarise(key: 'Status', value: "Offer received What to do if you’re unable to start training in #{application_choice.course_option.course.start_date.to_fs(:month_and_year)} You can defer your offer and start your course a year later. Contact #{application_choice.course_option.course.provider.name} to ask if it’s possible to defer, this will not affect your existing offer. If your provider agrees, you’ll need to accept the offer first.")
-        expect(rendered_component).to summarise(key: 'Conditions', value: 'DBS check Get a haircut Contact the provider to find out more about these conditions. They’ll confirm your place once you’ve met the conditions and they’ve checked your references.')
-      end
+      )
+      expect(rendered_component).to summarise(
+        key: 'Status',
+        value: "Offer received What to do if you’re unable to start training in #{application_choice.course_option.course.start_date.to_fs(:month_and_year)} You can defer your offer and start your course a year later. Contact #{application_choice.course_option.course.provider.name} to ask if it’s possible to defer, this will not affect your existing offer. If your provider agrees, you’ll need to accept the offer first.",
+      )
+      expect(rendered_component).to summarise(
+        key: 'Conditions',
+        value: 'DBS check Get a haircut Contact the provider to find out more about these conditions. They’ll confirm your place once you’ve met the conditions and they’ve checked your references.',
+      )
     end
 
     it 'shows some generic conditions copy if the offer is unconditional' do
       offer = create(:unconditional_offer)
 
-      render_inline(
-        described_class.new(application_form: offer.application_choice.application_form, editable: false, show_status: true),
-      ) do |rendered_component|
-        expect(rendered_component).to summarise(key: 'Conditions', value: 'Contact the provider to find out more about any conditions.They’ll confirm your place once you’ve met any conditions and they’ve checked your references.')
-      end
+      rendered_component = render_inline(
+        described_class.new(
+          application_form: offer.application_choice.application_form,
+          editable: false,
+          show_status: true,
+        ),
+      )
+      expect(rendered_component).to summarise(
+        key: 'Conditions',
+        value: 'Contact the provider to find out more about any conditions.They’ll confirm your place once you’ve met any conditions and they’ve checked your references.',
+      )
     end
 
     it 'renders component with the respond to offer link and message about waiting for providers to respond' do
@@ -192,7 +203,12 @@ RSpec.describe CandidateInterface::ApplicationDashboardCourseChoicesComponent, t
         .and(:application_choice).which_is(:awaiting_provider_decision)
         .create[:application_form].first
 
-      result = render_inline(described_class.new(application_form:, editable: false, show_status: true))
+      result = render_inline(
+        described_class.new(
+          application_form:,
+          editable: false,
+          show_status: true,
+        ))
 
       expect(result.css('.govuk-summary-list__value').text).to include('Respond to offer')
       expect(result.css('.govuk-summary-list__value a')[0].attr('href')).to include(
@@ -322,11 +338,13 @@ RSpec.describe CandidateInterface::ApplicationDashboardCourseChoicesComponent, t
     let(:offer) { create(:offer, conditions: [build(:reference_condition, description: nil)]) }
 
     it 'renders the references section with a default content' do
-      render_inline(
+      rendered_component = render_inline(
         described_class.new(application_form:, editable: false, show_status: true),
-      ) do |rendered_component|
-        expect(rendered_component).to summarise(key: 'References', value: "The provider will confirm your place once they've checked your references.")
-      end
+      )
+      expect(rendered_component).to summarise(
+        key: 'References',
+        value: "The provider will confirm your place once they've checked your references.",
+      )
     end
   end
 

--- a/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
+++ b/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
@@ -208,7 +208,8 @@ RSpec.describe CandidateInterface::ApplicationDashboardCourseChoicesComponent, t
           application_form:,
           editable: false,
           show_status: true,
-        ))
+        ),
+      )
 
       expect(result.css('.govuk-summary-list__value').text).to include('Respond to offer')
       expect(result.css('.govuk-summary-list__value a')[0].attr('href')).to include(

--- a/spec/components/candidate_interface/degree_review_component_spec.rb
+++ b/spec/components/candidate_interface/degree_review_component_spec.rb
@@ -64,103 +64,96 @@ RSpec.describe CandidateInterface::DegreeReviewComponent, type: :component do
     end
 
     it 'renders component with correct values for country' do
-      render_inline(described_class.new(application_form:)) do |component|
-        expect(component).to summarise(
-          key: t('application_form.degree.institution_country.review_label'),
-          value: 'United Kingdom',
-          action: {
-            text: "Change #{t('application_form.degree.institution_country.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
-            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :country),
-          },
-        )
-      end
+      component = render_inline(described_class.new(application_form:))
+      expect(component).to summarise(
+        key: t('application_form.degree.institution_country.review_label'),
+        value: 'United Kingdom',
+        action: {
+          text: "Change #{t('application_form.degree.institution_country.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
+          href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :country),
+        },
+      )
     end
 
     it 'renders component with correct values for a degree type' do
-      render_inline(described_class.new(application_form:)) do |component|
-        expect(component).to summarise(
-          key: t('application_form.degree.qualification_type.review_label'),
-          value: 'Bachelor degree',
-          action: {
-            text: "Change #{t('application_form.degree.qualification.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
-            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :degree_level),
-          },
-        )
-      end
+      component = render_inline(described_class.new(application_form:))
+      expect(component).to summarise(
+        key: t('application_form.degree.qualification_type.review_label'),
+        value: 'Bachelor degree',
+        action: {
+          text: "Change #{t('application_form.degree.qualification.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
+          href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :degree_level),
+        },
+      )
     end
 
     it 'renders component with correct values for a uk degree type' do
-      render_inline(described_class.new(application_form:)) do |component|
-        expect(component).to summarise(
-          key: 'Type of bachelor degree',
-          value: 'Bachelor of Arts in Architecture',
-          action: {
-            text: "Change #{t('application_form.degree.type_of_degree.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
-            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :type),
-          },
-        )
+      component = render_inline(described_class.new(application_form:))
+      expect(component).to summarise(
+        key: 'Type of bachelor degree',
+        value: 'Bachelor of Arts in Architecture',
+        action: {
+          text: "Change #{t('application_form.degree.type_of_degree.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
+          href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :type),
+        },
+      )
 
-        expect(component).to summarise(
-          key: 'Degree type',
-          value: 'Bachelor degree',
-          action: {
-            text: "Change #{t('application_form.degree.qualification.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
-            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :degree_level),
-          },
-        )
-      end
+      expect(component).to summarise(
+        key: 'Degree type',
+        value: 'Bachelor degree',
+        action: {
+          text: "Change #{t('application_form.degree.qualification.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
+          href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :degree_level),
+        },
+      )
     end
 
     it 'renders component with correct values for a subject' do
-      render_inline(described_class.new(application_form:)) do |component|
-        expect(component).to summarise(
-          key: t('application_form.degree.subject.review_label'),
-          value: 'Woof',
-          action: {
-            text: "Change #{t('application_form.degree.subject.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
-            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :subject),
-          },
-        )
-      end
+      component = render_inline(described_class.new(application_form:))
+      expect(component).to summarise(
+        key: t('application_form.degree.subject.review_label'),
+        value: 'Woof',
+        action: {
+          text: "Change #{t('application_form.degree.subject.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
+          href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :subject),
+        },
+      )
     end
 
     it 'renders component with correct values for an institution' do
-      render_inline(described_class.new(application_form:)) do |component|
-        expect(component).to summarise(
-          key: t('application_form.degree.institution_name.review_label'),
-          value: 'University of Doge',
-          action: {
-            text: "Change #{t('application_form.degree.institution_name.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
-            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :university),
-          },
-        )
-      end
+      component = render_inline(described_class.new(application_form:))
+      expect(component).to summarise(
+        key: t('application_form.degree.institution_name.review_label'),
+        value: 'University of Doge',
+        action: {
+          text: "Change #{t('application_form.degree.institution_name.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
+          href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :university),
+        },
+      )
     end
 
     it 'renders component with correct values for a start year' do
-      render_inline(described_class.new(application_form:)) do |component|
-        expect(component).to summarise(
-          key: t('application_form.degree.start_year.review_label'),
-          value: '2005',
-          action: {
-            text: "Change #{t('application_form.degree.start_year.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
-            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :start_year),
-          },
-        )
-      end
+      component = render_inline(described_class.new(application_form:))
+      expect(component).to summarise(
+        key: t('application_form.degree.start_year.review_label'),
+        value: '2005',
+        action: {
+          text: "Change #{t('application_form.degree.start_year.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
+          href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :start_year),
+        },
+      )
     end
 
     it 'renders component with correct values for an award year' do
-      render_inline(described_class.new(application_form:)) do |component|
-        expect(component).to summarise(
-          key: t('application_form.degree.award_year.review_label'),
-          value: '2008',
-          action: {
-            text: "Change #{t('application_form.degree.award_year.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
-            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :award_year),
-          },
-        )
-      end
+      component = render_inline(described_class.new(application_form:))
+      expect(component).to summarise(
+        key: t('application_form.degree.award_year.review_label'),
+        value: '2008',
+        action: {
+          text: "Change #{t('application_form.degree.award_year.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
+          href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :award_year),
+        },
+      )
     end
 
     context 'when the degree does not have a grade' do
@@ -178,12 +171,11 @@ RSpec.describe CandidateInterface::DegreeReviewComponent, type: :component do
       end
 
       it 'renders component with correct values for a grade' do
-        render_inline(described_class.new(application_form:)) do |component|
-          expect(component).to summarise(
-            key: t('application_form.degree.grade.review_label'),
-            value: t('application_form.degree.review.not_specified'),
-          )
-        end
+        component = render_inline(described_class.new(application_form:))
+        expect(component).to summarise(
+          key: t('application_form.degree.grade.review_label'),
+          value: t('application_form.degree.review.not_specified'),
+        )
       end
     end
 
@@ -201,12 +193,11 @@ RSpec.describe CandidateInterface::DegreeReviewComponent, type: :component do
       end
 
       it 'renders component with correct values for an award year' do
-        render_inline(described_class.new(application_form:)) do |component|
-          expect(component).to summarise(
-            key: t('application_form.degree.award_year.review_label'),
-            value: t('application_form.degree.review.not_specified'),
-          )
-        end
+        component = render_inline(described_class.new(application_form:))
+        expect(component).to summarise(
+          key: t('application_form.degree.award_year.review_label'),
+          value: t('application_form.degree.review.not_specified'),
+        )
       end
     end
 
@@ -215,25 +206,24 @@ RSpec.describe CandidateInterface::DegreeReviewComponent, type: :component do
         ActiveRecordRelationStub.new(ApplicationQualification, [degree1, degree2], scopes: [:degrees]),
       )
 
-      render_inline(described_class.new(application_form:)) do |component|
-        expect(component).to summarise(
-          key: t('application_form.degree.grade.review_label'),
-          value: 'Upper second',
-          action: {
-            text: "Change #{t('application_form.degree.grade.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
-            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :grade),
-          },
-        )
+      component = render_inline(described_class.new(application_form:))
+      expect(component).to summarise(
+        key: t('application_form.degree.grade.review_label'),
+        value: 'Upper second',
+        action: {
+          text: "Change #{t('application_form.degree.grade.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
+          href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :grade),
+        },
+      )
 
-        expect(component).to summarise(
-          key: t('application_form.degree.grade.review_label_predicted'),
-          value: 'First',
-          action: {
-            text: "Change #{t('application_form.degree.grade.change_action')} for Bachelor of Arts Economics, Meow, University of Cate, 2010",
-            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree2, :grade),
-          },
-        )
-      end
+      expect(component).to summarise(
+        key: t('application_form.degree.grade.review_label_predicted'),
+        value: 'First',
+        action: {
+          text: "Change #{t('application_form.degree.grade.change_action')} for Bachelor of Arts Economics, Meow, University of Cate, 2010",
+          href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree2, :grade),
+        },
+      )
     end
 
     it 'renders component with correct values for the completion status row' do
@@ -270,13 +260,12 @@ RSpec.describe CandidateInterface::DegreeReviewComponent, type: :component do
         ActiveRecordRelationStub.new(ApplicationQualification, [degree3], scopes: [:degrees]),
       )
 
-      render_inline(described_class.new(application_form:)) do |component|
-        expect(component).to have_css('.app-summary-card__title', text: 'BAArch (Hons) Hoot')
-        expect(component).to summarise(
-          key: t('application_form.degree.grade.review_label'),
-          value: 'Third-class honours',
-        )
-      end
+      component = render_inline(described_class.new(application_form:))
+      expect(component).to have_css('.app-summary-card__title', text: 'BAArch (Hons) Hoot')
+      expect(component).to summarise(
+        key: t('application_form.degree.grade.review_label'),
+        value: 'Third-class honours',
+      )
     end
 
     it 'renders component with correct values for multiple degrees' do
@@ -311,16 +300,15 @@ RSpec.describe CandidateInterface::DegreeReviewComponent, type: :component do
     end
 
     it 'renders component with no value for degree type row' do
-      render_inline(described_class.new(application_form:)) do |component|
-        expect(component).to summarise(
-          key: 'Degree type',
-          value: '',
-          action: {
-            text: "Change #{t('application_form.degree.qualification.change_action')} for , #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
-            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :degree_level),
-          },
-        )
-      end
+      component = render_inline(described_class.new(application_form:))
+      expect(component).to summarise(
+        key: 'Degree type',
+        value: '',
+        action: {
+          text: "Change #{t('application_form.degree.qualification.change_action')} for , #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
+          href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :degree_level),
+        },
+      )
     end
   end
 
@@ -343,16 +331,15 @@ RSpec.describe CandidateInterface::DegreeReviewComponent, type: :component do
         ActiveRecordRelationStub.new(ApplicationQualification, [degree1], scopes: [:degrees]),
       )
 
-      render_inline(described_class.new(application_form:)) do |component|
-        expect(component).to summarise(
-          key: t('application_form.degree.completion_status.review_label'),
-          value: '',
-          action: {
-            text: "Change #{t('application_form.degree.completion_status.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
-            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :completed),
-          },
-        )
-      end
+      component = render_inline(described_class.new(application_form:))
+      expect(component).to summarise(
+        key: t('application_form.degree.completion_status.review_label'),
+        value: '',
+        action: {
+          text: "Change #{t('application_form.degree.completion_status.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
+          href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :completed),
+        },
+      )
     end
   end
 
@@ -375,16 +362,15 @@ RSpec.describe CandidateInterface::DegreeReviewComponent, type: :component do
     end
 
     it 'renders component with correct values for an international institution' do
-      render_inline(described_class.new(application_form:)) do |component|
-        expect(component).to summarise(
-          key: t('application_form.degree.institution_name.review_label'),
-          value: 'University of Doge',
-          action: {
-            text: "Change #{t('application_form.degree.institution_name.change_action')} for Bachelor of Arts, Woof, University of Doge, 2008",
-            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :university),
-          },
-        )
-      end
+      component = render_inline(described_class.new(application_form:))
+      expect(component).to summarise(
+        key: t('application_form.degree.institution_name.review_label'),
+        value: 'University of Doge',
+        action: {
+          text: "Change #{t('application_form.degree.institution_name.change_action')} for Bachelor of Arts, Woof, University of Doge, 2008",
+          href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :university),
+        },
+      )
     end
 
     it 'renders the unabbreviated value on the summary card title' do
@@ -395,34 +381,33 @@ RSpec.describe CandidateInterface::DegreeReviewComponent, type: :component do
 
     context 'when a UK ENIC reference number has been provided' do
       it 'renders component with correct values for UK ENIC statement' do
-        render_inline(described_class.new(application_form:)) do |component|
-          expect(component).to summarise(
-            key: t('application_form.degree.enic_statement.review_label'),
-            value: 'Yes',
-            action: {
-              text: "Change #{t('application_form.degree.enic_statement.change_action')} for Bachelor of Arts, Woof, University of Doge, 2008",
-              href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :enic),
-            },
-          )
+        component = render_inline(described_class.new(application_form:))
+        expect(component).to summarise(
+          key: t('application_form.degree.enic_statement.review_label'),
+          value: 'Yes',
+          action: {
+            text: "Change #{t('application_form.degree.enic_statement.change_action')} for Bachelor of Arts, Woof, University of Doge, 2008",
+            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :enic),
+          },
+        )
 
-          expect(component).to summarise(
-            key: t('application_form.degree.enic_reference.review_label'),
-            value: '0123456789',
-            action: {
-              text: "Change #{t('application_form.degree.enic_reference.change_action')} for Bachelor of Arts, Woof, University of Doge, 2008",
-              href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :enic),
-            },
-          )
+        expect(component).to summarise(
+          key: t('application_form.degree.enic_reference.review_label'),
+          value: '0123456789',
+          action: {
+            text: "Change #{t('application_form.degree.enic_reference.change_action')} for Bachelor of Arts, Woof, University of Doge, 2008",
+            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :enic),
+          },
+        )
 
-          expect(component).to summarise(
-            key: t('application_form.degree.comparable_uk_degree.review_label'),
-            value: 'Bachelor (Honours) degree',
-            action: {
-              text: "Change #{t('application_form.degree.comparable_uk_degree.change_action')} for Bachelor of Arts, Woof, University of Doge, 2008",
-              href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :enic),
-            },
-          )
-        end
+        expect(component).to summarise(
+          key: t('application_form.degree.comparable_uk_degree.review_label'),
+          value: 'Bachelor (Honours) degree',
+          action: {
+            text: "Change #{t('application_form.degree.comparable_uk_degree.change_action')} for Bachelor of Arts, Woof, University of Doge, 2008",
+            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :enic),
+          },
+        )
       end
     end
 
@@ -445,24 +430,23 @@ RSpec.describe CandidateInterface::DegreeReviewComponent, type: :component do
       end
 
       it 'does not render a row for comparable UK degree and sets UK ENIC reference number to "Not provided"' do
-        render_inline(described_class.new(application_form:)) do |component|
-          expect(component).to summarise(
-            key: t('application_form.degree.enic_statement.review_label'),
-            value: 'No',
-            action: {
-              text: "Change #{t('application_form.degree.enic_statement.change_action')} for BA, Woof, University of Doge, 2008",
-              href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :enic),
-            },
-          )
+        component = render_inline(described_class.new(application_form:))
+        expect(component).to summarise(
+          key: t('application_form.degree.enic_statement.review_label'),
+          value: 'No',
+          action: {
+            text: "Change #{t('application_form.degree.enic_statement.change_action')} for BA, Woof, University of Doge, 2008",
+            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :enic),
+          },
+        )
 
-          expect(component).not_to summarise(
-            key: t('application_form.degree.enic_reference.review_label'),
-          )
+        expect(component).not_to summarise(
+          key: t('application_form.degree.enic_reference.review_label'),
+        )
 
-          expect(component).not_to summarise(
-            key: t('application_form.degree.comparable_uk_degree.review_label'),
-          )
-        end
+        expect(component).not_to summarise(
+          key: t('application_form.degree.comparable_uk_degree.review_label'),
+        )
       end
     end
   end
@@ -485,25 +469,24 @@ RSpec.describe CandidateInterface::DegreeReviewComponent, type: :component do
     end
 
     it 'renders a uk degree type row and changes value on type of degree row' do
-      render_inline(described_class.new(application_form:)) do |component|
-        expect(component).to summarise(
-          key: t('application_form.degree.type_of_degree.review_label', degree: 'bachelor degree'),
-          value: 'Bachelor of Arts',
-          action: {
-            text: "Change #{t('application_form.degree.type_of_degree.change_action')} for Bachelor of Arts, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
-            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :type),
-          },
-        )
+      component = render_inline(described_class.new(application_form:))
+      expect(component).to summarise(
+        key: t('application_form.degree.type_of_degree.review_label', degree: 'bachelor degree'),
+        value: 'Bachelor of Arts',
+        action: {
+          text: "Change #{t('application_form.degree.type_of_degree.change_action')} for Bachelor of Arts, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
+          href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :type),
+        },
+      )
 
-        expect(component).to summarise(
-          key: t('application_form.degree.qualification_type.review_label'),
-          value: 'Bachelor',
-          action: {
-            text: "Change #{t('application_form.degree.qualification.change_action')} for Bachelor of Arts, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
-            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :degree_level),
-          },
-        )
-      end
+      expect(component).to summarise(
+        key: t('application_form.degree.qualification_type.review_label'),
+        value: 'Bachelor',
+        action: {
+          text: "Change #{t('application_form.degree.qualification.change_action')} for Bachelor of Arts, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
+          href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :degree_level),
+        },
+      )
     end
   end
 
@@ -516,25 +499,24 @@ RSpec.describe CandidateInterface::DegreeReviewComponent, type: :component do
     end
 
     it 'does not render a uk degree type row' do
-      render_inline(described_class.new(application_form:)) do |component|
-        expect(component).not_to summarise(
-          key: t('application_form.degree.type_of_degree.review_label', degree: 'Bachelor degree'),
-          value: 'Bachelor of Hogwarts Studies',
-          action: {
-            text: "Change #{t('application_form.degree.type_of_degree.change_action')} for Bachelor of Hogwarts Studies, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
-            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :type),
-          },
-        )
+      component = render_inline(described_class.new(application_form:))
+      expect(component).not_to summarise(
+        key: t('application_form.degree.type_of_degree.review_label', degree: 'Bachelor degree'),
+        value: 'Bachelor of Hogwarts Studies',
+        action: {
+          text: "Change #{t('application_form.degree.type_of_degree.change_action')} for Bachelor of Hogwarts Studies, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
+          href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :type),
+        },
+      )
 
-        expect(component).to summarise(
-          key: t('application_form.degree.qualification_type.review_label'),
-          value: 'Bachelor of Hogwarts Studies',
-          action: {
-            text: "Change #{t('application_form.degree.qualification.change_action')} for Bachelor of Hogwarts Studies, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
-            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :degree_level),
-          },
-        )
-      end
+      expect(component).to summarise(
+        key: t('application_form.degree.qualification_type.review_label'),
+        value: 'Bachelor of Hogwarts Studies',
+        action: {
+          text: "Change #{t('application_form.degree.qualification.change_action')} for Bachelor of Hogwarts Studies, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
+          href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :degree_level),
+        },
+      )
     end
   end
 
@@ -548,33 +530,31 @@ RSpec.describe CandidateInterface::DegreeReviewComponent, type: :component do
     end
 
     it 'render the doctorate degree' do
-      render_inline(described_class.new(application_form:)) do |component|
-        expect(component).to summarise(
-          key: t('application_form.degree.qualification_type.review_label'),
-          value: 'Doctorate (PhD)',
-          action: {
-            text: "Change #{t('application_form.degree.qualification.change_action')} for Doctor of education, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
-            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :degree_level),
-          },
-        )
+      component = render_inline(described_class.new(application_form:))
+      expect(component).to summarise(
+        key: t('application_form.degree.qualification_type.review_label'),
+        value: 'Doctorate (PhD)',
+        action: {
+          text: "Change #{t('application_form.degree.qualification.change_action')} for Doctor of education, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
+          href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :degree_level),
+        },
+      )
 
-        expect(component).to summarise(
-          key: 'Type of doctorate',
-          value: 'Doctor of education',
-          action: {
-            text: "Change specific type of degree for Doctor of education, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
-            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :type),
-          },
-        )
-      end
+      expect(component).to summarise(
+        key: 'Type of doctorate',
+        value: 'Doctor of education',
+        action: {
+          text: "Change specific type of degree for Doctor of education, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
+          href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :type),
+        },
+      )
     end
 
     it 'does not render a grade' do
-      render_inline(described_class.new(application_form:)) do |component|
-        expect(component).not_to summarise(
-          key: t('application_form.degree.grade.review_label'),
-        )
-      end
+      component = render_inline(described_class.new(application_form:))
+      expect(component).not_to summarise(
+        key: t('application_form.degree.grade.review_label'),
+      )
     end
   end
 
@@ -582,29 +562,27 @@ RSpec.describe CandidateInterface::DegreeReviewComponent, type: :component do
     let(:degree1) { create(:non_uk_degree_qualification, qualification_type: 'Diplôme') }
 
     it 'only renders degree type row' do
-      render_inline(described_class.new(application_form:)) do |component|
-        expect(component).to summarise(
-          key: t('application_form.degree.qualification_type.review_label'),
-          value: 'Diplôme',
-          action: {
-            text: "Change #{t('application_form.degree.qualification.change_action')} for Diplôme, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
-            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :type),
-          },
-        )
-      end
+      component = render_inline(described_class.new(application_form:))
+      expect(component).to summarise(
+        key: t('application_form.degree.qualification_type.review_label'),
+        value: 'Diplôme',
+        action: {
+          text: "Change #{t('application_form.degree.qualification.change_action')} for Diplôme, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
+          href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :type),
+        },
+      )
     end
 
     it 'renders country row with correct value' do
-      render_inline(described_class.new(application_form:)) do |component|
-        expect(component).to summarise(
-          key: t('application_form.degree.institution_country.review_label'),
-          value: 'France',
-          action: {
-            text: "Change #{t('application_form.degree.institution_country.change_action')} for Diplôme, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
-            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :country),
-          },
-        )
-      end
+      component = render_inline(described_class.new(application_form:))
+      expect(component).to summarise(
+        key: t('application_form.degree.institution_country.review_label'),
+        value: 'France',
+        action: {
+          text: "Change #{t('application_form.degree.institution_country.change_action')} for Diplôme, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
+          href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :country),
+        },
+      )
     end
   end
 
@@ -612,25 +590,24 @@ RSpec.describe CandidateInterface::DegreeReviewComponent, type: :component do
     let(:degree1) { create(:non_uk_degree_qualification, predicted_grade: true) }
 
     it 'does not render the enic reference or comparable uk degree row' do
-      render_inline(described_class.new(application_form:)) do |component|
-        expect(component).not_to summarise(
-          key: t('application_form.degree.enic_reference.review_label'),
-          value: degree1.enic_reference,
-          action: {
-            text: "Change #{t('application_form.degree.enic_reference.change_action')} for #{degree1.qualification_type}, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
-            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :enic),
-          },
-        )
+      component = render_inline(described_class.new(application_form:))
+      expect(component).not_to summarise(
+        key: t('application_form.degree.enic_reference.review_label'),
+        value: degree1.enic_reference,
+        action: {
+          text: "Change #{t('application_form.degree.enic_reference.change_action')} for #{degree1.qualification_type}, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
+          href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :enic),
+        },
+      )
 
-        expect(component).not_to summarise(
-          key: t('application_form.degree.comparable_uk_degree.review_label'),
-          value: 'Bachelor (Ordinary) degree',
-          action: {
-            text: "Change #{t('application_form.degree.comparable_uk_degree.change_action')} for #{degree1.qualification_type}, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
-            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :enic),
-          },
-        )
-      end
+      expect(component).not_to summarise(
+        key: t('application_form.degree.comparable_uk_degree.review_label'),
+        value: 'Bachelor (Ordinary) degree',
+        action: {
+          text: "Change #{t('application_form.degree.comparable_uk_degree.change_action')} for #{degree1.qualification_type}, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
+          href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :enic),
+        },
+      )
     end
   end
 
@@ -638,25 +615,24 @@ RSpec.describe CandidateInterface::DegreeReviewComponent, type: :component do
     let(:degree1) { create(:non_uk_degree_qualification, predicted_grade: false) }
 
     it 'renders the enic reference and comparable uk degree row' do
-      render_inline(described_class.new(application_form:)) do |component|
-        expect(component).to summarise(
-          key: t('application_form.degree.enic_reference.review_label'),
-          value: degree1.enic_reference,
-          action: {
-            text: "Change #{t('application_form.degree.enic_reference.change_action')} for #{degree1.qualification_type}, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
-            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :enic),
-          },
-        )
+      component = render_inline(described_class.new(application_form:))
+      expect(component).to summarise(
+        key: t('application_form.degree.enic_reference.review_label'),
+        value: degree1.enic_reference,
+        action: {
+          text: "Change #{t('application_form.degree.enic_reference.change_action')} for #{degree1.qualification_type}, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
+          href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :enic),
+        },
+      )
 
-        expect(component).to summarise(
-          key: t('application_form.degree.comparable_uk_degree.review_label'),
-          value: 'Bachelor (Ordinary) degree',
-          action: {
-            text: "Change #{t('application_form.degree.comparable_uk_degree.change_action')} for #{degree1.qualification_type}, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
-            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :enic),
-          },
-        )
-      end
+      expect(component).to summarise(
+        key: t('application_form.degree.comparable_uk_degree.review_label'),
+        value: 'Bachelor (Ordinary) degree',
+        action: {
+          text: "Change #{t('application_form.degree.comparable_uk_degree.change_action')} for #{degree1.qualification_type}, #{degree1.subject}, #{degree1.institution_name}, #{degree1.award_year}",
+          href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :enic),
+        },
+      )
     end
   end
 end

--- a/spec/support/summarise_matcher.rb
+++ b/spec/support/summarise_matcher.rb
@@ -22,7 +22,7 @@ RSpec::Matchers.define :summarise do |expected|
   end
 
   def html
-    @html ||= Capybara::Node::Simple.new(actual)
+    @html ||= Capybara::Node::Simple.new(actual.is_a?(String) ? actual : actual.to_html)
   end
 
   def key_html


### PR DESCRIPTION
## Context

There were a number of tests that should have been failing that passed. We needed to investigate the cause and fix those tests.

## Changes proposed in this pull request

The cause of the hidden failures was putting assertions in the block passed to `render_inline`. This block gets called only when the rendered templated calls `yield` (which didn't happen in these cases). To solve this issue we can simply move the assertions outside the block (and remove the block altogether).

A secondary problem the `summarises` custom RSpec matcher doesn't work when the object being asserted (the `actual`) is a Nokogiri node (returned by `render_inline`). We need to convert this to a string.

## Guidance to review

Mostly repetitive changes. The most interesting change is in the `SummariseMatcher`.

## Link to Trello card

https://trello.com/c/jnQsukxH/1522-investigate-false-positives-in-the-tests

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
