### PR TITLE
Backlinks updated for continuous applications

### DIFF
--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class CandidateInterfaceController < ApplicationController
+    include BackLinks
+
     before_action :protect_with_basic_auth
     before_action :authenticate_candidate!
     before_action :set_user_context
@@ -57,22 +59,6 @@ module CandidateInterface
 
     def redirect_to_application_if_signed_in
       redirect_to candidate_interface_application_form_path if candidate_signed_in?
-    end
-
-    def return_to_after_edit(default:)
-      if redirect_back_to_application_review_page?
-        { back_path: candidate_interface_application_review_path, params: redirect_back_to_application_review_page_params }
-      else
-        { back_path: default, params: {} }
-      end
-    end
-
-    def redirect_back_to_application_review_page_params
-      { 'return-to' => 'application-review' }
-    end
-
-    def redirect_back_to_application_review_page?
-      params['return-to'] == 'application-review' || params[:return_to] == 'application-review'
     end
 
     def current_application

--- a/app/controllers/candidate_interface/contact_details/address_type_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_type_controller.rb
@@ -8,7 +8,7 @@ module CandidateInterface
 
     def edit
       @contact_details_form = load_contact_form
-      @return_to = return_to_after_edit(default: candidate_interface_personal_details_complete_path)
+      @return_to = return_to_after_edit(default: candidate_interface_contact_information_review_path)
     end
 
     def create

--- a/app/controllers/candidate_interface/english_foreign_language/ielts_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/ielts_controller.rb
@@ -5,7 +5,7 @@ module CandidateInterface
 
       def new
         @ielts_form = EnglishForeignLanguage::IeltsForm.new
-        @return_to = return_to_after_edit(default: candidate_interface_english_foreign_language_review_path)
+        @return_to = return_to_after_edit(default: candidate_interface_english_foreign_language_type_path)
       end
 
       def edit

--- a/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
@@ -10,7 +10,7 @@ module CandidateInterface
         @section_complete_form = SectionCompleteForm.new(
           completed: current_application.efl_completed,
         )
-        @return_to = return_to_after_edit(default: candidate_interface_application_form_path)
+        @return_to = return_to_after_edit(default: application_form_path)
       end
 
       def complete

--- a/app/controllers/candidate_interface/english_foreign_language/toefl_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/toefl_controller.rb
@@ -5,7 +5,7 @@ module CandidateInterface
 
       def new
         @toefl_form = EnglishForeignLanguage::ToeflForm.new(toefl_params)
-        @return_to = return_to_after_edit(default: candidate_interface_english_foreign_language_review_path)
+        @return_to = return_to_after_edit(default: candidate_interface_english_foreign_language_type_path)
       end
 
       def edit

--- a/app/controllers/candidate_interface/english_foreign_language/type_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/type_controller.rb
@@ -3,7 +3,11 @@ module CandidateInterface
     class TypeController < CandidateInterfaceController
       def new
         @type_form = EnglishForeignLanguage::TypeForm.new(type_params)
-        return_to = current_application.english_proficiency.present? ? candidate_interface_english_foreign_language_review_path : candidate_interface_english_foreign_language_start_path
+        return_to = if current_application.english_proficiency.present?
+                      candidate_interface_english_foreign_language_review_path
+                    else
+                      candidate_interface_english_foreign_language_start_path
+                    end
         @return_to = return_to_after_edit(default: return_to)
       end
 

--- a/app/controllers/candidate_interface/english_foreign_language/type_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/type_controller.rb
@@ -3,7 +3,8 @@ module CandidateInterface
     class TypeController < CandidateInterfaceController
       def new
         @type_form = EnglishForeignLanguage::TypeForm.new(type_params)
-        @return_to = return_to_after_edit(default: candidate_interface_english_foreign_language_start_path)
+        return_to = current_application.english_proficiency.present? ? candidate_interface_english_foreign_language_review_path : candidate_interface_english_foreign_language_start_path
+        @return_to = return_to_after_edit(default: return_to)
       end
 
       def create

--- a/app/controllers/candidate_interface/guidance_controller.rb
+++ b/app/controllers/candidate_interface/guidance_controller.rb
@@ -1,9 +1,16 @@
 module CandidateInterface
   class GuidanceController < CandidateInterfaceController
     skip_before_action :authenticate_candidate!
+    before_action :set_back_link
 
     def index
       @recruitment_cycle_year = CycleTimetable.current_year
