### PR TITLE
Redirect to E&D start page if not completed

### DIFF
--- a/app/components/candidate_interface/equality_and_diversity_review_component.html.erb
+++ b/app/components/candidate_interface/equality_and_diversity_review_component.html.erb
@@ -1,5 +1,5 @@
 <% if show_missing_banner? %>
-  <%= render(CandidateInterface::IncompleteSectionComponent.new(section: :equality_and_diversity, section_path: candidate_interface_review_equality_and_diversity_path, error: @missing_error)) %>
+  <%= render(CandidateInterface::IncompleteSectionComponent.new(section: :equality_and_diversity, section_path: incomplete_component_redirect_path, error: @missing_error)) %>
 <% else %>
   <%= render(SummaryCardComponent.new(rows: equality_and_diversity_rows, border: true, editable: @editable)) %>
 <% end %>

--- a/app/components/candidate_interface/equality_and_diversity_review_component.rb
+++ b/app/components/candidate_interface/equality_and_diversity_review_component.rb
@@ -18,6 +18,14 @@ module CandidateInterface
 
   private
 
+    def incomplete_component_redirect_path
+      if @application_form.equality_and_diversity_answers_provided?
+        candidate_interface_review_equality_and_diversity_path
+      else
+        candidate_interface_edit_equality_and_diversity_sex_path
+      end
+    end
+
     def sex_row
       {
         key: 'Sex',

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -116,7 +116,7 @@ module CandidateHelper
     @application = ApplicationForm.last
   end
 
-  def candidate_fills_in_diversity_information(school_meals: true)
+  def candidate_fills_in_diversity_information(school_meals: true, complete_section: true)
     # Equality and diversity questions
 
     # What is your sex?
@@ -138,7 +138,11 @@ module CandidateHelper
     end
 
     # Review page
-    choose 'Yes, I have completed this section'
+    if complete_section
+      choose 'Yes, I have completed this section'
+    else
+      choose 'No, I’ll come back to it later'
+    end
     click_button t('continue')
   end
 

--- a/spec/system/candidate_interface/submitting/candidate_reviews_application_and_completes_equality_and_diversity_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_application_and_completes_equality_and_diversity_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate is redirected correctly' do
+  include CandidateHelper
+
+  it 'Candidate reviews application and completes equality and diversity' do
+    given_i_am_signed_in
+    and_i_review_my_application
+    then_i_should_see_that_i_need_to_complete_the_equality_and_diversity_section
+
+    when_i_click_on_complete_your_equality_and_diversity_questions
+    then_i_should_be_redirected_to_the_sex_page
+
+    when_i_complete_the_equality_and_diversity_questions
+    and_i_review_my_application
+    then_i_should_see_that_i_need_to_complete_the_equality_and_diversity_section
+
+    when_i_click_on_complete_your_equality_and_diversity_questions
+    then_i_should_be_redirected_to_the_review_page
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_review_my_application
+    and_i_visit_the_application_form_page
+    when_i_click_on_check_your_answers
+  end
+
+  def then_i_should_see_that_i_need_to_complete_the_equality_and_diversity_section
+    expect(page).to have_selector("a[data-qa='incomplete-equality_and_diversity']")
+  end
+
+  def when_i_click_on_complete_your_equality_and_diversity_questions
+    click_link 'Complete your equality and diversity questions'
+  end
+
+  def then_i_should_be_redirected_to_the_sex_page
+    expect(page).to have_current_path(candidate_interface_edit_equality_and_diversity_sex_path)
+  end
+
+  def when_i_complete_the_equality_and_diversity_questions
+    candidate_fills_in_diversity_information(school_meals: false, complete_section: false)
+  end
+
+  def then_i_should_be_redirected_to_the_review_page
+    expect(page).to have_current_path(candidate_interface_review_equality_and_diversity_path)
+  end
+
+  def and_i_visit_the_application_form_page
+    visit candidate_interface_application_form_path
+  end
+
+  def when_i_click_on_check_your_answers
+    click_link 'Check and submit your application'
+  end
+
+  def then_i_should_be_redirected_to_the_application_review_page
+    expect(page).to have_current_path(candidate_interface_application_review_path)
+  end
+end


### PR DESCRIPTION
## Context

We recently added E&D as a new section on the application form, as default this is incomplete for all candidates. Clicking the link takes you to the review section:
<img width="822" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/e609535b-3a79-4c98-9e82-10d384815eac">

This is causing an error because the candidate hasn't provided any values yet:

<img width="716" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/53213122-ba03-422d-b936-7602026cd812">


## Changes proposed in this pull request

Redirect to the start page (sex question) if they haven't provided any answers yet.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/lojQU6Y1
