### PR TITLE
Secure Continuous Applications endpoints from legacy applications

### DIFF
--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -70,6 +70,10 @@ module CandidateInterface
       redirect_to candidate_interface_application_offer_dashboard_path if any_accepted_offer? || current_application.recruited?
     end
 
+    def render_error_if_continuous_applications_active
+      render_404 && return if current_application.continuous_applications?
+    end
+
     def redirect_to_new_continuous_applications_if_active
       return unless current_application.continuous_applications?
 

--- a/app/controllers/candidate_interface/course_choices/course_decision_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/course_decision_controller.rb
@@ -42,6 +42,9 @@ module CandidateInterface
         case action
         when /ask/
           redirect_to candidate_interface_continuous_applications_do_you_know_the_course_path
+        when /go_to_find/
+          redirect_to candidate_interface_continuous_applications_go_to_find_explanation_path
+        end
       end
     end
   end

--- a/app/controllers/candidate_interface/course_choices/course_decision_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/course_decision_controller.rb
@@ -3,7 +3,7 @@ module CandidateInterface
     class CourseDecisionController < BaseController
       include AdviserStatus
 
-      before_action { redirect_to_continuous_applications(action_name) }
+      before_action { redirect_to_continuous_applications(action_name) if current_application.continuous_applications? }
 
       def ask
         set_backlink

--- a/app/controllers/candidate_interface/course_choices/course_decision_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/course_decision_controller.rb
@@ -3,6 +3,8 @@ module CandidateInterface
     class CourseDecisionController < BaseController
       include AdviserStatus
 
+      before_action { redirect_to_continuous_applications(action_name) }
+
       def ask
         set_backlink
         @choice_form = CandidateInterface::CourseChosenForm.new
@@ -34,6 +36,12 @@ module CandidateInterface
                     else
                       candidate_interface_application_form_path
                     end
+      end
+
+      def redirect_to_continuous_applications(action)
+        case action
+        when /ask/
+          redirect_to candidate_interface_continuous_applications_do_you_know_the_course_path
       end
     end
   end

--- a/app/controllers/candidate_interface/course_choices/course_selection_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/course_selection_controller.rb
@@ -1,6 +1,8 @@
 module CandidateInterface
   module CourseChoices
     class CourseSelectionController < BaseController
