### PR TITLE
Update channel name for the slack stats post

### DIFF
--- a/app/workers/send_stats_summary_to_slack.rb
+++ b/app/workers/send_stats_summary_to_slack.rb
@@ -2,6 +2,6 @@ class SendStatsSummaryToSlack
   include Sidekiq::Worker
 
   def perform
-    SlackNotificationWorker.perform_async(StatsSummary.new.as_slack_message, nil, '#twd_apply')
+    SlackNotificationWorker.perform_async(StatsSummary.new.as_slack_message, nil, '#twd_find_and_apply')
   end
 end

--- a/app/workers/send_weekly_stats_summary_to_slack.rb
+++ b/app/workers/send_weekly_stats_summary_to_slack.rb
@@ -2,6 +2,6 @@ class SendWeeklyStatsSummaryToSlack
   include Sidekiq::Worker
 
   def perform
-    SlackNotificationWorker.perform_async(WeeklyStatsSummary.new.as_slack_message, nil, '#twd_apply')
+    SlackNotificationWorker.perform_async(WeeklyStatsSummary.new.as_slack_message, nil, '#twd_find_and_apply')
   end
 end


### PR DESCRIPTION
## Context

We have a daily (and weekly) slack post on our stats. Now the teams have merged we want this to be posted in the new channel.

## Changes proposed in this pull request

update channel name from `#twd_apply` to `#twd_find_and_apply`

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
