### PR TITLE
Change continuous apps check to application form

### DIFF
--- a/app/lib/time_limit_config.rb
+++ b/app/lib/time_limit_config.rb
@@ -42,7 +42,7 @@ class TimeLimitConfig
   end
 
   def self.stale_application_rules
-    working_days = RecruitmentCycle.continuous_applications? ? 30 : 40
+    working_days = FeatureFlag.active?(:continuous_applications) ? 30 : 40
 
     [
       Rule.new(nil, nil, working_days),

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -62,6 +62,8 @@ class ApplicationChoice < ApplicationRecord
   scope :decision_pending, -> { where(status: ApplicationStateChange::DECISION_PENDING_STATUSES) }
   scope :accepted, -> { where(status: ApplicationStateChange::ACCEPTED_STATES) }
 
+  delegate :continuous_applications?, to: :application_form
+
   def submitted?
     !unsubmitted?
   end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -80,6 +80,8 @@ class ApplicationForm < ApplicationRecord
     equality_and_diversity
   ].freeze
 
+  CONTINUOUS_APPLICATIONS_CYCLE_YEAR = 2024
+
   def equality_and_diversity_answers_provided?
     answered_questions = Hash(equality_and_diversity).keys
     EQUALITY_AND_DIVERSITY_MINIMAL_ATTR.all? { |attr| attr.in? answered_questions }
@@ -516,6 +518,11 @@ class ApplicationForm < ApplicationRecord
 
   def single_personal_statement_application?
     FeatureFlag.active?(:one_personal_statement) && single_personal_statement?
+  end
+
+  def continuous_applications?
+    @continuous_applications ||= recruitment_cycle_year >= CONTINUOUS_APPLICATIONS_CYCLE_YEAR &&
+                                 FeatureFlag.active?(:continuous_applications)
   end
 
 private

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -1,5 +1,4 @@
 module RecruitmentCycle
