### PR TITLE
Introduce course selection limit for continuous applications

### DIFF
--- a/app/components/candidate_interface/applications_left_message_component.rb
+++ b/app/components/candidate_interface/applications_left_message_component.rb
@@ -32,7 +32,7 @@ module CandidateInterface
           t('candidate_interface.applications_left_message.can_not_add_more_message'),
         ]
       else
-        [t('candidate_interface.applications_left_message.can_add_more', applications_left:)]
+        [t('candidate_interface.applications_left_message.can_add_more', count: applications_left)]
       end
     end
 

--- a/app/controllers/candidate_interface/continuous_applications/course_choices/base_controller.rb
+++ b/app/controllers/candidate_interface/continuous_applications/course_choices/base_controller.rb
@@ -2,6 +2,7 @@ module CandidateInterface
   module ContinuousApplications
     module CourseChoices
       class BaseController < ::CandidateInterface::ContinuousApplicationsController
+        before_action :redirect_to_your_applications_if_maximum_amount_of_choices_have_been_used, only: %i[new create]
         before_action :redirect_to_your_applications_if_cycle_is_over
         before_action :redirect_to_your_applications_if_submitted, only: %i[edit update]
 
@@ -94,6 +95,10 @@ module CandidateInterface
 
         def redirect_to_your_applications_if_cycle_is_over
           redirect_to candidate_interface_continuous_applications_choices_path unless CycleTimetable.can_add_course_choice?(current_application)
+        end
+
+        def redirect_to_your_applications_if_maximum_amount_of_choices_have_been_used
+          redirect_to candidate_interface_continuous_applications_choices_path unless current_application.can_add_more_choices?
         end
       end
     end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -281,11 +281,19 @@ class ApplicationForm < ApplicationRecord
   end
 
   def choices_left_to_make
-    number_of_choices_candidate_can_make - application_choices.size
+    number_of_choices_candidate_can_make - available_application_choices
   end
 
   def number_of_choices_candidate_can_make
     MAXIMUM_NUMBER_OF_COURSE_CHOICES
+  end
+
+  def available_application_choices
+    continuous_applications? ? application_choices.size - count_unsuccessful_choices : application_choices.size
+  end
+
+  def count_unsuccessful_choices
+    application_choices.count { |choice| ApplicationStateChange::UNSUCCESSFUL_STATES.include?(choice.status.to_sym) }
   end
 
   def can_add_more_choices?

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -296,6 +296,14 @@ class ApplicationForm < ApplicationRecord
     application_choices.count { |choice| ApplicationStateChange::UNSUCCESSFUL_STATES.include?(choice.status.to_sym) }
   end
 
+  def can_submit_further_applications?
+    count_of_in_progress_applications < MAXIMUM_NUMBER_OF_COURSE_CHOICES
+  end
+
+  def count_of_in_progress_applications
+    application_choices.count { |choice| ApplicationStateChange::IN_PROGRESS_STATES.include?(choice.status.to_sym) }
+  end
+
   def can_add_more_choices?
     choices_left_to_make.positive?
   end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -7,6 +7,7 @@ module CandidateInterface
     delegate :apply_2?,
              :cache_key_with_version,
              :candidate_has_previously_applied?,
+             :can_add_more_choices?,
              :english_main_language,
              :first_name,
              :first_nationality,

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -12,6 +12,7 @@ class ApplicationStateChange
   SUCCESSFUL_STATES = %i[pending_conditions offer offer_deferred recruited].freeze
   DECISION_PENDING_STATUSES = %i[awaiting_provider_decision interviewing].freeze
   TERMINAL_STATES = UNSUCCESSFUL_STATES + %i[recruited].freeze
+  IN_PROGRESS_STATES = DECISION_PENDING_STATUSES + ACCEPTED_STATES + %i[offer].freeze
 
   attr_reader :application_choice
 

--- a/app/services/candidate_interface/continuous_applications/application_choice_submission.rb
+++ b/app/services/candidate_interface/continuous_applications/application_choice_submission.rb
@@ -10,7 +10,8 @@ module CandidateInterface
                 your_details_completion: true,
                 submission_availability: true,
                 open_for_applications: true,
