### PR TITLE
Validate science GCSE

### DIFF
--- a/app/components/candidate_interface/continuous_applications/application_submit_component.html.erb
+++ b/app/components/candidate_interface/continuous_applications/application_submit_component.html.erb
@@ -10,6 +10,6 @@
   <%= form.govuk_submit t('continue') %>
 <% else %>
   <% Array(errors[:application_choice]).each do |error_message| %>
-    <p class="govuk-body"><%= error_message %></p>
+    <p class="govuk-body"><%= error_message.html_safe %>.</p>
   <% end %>
 <% end %>

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -251,6 +251,10 @@ class ApplicationChoice < ApplicationRecord
     ].compact.uniq
   end
 
+  def science_gcse_needed?
+    course.primary_course?
+  end
+
 private
 
   def set_initial_status

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -251,9 +251,7 @@ class ApplicationForm < ApplicationRecord
   end
 
   def science_gcse_needed?
-    application_choices.includes(%i[course_option course]).any? do |application_choice|
-      application_choice.course_option.course.primary_course?
-    end
+    application_choices.includes(%i[course_option course]).any?(&:science_gcse_needed?)
   end
 
   def full_name

--- a/app/presenters/candidate_interface/application_form_sections.rb
+++ b/app/presenters/candidate_interface/application_form_sections.rb
@@ -1,0 +1,42 @@
+module CandidateInterface
+  class ApplicationFormSections
+    def initialize(application_form:, application_choice:)
+      @application_form = application_form
+      @application_choice = application_choice
+    end
+
+    def all_completed?
+      all_sections.map(&:second).all?
+    end
+
+    def completed?(section_name)
+      sections_with_completion.find { |section| section[0] == section_name }&.second
+    end
+
+  private
+
+    attr_reader :application_form, :application_choice
+
+    def presenter
+      @presenter ||= ApplicationFormPresenter.new(application_form)
+    end
+
+    def sections_with_completion
+      presenter.sections_with_completion
+    end
+
+    def sections_with_validations
+      presenter.sections_with_validations
+    end
+
+    def required_sections_with_completion
+      sections_with_completion.reject do |section|
+        %i[course_choices science_gcse].include?(section[0])
+      end
+    end
+
+    def all_sections
+      required_sections_with_completion + sections_with_validations
+    end
+  end
+end

--- a/app/validators/your_details_completion_validator.rb
+++ b/app/validators/your_details_completion_validator.rb
@@ -1,14 +1,21 @@
 class YourDetailsCompletionValidator < ActiveModel::EachValidator
-  def validate_each(record, attribute, _application_choice)
-    presenter = CandidateInterface::ApplicationFormPresenter.new(record.application_form)
+  include Rails.application.routes.url_helpers
+  include ActionView::Helpers::UrlHelper
 
-    # on Continuous applications we don't have course choices section
-    # anymore
-    sections_with_completion = presenter.sections_with_completion.reject { |section| section[0] == :course_choices }
+  def validate_each(record, attribute, application_choice)
+    sections = CandidateInterface::ApplicationFormSections.new(application_form: record.application_form, application_choice:)
 
-    return if sections_with_completion.map(&:second).all? &&
-              presenter.sections_with_validations.map(&:second).all?
+    record.errors.add attribute, :incomplete_details unless sections.all_completed?
 
-    record.errors.add attribute, :incomplete_details
+    return unless application_choice.science_gcse_needed? && !sections.completed?(:science_gcse)
+
+    record.errors.add attribute, :science_gcse_missing
+    record.errors.add attribute, link_to(science_gcse_missing_guide_error, candidate_interface_gcse_details_new_type_path(subject: :science), class: 'govuk-link')
+  end
+
+private
+
+  def science_gcse_missing_guide_error
+    I18n.t('activemodel.errors.models.candidate_interface/continuous_applications/application_choice_submission.attributes.application_choice.science_gcse_missing_guide')
   end
 end

--- a/config/locales/candidate_interface/submit_application.yml
+++ b/config/locales/candidate_interface/submit_application.yml
@@ -14,6 +14,8 @@ en:
               site_invalid: You cannot submit this application because it’s no longer available. You need to either remove it or change the course.
               course_full: You cannot submit this application because there are no places left on the course.
               remove_or_change_application: You need to either remove this application or change your course.
+              science_gcse_missing: To apply for a Primary course, you need a GCSE in science at grade 4 (C) or above, or equivalent
+              science_gcse_missing_guide: Add your science GCSE grade (or equivalent) before submitting this application
   application_form:
     submit_application:
       title: Send application to training providers

--- a/spec/components/candidate_interface/continuous_applications/application_submit_component_spec.rb
+++ b/spec/components/candidate_interface/continuous_applications/application_submit_component_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationSubmitComp
       it 'renders error message' do
         expect(result.text).to include(
           'You cannot submit this application until you’ve completed your details.',
+          'To apply for a Primary course, you need a GCSE in science at grade 4 (C) or above, or equivalent.',
+          'Add your science GCSE grade (or equivalent) before submitting this application.',
         )
       end
     end

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -433,4 +433,21 @@ RSpec.describe ApplicationChoice do
       end
     end
   end
