### PR TITLE
Fix the publish sync

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -37,6 +37,7 @@ class FeatureFlag
     [:one_personal_statement, 'Combining the 2 personal statements into 1 for new applications', 'Frankie Roberto + Maeve Roseveare'],
     [:structured_reference_condition, 'Structured reference condition that can be added as a condition to an offer', 'Tomas Destefi'],
     [:continuous_applications, 'The new continuous applications flow', 'James Glenn'],
+    [:course_has_vacancies, 'Using the new publish status to set a course as open or closed', 'Tomas & James'],
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day

--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -47,10 +47,19 @@ module TeacherTrainingPublicAPI
       course.save!
       course.open! if new_course
 
+      job_args = [
+        provider.id,
+        recruitment_cycle_year,
+        course.id,
+        course_from_api.application_status,
+        incremental_sync,
+        suppress_sync_update_errors,
+      ]
+
       if run_in_background
-        TeacherTrainingPublicAPI::SyncSites.perform_async(provider.id, recruitment_cycle_year, course.id, incremental_sync, suppress_sync_update_errors)
+        TeacherTrainingPublicAPI::SyncSites.perform_async(*job_args)
       else
-        TeacherTrainingPublicAPI::SyncSites.new.perform(provider.id, recruitment_cycle_year, course.id, incremental_sync, suppress_sync_update_errors)
+        TeacherTrainingPublicAPI::SyncSites.new.perform(*job_args)
       end
     end
 

--- a/spec/examples/teacher_training_api/course_list_response.json
+++ b/spec/examples/teacher_training_api/course_list_response.json
@@ -15,6 +15,7 @@
         "additional_gcse_equivalencies": "Please contact us for more information",
         "age_minimum": 11,
         "age_maximum": 14,
+        "application_status": "open",
         "applications_open_from": "2019-10-08",
         "bursary_amount": 9000,
         "bursary_requirements": [

--- a/spec/examples/teacher_training_api/course_single_response.json
+++ b/spec/examples/teacher_training_api/course_single_response.json
@@ -14,6 +14,7 @@
       "accredited_body_code": "2FR",
       "age_minimum": 11,
       "age_maximum": 14,
+      "application_status": "open",
       "applications_open_from": "2019-10-08",
       "bursary_amount": 9000,
       "bursary_requirements": [

--- a/spec/examples/teacher_training_api/site_list_response_with_full_time_and_part_time_vacancies.json
+++ b/spec/examples/teacher_training_api/site_list_response_with_full_time_and_part_time_vacancies.json
@@ -87,9 +87,7 @@
       "type": "location_statuses",
       "attributes": {
         "publish": "published",
-        "status": "running",
-        "vacancy_status": "both_full_time_and_part_time_vacancies",
-        "has_vacancies": true
+        "status": "running"
       }
     },
     {
@@ -97,9 +95,7 @@
       "type": "location_statuses",
       "attributes": {
         "publish": "published",
-        "status": "running",
-        "vacancy_status": "both_full_time_and_part_time_vacancies",
-        "has_vacancies": true
+        "status": "running"
       }
     }
   ],

--- a/spec/examples/teacher_training_api/site_list_response_with_full_time_vacancies.json
+++ b/spec/examples/teacher_training_api/site_list_response_with_full_time_vacancies.json
@@ -87,9 +87,7 @@
       "type": "location_statuses",
       "attributes": {
         "publish": "published",
-        "status": "running",
-        "vacancy_status": "full_time_vacancies",
-        "has_vacancies": true
+        "status": "running"
       }
     },
     {
@@ -97,9 +95,7 @@
       "type": "location_statuses",
       "attributes": {
         "publish": "published",
-        "status": "running",
-        "vacancy_status": "full_time_vacancies",
-        "has_vacancies": true
+        "status": "running"
       }
     }
   ],

--- a/spec/examples/teacher_training_api/site_list_response_with_part_time_vacancies.json
+++ b/spec/examples/teacher_training_api/site_list_response_with_part_time_vacancies.json
@@ -87,9 +87,7 @@
       "type": "location_statuses",
       "attributes": {
         "publish": "published",
-        "status": "running",
-        "vacancy_status": "part_time_vacancies",
-        "has_vacancies": true
+        "status": "running"
       }
     },
     {
@@ -97,9 +95,7 @@
       "type": "location_statuses",
       "attributes": {
         "publish": "published",
-        "status": "running",
-        "vacancy_status": "part_time_vacancies",
-        "has_vacancies": true
+        "status": "running"
       }
     }
   ],

--- a/spec/system/teacher_training_public_api/site_has_no_vacancies_and_is_not_updated_spec.rb
+++ b/spec/system/teacher_training_public_api/site_has_no_vacancies_and_is_not_updated_spec.rb
@@ -5,10 +5,15 @@ RSpec.feature 'Sync sites' do
 
   it 'a site has no vacancies and is not set to vacancies by the sync' do
     given_there_is_a_provider_and_course_on_apply
+    and_course_vacancies_feature_flag_is_off
     and_that_course_exists_on_the_ttapi
 
     when_sync_provider_is_called
     then_the_vancacy_attribute_does_not_change