-                course_availability: true
+                course_availability: true,
+                can_add_more_choices: true
     end
   end
 end

--- a/app/validators/can_add_more_choices_validator.rb
+++ b/app/validators/can_add_more_choices_validator.rb
@@ -1,0 +1,7 @@
+class CanAddMoreChoicesValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, application_choice)
+    unless application_choice.application_form.can_submit_further_applications?
+      record.errors.add(attribute, :max_course_choices, message: 'You cannot submit this application because you have already submitted the maximum number of applications.')
+    end
+  end
+end

--- a/app/views/candidate_interface/continuous_applications_choices/index.html.erb
+++ b/app/views/candidate_interface/continuous_applications_choices/index.html.erb
@@ -6,19 +6,27 @@
       <%= t('page_titles.continuous_applications.your_applications') %>
     </h1>
 
-    <%= render CandidateInterface::ApplicationsLeftMessageComponent.new(@application_form_presenter.application_form) %>
+    <% unless @application_form_presenter.can_add_more_choices? %>
+      <p class="govuk-body">You cannot add any more applications.</p>
+      <p class="govuk-body">If one of your applications is unsuccessful, or you withdraw it, you will be able to add another application.<p>
+          <p class="govuk-body">
+            <%= govuk_link_to 'Read how the application process works', candidate_interface_guidance_path %>
+          </p>
+    <% else %>
 
-    <div class="govuk-inset-text">
-      <p class="govuk-body">Training providers offer places on courses as people apply throughout the year. Courses stay open until they are full.</p>
+      <%= render CandidateInterface::ApplicationsLeftMessageComponent.new(@application_form_presenter.application_form) %>
 
-      <p class="govuk-body">Courses can fill up quickly, so you should apply as soon as you’re ready rather than putting it off.</p>
+      <div class="govuk-inset-text">
+        <p class="govuk-body">Training providers offer places on courses as people apply throughout the year. Courses stay open until they are full.</p>
 
-      <p class="govuk-body">
-        <%= govuk_link_to 'Read how the application process works', candidate_interface_guidance_path %>
-      </p>
-    </div>
+        <p class="govuk-body">Courses can fill up quickly, so you should apply as soon as you’re ready rather than putting it off.</p>
 
-      <% if CycleTimetable.can_add_course_choice?(@application_form_presenter.application_form) %>
+        <p class="govuk-body">
+          <%= govuk_link_to 'Read how the application process works', candidate_interface_guidance_path %>
+        </p>
+      </div>
+
+      <% if CycleTimetable.can_add_course_choice?(@application_form_presenter.application_form) && @application_form_presenter.can_add_more_choices? %>
         <%= govuk_button_link_to t('section_items.add_application'), candidate_interface_continuous_applications_do_you_know_the_course_path %>
       <% else %>
         <div class="govuk-grid-row">
@@ -29,6 +37,7 @@
           </section>
         </div>
       <% end %>
+    <% end %>
 
     <%= render CandidateInterface::ContinuousApplications::DashboardComponent.new(application_form: @application_form_presenter.application_form) %>
   </div>

--- a/app/views/candidate_interface/continuous_applications_choices/index.html.erb
+++ b/app/views/candidate_interface/continuous_applications_choices/index.html.erb
@@ -8,7 +8,7 @@
 
     <% unless @application_form_presenter.can_add_more_choices? %>
       <p class="govuk-body">You cannot add any more applications.</p>
-      <p class="govuk-body">If one of your applications is unsuccessful, or you withdraw it, you will be able to add another application.<p>
+      <p class="govuk-body">If one of your applications is unsuccessful, or you withdraw or remove it, you will be able to add another application.<p>
           <p class="govuk-body">
             <%= govuk_link_to 'Read how the application process works', candidate_interface_guidance_path %>
           </p>

