### PR TITLE
Introduce invariant check for the monthly stats report

### DIFF
--- a/app/workers/detect_invariants_daily_check.rb
+++ b/app/workers/detect_invariants_daily_check.rb
@@ -8,6 +8,18 @@ class DetectInvariantsDailyCheck
     detect_submitted_applications_with_more_than_the_max_course_choices
     detect_application_choices_with_out_of_date_provider_ids
     detect_obsolete_feature_flags
+    detect_if_the_monthly_statistics_has_not_run
+  end
+
+  def detect_if_the_monthly_statistics_has_not_run
+    latest_monthly_report = Publications::MonthlyStatistics::MonthlyStatisticsReport.last
+
+    return if latest_monthly_report.generation_date >= MonthlyStatisticsTimetable.current_generation_date
+
+    latest_month = MonthlyStatisticsTimetable.last_publication_date.strftime('%B')
+
+    message = "The monthly statistics report has not been generated for #{latest_month}"
+    Sentry.capture_exception(MonthlyStatisticsReportHasNotRun.new(message))
   end
 
   def detect_applications_with_course_choices_in_previous_cycle
@@ -100,6 +112,7 @@ class DetectInvariantsDailyCheck
   class SubmittedApplicationHasMoreThanTheMaxCourseChoices < StandardError; end
   class ApplicationChoicesWithOutOfDateProviderIds < StandardError; end
   class ObsoleteFeatureFlags < StandardError; end
+  class MonthlyStatisticsReportHasNotRun < StandardError; end
 
 private
 


### PR DESCRIPTION
## Context

The monthly statistics report is generated a week before it is published. On a couple of occasions the report has not been generated and we are only alerted to it not appearing thanks to members of the public. This invariant check will alert us if the report has not been generated.

## Changes proposed in this pull request

new daily invariant check.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
