### PR TITLE
Remove link to the GSE Realistic Job Preview Survey

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,7 +64,6 @@ en:
     url: https://www.gov.uk/exoffenders-and-employment
   realistic_job_previews:
     url_apply_again: https://teacherselect.qualtrics.com/jfe/form/SV_4VHMkFk6TeonVeS
-    url_get_school_experience: https://teacherselect.qualtrics.com/jfe/form/SV_aXbiUM3xz0uVtuS
   page_titles:
     application_feedback: How can we improve %{section} section?
     application_form: Your application


### PR DESCRIPTION
## Context

We added a link to a survey recently, but this is not needed, we only need the apply one.

## Changes proposed in this pull request

Remove link 67 in EN.yml, added here initially:
https://github.com/DFE-Digital/apply-for-teacher-training/pull/8318/files

## Guidance to review

Are there any tests that need to be removed? It appears not from a search of the code.

## Link to Trello card

https://trello.com/c/BqxwAb60/241-remove-urlgetschoolexperience-from-a-previous-pr

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
