### PR TITLE
Create a 'reference status' report

### DIFF
--- a/app/components/provider_interface/feedback_statuses_component.html.erb
+++ b/app/components/provider_interface/feedback_statuses_component.html.erb
@@ -1,0 +1,4 @@
+<%= govuk_tag(
+    text: feedback_status_label,
+    colour: feedback_status_colour,
+  ) %>

--- a/app/components/provider_interface/feedback_statuses_component.rb
+++ b/app/components/provider_interface/feedback_statuses_component.rb
@@ -1,0 +1,26 @@
+class ProviderInterface::FeedbackStatusesComponent < ViewComponent::Base
+  include ViewHelper
+
+  attr_reader :feedback_status
+
+  def initialize(feedback_status:)
+    @feedback_status = feedback_status
+  end
+
+  def feedback_status_label
+    translated_feedback_status = mapped_feedback_status_label[feedback_status.downcase]
+    I18n.t("provider_interface.reference_status_report.feedback_status_labels.#{translated_feedback_status}", default: 'other')
+  end
+
+  def feedback_status_colour
+    I18n.t("provider_interface.reference_status_report.feedback_status_labels_colours.#{feedback_status.downcase}", default: 'grey')
+  end
+
+  def mapped_feedback_status_label
+    {
+      'received' => 'feedback_provided',
+      'not received' => 'feedback_requested',
+      'other' => 'other',
+    }
+  end
+end

--- a/app/components/provider_interface/reference_status_report_table_component.html.erb
+++ b/app/components/provider_interface/reference_status_report_table_component.html.erb
@@ -1,0 +1,34 @@
+<% if rows.any? %>
+  <% rows.each do |grouped_row| %>
+    <h2 class='govuk-heading-m'><%= "#{grouped_row[:header]}’s references" %></h2>
+    <p class='govuk-body'><%= govuk_link_to("View #{grouped_row[:header]}’s references", grouped_row[:link]) %></p>
+
+    <table class='govuk-table'>
+      <thead class="govuk-table__head">
+        <tr class='govuk-table__row'>
+          <th class='govuk-table__header' scope='col'><%= headers[0] %></th>
+          <% headers[1..].each do |header| %>
+            <th class='govuk-table__row govuk-table__header govuk-table__header--numeric' scope='col' style='width: 12%; text-align: left'><%= header %></th>
+          <% end %>
+        </tr>
+      </thead>
+      <tbody>
+        <% grouped_row[:values].each do |values| %>
+          <tr class='govuk-table__row'>
+            <% values.each do |value| %>
+              <% if value.is_a?(String) && ['received', 'sent'].include?(value.downcase) %>
+                <td class='govuk-table__cell' style='text-align: left; margin-bottom: 1000px'>
+                  <%= render ProviderInterface::FeedbackStatusesComponent.new(feedback_status: value) %>
+                </td>
+              <% else %>
+                <td class='govuk-table__cell govuk-table__cell--numeric' style='text-align: left'><%= value %></td>
+              <% end %>
+            <% end %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+<% else %>
+  <p class='govuk-body'>There are no references yet. Once an application has a status of ‘offer deferred’, ‘conditions pending’ or ‘recruited’, you‘ll be able to see references in this report.</p>
+<% end %>

--- a/app/components/provider_interface/reference_status_report_table_component.rb
+++ b/app/components/provider_interface/reference_status_report_table_component.rb
@@ -1,0 +1,35 @@
+module ProviderInterface
+  class ReferenceStatusReportTableComponent < ViewComponent::Base
+    include ViewHelper
+
+    attr_reader :headers, :rows, :show_footer, :exclude_from_footer, :bold_row_headers
+
+    def initialize(headers: [], rows: [], show_footer: true, exclude_from_footer: [], bold_row_headers: true)
+      @headers = headers
+      @rows = rows
+      @show_footer = show_footer
+      @exclude_from_footer = exclude_from_footer
+      @bold_row_headers = bold_row_headers
+    end
+
+    def footer
+      return [] unless show_footer && rows.any?
+
+      num_columns = rows.first[:values].length
+      @footer = Array.new(num_columns) { 0 }
+      rows.each do |row|
+        row[:values].each_with_index do |value, index|
+          next if excluded_column_index.include?(index)
+
+          @footer[index] += value
+        end
+      end
+
+      @footer.map.with_index { |value, index| excluded_column_index.include?(index) ? '-' : value }
+    end
+
+    def excluded_column_index
+      exclude_from_footer.map { |header| headers[1..].index(header) }.compact
+    end
+  end
+end

