### PR TITLE
Next cycle visible in support

### DIFF
--- a/app/components/support_interface/provider_courses_table_component.html.erb
+++ b/app/components/support_interface/provider_courses_table_component.html.erb
@@ -8,7 +8,7 @@
       <% end %>
       <th scope="col" class="govuk-table__header">Status</th>
       <% if accredited_bodies_vary? %>
-        <th scope="col" class="govuk-table__header">Accredited body</th>
+        <th scope="col" class="govuk-table__header">Accredited provider</th>
       <% end %>
     </tr>
   </thead>

--- a/app/components/support_interface/provider_courses_table_component.rb
+++ b/app/components/support_interface/provider_courses_table_component.rb
@@ -35,12 +35,12 @@ module SupportInterface
 
     def status_tag(course)
       # Special case when the course is in the future but has been imported with a status of open_on_apply
-      return govuk_tag(text: 'Not open on Apply', colour: 'blue') if course.recruitment_cycle_year == RecruitmentCycle.next_year
+      return govuk_tag(text: 'Closed on Apply', colour: 'blue') if course.recruitment_cycle_year == RecruitmentCycle.next_year
 
       if course.open_on_apply?
         govuk_tag(text: open_on_apply_message(course), colour: 'green')
       elsif course.exposed_in_find?
-        govuk_tag(text: 'Not open on Apply', colour: 'blue')
+        govuk_tag(text: 'Closed on Apply', colour: 'blue')
       else
         govuk_tag(text: 'Hidden in Find', colour: 'grey')
       end

--- a/app/components/support_interface/provider_courses_table_component.rb
+++ b/app/components/support_interface/provider_courses_table_component.rb
@@ -34,6 +34,9 @@ module SupportInterface
     attr_reader :provider, :courses
 
     def status_tag(course)
+      # Special case when the course is in the future but has been imported with a status of open_on_apply
+      return govuk_tag(text: 'Not open on Apply', colour: 'blue') if course.recruitment_cycle_year == RecruitmentCycle.next_year
+
       if course.open_on_apply?
         govuk_tag(text: open_on_apply_message(course), colour: 'green')
       elsif course.exposed_in_find?

--- a/app/controllers/register_api/applications_controller.rb
+++ b/app/controllers/register_api/applications_controller.rb
@@ -100,7 +100,7 @@ module RegisterAPI
 
     def recruitment_cycle_year_param
       year = params.fetch(:recruitment_cycle_year)
-      raise ParameterInvalid, 'Parameter is invalid: recruitment_cycle_year' unless year.in?(RecruitmentCycle.years_visible_in_support.map(&:to_s))
+      raise ParameterInvalid, 'Parameter is invalid: recruitment_cycle_year' unless year.in?(RecruitmentCycle.years_available_to_register.map(&:to_s))
 
       year
     end

--- a/app/controllers/support_interface/providers_controller.rb
+++ b/app/controllers/support_interface/providers_controller.rb
@@ -21,7 +21,11 @@ module SupportInterface
 
     def courses
       @provider = Provider.includes(courses: [:accredited_provider]).find(params[:provider_id])
-      @courses = @provider.courses.includes(accredited_provider: [:provider_agreements]).order(:name).group_by(&:recruitment_cycle_year)
+
+      courses = @provider.courses.includes(accredited_provider: [:provider_agreements]).order(:name).group_by(&:recruitment_cycle_year)
+      years = RecruitmentCycle.years_visible_in_support.each_with_object({}) { |year, hash| hash[year] = [] }
+
+      @courses_by_year = years.merge(courses)
     end
 
     def ratified_courses

--- a/app/controllers/support_interface/providers_controller.rb
+++ b/app/controllers/support_interface/providers_controller.rb
@@ -23,7 +23,7 @@ module SupportInterface
       @provider = Provider.includes(courses: [:accredited_provider]).find(params[:provider_id])
 
       courses = @provider.courses.includes(accredited_provider: [:provider_agreements]).order(:name).group_by(&:recruitment_cycle_year)
-      years = RecruitmentCycle.years_visible_in_support.each_with_object({}) { |year, hash| hash[year] = [] }
+      years = RecruitmentCycle.years_visible_in_support.each_with_object({}) { |year, hash| hash[year] = [] } # rubocop:disable Rails/IndexWith
 
       @courses_by_year = years.merge(courses)
     end

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -28,6 +28,10 @@ module RecruitmentCycle
   end
 
   def self.years_visible_in_support
