### PR TITLE
Fix deprecation and warning errors in RSpec tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,8 @@ require:
   - rubocop-rails
   - rubocop-rake
   - rubocop-rspec
+  - rubocop-capybara
+  - rubocop-factory_bot
   - ./lib/rubocop/cop/application_api_controller.rb
   - ./lib/rubocop/cop/govuk/govuk_button_to.rb
   - ./lib/rubocop/cop/govuk/govuk_link_to.rb

--- a/app/views/candidate_interface/guidance/index.html.erb
+++ b/app/views/candidate_interface/guidance/index.html.erb
@@ -25,13 +25,13 @@
 
             table.with_body do |body|
               body.with_row do |row|
-                row.with_cell(text: CycleTimetable.find_opens.to_s(:govuk_date_and_time))
+                row.with_cell(text: CycleTimetable.find_opens.to_fs(:govuk_date_and_time))
                 row.with_cell do
                   "Start #{govuk_link_to('finding postgraduate teacher training courses', find_url)} you might want to apply to.".html_safe
                 end
               end
               body.with_row do |row|
-                row.with_cell(text: CycleTimetable.apply_opens.to_s(:govuk_date_and_time))
+                row.with_cell(text: CycleTimetable.apply_opens.to_fs(:govuk_date_and_time))
                 row.with_cell do
                   "<p class='govuk-body'>Start applying for courses. You can apply to #{ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES} courses at a time. Courses can fill up quickly, so you should apply as soon as you can.</p>
                    <p class='govuk-body'>You should make sure each course you choose is offered by a different training provider so you can have more chance of success.</p>
@@ -42,18 +42,18 @@
                 end
               end
               body.with_row do |row|
-                row.with_cell(text: CycleTimetable.show_summer_recruitment_banner.to_s(:govuk_date))
+                row.with_cell(text: CycleTimetable.show_summer_recruitment_banner.to_fs(:govuk_date))
                 row.with_cell(text: 'The time training providers have to make a decision about your application is reduced from 40 working days to 20 working days.')
               end
               body.with_row do |row|
-                row.with_cell(text: CycleTimetable.apply_1_deadline.to_s(:govuk_date_and_time))
+                row.with_cell(text: CycleTimetable.apply_1_deadline.to_fs(:govuk_date_and_time))
                 row.with_cell do
-                  "<p class='govuk-body'>If you’ve not already applied for teacher training, you will not be able to apply after #{CycleTimetable.apply_1_deadline.to_s(:govuk_date)}.</p>
-                   <p class='govuk-body govuk-!-margin-bottom-0'>If you’ve already applied, but your applications were unsuccessful, you can continue to apply for courses until #{CycleTimetable.apply_2_deadline.to_s(:govuk_date_and_time)}.</p>".html_safe
+                  "<p class='govuk-body'>If you’ve not already applied for teacher training, you will not be able to apply after #{CycleTimetable.apply_1_deadline.to_fs(:govuk_date)}.</p>
+                   <p class='govuk-body govuk-!-margin-bottom-0'>If you’ve already applied, but your applications were unsuccessful, you can continue to apply for courses until #{CycleTimetable.apply_2_deadline.to_fs(:govuk_date_and_time)}.</p>".html_safe
                 end
               end
               body.with_row do |row|
-                row.with_cell(text: CycleTimetable.reject_by_default.to_s(:govuk_date_and_time))
+                row.with_cell(text: CycleTimetable.reject_by_default.to_fs(:govuk_date_and_time))
                 row.with_cell(text: "The last day for training providers to make a decision on all applications for courses starting in September #{@recruitment_cycle_year}.")
               end
             end
@@ -77,13 +77,13 @@
 
             table.with_body do |body|
               body.with_row do |row|
-                row.with_cell(text: CycleTimetable.find_opens.to_s(:govuk_date_and_time))
+                row.with_cell(text: CycleTimetable.find_opens.to_fs(:govuk_date_and_time))
                 row.with_cell do
                   "Start #{govuk_link_to('finding postgraduate teacher training courses', find_url)} you might want to apply to.".html_safe
                 end
               end
               body.with_row do |row|
-                row.with_cell(text: CycleTimetable.apply_opens.to_s(:govuk_date_and_time))
+                row.with_cell(text: CycleTimetable.apply_opens.to_fs(:govuk_date_and_time))
                 row.with_cell do
                   "<p class=\"govuk-body\">Start applying to courses. You can apply to #{ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES} courses offered by #{ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES} different training providers. Courses can fill up quickly, so you should apply as soon as you can.</p>
                    <p class=\"govuk-body\">You can withdraw an application at any time and apply to a different course if you want to.</p>
@@ -93,18 +93,18 @@
                 end
               end
               body.with_row do |row|