--- a/app/components/provider_interface/report_table_component.html.erb
+++ b/app/components/provider_interface/report_table_component.html.erb
@@ -8,20 +8,31 @@
     </tr>
   </thead>
 
-  <tbody>
-    <% rows.each do |row| %>
-      <tr class='govuk-table__row'>
-        <th class='govuk-table__header <%= 'govuk-!-font-weight-regular' unless bold_row_headers %>' scope='row'>
-          <%= row[:header] %>
-          <div class='govuk-hint govuk-!-margin-bottom-0'><%= row[:subheader] %></div>
-        </th>
-
-        <% row[:values].each do |value| %>
-          <td class='govuk-table__cell govuk-table__cell--numeric'><%= value %></td>
+    <% if rows.any? %>
+      <tbody>
+        <% rows.each do |row| %>
+          <tr class='govuk-table__row'>
+            <th class='govuk-table__header <%= 'govuk-!-font-weight-regular' unless bold_row_headers %>' scope='row'>
+              <%= row[:header] %>
+              <div class='govuk-hint govuk-!-margin-bottom-0'><%= row[:subheader] %></div>
+            </th>
+            <% row[:values].each do |value, index| %>
+              <% if value.is_a?(Hash) && value[:link].present? %>
+                <td class='govuk-table__cell'><%= govuk_link_to(value[:text], value[:link]) %></td>
+              <% else %>
+                <td class='govuk-table__cell govuk-table__cell--numeric'><%= value %></td>
+              <% end %>
+            <% end %>
+          </tr>
         <% end %>
+      </tbody>
+  <% else %>
+    <tbody>
+      <tr class='govuk-table__row'>
+        <td class='govuk-body' colspan='<%= headers.length + 1 %>'>No results found.</td>
       </tr>
-    <% end %>
-  </tbody>
+    </tbody>
+  <% end %>
 
   <% if footer.any? %>
     <tfoot>

--- a/app/controllers/provider_interface/reports/reference_status_reports_controller.rb
+++ b/app/controllers/provider_interface/reports/reference_status_reports_controller.rb
@@ -1,0 +1,20 @@
+module ProviderInterface
+  module Reports
+    class ReferenceStatusReportsController < ProviderInterfaceController
+      attr_reader :provider
+
+      def show
+        @provider = current_user.providers.find(provider_id)
+        @report = ProviderInterface::ReferenceStatusReport.new(@provider)
+
+        @rows = @report.rows
+      end
+
+    private
+
+      def provider_id
+        params.permit(:provider_id)[:provider_id]
+      end
+    end
+  end
+end

--- a/app/services/provider_interface/reference_status_report.rb
+++ b/app/services/provider_interface/reference_status_report.rb
@@ -1,0 +1,61 @@
+module ProviderInterface
+  class ReferenceStatusReport
+    attr_reader :provider_application_references, :context
+
+    def initialize(provider)
+      @provider = provider
+    end
+
+    def headers
+      I18n.t('provider_interface.reference_status_report.headers')
+    end
+
+    def rows
+      filtered_rows = report_data.select do |row|
+        %w[feedback_requested feedback_provided].include?(row.feedback_status)
+      end
+      return [] if filtered_rows.nil?
+
+      grouped_rows = filtered_rows.group_by { |row| row.application_form.full_name }
+
+      grouped_rows.map do |full_name, rows|
+        {
+          header: full_name,
+          link: application_link(rows.first),
+          values: rows.map do |row|
+            [
+              row.name,
+              feedback_status_label(row.feedback_status),
+            ]
+          end,
+        }
+      end
+    end
+
+    def application_link(row)
+      Rails.application.routes.url_helpers.provider_interface_application_choice_references_path(row.application_choice_id)
+    end
+
+    def feedback_status_label(status)
+      I18n.t("provider_interface.reference_status_report.feedback_status_labels.#{status}", default: 'Other')
+    end
+
+    def report_data
+      @provider
+        .application_references
+        .joins(application_form: { application_choices: :course_option })
+        .where(
+          application_choices: {
+            status: ApplicationStateChange::SUCCESSFUL_STATES - [:offer],
+          },
+        )
+          .where.not(application_choices: { accepted_at: nil })
+          .includes(:application_form)
+          .select(
+            '"references".*,
+      "application_choices".id as application_choice_id',
+          )
+          .distinct
+    end
+  end
+end

