### PR TITLE
Add v1.3 of the candidate api

### DIFF
--- a/app/controllers/candidate_api/candidates_controller.rb
+++ b/app/controllers/candidate_api/candidates_controller.rb
@@ -82,7 +82,9 @@ module CandidateAPI
 
     def serializer
       @serializer ||=
-        if version_param == 'v1.2'
+        if version_param == 'v1.3'
+          CandidateAPI::Serializers::V13.new(updated_since: updated_since_params)
+        elsif version_param == 'v1.2'
           CandidateAPI::Serializers::V12.new(updated_since: updated_since_params)
         else
           CandidateAPI::Serializers::V11.new(updated_since: updated_since_params)

--- a/app/lib/candidate_api_specification.rb
+++ b/app/lib/candidate_api_specification.rb
@@ -1,6 +1,6 @@
 class CandidateAPISpecification
   CURRENT_VERSION = 'v1.2'.freeze
-  VERSIONS = ['v1.1', 'v1.2'].freeze
+  VERSIONS = ['v1.1', 'v1.2', 'v1.3'].freeze
 
   def self.as_yaml(version = CURRENT_VERSION)
     spec(version).to_yaml

--- a/app/services/candidate_api/serializers/base.rb
+++ b/app/services/candidate_api/serializers/base.rb
@@ -6,6 +6,106 @@ module CandidateAPI
       def initialize(updated_since:)
         @updated_since = updated_since
       end
+
+      def serialize(candidates)
+        candidates.map do |candidate|
+          {
+            id: candidate.public_id,
+            type: 'candidate',
+            attributes: {
+              created_at: candidate.created_at.iso8601,
+              updated_at: api_updated_at(candidate),
+              email_address: candidate.email_address,
+              application_forms:
+              candidate.application_forms.sort_by { |form| [form.created_at, form.id] }.map do |application|
+                {
+                  id: application.id,
+                  created_at: application.created_at.iso8601,
+                  updated_at: application.updated_at.iso8601,
+                  application_status: ApplicationFormStateInferrer.new(application).state,
+                  application_phase: application.phase,
+                  recruitment_cycle_year: application.recruitment_cycle_year,
+                  submitted_at: application.submitted_at&.iso8601,
+                }
+              end,
+            },
+          }
+        end
+      end
+
+    private
+
+      def api_updated_at(candidate)
+        [
+          candidate.updated_at,
+          candidate.application_choices.map(&:updated_at),
+          candidate.application_forms.map do |application_form|
+            [
+              application_form.updated_at,
+              application_form.application_references.map(&:updated_at),
+              application_form.application_qualifications.map(&:updated_at),
+            ]
+          end,
+        ].flatten.max.iso8601
+      end
+
+      def serialize_references(application_form)
+        {
+          completed: application_form.references_completed,
+          data:
+          application_form.application_references.sort_by(&:id).map do |reference|
+            {
+              id: reference.id,
+              requested_at: reference.requested_at&.iso8601,
+              feedback_status: reference.feedback_status,
+              referee_type: reference.referee_type,
+              created_at: reference.created_at.iso8601,
+              updated_at: reference.updated_at.iso8601,
+            }
+          end,
+        }
+      end
+
+      def serialize_qualifications(application_form)
+        {
+          completed: application_form.qualifications_completed?,
+        }
+      end
+
+      def serialize_personal_statement(application_form)
+        {
+          completed: application_form.becoming_a_teacher_completed,
+        }
+      end
+
+      def serialize_provider(provider)
+        {
+          name: provider.name,
+        }
+      end
+
+      def serialize_course(course)
+        {
+          uuid: course.uuid,
+          name: course.name,
+        }
+      end
+
+      def serialize_interviews(application_choice)
+        application_choice.interviews.map do |interview|
+          serialize_interview(interview)
+        end
+      end
+
+      def serialize_interview(interview)
+        {
+          id: interview.id,
+          date_and_time: interview.date_and_time&.iso8601,
+          created_at: interview.created_at&.iso8601,
+          updated_at: interview.updated_at&.iso8601,
+          cancelled_at: interview.cancelled_at&.iso8601,
+        }
+      end
     end
   end
 end