+  end
+
+  def and_course_vacancies_feature_flag_is_off
+    FeatureFlag.deactivate(:course_has_vacancies)
   end
 
   def given_there_is_a_provider_and_course_on_apply
@@ -29,7 +34,12 @@ RSpec.feature 'Sync sites' do
   end
 
   def when_sync_provider_is_called
-    TeacherTrainingPublicAPI::SyncSites.new.perform(@provider.id, stubbed_recruitment_cycle_year, @course.id)
+    TeacherTrainingPublicAPI::SyncSites.new.perform(
+      @provider.id,
+      stubbed_recruitment_cycle_year,
+      @course.id,
+      'open',
+    )
   end
 
   def then_the_vancacy_attribute_does_not_change

--- a/spec/system/teacher_training_public_api/site_is_deleted_spec.rb
+++ b/spec/system/teacher_training_public_api/site_is_deleted_spec.rb
@@ -51,7 +51,12 @@ RSpec.feature 'Sync sites' do
   alias_method :given_that_the_course_on_TTAPI_with_multiple_sites, :and_that_course_on_ttapi_has_multiple_sites
 
   def when_sync_provider_is_called
-    TeacherTrainingPublicAPI::SyncSites.new.perform(@provider.id, stubbed_recruitment_cycle_year, @course.id)
+    TeacherTrainingPublicAPI::SyncSites.new.perform(
+      @provider.id,
+      stubbed_recruitment_cycle_year,
+      @course.id,
+      'closed',
+    )
   end
 
   def then_the_correct_course_options_are_created_on_apply

--- a/spec/system/teacher_training_public_api/sync_is_called_with_the_new_course_attribute_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_is_called_with_the_new_course_attribute_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.feature 'Sync sites' do
+  include TeacherTrainingPublicAPIHelper
+
+  it 'a site has no vacancies and is not set to vacancies by the sync' do
+    given_there_is_a_provider_and_has_two_courses_on_apply
+    and_course_vacancies_feature_flag_is_on
+    and_that_the_courses_exists_on_the_ttapi
+
+    when_sync_provider_is_called_with_an_open_course
+    then_the_site_has_vacancies
+
+    when_sync_provider_is_called_with_a_closed_course
+    then_the_site_has_no_vacancies
+  end
+
+  def and_course_vacancies_feature_flag_is_on
+    FeatureFlag.activate(:course_has_vacancies)
+  end
+
+  def given_there_is_a_provider_and_has_two_courses_on_apply
+    @site_uuid = SecureRandom.uuid
+    @provider = create(:provider, code: 'ABC')
+    @site = create(:site, code: 'A', provider: @provider, uuid: @site_uuid)
+    @course = create(:course, code: 'ABC1', provider: @provider, name: 'Secondary')
+
+    @second_course = create(:course, code: 'ABC2', provider: @provider, name: 'Secondary')
+  end
+
+  def and_that_the_courses_exists_on_the_ttapi
+    stub_teacher_training_api_course_with_site(provider_code: 'ABC',
+                                               course_code: 'ABC1',
+                                               site_code: 'A',
+                                               site_attributes: [{
+                                                 uuid: @site_uuid,
+                                               }])
+
+    stub_teacher_training_api_course_with_site(provider_code: 'ABC',
+                                               course_code: 'ABC2',
+                                               site_code: 'A',
+                                               site_attributes: [{
+                                                 uuid: @site_uuid,
+                                               }])
+  end
+
+  def when_sync_provider_is_called_with_an_open_course
+    TeacherTrainingPublicAPI::SyncSites.new.perform(
+      @provider.id,
+      stubbed_recruitment_cycle_year,
+      @course.id,
+      'open',
+    )
+  end
+
+  def then_the_site_has_vacancies
+    expect(@course.reload.course_options.count).to eq 1
+    expect(@course.reload.course_options.first.vacancy_status).to eq 'vacancies'
+  end
+
+  def when_sync_provider_is_called_with_a_closed_course
+    TeacherTrainingPublicAPI::SyncSites.new.perform(
+      @provider.id,
+      stubbed_recruitment_cycle_year,
+      @second_course.id,
+      'closed',
+    )
+  end
+
+  def then_the_site_has_no_vacancies
+    expect(@second_course.reload.course_options.count).to eq 1
+    expect(@second_course.reload.course_options.first.vacancy_status).to eq 'no_vacancies'
+  end
+end


### PR DESCRIPTION
## Context

Publish removed `vacancy_status` from the `site` object and [added](https://github.com/DFE-Digital/publish-teacher-training/blob/main/app/models/course.rb#L26-L29) `application_status` to the `course` object.

We're updating the API sync to work with this new attribute.

## Changes proposed in this pull request

If the course is set to `closed` then we set all sites to `no_vacancies`
If the course is set to `opened` then we set all site to `vacancies`

## Guidance to review

This is feature flagged and we will manually test the sync per environment.
If all is ✅  then we'll merge [8355](https://github.com/DFE-Digital/apply-for-teacher-training/pull/8355)

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
