### PR TITLE
Add a time to chase references spec

### DIFF
--- a/spec/services/get_referees_to_chase_spec.rb
+++ b/spec/services/get_referees_to_chase_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe GetRefereesToChase do
       end
     end
 
-    context 'when application is recruited or offer deferred' do
+    context 'when application is recruited or offer deferred', time: mid_cycle(2023) do
       it 'returns references to chase' do
         application_form = create(:application_form, :minimum_info, recruitment_cycle_year: 2023)
         reference = create(:reference, :feedback_requested, application_form:, requested_at: 8.days.ago)

--- a/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Entering their other qualifications', mid_cycle: false do
+RSpec.feature 'Entering their other qualifications', mid_cycle: true do
   include CandidateHelper
 
   scenario 'Candidate submits their other qualifications' do


### PR DESCRIPTION
## Context

The tests were failing the ones that runs 7 days in the future.

The reason is because the tests set (or didn't set!) the proper time to run those.

The time between apply one deadline and find opens is already tested and these specs needs to be run anytime during midcycle

