### PR TITLE
Fix find opens integration test failures

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -187,7 +187,7 @@ jobs:
       matrix:
         tests: [ unit_shared, unit_candidate-provider, unit_support-referee-api, integration_shared, integration_provider, integration_candidate ]
         feature-flags: [on, off]
-        offset-date: [real_world, 7.days.from_now]
+        offset-date: [real_world, 7.days.from_now, '2023-10-04 09:00:00']
         include:
           - tests: unit_shared
             include-pattern: spec/.*_spec.rb

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -187,7 +187,7 @@ jobs:
       matrix:
         tests: [ unit_shared, unit_candidate-provider, unit_support-referee-api, integration_shared, integration_provider, integration_candidate ]
         feature-flags: [on, off]
-        offset-date: [real_world, 7.days.from_now, '2023-10-04 09:00:00']
+        offset-date: [real_world, 7.days.from_now]
         include:
           - tests: unit_shared
             include-pattern: spec/.*_spec.rb

--- a/spec/services/candidate_interface/continuous_applications/application_choice_submission_spec.rb
+++ b/spec/services/candidate_interface/continuous_applications/application_choice_submission_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe CandidateInterface::ContinuousApplications::ApplicationChoiceSubmission do
+RSpec.describe CandidateInterface::ContinuousApplications::ApplicationChoiceSubmission, continuous_applications: false do
   subject(:application_choice_submission) do
     described_class.new(application_choice:)
   end

--- a/spec/system/candidate_api/candidate_api_application_state_change_triggers_update_spec.rb
+++ b/spec/system/candidate_api/candidate_api_application_state_change_triggers_update_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate API application status change' do
+RSpec.feature 'Candidate API application status change', continuous_applications: false do
   include SignInHelper
   include CandidateHelper
 

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_signs_up_for_an_adviser_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_signs_up_for_an_adviser_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate signs up for an adviser', continuous_applications: false, js: true do
+RSpec.feature 'Candidate signs up for an adviser', :js, continuous_applications: false do
   include_context 'get into teaching api stubbed endpoints'
 
   include CandidateHelper

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_signs_up_for_an_adviser_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_signs_up_for_an_adviser_spec.rb
@@ -105,7 +105,11 @@ RSpec.feature 'Candidate signs up for an adviser', :js do
   end
 
   def then_i_should_be_redirected_to_the_application_form_page
-    expect(page).to have_current_path(candidate_interface_application_form_path)
+    if FeatureFlag.active?(:continuous_applications)
+      expect(page).to have_current_path(candidate_interface_continuous_applications_details_path)
+    else
+      expect(page).to have_current_path(candidate_interface_application_form_path)
+    end
   end
 
   def and_i_should_see_the_success_message

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_signs_up_for_an_adviser_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_signs_up_for_an_adviser_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate signs up for an adviser', :js do
+RSpec.feature 'Candidate signs up for an adviser', continuous_applications: false, js: true do
   include_context 'get into teaching api stubbed endpoints'
 
   include CandidateHelper
@@ -105,11 +105,7 @@ RSpec.feature 'Candidate signs up for an adviser', :js do
   end
 
   def then_i_should_be_redirected_to_the_application_form_page
-    if FeatureFlag.active?(:continuous_applications)
-      expect(page).to have_current_path(candidate_interface_continuous_applications_details_path)
-    else
-      expect(page).to have_current_path(candidate_interface_application_form_path)
-    end
+    expect(page).to have_current_path(candidate_interface_application_form_path)
   end
 
   def and_i_should_see_the_success_message

--- a/spec/system/candidate_interface/apply_again/candidate_applies_again_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_applies_again_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
-RSpec.feature 'Apply again with four choices', continuous_applications: false, time: CycleTimetableHelper.after_apply_1_deadline do
+RSpec.feature 'Apply again with four choices', continuous_applications: false do
   include CandidateHelper
 
   it 'Candidate applies again with four choices' do
+    given_i_am_after_apply_1_deadline
     given_i_am_signed_in_as_a_candidate
     and_i_have_an_unsuccessful_application
     and_i_have_incomplete_equality_and_diversity_information
@@ -42,6 +43,10 @@ RSpec.feature 'Apply again with four choices', continuous_applications: false, t
     then_my_application_is_submitted_and_sent_to_the_provider
     and_i_receive_an_email_that_my_application_has_been_sent
     and_i_do_not_see_referee_related_guidance
+  end
+
+  def given_i_am_after_apply_1_deadline
+    TestSuiteTimeMachine.travel_permanently_to(after_apply_1_deadline(2023) + 1.day)
   end
 
   def given_i_am_signed_in_as_a_candidate

--- a/spec/system/candidate_interface/apply_again/candidate_applies_again_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_applies_again_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Apply again with four choices', time: CycleTimetableHelper.after_apply_1_deadline do
+RSpec.feature 'Apply again with four choices', continuous_applications: false, time: CycleTimetableHelper.after_apply_1_deadline do
   include CandidateHelper
 
   it 'Candidate applies again with four choices' do

--- a/spec/system/candidate_interface/apply_again/candidate_applies_again_updates_personal_statement_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_applies_again_updates_personal_statement_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Apply again with four choices', time: CycleTimetableHelper.after_apply_1_deadline do
+RSpec.feature 'Apply again with four choices', continuous_applications: false, time: CycleTimetableHelper.after_apply_1_deadline do
   include CandidateHelper
 
   it 'Candidate applies again with four choices' do

--- a/spec/system/candidate_interface/apply_again/candidate_applies_again_updates_personal_statement_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_applies_again_updates_personal_statement_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
-RSpec.feature 'Apply again with four choices', continuous_applications: false, time: CycleTimetableHelper.after_apply_1_deadline do
+RSpec.feature 'Apply again with four choices', continuous_applications: false do
   include CandidateHelper
 
   it 'Candidate applies again with four choices' do
