### PR TITLE
Update inactive at

### DIFF
--- a/app/services/mark_inactive_application.rb
+++ b/app/services/mark_inactive_application.rb
@@ -8,6 +8,9 @@ class MarkInactiveApplication
   end
 
   def call
-    @state_change.inactivate!
+    ActiveRecord::Base.transaction do
+      @state_change.inactivate!
+      application_choice.touch(:inactive_at)
+    end
   end
 end

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -88,6 +88,11 @@ FactoryBot.define do
       status { :unsubmitted }
     end
 
+    trait :inactive do
+      status { :inactive }
+      inactive_at { Time.zone.now }
+    end
+
     trait :application_not_sent do
       status { 'application_not_sent' }
       rejected_at { (created_at || Time.zone.now) + 1.second }

--- a/spec/services/mark_inactive_application_spec.rb
+++ b/spec/services/mark_inactive_application_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe MarkInactiveApplication do
+  subject(:mark_inactive_application) { described_class.new(application_choice:) }
+
+  describe '#call' do
+    let(:application_choice) { create(:application_choice, :awaiting_provider_decision) }
+
+    it 'changes to inactive state' do
+      expect { mark_inactive_application.call }.to change(application_choice, :status).from('awaiting_provider_decision').to('inactive')
+    end
+
+    it 'updates inactive at field', time: Time.zone.local(2023, 11, 10) do
+      expect { mark_inactive_application.call }.to change(application_choice, :inactive_at).from(nil).to(Time.zone.local(2023, 11, 10))
+    end
+  end
+end

--- a/spec/services/process_stale_applications_spec.rb
+++ b/spec/services/process_stale_applications_spec.rb
@@ -40,5 +40,29 @@ RSpec.describe ProcessStaleApplications do
       expect(other_application_choice.reload.status).to eq('awaiting_provider_decision')
       expect(application_choice.reload.status).to eq('inactive')
     end
+
+    it 'does not update already inactive applications' do
+      inactive_at = 1.business_days.ago
+      application_choice = create(
+        :application_choice,
+        :inactive,
+        :continuous_applications,
+        reject_by_default_at: 1.business_days.ago,
+        inactive_at:,
+      )
+      other_application_choice = create(
+        :application_choice,
+        :inactive,
+        :continuous_applications,
+        reject_by_default_at: 1.business_day.ago,
+        inactive_at:,
+      )
+
+      described_class.new.call
+      expect(other_application_choice.reload.status).to eq('inactive')
+      expect(other_application_choice.reload.inactive_at).to eq(inactive_at)
+      expect(application_choice.reload.status).to eq('inactive')
+      expect(application_choice.reload.inactive_at).to eq(inactive_at)
+    end
   end
 end


### PR DESCRIPTION
## Context

When we mark the application as inactive we need to have a field that contains the right time the application was inactive.
So write to this status with a timestamp at the 30 working day inactive mark. Default to nil otherwise.