--- a/app/views/provider_interface/reports/index.html.erb
+++ b/app/views/provider_interface/reports/index.html.erb
@@ -25,6 +25,9 @@
         <% if mid_cycle_report_present_for?(@providers.first) %>
           <%= govuk_link_to mid_cycle_report_label_for(@providers.first), provider_interface_reports_provider_mid_cycle_report_path(provider_id: @providers.first) %>
         <% end %>
+        <li>
+          <%= govuk_link_to t('page_titles.provider.reference_status_report'), provider_interface_reports_provider_reference_status_report_path(provider_id: @providers.first) %>
+        </li>
       <% end %>
     </ul>
     <% if @providers.many? %>
@@ -39,6 +42,9 @@
           </li>
           <li>
             <%= govuk_link_to t('page_titles.provider.withdrawal_report'), provider_interface_reports_provider_withdrawal_report_path(provider_id: provider) %>
+          </li>
+          <li>
+            <%= govuk_link_to t('page_titles.provider.reference_status_report'), provider_interface_reports_provider_reference_status_report_path(provider_id: provider) %>
           </li>
           <% if mid_cycle_report_present_for?(provider) %>
             <%= govuk_link_to mid_cycle_report_label_for(provider), provider_interface_reports_provider_mid_cycle_report_path(provider_id: provider) %>

--- a/app/views/provider_interface/reports/reference_status_reports/show.html.erb
+++ b/app/views/provider_interface/reports/reference_status_reports/show.html.erb
@@ -1,0 +1,29 @@
+<%= content_for :title, t('page_titles.provider.reference_status_report') %>
+<%= content_for :before_content, breadcrumbs(t('page_titles.provider.reports') => provider_interface_reports_path,
+                                             t('page_titles.provider.reference_status_report') => nil) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l"> <%= @provider.name %></span>
+      <%= t('page_titles.provider.reference_status_report') %>
+    </h1>
+    <div class="govuk-body">
+      <p>
+        This report shows references that have been received for applications in the following statuses:
+      </p>
+      <ul>
+        <li>offer deferred</li>
+        <li>conditions pending</li>
+        <li>recruited</li>
+      </ul>
+    </div>
+  </div>
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render ProviderInterface::ReferenceStatusReportTableComponent.new(headers: @report.headers,
+                                                                          rows: @rows,
+                                                                          bold_row_headers: false) %>
+    </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -280,6 +280,7 @@ en:
       reports: Reports
       diversity_report: Sex, disability, ethnicity and age of candidates
       withdrawal_report: Withdrawals
+      reference_status_report: References
     start_apply_again: Do you want to apply again?
     start_carry_over: Continue your application
     start_carry_over_between_cycles: You can apply again

--- a/config/locales/provider_interface/reference_status_report.yml
+++ b/config/locales/provider_interface/reference_status_report.yml
@@ -1,0 +1,15 @@
+en:
+  provider_interface:
+    reference_status_report:
+      headers:
+        - "Referee name"
+        - "Reference status"
+      feedback_status_labels:
+        feedback_requested: "Not Received"
+        feedback_provided: "Received"
+        other: "Other"
+      feedback_status_labels_colours:
+        sent: red
+        received: green
+        other: grey
+      link_text: "Application"

