### PR TITLE
Add inactive ApplicationChoice status VendorAPI

### DIFF
--- a/app/presenters/vendor_api/application_presenter.rb
+++ b/app/presenters/vendor_api/application_presenter.rb
@@ -9,6 +9,7 @@ module VendorAPI
     include HesaIttDataAPIData
 
     API_APPLICATION_STATES = { offer_withdrawn: 'rejected',
+                               inactive: 'awaiting_provider_decision',
                                interviewing: 'awaiting_provider_decision' }.freeze
     CACHE_EXPIRES_IN = 1.day
 

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -2,7 +2,7 @@ class ApplicationStateChange
   include Workflow
 
   STATES_NOT_VISIBLE_TO_PROVIDER = %i[unsubmitted cancelled application_not_sent].freeze
-  STATES_VISIBLE_TO_PROVIDER = %i[awaiting_provider_decision interviewing offer pending_conditions recruited rejected declined withdrawn conditions_not_met offer_withdrawn offer_deferred].freeze
+  STATES_VISIBLE_TO_PROVIDER = %i[awaiting_provider_decision interviewing offer pending_conditions recruited rejected declined withdrawn conditions_not_met offer_withdrawn offer_deferred inactive].freeze
 
   INTERVIEWABLE_STATES = %i[awaiting_provider_decision interviewing].freeze
   ACCEPTED_STATES = %i[pending_conditions conditions_not_met recruited offer_deferred].freeze

--- a/spec/components/provider_interface/application_timeline_component_spec.rb
+++ b/spec/components/provider_interface/application_timeline_component_spec.rb
@@ -258,6 +258,6 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
   end
 
   it 'has a title for all state transitions' do
-    expect(ApplicationStateChange.states_visible_to_provider).to match_array(ProviderInterface::ApplicationTimelineComponent::TITLES.keys.map(&:to_sym))
+    expect(ApplicationStateChange.states_visible_to_provider - %i[inactive]).to match_array(ProviderInterface::ApplicationTimelineComponent::TITLES.keys.map(&:to_sym))
   end
 end

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -88,11 +88,6 @@ FactoryBot.define do
       status { :unsubmitted }
     end
 
-    trait :inactive do
-      status { :inactive }
-      inactive_at { Time.zone.now }
-    end
-
     trait :application_not_sent do
       status { 'application_not_sent' }
       rejected_at { (created_at || Time.zone.now) + 1.second }
@@ -168,6 +163,8 @@ FactoryBot.define do
     end
 
     trait :awaiting_provider_decision do
+      with_submitted_application_form
+
       status { :awaiting_provider_decision }
 
       reject_by_default_days { 40 }
@@ -284,6 +281,13 @@ FactoryBot.define do
       rejected_by_default { true }
       rejection_reason { nil }
       rejection_reasons_type { nil }
+    end
+
+    trait :inactive do
+      with_completed_application_form
+
+      status { 'inactive' }
+      inactive_at { Time.zone.now }
     end
 
     trait :rejected_by_default_with_feedback do

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -108,6 +108,11 @@ FactoryBot.define do
       decline_by_default_days { 10 }
     end
 
+    # aliased name to match the status
+    trait :offer do
+      offered
+    end
+
     trait :course_changed do
       current_course_option do
         other_courses = course_option.provider.courses

--- a/spec/requests/vendor_api/v1.0/get_status_for_applications_spec.rb
+++ b/spec/requests/vendor_api/v1.0/get_status_for_applications_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe 'Vendor API - GET /api/v1.0/applications' do
+  include VendorAPISpecHelpers
+  include CourseOptionHelpers
+
+  it 'returns correct list of mapped API application statuses' do
+    expected_statuses = [
+      'awaiting_provider_decision',
+      'awaiting_provider_decision', # inactive mapped to awaiting_provider_decision
+      'awaiting_provider_decision', # interview mapped to awaiting_provider_decision
+      'conditions_not_met',
+      'declined',
+      'offer',
+      'offer_deferred',
+      'pending_conditions',
+      'recruited',
+      'rejected', # rejected mapped to offer_withdrawn
+      'rejected',
+      'withdrawn',
+    ]
+
+    # Statuses we expect ot have been created in the test setup
+    actual_statuses = %w[
+      awaiting_provider_decision
+      conditions_not_met
+      declined
+      inactive
+      interviewing
+      offer
+      offer_deferred
+      offer_withdrawn
+      pending_conditions
+      recruited
+      rejected
+      withdrawn
+    ]
+
+    # The API is not concerned with unsubmitted applications.
+    statuses = ApplicationStateChange.states_visible_to_provider - %w[unsubmitted]
+
+    statuses.each do |status|
+      create(:application_choice, status, course_option: course_option_for_provider(provider: currently_authenticated_provider))
+    end
+
+    # Make sure the test creates the full variety of statuses
+    expect(ApplicationChoice.pluck(:status)).to match_array(actual_statuses)
+
+    get_api_request '/api/v1.3/applications', params: { since: 1.year.ago.iso8601 }
+
+    api_response_statuses = response.parsed_body['data'].map { |a| a.dig('attributes', 'status') }
+    expect(api_response_statuses).to match_array(expected_statuses)
+  end
+end

