### PR TITLE
Ensure our 'go to find' page is up to date

### DIFF
--- a/app/controllers/candidate_interface/continuous_applications/course_choices/go_to_find_controller.rb
+++ b/app/controllers/candidate_interface/continuous_applications/course_choices/go_to_find_controller.rb
@@ -4,6 +4,7 @@ module CandidateInterface
       class GoToFindController < ::CandidateInterface::ContinuousApplicationsController
         def new
           @wizard = CourseSelectionWizard.new(current_step:)
+          @adviser_sign_up = Adviser::SignUp.new(current_application)
         end
 
       private

--- a/app/views/candidate_interface/continuous_applications/course_choices/go_to_find/new.html.erb
+++ b/app/views/candidate_interface/continuous_applications/course_choices/go_to_find/new.html.erb
@@ -16,9 +16,9 @@
       <li>contact details</li>
     </ul>
 
-    <% if adviser_sign_up.available? %>
+    <% if @adviser_sign_up.available? %>
       <p class="govuk-body"><%= govuk_link_to 'Get a teacher training adviser', new_candidate_interface_adviser_sign_up_path %> to help you understand your course options.</p>
-    <% elsif adviser_sign_up.waiting_to_be_assigned_to_an_adviser? || adviser_sign_up.already_assigned_to_an_adviser? %>
+    <% elsif @adviser_sign_up.waiting_to_be_assigned_to_an_adviser? || @adviser_sign_up.already_assigned_to_an_adviser? %>
       <p class="govuk-body">Your teacher training adviser can help you understand your course options.</p>
     <% else %>
       <p class="govuk-body">A <%= govuk_link_to_with_utm_params 'teacher training adviser', t('get_into_teaching.url_get_an_adviser_start'), utm_campaign(params), @current_application.phase %> can help you understand your course options.</p>

--- a/app/views/candidate_interface/continuous_applications/course_choices/go_to_find/new.html.erb
+++ b/app/views/candidate_interface/continuous_applications/course_choices/go_to_find/new.html.erb
@@ -7,16 +7,25 @@
       <%= t('page_titles.find_a_course') %>
     </h1>
 
-    <p class="govuk-body-l">
-      Search for courses near you on Find postgraduate teacher training.
-    </p>
+    <p class="govuk-body">You can find information about training providers and courses, including:</p>
 
-    <p class="govuk-body">
-      A <%= govuk_link_to 'teacher training adviser', 'https://adviser-getintoteaching.education.gov.uk/' %> can help you understand your course options and support you with your application.
-    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>entry requirements</li>
+      <li>school placements</li>
+      <li>whether bursaries or salaries are available</li>
+      <li>contact details</li>
+    </ul>
 
-    <%= govuk_button_link_to t('application_form.begin_button'), find_url %>
+    <% if adviser_sign_up.available? %>
+      <p class="govuk-body"><%= govuk_link_to 'Get a teacher training adviser', new_candidate_interface_adviser_sign_up_path %> to help you understand your course options.</p>
+    <% elsif adviser_sign_up.waiting_to_be_assigned_to_an_adviser? || adviser_sign_up.already_assigned_to_an_adviser? %>
+      <p class="govuk-body">Your teacher training adviser can help you understand your course options.</p>
+    <% else %>
+      <p class="govuk-body">A <%= govuk_link_to_with_utm_params 'teacher training adviser', t('get_into_teaching.url_get_an_adviser_start'), utm_campaign(params), @current_application.phase %> can help you understand your course options.</p>
+    <% end %>
 
-    <p class="govuk-body"><%= govuk_link_to 'Return to your application', candidate_interface_continuous_applications_choices_path %></p>
+    <%= govuk_button_link_to t('continue'), find_url %>
+
+    <p class="govuk-body">Join a <%= govuk_link_to_with_utm_params 'teacher training event', t('get_into_teaching.url_events'), 'apply_find_a_course' %> where you can meet local training providers, talk to existing teachers and get expert advice on your application.</p>
   </div>
 </div>

--- a/app/views/candidate_interface/continuous_applications/course_choices/go_to_find/new.html.erb
+++ b/app/views/candidate_interface/continuous_applications/course_choices/go_to_find/new.html.erb
@@ -24,7 +24,7 @@
       <p class="govuk-body">A <%= govuk_link_to_with_utm_params 'teacher training adviser', t('get_into_teaching.url_get_an_adviser_start'), utm_campaign(params), @current_application.phase %> can help you understand your course options.</p>
     <% end %>
 
-    <%= govuk_button_link_to t('continue'), find_url %>
+    <%= govuk_button_link_to t('application_form.begin_button'), find_url %>
 
     <p class="govuk-body">Join a <%= govuk_link_to_with_utm_params 'teacher training event', t('get_into_teaching.url_events'), 'apply_find_a_course' %> where you can meet local training providers, talk to existing teachers and get expert advice on your application.</p>
   </div>


### PR DESCRIPTION
## Context

We noticed that our 'Go to find' page is no longer mirroring production in our continous application section (i.e. when the feature flag is active).

## Changes proposed in this pull request

Old version:
File path: app/views/candidate_interface/course_choices/course_decision/go_to_find.html.erb

![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/35870975/fda97710-68f7-493b-ab54-724c807f09a0)

New version (behind continuous apps feature flag, outdated):
File path: app/views/candidate_interface/continuous_applications/course_choices/go_to_find/new.html.erb

![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/35870975/6fdcc0d3-d2c5-401f-9283-73254be73517)

This PR updates the 'New Version' to mirror the 'Old Version'.

## Guidance to review

- Does this look like our current version in prod?
- Does the quickfire TTA link still work?

## Link to Trello card

https://trello.com/c/n9XMij6c/644-update-content-on-find-a-course-page-to-show-for-continuous-applications

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