--- a/app/services/candidate_api/serializers/v1_1.rb
+++ b/app/services/candidate_api/serializers/v1_1.rb
@@ -1,32 +1,6 @@
 module CandidateAPI
   module Serializers
     class V11 < Base
-      def serialize(candidates)
-        candidates.map do |candidate|
-          {
-            id: candidate.public_id,
-            type: 'candidate',
-            attributes: {
-              created_at: candidate.created_at.iso8601,
-              updated_at: candidate.candidate_api_updated_at,
-              email_address: candidate.email_address,
-              application_forms:
-                candidate.application_forms.order(:created_at, :id).map do |application|
-                  {
-                    id: application.id,
-                    created_at: application.created_at.iso8601,
-                    updated_at: application.updated_at.iso8601,
-                    application_status: ApplicationFormStateInferrer.new(application).state,
-                    application_phase: application.phase,
-                    recruitment_cycle_year: application.recruitment_cycle_year,
-                    submitted_at: application.submitted_at&.iso8601,
-                  }
-                end,
-            },
-          }
-        end
-      end
-
       def query
         Candidate
         .left_outer_joins(:application_forms)

--- a/app/services/candidate_api/serializers/v1_2.rb
+++ b/app/services/candidate_api/serializers/v1_2.rb
@@ -2,32 +2,18 @@ module CandidateAPI
   module Serializers
     class V12 < Base
       def serialize(candidates)
-        candidates.map do |candidate|
-          {
-            id: candidate.public_id,
-            type: 'candidate',
-            attributes: {
-              created_at: candidate.created_at.iso8601,
-              updated_at: api_updated_at(candidate),
-              email_address: candidate.email_address,
-              application_forms:
-              candidate.application_forms.sort_by { |form| [form.created_at, form.id] }.map do |application|
-                {
-                  id: application.id,
-                  created_at: application.created_at.iso8601,
-                  updated_at: application.updated_at.iso8601,
-                  application_status: ApplicationFormStateInferrer.new(application).state,
-                  application_phase: application.phase,
-                  recruitment_cycle_year: application.recruitment_cycle_year,
-                  submitted_at: application.submitted_at&.iso8601,
-                  application_choices: serialize_application_choices(application),
-                  references: serialize_references(application),
-                  qualifications: serialize_qualifications(application),
-                  personal_statement: serialize_personal_statement(application),
-                }
-              end,
-            },
-          }
+        super(candidates).map do |candidate|
+          candidate[:attributes][:application_forms].each do |form|
+            application_form = ApplicationForm.find(form[:id])
+            form.merge!(
+              application_choices: serialize_application_choices(application_form),
+              references: serialize_references(application_form),
+              qualifications: serialize_qualifications(application_form),
+              personal_statement: serialize_personal_statement(application_form)
+            )
+          end
+
+          candidate
         end
       end
 
@@ -41,95 +27,23 @@ module CandidateAPI
           .distinct
       end
 
