### PR TITLE
Update safeguarding link type

### DIFF
--- a/app/views/candidate_interface/safeguarding/_form.html.erb
+++ b/app/views/candidate_interface/safeguarding/_form.html.erb
@@ -15,7 +15,7 @@
 
 <p class="govuk-body">
   Not all convictions or police cautions on a criminal record will stop you from training to be a teacher.
-  <a href="https://www.gov.uk/tell-employer-or-college-about-criminal-record">Learn more about when you need to tell someone about your criminal record.</a>
+  <%= govuk_link_to 'Learn more about when you need to tell someone about your criminal record', t('govuk.safeguarding') %>
 </p>
 
 <p class="govuk-body">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,6 +19,7 @@ en:
   govuk:
     url: https://www.gov.uk
     terms_conditions_url: https://www.gov.uk/help/terms-conditions
+    safeguarding: https://www.gov.uk/tell-employer-or-college-about-criminal-record
   teacher_training_courses_api:
     documentation_url: https://api.publish-teacher-training-courses.service.gov.uk/
   publish_teacher_training_courses:


### PR DESCRIPTION
## Context

Replace link with `govuk_link_to`

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="857" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/3de75dc6-c870-4dca-babf-45ee6b59dcdd">|<img width="683" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/513d0ff5-3145-4670-a02b-a42a6c73b9b1">|