### PR TITLE
Flakey test in OrganisationPermissionsExport

### DIFF
--- a/app/services/support_interface/organisation_permissions_export.rb
+++ b/app/services/support_interface/organisation_permissions_export.rb
@@ -51,7 +51,7 @@ module SupportInterface
           .joins('INNER JOIN provider_relationship_permissions prp ON audits.auditable_id = prp.id')
           .joins('INNER JOIN providers tp ON prp.training_provider_id = tp.id')
           .joins('INNER JOIN providers rp ON prp.ratifying_provider_id = rp.id')
-          .joins('LEFT JOIN provider_users_providers pup ON audits.user_id = pup.provider_user_id')
+          .joins('LEFT JOIN provider_users_providers pup ON audits.user_id = pup.provider_user_id AND audits.user_type = \'ProviderUser\'')
           .joins('LEFT JOIN providers ups ON pup.provider_id = ups.id')
           .where(auditable_type: 'ProviderRelationshipPermissions')
           .where(action: %w[create update])


### PR DESCRIPTION
## Context

This PR is an attempt to fix https://github.com/DFE-Digital/apply-for-teacher-training/actions/runs/5253338097/jobs/9490893914?pr=8318

## Changes proposed in this pull request
It's hard to reproduce this failure (couldn't do it locally). The error is a little hard to decipher due to the escape sequences in the output but what it boils down to is that the assertion
`expect(provider_code).to be_nil` fails even though the 'current user' in the audit trail is a support user.

Looking at the query there seems to be a loophole in the join `LEFT JOIN provider_users_providers pup ON audits.user_id = pup.provider_user_id`. To avoid getting joining to users that are not provider users we need to put a condition on the `user_type` too.


## Guidance to review

Does this make sense?

## Link to Trello card

n/a

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