+    given_i_am_after_apply_1_deadline
     given_i_am_signed_in_as_a_candidate
     and_the_one_personal_statement_feature_flag_is_active
     and_i_have_an_unsuccessful_application
@@ -40,6 +41,10 @@ RSpec.feature 'Apply again with four choices', continuous_applications: false, t
     then_my_application_is_submitted_and_sent_to_the_provider
     and_i_receive_an_email_that_my_application_has_been_sent
     and_i_do_not_see_referee_related_guidance
+  end
+
+  def given_i_am_after_apply_1_deadline
+    TestSuiteTimeMachine.travel_permanently_to(after_apply_1_deadline(2023) + 1.day)
   end
 
   def given_i_am_signed_in_as_a_candidate

--- a/spec/system/candidate_interface/course_selection/candidate_adds_a_course_theyve_already_chosen_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_adds_a_course_theyve_already_chosen_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Handling duplicate course choices' do
+RSpec.feature 'Handling duplicate course choices', continuous_applications: false do
   include CandidateHelper
 
   scenario "candidate adds a course they've already chosen" do

--- a/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_with_a_course_only_open_on_apply_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_with_a_course_only_open_on_apply_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate arrives from Find with provider and course params' do
+RSpec.feature 'Candidate arrives from Find with provider and course params', continuous_applications: false do
   include CandidateHelper
 
   scenario 'The provider is only accepting applications on the Apply service' do

--- a/spec/system/candidate_interface/course_selection/candidate_cannot_add_course_twice_with_back_button_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_cannot_add_course_twice_with_back_button_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate arrives from Find with provider and course params' do
+RSpec.feature 'Candidate arrives from Find with provider and course params', continuous_applications: false do
   include CandidateHelper
 
   scenario 'The candidate cannot add course twice with back button' do

--- a/spec/system/candidate_interface/course_selection/candidate_deletes_course_after_completing_section_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_deletes_course_after_completing_section_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate edits their choice section' do
+RSpec.feature 'Candidate edits their choice section', continuous_applications: false do
   include CandidateHelper
 
   it 'Candidate deletes and adds additional courses' do

--- a/spec/system/candidate_interface/course_selection/candidate_does_not_know_where_they_want_to_apply_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_does_not_know_where_they_want_to_apply_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Selecting a course' do
+RSpec.feature 'Selecting a course', continuous_applications: false do
   include CandidateHelper
 
   scenario 'Candidate does not know what course to apply for' do

--- a/spec/system/candidate_interface/course_selection/candidate_edits_course_choices_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_edits_course_choices_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate edits course choices' do
+RSpec.feature 'Candidate edits course choices', continuous_applications: false do
   include CandidateHelper
   include CourseOptionHelpers
 

--- a/spec/system/candidate_interface/course_selection/candidate_existing_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_existing_user_with_course_params_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'An existing candidate arriving from Find with a course and provider code (with course selection page)' do
+RSpec.feature 'An existing candidate arriving from Find with a course and provider code (with course selection page)', continuous_applications: false do
   include CourseOptionHelpers
   include SignInHelper
 

--- a/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_and_cancel_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_and_cancel_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate tries to sign in after selecting a course in find without an account then says no to selecting the course' do
+RSpec.feature 'Candidate tries to sign in after selecting a course in find without an account then says no to selecting the course', continuous_applications: false do
   include SignInHelper
 
   scenario 'Candidate signs in and receives an email inviting them to sign up and is prompted to select the course' do

--- a/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'A new candidate arriving from Find with a course and provider code' do
+RSpec.feature 'A new candidate arriving from Find with a course and provider code', continuous_applications: false do
   include SignInHelper
 
   scenario 'retaining their course selection through the sign up process' do

--- a/spec/system/candidate_interface/course_selection/candidate_sees_add_additional_courses_after_adding_course_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_sees_add_additional_courses_after_adding_course_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Add additional courses flow' do
+RSpec.feature 'Add additional courses flow', continuous_applications: false do
   include CandidateHelper
   include CourseOptionHelpers
 

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Selecting a course' do
+RSpec.feature 'Selecting a course', continuous_applications: false do
   include CandidateHelper
 
   it 'Candidate selects a course choice' do

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_study_mode_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_study_mode_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Selecting a study mode' do
+RSpec.feature 'Selecting a study mode', continuous_applications: false do
   include CandidateHelper
 
   scenario 'Candidate selects different study modes' do

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_full_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_full_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Selecting a full course' do
+RSpec.feature 'Selecting a full course', continuous_applications: false do
   include CandidateHelper
 
   scenario 'Candidate selects a full course' do

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_when_only_one_site_available_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_when_only_one_site_available_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Selecting a course when only a single site is available' do
+RSpec.feature 'Selecting a course when only a single site is available', continuous_applications: false do
   include CandidateHelper
 
   it 'Candidate selects a course choice' do

--- a/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_picks_study_mode_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_picks_study_mode_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'An existing candidate arriving from Find with course params selects a study mode' do
+RSpec.feature 'An existing candidate arriving from Find with course params selects a study mode', continuous_applications: false do
   include CourseOptionHelpers
 
   scenario 'Signed in user with Find course params selects a part time course' do

--- a/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'An existing candidate arriving from Find with a course and provider code' do
+RSpec.feature 'An existing candidate arriving from Find with a course and provider code', continuous_applications: false do
   include CourseOptionHelpers
   scenario 'candidate is signed in' do
     and_i_am_an_existing_candidate_on_apply

--- a/spec/system/candidate_interface/course_selection/sandbox_user_apply_from_find_spec.rb
+++ b/spec/system/candidate_interface/course_selection/sandbox_user_apply_from_find_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'A sandbox user arriving from Find with a course and provider code', continuous_applications: false, sandbox: true do
+RSpec.feature 'A sandbox user arriving from Find with a course and provider code', :sandbox, continuous_applications: false do
   include SignInHelper
 
   scenario 'can prefill their application with their chosen course' do