--- a/config/locales/candidate_interface/applications_left_message.yml
+++ b/config/locales/candidate_interface/applications_left_message.yml
@@ -6,5 +6,5 @@ en:
         one: 'You can add %{count} more application.'
         other: 'You can add %{count} more applications.'
       can_not_add_more_heading: "You cannot add any more applications because you’re waiting for decisions on %{maximum_number_of_course_choices} others."
-      can_not_add_more_message: "If one of your applications is unsuccessful, or you withdraw it, you will be able to add another application."
+      can_not_add_more_message: "If one of your applications is unsuccessful, or you withdraw or remove it, you will be able to add another application."
       incomplete_details_message: 'You will not be able to submit applications until you have completed your details.'

--- a/config/locales/candidate_interface/applications_left_message.yml
+++ b/config/locales/candidate_interface/applications_left_message.yml
@@ -2,7 +2,9 @@ en:
   candidate_interface:
     applications_left_message:
       default_message: 'You can add up to %{maximum_number_of_course_choices} applications at a time.'
-      can_add_more: 'You can add %{applications_left} more applications.'
+      can_add_more: 
+        one: 'You can add %{count} more application.'
+        other: 'You can add %{count} more applications.'
       can_not_add_more_heading: "You cannot add any more applications because you’re waiting for decisions on %{maximum_number_of_course_choices} others."
       can_not_add_more_message: "If one of your applications is unsuccessful, or you withdraw it, you will be able to add another application."
       incomplete_details_message: 'You will not be able to submit applications until you have completed your details.'

--- a/spec/components/candidate_interface/applications_left_message_component_spec.rb
+++ b/spec/components/candidate_interface/applications_left_message_component_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe CandidateInterface::ApplicationsLeftMessageComponent, continuous_
         create(:application_choice, :awaiting_provider_decision, application_form:)
         create(:application_choice, :awaiting_provider_decision, application_form:)
         expect(message).to include('You cannot add any more applications because you’re waiting for decisions on 4 others.')
-        expect(message).to include('If one of your applications is unsuccessful, or you withdraw it, you will be able to add another application.')
+        expect(message).to include('If one of your applications is unsuccessful, or you withdraw or remove it, you will be able to add another application.')
       end
     end
   end

--- a/spec/services/candidate_interface/continuous_applications/application_choice_submission_spec.rb
+++ b/spec/services/candidate_interface/continuous_applications/application_choice_submission_spec.rb
@@ -120,6 +120,19 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationChoiceSubm
       end
     end
 
+    context 'when the candidate has submitted the maximum amount of application choices' do
+      before do
+        application_form.application_choices << build_list(:application_choice, 4, status: :awaiting_provider_decision)
+      end
+
+      it 'adds error to application choice' do
+        application_choice_submission.valid?
+        expect(application_choice_submission.errors[:application_choice]).to include(
+          'You cannot submit this application because you have already submitted the maximum number of applications.',
+        )
+      end
+    end
+
     context 'when application is ready for submit' do
       let(:application_form) { create(:application_form, :completed, course_choices_completed: false) }
       let(:application_choice) { create(:application_choice, :unsubmitted, application_form:) }

--- a/spec/system/candidate_interface/continuous_applications/submitting/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/submitting/candidate_submitting_application_spec.rb
@@ -134,7 +134,7 @@ RSpec.feature 'Candidate submits the application', continuous_applications: true
   def then_i_can_no_longer_add_more_course_choices
     visit current_path
     expect(page).to have_content 'You cannot add any more applications.'
-    expect(page).to have_content 'If one of your applications is unsuccessful, or you withdraw it, you will be able to add another application.'
+    expect(page).to have_content 'If one of your applications is unsuccessful, or you withdraw or remove it, you will be able to add another application.'
   end
   alias_method :then_i_still_cannot_add_course_choices, :then_i_can_no_longer_add_more_course_choices
 

--- a/spec/system/candidate_interface/continuous_applications/submitting/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/submitting/candidate_submitting_application_spec.rb
@@ -24,8 +24,17 @@ RSpec.feature 'Candidate submits the application', continuous_applications: true
     and_i_am_redirected_to_the_application_dashboard
     and_my_application_is_submitted
     then_i_can_see_my_submitted_application