-                row.with_cell(text: CycleTimetable.show_summer_recruitment_banner.to_s(:govuk_date))
+                row.with_cell(text: CycleTimetable.show_summer_recruitment_banner.to_fs(:govuk_date))
                 row.with_cell(text: 'The time training providers have to make a decision about your application is reduced from 30 working days to 20 working days.')
               end
               body.with_row do |row|
-                row.with_cell(text: CycleTimetable.apply_1_deadline.to_s(:govuk_date_and_time))
+                row.with_cell(text: CycleTimetable.apply_1_deadline.to_fs(:govuk_date_and_time))
                 row.with_cell do
-                  "<p class=\"govuk-body\">If you have not already applied for teacher training, you will not be able to apply after #{CycleTimetable.apply_1_deadline.to_s(:govuk_date)}.</p>
-                   <p class=\"govuk-body\">If you've already applied, but your applications were unsuccessful, you can continue to apply for courses until #{CycleTimetable.apply_2_deadline.to_s(:govuk_date_and_time)}.</p>".html_safe
+                  "<p class=\"govuk-body\">If you have not already applied for teacher training, you will not be able to apply after #{CycleTimetable.apply_1_deadline.to_fs(:govuk_date)}.</p>
+                   <p class=\"govuk-body\">If you've already applied, but your applications were unsuccessful, you can continue to apply for courses until #{CycleTimetable.apply_2_deadline.to_fs(:govuk_date_and_time)}.</p>".html_safe
                 end
               end
               body.with_row do |row|
-                row.with_cell(text: CycleTimetable.reject_by_default.to_s(:govuk_date_and_time))
+                row.with_cell(text: CycleTimetable.reject_by_default.to_fs(:govuk_date_and_time))
                 row.with_cell(text: "The last day for training providers to make a decision on all applications for courses starting in September #{@recruitment_cycle_year}.")
               end
             end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -23,7 +23,7 @@ class Clock
   every(1.hour, 'DeclineOffersByDefault', at: '**:15') { DeclineOffersByDefaultWorker.perform_async }
   every(1.hour, 'ChaseReferences', at: '**:20') { ChaseReferences.perform_async }
   every(1.hour, 'UpdateOutOfDateProviderIdsOnApplicationChoices', at: '**:20') { UpdateOutOfDateProviderIdsOnApplicationChoices.perform_async }
-  every(1.hour, 'UpdateDuplicateMatchesWorker', at: '**:25') { UpdateDuplicateMatchesWorker.perform_async(notify_slack_at: 13) }
+  every(1.hour, 'UpdateDuplicateMatchesWorker', at: '**:25') { UpdateDuplicateMatchesWorker.perform_async('notify_slack_at' => 13) }
   every(1.hour, 'DetectInvariantsHourlyCheck', at: '**:30') { DetectInvariantsHourlyCheck.perform_async }
   every(1.hour, 'SendChaseEmailToProviders', at: '**:35') { SendChaseEmailToProvidersWorker.perform_async }
   every(1.hour, 'SendChaseEmailToCandidates', at: '**:40') { SendChaseEmailToCandidatesWorker.perform_async }

--- a/spec/forms/candidate_interface/personal_details_form_spec.rb
+++ b/spec/forms/candidate_interface/personal_details_form_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe CandidateInterface::PersonalDetailsForm, type: :model do
           model = described_class.new(day: '9301305922083', month: '01', year: '2022')
 
           expect(model).not_to be_valid
-        }.not_to raise_error(RangeError)
+        }.not_to raise_error
       end
     end
   end

--- a/spec/services/delete_application_spec.rb
+++ b/spec/services/delete_application_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe DeleteApplication do
       it 'allows delete if application has been submitted to providers' do
         application_choice = application_form.application_choices.first
         SendApplicationToProvider.call(application_choice)
-        expect { service.call! }.not_to raise_error('Application has been sent to providers')
+        expect { service.call! }.not_to raise_error
       end
     end
   end

--- a/spec/services/offer_validations_spec.rb
+++ b/spec/services/offer_validations_spec.rb
@@ -64,7 +64,9 @@ RSpec.describe OfferValidations, type: :model do
       end
 
       context 'when the offer details differ only by reference condition' do
-        let(:application_choice) { build_stubbed(:application_choice, :offered) }
+        let(:candidate) { create(:candidate) }
+        let(:current_course_option) { create(:course_option, :open_on_apply) }
+        let(:application_choice) { create(:application_choice, :offered, current_course_option:, candidate:) }
         let(:course_option) { application_choice.course_option }
         let(:conditions) { application_choice.offer.all_conditions_text }
         let(:reference_condition) { build(:reference_condition) }
@@ -74,12 +76,14 @@ RSpec.describe OfferValidations, type: :model do
 
         it 'does not raise an IdenticalOfferError' do
           allow(application_choice.offer).to receive(:reference_condition).and_return(reference_condition)
