### PR TITLE
Add course from find

### DIFF
--- a/app/controllers/candidate_interface/after_sign_in_controller.rb
+++ b/app/controllers/candidate_interface/after_sign_in_controller.rb
@@ -7,21 +7,37 @@ module CandidateInterface
     def interstitial
       current_candidate.update!(course_from_find_id: nil)
 
-      if current_application.submitted?
+      if current_application.submitted? && !current_application.continuous_applications?
         redirect_to candidate_interface_application_complete_path
       elsif current_application.contains_course?(course_from_find)
         flash[:warning] = "You have already selected #{course_from_find.name_and_code}."
-        redirect_to candidate_interface_course_choices_review_path
+        redirect_to course_choices_page
       elsif current_application.maximum_number_of_course_choices?
         flash[:warning] = I18n.t('errors.messages.too_many_course_choices', course_name_and_code: course_from_find.name_and_code)
 
-        redirect_to candidate_interface_course_choices_review_path
+        redirect_to course_choices_page
       else
-        redirect_to candidate_interface_course_confirm_selection_path(course_from_find.id)
+        redirect_to confirm_selection_page
       end
     end
 
   private
+
+    def course_choices_page
+      if current_application.continuous_applications?
+        candidate_interface_continuous_applications_choices_path
+      else
+        candidate_interface_course_choices_review_path
+      end
+    end
+
+    def confirm_selection_page
+      if current_application.continuous_applications?
+        candidate_interface_continuous_applications_course_confirm_selection_path(course_from_find.id)
+      else
+        candidate_interface_course_confirm_selection_path(course_from_find.id)
+      end
+    end
 
     def redirect_to_path_if_path_params_are_present
       redirect_to params[:path] if params[:path].present?

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -7,6 +7,7 @@ module CandidateInterface
       'continuous_applications/course_choices', # the course choice wizard
       'continuous_applications/application_choices', # deleting an application choice
       'decisions', # withdrawing from a course offer
+      'candidate_interface/apply_from_find',
     ].freeze
 
     before_action :protect_with_basic_auth

--- a/app/controllers/candidate_interface/continuous_applications/course_choices/find_course_selection_controller.rb
+++ b/app/controllers/candidate_interface/continuous_applications/course_choices/find_course_selection_controller.rb
@@ -1,0 +1,13 @@
+module CandidateInterface
+  module ContinuousApplications
+    module CourseChoices
+      class FindCourseSelectionController < BaseController
+      private
+
+        def current_step
+          :find_course_selection
+        end
+      end
+    end
+  end
+end

--- a/app/forms/candidate_interface/continuous_applications/concerns/course_selection_step_helper.rb
+++ b/app/forms/candidate_interface/continuous_applications/concerns/course_selection_step_helper.rb
@@ -14,6 +14,10 @@ module CandidateInterface
           )
         end
 
+        def completed?
+          !multiple_study_modes? && !multiple_sites?
+        end
+
         def multiple_study_modes?
           course.currently_has_both_study_modes_available?
         end

--- a/app/forms/candidate_interface/continuous_applications/course_selection_wizard.rb
+++ b/app/forms/candidate_interface/continuous_applications/course_selection_wizard.rb
@@ -11,6 +11,7 @@ module CandidateInterface
           { which_course_are_you_applying_to: WhichCourseAreYouApplyingToStep },
           { course_study_mode: CourseStudyModeStep },
           { course_site: CourseSiteStep },
+          { find_course_selection: FindCourseSelectionStep },
           { course_review: CourseReviewStep },
         ]
       end

--- a/app/forms/candidate_interface/continuous_applications/find_course_selection_step.rb
+++ b/app/forms/candidate_interface/continuous_applications/find_course_selection_step.rb
@@ -1,0 +1,39 @@
+module CandidateInterface
+  module ContinuousApplications
+    class FindCourseSelectionStep < DfE::WizardStep
+      include Concerns::CourseSelectionStepHelper
+      attr_accessor :course_id
+      validates :course_id, presence: true
+
+      delegate :find_url, :provider, :name_and_code, to: :course, prefix: true
+
+      def self.permitted_params
+        %i[course_id]
+      end
+
+      def next_step
+        return :course_review if completed?
+
+        if multiple_study_modes?
+          :course_study_mode
+        elsif multiple_sites?
+          :course_site
+        end
+      end
+
+      def next_step_path_arguments
+        if completed?
+          { application_choice_id: application_choice.id }
+        elsif multiple_study_modes?
+          { provider_id:, course_id: }
+        elsif multiple_sites?
+          { provider_id:, course_id:, study_mode: }
+        end
+      end
+
+      def course
+        Course.find(course_id)
+      end
+    end
+  end
+end