-
+    and_i_can_see_i_have_three_choices_left
     # and_i_receive_an_email_confirmation
+
+    when_i_have_three_further_draft_choices
+    then_i_can_no_longer_add_more_course_choices
+
+    when_i_submit_one_of_my_draft_applications
+    then_i_still_cannot_add_course_choices
+
+    when_one_of_my_applications_becomes_inactive
+    then_i_am_able_to_add_another_choice
   end
 
   def given_i_am_signed_in
@@ -112,5 +121,35 @@ RSpec.feature 'Candidate submits the application', continuous_applications: true
     expect(page).to have_content 'Primary (2XT2)'
     expect(page).to have_content 'PGCE with QTS full time'
     expect(page).to have_content 'Awaiting decision'
+  end
+
+  def and_i_can_see_i_have_three_choices_left
+    expect(page).to have_content 'You can add 3 more applications.'
+  end
+
+  def when_i_have_three_further_draft_choices
+    @current_candidate.current_application.application_choices << build_list(:application_choice, 3, :unsubmitted)
+  end
+
+  def then_i_can_no_longer_add_more_course_choices
+    visit current_path
+    expect(page).to have_content 'You cannot add any more applications.'
+    expect(page).to have_content 'If one of your applications is unsuccessful, or you withdraw it, you will be able to add another application.'
+  end
+  alias_method :then_i_still_cannot_add_course_choices, :then_i_can_no_longer_add_more_course_choices
+
+  def when_i_submit_one_of_my_draft_applications
+    click_on 'Continue application', match: :first
+    choose 'Yes, submit it now'
+    click_button t('continue')
+  end
+
+  def when_one_of_my_applications_becomes_inactive
+    @current_candidate.current_application.application_choices.where(status: 'awaiting_provider_decision').first.update!(status: 'inactive')
+  end
+
+  def then_i_am_able_to_add_another_choice
+    visit current_path
+    expect(page).to have_content 'You can add 1 more application.'
   end
 end

--- a/spec/workers/detect_invariants_daily_check_spec.rb
+++ b/spec/workers/detect_invariants_daily_check_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe DetectInvariantsDailyCheck do
       )
     end
 
-    context 'when continuous application', continuous_applications: true do
+    context 'when continuous application', :continuous_applications do
       it 'detects submitted applications with more than the maximum number of course choices' do
         allow(Sentry).to receive(:capture_exception).with(an_instance_of(described_class::SubmittedApplicationHasMoreThanTheMaxCourseChoices))
 

--- a/spec/workers/detect_invariants_daily_check_spec.rb
+++ b/spec/workers/detect_invariants_daily_check_spec.rb
@@ -74,29 +74,61 @@ RSpec.describe DetectInvariantsDailyCheck do
       )
     end
 
-    it 'detects submitted applications with more than the maximum number of course choices' do
-      allow(Sentry).to receive(:capture_exception).with(an_instance_of(described_class::SubmittedApplicationHasMoreThanTheMaxCourseChoices))
+    context 'when continuous application', continuous_applications: true do
+      it 'detects submitted applications with more than the maximum number of course choices' do
+        allow(Sentry).to receive(:capture_exception).with(an_instance_of(described_class::SubmittedApplicationHasMoreThanTheMaxCourseChoices))
 
-      good_application_form = create(:completed_application_form, submitted_application_choices_count: 4)
-      bad_application_form = create(:completed_application_form, submitted_application_choices_count: 3)
-      bad_application_form.application_choices << build_list(:application_choice, 2, status: :offer)
-      ApplicationChoice.all.each { |a| a.update_course_option_and_associated_fields! create(:course_option) }
+        good_application_form = create(:completed_application_form, submitted_application_choices_count: 4)
+        good_application_form.application_choices << build_list(:application_choice, 6, :inactive)
 
