### PR TITLE
Reimplement RecruitmentCycle::CYCLE

### DIFF
--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -1,14 +1,13 @@
 module RecruitmentCycle
-  CYCLES = {
-    '2023' => '2022 to 2023',
-    '2022' => '2021 to 2022',
-    '2021' => '2020 to 2021',
-    '2020' => '2019 to 2020',
-  }.freeze
-
   def self.cycle_string(year)
-    cycle = CYCLES.fetch(year.to_s)
+    cycle = cycle_strings.fetch(year.to_s)
     current_year.to_s == year.to_s ? "#{cycle} - current" : cycle
+  end
+
+  def self.cycle_strings(upto = current_year + 1)
+    2020.upto(upto.to_i).index_with do |year|
+      "#{year - 1} to #{year}"
+    end.stringify_keys
   end
 
   def self.current_year

--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -76,7 +76,7 @@ module SupportInterface
   private
 
     def year_filter
-      cycle_options = RecruitmentCycle::CYCLES.map do |year, _|
+      cycle_options = RecruitmentCycle.cycle_strings(RecruitmentCycle.current_year).map do |year, _|
         {
           value: year,
           label: RecruitmentCycle.cycle_string(year),

--- a/app/views/support_interface/performance/service_performance_dashboard.html.erb
+++ b/app/views/support_interface/performance/service_performance_dashboard.html.erb
@@ -7,7 +7,7 @@
     <%= govuk_link_to 'View in large screen mode', '?screen=1' %>
   </p>
 
-  <% year_choices = RecruitmentCycle::CYCLES.map do |year, label| %>
+  <% year_choices = RecruitmentCycle.cycle_strings(RecruitmentCycle.current_year).map do |year, label| %>
     <% { name: label, url: "?year=#{year}&screen=#{params[:screen] || 0}", current: params[:year] == year } %>
   <% end %>
 

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -1,6 +1,31 @@
 require 'rails_helper'
 
 RSpec.describe RecruitmentCycle, time: CycleTimetableHelper.mid_cycle(2023) do
+  describe '.cycle_strings' do
+    it 'returns an empty hash when start year is before 2020' do
+      expect(described_class.cycle_strings(2000)).to eq({})
+    end
+
+    it 'returns the cycle strings up to one year from current_year' do
+      expect(described_class.cycle_strings).to eq(
+        { '2020' => '2019 to 2020',
+          '2021' => '2020 to 2021',
+          '2022' => '2021 to 2022',
+          '2023' => '2022 to 2023',
+          '2024' => '2023 to 2024' },
+      )
+    end
+
+    it 'returns the cycle strings up to the arg year' do
+      expect(described_class.cycle_strings(2023)).to eq(
+        { '2020' => '2019 to 2020',
+          '2021' => '2020 to 2021',
+          '2022' => '2021 to 2022',
+          '2023' => '2022 to 2023' },
+      )
+    end
+  end
+
   describe '.cycle_string' do
     it 'throws an error when a cycle does not exist for the specified year' do
       expect { described_class.cycle_string(2000) }

--- a/spec/system/provider_interface/provider_user_exports_applications_to_csv_spec.rb
+++ b/spec/system/provider_interface/provider_user_exports_applications_to_csv_spec.rb
@@ -79,7 +79,7 @@ RSpec.feature 'Provider user exporting applications to a csv', mid_cycle: false 
   end
 
   def and_i_fill_out_the_form_for_applications_this_year_of_any_status_for_the_first_provider
-    check RecruitmentCycle::CYCLES[RecruitmentCycle.current_year.to_s]
+    check RecruitmentCycle.cycle_strings(RecruitmentCycle.current_year)
     choose 'All statuses'
     check @current_provider_user.providers.first.name
 
@@ -98,7 +98,7 @@ RSpec.feature 'Provider user exporting applications to a csv', mid_cycle: false 
 
   def and_i_fill_out_the_form_for_applications_all_years_of_deferred_and_accepted_offers_for_the_first_provider
     RecruitmentCycle.years_visible_to_providers.each do |year|
-      check RecruitmentCycle::CYCLES[year.to_s]
+      check RecruitmentCycle.cycle_strings(year)
     end
     choose 'Specific statuses'
     check 'Deferred'


### PR DESCRIPTION
  Make it a module method
  The single positional argument sets the limit on the labels generated

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Reimplement `RecruitemntCycle::CYCLES` to use a class method names similarly to the existing class method used to format the current cycle year into a label.


## Guidance to review

Is there a specific time when the next year should appear in the UI?

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
