### PR TITLE
Introduce word count on withdrawal feedback

### DIFF
--- a/app/forms/candidate_interface/feedback_form.rb
+++ b/app/forms/candidate_interface/feedback_form.rb
@@ -3,6 +3,7 @@ module CandidateInterface
     include ActiveModel::Model
 
     attr_accessor :satisfaction_level, :suggestions
+    validates :suggestions, word_count: { maximum: 500 }
 
     def save(application_form)
       return false unless valid?

--- a/app/forms/candidate_interface/withdrawal_feedback_form.rb
+++ b/app/forms/candidate_interface/withdrawal_feedback_form.rb
@@ -4,6 +4,7 @@ module CandidateInterface
     CONFIG_PATH = 'config/withdrawal_reasons.yml'.freeze
 
     attr_accessor :selected_reasons, :explanation
+    validates :explanation, word_count: { maximum: 500 }
 
     def save(application_choice)
       if valid?

--- a/app/views/candidate_interface/decisions/withdrawal_feedback.html.erb
+++ b/app/views/candidate_interface/decisions/withdrawal_feedback.html.erb
@@ -20,7 +20,7 @@
       <% end %>
     <% end %>
 
-    <%= f.govuk_text_area :explanation, label: { text: 'Is there anything else you would like to tell us? (optional)', size: 'm' }, hint: { text: "This will not be shared with #{@provider.name}." } %>
+    <%= f.govuk_text_area :explanation, label: { text: 'Is there anything else you would like to tell us? (optional)', size: 'm' }, hint: { text: "This will not be shared with #{@provider.name}." }, max_words: 500 %>
 
     <%= f.govuk_submit t('continue') %>
   <% end %>

--- a/app/views/candidate_interface/feedback_form/new.html.erb
+++ b/app/views/candidate_interface/feedback_form/new.html.erb
@@ -13,7 +13,7 @@
           <%= f.govuk_radio_button :satisfaction_level, value, label: { text: t("satisfaction_levels.#{value}") }, link_errors: i.zero? %>
         <% end %>
       <% end %>
-      <%= f.govuk_text_area :suggestions, label: { text: 'How could we improve this service? (optional)', size: 'm' }, rows: 8, max_words: 1200 %>
+      <%= f.govuk_text_area :suggestions, label: { text: 'How could we improve this service? (optional)', size: 'm' }, rows: 8, max_words: 500 %>
       <%= f.govuk_submit 'Continue' %>
     <% end %>
   </div>

--- a/config/locales/candidate_interface/feedback.yml
+++ b/config/locales/candidate_interface/feedback.yml
@@ -1,0 +1,9 @@
+en:
+  activemodel:
+    errors:
+      models:
+        candidate_interface/feedback_form:
+          attributes:
+            suggestions:
+              too_many_words: Your feedback must be %{maximum} words or fewer
+

--- a/config/locales/candidate_interface/withdrawal_feedback.yml
+++ b/config/locales/candidate_interface/withdrawal_feedback.yml
@@ -1,0 +1,9 @@
+en:
+  activemodel:
+    errors:
+      models:
+        candidate_interface/withdrawal_feedback_form:
+          attributes:
+            explanation:
+              too_many_words: Your withdrawal feedback must be %{maximum} words or fewer
+

--- a/spec/forms/candidate_interface/feedback_form_spec.rb
+++ b/spec/forms/candidate_interface/feedback_form_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::FeedbackForm, type: :model do
+  describe '#save' do
+    let(:application_form) { create(:application_form) }
+
+    it 'updates the application form with the satisfaction level and feedback if the form is valid' do
+      feedback_form = described_class.new(satisfaction_level: 'very_satisfied', suggestions: 'example')
+      feedback_form.save(application_form)
+
+      expect(application_form.feedback_satisfaction_level).to eq('very_satisfied')
+      expect(application_form.feedback_suggestions).to eq('example')
+    end
+
+    it 'accepts submission without values present in the optional fields' do
+      feedback_form = described_class.new(satisfaction_level: nil, suggestions: nil)
+
+      expect(feedback_form.save(application_form)).to be true
+
+      expect(application_form.feedback_satisfaction_level).to be_nil
+      expect(application_form.feedback_suggestions).to be_nil
+    end
+  end
+
+  describe 'validations' do
+    valid_text = Faker::Lorem.sentence(word_count: 500)
+    invalid_text = Faker::Lorem.sentence(word_count: 501)
+
+    it { is_expected.to allow_value(valid_text).for(:suggestions) }
+    it { is_expected.not_to allow_value(invalid_text).for(:suggestions) }
+  end
+end

--- a/spec/forms/candidate_interface/withdrawal_feedback_form_spec.rb
+++ b/spec/forms/candidate_interface/withdrawal_feedback_form_spec.rb
@@ -33,4 +33,12 @@ RSpec.describe CandidateInterface::WithdrawalFeedbackForm, type: :model do
       expect(withdrawal_feedback_form.selectable_reasons).to eq(%w[reason1 reason2])
     end
   end
+
+  describe 'validations' do
+    valid_text = Faker::Lorem.sentence(word_count: 500)
+    invalid_text = Faker::Lorem.sentence(word_count: 501)
+
+    it { is_expected.to allow_value(valid_text).for(:explanation) }
+    it { is_expected.not_to allow_value(invalid_text).for(:explanation) }
+  end
 end


### PR DESCRIPTION
## Context

We have two optional feedback fields, but we're not validating against the max word count. We should do this.

## Changes proposed in this pull request

|Feedback survey|Withdrawal reasons|
|---|---|
|<img width="671" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/36562294-322b-4ff4-8c9d-a0762426c592">|<img width="443" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/6aa9dc63-f99b-4d9e-b09e-602caa65a9cf">|

## Guidance to review

Test these fields on main vs this branch.

## Link to Trello card

https://trello.com/c/1cZ7j8PV/577-data-validation-unlimited-words-on-free-text-box-in-candidate-feedback-form
https://trello.com/c/DBlIRPnk/573-data-validation-unlimited-words-on-free-text-box-in-reasons-for-withdrawing

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
