### PR TITLE
Pause invariant check for the sync

### DIFF
--- a/app/workers/detect_invariants_hourly_check.rb
+++ b/app/workers/detect_invariants_hourly_check.rb
@@ -5,7 +5,7 @@ class DetectInvariantsHourlyCheck
   SIDEKIQ_LATENCY_THRESHOLD = 120
 
   def perform
-    detect_course_sync_not_succeeded_for_an_hour
+    # detect_course_sync_not_succeeded_for_an_hour
     detect_high_sidekiq_retries_queue_length
     detect_high_sidekiq_latency
     detect_unauthorised_application_form_edits

--- a/spec/workers/detect_invariants_hourly_check_spec.rb
+++ b/spec/workers/detect_invariants_hourly_check_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe DetectInvariantsHourlyCheck do
       expect(Sentry).not_to have_received(:capture_exception)
     end
 
-    it 'detects when the course sync hasn’t succeeded for an hour' do
+    it 'detects when the course sync hasn’t succeeded for an hour', skip: 'sync temporarily paused' do
       TeacherTrainingPublicAPI::SyncCheck.clear_last_sync
 
       described_class.new.perform


### PR DESCRIPTION
Following on from https://github.com/DFE-Digital/apply-for-teacher-training/pull/8341 we need to pause the invariant check, as we're getting spammed:
<img width="811" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/f347a992-37a9-4e21-be6e-8d51738392fd">
