### PR TITLE
Create submission service for continuous applications

### DIFF
--- a/app/services/candidate_interface/continuous_applications/application_not_ready_to_send_error.rb
+++ b/app/services/candidate_interface/continuous_applications/application_not_ready_to_send_error.rb
@@ -1,0 +1,15 @@
+module CandidateInterface
+  module ContinuousApplications
+    class ApplicationNotReadyToSendError < StandardError
+      attr_reader :application_choice
+
+      def initialize(application_choice)
+        @application_choice = application_choice
+      end
+
+      def message
+        "Tried to send an application in the #{application_choice.status} state to a provider"
+      end
+    end
+  end
+end

--- a/app/services/candidate_interface/continuous_applications/inactive_date_calculator.rb
+++ b/app/services/candidate_interface/continuous_applications/inactive_date_calculator.rb
@@ -1,0 +1,36 @@
+module CandidateInterface
+  module ContinuousApplications
+    class InactiveDateCalculator
+      def initialize(application_choice:, effective_date:, time_limit_calculator: TimeLimitCalculator)
+        @application_choice = application_choice
+        @time_limit_calculator = time_limit_calculator.new(rule: :reject_by_default, effective_date:)
+      end
+
+      def inactive_date
+        time_in_future = timetable[:time_in_future]
+
+        return reject_by_default_date if beyond_end_of_cycle_reject_by_default_deadline?(time_in_future) && !HostingEnvironment.sandbox_mode?
+
+        time_in_future
+      end
+
+      def inactive_days
+        timetable[:days]
+      end
+
+      def timetable
+        @time_limit_calculator.call
+      end
+
+    private
+
+      def beyond_end_of_cycle_reject_by_default_deadline?(time_in_future)
+        time_in_future >= reject_by_default_date
+      end
+
+      def reject_by_default_date
+        0.business_days.before(CycleTimetable.reject_by_default).end_of_day
+      end
+    end
+  end
+end

--- a/app/services/candidate_interface/continuous_applications/submit_application_choice.rb
+++ b/app/services/candidate_interface/continuous_applications/submit_application_choice.rb
@@ -1,0 +1,32 @@
+module CandidateInterface
+  module ContinuousApplications
+    class SubmitApplicationChoice
+      attr_reader :application_choice, :application_form, :inactive_date_calculator
+      delegate :inactive_date, :inactive_days, to: :inactive_date_calculator
+
+      def initialize(application_choice, inactive_date_calculator: InactiveDateCalculator)
+        @application_choice = application_choice
+        @application_form = application_choice.application_form
+        @inactive_date_calculator = inactive_date_calculator.new(application_choice:, effective_date:)
+      end
+
+      def call
+        raise ApplicationNotReadyToSendError, application_choice unless application_choice.unsubmitted?
+
+        ActiveRecord::Base.transaction do
+          application_form.update!(submitted_at:)
+          application_choice.update!(sent_to_provider_at:)
+          application_choice.update!(reject_by_default_at: inactive_date, reject_by_default_days: inactive_days)
+          ApplicationStateChange.new(application_choice).send_to_provider!
+        end
+      end
+
+      def current_time
+        Time.zone.now
+      end
+      alias effective_date current_time
+      alias submitted_at current_time
+      alias sent_to_provider_at current_time
+    end
+  end
+end

