### PR TITLE
Manage: updated dates and deadlines guidance page

### DIFF
--- a/app/views/content/dates_and_deadlines.md
+++ b/app/views/content/dates_and_deadlines.md
@@ -21,6 +21,6 @@ Training providers will still be able to make a decision after 30 working days o
 | **Date and time** | **What happens** |
 | --- | --- |
 | <%= CycleTimetable.find_opens(CycleTimetable.next_year).to_fs(:govuk_date_and_time) %> | Candidates can find courses for the <%= RecruitmentCycle.cycle_name(RecruitmentCycle.next_year) %> recruitment cycle on GOV.UK. |
-| <%= CycleTimetable.apply_opens(CycleTimetable.next_year).to_fs(:govuk_date_and_time) %> | Start of <%= RecruitmentCycle.cycle_name(RecruitmentCycle.next_year) %> recruitment cycle. Candidates can apply for courses. |
-| <%= CycleTimetable.apply_2_deadline(CycleTimetable.next_year).to_fs(:govuk_date_and_time) %> | The last day for candidates to apply for courses. |
+| <%= CycleTimetable.apply_opens(CycleTimetable.next_year).to_fs(:govuk_date_and_time) %> | Start of the <%= RecruitmentCycle.cycle_name(RecruitmentCycle.next_year) %> recruitment cycle. Candidates can apply for courses. |
+| <%= CycleTimetable.apply_2_deadline(CycleTimetable.next_year).to_fs(:govuk_date_and_time) %> | The last day for all candidates to apply for courses. |
 | <%= CycleTimetable.reject_by_default(CycleTimetable.next_year).to_fs(:govuk_date_and_time) %> | End of <%= RecruitmentCycle.cycle_name(RecruitmentCycle.next_year) %> recruitment cycle. Applications awaiting decisions are automatically rejected. |

--- a/app/views/content/dates_and_deadlines.md
+++ b/app/views/content/dates_and_deadlines.md
@@ -11,12 +11,16 @@
 
 
 ### <%= RecruitmentCycle.cycle_name(RecruitmentCycle.next_year) %> recruitment cycle
+
+In the <%= RecruitmentCycle.cycle_name(RecruitmentCycle.next_year) %> recruitment cycle, training providers will have more time to make decisions on applications.
+
+Applications from candidates will not be rejected after 40 working days. Instead, if candidates do not receive a decision on an application within 30 working days, they’ll be able to apply for another course.
+
+Training providers will still be able to make a decision after 30 working days on all applications.
+
 | **Date and time** | **What happens** |
 | --- | --- |
-| <%= CycleTimetable.apply_opens(CycleTimetable.next_year).to_fs(:govuk_date_and_time) %> | Start of <%= RecruitmentCycle.cycle_name(RecruitmentCycle.next_year) %> recruitment cycle - candidates can apply for courses. |
-| <%= next_years_holidays[:christmas][:begins].to_fs(:govuk_date) %> to <%= next_years_holidays[:christmas][:ends].to_fs(:govuk_date) %> | This period is not counted as working days when calculating time to make a decision. |
-| <%= next_years_holidays[:easter][:begins].to_fs(:day_and_month) %> to <%= next_years_holidays[:easter][:ends].to_fs(:govuk_date) %> | This period is not counted as working days when calculating time to make a decision. |
-| <%= CycleTimetable.show_summer_recruitment_banner(CycleTimetable.next_year).to_fs(:govuk_date) %> | Time to make a decision is reduced from 40 working days to 20 working days. |
-| <%= CycleTimetable.apply_1_deadline(CycleTimetable.next_year).to_fs(:govuk_date_and_time) %> | Candidates can no longer apply for courses, unless they have already applied within this recruitment cycle. |
-| <%= CycleTimetable.apply_2_deadline(CycleTimetable.next_year).to_fs(:govuk_date_and_time) %> | Candidates can no longer apply for courses. |
-| <%= CycleTimetable.reject_by_default(CycleTimetable.next_year).to_fs(:govuk_date_and_time) %> | End of <%= RecruitmentCycle.cycle_name(RecruitmentCycle.next_year) %> recruitment cycle - applications awaiting decisions are automatically rejected. |
+| <%= CycleTimetable.find_opens(CycleTimetable.next_year).to_fs(:govuk_date_and_time) %> | Candidates can find courses for the <%= RecruitmentCycle.cycle_name(RecruitmentCycle.next_year) %> recruitment cycle on GOV.UK. |
+| <%= CycleTimetable.apply_opens(CycleTimetable.next_year).to_fs(:govuk_date_and_time) %> | Start of <%= RecruitmentCycle.cycle_name(RecruitmentCycle.next_year) %> recruitment cycle. Candidates can apply for courses. |
+| <%= CycleTimetable.apply_2_deadline(CycleTimetable.next_year).to_fs(:govuk_date_and_time) %> | The last day for candidates to apply for courses. |
+| <%= CycleTimetable.reject_by_default(CycleTimetable.next_year).to_fs(:govuk_date_and_time) %> | End of <%= RecruitmentCycle.cycle_name(RecruitmentCycle.next_year) %> recruitment cycle. Applications awaiting decisions are automatically rejected. |


### PR DESCRIPTION
## Context

We need to update the 2023 to 2024 recruitment cycle dates on the guidance page for Manage users to reflect the new cycle and how things will work in continuous applications.

## Changes proposed in this pull request

- Added paragraph to explain there's no more 40 days rejection deadline in line with GOV.UK page
- Added row for when Find opens
- Removed rows talking about how holidays are not counted in the 40 working day deadline (this will no longer exist)
- Removed Apply 1 deadline

https://apply-review-8523.test.teacherservices.cloud/provider/service-guidance/dates-and-deadlines

![screencapture-apply-review-8523-test-teacherservices-cloud-provider-service-guidance-dates-and-deadlines-2023-09-06-15_06_00](https://github.com/DFE-Digital/apply-for-teacher-training/assets/68232608/d40d9ece-c694-4d98-b273-62be88ccb754)


## Link to Trello card

https://trello.com/c/SzDcNh0u/505-ca-edit-dates-and-deadlines-page-on-manage

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
