### PR TITLE
Dont set vacancy status from find

### DIFF
--- a/app/services/teacher_training_public_api/sync_sites.rb
+++ b/app/services/teacher_training_public_api/sync_sites.rb
@@ -68,13 +68,13 @@ module TeacherTrainingPublicAPI
         study_mode:,
       )
 
-      vacancy_status = vacancy_status(site_status.vacancy_status, study_mode)
+      # vacancy_status = vacancy_status(site_status.vacancy_status, study_mode)
 
-      if course_option.vacancy_status != vacancy_status.to_s
-        course_option.update!(vacancy_status:)
+      # if course_option.vacancy_status != vacancy_status.to_s
+      course_option.update!(vacancy_status: 'vacancies')
 
-        @updates.merge!(course_option: true) if !@incremental_sync
-      end
+      @updates.merge!(course_option: true) if !@incremental_sync
+      # end
     end
 
     def vacancy_status(vacancy_status_from_api, study_mode)

--- a/app/services/teacher_training_public_api/sync_sites.rb
+++ b/app/services/teacher_training_public_api/sync_sites.rb
@@ -71,7 +71,11 @@ module TeacherTrainingPublicAPI
       # vacancy_status = vacancy_status(site_status.vacancy_status, study_mode)
 
       # if course_option.vacancy_status != vacancy_status.to_s
-      course_option.update!(vacancy_status: 'vacancies')
+      # new courses - always set to vacancies
+      # old courses - keep the same (no vacancies will continue to be no
+      # vacancies, and those with vacancies will continue forever until we
+      # change to the new attribute from Find)
+      course_option.update!(vacancy_status: 'vacancies') unless course_option.no_vacancies?
 
       @updates.merge!(course_option: true) if !@incremental_sync
       # end

--- a/app/services/teacher_training_public_api/sync_sites.rb
+++ b/app/services/teacher_training_public_api/sync_sites.rb
@@ -61,7 +61,7 @@ module TeacherTrainingPublicAPI
       (from_existing_course_options + [course.study_mode]).uniq
     end
 
-    def create_course_options(site, study_mode, site_status)
+    def create_course_options(site, study_mode, _site_status)
       course_option = CourseOption.find_or_initialize_by(
         site:,
         course_id: course.id,

--- a/spec/system/teacher_training_public_api/site_has_no_vacancies_and_is_not_updated_spec.rb
+++ b/spec/system/teacher_training_public_api/site_has_no_vacancies_and_is_not_updated_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.feature 'Sync sites' do
+  include TeacherTrainingPublicAPIHelper
+
+  it 'a site has no vacancies and is not set to vacancies by the sync' do
+    given_there_is_a_provider_and_course_on_apply
+    and_that_course_exists_on_the_ttapi
+
+    when_sync_provider_is_called
+    then_the_vancacy_attribute_does_not_change
+  end
+
+  def given_there_is_a_provider_and_course_on_apply
+    @site_uuid = SecureRandom.uuid
+    @provider = create(:provider, code: 'ABC')
+    @site = create(:site, code: 'A', provider: @provider, uuid: @site_uuid)
+    @course = create(:course, code: 'ABC1', provider: @provider, name: 'Secondary')
+    @course_option = create(:course_option, :no_vacancies, course: @course, site: @site)
+  end
+
+  def and_that_course_exists_on_the_ttapi
+    stub_teacher_training_api_course_with_site(provider_code: 'ABC',
+                                               course_code: 'ABC1',
+                                               site_code: 'A',
+                                               site_attributes: [{
+                                                 uuid: @site_uuid,
+                                               }])
+  end
+
+  def when_sync_provider_is_called
+    TeacherTrainingPublicAPI::SyncSites.new.perform(@provider.id, stubbed_recruitment_cycle_year, @course.id)
+  end
+
+  def then_the_vancacy_attribute_does_not_change
+    expect(@course.reload.course_options.count).to eq 1
+    expect(@course.reload.course_options.first.vacancy_status).to eq 'no_vacancies'
+  end
+end

--- a/spec/system/teacher_training_public_api/study_mode_changes_spec.rb
+++ b/spec/system/teacher_training_public_api/study_mode_changes_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe 'Sync from Teacher Training API' do
   def then_the_part_time_course_option_is_set_to_no_vacancies
     expect(@course.course_options.count).to eq 2
     expect(@course.course_options.last.study_mode).to eq 'part_time'
-    expect(@course.course_options.last.vacancy_status).to eq 'no_vacancies'
+    # All new courses are being set to having vacancies due to Find changes
+    expect(@course.course_options.last.vacancy_status).to eq 'vacancies'
   end
 end

--- a/spec/system/teacher_training_public_api/sync_site_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_site_spec.rb
@@ -111,7 +111,8 @@ RSpec.feature 'Sync sites', sidekiq: true do
     site = get_site_by_provider_code('B', 'ABC')
     full_time_course_option = CourseOption.find_by(site:, course_id: course.id, study_mode: 'full_time')
     expect(full_time_course_option).not_to be_nil
-    expect(full_time_course_option.vacancy_status).to eql('no_vacancies')
+    # All new courses are being set to having vacancies due to Find changes
+    expect(full_time_course_option.vacancy_status).to eql('vacancies')
 
     part_time_course_option = CourseOption.find_by(site:, course_id: course.id, study_mode: 'part_time')
     expect(part_time_course_option).not_to be_nil


### PR DESCRIPTION
## Context

Following on from: [#8341](https://github.com/DFE-Digital/apply-for-teacher-training/pull/8341) we're taking steps to switch the sync back on.

We'll then test the sync on QA, provided this works we'll turn the job back on.

## Changes proposed in this pull request

All new courses from the sync will have vacancies.