--- a/config/routes/provider.rb
+++ b/config/routes/provider.rb
@@ -33,6 +33,7 @@ namespace :provider_interface, path: '/provider' do
       resource :diversity_report, only: :show, path: 'diversity-report'
       resource :withdrawal_report, only: :show, path: 'withdrawal-report'
       resource :mid_cycle_report, only: :show, path: 'mid-cycle-report'
+      resource :reference_status_report, only: :show, path: 'reference-report'
     end
   end
 

--- a/spec/services/provider_interface/reference_status_report_spec.rb
+++ b/spec/services/provider_interface/reference_status_report_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ReferenceStatusReport do
+  let(:reference_const) { 'Reference' }
+  let(:provider) { create(:provider) }
+
+  subject(:report_service) { described_class.new(provider) }
+
+  describe '#headers' do
+    it 'returns the correct headers' do
+      expect(report_service.headers).to eq([
+        'Referee name',
+        'Reference status',
+      ])
+    end
+  end
+
+  describe '#application_link' do
+    it 'returns the correct application link' do
+      row = instance_double(reference_const, application_choice_id: 123)
+
+      report_service = described_class.new(nil)
+      link = report_service.application_link(row)
+
+      expected_link = Rails.application.routes.url_helpers.provider_interface_application_choice_references_path(123)
+      expect(link).to eq(expected_link)
+    end
+  end
+
+  describe '#feedback_status_label' do
+    it 'returns "Sent" for "feedback_requested"' do
+      expect(report_service.feedback_status_label('feedback_requested')).to eq('Not Received')
+    end
+
+    it 'returns "Received" for "feedback_provided"' do
+      expect(report_service.feedback_status_label('feedback_provided')).to eq('Received')
+    end
+
+    it 'returns "Other" for unknown status' do
+      expect(report_service.feedback_status_label('unknown_status')).to eq('Other')
+    end
+  end
+
+  describe '#rows' do
+    context 'when there are rows with feedback status' do
+      it 'returns rows with correct header and values' do
+        application_choice1 = create(:application_choice, :with_completed_application_form)
+        application_choice2 = create(:application_choice, :with_completed_application_form)
+        reference1 = create(:reference, :feedback_requested, application_form: application_choice1.application_form)
+        reference2 = create(:reference, :feedback_provided, application_form: application_choice2.application_form)
+        rows_with_feedback =
+          [
+            instance_double(reference_const, feedback_status: reference1.feedback_status, name: reference1.name, application_choice_id: application_choice1.id, application_form: application_choice1.application_form),
+            instance_double(reference_const, feedback_status: reference2.feedback_status, name: reference2.name, application_choice_id: application_choice2.id, application_form: application_choice2.application_form),
+          ]
+        report_service = described_class.new(nil)
+        # Stub the report_data method to return the test data
+        allow(report_service).to receive(:report_data).and_return(rows_with_feedback)
+
+        expected_rows = [
+          {
+            header: application_choice1.application_form.full_name,
+            link: Rails.application.routes.url_helpers.provider_interface_application_choice_references_path(application_choice1.id),
+            values: [
+              [
+                reference1.name,
+                'Not Received',
+              ],
+            ],
+          },
+          {
+            header: application_choice2.application_form.full_name,
+            link: Rails.application.routes.url_helpers.provider_interface_application_choice_references_path(application_choice2.id),
+            values: [
+              [
+                reference2.name,
+                'Received',
+              ],
+            ],
+          },
+        ]
+        expect(report_service.rows).to eq(expected_rows)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add a report for reviewing reference status of references that have been sent out/received where a candidate is in a post acceptance state.


<img width="1254" alt="Screenshot 2023-07-24 at 15 16 21" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/45995847/d3ce0d5c-b6a7-4c18-b7a2-270d92589775">

<img width="1424" alt="Screenshot 2023-07-24 at 15 16 56" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/45995847/2a15de4e-622b-4ab2-a895-76205def3b51">

## Link to Trello card

https://trello.com/c/Idcf87an/301-create-a-reference-status-report-for-candidates-in-post-acceptance-states
