### PR TITLE
cycle_strings should return years in ascending order

### DIFF
--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -5,7 +5,7 @@ module RecruitmentCycle
   end
 
   def self.cycle_strings(upto = current_year)
-    2020.upto(upto.to_i).index_with do |year|
+    upto.to_i.downto(2020).index_with do |year|
       "#{year - 1} to #{year}"
     end.stringify_keys
   end

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -8,20 +8,20 @@ RSpec.describe RecruitmentCycle, time: CycleTimetableHelper.mid_cycle(2023) do
 
     it 'returns the cycle strings up to one year from current_year' do
       expect(described_class.cycle_strings).to eq(
-        { '2020' => '2019 to 2020',
-          '2021' => '2020 to 2021',
+        { '2023' => '2022 to 2023',
           '2022' => '2021 to 2022',
-          '2023' => '2022 to 2023' },
+          '2021' => '2020 to 2021',
+          '2020' => '2019 to 2020' },
       )
     end
 
     it 'returns the cycle strings up to the arg year' do
       expect(described_class.cycle_strings(2024)).to eq(
-        { '2020' => '2019 to 2020',
-          '2021' => '2020 to 2021',
-          '2022' => '2021 to 2022',
+        { '2024' => '2023 to 2024',
           '2023' => '2022 to 2023',
-          '2024' => '2023 to 2024' },
+          '2022' => '2021 to 2022',
+          '2021' => '2020 to 2021',
+          '2020' => '2019 to 2020' },
       )
     end
 


### PR DESCRIPTION
## Context

The Recruitment Cycle filter in the support interface shows the years in descending order when they should be in ascending order.

## Changes proposed in this pull request

Reverse the order of the recruitment cycle string method

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)