+    end
+
+  private
+
+    def set_back_link
+      @back_link = request.referer || application_form_path
     end
   end
 end

--- a/app/controllers/candidate_interface/restructured_work_history/review_controller.rb
+++ b/app/controllers/candidate_interface/restructured_work_history/review_controller.rb
@@ -3,7 +3,7 @@ module CandidateInterface
     def show
       @application_form = current_application
       @section_complete_form = SectionCompleteForm.new(completed: current_application.work_history_completed)
-      @return_to = return_to_after_edit(default: candidate_interface_application_form_path)
+      @return_to = return_to_after_edit(default: application_form_path)
     end
 
     def complete

--- a/app/controllers/concerns/back_links.rb
+++ b/app/controllers/concerns/back_links.rb
@@ -1,0 +1,46 @@
+# Extract and collect helper methods relating to backlinks
+#
+module BackLinks
+  extend ActiveSupport::Concern
+
+  def return_to_after_edit(default:)
+    if redirect_back_to_application_review_page?
+      { back_path: candidate_interface_application_review_path, params: redirect_back_to_application_review_page_params }
+    else
+      { back_path: default, params: {} }
+    end
+  end
+
+  def redirect_back_to_application_review_page_params
+    { 'return-to' => 'application-review' }
+  end
+
+  def redirect_back_to_application_review_page?
+    params['return-to'] == 'application-review' || params[:return_to] == 'application-review'
+  end
+
+  # Method to determine the path to the candidates current dashboard based on
+  # contextual information. For continuous applciations, the dahsboard path
+  def application_form_path
+    # `current_application` is a `helper_method` defined in CandidateInterfaceController
+    # It's not available in view specs
+    return '' unless defined?(current_application)
+
+    if current_application.continuous_applications?
+      if request.path.match?(/withdraw/)
+        candidate_interface_continuous_applications_choices_path
+      else
+        candidate_interface_continuous_applications_details_path
+      end
+    elsif !current_application.submitted?
+      candidate_interface_application_form_path
+    elsif current_application.submitted?
+      candidate_interface_application_review_submitted_path
+    end
+  end
+  module_function :application_form_path
+
+  included do
+    helper_method :application_form_path
+  end
+end

--- a/app/controllers/concerns/back_links.rb
+++ b/app/controllers/concerns/back_links.rb
@@ -1,4 +1,4 @@
-# Extract and collect helper methods relating to backlinks
+# Helper methods relating to backlinks
 #
 module BackLinks
   extend ActiveSupport::Concern
@@ -20,7 +20,7 @@ module BackLinks
   end
 
   # Method to determine the path to the candidates current dashboard based on
-  # contextual information. For continuous applciations, the dahsboard path
+  # contextual information.
   def application_form_path
     # `current_application` is a `helper_method` defined in CandidateInterfaceController
     # It's not available in view specs
@@ -32,10 +32,10 @@ module BackLinks
       else
         candidate_interface_continuous_applications_details_path
       end
-    elsif !current_application.submitted?
-      candidate_interface_application_form_path
     elsif current_application.submitted?
       candidate_interface_application_review_submitted_path
+    else
+      candidate_interface_application_form_path
     end
   end
   module_function :application_form_path

--- a/app/controllers/concerns/back_links.rb
+++ b/app/controllers/concerns/back_links.rb
@@ -27,18 +27,28 @@ module BackLinks
     return '' unless defined?(current_application)
 
     if current_application.continuous_applications?
-      if request.path.match?(/withdraw/)
-        candidate_interface_continuous_applications_choices_path
-      else
-        candidate_interface_continuous_applications_details_path
-      end
-    elsif current_application.submitted?
+      continuous_application_form_path
+    else
+      old_cycle_application_form_path
+    end
+  end
+  module_function :application_form_path
+
+  def continuous_application_form_path
+    if request.path.match?(/withdraw/)
+      candidate_interface_continuous_applications_choices_path
+    else
+      candidate_interface_continuous_applications_details_path
+    end
+  end
+
+  def old_cycle_application_form_path
+    if current_application.submitted?
       candidate_interface_application_review_submitted_path
     else
       candidate_interface_application_form_path
     end
   end
-  module_function :application_form_path
 
   included do
     helper_method :application_form_path

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -6,7 +6,11 @@ module ViewHelper
 
     url = back_link_url if url == :back
 
