### PR TITLE
Pluralise Your applications title

### DIFF
--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -5,7 +5,7 @@ class NavigationItems
     include Rails.application.routes.url_helpers
     include AbstractController::Translation
 
-    def candidate_primary_navigation(current_candidate:, current_controller:, current_application:)
+    def candidate_primary_navigation(current_candidate:, current_controller:)
       return [] unless current_candidate
 
       menu = []
@@ -15,7 +15,7 @@ class NavigationItems
         active?(current_controller, %w[continuous_applications_details])
       )
 
-      application_title = t('page_titles.continuous_applications.your_application', count: current_application.courses.count)
+      application_title = t('page_titles.continuous_applications.your_applications')
 
       menu << NavigationItem.new(
         application_title, candidate_interface_continuous_applications_choices_path,

--- a/app/views/candidate_interface/continuous_applications_choices/index.html.erb
+++ b/app/views/candidate_interface/continuous_applications_choices/index.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
-      <%= t('page_titles.continuous_applications.your_application', count: current_application.courses.count) %>
+      <%= t('page_titles.continuous_applications.your_applications') %>
     </h1>
 
     <%= render CandidateInterface::ApplicationsLeftMessageComponent.new(@application_form_presenter.application_form) %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -9,7 +9,7 @@
   <% if current_candidate %>
     <% if current_candidate.current_application.continuous_applications? %>
       <%= render(PrimaryNavigationComponent.new(
-        items: NavigationItems.candidate_primary_navigation(current_candidate:, current_controller: controller, current_application: current_candidate.current_application),
+        items: NavigationItems.candidate_primary_navigation(current_candidate:, current_controller: controller),
         items_right: [NavigationItems::NavigationItem.new('Sign out', candidate_interface_sign_out_path)],
       )) %>
   <% else %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,10 +66,7 @@ en:
     url_apply_again: https://teacherselect.qualtrics.com/jfe/form/SV_4VHMkFk6TeonVeS
   page_titles:
     continuous_applications:
-      your_application:
-        zero: Your application
-        one: Your application
-        other: Your applications
+      your_applications: Your applications
     application_feedback: How can we improve %{section} section?
     application_form: Your application
     application_dashboard: Your application

--- a/spec/helpers/navigation_items_spec.rb
+++ b/spec/helpers/navigation_items_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe NavigationItems do
   describe '.candidate_primary_navigation', continuous_applications: true do
     context 'when no candidate is provided' do
       it 'renders the correct items' do
-        expect(described_class.candidate_primary_navigation(current_candidate: nil, current_controller: nil, current_application: nil).map(&:text)).to eq([])
+        expect(described_class.candidate_primary_navigation(current_candidate: nil, current_controller: nil).map(&:text)).to eq([])
       end
     end
 
@@ -19,34 +19,7 @@ RSpec.describe NavigationItems do
       end
 
       it 'renders the correct items' do
-        expect(described_class.candidate_primary_navigation(current_candidate:, current_controller:, current_application:).map(&:text)).to eq(['Your details', 'Your application'])
-      end
-    end
-
-    context 'when candidate has zero applications' do
-      let(:current_controller) do
-        instance_double(CandidateInterface::ContinuousApplicationsDetailsController, controller_name: 'continuous_applications_details')
-      end
-      let(:current_candidate) do
-        create(:candidate, application_forms: [create(:application_form, application_choices: [])])
-      end
-
-      it 'renders the correct items' do
-        expect(described_class.candidate_primary_navigation(current_candidate:, current_controller:, current_application:).map(&:text)).to eq(['Your details', 'Your application'])
-      end
-    end
-
-    context 'when candidate has many applications' do
-      let(:current_controller) do
-        instance_double(CandidateInterface::ContinuousApplicationsDetailsController, controller_name: 'continuous_applications_details')
-      end
-      let(:current_candidate) do
-        create(:candidate, application_forms: [create(:application_form, application_choices: [build(:application_choice, :pending_conditions), build(:application_choice, :unsubmitted)])])
-      end
-      let(:current_application) { current_candidate.current_application }
-
-      it 'pluralizes the applications title' do
-        expect(described_class.candidate_primary_navigation(current_candidate:, current_controller:, current_application:).map(&:text)).to eq(['Your details', 'Your applications'])
+        expect(described_class.candidate_primary_navigation(current_candidate:, current_controller:).map(&:text)).to eq(['Your details', 'Your applications'])
       end
     end
   end


### PR DESCRIPTION
## Context

The Primary Navigation contains items Your details and Your application(s). If the candidate has none or one application at least in draft, the navigation item displays singularly. If there is more than one, it pluralises "application".

We've decided it's better to just keep it pluralised even if there's only one or none.

## Changes proposed in this pull request

Change the local file and all call sites for Your applications page_title

## Screenshot
![your-applications](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/a2244e2c-c4cd-4488-99bb-bfc029dc3d9a)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

[Trello Ticket](https://trello.com/c/9nhr6Ure/551-ca-pluralisation-of-your-applications)

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
