### PR TITLE
Show Previous application heading if submitted

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -265,7 +265,7 @@ class ApplicationForm < ApplicationRecord
   end
 
   def candidate_has_previously_applied?
-    previous_application_form_id.present?
+    previous_application_form&.submitted?
   end
 
   def carry_over?

--- a/spec/system/candidate_interface/continuous_applications/carry_over/candidate_carries_over_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/carry_over/candidate_carries_over_spec.rb
@@ -19,6 +19,7 @@ RSpec.feature 'Carry over', continuous_applications: true, sidekiq: true do
 
     when_i_go_to_your_applications_tab
     then_i_should_not_see_the_add_course_button
+    and_i_should_not_see_previous_applications_heading
 
     when_i_visit_add_course_url
     then_i_should_be_redirect_to_your_applications_tab
@@ -50,6 +51,7 @@ RSpec.feature 'Carry over', continuous_applications: true, sidekiq: true do
 
     when_i_go_to_your_applications_tab
     then_i_should_not_see_the_add_course_button
+    and_i_should_not_see_previous_applications_heading
 
     when_i_visit_add_course_url
     then_i_should_be_redirect_to_your_applications_tab
@@ -273,6 +275,14 @@ private
   def then_i_should_not_see_the_add_course_button
     expect(page).not_to have_content('Add application')
     expect(page).to have_content('You can find courses from 9am on 3 October 2023. You can keep making changes to your application until then.')
+  end
+
+  def and_i_should_not_see_previous_applications_heading
+    expect(page).not_to have_content('Previous applications')
+  end
+
+  def and_i_should_see_previous_applications_heading
+    expect(page).to have_content('Previous applications')
   end
 
   def when_i_visit_add_course_url


### PR DESCRIPTION
## Context

Previous applications heading appears in the right sidebar on the Your applications page for legacy applications. In Continuous applications, this component will not be required. Previous application refers to applications from which the current application has been carried over/apply again. There is no such concept in continuous applications.

## Changes proposed in this pull request

Only show the heading if there are previous applications and any of them are submitted. Currently, the heading shows if there are any previous applications, but only applications that are submitted are listed under the heading. 

Now we only show the heading if there are any applications to be listed under the heading.

## Guidance to review

Do you think a test should be written for this?

## Link to Trello card

[Trello Ticket ](https://trello.com/c/bJR9qRKf/569-on-the-your-details-page-there-is-a-heading-for-previous-applications)

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
