### PR TITLE
Remove Redis flushdb from the spec helper

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -130,7 +130,6 @@ RSpec.configure do |config|
     allow(Postcodes::IO).to receive(:new).and_return(instance_double(Postcodes::IO, lookup: nil))
   end
 
-  config.before { Redis.new.flushdb }
   config.before { Rails.cache.clear }
   config.before { Faker::UniqueGenerator.clear }
   config.before { ActionMailer::Base.deliveries.clear }


### PR DESCRIPTION
This is causing issues on my local machine, making the redis server
crash. I don't think it is required for the specs to run. Was added in https://github.com/DFE-Digital/apply-for-teacher-training/pull/763