### PR TITLE
[450] Reduce production pods cpu_min requests to 0.8

### DIFF
--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -149,7 +149,7 @@ locals {
       cluster_resource_group_name = "s189p01-tsc-pd-rg"
       cluster_resource_prefix     = "s189p01-tsc-production"
       dns_zone_prefix             = null
-      cpu_min                     = 1
+      cpu_min                     = 0.8
     }
   }
   cluster_name = "${local.cluster[var.cluster].cluster_resource_prefix}-aks"


### PR DESCRIPTION
## Context
Optimise VMs of the AKS cluster

## Changes proposed in this pull request
Reduce cpu min allocation to squeeze more containers per VM and allow using fewer VMs.

## Guidance to review
It was reduce globally already in the terraform modules: https://github.com/DFE-Digital/terraform-modules/blob/main/aks/cluster_data/variables.tf

## Link to Trello card
https://trello.com/c/5Jn9potA

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