--- a/spec/services/candidate_interface/continuous_applications/inactive_date_calculator_spec.rb
+++ b/spec/services/candidate_interface/continuous_applications/inactive_date_calculator_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::ContinuousApplications::InactiveDateCalculator, continuous_applications: true do
+  subject(:calculator) { described_class.new(application_choice:, effective_date: Time.zone.now) }
+
+  let(:application_choice) { create(:application_choice, :unsubmitted) }
+
+  describe 'inactive calculation' do
+    submitted_vs_inactive_dates = [
+      ['28 Oct 2023 9:00:00 AM BST', '11 Dec 2023 23:59:59 PM GMT', 'near the BST/GMT boundary'],
+      ['1 Apr 2024 9:00:00 AM BST',  '15 May 2024 23:59:59 PM BST', 'safely within BST'],
+      ['4 Jan 2024 11:00:00 PM GMT', '15 Feb 2024 23:59:59 PM GMT', 'safely within GMT'],
+      ['1 Jul 2024 11:00:00 PM BST', '29 Jul 2024 23:59:59 PM BST', 'during the 20-day summer period'],
+      ['01 Dec 2023 12:00:00 PM GMT', '17 Jan 2024 23:59:59 PM GMT', 'near the Christmas holidays'],
+      ['02 Sep 2024 0:00:00 AM BST', '25 Sep 2024 23:59:59 PM BST', '1 day before apply 1 deadline'],
+      ['16 Sep 2024 0:00:00 AM BST', '25 Sep 2024 23:59:59 PM BST', '1 day before apply 2 deadline'],
+    ].freeze
+
+    submitted_vs_inactive_dates.each do |submitted, correct_rbd, test_case|
+      it "is correct when the application is delivered #{test_case}", continuous_applications: true do
+        travel_temporarily_to(Time.zone.parse(submitted)) do
+          expect(calculator.inactive_date).to be_within(1.second).of(Time.zone.parse(correct_rbd))
+        end
+      end
+    end
+
+    # we’re going to keep Sandbox open while Apply is closed irl, but we don’t want
+    # to set short inactive dates due to the proximity of the deadline when
+    # we're using the cycle switcher
+    specify 'proximity to the deadline is ignored on Sandbox', sandbox: true do
+      submitted = '20 Sept 2023 0:00:00 AM BST'
+      correct_rbd = '18 Oct 2023 23:59:59 PM BST'
+
+      travel_temporarily_to(Time.zone.parse(submitted)) do
+        expect(calculator.inactive_date).to be_within(1.second).of(Time.zone.parse(correct_rbd))
+      end
+    end
+  end
+end

--- a/spec/services/candidate_interface/continuous_applications/submit_application_choice_spec.rb
+++ b/spec/services/candidate_interface/continuous_applications/submit_application_choice_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::ContinuousApplications::SubmitApplicationChoice, continuous_applications: true do
+  subject(:submit_application) { described_class.new(application_choice).call }
+
+  let(:application_form) { application_choice.application_form }
+
+  describe '#call' do
+    context 'when application is already submitted' do
+      let(:application_choice) { create(:application_choice, :awaiting_provider_decision) }
+
+      it 'raises error' do
+        expect {
+          submit_application
+        }.to raise_error(
+          CandidateInterface::ContinuousApplications::ApplicationNotReadyToSendError,
+          'Tried to send an application in the awaiting_provider_decision state to a provider',
+        )
+      end
+    end
+
+    context 'when application is unsubmitted' do
+      let(:application_choice) { create(:application_choice, :unsubmitted) }
+
+      it 'updates timestamps relevant to submitting an application' do
+        travel_temporarily_to(Time.zone.local(0)) do
+          submit_application
+          expect(application_form.submitted_at).to eq Time.zone.local(0)
+          expect(application_choice.sent_to_provider_at).to eq Time.zone.local(0)
+        end
+      end
+
+      it 'updates inactive date for application' do
+        travel_temporarily_to(Time.zone.local(2023, 10, 20)) do
+          submit_application
+          expect(application_choice.reject_by_default_at).to be_within(1.second).of(Time.zone.parse('01 Dec 2023 23:59:59 GMT'))
+          expect(application_choice.reject_by_default_days).to eq 30
+        end
+      end
+
+      it 'updates application choice status' do
+        expect(application_choice).to be_unsubmitted
+        submit_application
+        expect(application_choice).to be_awaiting_provider_decision
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Created Submit application service and inactive date calculator to have a more transactional code around submission.

Then we can pass this values to future mailers without having bug of code that doesn't know how to handle transactions
