### PR TITLE
Add issuer value to DSI config

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -20,6 +20,8 @@ options = {
     secret: dfe_sign_in_secret,
     redirect_uri: dfe_sign_in_redirect_uri&.to_s,
   },
+  issuer:
+  ("#{dfe_sign_in_issuer_uri}:#{dfe_sign_in_issuer_uri.port}" if dfe_sign_in_issuer_uri.present?),
 }
 
 # this needs to be declared inline or zeitwerk complains about autoloading during initialization


### PR DESCRIPTION
## Context

We're having issues with DfE Sign in on QA due to a recent release.

Another service had a simple issue that was resolved with [#232](https://github.com/DFE-Digital/access-your-teaching-qualifications/pull/232)