--- a/spec/system/candidate_interface/course_selection/sandbox_user_apply_from_find_spec.rb
+++ b/spec/system/candidate_interface/course_selection/sandbox_user_apply_from_find_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'A sandbox user arriving from Find with a course and provider code', :sandbox do
+RSpec.feature 'A sandbox user arriving from Find with a course and provider code', continuous_applications: false, sandbox: true do
   include SignInHelper
 
   scenario 'can prefill their application with their chosen course' do

--- a/spec/system/candidate_interface/entering_details/candidate_becoming_a_teacher_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_becoming_a_teacher_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Entering "Why do you want to be a teacher?"' do
+RSpec.feature 'Entering "Why do you want to be a teacher?"', continuous_applications: false do
   include CandidateHelper
 
   scenario 'Candidate submits why they want to be a teacher' do

--- a/spec/system/candidate_interface/entering_details/candidate_completes_contact_details_with_a_missing_address_feature_flag_disabled_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_completes_contact_details_with_a_missing_address_feature_flag_disabled_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate attempts to submit their application without a valid address' do
+RSpec.feature 'Candidate attempts to submit their application without a valid address', continuous_applications: false do
   include CandidateHelper
 
   it 'The candidate has completed their contact details without entering an address' do

--- a/spec/system/candidate_interface/entering_details/candidate_entering_disability_info_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_disability_info_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Entering their disability information' do
+RSpec.feature 'Entering their disability information', continuous_applications: false do
   include CandidateHelper
 
   scenario 'Candidate submits their disability information' do

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_spec.rb
@@ -193,6 +193,10 @@ RSpec.feature 'Candidate entering GCSE details' do
   end
 
   def then_i_am_returned_to_the_application_form
-    expect(page).to have_current_path candidate_interface_application_form_path
+    if FeatureFlag.active?(:continuous_applications)
+      expect(page).to have_current_path candidate_interface_continuous_applications_details_path
+    else
+      expect(page).to have_current_path candidate_interface_application_form_path
+    end
   end
 end

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate entering GCSE details' do
+RSpec.feature 'Candidate entering GCSE details', continuous_applications: false do
   include CandidateHelper
 
   scenario 'Candidate submits their maths GCSE details and then update them' do
@@ -193,10 +193,6 @@ RSpec.feature 'Candidate entering GCSE details' do
   end
 
   def then_i_am_returned_to_the_application_form
-    if FeatureFlag.active?(:continuous_applications)
-      expect(page).to have_current_path candidate_interface_continuous_applications_details_path
-    else
-      expect(page).to have_current_path candidate_interface_application_form_path
-    end
+    expect(page).to have_current_path candidate_interface_application_form_path
   end
 end

--- a/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Entering their other qualifications', :mid_cycle do
+RSpec.feature 'Entering their other qualifications', continuous_applications: false, mid_cycle: true do
   include CandidateHelper
 
   scenario 'Candidate submits their other qualifications' do

--- a/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Entering their other qualifications', continuous_applications: false, mid_cycle: true do
+RSpec.feature 'Entering their other qualifications', :mid_cycle, continuous_applications: false do
   include CandidateHelper
 
   scenario 'Candidate submits their other qualifications' do

--- a/spec/system/candidate_interface/entering_details/candidate_entering_subject_knowledge_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_subject_knowledge_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Entering subject knowledge' do
+RSpec.feature 'Entering subject knowledge', continuous_applications: false do
   include CandidateHelper
 
   it 'Candidate submits their subject knowledge' do

--- a/spec/system/candidate_interface/entering_details/candidate_viewing_a_science_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_viewing_a_science_gcse_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate viewing Science GCSE' do
+RSpec.feature 'Candidate viewing Science GCSE', continuous_applications: false do
   include CandidateHelper
 
   it 'Candidate views a Science GCSE only when a primary course is chosen' do

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_delete_and_replace_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_delete_and_replace_degrees_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Deleting and replacing a degree' do
+RSpec.feature 'Deleting and replacing a degree', continuous_applications: false do
   include CandidateHelper
 
   scenario 'Candidate deletes and replaces their degree' do

--- a/spec/system/candidate_interface/feedback/candidate_completes_the_feedback_form_spec.rb
+++ b/spec/system/candidate_interface/feedback/candidate_completes_the_feedback_form_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Candidate feedback form' do
   include CandidateHelper
 
-  it 'Candidate completes the feedback form' do
+  it 'Candidate completes the feedback form', continuous_applications: false do
     given_i_complete_and_submit_my_application
     then_i_should_see_the_feedback_form
 

--- a/spec/system/candidate_interface/feedback/candidate_submits_application_with_feedback_form_previously_completed_spec.rb
+++ b/spec/system/candidate_interface/feedback/candidate_submits_application_with_feedback_form_previously_completed_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate submits application with feedback form previously completed' do
+RSpec.feature 'Candidate submits application with feedback form previously completed', continuous_applications: false do
   include CandidateHelper
 
   it 'Candidate submits application, skips feedback and goes straight to the application dashboard' do

--- a/spec/system/candidate_interface/guidance/public_user_spec.rb
+++ b/spec/system/candidate_interface/guidance/public_user_spec.rb
@@ -1,8 +1,35 @@
 require 'rails_helper'
 
 RSpec.describe 'Non logged in user can visit guidance' do
