### PR TITLE
[282] Enable support to change an application choice to salaried course

### DIFF
--- a/app/controllers/support_interface/application_forms/application_choices/change_offered_course_controller.rb
+++ b/app/controllers/support_interface/application_forms/application_choices/change_offered_course_controller.rb
@@ -68,9 +68,6 @@ module SupportInterface
               @show_course_change_confirmation = checkbox_rendered?
               render :confirm_offered_course_option
             end
-          rescue FundingTypeError => e
-            flash[:warning] = e.message
-            render :confirm_offered_course_option
           rescue CourseFullError => e
             flash[:warning] = e.message
             @show_course_change_confirmation = true

--- a/app/controllers/support_interface/application_forms/courses_controller.rb
+++ b/app/controllers/support_interface/application_forms/courses_controller.rb
@@ -60,7 +60,7 @@ module SupportInterface
             @show_course_change_confirmation = checkbox_rendered?
             render :edit
           end
-        rescue CourseChoiceError, FundingTypeError => e
+        rescue CourseChoiceError => e
           flash[:warning] = e.message
           render :edit
         rescue ApplicationStateError, CourseFullError, ProviderInterviewError => e

--- a/app/errors/funding_type_error.rb
+++ b/app/errors/funding_type_error.rb
@@ -1,1 +1,0 @@
-class FundingTypeError < StandardError; end

--- a/app/forms/support_interface/application_forms/update_offered_course_option_form.rb
+++ b/app/forms/support_interface/application_forms/update_offered_course_option_form.rb
@@ -14,7 +14,6 @@ module SupportInterface
 
         return false unless valid?
 
-        check_course_funding_type!(application_choice)
         check_course_full!
 
         application_choice.update_course_option_and_associated_fields!(course_option, audit_comment:)
@@ -26,15 +25,6 @@ module SupportInterface
       end
 
     private
-
-      def check_course_funding_type!(application_choice)
-        current_course = application_choice.course
-        new_course = course_option.course
-
-        return unless current_course.fee_paying? && new_course.salaried_or_apprenticeship?
-
-        raise FundingTypeError, I18n.t('support_interface.errors.messages.funding_type_error', course: 'an offered course')
-      end
 
       def check_course_full!
         return if confirm_course_change.present?

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -128,14 +128,6 @@ class Course < ApplicationRecord
     applications_open_from <= Time.zone.today
   end
 
-  def fee_paying?
-    funding_type == 'fee'
-  end
-
-  def salaried_or_apprenticeship?
-    funding_type == 'salary' || funding_type == 'apprenticeship'
-  end
-
   def find_url
     url = if HostingEnvironment.sandbox_mode?
             I18n.t('find_postgraduate_teacher_training.sandbox_url')

--- a/app/services/support_interface/change_application_choice_course_option.rb
+++ b/app/services/support_interface/change_application_choice_course_option.rb
@@ -26,7 +26,6 @@ module SupportInterface
     def call
       check_application_state!
       check_interviewing_providers!
-      check_course_funding_type!
       check_course_full!
 
       application_choice.update_course_option_and_associated_fields!(course_option, other_fields:, audit_comment:)
@@ -46,15 +45,6 @@ module SupportInterface
       return if !application_choice.interviewing? || (application_choice.interviewing? && application_choice.provider_ids.include?(provider_id))
 
       raise ProviderInterviewError, 'Changing a course choice when the provider is not on the interview is not allowed'
-    end
-
-    def check_course_funding_type!
-      current_course = application_choice.course
-      new_course = course_option.course
-
-      return unless current_course.fee_paying? && new_course.salaried_or_apprenticeship?
-
-      raise FundingTypeError, I18n.t('support_interface.errors.messages.funding_type_error', course: 'a course choice')
     end
 
     def check_course_full!

--- a/config/locales/candidate_interface/courses.yml
+++ b/config/locales/candidate_interface/courses.yml
@@ -43,6 +43,3 @@ en:
           attributes:
             add_another_course:
               blank: Select if you want to add another course
-  errors:
-    messages:
-      funding_type_error: Changing %{course} from fee paying to salaried or an apprenticeship is not allowed. Please raise a dev support ticket.

--- a/spec/forms/support_interface/application_forms/update_offered_course_option_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/update_offered_course_option_form_spec.rb
@@ -31,36 +31,6 @@ RSpec.describe SupportInterface::ApplicationForms::UpdateOfferedCourseOptionForm
       expect(application_choice.audits.last.comment).to include(zendesk_ticket)
     end
 