-          expect { offer.valid? }.not_to raise_error(IdenticalOfferError)
+          expect { offer.valid? }.not_to raise_error
         end
       end
 
       context 'when the offer details differ only by SKE condition' do
-        let(:application_choice) { build_stubbed(:application_choice, :offered) }
+        let(:candidate) { create(:candidate) }
+        let(:current_course_option) { create(:course_option, :open_on_apply) }
+        let(:application_choice) { create(:application_choice, :offered, current_course_option:, candidate:) }
         let(:course_option) { application_choice.course_option }
         let(:conditions) { application_choice.offer.all_conditions_text }
         let(:ske_conditions) { [build(:ske_condition)] }
@@ -89,7 +93,7 @@ RSpec.describe OfferValidations, type: :model do
 
         it 'does not raise an IdenticalOfferError' do
           allow(application_choice.offer).to receive(:ske_conditions).and_return(ske_conditions)
-          expect { offer.valid? }.not_to raise_error(IdenticalOfferError)
+          expect { offer.valid? }.not_to raise_error
         end
       end
     end

--- a/spec/support/constants.rb
+++ b/spec/support/constants.rb
@@ -1,0 +1,7 @@
+OPEN_API_YAML_BOILERPLATE = <<~YAML
+  openapi: '3.0.0'
+  info:
+    version: 'v1'
+  paths: {}
+YAML
+.freeze

--- a/spec/support/open_api_example_spec.rb
+++ b/spec/support/open_api_example_spec.rb
@@ -1,14 +1,6 @@
 class OpenAPIExampleSpec
-  BOILERPLATE = <<~YAML
-    openapi: '3.0.0'
-    info:
-      version: 'v1'
-    paths: {}
-  YAML
-  .freeze
-
   def self.build_with(yaml)
-    spec = YAML.safe_load(BOILERPLATE)
+    spec = YAML.safe_load(OPEN_API_YAML_BOILERPLATE)
     spec.merge(YAML.safe_load(yaml))
   end
 end

--- a/spec/support_specs/clockwork_spec.rb
+++ b/spec/support_specs/clockwork_spec.rb
@@ -55,8 +55,8 @@ RSpec.describe Clockwork, clockwork: true do
     Clockwork::Test.run(
       start_time:,
       end_time:,
-      tick_speed:
-      1.minute, file: './config/clock.rb'
+      tick_speed: 1.minute,
+      file: './config/clock.rb',
     )
 
     Clockwork::Test.manager.send(:history).jobs.each do |job|

--- a/spec/system/provider_interface/see_individual_application_new_personal_statement_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_new_personal_statement_spec.rb
@@ -1,11 +1,10 @@
 require 'rails_helper'
 
-ANYTIME_IN_RECRUITMENT_CYCLE_APPLY_OPEN = Time.zone.local(2022, 10, 15, 12, 0, 0)
-RSpec.describe 'A Provider viewing an individual application', time: ANYTIME_IN_RECRUITMENT_CYCLE_APPLY_OPEN, with_audited: true do
+RSpec.describe 'A Provider viewing an individual application', with_audited: true do
   include CourseOptionHelpers
   include DfESignInHelpers
 
-  scenario 'the application data is visible' do
+  scenario 'the application data is visible', time: mid_cycle(2023) do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_my_organisation_has_received_an_application_without_restructured_work_history
     and_i_am_permitted_to_see_applications_for_my_provider

--- a/spec/system/provider_interface/see_individual_application_old_personal_statement_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_old_personal_statement_spec.rb
@@ -1,11 +1,10 @@
 require 'rails_helper'
 
-ANYTIME_IN_RECRUITMENT_CYCLE_APPLY_OPEN = Time.zone.local(2022, 10, 15, 12, 0, 0)
-RSpec.describe 'A Provider viewing an individual application', time: ANYTIME_IN_RECRUITMENT_CYCLE_APPLY_OPEN, with_audited: true do
+RSpec.describe 'A Provider viewing an individual application', with_audited: true do
   include CourseOptionHelpers
   include DfESignInHelpers
 
-  scenario 'the application data is visible' do
+  scenario 'the application data is visible', time: mid_cycle(2023) do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_my_organisation_has_received_an_application_without_restructured_work_history
     and_i_am_permitted_to_see_applications_for_my_provider


### PR DESCRIPTION
* TimeWithZone#to_s is deprecated in favor of TimeWithZone#to_fs
* The arguments you pass to perform_async must be composed of simple JSON datatypes and not ruby symbols
* Using `expect { }.not_to raise_error(SpecificErrorClass)` risks false positives, since `expect` swallows errors.
* already initialized constant `BOILERPLATE` and `ANYTIME_IN_RECRUITMENT_CYCLE_APPLY_OPEN` I moved this to a `constants.rb` file in the `spec/support`, but let me know if you think it should be done differently