-  scenario 'User can visit the guidance page without session' do
-    visit(candidate_interface_guidance_path)
-    expect(page).to have_content('Start applying for courses')
+  context 'when legacy applications', continuous_applications: false do
+    context 'when mid cycle', time: mid_cycle do
+      scenario 'User can visit the guidance page without session' do
+        visit(candidate_interface_guidance_path)
+        expect(page).to have_content('Apply for teacher training')
+      end
+    end
+
+    context 'when after_apply_reopens', time: after_apply_reopens do
+      scenario 'User can visit the guidance page without session' do
+        visit(candidate_interface_guidance_path)
+        expect(page).to have_content('Apply for teacher training')
+      end
+    end
+  end
+
+  context 'when continuous applications mid cycle', continuous_applications: true do
+    context 'when mid cycle', time: mid_cycle do
+      scenario 'User can visit the guidance page without session' do
+        visit(candidate_interface_guidance_path)
+        expect(page).to have_content('Apply for teacher training')
+      end
+    end
+
+    context 'when after_apply_reopens', time: after_apply_reopens do
+      scenario 'User can visit the guidance page without session' do
+        visit(candidate_interface_guidance_path)
+        expect(page).to have_content('Apply for teacher training')
+      end
+    end
   end
 end

--- a/spec/system/candidate_interface/guidance/public_user_spec.rb
+++ b/spec/system/candidate_interface/guidance/public_user_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Non logged in user can visit guidance' do
     end
   end
 
-  context 'when continuous applications mid cycle', continuous_applications: true do
+  context 'when continuous applications mid cycle', :continuous_applications do
     context 'when mid cycle', time: mid_cycle do
       scenario 'User can visit the guidance page without session' do
         visit(candidate_interface_guidance_path)

--- a/spec/system/candidate_interface/navigation_tabs_spec.rb
+++ b/spec/system/candidate_interface/navigation_tabs_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Primary Navigation' do
+RSpec.describe 'Primary Navigation', continuous_applications: false do
   include CandidateHelper
   scenario 'highlights the primary navigation' do
     given_i_am_signed_in

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_can_see_their_rejection_reasons_on_apply_again_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_can_see_their_rejection_reasons_on_apply_again_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate can see their rejection reasons on apply again' do
+RSpec.feature 'Candidate can see their rejection reasons on apply again', continuous_applications: false do
   scenario 'when a candidate visits their apply again application form they can see apply1 rejection reasons' do
     given_i_am_signed_in
     and_i_have_an_apply1_application_with_3_rejections

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_declines_offer_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_declines_offer_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate declines an offer' do
+RSpec.feature 'Candidate declines an offer', continuous_applications: false do
   include CourseOptionHelpers
 
   scenario 'Candidate views an offer and declines' do

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_withdraws_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'A candidate withdraws her application', :bullet do
+RSpec.feature 'A candidate withdraws her application', bullet: true, continuous_applications: false do
   include CandidateHelper
 
   # bullet complains about wanting an includes on associated objects.

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_withdraws_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'A candidate withdraws her application', bullet: true, continuous_applications: false do
+RSpec.feature 'A candidate withdraws her application', :bullet, continuous_applications: false do
   include CandidateHelper
 
   # bullet complains about wanting an includes on associated objects.

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_withdraws_with_upcoming_interviews_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_withdraws_with_upcoming_interviews_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'A candidate withdraws with upcoming interviews' do
+RSpec.feature 'A candidate withdraws with upcoming interviews', continuous_applications: false do
   include CandidateHelper
 
   scenario 'successful withdrawal' do

--- a/spec/system/candidate_interface/references/candidate_carries_over_unsubmitted_application_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_carries_over_unsubmitted_application_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'References' do
   include CandidateHelper
 
-  scenario 'Candidate carries over their application to the new cycle' do
+  scenario 'Candidate carries over their application to the new cycle', continuous_applications: false do
     given_i_am_signed_in
     and_i_have_an_unsubmitted_application_with_references
 
@@ -60,7 +60,11 @@ RSpec.feature 'References' do
   end
 
   def and_i_visit_the_application_dashboard
-    visit candidate_interface_application_complete_path
+    if FeatureFlag.active?(:continuous_applications)
+      visit candidate_interface_continuous_applications_details_path
+    else
+      visit candidate_interface_application_complete_path
+    end
   end
 
   def and_references_is_marked_as_incomplete

--- a/spec/system/candidate_interface/references/candidate_request_references_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_request_references_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'New References', :with_audited, time: CycleTimetableHelper.after_apply_1_deadline do
+RSpec.feature 'New References', continuous_applications: false, time: CycleTimetableHelper.after_apply_1_deadline, with_audited: true do
   include CandidateHelper
 
   scenario 'Candidate request their references on the post offer dashboard' do

--- a/spec/system/candidate_interface/references/candidate_request_references_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_request_references_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'New References', continuous_applications: false, time: CycleTimetableHelper.after_apply_1_deadline, with_audited: true do
+RSpec.feature 'New References', :with_audited, continuous_applications: false, time: CycleTimetableHelper.after_apply_1_deadline do
   include CandidateHelper
 
   scenario 'Candidate request their references on the post offer dashboard' do

--- a/spec/system/candidate_interface/references/candidate_submits_a_duplicate_application_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_submits_a_duplicate_application_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Submitting an application' do
+RSpec.feature 'Submitting an application', continuous_applications: false do
   include CandidateHelper
 
   it 'Candidate submits complete application' do

--- a/spec/system/candidate_interface/references/candidate_views_their_references_on_the_post_offer_dashboard_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_views_their_references_on_the_post_offer_dashboard_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Post-offer references', continuous_applications: false, time: CycleTimetableHelper.after_apply_1_deadline, with_audited: true do
+RSpec.feature 'Post-offer references', :with_audited, continuous_applications: false, time: CycleTimetableHelper.after_apply_1_deadline do
   include CandidateHelper
 
   scenario 'Candidate views their references on the post offer dashboard' do

