### PR TITLE
Include new 2024 program types in Apply

### DIFF
--- a/app/exports/common_columns/_provider_information.yml
+++ b/app/exports/common_columns/_provider_information.yml
@@ -44,8 +44,10 @@ program_type:
   description: The program type
   enum:
     - scitt_programme
+    - scitt_salaried_programme
     - school_direct_training_programme
     - higher_education_programme
+    - higher_education_salaried_programme
     - school_direct_salaried_training_programme
     - pg_teaching_apprenticeship
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -47,9 +47,11 @@ class Course < ApplicationRecord
   # also copied from Find
   enum program_type: {
     higher_education_programme: 'HE',
+    higher_education_salaried_programme: 'HES',
     school_direct_training_programme: 'SD',
     school_direct_salaried_training_programme: 'SS',
     scitt_programme: 'SC',
+    scitt_salaried_programme: 'SSC',
     pg_teaching_apprenticeship: 'TA',
   }
 

--- a/app/models/publications/monthly_statistics/by_course_type.rb
+++ b/app/models/publications/monthly_statistics/by_course_type.rb
@@ -46,8 +46,10 @@ module Publications
       def program_type_lookup(subject)
         {
           'higher_education_programme' => 'Higher education',
+          'higher_education_salaried_programme' => 'Higher education (salaried)',
           'pg_teaching_apprenticeship' => 'Postgraduate teaching apprenticeship',
           'scitt_programme' => 'School-centred initial teacher training (SCITT)',
+          'scitt_salaried_programme' => 'School-cented initial teacher training (SCITT) (salaried)',
           'school_direct_training_programme' => 'School Direct (fee-paying)',
           'school_direct_salaried_training_programme' => 'School Direct (salaried)',
         }[subject]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -473,7 +473,9 @@ en:
         apprenticeship: Apprenticeship
       course/program_type:
         higher_education_programme: Higher education institution
+        higher_education_salaried_programme: Higher education institution (salaried)
         scitt_programme: SCITT
+        scitt_salaried_programme: SCITT (salaried)
         school_direct_training_programme: School direct (unsalaried)
         school_direct_salaried_training_programme: School direct (salaried)
         pg_teaching_apprenticeship: Postgraduate teaching apprenticeship


### PR DESCRIPTION
## Context

Introduced two additional program types in the Publish PR: [#3683](https://github.com/DFE-Digital/publish-teacher-training/pull/3683).

We ran a test sync in staging for 2024 today and encountered:
<img width="609" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/c97d496e-47a2-4490-babc-c053fc8f7339">

A reminder to update ahead of end of cycle.

## Changes proposed in this pull request

Add the two program types.

## Guidance to review

Have I missed anywhere?

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