-    if url.is_a?(String) && url.end_with?(candidate_interface_application_form_path)
+    if url.to_s.end_with?(candidate_interface_continuous_applications_details_path)
+      body = 'Back to your details'
+    elsif url.to_s.end_with?(candidate_interface_continuous_applications_choices_path)
+      body = 'Back to your applications'
+    elsif url.to_s.end_with?(candidate_interface_application_form_path)
       body = 'Back to application'
     end
 
@@ -120,6 +124,10 @@ module ViewHelper
     else
       govuk_link_to 'Confirm environment to make changes', support_interface_confirm_environment_path(from: [request.fullpath, anchor].join('#'))
     end
+  end
+
+  def application_form_path
+    BackLinks.application_form_path
   end
 
 private

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -6,16 +6,18 @@ module ViewHelper
 
     url = back_link_url if url == :back
 
-    if url.to_s.end_with?(candidate_interface_continuous_applications_details_path)
-      body = 'Back to your details'
-    elsif url.to_s.end_with?(candidate_interface_continuous_applications_choices_path)
-      body = 'Back to your applications'
-    elsif url.to_s.end_with?(candidate_interface_application_form_path)
-      body = 'Back to application'
-    end
+    text = if url.to_s.end_with?(candidate_interface_continuous_applications_details_path)
+             'Back to your details'
+           elsif url.to_s.end_with?(candidate_interface_continuous_applications_choices_path)
+             'Back to your applications'
+           elsif url.to_s.end_with?(candidate_interface_application_form_path)
+             'Back to application'
+           else
+             body
+           end
 
     render GovukComponent::BackLinkComponent.new(
-      text: body,
+      text: text,
       href: url,
       classes:,
     )

--- a/app/views/candidate_interface/application_choices/review.html.erb
+++ b/app/views/candidate_interface/application_choices/review.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.courses') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for(:before_content, govuk_back_link_to(application_form_path)) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_course_choices_complete_path, method: :patch do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/candidate_interface/application_form/review_previous_application.html.erb
+++ b/app/views/candidate_interface/application_form/review_previous_application.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, submitted_at_date.present? ? t('page_titles.submitted_application') : t('page_titles.unsubmitted_previous_application') %>
 
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
+<% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <h1 class="govuk-heading-xl">
   <%= submitted_at_date.present? ? t('page_titles.submitted_application') : t('page_titles.unsubmitted_previous_application') %>

--- a/app/views/candidate_interface/contact_details/address/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/address/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.address'), @contact_details_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(@return_to[:back_path]) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_edit_address_type_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/contact_details/phone_number/new.html.erb
+++ b/app/views/candidate_interface/contact_details/phone_number/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.contact_details'), @contact_details_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
+<% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/contact_details/review/show.html.erb
+++ b/app/views/candidate_interface/contact_details/review/show.html.erb
@@ -2,7 +2,7 @@
   :title,
   title_with_error_prefix(t('page_titles.contact_information'), @contact_details_form&.errors&.any?),
 ) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for(:before_content, govuk_back_link_to(application_form_path)) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_contact_information_complete_path, method: :patch do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/candidate_interface/contact_details/review/show.html.erb
+++ b/app/views/candidate_interface/contact_details/review/show.html.erb
@@ -2,7 +2,7 @@
   :title,
   title_with_error_prefix(t('page_titles.contact_information'), @contact_details_form&.errors&.any?),
 ) %>