+    next_year.downto(CycleTimetable::CYCLE_DATES.keys.min)
+  end
+
+  def self.years_available_to_register
     current_year.downto(CycleTimetable::CYCLE_DATES.keys.min)
   end
 

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -28,7 +28,8 @@ module RecruitmentCycle
   end
 
   def self.years_visible_in_support
-    next_year.downto(CycleTimetable::CYCLE_DATES.keys.min)
+    from_year = HostingEnvironment.production? ? current_year : next_year
+    from_year.downto(CycleTimetable::CYCLE_DATES.keys.min)
   end
 
   def self.years_available_to_register

--- a/app/views/support_interface/providers/courses.html.erb
+++ b/app/views/support_interface/providers/courses.html.erb
@@ -5,11 +5,11 @@
 <% end %>
 
 <% if @provider.courses.any? %>
-  <% RecruitmentCycle.years_visible_in_support.each do |year| %>
-    <% if @courses[year] %>
-      <h2 class="govuk-heading-m"><%= year %>: <%= pluralize(@courses[year].size, 'course') %> (<%= @courses[year].count(&:open_on_apply?) %> on DfE Apply)</h2>
+  <% @courses_by_year.each do |year, courses| %>
+    <% if courses.any? %>
+      <h2 class="govuk-heading-m"><%= year %>: <%= pluralize(courses.size, 'course') %> (<%= courses.count(&:open_on_apply?) %> on DfE Apply) <%= 'Not yet published' if RecruitmentCycle.next_year == year %></h2>
 
-      <%= render(SupportInterface::ProviderCoursesTableComponent.new(provider: @provider, courses: @courses[year])) %>
+      <%= render(SupportInterface::ProviderCoursesTableComponent.new(provider: @provider, courses: courses)) %>
     <% else %>
       <h3 class="govuk-heading-m"><%= year %>: No courses</h3>
 
@@ -18,5 +18,4 @@
   <% end %>
 <% else %>
   <p class="govuk-body">There aren’t any courses for this provider currently.</p>
-
 <% end %>

--- a/app/views/support_interface/providers/courses.html.erb
+++ b/app/views/support_interface/providers/courses.html.erb
@@ -9,6 +9,10 @@
     <% if courses.any? %>
       <h2 class="govuk-heading-m"><%= year %>: <%= pluralize(courses.size, 'course') %> (<%= courses.count(&:open_on_apply?) %> on DfE Apply) <%= 'Not yet published' if RecruitmentCycle.next_year == year %></h2>
 
+      <% if RecruitmentCycle.next_year == year %>
+        <p class="govuk-body">These courses will be published on Find and Apply when the recruitment cycle opens.</p>
+      <% end %>
+
       <%= render(SupportInterface::ProviderCoursesTableComponent.new(provider: @provider, courses: courses)) %>
     <% else %>
       <h3 class="govuk-heading-m"><%= year %>: No courses</h3>

--- a/app/views/support_interface/providers/courses.html.erb
+++ b/app/views/support_interface/providers/courses.html.erb
@@ -7,19 +7,19 @@
 <% if @provider.courses.any? %>
   <% @courses_by_year.each do |year, courses| %>
     <% if courses.any? %>
-      <h2 class="govuk-heading-m"><%= year %>: <%= pluralize(courses.size, 'course') %> (<%= courses.count(&:open_on_apply?) %> on DfE Apply) <%= 'Not yet published' if RecruitmentCycle.next_year == year %></h2>
+      <h2 class="govuk-heading-m"><%= year %>: <%= pluralize(courses.size, 'course') %> (<%= courses.count(&:open_on_apply?) %> on DfE Apply) <%= t('.not_yet_published') if RecruitmentCycle.next_year == year %></h2>
 
       <% if RecruitmentCycle.next_year == year %>
-        <p class="govuk-body">These courses will be published on Find and Apply when the recruitment cycle opens.</p>
+        <p class="govuk-body"><%= t('.courses_published_recruitment_opens') %></p>
       <% end %>
 
       <%= render(SupportInterface::ProviderCoursesTableComponent.new(provider: @provider, courses: courses)) %>
     <% else %>
       <h3 class="govuk-heading-m"><%= year %>: No courses</h3>
 
-      <p class="govuk-body">There aren’t any courses for <%= year %>.</p>
+      <p class="govuk-body"><%= t('.no_courses_for_year', year: year) %></p>
     <% end %>
   <% end %>
 <% else %>
