### PR TITLE
Add corrected data migration to remove `mid_cycle_report` FF

### DIFF
--- a/app/services/data_migrations/remove_mid_cycle_report_feature_flag.rb
+++ b/app/services/data_migrations/remove_mid_cycle_report_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class RemoveMidCycleReportFeatureFlag
+    TIMESTAMP = 20230609131625
+    MANUAL_RUN = false
+
+    def change
+      Feature.where(name: :mid_cycle_report).delete_all
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveMidCycleReportFeatureFlag',
   'DataMigrations::BackfillEqualityAndDiversityCompletedAttributes',
   'DataMigrations::RemoveMidCycleReportsFeatureFlag',
   'DataMigrations::RemoveProviderReportsFeatureFlag',

--- a/spec/services/data_migrations/remove_mid_cycle_report_feature_flag_spec.rb
+++ b/spec/services/data_migrations/remove_mid_cycle_report_feature_flag_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveMidCycleReportFeatureFlag do
+  context 'when the feature flag exists' do
+    before do
+      create(:feature, name: 'mid_cycle_report')
+      create(:feature, name: 'foo')
+    end
+
+    it 'removes the relevant feature flag' do
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: 'mid_cycle_report')).to be_none
+      expect(Feature.where(name: 'foo')).to be_present
+    end
+  end
+
+  context 'when the feature flags have already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end


### PR DESCRIPTION
## Context

The original data migration to remove the `mid_cycle_report` feature flag contained a typo. This PR adds a corrected version.

## Changes proposed in this pull request

Add data migration to remove `mid_cycle_report` feature flag.

## Guidance to review

## Link to Trello card

https://trello.com/c/iGQFL751/1491-remove-provider-reports-feature-flags

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