--- a/spec/services/application_state_change_spec.rb
+++ b/spec/services/application_state_change_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ApplicationStateChange do
     describe '.states_visible_to_provider' do
       it 'matches the valid states and states not visible' do
         expect(described_class.states_visible_to_provider)
-          .to match_array(described_class.valid_states - described_class::STATES_NOT_VISIBLE_TO_PROVIDER - %i[inactive])
+          .to match_array(described_class.valid_states - described_class::STATES_NOT_VISIBLE_TO_PROVIDER)
       end
     end
   end
@@ -32,7 +32,7 @@ RSpec.describe ApplicationStateChange do
     it 'has corresponding entries in the OpenAPI spec - excluding the interview state' do
       valid_states_in_openapi = VendorAPISpecification.new.as_hash['components']['schemas']['ApplicationAttributes']['properties']['status']['enum']
 
-      expect(described_class.states_visible_to_provider_without_deferred - %i[interviewing offer_withdrawn])
+      expect(described_class.states_visible_to_provider_without_deferred - %i[interviewing offer_withdrawn inactive])
         .to match_array(valid_states_in_openapi.map(&:to_sym) - %i[offer_deferred])
     end
   end

--- a/spec/services/provider_interface/sort_application_choices_spec.rb
+++ b/spec/services/provider_interface/sort_application_choices_spec.rb
@@ -170,8 +170,10 @@ RSpec.describe ProviderInterface::SortApplicationChoices, time: Time.zone.local(
     end
 
     it 'sorts by updated_at DESC if not awaiting_provider_decision' do
-      choice_one = create(:application_choice, :offer, reject_by_default_at: 1.day.from_now.end_of_day, updated_at: 2.minutes.ago)
-      choice_two = create(:application_choice, :offer, reject_by_default_at: 2.days.from_now.end_of_day, updated_at: 1.minute.ago)
+      choice_one = create(:application_choice, :offer, reject_by_default_at: 1.day.from_now.end_of_day)
+      choice_one.update(updated_at: 2.minutes.ago)
+      choice_two = create(:application_choice, :offer, reject_by_default_at: 2.days.from_now.end_of_day)
+      choice_two.update(updated_at: 1.minute.ago)
 
       expect(described_class.call(application_choices: ApplicationChoice.all)).to eq [choice_two, choice_one]
     end

--- a/spec/system/provider_interface/provider_application_filter_by_subject_spec.rb
+++ b/spec/system/provider_interface/provider_application_filter_by_subject_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe 'Providers should be able to filter applications by subject', js:
   def then_i_should_only_see_provider_applications_related_to_the_subjects
     expect(page).to have_content("Applications (#{@other_math_applications.count})")
 
-    @math_applications.each do |application|
+    @other_math_applications.each do |application|
       expect(page).to have_content(application.application_form.full_name)
     end
   end


### PR DESCRIPTION
## Context

The next recruitment cycle introduces the inactive status to ApplicationChoices. When an application is submitted and the provider doesn't respond within 20-30 days, the application is marked as inactive.

The VendorAPI serves relevant data to the providers. The providers will want to see the applications that have been marked as inactive. However, we do not want the providers to see the status `inactive`. We map the application choice status `inactive` to `awaiting_provider_decision` when returning the application choice in the VendorAPI.

## Changes proposed in this pull request

 - Map `inactive` to `awaiting_provider_decision` in the VendorAPI
 - Alias ApplicationChoice factory trait `offered` to `offer` so it's easy to iterate over the various application choice states and create corresponding factories with those states
 - Add a comprehensive test demonstrating that the VendorAPI returns the correct status` for each application choice state.
 - Fix a false positive test. The test was generating application forms and asserting that the full name on the form was present in the UI. The forms were being created without first_name and last_name however. This means that the test asserted that " " was present on the page.


## Guidance to review

More work is needed to clear up the constants in the `ApplicationStateChange` file. States that are "visible" to providers in one sense may not be compatible with visible in another sense.

## Link to Trello card

[Trello Ticket](https://trello.com/c/JsaWjn5o/360-ca-add-inactive-status-to-vendor-api)

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)

