### PR TITLE
Revert "Wrap a submit application around transaction block"

### DIFF
--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -7,12 +7,10 @@ class SubmitApplication
   end
 
   def call
-    ActiveRecord::Base.transaction do
-      application_form.update!(submitted_at: Time.zone.now)
+    application_form.update!(submitted_at: Time.zone.now)
 
-      application_choices.includes(%i[original_course_option course_option current_course_option provider accredited_provider application_form candidate]).each do |application_choice|
-        SendApplicationToProvider.call(application_choice)
-      end
+    application_choices.includes(%i[original_course_option course_option current_course_option provider accredited_provider application_form candidate]).each do |application_choice|
+      SendApplicationToProvider.call(application_choice)
     end
 
     CandidateMailer.application_submitted(application_form).deliver_later


### PR DESCRIPTION
Reverts DFE-Digital/apply-for-teacher-training#8294

Nested transaction blocks causing:
<img width="900" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/df861f42-da1e-4805-ba83-942b6e281e9b">

Revert for now and then think about exception handling

https://trello.com/c/swo1kM2V/380-fix-issue-with-provider-notification-email-when-a-cadidate-submits