### PR TITLE
Reword heading in support playbook for delete account application

### DIFF
--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -184,7 +184,7 @@ Update [ApplicationChoice](../app/models/application_choice.rb) to `recruited`.
 ApplicationChoice.find(_id).update!(status: :recruited, decline_by_default_at: nil, audit_comment: "Support request: #{_zendesk_url}")
 ```
 
-## Delete an application
+## Delete an account / application
 
 If an individual requests we delete their data we have 1 month to comply with this. At the same time we need the record to track for stats purposes.
 

--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -188,7 +188,7 @@ ApplicationChoice.find(_id).update!(status: :recruited, decline_by_default_at: n
 
 If an individual requests we delete their data we have 1 month to comply with this. At the same time we need the record to track for stats purposes.
 
-Use the [DeleteApplication](../app/services/delete_application.rb) service if the application has not been submitted yet.
+Use the [DeleteApplication](../app/services/delete_application.rb) service if the application has not been submitted yet. You may use the `force` option provided it has been cleared with the support team.
 
 If the application has been submitted, start a discussion to determine what steps we should take (eg - contacting the provider before deleting anything on our side).
 


### PR DESCRIPTION
## Context

It's not unusual for support tickets to phrase this operation as Delete Account. It's useful if the playbook reflects the language used by the support team.

Make reference to the `force` option for cases where it is ok to `DeleteApplication` despite not all `ApplicationChoices` being unsubmitted.

## Changes proposed in this pull request

Reword support playbook guide

## Guidance to review

No guidance

## Link to Trello card

No trello card

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