-<% content_for(:before_content, govuk_back_link_to(application_form_path)) %>
+<% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_contact_information_complete_path, method: :patch do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/candidate_interface/continuous_applications/course_choices/review/show.html.erb
+++ b/app/views/candidate_interface/continuous_applications/course_choices/review/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.application_review', provider_name: @application_choice.provider.name) %>
-<% content_for(:before_content, govuk_back_link_to(candidate_interface_continuous_applications_choices_path, 'Back to applications')) %>
+<% content_for(:before_content, govuk_back_link_to(candidate_interface_continuous_applications_choices_path)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">

--- a/app/views/candidate_interface/course_choices/add_another_course/ask.html.erb
+++ b/app/views/candidate_interface/course_choices/add_another_course/ask.html.erb
@@ -1,6 +1,6 @@
 <% title = "You can choose #{pluralize(current_application.choices_left_to_make, 'more course')}" %>
 <% content_for :title, title_with_error_prefix(title, @add_another_course.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
+<% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <%= form_with model: @add_another_course, url: candidate_interface_course_choices_add_another_course_selection_path do |f| %>
   <div class="govuk-grid-row">

--- a/app/views/candidate_interface/decisions/withdraw.html.erb
+++ b/app/views/candidate_interface/decisions/withdraw.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.decisions.withdraw') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_complete_path) %>
+<% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/degrees/review/show.html.erb
+++ b/app/views/candidate_interface/degrees/review/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.degree') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_degree_complete_path, method: :patch do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/candidate_interface/english_foreign_language/start/new.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/start/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.efl.start'), @start_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
+<% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/equality_and_diversity/edit_sex.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_sex.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('equality_and_diversity.sex.title'), @sex.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(@review_back_link || candidate_interface_application_form_path) %>
+<% content_for :before_content, govuk_back_link_to(@review_back_link || application_form_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/equality_and_diversity/review.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/review.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, 'Check your answers' %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
+<% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/feedback_form/new.html.erb
+++ b/app/views/candidate_interface/feedback_form/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.your_feedback'), @feedback_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_submit_path) %>
+<% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/gcse/review/show.html.erb
+++ b/app/views/candidate_interface/gcse/review/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t("gcse_summary.page_titles.#{@subject}") %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for(:before_content, govuk_back_link_to(application_form_path)) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_gcse_complete_path, method: :patch do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/candidate_interface/gcse/type/new.html.erb
+++ b/app/views/candidate_interface/gcse/type/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t("gcse_edit_type.page_titles.#{@subject}"), @type_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
+<% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/guidance/index.html.erb
+++ b/app/views/candidate_interface/guidance/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, t('page_titles.application_guidance') %>
 
 <% if current_candidate.present? %>
-  <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+  <% content_for :before_content, govuk_back_link_to(@back_link) %>
 <% else %>
   <% content_for :before_content, govuk_back_link_to(candidate_interface_create_account_or_sign_in_path, 'Back') %>
 <% end %>

--- a/app/views/candidate_interface/interview_availability/new.html.erb
+++ b/app/views/candidate_interface/interview_availability/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.interview_preferences.heading'), @interview_preferences_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
+<% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/interview_availability/show.html.erb
+++ b/app/views/candidate_interface/interview_availability/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.interview_preferences.review') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_interview_preferences_complete_path, method: :patch do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/candidate_interface/other_qualifications/review/show.html.erb
+++ b/app/views/candidate_interface/other_qualifications/review/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, other_qualifications_title(@application_form) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
+<% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_complete_other_qualifications_path, method: :patch do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/candidate_interface/other_qualifications/type/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, title_with_error_prefix(other_qualifications_title(current_application), @form.errors.any?) %>
 <% if current_application.application_qualifications.other.blank? && !current_application.no_other_qualifications %>
-  <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
+  <% content_for :before_content, govuk_back_link_to(application_form_path) %>
 <% else %>
   <% content_for :before_content, govuk_back_link_to(candidate_interface_review_other_qualifications_path) %>
 <% end %>

--- a/app/views/candidate_interface/personal_details/name_and_dob/new.html.erb
+++ b/app/views/candidate_interface/personal_details/name_and_dob/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.personal_information.heading'), @personal_details_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/personal_details/review/show.html.erb
+++ b/app/views/candidate_interface/personal_details/review/show.html.erb
@@ -3,7 +3,7 @@
                                                  @nationalities_form.errors.any? ||
                                                   @section_complete_form.errors.any?) %>
 
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_personal_details_complete_path, method: :patch do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/candidate_interface/personal_statement/new.html.erb
+++ b/app/views/candidate_interface/personal_statement/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.becoming_a_teacher'), @becoming_a_teacher_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
+<% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/personal_statement/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.becoming_a_teacher') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_becoming_a_teacher_complete_path, method: :patch do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/candidate_interface/references/review/show.html.erb
+++ b/app/views/candidate_interface/references/review/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.references'), @section_complete_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
+<% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_references_complete_path, method: :patch do |f| %>
   <div class="govuk-grid-row">

--- a/app/views/candidate_interface/restructured_work_history/start/choice.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/start/choice.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.restructured_work_history_choice'), @choice_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
+<% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/safeguarding/new.html.erb
+++ b/app/views/candidate_interface/safeguarding/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.suitability_to_work_with_children'), @safeguarding_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
+<% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/safeguarding/show.html.erb
+++ b/app/views/candidate_interface/safeguarding/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.suitability_to_work_with_children') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_complete_safeguarding_path, method: :post do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/candidate_interface/subject_knowledge/new.html.erb
+++ b/app/views/candidate_interface/subject_knowledge/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.subject_knowledge'), @subject_knowledge_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/subject_knowledge/show.html.erb
+++ b/app/views/candidate_interface/subject_knowledge/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.subject_knowledge') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_subject_knowledge_complete_path, method: :patch do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/candidate_interface/training_with_a_disability/new.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.training_with_a_disability'), @training_with_a_disability_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
+<% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/training_with_a_disability/show.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.training_with_a_disability') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_training_with_a_disability_complete_path, method: :patch do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('review_application.title'), @incomplete_sections && @incomplete_sections.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
+<% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <%= render(CandidateInterface::DeadlineBannerComponent.new(application_form: @application_form, flash_empty: flash.empty?)) %>
 <%= render(CandidateInterface::ReopenBannerComponent.new(phase: @application_form.phase, flash_empty: flash.empty?)) %>

