### PR TITLE
Turn the publish API sync back on

### DIFF
--- a/app/workers/detect_invariants_hourly_check.rb
+++ b/app/workers/detect_invariants_hourly_check.rb
@@ -5,7 +5,7 @@ class DetectInvariantsHourlyCheck
   SIDEKIQ_LATENCY_THRESHOLD = 120
 
   def perform
-    # detect_course_sync_not_succeeded_for_an_hour
+    detect_course_sync_not_succeeded_for_an_hour
     detect_high_sidekiq_retries_queue_length
     detect_high_sidekiq_latency
     detect_unauthorised_application_form_edits

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -10,9 +10,9 @@ class Clock
 
   # More-than-hourly jobs
 
-  # every(10.minutes, 'IncrementalSyncAllFromTeacherTrainingPublicAPI', skip_first_run: true) do
-  #  TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(true)
-  # end
+  every(10.minutes, 'IncrementalSyncAllFromTeacherTrainingPublicAPI', skip_first_run: true) do
+    TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(true)
+  end
 
   # Hourly jobs
 
@@ -49,9 +49,9 @@ class Clock
   every(1.day, 'SendStatsSummaryToSlack', at: '17:00', if: ->(period) { period.wday.between?(1, 4) }) { SendStatsSummaryToSlack.new.perform }
 
   # Weekly jobs
-  # every(7.days, 'FullSyncAllFromTeacherTrainingPublicAPI', at: 'Saturday 00:59') do
-  #  TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(false)
-  # end
+  every(7.days, 'FullSyncAllFromTeacherTrainingPublicAPI', at: 'Saturday 00:59') do
+    TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async(false)
+  end
 
   every(7.days, 'TADSubjectDomicileNationalityExport', at: 'Sunday 23:59') do
     DataAPI::TADSubjectDomicileNationalityExport.run_weekly

--- a/spec/workers/detect_invariants_hourly_check_spec.rb
+++ b/spec/workers/detect_invariants_hourly_check_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe DetectInvariantsHourlyCheck do
       expect(Sentry).not_to have_received(:capture_exception)
     end
 
-    it 'detects when the course sync hasn’t succeeded for an hour', skip: 'sync temporarily paused' do
+    it 'detects when the course sync hasn’t succeeded for an hour' do
       TeacherTrainingPublicAPI::SyncCheck.clear_last_sync
 
       described_class.new.perform


### PR DESCRIPTION
## Context

After [8350](https://github.com/DFE-Digital/apply-for-teacher-training/pull/8350) we're now ready to turn the sync back on