### PR TITLE
Remove URL for 'talk-to-us' and update email template

### DIFF
--- a/app/views/candidate_mailer/nudge_unstarted.text.erb
+++ b/app/views/candidate_mailer/nudge_unstarted.text.erb
@@ -32,6 +32,6 @@ You could speak to our teacher training advisers. They were teachers and can giv
 
 Call 0800 389 2500 or chat online:
 
-[<%= t('get_into_teaching.url_talk_to_us') %>](<%= email_link_with_utm_params t('get_into_teaching.url_talk_to_us'), GetUnstartedApplicationsReadyToNudge::MAIL_TEMPLATE, @application_form.phase %>)
+[<%= t('get_into_teaching.url_online_chat') %>](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), GetUnstartedApplicationsReadyToNudge::MAIL_TEMPLATE, @application_form.phase %>)
 
 Monday to Friday, 8:30am to 5:30pm (except public holidays).

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,7 +42,6 @@ en:
     url_choose_your_referees: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/how-to-apply-for-teacher-training#choose-your-references
     url_if_you_dont_have_a_degree: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/if-you-dont-have-a-degree
     url_subject_knowledge_enhancement: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement
-    url_talk_to_us: https://getintoteaching.education.gov.uk/#talk-to-us
   train_to_teach_in_england:
     url: https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration
     url_citizen_visa: https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-if-youre-a-non-uk-citizen#visa


### PR DESCRIPTION
## Context

We shipped a nudge recently, and perhaps should have pointed to help and support page on GIT, not talk to us.

## Changes proposed in this pull request

This is the only place we've used the 'talk to us' jump link, so removing the variable from our codebase.

Also updating our nudge unsubmitted accordingly.

## Guidance to review

Any failing tests?

## Link to Trello card

https://trello.com/c/RwJMHAxt/1557-update-talk-to-us-in-our-notify-templates

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
