### PR TITLE
Only write to submitted_at on the first application choice submission

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -389,6 +389,10 @@ class ApplicationForm < ApplicationRecord
     application_choices.reject(&:application_unsuccessful?)
   end
 
+  def submitted_applications?
+    application_choices.map(&:sent_to_provider_at).any?
+  end
+
   def support_cannot_add_course_choice?
     number_of_unsuccessful_application_choices >= maximum_number_of_course_choices
   end

--- a/app/services/candidate_interface/continuous_applications/submit_application_choice.rb
+++ b/app/services/candidate_interface/continuous_applications/submit_application_choice.rb
@@ -15,7 +15,7 @@ module CandidateInterface
 
         ActiveRecord::Base.transaction do
           application_choice.assign_attributes(personal_statement: application_form.becoming_a_teacher)
-          application_form.update!(submitted_at:)
+          application_form.update!(submitted_at:) unless application_form.submitted_applications?
           application_choice.update!(sent_to_provider_at:)
           application_choice.update!(reject_by_default_at: inactive_date, reject_by_default_days: inactive_days)
           ApplicationStateChange.new(application_choice).send_to_provider!

--- a/spec/services/candidate_interface/continuous_applications/submit_application_choice_spec.rb
+++ b/spec/services/candidate_interface/continuous_applications/submit_application_choice_spec.rb
@@ -30,6 +30,17 @@ RSpec.describe CandidateInterface::ContinuousApplications::SubmitApplicationChoi
         end
       end
 
+      it 'does not updated submitted_at for a second application choice' do
+        submit_application
+
+        travel_temporarily_to(Time.zone.local(0)) do
+          new_application_choice = create(:application_choice, :unsubmitted, application_form: application_form)
+          expect {
+            described_class.new(new_application_choice).call
+          }.not_to(change { application_form.reload.submitted_at })
+        end
+      end
+
       it 'updates inactive date for application' do
         travel_temporarily_to(Time.zone.local(2023, 10, 20)) do
           submit_application


### PR DESCRIPTION
## Context

We only want to write to the `ApplicationForm` `submitted_at` attribute on the first application choice submission, any subsequent choices should not update this field. Instead D&I will be using the `ApplicationChoice` `sent_to_provider_at` field to determine the submission date.

## Changes proposed in this pull request

`SubmitApplicationChoice` will only write to `application_form.submitted at` on the first application choice submission.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/744TNJUF/640-ca-only-write-to-applicationformsubmittedat-on-the-first-submission

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
