### PR TITLE
Fix API tests that fail when new cycle opens

### DIFF
--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -25,6 +25,7 @@ FactoryBot.define do
     end
 
     current_recruitment_cycle_year { recruitment_cycle_year || course_option.course.recruitment_cycle_year }
+    personal_statement { Faker::Lorem.paragraph_by_chars(number: 50) }
     original_course_option { course_option }
     current_course_option { course_option }
     provider_ids { provider_ids_for_access }

--- a/spec/forms/support_interface/application_forms/edit_becoming_a_teacher_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/edit_becoming_a_teacher_form_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe SupportInterface::ApplicationForms::EditBecomingATeacherForm, typ
     context 'when saving personal_statement records fails' do
       it 'does not update becoming_a_teacher or personal_statement' do
         application_form = create(:application_form, becoming_a_teacher: nil)
-        application_choice = create(:application_choice, application_form: application_form)
+        application_choice = create(:application_choice, application_form: application_form, personal_statement: nil)
         form = described_class.new(becoming_a_teacher: 'I really want to teach.', audit_comment: 'It was on a zendesk ticket.')
 
         allow_any_instance_of(ApplicationForm).to receive(:update!).and_raise(ActiveRecord::LockWaitTimeout) # rubocop:disable RSpec/AnyInstance

--- a/spec/requests/candidate_api/get_candidates_v1_2_spec.rb
+++ b/spec/requests/candidate_api/get_candidates_v1_2_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'GET /candidate-api/v1.2/candidates' do
   it_behaves_like 'an API endpoint requiring a date param', '/candidate-api/v1.2/candidates', 'updated_since', ServiceAPIUser.candidate_user.create_magic_link_token!
   it_behaves_like 'a candidate API endpoint', '/candidate-api/v1.2/candidates', 'updated_since', 'v1.2'
 
-  it 'returns candidates ordered by `updated_at` timestamp desc across multiple associations, with applications ordered by `created_at` asc' do
+  it 'returns candidates ordered by `updated_at` timestamp desc across multiple associations, with applications ordered by `created_at` asc', time: '2023-11-04 09:00:00' do
     allow(ApplicationFormStateInferrer).to receive(:new).and_return(instance_double(ApplicationFormStateInferrer, state: :unsubmitted_not_started_form))
 
     application_forms = []

--- a/spec/requests/vendor_api/v1.0/get_multiple_applications_spec.rb
+++ b/spec/requests/vendor_api/v1.0/get_multiple_applications_spec.rb
@@ -42,7 +42,17 @@ RSpec.describe 'Vendor API - GET /api/v1.0/applications' do
     expect(parsed_response['data'].size).to eq(1)
   end
 
-  it 'returns a response that is valid according to the OpenAPI schema' do
+  it 'returns a response that is valid according to the OpenAPI schema after 2024', continuous_applications: true do
+    create_application_choice_for_currently_authenticated_provider(
+      status: 'awaiting_provider_decision',
+    )
+
+    get_api_request "/api/v1.0/applications?since=#{CGI.escape(1.day.ago.iso8601)}"
+
+    expect(parsed_response).to be_valid_against_openapi_schema('MultipleApplicationsResponse', '1.0')
+  end
+
+  it 'returns a response that is valid according to the OpenAPI schema before 2024', continuous_applications: false do
     create_application_choice_for_currently_authenticated_provider(
       status: 'awaiting_provider_decision',
     )


### PR DESCRIPTION
## Context

Tests are failing when the test time is in after apply opens in the continuous applications recruitment cycle (2024).

## Changes proposed in this pull request

All except for these three were solved by setting `personal_statement` as a default attribute on ApplicationChoice factory.
 - [x] ./spec/requests/candidate_api/get_candidates_v1_2_spec.rb:11
 - [x] ./spec/presenters/vendor_api/v1.0/application_presenter_spec.rb:127
 - [x] ./spec/presenters/vendor_api/v1.0/application_presenter_spec.rb:136


## Checklist

 - [x] ./spec/requests/vendor_api/v1.0/get_multiple_applications_spec.rb:45
 - [x] ./spec/requests/vendor_api/v1.1/post_create_interview_spec.rb:30
 - [x] ./spec/requests/vendor_api/v1.1/post_update_interview_spec.rb:33
 - [x] ./spec/requests/vendor_api/v1.1/get_single_application_spec.rb:23
 - [x] ./spec/requests/vendor_api/v1.2/post_reject_by_codes_spec.rb:130
 - [x] ./spec/requests/vendor_api/v1.2/post_reject_by_codes_spec.rb:16
 - [x] ./spec/requests/vendor_api/v1.2/post_reject_by_codes_spec.rb:61
 - [x] ./spec/requests/vendor_api/v1.1/post_cancel_interview_spec.rb:24
 - [x] ./spec/requests/vendor_api/v1.1/post_withdraw_or_decline_application_spec.rb:9
 - [x] ./spec/requests/vendor_api/v1.0/post_confirm_enrolment_spec.rb:9
 - [x] ./spec/requests/vendor_api/v1.0/post_reject_application_spec.rb:36
 - [x] ./spec/requests/vendor_api/v1.0/post_reject_application_spec.rb:10
 - [x] ./spec/presenters/vendor_api/v1.0/application_presenter_spec.rb:21
 - [x] ./spec/requests/candidate_api/get_candidates_v1_2_spec.rb:11
 - [x] ./spec/presenters/vendor_api/v1.0/application_presenter_spec.rb:127
 - [x] ./spec/presenters/vendor_api/v1.0/application_presenter_spec.rb:136


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

[Trello Ticket](https://trello.com/c/6pcn4zUl/586-ca-failing-future-specs-find-opens-unitsupport-referee-api)

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
