### PR TITLE
Fix schema declaration disability_or_health_condition

### DIFF
--- a/config/register-api.yml
+++ b/config/register-api.yml
@@ -299,7 +299,7 @@ components:
           type: array
           description: The candidate’s disability or health conditions as an array of DisabilityOrHealthCondition objects
           items:
-            type: DisabilityOrHealthCondition
+            "$ref": "#/components/schemas/DisabilityOrHealthCondition"
         ethnic_group:
           type: string
           maxLength: 256


### PR DESCRIPTION


## Context

In the examples this was not picking up the associated `DisabilityOrHealthCondition` object because it was declared as a simple string rather than a `$ref`. This should make the example reponses under `GET /applications` a bit more realistic.

## Changes proposed in this pull request

Change to a `$ref`.

## Guidance to review

If you need to test it head to `/register-api`

## Link to Trello card

n/a

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