--- a/app/forms/candidate_interface/continuous_applications/find_course_selection_step.rb
+++ b/app/forms/candidate_interface/continuous_applications/find_course_selection_step.rb
@@ -6,6 +6,7 @@ module CandidateInterface
       validates :course_id, presence: true
 
       delegate :find_url, :provider, :name_and_code, to: :course, prefix: true
+      delegate :provider_id, to: :course
 
       def self.permitted_params
         %i[course_id]
@@ -29,6 +30,10 @@ module CandidateInterface
         elsif multiple_sites?
           { provider_id:, course_id:, study_mode: }
         end
+      end
+
+      def study_mode
+        course.available_study_modes_with_vacancies.first
       end
 
       def course

--- a/app/forms/candidate_interface/continuous_applications/which_course_are_you_applying_to_step.rb
+++ b/app/forms/candidate_interface/continuous_applications/which_course_are_you_applying_to_step.rb
@@ -55,10 +55,6 @@ module CandidateInterface
         course.available_study_modes_with_vacancies.first
       end
 
-      def completed?
-        !multiple_study_modes? && !multiple_sites?
-      end
-
     private
 
       def default_path_arguments

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,6 +22,8 @@ module ApplicationHelper
   def find_url
     if HostingEnvironment.sandbox_mode?
       t('find_postgraduate_teacher_training.sandbox_url')
+    elsif HostingEnvironment.qa?
+      t('find_postgraduate_teacher_training.qa_url')
     else
       t('find_postgraduate_teacher_training.production_url')
     end

--- a/app/views/candidate_interface/continuous_applications/course_choices/find_course_selection/new.html.erb
+++ b/app/views/candidate_interface/continuous_applications/course_choices/find_course_selection/new.html.erb
@@ -1,0 +1,31 @@
+<% content_for :title, t('application_form.confirm_selection.heading') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @wizard.current_step, url: candidate_interface_continuous_applications_course_confirm_selection_path(@wizard.current_step.course_id), method: :post do |f| %>
+      <%= f.hidden_field :course_id %>
+
+      <h1 class="govuk-heading-xl">
+        <%= t('application_form.confirm_selection.heading') %>
+      </h1>
+
+      <%= govuk_inset_text(classes: 'govuk-!-margin-top-0') do %>
+        <%= govuk_link_to(@wizard.current_step.course_find_url, class: 'govuk-!-font-weight-bold', style: 'text-decoration: none') do %>
+          <span class="govuk-!-font-size-19">
+            <%= @wizard.current_step.course_provider.name %>
+          </span><br>
+          <span class="search-result-link-name govuk-!-font-size-24" style="text-decoration: underline">
+            <%= @wizard.current_step.course_name_and_code %>
+          </span>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_radio_buttons_fieldset :confirm, legend: { text: t('application_form.confirm_selection.question'), size: 'm' } do %>
+        <%= f.govuk_radio_button :confirm, true, label: { text: 'Yes' }, link_errors: true %>
+        <%= f.govuk_radio_button :confirm, false, label: { text: 'No' } %>
+      <% end %>
+
+      <%= f.govuk_submit t('continue') %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,7 @@ en:
   find_postgraduate_teacher_training:
     production_url: https://www.find-postgraduate-teacher-training.service.gov.uk/
     sandbox_url: https://sandbox.find-postgraduate-teacher-training.service.gov.uk/
+    qa_url: https://qa.find-postgraduate-teacher-training.service.gov.uk/
   get_into_teaching:
     tel: 0800 389 2500
     opening_times: "Monday to Friday, 8:30am to 5:30pm (except public\u00A0holidays)"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -543,7 +543,7 @@ en:
     messages:
       too_long: "%{attribute} must be %{count} characters or fewer"
       too_many_words: Must be %{maximum} words or less
-      too_many_course_choices: You cannot have more than 3 course choices. You must delete a choice if you want to apply to %{course_name_and_code}.
+      too_many_course_choices: You cannot have more than 4 course choices. You must delete a choice if you want to apply to %{course_name_and_code}.
       invalid_year: Enter a real %{attribute}
       multiple_year: Enter a single %{attribute}
       invalid_date: Enter a real %{attribute}

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -374,6 +374,9 @@ namespace :candidate_interface, path: '/candidate' do
       get '/:application_choice_id/courses/:course_id/:study_mode/edit' => 'continuous_applications/course_choices/course_site#edit', as: :edit_continuous_applications_course_site
       patch '/:application_choice_id/courses/:course_id/:study_mode/edit' => 'continuous_applications/course_choices/course_site#update'
 