-    private
-
-      def api_updated_at(candidate)
-        [
-          candidate.updated_at,
-          candidate.application_choices.map(&:updated_at),
-          candidate.application_forms.map do |application_form|
-            [
-              application_form.updated_at,
-              application_form.application_references.map(&:updated_at),
-              application_form.application_qualifications.map(&:updated_at),
-            ]
-          end,
-        ].flatten.max.iso8601
-      end
-
-      def serialize_references(application_form)
-        {
-          completed: application_form.references_completed,
-          data:
-            application_form.application_references.sort_by(&:id).map do |reference|
-              {
-                id: reference.id,
-                requested_at: reference.requested_at&.iso8601,
-                feedback_status: reference.feedback_status,
-                referee_type: reference.referee_type,
-                created_at: reference.created_at.iso8601,
-                updated_at: reference.updated_at.iso8601,
-              }
-            end,
-        }
-      end
-
-      def serialize_qualifications(application_form)
-        {
-          completed: application_form.qualifications_completed?,
-        }
-      end
-
-      def serialize_personal_statement(application_form)
-        {
-          completed: application_form.becoming_a_teacher_completed,
-        }
-      end
+      private
 
       def serialize_application_choices(application_form)
         {
           completed: application_form.course_choices_completed,
           data:
-            application_form.application_choices.sort_by(&:id).map do |application_choice|
-              {
-                id: application_choice.id,
-                created_at: application_choice.created_at&.iso8601,
-                updated_at: application_choice.updated_at&.iso8601,
-                status: application_choice.status,
-                provider: serialize_provider(application_choice.provider),
-                course: serialize_course(application_choice.course),
-                interviews: serialize_interviews(application_choice),
-              }
-            end,
-        }
-      end
-
-      def serialize_provider(provider)
-        {
-          name: provider.name,
-        }
-      end
-
-      def serialize_course(course)
-        {
-          uuid: course.uuid,
-          name: course.name,
-        }
-      end
-
-      def serialize_interviews(application_choice)
-        application_choice.interviews.map do |interview|
-          serialize_interview(interview)
-        end
-      end
-
-      def serialize_interview(interview)
-        {
-          id: interview.id,
-          date_and_time: interview.date_and_time&.iso8601,
-          created_at: interview.created_at&.iso8601,
-          updated_at: interview.updated_at&.iso8601,
-          cancelled_at: interview.cancelled_at&.iso8601,
+          application_form.application_choices.sort_by(&:id).map do |application_choice|
+            {
+              id: application_choice.id,
+              created_at: application_choice.created_at&.iso8601,
+              updated_at: application_choice.updated_at&.iso8601,
+              status: application_choice.status,
+              provider: serialize_provider(application_choice.provider),
+              course: serialize_course(application_choice.course),
+              interviews: serialize_interviews(application_choice),
+            }
+          end,
         }
       end
     end

--- a/app/services/candidate_api/serializers/v1_2.rb
+++ b/app/services/candidate_api/serializers/v1_2.rb
@@ -9,7 +9,7 @@ module CandidateAPI
               application_choices: serialize_application_choices(application_form),
               references: serialize_references(application_form),
               qualifications: serialize_qualifications(application_form),
-              personal_statement: serialize_personal_statement(application_form)
+              personal_statement: serialize_personal_statement(application_form),
             )
           end
 
@@ -27,7 +27,7 @@ module CandidateAPI
           .distinct
       end
 