+      before_action { redirect_to_continuous_applications(action_name) }
+
       def new
         @pick_course = PickCourseForm.new(
           provider_id: params.fetch(:provider_id),
@@ -129,6 +131,13 @@ module CandidateInterface
         if application_form.contains_course? course
           flash[:info] = I18n.t!('errors.application_choices.already_added', course_name_and_code: course.name_and_code)
           redirect_to candidate_interface_course_choices_review_path
+        end
+      end
+
+      def redirect_to_continuous_applications(action)
+        case action
+        when /new/
+          redirect_to candidate_interface_continuous_applications_which_course_are_you_applying_to_path(params['provider_id'])
         end
       end
     end

--- a/app/controllers/candidate_interface/course_choices/course_selection_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/course_selection_controller.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   module CourseChoices
     class CourseSelectionController < BaseController
-      before_action { redirect_to_continuous_applications(action_name) }
+      before_action { redirect_to_continuous_applications(action_name) if current_application.continuous_applications? }
 
       def new
         @pick_course = PickCourseForm.new(

--- a/app/controllers/candidate_interface/course_choices/provider_selection_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/provider_selection_controller.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   module CourseChoices
     class ProviderSelectionController < BaseController
-      before_action { redirect_to_continuous_applications(action_name) }
+      before_action { redirect_to_continuous_applications(action_name) if current_application.continuous_applications? }
 
       def new
         @pick_provider = PickProviderForm.new

--- a/app/controllers/candidate_interface/course_choices/provider_selection_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/provider_selection_controller.rb
@@ -1,6 +1,8 @@
 module CandidateInterface
   module CourseChoices
     class ProviderSelectionController < BaseController
+      before_action { redirect_to_continuous_applications(action_name) }
+
       def new
         @pick_provider = PickProviderForm.new
         @provider_cache_key = "provider-list-#{Provider.maximum(:updated_at)}"
@@ -13,6 +15,15 @@ module CandidateInterface
         render :new and return unless @pick_provider.valid?
 
         redirect_to candidate_interface_course_choices_course_path(@pick_provider.provider_id)
+      end
+
+    private
+
+      def redirect_to_continuous_applications(action)
+        case action
+        when /new/
+          redirect_to candidate_interface_continuous_applications_provider_selection_path
+        end
       end
     end
   end

--- a/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
@@ -2,6 +2,7 @@ module CandidateInterface
   class UnsubmittedApplicationFormController < CandidateInterfaceController
     before_action :redirect_to_dashboard_if_submitted
     before_action :redirect_to_application_if_between_cycles, except: %w[show review]
+    before_action :render_error_if_continuous_applications_active, only: %w[submit]
     before_action :redirect_to_new_continuous_applications_if_active, only: %w[show]
     before_action :redirect_to_carry_over, except: %w[review]
     before_action :set_unavailable_courses, only: %w[review submit_show]

--- a/spec/requests/candidate_interface/continuous_applications_choose_course_spec.rb
+++ b/spec/requests/candidate_interface/continuous_applications_choose_course_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'continuous applications redirects', continuous_applications: true do
+RSpec.describe 'continuous applications redirects' do
   include Devise::Test::IntegrationHelpers
   let(:candidate) { create(:candidate) }
 
@@ -8,36 +8,74 @@ RSpec.describe 'continuous applications redirects', continuous_applications: tru
     sign_in candidate
   end
 
-  describe 'choose' do
-    it 'redirects choose to continuous applications' do
-      get candidate_interface_course_choices_choose_path
+  context 'when continuous applications', continuous_applications: true do
+    describe 'choose' do
+      it 'redirects choose to continuous applications' do
+        get candidate_interface_course_choices_choose_path
 
-      expect(response).to redirect_to(candidate_interface_continuous_applications_do_you_know_the_course_path)
+        expect(response).to redirect_to(candidate_interface_continuous_applications_do_you_know_the_course_path)
+      end
+    end
+
+    describe 'find' do
+      it 'redirects find to continuous applications' do
+        get candidate_interface_go_to_find_path
+
+        expect(response).to redirect_to(candidate_interface_continuous_applications_go_to_find_explanation_path)
+      end
+    end
+
+    describe 'provider' do
+      it 'redirects to provider continuous applications' do
+        get candidate_interface_course_choices_provider_path
+        expect(response).to redirect_to(candidate_interface_continuous_applications_provider_selection_path)
+      end
+    end
+
+    describe 'course selection' do
+      let(:provider) { create(:provider) }
+
+      it 'redirects to provider continuous applications' do
+        get candidate_interface_course_choices_course_path(provider.id)
+
+        expect(response).to redirect_to(candidate_interface_continuous_applications_which_course_are_you_applying_to_path(provider.id))
+      end
     end
   end
 
-  describe 'find' do
-    it 'redirects find to continuous applications' do
-      get candidate_interface_go_to_find_path
+  context 'when not continuous applications', continuous_applications: false do
+    describe 'choose' do
+      it 'redirects choose to continuous applications' do
+        get candidate_interface_course_choices_choose_path
 
-      expect(response).to redirect_to(candidate_interface_continuous_applications_go_to_find_explanation_path)
+        expect(response).not_to redirect_to(candidate_interface_continuous_applications_do_you_know_the_course_path)
+      end
     end
-  end
 
-  describe 'provider' do
-    it 'redirects to provider continuous applications' do
-      get candidate_interface_course_choices_provider_path
-      expect(response).to redirect_to(candidate_interface_continuous_applications_provider_selection_path)
+    describe 'find' do
+      it 'redirects find to continuous applications' do
+        get candidate_interface_go_to_find_path
+
+        expect(response).not_to redirect_to(candidate_interface_continuous_applications_go_to_find_explanation_path)
+      end
     end
-  end
 
-  describe 'course selection' do
-    let(:provider) { create(:provider) }
+    describe 'provider' do
+      it 'redirects to provider continuous applications' do
+        get candidate_interface_course_choices_provider_path
 
-    it 'redirects to provider continuous applications' do
-      get candidate_interface_course_choices_course_path(provider.id)
+        expect(response).not_to redirect_to(candidate_interface_continuous_applications_provider_selection_path)
+      end
+    end
 
-      expect(response).to redirect_to(candidate_interface_continuous_applications_which_course_are_you_applying_to_path(provider.id))
+    describe 'course selection' do
+      let(:provider) { create(:provider) }
+
+      it 'redirects to provider continuous applications' do
+        get candidate_interface_course_choices_course_path(provider.id)
+
+        expect(response).not_to redirect_to(candidate_interface_continuous_applications_which_course_are_you_applying_to_path(provider.id))
+      end
     end
   end
 end

--- a/spec/requests/candidate_interface/continuous_applications_choose_course_spec.rb
+++ b/spec/requests/candidate_interface/continuous_applications_choose_course_spec.rb
@@ -23,4 +23,11 @@ RSpec.describe 'continuous applications redirects', continuous_applications: tru
       expect(response).to redirect_to(candidate_interface_continuous_applications_go_to_find_explanation_path)
     end
   end
+
+  describe 'provider' do
+    it 'redirects to provider continuous applications' do
+      get candidate_interface_course_choices_provider_path
+      expect(response).to redirect_to(candidate_interface_continuous_applications_provider_selection_path)
+    end
+  end
 end

--- a/spec/requests/candidate_interface/continuous_applications_choose_course_spec.rb
+++ b/spec/requests/candidate_interface/continuous_applications_choose_course_spec.rb
@@ -15,4 +15,12 @@ RSpec.describe 'continuous applications redirects', continuous_applications: tru
       expect(response).to redirect_to(candidate_interface_continuous_applications_do_you_know_the_course_path)
     end
   end
+
+  describe 'find' do
+    it 'redirects find to continuous applications' do
+      get candidate_interface_go_to_find_path
+
+      expect(response).to redirect_to(candidate_interface_continuous_applications_go_to_find_explanation_path)
+    end
+  end
 end

--- a/spec/requests/candidate_interface/continuous_applications_choose_course_spec.rb
+++ b/spec/requests/candidate_interface/continuous_applications_choose_course_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe 'continuous applications redirects', continuous_applications: true do
+  include Devise::Test::IntegrationHelpers
+  let(:candidate) { create(:candidate) }
+
+  before do
+    sign_in candidate
+  end
+
+  describe 'choose' do
+    it 'redirects choose to continuous applications' do
+      get candidate_interface_course_choices_choose_path
+
+      expect(response).to redirect_to(candidate_interface_continuous_applications_do_you_know_the_course_path)
+    end
+  end
+end

--- a/spec/requests/candidate_interface/continuous_applications_choose_course_spec.rb
+++ b/spec/requests/candidate_interface/continuous_applications_choose_course_spec.rb
@@ -30,4 +30,14 @@ RSpec.describe 'continuous applications redirects', continuous_applications: tru
       expect(response).to redirect_to(candidate_interface_continuous_applications_provider_selection_path)
     end
   end
+
+  describe 'course selection' do
+    let(:provider) { create(:provider) }
+
+    it 'redirects to provider continuous applications' do
+      get candidate_interface_course_choices_course_path(provider.id)
+
+      expect(response).to redirect_to(candidate_interface_continuous_applications_which_course_are_you_applying_to_path(provider.id))
+    end
+  end
 end

--- a/spec/requests/candidate_interface/continuous_applications_reject_legacy_submits_spec.rb
+++ b/spec/requests/candidate_interface/continuous_applications_reject_legacy_submits_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe 'legacy applications cannot submit to continuous apps' do
+  include Devise::Test::IntegrationHelpers
+  let(:candidate) { create(:candidate, application_forms: [create(:application_form, :completed, application_choices_count: 1)]) }
+  let(:application) { candidate.application_forms.last }
+  let(:choice) { application.application_choices.last }
+
+  before { sign_in candidate }
+
+  context 'when continuous applications', continuous_applications: true do
+    it 'be successful' do
+      post candidate_interface_continuous_applications_submit_course_choice_path(choice.id), params: {
+        candidate_interface_continuous_applications_submit_application_form: { submit_answer: true },
+      }
+      expect(response).to redirect_to(candidate_interface_continuous_applications_choices_path)
+    end
+  end
+
+  context 'when not continuous applications', continuous_applications: false do
+    it 'be not found' do
+      post candidate_interface_continuous_applications_submit_course_choice_path(choice.id)
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/requests/candidate_interface/continuous_applications_reject_legacy_submits_spec.rb
+++ b/spec/requests/candidate_interface/continuous_applications_reject_legacy_submits_spec.rb
@@ -2,25 +2,43 @@ require 'rails_helper'
 
 RSpec.describe 'legacy applications cannot submit to continuous apps' do
   include Devise::Test::IntegrationHelpers
-  let(:candidate) { create(:candidate, application_forms: [create(:application_form, :completed, application_choices_count: 1)]) }
+  let(:candidate) { create(:candidate, application_forms: [create(:application_form, :completed, submitted_at: nil, application_choices_count: 1)]) }
   let(:application) { candidate.application_forms.last }
   let(:choice) { application.application_choices.last }
 
   before { sign_in candidate }
 
   context 'when continuous applications', continuous_applications: true do
-    it 'be successful' do
-      post candidate_interface_continuous_applications_submit_course_choice_path(choice.id), params: {
-        candidate_interface_continuous_applications_submit_application_form: { submit_answer: true },
-      }
-      expect(response).to redirect_to(candidate_interface_continuous_applications_choices_path)
+    context 'when submitting to continuous applications' do
+      it 'be successful' do
+        post candidate_interface_continuous_applications_submit_course_choice_path(choice.id), params: {
+          candidate_interface_continuous_applications_submit_application_form: { submit_answer: true },
+        }
+        expect(response).to redirect_to(candidate_interface_continuous_applications_choices_path)
+      end
+    end
+
+    context 'when submitting to legacy applications endpoint' do
+      it 'be not found' do
+        post candidate_interface_application_submit_path
+        expect(response).to have_http_status(:not_found)
+      end
     end
   end
 
   context 'when not continuous applications', continuous_applications: false do
-    it 'be not found' do
-      post candidate_interface_continuous_applications_submit_course_choice_path(choice.id)
-      expect(response).to have_http_status(:not_found)
+    context 'when submitting to continuous applications' do
+      it 'be not found' do
+        post candidate_interface_continuous_applications_submit_course_choice_path(choice.id)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when submitting to legacy applications endpoint' do
+      it 'be redirect' do
+        post candidate_interface_application_submit_path
+        expect(response).to redirect_to(candidate_interface_feedback_form_path)
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

While candidates are still in the 2023 (legacy) applications cycle, the continuous applications endpoints should all be unavailable.
When candidates are in 2024 (continuous) application cycle, the legacy applications endpoints should all be unavailable.

## Changes proposed in this pull request

Add non-successful responses to continuous applications endpoints if the current candidate is in the legacy cycle.

1. Prevent continuous applications candidates from accessing the legacy course choice wizard.
2. Prevent legacy applications candidates from accessing the continuous applications course choice wizard.

 - `GET` endpoints should `redirect` to a suitable legacy alternative
 - `POST` endpoints return `not_found`

## Guidance to review

Feedback on assumptions outlined above.
Are there other endpoints that need to be tested and secured?

## Link to Trello card

[Trello Ticket](https://trello.com/c/fja0sXkH/448-ca-ensure-the-functionality-is-securely-used-as-intended)

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)