### PR TITLE
Users without session can visit the guidance page

### DIFF
--- a/app/controllers/candidate_interface/guidance_controller.rb
+++ b/app/controllers/candidate_interface/guidance_controller.rb
@@ -10,7 +10,9 @@ module CandidateInterface
   private
 
     def set_back_link
-      @back_link = request.referer || application_form_path
+      @back_link = if current_candidate
+                     request.referer || application_form_path
+                   end
     end
   end
 end

--- a/spec/system/candidate_interface/guidance/public_user_spec.rb
+++ b/spec/system/candidate_interface/guidance/public_user_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe 'Non logged in user can visit guidance' do
+  scenario 'User can visit the guidance page without session' do
+    visit(candidate_interface_guidance_path)
+    expect(page).to have_content('Start applying for courses')
+  end
+end


### PR DESCRIPTION
## Context

  The guidance controller sets a back link for authenticated users. Only
  try to establish the authenticated back link if the current_candidate
  exists.

## Changes proposed in this pull request

`@back_link` instance var is unset if the user requesting the guidance page is not authenticated. The method that depends on an authenticated candidate is not called. (`application_form_path`)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

[Trello Ticket](https://trello.com/c/iKh81Wsm/559-bug-guidance-page-error)


## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