--- a/app/views/candidate_interface/volunteering/review/show.html.erb
+++ b/app/views/candidate_interface/volunteering/review/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.volunteering.short') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
+<% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <%= form_with model: @section_complete_form, url: candidate_interface_complete_volunteering_path, method: :patch do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/candidate_interface/volunteering/start/show.html.erb
+++ b/app/views/candidate_interface/volunteering/start/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.volunteering.long'), @volunteering_experience_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
+<% content_for :before_content, govuk_back_link_to(application_form_path) %>
 
 <div class="govuk-grid-row">
   <%= form_with model: @volunteering_experience_form, url: candidate_interface_volunteering_experience_path do |f| %>

--- a/spec/controllers/concerns/back_links_spec.rb
+++ b/spec/controllers/concerns/back_links_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe BackLinks do
+  let(:application_form) { create(:application_form) }
+  let(:candidate) { application_form.candidate }
+  let(:routes) { Rails.application.routes.url_helpers }
+  let(:request) { ActionDispatch::TestRequest.create }
+
+  describe '#application_form_path' do
+    before do
+      stub_const('BackLinkController', Class.new(CandidateInterface::CandidateInterfaceController) { include BackLinks })
+      allow(instance).to receive_messages(current_application: application_form, current_candidate: candidate)
+      instance.set_request!(request)
+    end
+
+    let(:instance) { BackLinkController.new }
+
+    context 'with legacy applications' do
+      it 'excludes deferrals' do
+        expect(instance.send(:application_form_path)).to eq routes.candidate_interface_application_form_path
+      end
+    end
+
+    context 'with submitted applications' do
+      let(:application_form) { create(:application_form, :submitted) }
+
+      it 'returns path to review submitted' do
+        expect(instance.send(:application_form_path)).to eq routes.candidate_interface_application_review_submitted_path
+      end
+    end
+
+    describe 'continuous applications', continuous_applications: true do
+      context 'default application home' do
+        let(:application_form) { create(:application_form) }
+
+        it 'returns path to application details' do
+          expect(instance.send(:application_form_path)).to eq routes.candidate_interface_continuous_applications_details_path
+        end
+      end
+
+      context 'when referer matches "withdraw"' do
+        let(:application_form) { create(:application_form) }
+
+        before do
+          request.set_header('PATH_INFO', routes.candidate_interface_withdraw_path(1))
+        end
+
+        it 'returns path to application details' do
+          expect(instance.send(:application_form_path)).to eq routes.candidate_interface_continuous_applications_choices_path
+        end
+      end
+    end
+  end
+end

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -35,6 +35,22 @@ RSpec.describe ViewHelper do
 
       expect(anchor_tag).to eq('<a class="govuk-back-link govuk-!-display-none-print" href="/">Back</a>')
     end
+
+    context 'when path ends with candidate/application/details' do
+      it 'renders a link with the text Back to your details' do
+        anchor_tag = helper.govuk_back_link_to(candidate_interface_continuous_applications_details_path)
+
+        expect(anchor_tag).to eq('<a class="govuk-back-link govuk-!-display-none-print" href="/candidate/application/details">Back to your details</a>')
+      end
+    end
+
+    context 'when path ends with candidate/application' do
+      it 'renders a link with the text Back to your application' do
+        anchor_tag = helper.govuk_back_link_to(candidate_interface_application_form_path)
+
+        expect(anchor_tag).to eq('<a class="govuk-back-link govuk-!-display-none-print" href="/candidate/application">Back to application</a>')
+      end
+    end
   end
 
   describe '#bat_contact_mail_to' do

