### PR TITLE
Equality and diversity component will return Not answered

### DIFF
--- a/app/components/candidate_interface/equality_and_diversity_review_component.rb
+++ b/app/components/candidate_interface/equality_and_diversity_review_component.rb
@@ -18,6 +18,12 @@ module CandidateInterface
 
   private
 
+    def row_value(attribute)
+      return 'Not answered' if @application_form.equality_and_diversity.blank?
+
+      @application_form.equality_and_diversity[attribute]
+    end
+
     def incomplete_component_redirect_path
       if @application_form.equality_and_diversity_answers_provided?
         candidate_interface_review_equality_and_diversity_path
@@ -29,7 +35,7 @@ module CandidateInterface
     def sex_row
       {
         key: 'Sex',
-        value: @application_form.equality_and_diversity['sex'].capitalize,
+        value: row_value('sex')&.capitalize,
         action: {
           href: candidate_interface_edit_equality_and_diversity_sex_path(return_to_params),
           visually_hidden_text: 'sex',
@@ -38,12 +44,12 @@ module CandidateInterface
     end
 
     def disabilities_row
-      disabilties = if @application_form.equality_and_diversity['disabilities'].include?(I18n.t('equality_and_diversity.disabilities.no.label')) || @application_form.equality_and_diversity['disabilities'].blank?
+      disabilties = if row_value('disabilities').include?(I18n.t('equality_and_diversity.disabilities.no.label')) || row_value('disabilities').blank?
                       'I do not have any of these disabilities or health conditions'
-                    elsif @application_form.equality_and_diversity['disabilities'].include?(I18n.t('equality_and_diversity.disabilities.opt_out.label'))
+                    elsif row_value('disabilities').include?(I18n.t('equality_and_diversity.disabilities.opt_out.label'))
                       'Prefer not to say'
                     else
-                      @application_form.equality_and_diversity['disabilities']
+                      row_value('disabilities')
                     end
 
       {
@@ -57,12 +63,12 @@ module CandidateInterface
     end
 
     def ethnicity_row
-      ethnicity = if @application_form.equality_and_diversity['ethnic_group'] == 'Prefer not to say'
+      ethnicity = if row_value('ethnic_group') == 'Prefer not to say'
                     'Prefer not to say'
-                  elsif @application_form.equality_and_diversity['ethnic_background'] == 'Prefer not to say'
-                    @application_form.equality_and_diversity['ethnic_group']
+                  elsif row_value('ethnic_background') == 'Prefer not to say'
+                    row_value('ethnic_group')
                   else
-                    @application_form.equality_and_diversity['ethnic_background'].to_s
+                    row_value('ethnic_background').to_s
                   end
 
       {
@@ -78,14 +84,14 @@ module CandidateInterface
     def free_school_meals_row
       return if not_answered_free_school_meals?
 
-      free_school_meals = if @application_form.equality_and_diversity['free_school_meals'] == 'no'
+      free_school_meals = if row_value('free_school_meals') == 'no'
                             t('equality_and_diversity.free_school_meals.no.review_value')
-                          elsif @application_form.equality_and_diversity['free_school_meals'] == 'yes'
+                          elsif row_value('free_school_meals') == 'yes'
                             t('equality_and_diversity.free_school_meals.yes.review_value')
-                          elsif @application_form.equality_and_diversity['free_school_meals'] == 'I do not know'
+                          elsif row_value('free_school_meals') == 'I do not know'
                             t('equality_and_diversity.free_school_meals.unknown.review_value')
                           else
-                            @application_form.equality_and_diversity['free_school_meals']
+                            row_value('free_school_meals')
                           end
       {
         key: 'Free school meals',
@@ -98,7 +104,7 @@ module CandidateInterface
     end
 
     def not_answered_free_school_meals?
-      @application_form.equality_and_diversity['free_school_meals'].nil?
+      row_value('free_school_meals').nil?
     end
 
     def return_to_params

--- a/app/components/candidate_interface/equality_and_diversity_review_component.rb
+++ b/app/components/candidate_interface/equality_and_diversity_review_component.rb
@@ -44,17 +44,9 @@ module CandidateInterface
     end
 
     def disabilities_row
-      disabilties = if row_value('disabilities').include?(I18n.t('equality_and_diversity.disabilities.no.label')) || row_value('disabilities').blank?
-                      'I do not have any of these disabilities or health conditions'
-                    elsif row_value('disabilities').include?(I18n.t('equality_and_diversity.disabilities.opt_out.label'))
-                      'Prefer not to say'
-                    else
-                      row_value('disabilities')
-                    end
-
       {
         key: 'Disabilities or health conditions',
-        value: disabilties,
+        value: disabilities,
         action: {
           href: candidate_interface_edit_equality_and_diversity_disabilities_path(return_to_params),
           visually_hidden_text: 'disability',
@@ -112,6 +104,18 @@ module CandidateInterface
         { return_to: 'application-review' }
       else
         { return_to: 'review' }
+      end
+    end
+
+    def disabilities
+      all_disabilities = Array(row_value('disabilities'))
+
+      if all_disabilities.include?(I18n.t('equality_and_diversity.disabilities.no.label')) || (@application_form.equality_and_diversity.present? && @application_form.equality_and_diversity.key?('disabilities') && all_disabilities.blank?)
+        'I do not have any of these disabilities or health conditions'
+      elsif all_disabilities.include?(I18n.t('equality_and_diversity.disabilities.opt_out.label'))
+        'Prefer not to say'
+      else
+        row_value('disabilities')
       end
     end
   end

--- a/app/controllers/candidate_interface/equality_and_diversity_controller.rb
+++ b/app/controllers/candidate_interface/equality_and_diversity_controller.rb
@@ -89,11 +89,11 @@ module CandidateInterface
     end
 
     def review
-      @section_complete_form = SectionCompleteForm.new(completed: current_application.equality_and_diversity_completed)
+      @section_complete_form = EqualityAndDiversityCompleteForm.new(completed: current_application.equality_and_diversity_completed)
     end
 
     def complete
-      @section_complete_form = SectionCompleteForm.new(form_params)
+      @section_complete_form = EqualityAndDiversityCompleteForm.new(form_params.merge(current_application:))
 
       if @section_complete_form.save(current_application, :equality_and_diversity_completed)
         redirect_to candidate_interface_application_form_path
@@ -128,7 +128,7 @@ module CandidateInterface
     end
 
     def form_params
-      strip_whitespace params.fetch(:candidate_interface_section_complete_form, {}).permit(:completed)
+      strip_whitespace params.fetch(:candidate_interface_equality_and_diversity_complete_form, {}).permit(:completed)
     end
 
     def free_school_meals_or_review(application)

--- a/app/forms/candidate_interface/equality_and_diversity_complete_form.rb
+++ b/app/forms/candidate_interface/equality_and_diversity_complete_form.rb
@@ -1,0 +1,11 @@
+module CandidateInterface
+  class EqualityAndDiversityCompleteForm < SectionCompleteForm
+    attr_accessor :current_application
+    delegate :equality_and_diversity_answers_provided?, to: :current_application
+    validate :verify_incomplete_answers, if: :completed?
+
+    def verify_incomplete_answers
+      errors.add(:completed, :incomplete_answers) unless equality_and_diversity_answers_provided?
+    end
+  end
+end

--- a/app/views/candidate_interface/equality_and_diversity/review.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/review.html.erb
@@ -12,7 +12,7 @@
       </h1>
 
       <%= render(CandidateInterface::EqualityAndDiversityReviewComponent.new(application_form: @current_application)) %>
-      <% unless @current_application.nil? %>
+      <% if @current_application.equality_and_diversity_answers_provided? %>
         <%= render CandidateInterface::CompleteSectionComponent.new(form: f) %>
       <%= f.govuk_submit t('continue') %>
     <% end %>

--- a/app/views/candidate_interface/equality_and_diversity/review.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/review.html.erb
@@ -12,8 +12,10 @@
       </h1>
 
       <%= render(CandidateInterface::EqualityAndDiversityReviewComponent.new(application_form: @current_application)) %>
-      <%= render CandidateInterface::CompleteSectionComponent.new(form: f) %>
+      <% unless @current_application.nil? %>
+        <%= render CandidateInterface::CompleteSectionComponent.new(form: f) %>
       <%= f.govuk_submit t('continue') %>
+    <% end %>
     <% end %>
   </div>
 </div>

--- a/config/locales/candidate_interface/section_complete.yml
+++ b/config/locales/candidate_interface/section_complete.yml
@@ -5,7 +5,7 @@ en:
         candidate_interface/equality_and_diversity_complete_form:
           attributes:
             completed:
-              incomplete_answers: 'You need to answer all the questions before marking as completed.'
+              incomplete_answers: 'Answer each question before marking this section as complete or not'
         candidate_interface/section_complete_form:
           attributes:
             completed:

--- a/config/locales/candidate_interface/section_complete.yml
+++ b/config/locales/candidate_interface/section_complete.yml
@@ -2,6 +2,10 @@ en:
   activemodel:
     errors:
       models:
+        candidate_interface/equality_and_diversity_complete_form:
+          attributes:
+            completed:
+              incomplete_answers: 'You need to answer all the questions before marking as completed.'
         candidate_interface/section_complete_form:
           attributes:
             completed:

--- a/spec/components/candidate_interface/equality_and_diversity_review_component_spec.rb
+++ b/spec/components/candidate_interface/equality_and_diversity_review_component_spec.rb
@@ -45,6 +45,18 @@ RSpec.describe CandidateInterface::EqualityAndDiversityReviewComponent do
     end
   end
 
+  context 'when disabilities key is nil' do
+    it 'displays other fields' do
+      application_form.equality_and_diversity = { 'sex' => 'male' }
+
+      result = render_inline(described_class.new(application_form:))
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Disabilities or health conditions')
+      # Display other fields but an empty disabilities field
+      expect(result.css('.govuk-summary-list__value').text).to eq('Male')
+    end
+  end
+
   context 'when disabilities are empty' do
     it 'displays "No"' do
       application_form.equality_and_diversity = { 'sex' => 'male', 'disabilities' => [] }

--- a/spec/forms/candidate_interface/equality_and_diversity_complete_form_spec.rb
+++ b/spec/forms/candidate_interface/equality_and_diversity_complete_form_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::EqualityAndDiversityCompleteForm do
+  context 'when did not answer all questions' do
+    let(:current_application) { create(:application_form, equality_and_diversity: nil) }
+
+    context 'when mark as incomplete' do
+      it 'is valid' do
+        form = described_class.new(current_application:, completed: 'false')
+        expect(form).to be_valid
+      end
+    end
+
+    context 'when mark as completed' do
+      it 'is invalid' do
+        form = described_class.new(current_application:, completed: 'true')
+        expect(form).to be_invalid
+      end
+    end
+  end
+
+  context 'when did not answer any questions' do
+    let(:current_application) do
+      create(:application_form, equality_and_diversity: { sex: 'male' })
+    end
+
+    context 'when mark as incomplete' do
+      it 'is valid' do
+        form = described_class.new(current_application:, completed: 'false')
+        expect(form).to be_valid
+      end
+    end
+
+    context 'when mark as completed' do
+      it 'is invalid' do
+        form = described_class.new(current_application:, completed: 'true')
+        expect(form).to be_invalid
+      end
+    end
+  end
+
+  context 'when all minimal answers are provided' do
+    let(:current_application) do
+      create(
+        :application_form,
+        equality_and_diversity: {
+          sex: 'answer',
+          ethnic_group: 'some answer',
+          disabilities: ['some answer'],
+        },
+      )
+    end
+
+    context 'when mark as incomplete' do
+      it 'is valid' do
+        form = described_class.new(current_application:, completed: 'false')
+        expect(form).to be_valid
+      end
+    end
+
+    context 'when mark as completed' do
+      it 'is valid' do
+        form = described_class.new(current_application:, completed: 'true')
+        expect(form).to be_valid
+      end
+    end
+  end
+end

--- a/spec/system/candidate_interface/apply_again/candidate_applies_again_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_applies_again_spec.rb
@@ -6,10 +6,15 @@ RSpec.feature 'Apply again with four choices', time: CycleTimetableHelper.after_
   it 'Candidate applies again with four choices' do
     given_i_am_signed_in_as_a_candidate
     and_i_have_an_unsuccessful_application
+    and_i_have_incomplete_equality_and_diversity_information
 
     when_i_visit_the_application_dashboard
     then_i_should_see_the_apply_again_banner
     and_i_should_see_the_deadline_banner
+
+    when_i_click_view_application
+    then_i_should_see_not_yet_provided_for_my_equality_and_diversity_questions
+    and_i_click_back_to_application
 
     when_i_click_on_apply_again
     then_i_am_redirected_to_the_new_application_form
@@ -57,6 +62,10 @@ RSpec.feature 'Apply again with four choices', time: CycleTimetableHelper.after_
     end
   end
 
+  def and_i_have_incomplete_equality_and_diversity_information
+    @application_form.update!(equality_and_diversity: nil)
+  end
+
   def when_i_visit_the_application_dashboard
     visit candidate_interface_application_complete_path
   end
@@ -71,6 +80,18 @@ RSpec.feature 'Apply again with four choices', time: CycleTimetableHelper.after_
     deadline_time = CycleTimetable.date(:apply_2_deadline).to_fs(:govuk_time)
 
     expect(page).to have_content("The deadline for applying to courses starting in the #{year_range} academic year is #{deadline_time} on #{deadline_date}")
+  end
+
+  def when_i_click_view_application
+    click_link 'View application'
+  end
+
+  def then_i_should_see_not_yet_provided_for_my_equality_and_diversity_questions
+    expect(page).to have_content 'Not answered'
+  end
+
+  def and_i_click_back_to_application
+    click_link 'Back to application'
   end
 
   def when_i_click_on_apply_again


### PR DESCRIPTION
## Context

We're still encountering:
<img width="733" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/643bc576-fea4-45c2-978a-dac10ec8ba15">

We'll have placeholder text of 'Not answered' if they haven't answered the questionnaire and go to review this component:
<img width="1092" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/0aa541cd-e11a-460d-ba40-1ada4c84b77f">



## Link to Trello card

https://trello.com/c/qaurzgOG/1594-return-of-the-ed-error

