### PR TITLE
Fix candidate unit tests in future

### DIFF
--- a/app/components/candidate_interface/application_dashboard_component.rb
+++ b/app/components/candidate_interface/application_dashboard_component.rb
@@ -13,8 +13,9 @@ module CandidateInterface
     end
 
     def title
-      title = @title&.pluralize if multiple_choices? || multiple_applications?
-      title
+      return @title unless multiple_choices? || multiple_applications?
+
+      @title&.pluralize
     end
 
   private

--- a/spec/components/candidate_interface/application_dashboard_component_spec.rb
+++ b/spec/components/candidate_interface/application_dashboard_component_spec.rb
@@ -29,6 +29,18 @@ RSpec.describe CandidateInterface::ApplicationDashboardComponent do
       render_result = render_inline(described_class.new(application_form:))
 
       expect(render_result.text).to include('Your applications')
+
+    context 'continuous applications', continuous_applications: true, time: mid_cycle do
+      it 'renders no title when continuous applications' do
+        application_form = create_application_form_with_course_choices(
+          statuses: %w[awaiting_provider_decision],
+          apply_again: true,
+        )
+
+        render_result = render_inline(described_class.new(application_form:))
+
+        expect(render_result).not_to have_css('h1')
+      end
     end
   end
 

--- a/spec/components/candidate_interface/application_dashboard_component_spec.rb
+++ b/spec/components/candidate_interface/application_dashboard_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CandidateInterface::ApplicationDashboardComponent do
 
       render_result = render_inline(described_class.new(application_form:))
 
-      expect(render_result.text).to include('Your application')
+      expect(render_result).to have_css('h1', text: 'Your application')
     end
 
     it 'renders the correct title for an application with multiple application choices' do
@@ -17,7 +17,7 @@ RSpec.describe CandidateInterface::ApplicationDashboardComponent do
 
       render_result = render_inline(described_class.new(application_form:))
 
-      expect(render_result.text).to include('Your applications')
+      expect(render_result).to have_css('h1', text: 'Your applications')
     end
 
     it 'renders the correct title for an apply again application' do
@@ -28,7 +28,8 @@ RSpec.describe CandidateInterface::ApplicationDashboardComponent do
 
       render_result = render_inline(described_class.new(application_form:))
 
-      expect(render_result.text).to include('Your applications')
+      expect(render_result).to have_css('h1', text: 'Your application')
+    end
 
     context 'continuous applications', continuous_applications: true, time: mid_cycle do
       it 'renders no title when continuous applications' do


### PR DESCRIPTION
## Context

Tests are failing when the test time is in after apply opens in the continuous applications recruitment cycle (2024).

## Changes proposed in this pull request

Update tests to satisfy expectations about how the application should behave in the new recruitment cycle.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

[Trello Ticket](https://trello.com/c/AezcLpI1/585-ca-failing-future-specs-find-opens-unitcandidate-provider)

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)