### PR TITLE
Highlight the primary navigation items based on controller path

### DIFF
--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -37,17 +37,17 @@ module CandidateInterface
     # Should the current request be considered as made under the Your
     # applications tab
     def choices_controller?
-      @answer ||= if current_application.continuous_applications?
-                    choices_controllers = Regexp.compile(APPLICATION_CHOICE_CONTROLLER_PATHS.join('|'))
+      @choices_controller ||= if current_application.continuous_applications?
+                                choices_controllers = Regexp.compile(APPLICATION_CHOICE_CONTROLLER_PATHS.join('|'))
 
-                    if controller_path.match?(choices_controllers)
-                      true
-                    elsif controller_path.match('candidate_interface/guidance')
-                      request.referer&.match?('choices')
-                    end
-                  else
-                    false
-                  end
+                                if controller_path.match?(choices_controllers)
+                                  true
+                                elsif controller_path.match('candidate_interface/guidance')
+                                  request.referer&.match?('choices')
+                                end
+                              else
+                                false
+                              end
     end
 
   private

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -2,6 +2,13 @@ module CandidateInterface
   class CandidateInterfaceController < ApplicationController
     include BackLinks
 
+    APPLICATION_CHOICE_CONTROLLER_PATHS = [
+      'continuous_applications_choices', # controller for Your applications
+      'continuous_applications/course_choices', # the course choice wizard
+      'continuous_applications/application_choices', # deleting an application choice
+      'decisions', # withdrawing from a course offer
+    ].freeze
+
     before_action :protect_with_basic_auth
     before_action :authenticate_candidate!
     before_action :set_user_context
@@ -25,6 +32,22 @@ module CandidateInterface
         @google_analytics_id = ENV.fetch('GOOGLE_ANALYTICS_APPLY', '')
         @google_tag_manager_id = ENV.fetch('GOOGLE_TAG_MANAGER_APPLY', '')
       end
+    end
+
+    # Should the current request be considered as made under the Your
+    # applications tab
+    def choices_controller?
+      @answer ||= if current_application.continuous_applications?
+                    choices_controllers = Regexp.compile(APPLICATION_CHOICE_CONTROLLER_PATHS.join('|'))
+
+                    if controller_path.match?(choices_controllers)
+                      true
+                    elsif controller_path.match('candidate_interface/guidance')
+                      request.referer&.match?('choices')
+                    end
+                  else
+                    false
+                  end
     end
 
   private

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -12,14 +12,14 @@ class NavigationItems
 
       menu << NavigationItem.new(
         t('page_titles.your_details'), candidate_interface_continuous_applications_details_path,
-        active?(current_controller, %w[continuous_applications_details])
+        !current_controller.choices_controller?
       )
 
       application_title = t('page_titles.continuous_applications.your_applications')
 
       menu << NavigationItem.new(
         application_title, candidate_interface_continuous_applications_choices_path,
-        active?(current_controller, %w[continuous_applications_choices])
+        current_controller.choices_controller?
       )
     end
 

--- a/spec/helpers/navigation_items_spec.rb
+++ b/spec/helpers/navigation_items_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe NavigationItems do
 
     context 'when candidate is provided' do
       let(:current_controller) do
-        instance_double(CandidateInterface::ContinuousApplicationsDetailsController, controller_name: 'continuous_applications_details')
+        instance_double(CandidateInterface::ContinuousApplicationsDetailsController, controller_name: 'continuous_applications_details', choices_controller?: true)
       end
       let(:current_candidate) do
         create(:candidate, application_forms: [create(:application_form, application_choices: [build(:application_choice, :pending_conditions)])])

--- a/spec/system/candidate_interface/navigation_tabs_spec.rb
+++ b/spec/system/candidate_interface/navigation_tabs_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe 'Primary Navigation' do
+  include CandidateHelper
+  scenario 'highlights the primary navigation' do
+    given_i_am_signed_in
+    when_i_visit_the_application_dashboard
+    then_i_should_see_your_application_as_active
+  end
+
+  scenario 'highlights the primary navigation correct item for continuous applications', continuous_applications: true, js: true do
+    given_i_am_signed_in
+    when_i_visit_the_application_dashboard
+    then_i_should_see_your_details_as_active
+
+    when_i_click_on_personal_information
+    then_i_should_see_your_details_as_active
+
+    when_i_click_on_your_applications
+    then_i_should_see_your_applications_as_active
+
+    when_i_click_on_link_to_guidance
+    then_i_should_see_your_applications_as_active
+
+    when_i_click_on_your_details
+    and_i_click_on_link_to_guidance
+    then_i_should_see_your_details_as_active
+
+    when_i_visit_guidance_page_without_referer
+    then_i_should_see_your_details_as_active
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def when_i_visit_the_application_dashboard
+    visit(candidate_interface_application_form_path)
+  end
+
+  def when_i_click_on_personal_information
+    click_link 'Personal information'
+  end
+
+  def when_i_click_on_your_details
+    click_link 'Your details'
+  end
+
+  def when_i_click_on_your_applications
+    click_link 'Your applications'
+  end
+
+  def when_i_click_on_link_to_guidance
+    click_link 'Read how the application process works'
+  end
+  alias_method :and_i_click_on_link_to_guidance, :when_i_click_on_link_to_guidance
+
+  def then_i_should_see_your_details_as_active
+    expect(page).to have_css('.govuk-link.app-primary-navigation__link[aria-current=page]', text: 'Your details')
+  end
+
+  def then_i_should_see_your_application_as_active
+    expect(page).to have_css('.govuk-link.app-primary-navigation__link[aria-current=page]', text: 'Your application')
+  end
+
+  def then_i_should_see_your_applications_as_active
+    expect(page).to have_css('.govuk-link.app-primary-navigation__link[aria-current=page]', text: 'Your applications')
+  end
+
+  def when_i_visit_guidance_page_without_referer
+    visit(candidate_interface_guidance_path)
+  end
+end


### PR DESCRIPTION
## Context

  The primary navigation items are split between "details" and "applications"
  for continuous applications. All general application form details
  conceptually belong to the "details" tab. All application choice specific
  pages belong to the "applications" tab.

  Create a method that decides which tab should be displayed as active
  based on the current requests controller path.

  For legacy application form, only one tab exists, so the decision
  method returns false always. if continuous applications, check the
  current controller path against a list of matches.

  For guidance, this page can be reached from either tab. if the
  controller is guidance we check the referer matches choices.

## Changes proposed in this pull request

Add `choices_controller?` method to `CandidateInterface::CandidateInterfaceController`. This is used to determine whether the controller processed by the current request should be considered as happening within the "Your applciations" tab in the Candidate Interface.

This method is used to make the Primary Navigation item appear active. If it's not active, then the "Your details" tab is shown as active.

## Guidance to review

Visit pages and subpages and confirm that the corresponding primary navigation appears as active.

## Link to Trello cardTrello Ticket

[Trello Ticket](https://trello.com/c/YDF798We/538-ca-navigation-section-active-for-details-or-application)

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