--- a/spec/system/candidate_interface/references/candidate_views_their_references_on_the_post_offer_dashboard_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_views_their_references_on_the_post_offer_dashboard_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Post-offer references', :with_audited, time: CycleTimetableHelper.after_apply_1_deadline do
+RSpec.feature 'Post-offer references', continuous_applications: false, time: CycleTimetableHelper.after_apply_1_deadline, with_audited: true do
   include CandidateHelper
 
   scenario 'Candidate views their references on the post offer dashboard' do

--- a/spec/system/candidate_interface/rejection/candidate_reviews_reasons_for_rejection_spec.rb
+++ b/spec/system/candidate_interface/rejection/candidate_reviews_reasons_for_rejection_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate can see their structured reasons for rejection when reviewing their application', time: CycleTimetableHelper.mid_cycle do
+RSpec.feature 'Candidate can see their structured reasons for rejection when reviewing their application', continuous_applications: false, time: CycleTimetableHelper.mid_cycle do
   scenario 'when a candidate visits their apply again application form they can see apply1 rejection reasons' do
     given_i_am_signed_in
 

--- a/spec/system/candidate_interface/rejection/deleting_a_reason_for_rejection_does_not_impact_the_candidate_interface_spec.rb
+++ b/spec/system/candidate_interface/rejection/deleting_a_reason_for_rejection_does_not_impact_the_candidate_interface_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate can see their structured reasons for rejection when reviewing their application', time: CycleTimetableHelper.mid_cycle do
+RSpec.feature 'Candidate can see their structured reasons for rejection when reviewing their application', continuous_applications: false, time: CycleTimetableHelper.mid_cycle do
   scenario 'despite us removing one of them as a valid reason for rejection' do
     given_i_am_signed_in
 

--- a/spec/system/candidate_interface/signup_and_signin/candidate_email_tracking_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_email_tracking_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate email click tracking' do
+RSpec.feature 'Candidate email click tracking', continuous_applications: false do
   include CandidateHelper
 
   it 'Candidate clicks a magic link in a nudge email' do

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_and_prefills_application_in_sandbox_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_and_prefills_application_in_sandbox_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate signs in and prefills application in Sandbox', continuous_applications: false, sandbox: true do
+RSpec.feature 'Candidate signs in and prefills application in Sandbox', :sandbox, continuous_applications: false do
   include SignInHelper
 
   scenario 'User is directed to prefill option page and chooses to prefill the application' do

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_and_prefills_application_in_sandbox_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_and_prefills_application_in_sandbox_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate signs in and prefills application in Sandbox', :sandbox do
+RSpec.feature 'Candidate signs in and prefills application in Sandbox', continuous_applications: false, sandbox: true do
   include SignInHelper
 
   scenario 'User is directed to prefill option page and chooses to prefill the application' do

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_and_starts_blank_application_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_and_starts_blank_application_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate signs in and starts blank application in Sandbox', continuous_applications: false, sandbox: true do
+RSpec.feature 'Candidate signs in and starts blank application in Sandbox', :sandbox, continuous_applications: false do
   include SignInHelper
 
   scenario 'User is directed to prefill option page and chooses to start a blank application' do

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_and_starts_blank_application_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_and_starts_blank_application_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate signs in and starts blank application in Sandbox', :sandbox do
+RSpec.feature 'Candidate signs in and starts blank application in Sandbox', continuous_applications: false, sandbox: true do
   include SignInHelper
 
   scenario 'User is directed to prefill option page and chooses to start a blank application' do
@@ -16,7 +16,7 @@ RSpec.feature 'Candidate signs in and starts blank application in Sandbox', :san
   end
 
   def and_a_course_is_available
-    create(:course_option, course: create(:course, :open_on_apply, recruitment_cycle_year: RecruitmentCycle.current_year))
+    create(:course_option, course: create(:course, :open_on_apply))
   end
 
   def and_i_am_a_candidate_with_a_blank_application

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_with_the_penultimate_valid_token_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_with_the_penultimate_valid_token_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate tries to sign up using magic link with an invalid token' do
+RSpec.feature 'Candidate tries to sign up using magic link with an invalid token', continuous_applications: false do
   include SignInHelper
 
   scenario 'Candidate signs in and receives an email inviting them to sign up' do

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate tries to sign up using magic link with an invalid token' do
+RSpec.feature 'Candidate tries to sign up using magic link with an invalid token', continuous_applications: false do
   include SignInHelper
 
   scenario 'Candidate signs in and receives an email inviting them to sign up' do

--- a/spec/system/candidate_interface/signup_and_signin/candidate_views_guidance_from_unsubmitted_application_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_views_guidance_from_unsubmitted_application_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Candidate signs in and starts blank application' do
   include SignInHelper
 
-  scenario 'User can start an application and then view the guidance', continuous_applications: true do
+  scenario 'User can start an application and then view the guidance', :continuous_applications do
     given_a_course_is_available
     and_i_am_a_candidate_with_a_blank_application
 

--- a/spec/system/candidate_interface/signup_and_signin/candidate_views_guidance_from_unsubmitted_application_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_views_guidance_from_unsubmitted_application_spec.rb
@@ -3,9 +3,8 @@ require 'rails_helper'
 RSpec.feature 'Candidate signs in and starts blank application' do
   include SignInHelper
 
-  scenario 'User can start an application and then view the guidance' do
+  scenario 'User can start an application and then view the guidance', continuous_applications: true do
     given_a_course_is_available
-    and_the_continuous_applications_feature_is_enabled
     and_i_am_a_candidate_with_a_blank_application
 
     when_i_fill_in_the_sign_in_form
@@ -18,10 +17,6 @@ RSpec.feature 'Candidate signs in and starts blank application' do
 
   def given_a_course_is_available
     create(:course_option, course: create(:course, :open_on_apply))
-  end
-
-  def and_the_continuous_applications_feature_is_enabled
-    FeatureFlag.activate(:continuous_applications)
   end
 
   def and_i_am_a_candidate_with_a_blank_application