--- a/spec/system/candidate_interface/continuous_applications/course_selection/backlinks_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/backlinks_spec.rb
@@ -1,0 +1,121 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate edits course choices', continuous_applications: true do
+  include CandidateHelper
+  include CourseOptionHelpers
+
+  it 'Candidate edit their applications' do
+    given_i_am_signed_in
+    and_there_is_a_course_with_one_course_option
+    and_there_is_a_course_with_multiple_course_options
+    and_there_is_a_course_with_both_study_modes_but_one_site
+
+    when_i_visit_my_application_page
+    and_i_click_on_course_choices
+
+    when_i_choose_that_i_know_where_i_want_to_apply
+    and_i_choose_a_provider
+    and_i_choose_the_third_course_as_my_first_course_choice
+    and_i_choose_the_full_time_study_mode
+    then_i_be_on_the_application_choice_review_page
+
+    # back during form choice
+    and_i_click_the_back_to_application_link
+    then_i_see_the_application_page
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_there_is_a_course_with_one_course_option
+    @provider = create(:provider)
+    create(:course, :open_on_apply, name: 'English', provider: @provider, study_mode: :full_time)
+
+    course_option_for_provider(provider: @provider, course: @provider.courses.first)
+  end
+
+  def and_there_is_a_course_with_multiple_course_options
+    create(:course, :open_on_apply, :with_both_study_modes, name: 'Maths', provider: @provider)
+
+    # Sites with full time study mode
+    course_option_for_provider(provider: @provider, course: @provider.courses.second, study_mode: 'full_time')
+    course_option_for_provider(provider: @provider, course: @provider.courses.second, study_mode: 'full_time')
+
+    # Sites with part time study mode
+    course_option_for_provider(provider: @provider, course: @provider.courses.second, study_mode: 'part_time')
+    course_option_for_provider(provider: @provider, course: @provider.courses.second, study_mode: 'part_time')
+  end
+
+  def and_there_is_a_course_with_both_study_modes_but_one_site
+    create(:course, :open_on_apply, :with_both_study_modes, name: 'Entomology', provider: @provider)
+
+    site = create(:site, provider: @provider)
+
+    course_option_for_provider(provider: @provider, course: @provider.courses.third, site:, study_mode: 'full_time')
+    course_option_for_provider(provider: @provider, course: @provider.courses.third, site:, study_mode: 'part_time')
+  end
+
+  def when_i_visit_my_application_page
+    visit candidate_interface_continuous_applications_choices_path
+  end
+
+  def and_i_click_on_course_choices
+    click_link 'Your application'
+    click_link 'Add application'
+  end
+
+  def when_i_choose_that_i_know_where_i_want_to_apply
+    choose 'Yes, I know where I want to apply'
+    click_button t('continue')
+  end
+
+  def and_i_choose_a_provider
+    select @provider.name_and_code
+    # find('div.autocomplete__wrapper').click
+    # find('ul.autocomplete__menu li', text: @provider.name_and_code).click
+    click_button t('continue')
+  end
+
+  def and_i_choose_the_third_course_as_my_first_course_choice
+    choose @provider.courses.third.name_and_code
+    click_button t('continue')
+  end
+
+  def when_i_click_the_back_link
+    click_on 'Back'
+  end
+
+  def then_i_see_a_back_link_to_study_mode_choice
+    expect(page.current_url).to match(/\/candidate\/application\/continuous-applications\/provider\/\d+\/courses\/\d+/)
+  end
+
+  def and_i_choose_the_full_time_study_mode
+    choose 'Full time'
+    click_button t('continue')
+  end
+
+  def then_i_be_on_the_application_choice_review_page
+    expect(page).to have_current_path(/candidate\/application\/continuous-applications\/[0-9]*\/review/)
+  end
+
+  def when_i_visit_the_review_page_directly
+    page.visit(@review_url)
+  end
+
+  def and_i_view_the_application_
+    click_on 'View application'
+  end
+
+  def and_i_click_the_back_to_application_link
+    click_on 'Back to your application'
+  end
+
+  def then_i_see_the_application_page
+    expect(page).to have_current_path(candidate_interface_continuous_applications_choices_path)
+  end
+
+  def and_i_save_the_review_page_url_for_later
+    @review_url = page.current_url
+  end
+end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_spec.rb
@@ -23,8 +23,8 @@ RSpec.feature 'Selecting a course', continuous_applications: true do
     then_i_should_see_an_error
     and_i_choose_a_course
     then_i_should_be_on_the_application_choice_review_page
