### PR TITLE
Reject unsent references from vendor api payload

### DIFF
--- a/app/presenters/vendor_api/application_presenter.rb
+++ b/app/presenters/vendor_api/application_presenter.rb
@@ -88,7 +88,7 @@ module VendorAPI
       return [] unless show_references?
 
       references = if version_1_3_or_above?
-                     application_form.application_references.creation_order
+                     application_form.application_references.creation_order.reject { |reference| reference.feedback_status == 'not_requested_yet' }
                    else
                      application_form.application_references.creation_order.feedback_provided
                    end

--- a/spec/requests/vendor_api/application_references_spec.rb
+++ b/spec/requests/vendor_api/application_references_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'Vendor API application references' do
   let(:returned_reference) { returned_references.first&.deep_symbolize_keys }
 
   let(:reference) { application_choice.application_form.application_references.creation_order.first }
+  let!(:unsent_reference) { application_choice.application_form.application_references.creation_order.second.update(feedback_status: 'not_requested_yet') }
 
   before do
     get_api_request "/api/v#{version}/applications/#{application_choice.id}"
@@ -43,17 +44,27 @@ RSpec.describe 'Vendor API application references' do
     context 'for version 1.3' do
       let(:version) { '1.3' }
 
-      it 'returns the full application references with the reference status' do
-        expect(returned_reference).to eq(
-          id: reference.id,
-          name: reference.name,
-          email: reference.email_address,
-          relationship: reference.relationship,
-          reference: reference.feedback,
-          referee_type: reference.referee_type,
-          safeguarding_concerns: reference.has_safeguarding_concerns_to_declare?,
-          reference_received: true,
-        )
+      context 'when the reference request has not been sent' do
+        let(:returned_reference) { returned_references.second&.deep_symbolize_keys }
+
+        it 'does not return the reference' do
+          expect(returned_reference).to be_nil
+        end
+      end
+
+      context 'when the reference request has been sent' do
+        it 'returns the full application references with the reference status' do
+          expect(returned_reference).to eq(
+            id: reference.id,
+            name: reference.name,
+            email: reference.email_address,
+            relationship: reference.relationship,
+            reference: reference.feedback,
+            referee_type: reference.referee_type,
+            safeguarding_concerns: reference.has_safeguarding_concerns_to_declare?,
+            reference_received: true,
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
## Context

A provider has alerted us to a bug with references sent over the API.

In the post offer dashboard a candidate can add a reference request but not complete it, these will still be served in the payload due to the fact the candidate is in an accepted offer state. Because of this providers are receiving `null` references.

## Changes proposed in this pull request

Reject references from the v1.3 payload if they contain a feedback_status of 'not_requested_yet'.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
