### PR TITLE
Fix personal statement completion bug

### DIFF
--- a/app/controllers/candidate_interface/personal_statement_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement_controller.rb
@@ -56,6 +56,9 @@ module CandidateInterface
     end
 
     def complete
+      @becoming_a_teacher_form = BecomingATeacherForm.build_from_application(
+        current_application,
+      )
       @application_form = current_application
       @section_complete_form = SectionCompleteForm.new(form_params)
 

--- a/spec/system/candidate_interface/entering_details/candidate_personal_statement_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_personal_statement_spec.rb
@@ -32,6 +32,9 @@ RSpec.feature 'Entering "Personal statement"' do
     and_i_submit_the_form
     then_i_can_check_my_revised_answers
 
+    when_i_try_to_continue
+    then_i_am_told_to_select_whether_i_have_completed_the_section
+
     when_i_mark_the_section_as_completed
     and_i_submit_the_form
     then_i_should_see_the_form
@@ -94,6 +97,7 @@ RSpec.feature 'Entering "Personal statement"' do
   def and_i_submit_the_form
     click_button t('continue')
   end
+  alias_method :when_i_try_to_continue, :and_i_submit_the_form
 
   def when_i_click_to_change_my_answer
     click_change_link('personal statement')
@@ -115,6 +119,10 @@ RSpec.feature 'Entering "Personal statement"' do
   def then_i_can_check_my_revised_answers
     expect(page).to have_content 'Personal statement'
     expect(page).to have_content 'Hello world again'
+  end
+
+  def then_i_am_told_to_select_whether_i_have_completed_the_section
+    expect(page).to have_content 'Select whether you have completed this section'
   end
 
   def when_i_mark_the_section_as_completed


### PR DESCRIPTION
## Context

There's a bug on the personal statement page if the user clicks 'Continue' without marking the section as completed/not completed. This is because it requires the presence of a `becoming_a_teacher_form` introduced in this [PR](https://github.com/DFE-Digital/apply-for-teacher-training/pull/8021).

## Changes proposed in this pull request

Include a `becoming_a_teacher_form`in the `complete` action
<img width="782" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/66e94a5f-212c-44d5-8e3e-b81795fcf76e">


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/a6Oocre0

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