-  CONTINUOUS_APPLICATIONS_CYCLE_YEAR = 2024
   CYCLES = {
     '2023' => '2022 to 2023',
     '2022' => '2021 to 2022',
@@ -38,9 +37,5 @@ module RecruitmentCycle
 
   def self.verbose_cycle_name(year = current_year)
     "October #{year - 1} to September #{year}"
-  end
-
-  def self.continuous_applications?
-    FeatureFlag.active?(:continuous_applications) && current_year >= CONTINUOUS_APPLICATIONS_CYCLE_YEAR
   end
 end

--- a/app/services/process_stale_applications.rb
+++ b/app/services/process_stale_applications.rb
@@ -5,12 +5,12 @@ class ProcessStaleApplications
 
   def call
     @application_choices.each do |application_choice|
-      stale_application_processor.new(application_choice:).call
+      stale_application_processor(application_choice:).new(application_choice:).call
     end
   end
 
-  def stale_application_processor
-    if RecruitmentCycle.continuous_applications?
+  def stale_application_processor(application_choice:)
+    if application_choice.continuous_applications?
       MarkInactiveApplication
     else
       RejectApplicationByDefault

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -44,6 +44,10 @@ FactoryBot.define do
       personal_statement { Faker::Lorem.paragraph_by_chars(number: 500) }
     end
 
+    trait :continuous_applications do
+      recruitment_cycle_year { 2024 }
+    end
+
     trait :previous_year do
       association(:course_option, :previous_year)
 

--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -367,6 +367,10 @@ FactoryBot.define do
       end
     end
 
+    trait :continuous_applications do
+      recruitment_cycle_year { 2024 }
+    end
+
     trait :carry_over do
       completed
       recruitment_cycle_year { CycleTimetable.current_year }

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -3,6 +3,34 @@ require 'rails_helper'
 RSpec.describe ApplicationForm do
   include CycleTimetableHelper
 
+  describe '#continuous_applications?' do
+    let(:recruitment_cycle_year) { 2024 }
+
+    subject(:application_form) do
+      create(:application_form, recruitment_cycle_year:)
+    end
+
+    context 'when feature flag is on', continuous_applications: true do
+      it 'returns true' do
+        expect(application_form).to be_continuous_applications
+      end
+    end
+
+    context 'when feature flag is off', continuous_applications: false do
+      it 'returns false' do
+        expect(application_form).not_to be_continuous_applications
+      end
+    end
+
+    context 'when recruitment cycle is before continuous applications delivery' do
+      let(:recruitment_cycle_year) { 2023 }
+
+      it 'returns false' do
+        expect(application_form).not_to be_continuous_applications
+      end
+    end
+  end
+
   it 'sets a unique support reference upon creation' do
     create(:application_form, support_reference: 'AB1234')
     allow(GenerateSupportReference).to receive(:call).and_return('AB1234', 'OK1234')

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -182,6 +182,7 @@ RSpec.configure do |config|
       FeatureFlag.activate(:continuous_applications)
       set_time(mid_cycle(CycleTimetable.next_year))
     else
+      set_time(mid_cycle(2023))
       FeatureFlag.deactivate(:continuous_applications)
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -146,7 +146,7 @@ RSpec.configure do |config|
     end
   end
 
-  config.before do
+  config.before do |example|
     RequestStore.store[:allow_unsafe_application_choice_touches] = true
 
     if ENV['DEFAULT_FEATURE_FLAG_STATE'] == 'on'
@@ -157,6 +157,15 @@ RSpec.configure do |config|
       Feature.insert_all(records)
 
       FeatureFlag.deactivate(:adviser_sign_up)
+    end
+
+    # Make sure that this check run after the feature flags are turn on
+    if example.metadata[:continuous_applications].present?
+      FeatureFlag.activate(:continuous_applications)
+      set_time(mid_cycle(CycleTimetable.next_year))
+    elsif example.metadata.key?(:continuous_applications) && example.metadata[:continuous_applications].blank?
+      set_time(mid_cycle(2023))
+      FeatureFlag.deactivate(:continuous_applications)
     end
   end
 
@@ -175,16 +184,6 @@ RSpec.configure do |config|
 
   config.before(type: 'system') do
     TestSuiteTimeMachine.travel_permanently_to(CycleTimetable.apply_opens + 1.day)
-  end
-
-  config.before(:each, :continuous_applications) do |example|
-    if example.metadata[:continuous_applications].present?
-      FeatureFlag.activate(:continuous_applications)
-      set_time(mid_cycle(CycleTimetable.next_year))
-    else
-      set_time(mid_cycle(2023))
-      FeatureFlag.deactivate(:continuous_applications)
-    end
   end
 
   config.around do |example|

--- a/spec/services/process_stale_applications_spec.rb
+++ b/spec/services/process_stale_applications_spec.rb
@@ -1,17 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe ProcessStaleApplications do
-  let!(:application_choice) do
-    create(
-      :application_choice,
-      :awaiting_provider_decision,
-      reject_by_default_at: 1.business_days.ago,
-      recruitment_cycle_year: 2023,
-    )
-  end
-
   context 'when cycle is 2023', continuous_applications: false do
     it 'rejects an application that is ready for rejection but leaves other untouched' do
+      application_choice = create(
+        :application_choice,
+        :awaiting_provider_decision,
+        reject_by_default_at: 1.business_days.ago,
+        recruitment_cycle_year: 2023,
+      )
       other_application_choice = create(
         :application_choice,
         :awaiting_provider_decision,
@@ -26,14 +23,18 @@ RSpec.describe ProcessStaleApplications do
 
   context 'when 2024 recruitment cycle', continuous_applications: true do
     it 'rejects an application that is ready for rejection but leaves other untouched' do
+      application_choice = create(
+        :application_choice,
+        :awaiting_provider_decision,
+        :continuous_applications,
+        reject_by_default_at: 1.business_days.ago,
+      )
       other_application_choice = create(
         :application_choice,
         :awaiting_provider_decision,
+        :continuous_applications,
         reject_by_default_at: 1.business_day.from_now,
-        recruitment_cycle_year: 2024,
       )
-
-      application_choice.application_form.update!(recruitment_cycle_year: 2024)
 
       described_class.new.call
       expect(other_application_choice.reload.status).to eq('awaiting_provider_decision')

--- a/spec/services/process_stale_applications_spec.rb
+++ b/spec/services/process_stale_applications_spec.rb
@@ -6,14 +6,11 @@ RSpec.describe ProcessStaleApplications do
       :application_choice,
       :awaiting_provider_decision,
       reject_by_default_at: 1.business_days.ago,
+      recruitment_cycle_year: 2023,
     )
   end
 
-  before do
-    FeatureFlag.activate(:continuous_applications)
-  end
-
-  context 'when cycle is 2023', time: Time.zone.local(2023, 6, 20, 12, 10, 0) do
+  context 'when cycle is 2023', continuous_applications: false do
     it 'rejects an application that is ready for rejection but leaves other untouched' do
       other_application_choice = create(
         :application_choice,
@@ -27,13 +24,16 @@ RSpec.describe ProcessStaleApplications do
     end
   end
 
-  context 'when 2024 recruitment cycle', time: Time.zone.local(2023, 11, 11, 11, 11, 11) do
+  context 'when 2024 recruitment cycle', continuous_applications: true do
     it 'rejects an application that is ready for rejection but leaves other untouched' do
       other_application_choice = create(
         :application_choice,
         :awaiting_provider_decision,
         reject_by_default_at: 1.business_day.from_now,
+        recruitment_cycle_year: 2024,
       )
+
+      application_choice.application_form.update!(recruitment_cycle_year: 2024)
 
       described_class.new.call
       expect(other_application_choice.reload.status).to eq('awaiting_provider_decision')

--- a/spec/services/set_reject_by_default_spec.rb
+++ b/spec/services/set_reject_by_default_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe SetRejectByDefault do
     ].freeze
 
     submitted_vs_rbd_dates.each do |submitted, correct_rbd, test_case|
-      it "is correct when the application is delivered #{test_case}" do
+      it "is correct when the application is delivered #{test_case}", continuous_applications: false do
         if test_case == 'near the Christmas holidays'
           pending('RBD rules have changed for this cycle (different holidays). Unsure of the value of these hardcoded dates.')
         end


### PR DESCRIPTION
## Context

Today is not possible to have a global check because we don't have a full cycle simulator so we can't simulate that the current recruitment cycle is 2024, but we can
generate applications in 2024 recruitment cycle and turn on the feature flag of continuous applications in order to simulate next cycle
