### PR TITLE
Add keys dates to our build to check if specs fail or not

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -187,7 +187,7 @@ jobs:
       matrix:
         tests: [ unit_shared, unit_candidate-provider, unit_support-referee-api, integration_shared, integration_provider, integration_candidate ]
         feature-flags: [on, off]
-        offset-date: [real_world, 7.days.from_now]
+        offset-date: [real_world, 7.days.from_now, '2023-09-20 09:00:00', '2023-10-04 09:00:00', '2023-10-11 09:00:00']
         include:
           - tests: unit_shared
             include-pattern: spec/.*_spec.rb


### PR DESCRIPTION
## Context 

I am creating this PR to check if the specs will fail in important dates.

Running the tests simulating we are on these key dates:

* 1 day after Apply 2 deadline
* 1 day after Find opens (my birthday!)
* 1 day after Apply opens
