### PR TITLE
Add realistic job previews link with UTM tracking

### DIFF
--- a/app/components/candidate_interface/apply_again_call_to_action_component.html.erb
+++ b/app/components/candidate_interface/apply_again_call_to_action_component.html.erb
@@ -6,6 +6,10 @@
     A <%= govuk_link_to_with_utm_params('teacher training adviser', I18n.t('get_into_teaching.url_get_an_adviser_start'), utm_campaign(params), @application_form.phase) %> can help you apply again.
   </p>
 
+  <p class="govuk-body">
+    Please visit <%= govuk_link_to_with_utm_params('realistic job previews', I18n.t('realistic_job_previews.url_apply_again'), utm_campaign(params), @application_form.support_reference) %> for further help.
+  </p>
+
   <%= govuk_button_to(
     'Apply again',
     candidate_interface_apply_again_path,

--- a/app/components/candidate_interface/apply_again_call_to_action_component.html.erb
+++ b/app/components/candidate_interface/apply_again_call_to_action_component.html.erb
@@ -7,7 +7,7 @@
   </p>
 
   <p class="govuk-body">
-    Please visit <%= govuk_link_to_with_utm_params('realistic job previews', I18n.t('realistic_job_previews.url_apply_again'), utm_campaign(params), @application_form.support_reference) %> for further help.
+    You can also <%= govuk_link_to_with_utm_params('respond to these classroom scenarios', I18n.t('realistic_job_previews.url_apply_again'), utm_campaign(params), @application_form.support_reference) %> to learn what it’s like to be a teacher.
   </p>
 
   <%= govuk_button_to(

--- a/app/helpers/utm_link_helper.rb
+++ b/app/helpers/utm_link_helper.rb
@@ -1,6 +1,6 @@
 module UtmLinkHelper
   UTM_PARAMS = {
-    utm_source: 'apply-for-teacher-training.service.gov.uk',
+    uitm_source: 'apply-for-teacher-training.service.gov.uk',
     utm_medium: 'referral',
   }.freeze
 

--- a/app/helpers/utm_link_helper.rb
+++ b/app/helpers/utm_link_helper.rb
@@ -1,6 +1,6 @@
 module UtmLinkHelper
   UTM_PARAMS = {
-    uitm_source: 'apply-for-teacher-training.service.gov.uk',
+    utm_source: 'apply-for-teacher-training.service.gov.uk',
     utm_medium: 'referral',
   }.freeze
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,6 +62,9 @@ en:
     url: https://ico.org.uk
   tell_employee_about_criminal_record:
     url: https://www.gov.uk/exoffenders-and-employment
+  realistic_job_previews:
+    url_apply_again: https://teacherselect.qualtrics.com/jfe/form/SV_4VHMkFk6TeonVeS
+    url_get_school_experience: https://teacherselect.qualtrics.com/jfe/form/SV_aXbiUM3xz0uVtuS
   page_titles:
     application_feedback: How can we improve %{section} section?
     application_form: Your application

--- a/spec/system/candidate_interface/apply_again/candidate_applies_again_updates_personal_statement_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_applies_again_updates_personal_statement_spec.rb
@@ -66,6 +66,8 @@ RSpec.feature 'Apply again with four choices', time: CycleTimetableHelper.after_
 
   def then_i_should_see_the_apply_again_banner
     expect(page).to have_content 'If now’s the right time for you, you can still apply for courses that start this academic year.'
+    expect(page).to have_link 'teacher training adviser'
+    expect(page).to have_link 'realistic job previews'
   end
 
   def and_i_should_see_the_deadline_banner

--- a/spec/system/candidate_interface/apply_again/candidate_applies_again_updates_personal_statement_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_applies_again_updates_personal_statement_spec.rb
@@ -67,7 +67,7 @@ RSpec.feature 'Apply again with four choices', time: CycleTimetableHelper.after_
   def then_i_should_see_the_apply_again_banner
     expect(page).to have_content 'If now’s the right time for you, you can still apply for courses that start this academic year.'
     expect(page).to have_link 'teacher training adviser'
-    expect(page).to have_link 'realistic job previews'
+    expect(page).to have_link 'respond to these classroom scenarios'
   end
 
   def and_i_should_see_the_deadline_banner


### PR DESCRIPTION
## Context

We need to add the Apply Realistic Job Previews link to the rejection flow.

This link will be added to the ‘Your applications were unsuccessful’ part of the rejection page. The link is https://teacherselect.qualtrics.com/jfe/form/SV_4VHMkFk6TeonVeS and it needs to be decorated with UTM tracking query params.

## Changes proposed in this pull request

* Add link

![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/450843/0650c84d-1f84-46b0-a524-8dc8dc924d71)


* Extend existing system spec to cover these links

## Guidance to review

* Are the UTM params correct?

## Link to Trello card

https://trello.com/c/c96wVDv6/1450-realistic-job-previews-programmatically-add-a-utm-tracking-link-with-candidateid-to-a-link-on-the-rejection-page

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