@@ -42,7 +37,7 @@ RSpec.feature 'Candidate signs in and starts blank application' do
   end
 
   def then_i_am_taken_to_the_application_page
-    expect(page).to have_current_path(candidate_interface_application_form_path)
+    expect(page).to have_current_path(candidate_interface_continuous_applications_details_path)
   end
 
   def when_i_click_on_the_guidance_link

--- a/spec/system/candidate_interface/submitting/candidate_reviewing_application_with_unavailable_course_options_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviewing_application_with_unavailable_course_options_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate reviewing an application with unavailable course options' do
+RSpec.feature 'Candidate reviewing an application with unavailable course options', continuous_applications: false do
   include CandidateHelper
 
   scenario 'sees warning messages for unavailable course options' do

--- a/spec/system/candidate_interface/submitting/candidate_reviews_application_and_completes_equality_and_diversity_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_application_and_completes_equality_and_diversity_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate is redirected correctly' do
+RSpec.feature 'Candidate is redirected correctly', continuous_applications: false do
   include CandidateHelper
 
   it 'Candidate reviews application and completes equality and diversity' do

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_adjustments_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_adjustments_section_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate is redirected correctly' do
+RSpec.feature 'Candidate is redirected correctly', continuous_applications: false do
   include CandidateHelper
 
   it 'Candidate reviews completed application and updates adjustments section' do

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_contact_details_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_contact_details_section_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate is redirected correctly' do
+RSpec.feature 'Candidate is redirected correctly', continuous_applications: false do
   include CandidateHelper
 
   it 'Candidate reviews completed application and updates contact details section' do

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_course_selection_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_course_selection_section_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'Candidate is redirected correctly' do
   include CandidateHelper
   include CourseOptionHelpers
 
-  it 'Candidate reviews completed application and updates course selection section' do
+  it 'Candidate reviews completed application and updates course selection section', continuous_applications: false do
     given_i_am_signed_in
     and_two_courses_are_available
     when_i_add_a_course_choice

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_english_as_foreign_language_section_feature_flag_disabled_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_english_as_foreign_language_section_feature_flag_disabled_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate is redirected correctly' do
+RSpec.feature 'Candidate is redirected correctly', continuous_applications: false do
   include CandidateHelper
   include EFLHelper
 

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_details_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_details_section_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate is redirected correctly' do
+RSpec.feature 'Candidate is redirected correctly', continuous_applications: false do
   include CandidateHelper
 
   it 'Candidate reviews completed application and updates personal details section' do

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_statement_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_statement_section_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate is redirected correctly' do
+RSpec.feature 'Candidate is redirected correctly', continuous_applications: false do
   include CandidateHelper
 
   it 'Candidate reviews completed application and updates personal statement section' do

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_qualifications_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_qualifications_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate is redirected correctly' do
+RSpec.feature 'Candidate is redirected correctly', continuous_applications: false do
   include CandidateHelper
 
   it 'Candidate reviews completed application and updates qualification details section' do

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_references_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_references_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate is redirected correctly' do
+RSpec.feature 'Candidate is redirected correctly', continuous_applications: false do
   include CandidateHelper
 
   it 'Candidate reviews completed application and updates references section' do

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_safeguarding_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_safeguarding_section_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate is redirected correctly' do
+RSpec.feature 'Candidate is redirected correctly', continuous_applications: false do
   include CandidateHelper
 
   it 'Candidate reviews completed application and updates adjustments section' do

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_unpaid_experience_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_unpaid_experience_section_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate is redirected correctly' do
+RSpec.feature 'Candidate is redirected correctly', continuous_applications: false do
   include CandidateHelper
 
   it 'Candidate reviews completed application and updates unpaid experience section' do

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_work_experience_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_work_experience_section_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate is redirected correctly' do
+RSpec.feature 'Candidate is redirected correctly', continuous_applications: false do
   include CandidateHelper
 
   it 'Candidate reviews completed application and updates restructured work experience section' do

--- a/spec/system/candidate_interface/submitting/candidate_submits_application_with_a_missing_address_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submits_application_with_a_missing_address_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate attempts to submit their application without a valid address' do
+RSpec.feature 'Candidate attempts to submit their application without a valid address', continuous_applications: false do
   include CandidateHelper
 
   it 'The candidate has completed their contact details without entering an address' do

--- a/spec/system/candidate_interface/submitting/candidate_submits_application_with_a_removed_site_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submits_application_with_a_removed_site_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate attempts to submit their application with a removed site' do
+RSpec.feature 'Candidate attempts to submit their application with a removed site', continuous_applications: false do
   include CandidateHelper
 
   it 'The location that the candidate picked has been removed by the provider' do

--- a/spec/system/candidate_interface/submitting/candidate_submits_application_with_course_not_yet_available_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submits_application_with_course_not_yet_available_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate submits the application with a course that is not available and full' do
+RSpec.feature 'Candidate submits the application with a course that is not available and full', continuous_applications: false do
   include CandidateHelper
 
   it 'Candidate with a completed application form' do

--- a/spec/system/candidate_interface/submitting/candidate_submits_application_with_full_course_location_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submits_application_with_full_course_location_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate submits the application with full course choice location' do
+RSpec.feature 'Candidate submits the application with full course choice location', continuous_applications: false do
   include CandidateHelper
 
   it 'The location that the candidate picked is full but others have vacancies' do

--- a/spec/system/candidate_interface/submitting/candidate_submits_application_with_full_course_study_mode_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submits_application_with_full_course_study_mode_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate submits the application with full course study mode' do
+RSpec.feature 'Candidate submits the application with full course study mode', continuous_applications: false do
   include CandidateHelper
 
   it 'The location that the candidate picked has no full time vacancies but does have part time vacancies' do