-    and_i_return_to_my_applications
-    and_i_see_my_course_choices
+    and_i_click_the_back_button
+    then_i_should_be_on_the_application_choices_page
 
     given_the_provider_has_over_twenty_courses
     and_i_click_on_course_choices
@@ -107,29 +107,6 @@ RSpec.feature 'Selecting a course', continuous_applications: true do
     click_button t('continue')
   end
 
-  def and_i_choose_a_course_with_multiple_study_modes_where_one_is_full
-    choose 'Physics (1ABZ)'
-    click_button t('continue')
-  end
-
-  def then_i_see_the_address
-    expect(page).to have_content('Gorse SCITT, C/O The Bruntcliffe Academy, Bruntcliffe Lane, MORLEY, lEEDS, LS27 0LZ')
-  end
-
-  def and_i_choose_a_location
-    choose 'Main site'
-    click_button t('continue')
-  end
-
-  def and_i_visit_my_course_choices_page
-    visit candidate_interface_course_choices_review_path
-  end
-
-  def then_i_see_my_completed_course_choice
-    expect(page).to have_content('Gorse SCITT')
-    expect(page).to have_content('Primary (2XT2)')
-  end
-
   def when_i_click_continue
     click_button t('continue')
   end
@@ -150,13 +127,17 @@ RSpec.feature 'Selecting a course', continuous_applications: true do
     expect(find_by_id('which-course-are-you-applying-to-course-id-field').value).to eq ''
   end
 
-  def and_i_return_to_my_applications
-    click_link 'Back to applications'
+  def and_i_click_the_back_button
+    click_link 'Back to your applications'
   end
 
   def and_i_see_my_course_choices
     within("#course-choice-#{application_choice.id}") do
       expect(page).to have_content('Primary (2XT2)')
     end
+  end
+
+  def then_i_should_be_on_the_application_choices_page
+    expect(page.current_url).to end_with(candidate_interface_continuous_applications_choices_path)
   end
 end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_with_multiple_sites_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_with_multiple_sites_spec.rb
@@ -135,7 +135,7 @@ RSpec.feature 'Selecting a course with multiple sites', continuous_applications:
   end
 
   def and_i_return_to_my_applications
-    click_link 'Back to applications'
+    click_link 'Back to your applications'
   end
 
   def and_i_see_my_course_choices

--- a/spec/system/candidate_interface/references/candidate_add_references_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_add_references_spec.rb
@@ -371,7 +371,11 @@ RSpec.feature 'References', time: CycleTimetableHelper.after_apply_1_deadline do
 
   def then_my_application_references_should_be_incomplete
     expect(@application.reload.references_completed).to be false
-    click_link 'Back to application'
+    if FeatureFlag.active?(:continuous_applications)
+      click_link 'Back to your details'
+    else
+      click_link 'Back to application'
+    end
     expect(safeguarding_section.text.downcase).to include('references to be requested if you accept an offer incomplete')
   end
 


### PR DESCRIPTION
## Context

Dynamic back links for continuous applications candidate interface


## Changes proposed in this pull request

1. Move the "Backlinks" methods out of `ViewHelper` and into a concern and include them in `CandidateInterfaceController`.
2. Add `application_form_path` method which will return a path based on whether the user is in continuous applications or not. If continuous apps then point to Your Details page, otherwise point to current application form url.
3. Update `govuk_back_link_to` method to automatically apply "Back to your details" or "Back to your applications" based on the the url pattern.

There is an issue with the Backlinks `application_form_path` method.
The method calls `current_application`. This is a method defined on `CandidateInterfaceController` and made into a `helper_method` there. This method does not become a `helper_method` in isolated view specs however. I've defined the method in `ViewHelper` to fix this. I don't know how else do manage this for now.


Mostly the PR swaps out `candidate_interface_application_form_path` for `application_form_path`.

I think I need to pluralise "Back to your application" but will wait on review feedback. This PR is complicated enough IMO.


## Guidance to review
Are the links pointing to the right target?
Do the links have the correct text?
Should there be more tests? What should be tested?


## Link to Trello card

[Trello Ticket](https://trello.com/c/HjbFc42c/503-ca-update-the-breadcrumbs)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