-  <p class="govuk-body">There aren’t any courses for this provider currently.</p>
+  <p class="govuk-body"><%= t('.no_courses_yet') %></p>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -330,6 +330,13 @@ en:
       privacy: Privacy
       roadmap: Changes to this service
       not_logged_in: candidate_not_logged_in
+  support_interface:
+    providers:
+      courses:
+        not_yet_published: not yet published
+        no_courses_yet: There aren’t any courses for this provider currently.
+        no_courses_for_year: "There aren’t any courses for %{year}."
+        courses_published_recruitment_opens: These courses will be published on Find and Apply when the recruitment cycle opens.
   activemodel:
     attributes:
       vendor_api/metadata:

--- a/docs/ttapi.md
+++ b/docs/ttapi.md
@@ -1,0 +1,74 @@
+# Teacher Training API (TTAPI)
+
+
+TTAPI is the public API on the Find and Publish repo. In this repo we populate the courses and providers within this application by fetching them from the find and publish repo.
+
+
+### JsonApiClient
+
+The TTAPI is modeled using the [JsonApiClient](https://github.com/JsonApiClient/json_api_client) gem. Each resource inherits from this and behaves very like ActiveRecord, allowing us to declare associations.
+
+The API Client defines models each of which inherit from `JsonApiClient::Resource`. The API Client is encapsulated within the resources just like the database is encapsulated in `ActiveRecord`.
+
+    module TeacherTrainingPublicAPI
+      class Resource < JsonApiClient::Resource
+        self.site = ENV.fetch('TEACHER_TRAINING_API_BASE_URL')
+
+
+    module TeacherTrainingPublicAPI
+      class RecruitmentCycle < TeacherTrainingPublicAPI::Resource
+
+
+### Models
+
+Below is a list of classes we use to model the API:
+
+    ▼ 📂 models
+        ▼ 📂 teacher_training_public_api
+            💎 course.rb
+            💎 location.rb
+            💎 location_status.rb
+            💎 provider.rb
+            💎 recruitment_cycle.rb
+            💎 resource.rb
+            💎 subject.rb
+
+### Schedule
+
+The data is fetched from the TTAPI on a schedule using the `clock` gem. `clock` basically implements cron in ruby.
+
+    # config/clock.rb
+
+    # Every 10 minutes
+    IncrementalSyncAllFromTeacherTrainingPublicAPI
+
+
+    # Every 7 days
+    FullSyncAllFromTeacherTrainingPublicAPI
+
+
+### The Sync classes
+
+These classes are responsible for using the JsonApi classes to make the request to the api. Currently, they also transform the api data into application data within the jobs.
+
+
+    ▼ 📂 services
+        ▼ 📂 teacher_training_public_api
+            💎 assign_site_attributes.rb            # SiteMapper
+            💎 full_sync_update_error.rb            # ErrorClass
+            💎 sync_all_providers_and_courses.rb    # Sync Entry
+            💎 sync_courses.rb                      # SidekiqWorker
+            💎 sync_error.rb                        # ErrorClass
+            💎 sync_provider.rb                     # Sync Entry
+            💎 sync_sites.rb                        # SidekiqWorker
+            💎 sync_subjects.rb                     # SidekiqWorker
+            💎 trigger_full_sync_if_find_closed.rb  # Sync Entry
+
+    ▼ 📂 workers
+        ▼ 📂 teacher_training_public_api
+            💎 sync_all_providers_and_courses_worker.rb
+
+
+`SyncAllProvidersAndCourses`
+
+There are a models backed by `ActiveRecord` tables in the application. When data is imported from the TTAPI we need to transform the data so it can be saved as the `ActiveRecord` classes in the application.

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -23,8 +23,20 @@ RSpec.describe RecruitmentCycle, time: CycleTimetableHelper.mid_cycle(2023) do
   end
 
   describe '.years_visible_in_support' do
-    it 'returns correct array of years' do
-      expect(described_class.years_visible_in_support).to contain_exactly(2024, 2023, 2022, 2021, 2020, 2019)
+    context 'when in production hosting environment' do
+      it 'returns correct array of years' do
+        ClimateControl.modify HOSTING_ENVIRONMENT_NAME: 'production' do
+          expect(described_class.years_visible_in_support).to contain_exactly(2023, 2022, 2021, 2020, 2019)
+        end
+      end
+    end
+
+    context 'when in staging hosting environment' do
+      it 'returns correct array of years' do
+        ClimateControl.modify HOSTING_ENVIRONMENT_NAME: 'staging' do
+          expect(described_class.years_visible_in_support).to contain_exactly(2024, 2023, 2022, 2021, 2020, 2019)
+        end
+      end
     end
   end
 
@@ -33,7 +45,6 @@ RSpec.describe RecruitmentCycle, time: CycleTimetableHelper.mid_cycle(2023) do
       expect(described_class.years_available_to_register).to contain_exactly(2023, 2022, 2021, 2020, 2019)
     end
   end
-
 
   describe '.current_year' do
     it 'delegates to CycleTimetable' do

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -24,18 +24,14 @@ RSpec.describe RecruitmentCycle, time: CycleTimetableHelper.mid_cycle(2023) do
 
   describe '.years_visible_in_support' do
     context 'when in production hosting environment' do
-      it 'returns correct array of years' do
-        ClimateControl.modify HOSTING_ENVIRONMENT_NAME: 'production' do
-          expect(described_class.years_visible_in_support).to contain_exactly(2023, 2022, 2021, 2020, 2019)
-        end
+      it 'returns correct array of years', hosting_env: 'production' do
+        expect(described_class.years_visible_in_support).to contain_exactly(2023, 2022, 2021, 2020, 2019)
       end
     end
 
     context 'when in staging hosting environment' do
-      it 'returns correct array of years' do
-        ClimateControl.modify HOSTING_ENVIRONMENT_NAME: 'staging' do
-          expect(described_class.years_visible_in_support).to contain_exactly(2024, 2023, 2022, 2021, 2020, 2019)
-        end
+      it 'returns correct array of years', hosting_env: 'staging' do
+        expect(described_class.years_visible_in_support).to contain_exactly(2024, 2023, 2022, 2021, 2020, 2019)
       end
     end
   end

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe RecruitmentCycle do
+RSpec.describe RecruitmentCycle, time: CycleTimetableHelper.mid_cycle(2023) do
   describe '.cycle_string' do
     it 'throws an error when a cycle does not exist for the specified year' do
       expect { described_class.cycle_string(2000) }
@@ -24,11 +24,16 @@ RSpec.describe RecruitmentCycle do
 
   describe '.years_visible_in_support' do
     it 'returns correct array of years' do
-      allow(CycleTimetable).to receive(:current_year).and_return(2023)
-
-      expect(described_class.years_visible_in_support).to contain_exactly(2023, 2022, 2021, 2020, 2019)
+      expect(described_class.years_visible_in_support).to contain_exactly(2024, 2023, 2022, 2021, 2020, 2019)
     end
   end
+
+  describe '.years_available_to_register' do
+    it 'returns correct array of years' do
+      expect(described_class.years_available_to_register).to contain_exactly(2023, 2022, 2021, 2020, 2019)
+    end
+  end
+
 
   describe '.current_year' do
     it 'delegates to CycleTimetable' do

--- a/spec/support/hosting_env.rb
+++ b/spec/support/hosting_env.rb
@@ -1,0 +1,11 @@
+RSpec.configure do |config|
+  config.around(:each, :hosting_env) do |example|
+    if example.metadata[:hosting_env].present?
+      ClimateControl.modify HOSTING_ENVIRONMENT_NAME: example.metadata[:hosting_env] do
+        example.run
+      end
+    else
+      example.run
+    end
+  end
+end


### PR DESCRIPTION
## Context

Admins and support users want to be able to see the data for the next cycle in the Support Interface. Right now they can only see up to the current cycle.


## Changes proposed in this pull request

- Add RSpec metadata hook for setting the HostingEnvironment in the test suite.
  - `describe 'some test', hosting_env: 'production' do`
- Change Support Interface course table heading from "Accredited body" to "Accredited provider"

### Screenshots

|With courses in next cycle| Without courses in next cycle|
|---|---|
|![with-courses](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/3616efe4-4f45-4c96-97ae-c31c08f31ab2)|![without-courses](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/ac2a807b-c765-4af7-af37-c963abf91624)|



Bonus: Some developer documentation around TTAPI

## Guidance to review

The refactoring of the Courses controller action and template could be improved, not sure how to make the controller action cleaner just now, but I feel it's better to push complexity up the stack (out of the view).

## Link to Trello card

[Preview next cycle data in SupportInterface](https://trello.com/c/3x2ac8YG/396-itt-reform-preview-2024-courses-in-manage)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