+      get '/confirm-selection/:course_id' => 'continuous_applications/course_choices/find_course_selection#new', as: :continuous_applications_course_confirm_selection
+      post '/confirm-selection/:course_id' => 'continuous_applications/course_choices/find_course_selection#create'
+
       post '/:id/submit' => 'continuous_applications/application_choices#submit', as: :continuous_applications_submit_course_choice
       get '/delete/:id' => 'continuous_applications/application_choices#confirm_destroy', as: :continuous_applications_confirm_destroy_course_choice
       delete '/delete/:id' => 'continuous_applications/application_choices#destroy'

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationHelper do
+  describe '#find_url' do
+    context 'when sandbox', sandbox: true do
+      it 'returns sandbox url' do
+        expect(helper.find_url).to eq(I18n.t('find_postgraduate_teacher_training.sandbox_url'))
+      end
+    end
+
+    context 'when qa' do
+      it 'returns qa url' do
+        ClimateControl.modify HOSTING_ENVIRONMENT_NAME: 'qa' do
+          expect(helper.find_url).to eq(I18n.t('find_postgraduate_teacher_training.qa_url'))
+        end
+      end
+    end
+
+    context 'when other environments' do
+      it 'returns production url' do
+        expect(helper.find_url).to eq(I18n.t('find_postgraduate_teacher_training.production_url'))
+      end
+    end
+  end
+
   # rubocop:disable RSpec/AnyInstance
   describe '#service_key' do
     it 'is apply for candidate_interface namespace' do

--- a/spec/requests/candidate_interface/continuous_applications_choose_course_spec.rb
+++ b/spec/requests/candidate_interface/continuous_applications_choose_course_spec.rb
@@ -9,6 +9,18 @@ RSpec.describe 'continuous applications redirects' do
   end
 
   context 'when continuous applications', continuous_applications: true do