-      private
+    private
 
       def serialize_application_choices(application_form)
         {

--- a/app/services/candidate_api/serializers/v1_3.rb
+++ b/app/services/candidate_api/serializers/v1_3.rb
@@ -1,0 +1,51 @@
+module CandidateAPI
+  module Serializers
+    class V13 < Base
+      def serialize(candidates)
+        super(candidates).map do |candidate|
+          candidate[:attributes][:application_forms].each do |form|
+            application_form = ApplicationForm.find(form[:id])
+            form.merge!(
+              application_choices: serialize_application_choices(application_form),
+              references: serialize_references(application_form),
+              qualifications: serialize_qualifications(application_form),
+              personal_statement: serialize_personal_statement(application_form),
+            )
+          end
+
+          candidate
+        end
+      end
+
+      def query
+        Candidate
+          .left_outer_joins(application_forms: { application_choices: %i[provider course interviews], application_references: [], application_qualifications: [] })
+          .includes(application_forms: { application_choices: %i[provider course course_option interviews], application_qualifications: [], application_references: [] })
+          .where('candidates.updated_at > :updated_since OR application_forms.updated_at > :updated_since OR application_choices.updated_at > :updated_since OR "references".updated_at > :updated_since OR application_qualifications.updated_at > :updated_since', updated_since:)
+          .where('application_forms.recruitment_cycle_year = ? OR candidates.created_at > ?', RecruitmentCycle.current_year, CycleTimetable.apply_1_deadline(RecruitmentCycle.previous_year))
+          .order(id: :asc)
+          .distinct
+      end
+
+    private
+
+      def serialize_application_choices(application_form)
+        {
+          data:
+          application_form.application_choices.sort_by(&:id).map do |application_choice|
+            {
+              id: application_choice.id,
+              created_at: application_choice.created_at&.iso8601,
+              updated_at: application_choice.updated_at&.iso8601,
+              sent_to_provider_at: application_choice.sent_to_provider_at&.iso8601,
+              status: application_choice.status,
+              provider: serialize_provider(application_choice.provider),
+              course: serialize_course(application_choice.course),
+              interviews: serialize_interviews(application_choice),
+            }
+          end,
+        }
+      end
+    end
+  end
+end

--- a/config/candidate_api/v1.2.yml
+++ b/config/candidate_api/v1.2.yml
@@ -1,7 +1,7 @@
 ---
 openapi: 3.0.0
 info:
-  version: v1.1
+  version: v1.2
   title: Apply candidate API
   contact:
     name: DfE

--- a/config/candidate_api/v1.3.yml
+++ b/config/candidate_api/v1.3.yml
@@ -1,0 +1,513 @@
+---
+openapi: 3.0.0
+info:
+  version: v1.3
+  title: Apply candidate API
+  contact:
+    name: DfE
+    email: becomingateacher@digital.education.gov.uk
+  description: |
+    API for candidates from DfE’s Apply for teacher training service.
+servers:
+- description: Sandbox (test environment)
+  url: https://sandbox.apply-for-teacher-training.service.gov.uk/candidate-api
+- description: Production
+  url: https://www.apply-for-teacher-training.service.gov.uk/candidate-api
+paths:
+  "/candidates":
+    get:
+      summary: Get a list of candidates
+      parameters:
+        - in: query
+          name: updated_since
+          schema:
+            type: string
+            format: date-time
+            example: 2021-05-20T12:34:00Z
+          required: true
+          description: Records updated since this date
+        - in: query
+          name: page
+          schema:
+            type: integer
+            example: 2
+          required: false
+          description: Page number
+        - in: query
+          name: per_page
+          schema:
+            type: integer
+            example: 20
+          required: false
+          description: Number of records to return per page
+      responses:
+        '200':
+          description: Candidate data updated since a certain date and time
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/CandidateList"
+        '401':
+          "$ref": "#/components/responses/Unauthorized"
+        '422':
+          "$ref": "#/components/responses/UnprocessableEntity"
+components:
+  responses:
+    Unauthorized:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            "$ref": "#/components/schemas/UnauthorizedResponse"
+    UnprocessableEntity:
+      description: Returned when the request body was missing data or contained invalid
+        data
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - "$ref": "#/components/schemas/ParameterMissingResponse"
+              - "$ref": "#/components/schemas/ParameterInvalidResponse"
+              - "$ref": "#/components/schemas/PageParameterInvalidResponse"
+              - "$ref": "#/components/schemas/PerPageParameterInvalidResponse"
+  schemas:
+    CandidateList:
+      type: object
+      additionalProperties: false
+      required:
+      - data
+      properties:
+        data:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Candidate"
+    Candidate:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - type
+        - attributes
+      properties:
+        id:
+          type: string
+          description: A candidate’s id
+          example: C1234
+        type:
+          type: string
+          description: Type of Apply user
+          example: candidate
+        attributes:
+          "$ref": "#/components/schemas/CandidateAttributes"
+    CandidateAttributes:
+      type: object
+      additionalProperties: false
+      required:
+        - email_address
+        - created_at
+        - updated_at
+        - application_forms
+      properties:
+        created_at:
+          type: string
+          format: date-time
+          description: Time of candidate creation
+          example: 2021-05-20T12:34:00Z
+        updated_at:
+          type: string
+          format: date-time
+          description: Time of last change
+          example: 2021-05-20T12:34:00Z
+        email_address:
+          type: string
+          description: Candidate email address
+          example: email@example.com
+        application_forms:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ApplicationForm"
+    ApplicationForm:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - created_at
+        - application_status
+        - application_phase
+        - recruitment_cycle_year
+        - submitted_at
+      properties:
+        id:
+          type: integer
+          description: The unique ID of the candidates application form
+          example: 10
+        created_at:
+          type: string
+          format: date-time
+          description: The date an application was created
+          example: 2021-05-20T12:34:00Z
+        updated_at:
+          type: string
+          format: date-time
+          description: Time of last change
+          example: 2021-05-20T12:34:00Z
+        application_status:
+          type: string
+          description: The status of the candidates current application form
+          enum:
+            - never_signed_in
+            - unsubmitted_not_started_form
+            - unsubmitted_in_progress
+            - awaiting_provider_decisions
+            - awaiting_candidate_response
+            - recruited
+            - pending_conditions
+            - offer_deferred
+            - ended_without_success
+            - unknown_state
+          example: awaiting_provider_decisions
+        application_phase:
+          type: string
+          description: The phase of the candidates current application. In the first phase, "Apply 1", the
+            candidate can choose up to 4 courses. If all of those choices are rejected,
+            declined, or withdrawn, the user can go into "Apply 2".
+            In "Apply 2", a user can also choose up to 4 courses.
+          enum:
+            - apply_1
+            - apply_2
+          example: apply_1
+        recruitment_cycle_year:
+          type: integer
+          description: The recruitment cycle that the application form was created in
+          example: 2022
+        submitted_at:
+          type: string
+          nullable: true
+          format: date-time
+          description: Time of last change
+          example: 2021-05-20T12:34:00Z
+        application_choices:
+          "$ref": "#/components/schemas/ApplicationChoices"
+        references:
+          "$ref": "#/components/schemas/References"
+        qualifications:
+          "$ref": "#/components/schemas/Qualifications"
+        personal_statement:
+          "$ref": "#/components/schemas/PersonalStatement"
+    ApplicationChoices:
+      type: object
+      additionalProperties: false
+      description: The course choices that the candidate has selected
+      required:
+        - data
+      properties:
+        completed:
+          type: boolean
+          description: Indicates whether the candidate has marked the application choices section complete
+          example: true
+          deprecated: true
+        data:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ApplicationChoice"
+          description: The collection of course choices that the candidate has selected
+    ApplicationChoice:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - created_at
+        - updated_at
+        - sent_to_provider_at
+        - status
+        - provider
+        - course
+      properties:
+        id:
+          type: integer
+          description: The unique ID of the application choice
+          example: 10
+        created_at:
+          type: string
+          format: date-time
+          description: The date and time the application choice was created
+          example: 2021-05-20T12:34:00Z
+        updated_at:
+          type: string
+          format: date-time
+          description: The date and time the application choice was last updated
+          example: 2021-05-20T12:34:00Z
+        sent_to_provider_at:
+          type: string
+          format: date-time
+          description: The date and time the application choice was submitted to the provider
+          example: 2021-05-20T12:34:00Z
+        status:
+          type: string
+          description: The status of the application choice
+          enum:
+            - unsubmitted
+            - cancelled
+            - awaiting_provider_decision
+            - interviewing
+            - offer
+            - pending_conditions
+            - recruited
+            - rejected
+            - application_not_sent
+            - offer_withdrawn
+            - declined
+            - withdrawn
+            - conditions_not_met
+            - offer_deferred
+          example: awaiting_provider_decision
+        course:
+          "$ref": "#/components/schemas/Course"
+        provider:
+          "$ref": "#/components/schemas/Provider"
+        interviews:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Interview"
+    Course:
+      type: object
+      additionalProperties: false
+      required:
+        - uuid
+        - name
+      properties:
+        uuid:
+          type: string
+          description: The universally unique ID of the course
+          example: f2c0ada1-0d99-4574-a950-bf53e176507c
+        name:
+          type: string
+          description: The name of the course
+          example: Mathematics
+    Provider:
+      type: object
+      additionalProperties: false
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: The name of the provider
+          example: University of West Anglia
+    Interview:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - created_at
+        - updated_at
+        - date_and_time
+      properties:
+        id:
+          type: integer
+          description: The unique ID of the interview
+          example: 10
+        created_at:
+          type: string
+          format: date-time
+          description: The date and time the interview was created
+          example: 2021-05-20T12:34:00Z
+        updated_at:
+          type: string
+          format: date-time
+          description: The date and time the interview was last updated
+          example: 2021-05-20T12:34:00Z
+        date_and_time:
+          type: string
+          format: date-time
+          description: The date and time that the interview is scheduled for
+          example: 2021-05-20T10:00:00Z
+        cancelled_at:
+          type: string
+          format: date-time
+          description: The date and time the interview was cancelled (if applicable)
+          example: 2021-05-20T12:34:00Z
+    References:
+      type: object
+      additionalProperties: false
+      description: The reference requests that the candidate has entered and their completion status
+      required:
+        - completed
+        - data
+      properties:
+        completed:
+          type: boolean
+          description: Indicates whether the candidate has marked the references section complete
+          example: true
+        data:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Reference"
+          description: The collection of reference requests that the candidate has entered
+    Reference:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - feedback_status
+        - referee_type
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: integer
+          description: The unique ID of the reference
+          example: 10
+        created_at:
+          type: string
+          format: date-time
+          description: The date and time the reference was created
+          example: 2021-05-20T12:34:00Z
+        updated_at:
+          type: string
+          format: date-time
+          description: The date and time the reference was last updated
+          example: 2021-05-20T12:34:00Z
+        requested_at:
+          type: string
+          format: date-time
+          description: The date and time the reference was sent to the referee
+          example: 2021-05-20T12:34:00Z
+        feedback_status:
+          type: string
+          description: The status of the reference
+          enum:
+            - cancelled
+            - cancelled_at_end_of_cycle
+            - not_requested_yet
+            - feedback_requested
+            - feedback_provided
+            - feedback_refused
+            - email_bounced
+          example: feedback_requested
+        referee_type:
+          type: string
+          description: The type of referee that the candidate has requested a reference from
+            - academic
+            - professional
+            - school_based
+            - character
+          example: academic
+    Qualifications:
+      type: object
+      additionalProperties: false
+      description: The completion status of the qualifications section
+      required:
+        - completed
+      properties:
+        completed:
+          type: boolean
+          description: Indicates whether the candidate has marked the qualifications section complete
+          example: true
+    PersonalStatement:
+      type: object
+      additionalProperties: false
+      description: completion status of the personal statement section
+      required:
+        - completed
+      properties:
+        completed:
+          type: boolean
+          description: Indicates whether the candidate has marked the personal statement section complete
+          example: true
+    UnauthorizedResponse:
+      type: object
+      additionalProperties: false
+      required:
+      - errors
+      properties:
+        errors:
+          type: array
+          minItems: 1
+          description: Error objects describing the problem
+          items:
+            "$ref": "#/components/schemas/Error"
+          example:
+          - error: Unauthorized
+            message: Please provide a valid authentication token
+    ParameterMissingResponse:
+      type: object
+      additionalProperties: false
+      required:
+      - errors
+      properties:
+        errors:
+          type: array
+          minItems: 1
+          description: Error objects describing the problem
+          items:
+            "$ref": "#/components/schemas/Error"
+          example:
+          - error: ParameterMissing
+            message: "param is missing or the value is empty: updated_since"
+    ParameterInvalidResponse:
+      type: object
+      additionalProperties: false
+      required:
+      - errors
+      properties:
+        errors:
+          type: array
+          minItems: 1
+          description: Error objects describing the problem
+          items:
+            "$ref": "#/components/schemas/Error"
+          example:
+          - error: ParameterInvalid
+            message: "Parameter is invalid: updated_since"
+    PageParameterInvalidResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - errors
+      properties:
+        errors:
+          type: array
+          minItems: 1
+          description: Error objects describing the problem
+          items:
+            "$ref": "#/components/schemas/Error"
+          example:
+          - error: PageParameterInvalid
+            message: "expected 'page' parameter to be between 1 and 1, got 2"
+    PerPageParameterInvalidResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - errors
+      properties:
+        errors:
+          type: array
+          minItems: 1
+          description: Error objects describing the problem
+          items:
+            "$ref": "#/components/schemas/Error"
+          example:
+          - error: PerPageParameterInvalid
+            message: "the 'per_page' parameter cannot exceed 500 results per page"
+    Error:
+      type: object
+      additionalProperties: false
+      properties:
+        error:
+          type: string
+          description: Name of the current error
+          example: Unauthorized
+        message:
+          type: string
+          description: Description of the current error
+          example: Please provide a valid authentication token
+      required:
+      - error
+      - message
+  securitySchemes:
+    tokenAuth:
+      type: http
+      scheme: bearer
+security:
+- tokenAuth: []

--- a/spec/requests/candidate_api/get_candidates_v1_3_spec.rb
+++ b/spec/requests/candidate_api/get_candidates_v1_3_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /candidate-api/v1.3/candidates' do
+  include CandidateAPISpecHelper
+
+  let(:root_path) { '/candidate-api/v1.3/candidates' }
+
+  it_behaves_like 'an API endpoint requiring a date param', '/candidate-api/v1.3/candidates', 'updated_since', ServiceAPIUser.candidate_user.create_magic_link_token!
+  it_behaves_like 'a candidate API endpoint', '/candidate-api/v1.3/candidates', 'updated_since', 'v1.3'
+
+  it 'returns candidates ordered by `updated_at` timestamp desc across multiple associations, with applications ordered by `created_at` asc' do
+    allow(ApplicationFormStateInferrer).to receive(:new).and_return(instance_double(ApplicationFormStateInferrer, state: :unsubmitted_not_started_form))
+
+    candidate = create(:candidate)
+    application_forms = []
+
+    application_forms << create(:completed_application_form, submitted_application_choices_count: 3, candidate:)
+
+    get_api_request "#{root_path}?updated_since=#{CGI.escape(1.day.ago.iso8601)}", token: candidate_api_token
+
+    response_data = parsed_response.dig('data', 0, 'attributes', 'application_forms')
+
+    expect(response_data.size).to eq(1)
+
+    first_application_choice = application_forms.first.application_choices.first
+
+    expect(response_data.first['id']).to eq(application_forms.first.id)
+    expect(response_data.first['application_phase']).to eq(application_forms.first.phase)
+    expect(response_data.first['application_status']).to eq(ApplicationFormStateInferrer.new(application_forms.first).state.to_s)
+    expect(response_data.first['recruitment_cycle_year']).to eq(application_forms.first.recruitment_cycle_year)
+    expect(response_data.first['submitted_at']).to eq(application_forms.first.submitted_at.iso8601)
+    expect(response_data.first['application_choices']['completed']).to be_nil
+    expect(response_data.first['application_choices']['data'].first['sent_to_provider_at']).to eq(first_application_choice.sent_to_provider_at.iso8601)
+    expect(response_data.first['application_choices']['data'].count).to eq(3)
+    expect(response_data.first['application_choices']['data'].first['status']).to eq(first_application_choice.status)
+  end
+end


### PR DESCRIPTION
## Context

We need to update the candidate API (used by GIT) to reflect changes we'll be implementing with continuous applications.

## Changes proposed in this pull request

Introduce v1.3:
- Deprecate the `completed` attribute on the application form object – this section will no longer be marked as incomplete/completed due to the nature of continuously applying
- Add a `sent_to_provider_at` attribute to the application choice object – the `submitted_at` attribute that sits on the application form object will only be written to upon the first application choice submission and then never again. To accurately determine when an individual application choice was submitted you'll need to use this attribute.

## Guidance to review

Check docs on https://editor.swagger.io/
Check API on postman (or preferred method)

Post launch we can have a discussion how we version this API going forward. Our only consumers are the GIT team (internal), we could maintain a single version.

## Link to Trello card

https://trello.com/c/3aPmQple/252-ca-update-the-candidate-api-with-ca-changes

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