--- a/spec/system/candidate_interface/submitting/candidate_submits_application_with_missing_references_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submits_application_with_missing_references_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate attempts to submit their application without valid references' do
+RSpec.feature 'Candidate attempts to submit their application without valid references', continuous_applications: false do
   include CandidateHelper
 
   it 'The candidate tries to complete application without entering references' do

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate submits the application' do
+RSpec.feature 'Candidate submits the application', continuous_applications: false do
   include CandidateHelper
 
   it 'Candidate with a completed application' do

--- a/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'International candidate submits the application' do
+RSpec.feature 'International candidate submits the application', continuous_applications: false do
   include CandidateHelper
   include EFLHelper
 

--- a/spec/system/provider_interface/provider_acts_as_candidate_on_sandbox_spec.rb
+++ b/spec/system/provider_interface/provider_acts_as_candidate_on_sandbox_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'A Provider can sign in as a candidate' do
   include CourseOptionHelpers
   include DfESignInHelpers
 
-  scenario 'when viewing an application on non-production environments' do
+  scenario 'when viewing an application on non-production environments', continuous_applications: false do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_permitted_to_see_applications_for_my_provider
     and_my_organisation_has_received_an_application

--- a/spec/system/register_api/register_receives_application_spec.rb
+++ b/spec/system/register_api/register_receives_application_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 # This is an end-to-end test for the API response. To test complex logic in
 # the presenter, see spec/presenters/register_api/single_application_presenter_spec.rb.
-RSpec.feature 'Register receives an application data' do
+RSpec.feature 'Register receives an application data', continuous_applications: false, time: CycleTimetableHelper.mid_cycle(2023) do
   include CandidateHelper
 
   it 'A candidate is recruited' do


### PR DESCRIPTION
## Context

Tests are failing when the test time is in after apply opens in the continuous applications recruitment cycle (2024).

## Changes proposed in this pull request

When the current time is in the new recruitment cycle for continuous applications, many of the existing tests fail. This is because some of the test helpers only work in legacy applications flow. 

Once we are past apply opens in the new recruitement cycle 2024 we can do a wholesale update to the tests and remove all legacy flows and helpers.


### Checklist 

**integration_shared, on**


- [x] ./spec/system/register_api/register_receives_application_spec.rb:8
- [x] ./spec/system/inactive_application_spec.rb:6

**integration_shared, off**

- [x] ./spec/system/inactive_application_spec.rb:6

**integration_provider, on**

- [x] ./spec/system/provider_interface/provider_acts_as_candidate_on_sandbox_spec.rb:7

**integration_candidate, on**

 - [x] ./spec/system/candidate_interface/adviser_sign_up/candidate_signs_up_for_an_adviser_spec.rb:8
 - [x] ./spec/system/candidate_interface/entering_details/candidate_entering_gcse_science_award_spec.rb:6
 - [x] ./spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_course_selection_section_spec.rb:7
 - [x] ./spec/system/candidate_interface/rejection/deleting_a_reason_for_rejection_does_not_impact_the_candidate_interface_spec.rb:4
 - [x] ./spec/system/candidate_interface/entering_details/candidate_entering_gcse_spec.rb:6
 - [x] ./spec/system/candidate_interface/feedback/candidate_completes_the_feedback_form_spec.rb:6
 - [x] ./spec/system/candidate_interface/continuous_applications/withdraws/candidate_withdraws_spec.rb:18
 - [x] ./spec/system/candidate_interface/entering_details/candidate_viewing_a_science_gcse_spec.rb:6
 - [x] ./spec/system/candidate_interface/continuous_applications/course_selection/candidate_edits_course_choices_spec.rb:7
 - [x] ./spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_contact_details_section_spec.rb:6
 - [x] ./spec/system/candidate_interface/rejection/candidate_reviews_reasons_for_rejection_spec.rb:4
 - [x] ./spec/system/candidate_interface/course_selection/candidate_does_not_know_where_they_want_to_apply_spec.rb:6
 - [x] ./spec/system/candidate_interface/course_selection/candidate_sees_add_additional_courses_after_adding_course_spec.rb:7
 - [x] ./spec/system/candidate_interface/submitting/candidate_reviews_application_and_completes_equality_and_diversity_spec.rb:6
 - [x] ./spec/system/candidate_interface/signup_and_signin/candidate_email_tracking_spec.rb:6
 - [x] ./spec/system/candidate_interface/course_selection/candidate_edits_course_choices_spec.rb:7
 - [x] ./spec/system/candidate_interface/references/candidate_carries_over_unsubmitted_application_spec.rb:6
 - [x] ./spec/system/candidate_interface/offers_and_withdrawals/candidate_withdraws_spec.rb:18
 - [x] ./spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_details_section_spec.rb:6
 - [x] ./spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_adjustments_section_spec.rb:6
 - [x] ./spec/system/candidate_interface/references/candidate_submits_a_duplicate_application_spec.rb:6
 - [x] ./spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_unpaid_experience_section_spec.rb:6
 - [x] ./spec/system/candidate_interface/references/candidate_request_references_spec.rb:6
 - [x] ./spec/system/candidate_interface/course_selection/sandbox_user_apply_from_find_spec.rb:6
 - [x] ./spec/system/candidate_interface/entering_details/candidate_completes_contact_details_with_a_missing_address_feature_flag_disabled_spec.rb:6
 - [x] ./spec/system/candidate_interface/course_selection/candidate_selecting_a_course_spec.rb:6
 - [x] ./spec/system/candidate_interface/signup_and_signin/candidate_views_guidance_from_unsubmitted_application_spec.rb:6
 - [x] ./spec/system/candidate_interface/submitting/candidate_reviewing_application_with_unavailable_course_options_spec.rb:6
 - [x] ./spec/system/candidate_interface/submitting/candidate_submits_application_with_full_course_study_mode_spec.rb:6
 - [x] ./spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_statement_section_spec.rb:6
 - [x] ./spec/system/candidate_interface/guidance/public_user_spec.rb:4
 - [x] ./spec/system/candidate_interface/continuous_applications/course_selection/backlinks_spec.rb:7
 - [x] ./spec/system/candidate_interface/signup_and_signin/candidate_signs_in_with_the_penultimate_valid_token_spec.rb:6
 - [x] ./spec/system/candidate_interface/submitting/candidate_submits_application_with_a_removed_site_spec.rb:6
 - [x] ./spec/system/candidate_interface/continuous_applications/course_selection/candidate_deletes_application_spec.rb:6
 - [x] ./spec/system/candidate_interface/course_selection/candidate_deletes_course_after_completing_section_spec.rb:6
 - [x] ./spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_qualifications_spec.rb:6
 - [x] ./spec/system/candidate_interface/continuous_applications/submitting/redirect_to_your_applications_spec.rb:6
 - [x] ./spec/system/candidate_interface/continuous_applications/submitting/redirect_to_your_applications_spec.rb:18
 - [x] ./spec/system/candidate_interface/continuous_applications/submitting/redirect_to_your_applications_spec.rb:12
 - [x] ./spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb:7
 - [x] ./spec/system/candidate_interface/entering_details/candidate_entering_english_gcse_spec.rb:6