-      expect(good_application_form.reload.application_choices.count).to eq(4)
-      expect(bad_application_form.reload.application_choices.count).to eq(5)
+        bad_application_form = create(:completed_application_form, submitted_application_choices_count: 3)
+        bad_application_form.application_choices << build_list(:application_choice, 2, status: :offer)
 
-      described_class.new.perform
+        ApplicationChoice.all.each { |a| a.update_course_option_and_associated_fields! create(:course_option) }
 
-      expect(Sentry).to have_received(:capture_exception).once
-      expect(Sentry).to have_received(:capture_exception).with(
-        described_class::SubmittedApplicationHasMoreThanTheMaxCourseChoices.new(
-          <<~MSG,
-            The following application forms have been submitted with more than #{ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES.humanize} course choices
+        expect(good_application_form.reload.application_choices.count).to eq(10)
+        expect(bad_application_form.reload.application_choices.count).to eq(5)
 
-            #{HostingEnvironment.application_url}/support/applications/#{bad_application_form.id}
-          MSG
-        ),
-      )
+        described_class.new.perform
+
+        expect(Sentry).to have_received(:capture_exception).once
+        expect(Sentry).to have_received(:capture_exception).with(
+          described_class::SubmittedApplicationHasMoreThanTheMaxCourseChoices.new(
+            <<~MSG,
+              The following application forms have been submitted with more than #{ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES.humanize} course choices
+
+              #{HostingEnvironment.application_url}/support/applications/#{bad_application_form.id}
+            MSG
+          ),
+        )
+      end
+    end
+
+    context 'when not continuous applications', continuous_applications: false do
+      it 'detects submitted applications with more than the maximum number of course choices' do
+        allow(Sentry).to receive(:capture_exception).with(an_instance_of(described_class::SubmittedApplicationHasMoreThanTheMaxCourseChoices))
+
+        good_application_form = create(:completed_application_form, submitted_application_choices_count: 4)
+        bad_application_form = create(:completed_application_form, submitted_application_choices_count: 3)
+        bad_application_form.application_choices << build_list(:application_choice, 2, status: :offer)
+        ApplicationChoice.all.each { |a| a.update_course_option_and_associated_fields! create(:course_option) }
+
+        expect(good_application_form.reload.application_choices.count).to eq(4)
+        expect(bad_application_form.reload.application_choices.count).to eq(5)
+
+        described_class.new.perform
+
+        expect(Sentry).to have_received(:capture_exception).once
+        expect(Sentry).to have_received(:capture_exception).with(
+          described_class::SubmittedApplicationHasMoreThanTheMaxCourseChoices.new(
+            <<~MSG,
+              The following application forms have been submitted with more than #{ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES.humanize} course choices
+
+              #{HostingEnvironment.application_url}/support/applications/#{bad_application_form.id}
+            MSG
+          ),
+        )
+      end
     end
 
     it 'detects application choices with out-of-date provider_ids' do


### PR DESCRIPTION
## Context

Adding a limit to the number of applications in draft (pre submission) and in progress (post submission) that a candidate can add. The limit is 4 (total) which is the current application choice cap.

## Changes proposed in this pull request
- Render copy and hide the 'add application' button if the candidate has 4 draft/submitted applications
- Redirect away from the add a course journey is this limit is true
- Pluralise the 'You can add X application(s)' count
- Ensure the detect invariant check will fire correctly in continuous applications (i.e. taking into consideration inactive)

|Can add a choice|Can no longer add a choice|
|---|---|
|<img width="789" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/539ab379-f64b-413d-b323-eddd349ccf1b">|<img width="780" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/7a7dfa88-0318-4b1b-b888-3060bcad5394">|

## Guidance to review

- Play around with a different combination of application choices. Try and manually enter URLs into the browser to ensure the redirects work
- Should we raise an error on the `SubmitApplicationChoice` service if `can_add_more_choices?` returns `false`?

## Link to Trello card

https://trello.com/c/PKgtbpJ2/446-ca-course-selection-limit-and-validate-maximum-applications-in-draft-in-progress

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