+
+  describe '#science_gcse_needed?' do
+    it 'is true for primary courses' do
+      course = create(:course, level: 'primary')
+      course_option = create(:course_option, course:)
+      application_choice = create(:application_choice, course_option:)
+      expect(application_choice.science_gcse_needed?).to be true
+    end
+
+    it 'is false for secondary courses' do
+      course = create(:course, level: 'secondary')
+      course_option = create(:course_option, course:)
+      application_choice = create(:application_choice, course_option:)
+
+      expect(application_choice.science_gcse_needed?).to be false
+    end
+  end
 end

--- a/spec/presenters/candidate_interface/application_form_sections_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_sections_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::ApplicationFormSections do
+  let(:application_form) { build_stubbed(:application_form, :completed) }
+  let(:application_choice) { build_stubbed(:application_choice, application_form:) }
+  let(:sections) { described_class.new(application_form:, application_choice:) }
+
+  describe '#all_completed?' do
+    subject(:all_completed?) { sections.all_completed? }
+
+    context 'when all sections are completed' do
+      it { is_expected.to be(true) }
+    end
+
+    context 'when not all sections are completed' do
+      let(:application_form) { build_stubbed(:application_form, :completed, contact_details_completed: nil) }
+
+      it { is_expected.to be(false) }
+    end
+  end
+
+  describe '#completed?' do
+    subject(:completed?) { sections.completed?(section_name) }
+
+    context 'when the section is completed' do
+      let(:section_name) { :personal_details }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when the section is not completed' do
+      let(:application_form) { build_stubbed(:application_form, :completed, contact_details_completed: false) }
+      let(:section_name) { :contact_details }
+
+      it { is_expected.to be(false) }
+    end
+  end
+end

--- a/spec/services/candidate_interface/continuous_applications/application_choice_submission_spec.rb
+++ b/spec/services/candidate_interface/continuous_applications/application_choice_submission_spec.rb
@@ -12,9 +12,23 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationChoiceSubm
     context 'when your details are incomplete' do
       let(:application_form) { create(:application_form, :minimum_info) }
 
-      it 'adds error to application choice' do
+      it 'adds errors to application choice' do
         expect(application_choice_submission).not_to be_valid
         expect(application_choice_submission.errors[:application_choice]).to include('You cannot submit this application until you’ve completed your details.')
+        expect(application_choice_submission.errors[:application_choice]).to include('To apply for a Primary course, you need a GCSE in science at grade 4 (C) or above, or equivalent')
+        expect(application_choice_submission.errors[:application_choice]).to include('<a class="govuk-link" href="/candidate/application/gcse/science">Add your science GCSE grade (or equivalent) before submitting this application</a>')
+      end
+
+      context 'when science GCSE is not needed' do
+        let(:course) { create(:course, level: 'secondary') }
+        let(:course_option) { create(:course_option, course:) }
+        let(:application_choice) { create(:application_choice, course_option:) }
+
+        it 'does not add the science GCSE errors' do
+          expect(application_choice_submission).not_to be_valid
+          expect(application_choice_submission.errors[:application_choice]).not_to include('To apply for a Primary course, you need a GCSE in science at grade 4 (C) or above, or equivalent.')
+          expect(application_choice_submission.errors[:application_choice]).not_to include('<a href="/candidate/application/gcse/science">Add your science GCSE grade (or equivalent) before submitting this application.</a>')
+        end
       end
     end
 


### PR DESCRIPTION
## Context

Show validation messages and a link to the Science GCSE page if the candidate has not completed this section and is applying for a course that requires it (primary).

## Changes proposed in this pull request

Incomplete for that requires Science GCSE:
<img width="757" alt="Screenshot 2023-09-07 at 13 51 19" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/612e3e81-1ba9-4ad8-89db-d1d9ad5c8d21">

Complete form that requires Science GCSE:
<img width="800" alt="Screenshot 2023-09-07 at 13 50 22" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/84690721-0fdf-466e-856f-c2b9210a5d74">

## Guidance to review

There are a lot of scenarios to test. I've tried quite a few and it seemed to be working fine. Bear in mind that because we currently don't allow editing of sections once the form has been submitted, once you apply for a secondary course, you can't apply for a primary because you get redirected when trying to access the `Science GCSE or equivalent` page.

I'm not entirely happy with the way `YourDetailsCompletionValidator` works as it relies too much on getting data from that array of sections. Feedback is welcome.

Example scenarios:
- Candidate fills out ‘Your details’ then goes to add an application, they choose a Primary course - we can’t let them submit until they add their science GCSE
- Candidate applies to a secondary course, submit that, then adds an application and chooses a primary course - we can’t let them submit until they add their science GCSEs
- Candidate adds applications first, if they select a primary course, we show the science GCSE in ‘Your details’

@MaeveRoseveare to keep the wording consistent between errors, I have updated the error message for Science to include the general error message for an incomplete form:

From `You cannot submit this application yet.` to `You cannot submit this application until you've completed your details.`
