### PR TITLE
Edit 'Find and Apply' has opened emails and 1 sign in email (continuous applications)

### DIFF
--- a/app/views/authentication_mailer/sign_in_email.text.erb
+++ b/app/views/authentication_mailer/sign_in_email.text.erb
@@ -2,6 +2,6 @@
   Dear <%= @application_form.first_name %>
 <% end %>
 
-Sign in to continue your application for teacher training:
+<%= I18n.t('authentication.sign_in.email.subject') %>:
 
 <%= @magic_link %>

--- a/app/views/candidate_mailer/find_has_opened.erb
+++ b/app/views/candidate_mailer/find_has_opened.erb
@@ -6,11 +6,15 @@ You can now find teacher training courses starting in the <%= @academic_year %> 
 
 [Find your courses](<%= I18n.t('find_postgraduate_teacher_training.production_url') %>).
 
-Apply early to have the best chance of getting onto the course you want, as courses fill up throughout the year.
+You can start preparing your applications and submit them from 9am on <%= @apply_opens %>.
 
-[Get your application ready](<%= candidate_magic_link(@application_form.candidate) %>).
+Courses can fill up quickly, so apply as soon as you can.
 
-You can submit from 9am on <%= @apply_opens %>.
+[Start preparing your applications](<%= candidate_magic_link(@application_form.candidate) %>).
+
+Training providers offer places on courses as people apply throughout the year. Courses stay open until they are full.
+
+[Read how the application process works](<%= candidate_interface_guidance_url %>).
 
 # Get help
 

--- a/app/views/candidate_mailer/new_cycle_has_started.erb
+++ b/app/views/candidate_mailer/new_cycle_has_started.erb
@@ -2,24 +2,26 @@
   Dear <%= @application_form.first_name %>
 <% end %>
 
-You can now apply for teacher training courses which will start in the <%= @academic_year %> academic year.
+You can now apply for teacher training courses that start in the <%= @academic_year %> academic year.
 
-<% unless @application_form.submitted? %>
-Sign into your account to finish and submit your application.
+Courses can fill up quickly, so apply as soon as you’re ready.
 
-[Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>).
-<% end %>
+[Sign into your account to apply for courses](<%= candidate_magic_link(@application_form.candidate) %>).
 
-<% if @application_form.ended_without_success? %>
-Sign into your account to make changes to your previous application and apply again.
+Training providers offer places on courses as people apply throughout the year. Courses stay open until they are full.
 
-[Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>).
-<% end %>
+[Read how the application process works](<%= candidate_interface_guidance_url %>).
 
-# Get help
+# Get a teacher training adviser
 
 A teacher training adviser can help you write a strong application:
 
 [Get a teacher training adviser](<%= email_link_with_utm_params I18n.t('get_into_teaching.url_get_an_adviser_start'), 'new_cycle_has_started', @application_form.phase %>)
 
 All our advisers are experienced former teachers who provide free, one-to-one support and can help you with your personal statement and interview preparation.
+
+# Get help
+
+Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'find_has_opened', @application_form.phase %>)
+
+<%= t('get_into_teaching.opening_times') %>.

--- a/config/locales/candidate_interface/authentication.yml
+++ b/config/locales/candidate_interface/authentication.yml
@@ -11,7 +11,7 @@ en:
     sign_in:
       heading: Sign in
       email:
-        subject: Sign in to continue your application for teacher training
+        subject: Sign in to continue your applications for teacher training
       email_address:
         label: Email address
     sign_in_without_account:

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -613,7 +613,7 @@ RSpec.describe CandidateMailer do
         "Apply for teacher training starting in the #{CycleTimetable.current_year} to #{CycleTimetable.next_year} academic year",
         'greeting' => 'Dear Fred',
         'academic_year' => "#{CycleTimetable.current_year} to #{CycleTimetable.next_year}",
-        'details' => 'Sign into your account to finish and submit your application.',
+        'details' => 'Courses can fill up quickly, so apply as soon as you’re ready.',
       )
     end
 
@@ -627,7 +627,7 @@ RSpec.describe CandidateMailer do
         "Apply for teacher training starting in the #{CycleTimetable.current_year} to #{CycleTimetable.next_year} academic year",
         'greeting' => 'Dear Fred',
         'academic_year' => "#{CycleTimetable.current_year} to #{CycleTimetable.next_year}",
-        'details' => 'Sign into your account to make changes to your previous application and apply again.',
+        'details' => 'Training providers offer places on courses as people apply throughout the year. Courses stay open until they are full.',
       )
     end
 


### PR DESCRIPTION
## Context

We need to edit our emails so they make sense for continuous applications (and some of them are very old so an opportunity to refresh them).

This change relates to the emails we send to candidates when Find and Apply open for the new cycle
It also includes a small change to one of our sign in emails.

## Changes proposed in this pull request

[Trello ticket for find and apply open emails](https://trello.com/c/NlmTYuFx/467-edit-content-for-find-and-apply-has-opened-emails)
Changes:
Edited content to make more sense for continuous applications
Added link to guidance on the applications process
Added appropriate footer to one of the emails

[Trello ticket for sign in email](https://trello.com/c/kbPLJUBT/474-edit-content-on-apply-sign-in-emails)
Small content change to make 'application' plural
I've put this around a feature flag for continuous applications, which James showed me - need to make sure this works.

## Guidance to review

Make sure the code is correct (it was mainly content changes)
If tests break, I might need help fixing them

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
