### PR TITLE
Add content message about your details are incomplete

### DIFF
--- a/app/components/candidate_interface/applications_left_message_component.rb
+++ b/app/components/candidate_interface/applications_left_message_component.rb
@@ -10,9 +10,20 @@ module CandidateInterface
 
     def initialize(application_form)
       @application_form = application_form
+      @completed_application_form_details = CandidateInterface::CompletedApplicationForm.new(application_form:)
     end
 
     def messages
+      [maximum_number_of_applications_message, incomplete_details_message].flatten.compact
+    end
+
+  private
+
+    def incomplete_details_message
+      t('candidate_interface.applications_left_message.incomplete_details_message') unless @completed_application_form_details.valid?
+    end
+
+    def maximum_number_of_applications_message
       return [default_message] unless submitted?
 
       if maximum_number_of_course_choices?
@@ -24,8 +35,6 @@ module CandidateInterface
         [t('candidate_interface.applications_left_message.can_add_more', applications_left:)]
       end
     end
-
-  private
 
     def default_message
       t('candidate_interface.applications_left_message.default_message', maximum_number_of_course_choices:)

--- a/app/forms/candidate_interface/completed_application_form.rb
+++ b/app/forms/candidate_interface/completed_application_form.rb
@@ -1,0 +1,7 @@
+module CandidateInterface
+  class CompletedApplicationForm
+    include ActiveModel::Model
+    attr_accessor :application_form
+    validates :application_form, your_details_completion: true
+  end
+end

--- a/config/locales/candidate_interface/applications_left_message.yml
+++ b/config/locales/candidate_interface/applications_left_message.yml
@@ -5,3 +5,4 @@ en:
       can_add_more: 'You can add %{applications_left} more applications.'
       can_not_add_more_heading: "You cannot add any more applications because you’re waiting for decisions on %{maximum_number_of_course_choices} others."
       can_not_add_more_message: "If one of your applications is unsuccessful, or you withdraw it, you will be able to add another application."
+      incomplete_details_message: 'You will not be able to submit applications until you have completed your details.'

--- a/spec/components/candidate_interface/applications_left_message_component_spec.rb
+++ b/spec/components/candidate_interface/applications_left_message_component_spec.rb
@@ -7,6 +7,22 @@ RSpec.describe CandidateInterface::ApplicationsLeftMessageComponent, continuous_
     render_inline(described_class.new(application_form)).text
   end
 
+  context 'when details are incomplete' do
+    let(:application_form) { create(:application_form, :minimum_info) }
+
+    it 'returns incomplete details message' do
+      expect(message).to include('You will not be able to submit applications until you have completed your details.')
+    end
+  end
+
+  context 'when details are complete' do
+    let(:application_form) { create(:application_form, :completed) }
+
+    it 'does not return incomplete details message' do
+      expect(message).not_to include('You will not be able to submit applications until you have completed your details.')
+    end
+  end
+
   context 'when unsubmitted' do
     it 'returns default message' do
       expect(message).to include('You can add up to 4 applications at a time.')

--- a/spec/forms/candidate_interface/completed_application_form_spec.rb
+++ b/spec/forms/candidate_interface/completed_application_form_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::CompletedApplicationForm do
+  subject(:completed_application_form) do
+    described_class.new(application_form:)
+  end
+
+  describe 'validations' do
+    context 'when application form is incomplete' do
+      let(:application_form) { create(:application_form, :minimum_info) }
+
+      it 'be invalid' do
+        expect(completed_application_form).not_to be_valid
+      end
+    end
+
+    context 'when application form is complete' do
+      let(:application_form) { create(:application_form, :completed) }
+
+      it 'be valid' do
+        expect(completed_application_form).to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

When a candidate has not completed all sections of ‘Your details’, and they go to the ‘Your applications’ tab, we show the following content:

You can add up to 4 applications at a time.

You will not be able to submit applications until you have completed your details.

The second line disappears if all sections are completed in ‘Your details’