**integration_candidate, off**

 - [x] ./spec/system/candidate_interface/continuous_applications/course_selection/backlinks_spec.rb:7
 - [x] ./spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_statement_section_spec.rb:6
 - [x] ./spec/system/candidate_interface/continuous_applications/submitting/redirect_to_your_applications_spec.rb:12
 - [x] ./spec/system/candidate_interface/continuous_applications/submitting/redirect_to_your_applications_spec.rb:6
 - [x] ./spec/system/candidate_interface/continuous_applications/submitting/redirect_to_your_applications_spec.rb:18
 - [x] ./spec/system/candidate_interface/guidance/public_user_spec.rb:4
 - [x] ./spec/system/candidate_interface/references/candidate_request_references_spec.rb:6
 - [x] ./spec/system/candidate_interface/signup_and_signin/candidate_views_guidance_from_unsubmitted_application_spec.rb:6
 - [x] ./spec/system/candidate_interface/continuous_applications/course_selection/candidate_deletes_application_spec.rb:6
 - [x] ./spec/system/candidate_interface/continuous_applications/withdraws/candidate_withdraws_spec.rb:18
 - [x] ./spec/system/candidate_interface/continuous_applications/course_selection/candidate_edits_course_choices_spec.rb:7


More test that fail 

 - [x] spec/system/candidate_interface/signup_and_signin/candidate_signs_in_and_prefills_application_in_sandbox_spec.rb:6
 - [x] spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_spec.rb:6
 - [x] spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_references_spec.rb:6
 - [x] spec/system/candidate_interface/feedback/candidate_submits_application_with_feedback_form_previously_completed_spec.rb:6
 - [x] spec/system/candidate_interface/references/candidate_views_their_references_on_the_post_offer_dashboard_spec.rb:6
 - [x] spec/system/candidate_interface/offers_and_withdrawals/candidate_can_see_their_rejection_reasons_on_apply_again_spec.rb:4
 - [x] spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb:6
 - [x] spec/system/candidate_interface/submitting/candidate_submits_application_with_full_course_location_spec.rb:6
 - [x] spec/system/candidate_interface/course_selection/candidate_selecting_a_course_when_only_one_site_available_spec.rb:6
 - [x] spec/system/candidate_interface/entering_details/candidate_entering_disability_info_spec.rb:6
 - [x] spec/system/candidate_interface/signup_and_signin/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb:6
 - [x] spec/system/candidate_interface/offers_and_withdrawals/candidate_withdraws_with_upcoming_interviews_spec.rb:6
 - [x] spec/system/candidate_interface/offers_and_withdrawals/candidate_declines_offer_spec.rb:6
 - [x] spec/system/candidate_interface/entering_details/degrees/candidate_delete_and_replace_degrees_spec.rb:6


**More again**

 - [x] ./spec/system/candidate_interface/entering_details/degrees/candidate_delete_and_replace_degrees_spec.rb:6
 - [x] ./spec/system/candidate_interface/entering_details/candidate_entering_subject_knowledge_spec.rb:6
 - [x] ./spec/system/candidate_interface/navigation_tabs_spec.rb:5
 - [x] ./spec/system/candidate_interface/submitting/candidate_submits_application_with_a_missing_address_spec.rb:6
 - [x] ./spec/system/candidate_interface/entering_details/candidate_becoming_a_teacher_spec.rb:6
 - [x] ./spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_full_spec.rb:6
 - [x] ./spec/system/candidate_interface/submitting/candidate_submits_application_with_course_not_yet_available_spec.rb:6
 - [x] ./spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_english_as_foreign_language_section_feature_flag_disabled_spec.rb:7
 - [x] ./spec/system/candidate_interface/course_selection/candidate_selecting_a_course_study_mode_spec.rb:6
 - [x] ./spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_work_experience_section_spec.rb:6
 - [x] ./spec/system/candidate_interface/course_selection/candidate_adds_a_course_theyve_already_chosen_spec.rb:6
 - [x] spec/system/candidate_interface/course_selection/candidate_adds_a_course_theyve_already_chosen_spec.rb
 - [x] spec/system/candidate_interface/signup_and_signin/candidate_signs_in_and_starts_blank_application_spec.rb

**Final set of failures?**

- [ ] rspec ./spec/system/candidate_interface/apply_again/candidate_applies_again_spec.rb:6
- [ ] rspec ./spec/system/candidate_interface/apply_again/candidate_applies_again_updates_personal_statement_spec.rb:6


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
