### PR TITLE
Remove the manual inclusion of DfE::Analytics::Entities

### DIFF
--- a/app/models/offer_condition.rb
+++ b/app/models/offer_condition.rb
@@ -1,5 +1,4 @@
 class OfferCondition < ApplicationRecord
-  include DfE::Analytics::Entities
   STANDARD_CONDITIONS = ['Fitness to train to teach check', 'Disclosure and Barring Service (DBS) check'].freeze
 
   belongs_to :offer, touch: true


### PR DESCRIPTION
## Context

Thanks to DfE::Analytics [#77](https://github.com/DFE-Digital/dfe-analytics/pull/77) this issue has now been resolved and we no longer need to manually include it.