### PR TITLE
Remove `provider_reports` feature flag

### DIFF
--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -55,9 +55,7 @@ class NavigationItems
         items << NavigationItem.new('Interview schedule', provider_interface_interview_schedule_path, active?(current_controller, %w[interview_schedules]), [])
 
         reports_label = 'Reports'.html_safe
-        if FeatureFlag.active?(:provider_reports)
-          reports_label += ' <strong class="govuk-tag govuk-tag--blue app-tag--navbar">New</strong>'.html_safe
-        end
+        reports_label += ' <strong class="govuk-tag govuk-tag--blue app-tag--navbar">New</strong>'.html_safe
 
         items << NavigationItem.new(reports_label, provider_interface_reports_path, active?(current_controller, %w[reports application_data_export hesa_export]))
 

--- a/app/services/data_migrations/remove_provider_reports_feature_flag.rb
+++ b/app/services/data_migrations/remove_provider_reports_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class RemoveProviderReportsFeatureFlag
+    TIMESTAMP = 20230602121327
+    MANUAL_RUN = false
+
+    def change
+      Feature.where(name: :provider_reports).delete_all
+    end
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -36,7 +36,6 @@ class FeatureFlag
     [:adviser_sign_up, 'Allow candidates to sign up for a teacher training adviser', 'Ross Oliver'],
     [:one_personal_statement, 'Combining the 2 personal statements into 1 for new applications', 'Frankie Roberto + Maeve Roseveare'],
     [:structured_reference_condition, 'Structured reference condition that can be added as a condition to an offer', 'Tomas Destefi'],
-    [:provider_reports, 'Diversity and withdrawal reports for providers', 'James Glenn'],
     [:mid_cycle_report, 'The provider mid cycle report', 'James Glenn'],
     [:continuous_applications, 'The new continuous applications flow', 'James Glenn'],
   ].freeze

--- a/app/views/provider_interface/reports/index.html.erb
+++ b/app/views/provider_interface/reports/index.html.erb
@@ -16,14 +16,12 @@
         <li>
           <%= govuk_link_to t('page_titles.provider.status_of_active_applications'), provider_interface_reports_provider_status_of_active_applications_path(provider_id: @providers.first) %>
         </li>
-        <% if FeatureFlag.active?(:provider_reports) %>
-          <li>
-            <%= govuk_link_to t('page_titles.provider.diversity_report'), provider_interface_reports_provider_diversity_report_path(provider_id: @providers.first) %>
-          </li>
-          <li>
-            <%= govuk_link_to t('page_titles.provider.withdrawal_report'), provider_interface_reports_provider_withdrawal_report_path(provider_id: @providers.first) %>
-          </li>
-        <% end %>
+        <li>
+          <%= govuk_link_to t('page_titles.provider.diversity_report'), provider_interface_reports_provider_diversity_report_path(provider_id: @providers.first) %>
+        </li>
+        <li>
+          <%= govuk_link_to t('page_titles.provider.withdrawal_report'), provider_interface_reports_provider_withdrawal_report_path(provider_id: @providers.first) %>
+        </li>
         <% if FeatureFlag.active?(:mid_cycle_report) %>
           <%= govuk_link_to '2022 to 2023 recruitment cycle performance (data from 11 October 2022 to 3 April 2023)', provider_interface_reports_provider_mid_cycle_report_path(provider_id: @providers.first) %>
         <% end %>
@@ -36,14 +34,12 @@
           <li>
             <%= govuk_link_to t('page_titles.provider.status_of_active_applications'), provider_interface_reports_provider_status_of_active_applications_path(provider_id: provider) %>
           </li>
-          <% if FeatureFlag.active?(:provider_reports) %>
-            <li>
-              <%= govuk_link_to t('page_titles.provider.diversity_report'), provider_interface_reports_provider_diversity_report_path(provider_id: provider) %>
-            </li>
-            <li>
-              <%= govuk_link_to t('page_titles.provider.withdrawal_report'), provider_interface_reports_provider_withdrawal_report_path(provider_id: provider) %>
-            </li>
-          <% end %>
+          <li>
+            <%= govuk_link_to t('page_titles.provider.diversity_report'), provider_interface_reports_provider_diversity_report_path(provider_id: provider) %>
+          </li>
+          <li>
+            <%= govuk_link_to t('page_titles.provider.withdrawal_report'), provider_interface_reports_provider_withdrawal_report_path(provider_id: provider) %>
+          </li>
         <% if FeatureFlag.active?(:mid_cycle_report) %>
           <%= govuk_link_to '2022 to 2023 recruitment cycle performance (data from 11 October 2022 to 3 April 2023)', provider_interface_reports_provider_mid_cycle_report_path(provider_id: provider) %>
         <% end %>

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveProviderReportsFeatureFlag',
   'DataMigrations::RemoveSkeFeatureFlag',
   'DataMigrations::StoreEnumForSkeReason',
   'DataMigrations::SetMissingSectionCompletedAtTimestamps',

--- a/spec/services/data_migrations/remove_provider_reports_feature_flag_spec.rb
+++ b/spec/services/data_migrations/remove_provider_reports_feature_flag_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveProviderReportsFeatureFlag do
+  context 'when the feature flag exists' do
+    before do
+      create(:feature, name: 'provider_reports')
+      create(:feature, name: 'foo')
+    end
+
+    it 'removes the relevant feature flag' do
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: 'provider_reports')).to be_none
+      expect(Feature.where(name: 'foo')).to be_present
+    end
+  end
+
+  context 'when the feature flags have already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end

--- a/spec/system/provider_interface/provider_reports_page_spec.rb
+++ b/spec/system/provider_interface/provider_reports_page_spec.rb
@@ -19,7 +19,6 @@ RSpec.feature 'Provider reports page' do
     when_i_visit_the_reports_page
     then_i_should_see_links_for_all_the_provider_status_application_records
 
-    when_the_provider_reports_feature_flag_is_active
     when_i_visit_the_reports_page
     then_i_should_see_new_links_for_all_the_provider_reports
   end
@@ -70,10 +69,6 @@ RSpec.feature 'Provider reports page' do
       expect(page).to have_content(provider.name)
       expect(page).to have_link('Status of active applications', href: provider_interface_reports_provider_status_of_active_applications_path(provider_id: provider))
     end
-  end
-
-  def when_the_provider_reports_feature_flag_is_active
-    FeatureFlag.activate(:provider_reports)
   end
 
   def then_i_should_see_new_links_for_all_the_provider_reports


### PR DESCRIPTION
## Context

This flag has been active on production since 15 May 2023.

## Changes proposed in this pull request

- [x] Remove the flag from the codebase.
- [x] Remove the flag from the database (data migration).

## Guidance to review

Have I missed anything?

## Link to Trello card

https://trello.com/c/8DmVSG9P/1466-remove-reports-feature-flags

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
