### PR TITLE
Fix carried-over application references complete bug

### DIFF
--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -83,7 +83,8 @@ class DuplicateApplication
         change_references_to_not_requested_yet(references_cancelled_at_eoc)
       end
 
-      new_application_form.update!(references_completed: apply_again?)
+      references_completed = apply_again? && new_application_form.complete_references_information?
+      new_application_form.update!(references_completed:)
 
       original_application_form.application_work_history_breaks.each do |w|
         new_application_form.application_work_history_breaks.create!(

--- a/spec/services/duplicate_application_spec.rb
+++ b/spec/services/duplicate_application_spec.rb
@@ -98,5 +98,49 @@ RSpec.describe DuplicateApplication do
         expect(duplicate_application_form.subject_knowledge).to be_nil
       end
     end
+
+    context 'when the candidate has cancelled references' do
+      context 'all references are cancelled' do
+        before do
+          @original_application_form.application_references.each(&:cancelled!)
+        end
+
+        it 'does not transfer any references' do
+          expect(duplicate_application_form.application_references.count).to eq 0
+        end
+
+        it 'marks reference as incomplete' do
+          expect(duplicate_application_form).not_to be_references_completed
+        end
+      end
+
+      context 'some references are cancelled and candidate has one valid' do
+        before do
+          @original_application_form.application_references[1..].each(&:cancelled!)
+        end
+
+        it 'transfers one reference' do
+          expect(duplicate_application_form.application_references.count).to eq 1
+        end
+
+        it 'marks reference as incomplete' do
+          expect(duplicate_application_form).not_to be_references_completed
+        end
+      end
+
+      context 'some references are cancelled but candidate still has two valid' do
+        before do
+          @original_application_form.application_references.last.cancelled!
+        end
+
+        it 'transfers two references' do
+          expect(duplicate_application_form.application_references.count).to eq 2
+        end
+
+        it 'marks reference as complete' do
+          expect(duplicate_application_form).to be_references_completed
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

The bug was that if an application was duplicated, the references section would be marked as complete even if fewer than two references were transferred over.

## Changes proposed in this pull request

Mark referrals as complete only if the new application has at least two referrals.