### PR TITLE
The ‘Continue’ button should navigate back to the ‘Your details’ page

### DIFF
--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -73,7 +73,11 @@ module CandidateInterface
     def redirect_to_new_continuous_applications_if_active
       return unless current_application.continuous_applications?
 
-      if current_application.application_choices.any?
+      completed_application_form = CandidateInterface::CompletedApplicationForm.new(
+        application_form: current_application,
+      )
+
+      if current_application.application_choices.any? && completed_application_form.valid?
         redirect_to candidate_interface_continuous_applications_choices_path
       else
         redirect_to candidate_interface_continuous_applications_details_path

--- a/spec/system/candidate_interface/continuous_applications/entering_details/candidate_marking_section_complete_or_incomplete_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/entering_details/candidate_marking_section_complete_or_incomplete_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.feature 'Marking section as complete or incomplete', continuous_applications: true do
+  include CandidateHelper
+
+  scenario 'when marking section redirects the user' do
+    given_i_have_a_completed_application_form
+    when_i_sign_in
+    and_i_mark_a_section_as_incomplete
+    then_i_should_be_redirected_to_your_details_page
+    when_i_mark_a_section_as_complete
+    and_all_sections_are_complete
+    then_i_should_be_redirected_to_your_applications_page
+  end
+
+  def given_i_have_a_completed_application_form
+    @application_form = create(
+      :application_form,
+      :completed,
+      candidate: current_candidate,
+      submitted_at: nil,
+    )
+    create(:application_choice, :unsubmitted, application_form: @application_form)
+  end
+
+  def when_i_sign_in
+    login_as(current_candidate)
+    visit root_path
+  end
+
+  def and_i_mark_a_section_as_incomplete
+    mark_section(section: 'Declare any safeguarding issues', complete: false)
+  end
+
+  def then_i_should_be_redirected_to_your_details_page
+    expect(page).to have_current_path(candidate_interface_continuous_applications_details_path)
+  end
+
+  def when_i_mark_a_section_as_complete
+    mark_section(section: 'Declare any safeguarding issues', complete: true)
+  end
+
+  def and_all_sections_are_complete
+    completed_application_form = CandidateInterface::CompletedApplicationForm.new(application_form: @application_form)
+    expect(completed_application_form).to be_valid
+  end
+
+  def then_i_should_be_redirected_to_your_applications_page
+    expect(page).to have_current_path candidate_interface_continuous_applications_choices_path
+  end
+
+  def mark_section(section:, complete:)
+    complete_choice = complete.present? ? 'Yes, I have completed this section' : 'No, I’ll come back to it later'
+    click_on 'Your details'
+    click_link section
+    choose(complete_choice)
+    click_on 'Continue'
+  end
+end


### PR DESCRIPTION
## Context

When someone has an application in draft and tries to update details we were redirecting to the your applications but we should only redirect the candidate to your applications when they are ready to submit

## Steps to replicate the issue prior to the PR

1. Continuus applications feature flag is on
2. Cycle is switched to new 2024 cycle
3. I went to user with a draft application
4. I went to ‘Your applications’ tab where I saw content telling me I cannot submit because I need to complete all my details
5. I went back to ‘Your details’ tab
6. I saw that ‘Ask for support if you’re disabled' was marked as Incomplete
7. I clicked into that section and saw review page
8. I checked the ‘this section is complete’ radio
9. I clicked the ‘Continue’ button
10. The continue button navigated me to the ‘Your applications’ tab