### PR TITLE
Bump prometheus-client and dependencies (Dependabot)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,7 @@ GEM
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     aes_key_wrap (1.1.0)
-    anyway_config (2.3.0)
+    anyway_config (2.5.0)
       ruby-next-core (>= 0.14.0)
     ar-sequence (0.2.1)
       activerecord
@@ -271,9 +271,9 @@ GEM
     geocoder (1.8.2)
     globalid (1.1.0)
       activesupport (>= 5.0)
-    google-apis-bigquery_v2 (0.56.0)
+    google-apis-bigquery_v2 (0.57.0)
       google-apis-core (>= 0.11.0, < 2.a)
-    google-apis-core (0.11.0)
+    google-apis-core (0.11.1)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.16.2, < 2.a)
       httpclient (>= 2.8.1, < 3.a)
@@ -408,11 +408,11 @@ GEM
     mime-types-data (3.2022.0105)
     mini_mime (1.1.2)
     mini_portile2 (2.8.4)
-    minitest (5.18.1)
+    minitest (5.19.0)
     multi_json (1.15.0)
     multipart-post (2.3.0)
     nenv (0.3.0)
-    net-imap (0.3.6)
+    net-imap (0.3.7)
       date
       net-protocol
     net-pop (0.1.2)
@@ -472,7 +472,7 @@ GEM
     pg (1.5.3)
     postcodes_io (0.4.0)
       excon (~> 0.39)
-    prometheus-client (2.1.0)
+    prometheus-client (4.2.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -485,7 +485,7 @@ GEM
     puma (6.3.0)
       nio4r (~> 2.0)
     racc (1.7.1)
-    rack (2.2.7)
+    rack (2.2.8)
     rack-attack (6.7.0)
       rack (>= 1.0, < 4)
     rack-mini-profiler (3.1.0)
@@ -569,7 +569,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     retriable (3.1.2)
-    rexml (3.2.5)
+    rexml (3.2.6)
     rouge (4.1.3)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
@@ -591,7 +591,7 @@ GEM
       rspec-expectations (~> 3.12)
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
-    rspec-support (3.12.0)
+    rspec-support (3.12.1)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (1.54.2)
@@ -745,14 +745,14 @@ GEM
       semantic_range (>= 2.3.0)
     webrick (1.8.1)
     websocket (1.2.9)
-    websocket-driver (0.7.5)
+    websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     wkhtmltopdf-binary (0.12.6.5)
     workflow (3.0.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yabeda (0.11.0)
+    yabeda (0.12.0)
       anyway_config (>= 1.0, < 3)
       concurrent-ruby
       dry-initializer
@@ -761,8 +761,8 @@ GEM
     yabeda-http_requests (0.2.0)
       sniffer
       yabeda
-    yabeda-prometheus (0.8.0)
-      prometheus-client (>= 0.10, < 3.0)
+    yabeda-prometheus (0.9.0)
+      prometheus-client (>= 3.0, < 5.0)
       rack
       yabeda (~> 0.10)
     yabeda-puma-plugin (0.7.1)
@@ -778,7 +778,7 @@ GEM
       anyway_config (>= 1.3, < 3)
       sidekiq
       yabeda (~> 0.6)
-    zeitwerk (2.6.8)
+    zeitwerk (2.6.10)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Bump prometheus-client, dfe-analytics, dfe-autocomplete, dfe-reference-data, get_into_teaching_api_client_faraday, rspec-retry and yabeda-prometheus

Bumps [prometheus-client](https://github.com/prometheus/client_ruby), [dfe-analytics](https://github.com/DFE-Digital/dfe-analytics), [dfe-autocomplete](https://github.com/DFE-Digital/dfe-autocomplete), [dfe-reference-data](https://github.com/DFE-Digital/dfe-reference-data), [get_into_teaching_api_client_faraday](https://github.com/DFE-Digital/get-into-teaching-api-ruby-client), [rspec-retry](https://github.com/DFE-Digital/rspec-retry) and [yabeda-prometheus](https://github.com/yabeda-rb/yabeda-prometheus). These dependencies needed to be updated together.

Updates `prometheus-client` from 2.1.0 to 4.2.0
- [Release notes](https://github.com/prometheus/client_ruby/releases)
- [Changelog](https://github.com/prometheus/client_ruby/blob/main/CHANGELOG.md)
- [Commits](https://github.com/prometheus/client_ruby/compare/v2.1.0...v4.2.0)

Updates `dfe-analytics` from `11d75a3` to 1.10.1
- [Commits](https://github.com/DFE-Digital/dfe-analytics/compare/11d75a3c92cc15439c00ea7f2f8686acffefc103...v1.10.1)

Updates `dfe-autocomplete` from `c31601c` to 0.1.0
- [Commits](https://github.com/DFE-Digital/dfe-autocomplete/compare/c31601c145381accab91a6b6983b16de7ddada56...v0.1.0)

Updates `dfe-reference-data` from `4ef58a6` to 2.3.0
- [Release notes](https://github.com/DFE-Digital/dfe-reference-data/releases)
- [Commits](https://github.com/DFE-Digital/dfe-reference-data/compare/4ef58a61ea29102c9decd5f300984af7f446943a...v2.3.0)

Updates `get_into_teaching_api_client_faraday` from `6619b0f` to 3.3.0
- [Commits](https://github.com/DFE-Digital/get-into-teaching-api-ruby-client/commits)

Updates `rspec-retry` from `306b42b` to 0.7.0
- [Commits](https://github.com/DFE-Digital/rspec-retry/commits)

Updates `yabeda-prometheus` from 0.8.0 to 0.9.0
- [Release notes](https://github.com/yabeda-rb/yabeda-prometheus/releases)
- [Changelog](https://github.com/yabeda-rb/yabeda-prometheus/blob/master/CHANGELOG.md)
- [Commits](https://github.com/yabeda-rb/yabeda-prometheus/compare/v0.8.0...v0.9.0)

---
updated-dependencies:
- dependency-name: prometheus-client dependency-type: direct:production update-type: version-update:semver-major
- dependency-name: dfe-analytics dependency-type: direct:production
- dependency-name: dfe-autocomplete dependency-type: direct:production
- dependency-name: dfe-reference-data dependency-type: direct:production
- dependency-name: get_into_teaching_api_client_faraday dependency-type: direct:production
- dependency-name: rspec-retry dependency-type: direct:development
- dependency-name: yabeda-prometheus dependency-type: direct:production update-type: version-update:semver-minor ...

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
