### PR TITLE
Add postgresql to .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -2,8 +2,9 @@ ruby 3.1.2
 nodejs 16.13.0
 yarn 1.22.17
 cf 8.4.0
-az 2.36.0
+azure-cli 2.51.0
 jq 1.6
 make 4.2.1
 terraform 1.3.5
 redis 7.0.12
+postgres 14.7


### PR DESCRIPTION
Adds the postgres version currently used in production.
Also updates the version of azure-cli to the latest one. I think this is the correct name instead of az.