### PR TITLE
Migration to backfill E&D completed attributes

### DIFF
--- a/app/services/data_migrations/backfill_equality_and_diversity_completed_attributes.rb
+++ b/app/services/data_migrations/backfill_equality_and_diversity_completed_attributes.rb
@@ -1,0 +1,21 @@
+module DataMigrations
+  class BackfillEqualityAndDiversityCompletedAttributes
+    TIMESTAMP = 20230606115559
+    MANUAL_RUN = true
+
+    def change
+      applications.find_each(batch_size: 500) do |application|
+        application.update_columns(equality_and_diversity_completed: true, equality_and_diversity_completed_at: application.submitted_at)
+      end
+    end
+
+  private
+
+    def applications
+      ApplicationForm
+        .where.not(equality_and_diversity: nil)
+        .where.not(submitted_at: nil)
+        .where(equality_and_diversity_completed: nil)
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillEqualityAndDiversityCompletedAttributes',
   'DataMigrations::RemoveProviderReportsFeatureFlag',
   'DataMigrations::RemoveSkeFeatureFlag',
   'DataMigrations::StoreEnumForSkeReason',

--- a/spec/services/data_migrations/backfill_equality_and_diversity_completed_attributes_spec.rb
+++ b/spec/services/data_migrations/backfill_equality_and_diversity_completed_attributes_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillEqualityAndDiversityCompletedAttributes do
+  context 'when the application has been submitted' do
+    it 'backfills the completed attributes' do
+      application_form = create(:application_form, :submitted, :with_equality_and_diversity_data)
+      described_class.new.change
+      expect(application_form.reload.equality_and_diversity_completed).to be true
+      expect(application_form.reload.equality_and_diversity_completed_at).to eq application_form.submitted_at
+    end
+  end
+
+  context 'when the application has not been submitted' do
+    it 'does not backfill the completed attributes' do
+      application_form = create(:application_form)
+      described_class.new.change
+      expect(application_form.reload.equality_and_diversity_completed).to be_nil
+      expect(application_form.reload.equality_and_diversity_completed_at).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Context

We've moved the E&D onto the application form, as a new section. This means we have a new `section_completed` boolean and `section_completed_at` timestamp. Any application that has not been submitted will be required to complete this section, therefore updating the boolean. However, applications that have already been submitted will have this boolean set to `nil`. This shouldn't break anything as these booleans are only used as a submission validation but for cleanliness it would be good to backfill this.

## Changes proposed in this pull request

Backfill:
`equality_and_diversity_completed`
`equality_and_diversity_completed_at` (using the `submitted_at` value)

## Guidance to review

Will update ~96k records. Using `update_columns` to avoid changing the timestamp.

## Link to Trello card

https://trello.com/c/HBUslouw/1512-ca-move-the-ed-survey-onto-the-application-form

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