-    context 'course choice funding type check' do
-      let(:salaried_course) { create(:course, :salaried) }
-      let(:application_choice) { create(:application_choice, :offered, course_option: create(:course_option, course: fee_paying_course)) }
-      let(:course_option) { create(:course_option, course: salaried_course) }
-      let!(:error_message) { I18n.t('support_interface.errors.messages.funding_type_error', course: 'an offered course') }
-
-      it 'raises a FundingTypeError if current course is fee paying and the new course is salaried' do
-        expect {
-          described_class.new(course_option_id: course_option.id, audit_comment: zendesk_ticket, accept_guidance: 'true').save(application_choice)
-        }.to raise_error(FundingTypeError, error_message)
-      end
-
-      it 'raises a FundingType error if current course is fee paying and the new course is an apprenticeship' do
-        apprenticeship = create(:course, :apprenticeship)
-        course_option = create(:course_option, course: apprenticeship)
-
-        expect {
-          described_class.new(course_option_id: course_option.id, audit_comment: zendesk_ticket, accept_guidance: 'true').save(application_choice)
-        }.to raise_error(FundingTypeError, error_message)
-      end
-
-      it 'does not raise an error for other combinations of funding types for courses' do
-        course_option = create(:course_option, course: fee_paying_course)
-
-        expect {
-          described_class.new(course_option_id: course_option.id, audit_comment: zendesk_ticket, accept_guidance: 'true').save(application_choice)
-        }.not_to raise_error
-      end
-    end
-
     context 'course full check' do
       let(:application_choice) { create(:application_choice, :offered) }
 

--- a/spec/services/support_interface/change_application_choice_course_option_spec.rb
+++ b/spec/services/support_interface/change_application_choice_course_option_spec.rb
@@ -113,51 +113,6 @@ RSpec.describe SupportInterface::ChangeApplicationChoiceCourseOption do
       end
     end
 
-    context 'course choice funding type check' do
-      let(:salaried_course) { create(:course, funding_type: 'salary') }
-      let(:application_choice) { create(:application_choice, :awaiting_provider_decision, course_option: create(:course_option, course: fee_paying_course)) }
-      let(:course_option) { create(:course_option, course: salaried_course) }
-      let!(:error_message) { I18n.t('support_interface.errors.messages.funding_type_error', course: 'a course choice') }
-
-      it 'raises a FundingTypeError if current course is fee paying and the new course is salaried' do
-        expect {
-          described_class.new(application_choice_id: application_choice.id,
-                              provider_id: course_option.course.provider_id,
-                              course_code: course_option.course.code,
-                              study_mode: course_option.course.study_mode,
-                              site_code: course_option.site.code,
-                              audit_comment:).call
-        }.to raise_error(FundingTypeError, error_message)
-      end
-
-      it 'raises a FundingType error if current course is fee paying and the new course is an apprenticeship' do
-        apprenticeship = create(:course, funding_type: 'apprenticeship')
-        course_option = create(:course_option, course: apprenticeship)
-
-        expect {
-          described_class.new(application_choice_id: application_choice.id,
-                              provider_id: course_option.course.provider_id,
-                              course_code: course_option.course.code,
-                              study_mode: course_option.course.study_mode,
-                              site_code: course_option.site.code,
-                              audit_comment:).call
-        }.to raise_error(FundingTypeError, error_message)
-      end
-
-      it 'does not raise an error for other combinations of funding types for courses' do
-        course_option =  create(:course_option, course: fee_paying_course)
-
-        expect {
-          described_class.new(application_choice_id: application_choice.id,
-                              provider_id: course_option.course.provider_id,
-                              course_code: course_option.course.code,
-                              study_mode: course_option.course.study_mode,
-                              site_code: course_option.site.code,
-                              audit_comment:).call
-        }.not_to raise_error
-      end
-    end
-
     context 'course full check' do
       it 'raises a CourseFullError if the new course has no vacancies' do
         course_option = create(:course_option, :no_vacancies, course: fee_paying_course)

--- a/spec/system/support_interface/change_course_choice_spec.rb
+++ b/spec/system/support_interface/change_course_choice_spec.rb
@@ -93,7 +93,7 @@ RSpec.feature 'Change course choice' do
   end
 
   def when_i_enter_the_new_course_choice_for_a_course_with_no_vacancies_and_press_change
-    @course_option = create(:course_option, :no_vacancies, study_mode: :full_time, course: create(:course, funding_type: 'fee'))
+    @course_option = create(:course_option, :no_vacancies, study_mode: :full_time)
 
     fill_in_course_details
   end

--- a/spec/system/support_interface/change_offered_course_for_a_submitted_application_spec.rb
+++ b/spec/system/support_interface/change_offered_course_for_a_submitted_application_spec.rb
@@ -138,7 +138,7 @@ RSpec.feature 'Add course to submitted application' do
   end
 
   def and_i_enter_a_course_code_for_a_course_that_has_the_same_ratifying_provider
-    @course_option = create(:course_option, course: create(:course, :open_on_apply, funding_type: 'fee', provider: @application_choice.provider))
+    @course_option = create(:course_option, course: create(:course, :open_on_apply, provider: @application_choice.provider))
     @course_code = @course_option.course.code
     fill_in('Course code', with: @course_code)
   end


### PR DESCRIPTION
## Context

Previously a decision was made to prevent support from changing an application choice to a salaried course due to funding concerns.

See PR: https://github.com/DFE-Digital/apply-for-teacher-training/pull/7289/files

A decision has been made to revert this change, as this is something that we regularly have to do.

## Changes proposed in this pull request

Revert: https://github.com/DFE-Digital/apply-for-teacher-training/pull/7289/files

## Guidance to review

Change an application choice to salaried course and ensure it works. `support/applications/{id}`

## Link to Trello card

https://trello.com/c/oewLZfW5/282-allow-support-to-change-a-course-choice-to-a-salaried-course

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
