### PR TITLE
DeleteApplication accepts force option

### DIFF
--- a/app/services/delete_application.rb
+++ b/app/services/delete_application.rb
@@ -50,15 +50,18 @@ class DeleteApplication
     application_feedback
   ].freeze
 
-  def initialize(actor:, application_form:, zendesk_url:)
+  def initialize(actor:, application_form:, zendesk_url:, force: false)
     @actor = actor
     @application_form = application_form
     @zendesk_url = zendesk_url
+    @force = force
   end
 
   def call!
-    raise 'Application has been sent to providers' \
-      unless application_form.application_choices.all?(&:unsubmitted?)
+    if !@force && !application_form.application_choices.all?(&:unsubmitted?)
+      raise 'Application has been sent to providers' \
+
+    end
 
     audit(actor) do
       ActiveRecord::Base.transaction do

--- a/spec/services/delete_application_spec.rb
+++ b/spec/services/delete_application_spec.rb
@@ -13,11 +13,13 @@ RSpec.describe DeleteApplication do
     )
   end
   let(:zendesk_url) { 'https://becomingateacher.zendesk.com/agent/tickets/1234' }
+  let(:force) { false }
   let(:service) do
     described_class.new(
       actor: support_user,
       application_form:,
       zendesk_url:,
+      force:,
     )
   end
 
@@ -62,6 +64,16 @@ RSpec.describe DeleteApplication do
       audit = application_form.own_and_associated_audits.first
       expect(audit.user).to eq(support_user)
       expect(audit.comment).to eq("Data deletion request: #{zendesk_url}")
+    end
+
+    context 'when force option is provided' do
+      let(:force) { true }
+
+      it 'allows delete if application has been submitted to providers' do
+        application_choice = application_form.application_choices.first
+        SendApplicationToProvider.call(application_choice)
+        expect { service.call! }.not_to raise_error('Application has been sent to providers')
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

  Normally we would not allow an Application/Account to be deleted
  unless all the application choices are `unsubmitted`. There are times
  when this is appropriate for support developers in the console.

  This PR doesn't make the force option used in any application code but
  provides the option in the console.

## Changes proposed in this pull request

Add `force` option which allows an Account to be deleted despite not all choices being in the `unsubmitted` state.

## Guidance to review

Is this an appropriate change?

## Link to Trello card

No Trello ticket

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
