### PR TITLE
Add withdraw to continuous applications

### DIFF
--- a/app/components/candidate_interface/continuous_applications/application_summary_component.html.erb
+++ b/app/components/candidate_interface/continuous_applications/application_summary_component.html.erb
@@ -20,7 +20,7 @@
           </li>
         <% elsif application_can_be_withdrawn? %>
           <li class="govuk-summary-card__action">
-            <%= govuk_link_to candidate_interface_continuous_applications_confirm_destroy_course_choice_path(application_choice.id), data: { action: :delete } do %>
+            <%= govuk_link_to candidate_interface_withdraw_path(application_choice.id), data: { action: :delete } do %>
               <%= t('application_form.continuous_applications.courses.withdraw') %>
               <span class="govuk-visually-hidden"> <%= title %></span>
             <% end %>

--- a/app/controllers/candidate_interface/decisions_controller.rb
+++ b/app/controllers/candidate_interface/decisions_controller.rb
@@ -72,7 +72,7 @@ module CandidateInterface
       if @withdrawal_feedback_form.save(@application_choice)
         flash[:success] = "Your application for #{@application_choice.current_course.name_and_code} at #{@application_choice.provider.name} has been withdrawn"
 
-        redirect_to candidate_interface_application_complete_path
+        redirect_to applications_list_page
       else
         track_validation_error(@withdrawal_feedback_form)
         @provider = @application_choice.provider
@@ -83,6 +83,14 @@ module CandidateInterface
     end
 
   private
+
+    def applications_list_page
+      if @application_choice.continuous_applications?
+        candidate_interface_continuous_applications_choices_path
+      else
+        candidate_interface_application_complete_path
+      end
+    end
 
     def set_application_choice
       @application_choice = @current_application.application_choices.find(params[:id])

--- a/app/views/candidate_interface/continuous_applications_choices/index.html.erb
+++ b/app/views/candidate_interface/continuous_applications_choices/index.html.erb
@@ -1,3 +1,5 @@
+<%= render ServiceInformationBanner.new(namespace: :candidate) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">

--- a/spec/system/candidate_interface/continuous_applications/withdraws/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/withdraws/candidate_withdraws_spec.rb
@@ -1,0 +1,126 @@
+require 'rails_helper'
+
+RSpec.feature 'A candidate withdraws their application', bullet: true, continuous_applications: true do
+  include CandidateHelper
+
+  # bullet complains about wanting an includes on associated objects.
+  # You cannot call includes on a build_stubbed object.
+  # Our mailer previews are reliant on build_stubbed so we need to exclude this test.
+
+  before do
+    Bullet.raise = false
+  end
+
+  after do
+    Bullet.raise = true
+  end
+
+  scenario 'successful withdrawal' do
+    given_i_am_signed_in_as_a_candidate
+    and_i_have_multiple_application_choice_awaiting_provider_decision
+
+    when_i_visit_the_application_dashboard
+    and_i_click_the_withdraw_link_on_my_first_choice
+    then_i_see_a_confirmation_page
+
+    when_i_click_to_confirm_withdrawal
+    then_i_see_the_withdraw_choice_reason_page
+    and_the_provider_has_received_an_email
+
+    when_i_select_my_reasons
+    and_i_click_continue
+    then_i_see_my_application_dashboard
+    and_i_am_thanked_for_my_feedback
+
+    when_i_try_to_visit_the_withdraw_page
+    then_i_see_the_page_not_found
+
+    when_i_visit_the_application_dashboard
+    and_i_click_the_withdraw_link_on_my_final_choice
+    then_i_see_a_confirmation_page
+
+    when_i_click_to_confirm_withdrawal
+    when_i_select_my_reasons
+    and_i_click_continue
+    and_the_candidate_has_received_an_email_with_information_on_apply_again
+  end
+
+  def given_i_am_signed_in_as_a_candidate
+    create_and_sign_in_candidate
+  end
+
+  def and_i_have_multiple_application_choice_awaiting_provider_decision
+    form = create(:completed_application_form, :with_completed_references, candidate: current_candidate)
+    @application_choice = create(:application_choice, :awaiting_provider_decision, application_form: form)
+    @application_choice2 = create(:application_choice, :awaiting_provider_decision, application_form: form)
+    @provider_user = create(:provider_user, :with_notifications_enabled)
+    create(:provider_permissions, provider_id: @application_choice.provider.id, provider_user_id: @provider_user.id)
+  end
+
+  def when_i_visit_the_application_dashboard
+    visit candidate_interface_continuous_applications_choices_path
+  end
+
+  def and_i_click_the_withdraw_link_on_my_first_choice
+    click_link 'Withdraw', match: :first
+  end
+
+  def and_i_click_the_withdraw_link_on_my_final_choice
+    and_i_click_the_withdraw_link_on_my_first_choice
+  end
+
+  def then_i_see_a_confirmation_page
+    expect(page).to have_content('Are you sure you want to withdraw this application?')
+    expect(page).to have_content('Any upcoming interviews will be cancelled.')
+  end
+
+  def when_i_click_to_confirm_withdrawal
+    click_button 'Yes I’m sure – withdraw this application'
+  end
+
+  def then_i_see_the_withdraw_choice_reason_page
+    expect(page).to have_current_path candidate_interface_withdrawal_feedback_path(@application_choice.id)
+  end
+
+  def when_i_try_to_visit_the_withdraw_page
+    visit candidate_interface_withdraw_path(id: @application_choice.id)
+  end
+
+  def then_i_see_the_page_not_found
+    expect(page).to have_content('Page not found')
+  end
+
+  def and_the_provider_has_received_an_email
+    open_email(@provider_user.email_address)
+    expect(current_email.subject).to have_content "#{@application_choice.application_form.full_name} withdrew their application"
+  end
+
+  def when_i_submit_the_questionnaire_without_choosing_options
+    click_button t('continue')
+  end
+
+  def then_i_am_asked_to_choose_my_reasons
+    expect(page).to have_content 'Select at least one reason'
+  end
+
+  def when_i_select_my_reasons
+    check 'I’m going to apply (or have applied) to a different course at the same training provider', match: :first
+  end
+
+  def and_i_click_continue
+    click_button t('continue')
+  end
+
+  def then_i_see_my_application_dashboard
+    expect(page).to have_current_path candidate_interface_continuous_applications_choices_path
+  end
+
+  def and_i_am_thanked_for_my_feedback
+    expect(page).to have_content("Your application for #{@application_choice.course_option.course.name_and_code} at #{@application_choice.course_option.provider.name} has been withdrawn")
+  end
+
+  def and_the_candidate_has_received_an_email_with_information_on_apply_again
+    open_email(@application_choice.application_form.candidate.email_address)
+    expect(current_email.subject).to have_content 'You’ve withdrawn your application'
+  end
+end