+    context 'when cycle is over' do
+      it 'redirects the user when trying to add a course from find' do
+        TestSuiteTimeMachine.travel_permanently_to(after_apply_1_deadline + 1.day)
+        provider = create(:provider, code: '8N5', name: 'Snape University')
+        course = create(:course, :open_on_apply, name: 'Potions', provider:)
+
+        get candidate_interface_continuous_applications_course_confirm_selection_path(course.id)
+
+        expect(response).to redirect_to(candidate_interface_continuous_applications_choices_path)
+      end
+    end
+
     describe 'choose' do
       it 'redirects choose to continuous applications' do
         get candidate_interface_course_choices_choose_path

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_only_open_on_apply_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_only_open_on_apply_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate arrives from Find with provider and course params', continuous_applications: true do
+  include CandidateHelper
+
+  scenario 'The provider is only accepting applications on the Apply service' do
+    given_there_is_a_provider_with_a_course_that_is_only_accepting_applications_on_apply
+
+    when_i_follow_a_link_from_find
+    then_i_am_redirected_to_the_create_account_or_sign_in_path
+
+    given_i_am_signed_in
+
+    when_i_follow_a_link_from_find
+    then_i_am_redirected_to_the_course_confirm_selection_page
+
+    when_i_confirm_the_course
+    then_i_should_be_redirected_to_the_course_review_path
+  end
+
+  def given_there_is_a_provider_with_a_course_that_is_only_accepting_applications_on_apply
+    @provider = create(:provider, code: '8N5', name: 'Snape University')
+    @course = create(:course, :open_on_apply, name: 'Potions', provider: @provider, recruitment_cycle_year: 2024)
+    create(:course_option, course: @course)
+  end
+
+  def when_i_follow_a_link_from_find
+    visit candidate_interface_apply_from_find_path(
+      providerCode: @course.provider.code,
+      courseCode: @course.code,
+    )
+  end
+
+  def then_i_am_redirected_to_the_create_account_or_sign_in_path
+    expect(page).to have_current_path candidate_interface_create_account_or_sign_in_path(
+      providerCode: @provider.code,
+      courseCode: @course.code,
+    )
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def then_i_am_redirected_to_the_course_confirm_selection_page
+    expect(page).to have_current_path(
+      candidate_interface_continuous_applications_course_confirm_selection_path(@course.id),
+    )
+  end
+
+  def when_i_confirm_the_course
+    choose 'Yes'
+    click_on 'Continue'
+  end
+
+  def then_i_should_be_redirected_to_the_course_review_path
+    expect(page).to have_current_path(
+      candidate_interface_continuous_applications_course_review_path(application_choice_id: application_choice.id),
+    )
+  end
+end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_with_multiple_sites_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_with_multiple_sites_spec.rb
@@ -1,0 +1,102 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate arrives from Find with provider and course with multiple sites', continuous_applications: true do
+  include CandidateHelper
+
+  scenario 'The provider is only accepting applications on the Apply service' do
+    given_there_is_a_provider_with_a_course_that_is_only_accepting_applications_on_apply
+
+    when_i_follow_a_link_from_find
+    then_i_am_redirected_to_the_create_account_or_sign_in_path
+
+    given_i_am_signed_in
+
+    when_i_follow_a_link_from_find
+    then_i_am_redirected_to_the_course_confirm_selection_page
+
+    when_i_confirm_the_course
+    then_i_should_be_redirected_to_the_course_site_path
+
+    when_i_choose_a_location
+    then_i_should_be_redirected_to_the_course_review_path
+  end
+
+  def given_there_is_a_provider_with_a_course_that_is_only_accepting_applications_on_apply
+    @provider = create(:provider, code: '8N5', name: 'Snape University')
+    @course = create(:course, :open_on_apply, name: 'Potions', provider: @provider, recruitment_cycle_year: 2024)
+    first_site = create(
+      :site,
+      name: 'Main site',
+      code: '-',
+      provider: @provider,
+      address_line1: 'Gorse SCITT',
+      address_line2: 'C/O The Bruntcliffe Academy',
+      address_line3: 'Bruntcliffe Lane',
+      address_line4: 'MORLEY, lEEDS',
+      postcode: 'LS27 0LZ',
+    )
+    second_site = create(
+      :site,
+      name: 'Harehills Primary School',
+      code: '1',
+      provider: @provider,
+      address_line1: 'Darfield Road',
+      address_line2: '',
+      address_line3: 'Leeds',
+      address_line4: 'West Yorkshire',
+      postcode: 'LS8 5DQ',
+    )
+    create(:course_option, site: first_site, course: @course)
+    create(:course_option, site: second_site, course: @course)
+  end
+
+  def when_i_follow_a_link_from_find
+    visit candidate_interface_apply_from_find_path(
+      providerCode: @course.provider.code,
+      courseCode: @course.code,
+    )
+  end
+
+  def then_i_am_redirected_to_the_create_account_or_sign_in_path
+    expect(page).to have_current_path candidate_interface_create_account_or_sign_in_path(
+      providerCode: @provider.code,
+      courseCode: @course.code,
+    )
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def then_i_am_redirected_to_the_course_confirm_selection_page
+    expect(page).to have_current_path(
+      candidate_interface_continuous_applications_course_confirm_selection_path(@course.id),
+    )
+  end
+
+  def when_i_confirm_the_course
+    choose 'Yes'
+    click_on 'Continue'
+  end
+
+  def then_i_should_be_redirected_to_the_course_site_path
+    expect(page).to have_current_path(
+      candidate_interface_continuous_applications_course_site_path(
+        @provider.id,
+        @course.id,
+        'full_time',
+      ),
+    )
+  end
+
+  def when_i_choose_a_location
+    choose 'Main site'
+    click_button t('continue')
+  end
+
+  def then_i_should_be_redirected_to_the_course_review_path
+    expect(page).to have_current_path(
+      candidate_interface_continuous_applications_course_review_path(application_choice_id: application_choice.id),
+    )
+  end
+end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_with_multiple_study_modes_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_with_multiple_study_modes_spec.rb
@@ -1,0 +1,123 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate arrives from Find with provider and course with multiple study modes', continuous_applications: true do
+  include CandidateHelper
+
+  scenario 'The provider is only accepting applications on the Apply service' do
+    given_there_is_a_provider_with_a_course_that_is_only_accepting_applications_on_apply
+
+    when_i_follow_a_link_from_find
+    then_i_am_redirected_to_the_create_account_or_sign_in_path
+
+    given_i_am_signed_in
+
+    when_i_follow_a_link_from_find
+    then_i_am_redirected_to_the_course_confirm_selection_page
+
+    when_i_confirm_the_course
+    then_i_should_be_redirect_to_the_course_study_mode_path
+
+    when_i_choose_the_study_mode
+    then_i_should_be_redirected_to_the_course_site_path
+
+    when_i_choose_a_location
+    then_i_should_be_redirected_to_the_course_review_path
+  end
+
+  def given_there_is_a_provider_with_a_course_that_is_only_accepting_applications_on_apply
+    @provider = create(:provider)
+
+    @first_site = create(:site, provider: @provider, name: 'Site 1')
+    @second_site = create(:site, provider: @provider, name: 'Site 2')
+    @third_site = create(:site, provider: @provider, name: 'Site 3')
+
+    @course = create(
+      :course,
+      :with_both_study_modes,
+      :open_on_apply,
+      provider: @provider,
+      name: 'Software Engineering',
+    )
+
+    create(
+      :course_option,
+      site: @first_site,
+      course: @course,
+      study_mode: :part_time,
+    )
+    create(
+      :course_option,
+      site: @second_site,
+      course: @course,
+      study_mode: :part_time,
+    )
+    create(
+      :course_option,
+      site: @third_site,
+      course: @course,
+      study_mode: :full_time,
+    )
+  end
+
+  def when_i_follow_a_link_from_find
+    visit candidate_interface_apply_from_find_path(
+      providerCode: @course.provider.code,
+      courseCode: @course.code,
+    )
+  end
+
+  def then_i_am_redirected_to_the_create_account_or_sign_in_path
+    expect(page).to have_current_path candidate_interface_create_account_or_sign_in_path(
+      providerCode: @provider.code,
+      courseCode: @course.code,
+    )
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def then_i_am_redirected_to_the_course_confirm_selection_page
+    expect(page).to have_current_path(
+      candidate_interface_continuous_applications_course_confirm_selection_path(@course.id),
+    )
+  end
+
+  def when_i_confirm_the_course
+    choose 'Yes'
+    click_on 'Continue'
+  end
+
+  def then_i_should_be_redirected_to_the_course_site_path
+    expect(page).to have_current_path(
+      candidate_interface_continuous_applications_course_site_path(
+        @provider.id,
+        @course.id,
+        'part_time',
+      ),
+    )
+  end
+
+  def when_i_choose_the_study_mode
+    choose 'Part time'
+    click_button t('continue')
+  end
+
+  def when_i_choose_a_location
+    choose @second_site.name
+    click_button t('continue')
+  end
+
+  def then_i_should_be_redirect_to_the_course_study_mode_path
+    expect(page).to have_text 'Full time or part time?'
+    expect(page).to have_current_path(
+      candidate_interface_continuous_applications_course_study_mode_path(@provider.id, @course.id),
+    )
+  end
+
+  def then_i_should_be_redirected_to_the_course_review_path
+    expect(page).to have_current_path(
+      candidate_interface_continuous_applications_course_review_path(application_choice_id: application_choice.id),
+    )
+  end
+end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_duplicate_application_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_duplicate_application_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate arrives from Find with provider and course that is already added', continuous_applications: true do
+  include CandidateHelper
+
+  scenario 'The provider is only accepting applications on the Apply service' do
+    given_there_is_a_provider_with_a_course_that_is_only_accepting_applications_on_apply
+
+    when_i_follow_a_link_from_find
+    then_i_am_redirected_to_the_create_account_or_sign_in_path
+
+    given_i_am_signed_in
+    and_i_already_have_this_application
+
+    when_i_follow_a_link_from_find
+
+    then_i_am_redirected_to_your_applications_tab
+    and_i_see_a_message_about_the_duplication
+  end
+
+  def given_there_is_a_provider_with_a_course_that_is_only_accepting_applications_on_apply
+    @provider = create(:provider, code: '8N5', name: 'Snape University')
+    @course = create(:course, :open_on_apply, name: 'Potions', code: 'D75F', provider: @provider, recruitment_cycle_year: 2024)
+    create(:course_option, course: @course)
+  end
+
+  def and_i_already_have_this_application
+    create(
+      :application_choice,
+      :unsubmitted,
+      application_form: current_candidate.current_application,
+      course: @course,
+    )
+  end
+
+  def when_i_follow_a_link_from_find
+    visit candidate_interface_apply_from_find_path(
+      providerCode: @course.provider.code,
+      courseCode: @course.code,
+    )
+  end
+
+  def then_i_am_redirected_to_the_create_account_or_sign_in_path
+    expect(page).to have_current_path candidate_interface_create_account_or_sign_in_path(
+      providerCode: @provider.code,
+      courseCode: @course.code,
+    )
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def then_i_am_redirected_to_your_applications_tab
+    expect(page).to have_current_path(
+      candidate_interface_continuous_applications_choices_path,
+    )
+  end
+
+  def and_i_see_a_message_about_the_duplication
+    expect(page).to have_content('You have already selected Potions (D75F)')
+  end
+end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_max_applications_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_max_applications_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate arrives from Find with provider and course that is already added', continuous_applications: true do
+  include CandidateHelper
+
+  scenario 'The provider is only accepting applications on the Apply service' do
+    given_there_is_a_provider_with_a_course_that_is_only_accepting_applications_on_apply
+
+    when_i_follow_a_link_from_find
+    then_i_am_redirected_to_the_create_account_or_sign_in_path
+
+    given_i_am_signed_in
+    and_i_already_have_max_applications
+
+    when_i_follow_a_link_from_find
+
+    then_i_am_redirected_to_your_applications_tab
+    and_i_see_a_message_about_the_limit
+  end
+
+  def given_there_is_a_provider_with_a_course_that_is_only_accepting_applications_on_apply
+    @provider = create(:provider, code: '8N5', name: 'Snape University')
+    @course = create(:course, :open_on_apply, name: 'Potions', code: 'D75F', provider: @provider, recruitment_cycle_year: 2024)
+    create(:course_option, course: @course)
+  end
+
+  def and_i_already_have_max_applications
+    create_list(:application_choice, ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES,
+                :unsubmitted,
+                application_form: current_candidate.current_application)
+  end
+
+  def when_i_follow_a_link_from_find
+    visit candidate_interface_apply_from_find_path(
+      providerCode: @course.provider.code,
+      courseCode: @course.code,
+    )
+  end
+
+  def then_i_am_redirected_to_the_create_account_or_sign_in_path
+    expect(page).to have_current_path candidate_interface_create_account_or_sign_in_path(
+      providerCode: @provider.code,
+      courseCode: @course.code,
+    )
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def then_i_am_redirected_to_your_applications_tab
+    expect(page).to have_current_path(
+      candidate_interface_continuous_applications_choices_path,
+    )
+  end
+
+  def and_i_see_a_message_about_the_limit
+    expect(page).to have_content('You cannot have more than 4 course choices. You must delete a choice if you want to apply to Potions (D75F)')
+  end
+end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_attempts_to_add_course_from_find_to_application_from_previous_cycle_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_attempts_to_add_course_from_find_to_application_from_previous_cycle_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate attempts to add course via Find to application from previous cycle' do
+  include CandidateHelper
+
+  scenario 'The candidate cannot add course to an application from the previous cycle' do
+    given_i_have_made_an_application_in_the_previous_cycle
+
+    travel_temporarily_to('2021-03-02') do
+      given_i_am_signed_in
+      and_there_are_course_options
+
+      when_i_visit_the_site_with_a_course_id_from_find
+      then_i_see_that_my_application_must_be_carried_over
+    end
+  end
+
+  def given_i_have_made_an_application_in_the_previous_cycle
+    travel_temporarily_to('2020-08-15') do
+      @previous_application_form = create(
+        :application_form,
+        :minimum_info,
+        candidate: current_candidate,
+        recruitment_cycle_year: 2020,
+        support_reference: 'AB1234',
+        submitted_at: nil,
+      )
+    end
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_there_are_course_options
+    given_courses_exist
+    @course = Course.find_by(code: '2XT2')
+  end
+
+  def when_i_visit_the_site_with_a_course_id_from_find
+    visit candidate_interface_apply_from_find_path(providerCode: @provider.code, courseCode: @course.code)
+  end
+
+  def then_i_see_that_my_application_must_be_carried_over
+    expect(page).to have_content('You started an application for courses starting in the 2020 to 2021 academic year, which have now closed.')
+    expect(page).to have_content('Continue your application to apply for courses starting in the 2021 to 2022 academic year instead.')
+
+    # Normally we'd avoid a trip directly to the db in a system spec,
+    # this is here to prove a particular bug has been solved.
+    expect(@previous_application_form.application_choices).to be_empty
+  end
+end


### PR DESCRIPTION
## Context

Candidates can also select a course directly from Find:

1. Candidate visits Find
2. They click on the button "Apply for this course"
3. Then goes to Apply 
4. Then we redirect them to continuous applications course selection

Observation: On Friday Itried to rewrite and create a better approach for this BUT for the 3rd October we don't have time to do a full rewrite on this feature so on Monday I decided to modify the existing feature to accomodate continuous applications redirection.