--- a/spec/system/candidate_interface/continuous_applications/withdraws/candidate_withdraws_with_upcoming_interviews_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/withdraws/candidate_withdraws_with_upcoming_interviews_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+RSpec.feature 'A candidate withdraws with upcoming interviews', continuous_applications: true do
+  include CandidateHelper
+
+  scenario 'successful withdrawal' do
+    given_i_am_signed_in_as_a_candidate
+    and_i_have_an_application_choice_with_an_upcoming_interview
+
+    when_i_visit_the_application_dashboard
+    and_i_click_the_withdraw_link_on_my_first_choice
+    then_i_see_a_confirmation_page
+
+    when_i_click_to_confirm_withdrawal
+    then_i_see_the_withdraw_choice_reason_page
+
+    when_i_select_my_reasons
+    and_i_click_continue
+    then_i_see_my_application_dashboard
+
+    and_the_provider_has_received_an_email
+    and_the_interview_has_been_cancelled
+    and_i_received_an_interview_cancelled_email
+  end
+
+  def given_i_am_signed_in_as_a_candidate
+    create_and_sign_in_candidate
+  end
+
+  def and_i_have_an_application_choice_with_an_upcoming_interview
+    form = create(:completed_application_form, :with_completed_references, candidate: current_candidate)
+    @application_choice = create(:application_choice, :interviewing, application_form: form)
+    create(:application_choice, :awaiting_provider_decision, application_form: form)
+    @provider_user = create(:provider_user, :with_notifications_enabled)
+    create(:provider_permissions, provider_id: @application_choice.provider.id, provider_user_id: @provider_user.id)
+  end
+
+  def when_i_visit_the_application_dashboard
+    visit candidate_interface_continuous_applications_choices_path
+  end
+
+  def and_i_click_the_withdraw_link_on_my_first_choice
+    click_link 'Withdraw', match: :first
+  end
+
+  def then_i_see_a_confirmation_page
+    expect(page).to have_content('Are you sure you want to withdraw this application?')
+  end
+
+  def when_i_click_to_confirm_withdrawal
+    click_button 'Yes I’m sure – withdraw this application'
+  end
+
+  def then_i_see_the_withdraw_choice_reason_page
+    expect(page).to have_current_path candidate_interface_withdrawal_feedback_path(@application_choice.id)
+  end
+
+  def when_i_select_my_reasons
+    check 'I’m going to apply (or have applied) to a different course at the same training provider'
+    check 'I have concerns that I will not have time to train'
+  end
+
+  def and_i_click_continue
+    click_button t('continue')
+  end
+
+  def then_i_see_my_application_dashboard
+    expect(page).to have_current_path candidate_interface_continuous_applications_choices_path
+  end
+
+  def and_that_my_application_has_been_withdrawn
+    expect(page).to have_content("You’ve withdrawn your application for #{@application_choice.course_option.course.name_and_code} at #{@application_choice.course_option.provider.name}")
+  end
+
+  def and_the_provider_has_received_an_email
+    open_email(@provider_user.email_address)
+    expect(current_email.subject).to have_content "#{@application_choice.application_form.full_name} withdrew their application"
+  end
+
+  def and_the_interview_has_been_cancelled
+    interview = @application_choice.interviews.first.reload
+    expect(interview.cancelled_at).not_to be_nil
+    expect(interview.cancellation_reason).to eq('You withdrew your application.')
+  end
+
+  def and_i_received_an_interview_cancelled_email
+    open_email(current_candidate.email_address)
+    expect(current_email.subject).to have_content('Interview cancelled')
+    expect(current_email.text).to have_content('You withdrew your application.')
+  end
+end


### PR DESCRIPTION
## Context

This PR adds the withdraw to continuous applications.

Firstly, I tried to create new controller and actions but then I realised that withdraw has more things to do like adding the reasons for withdraw and then I change my idea to re-use the same controllers/actions and just change the redirect for continuous applications. Let me know your thoughts!