### PR TITLE
[487] Disable provider RBD automated emails

### DIFF
--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -136,6 +136,10 @@ class CycleTimetable
     now
   end
 
+  def self.after_end_of_cycle?
+    current_date > CycleTimetable.reject_by_default(current_year)
+  end
+
   def self.show_apply_1_deadline_banner?(application_form)
     current_date.between?(date(:show_deadline_banner), date(:apply_1_deadline)) &&
       application_form.phase == 'apply_1' &&

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -136,10 +136,6 @@ class CycleTimetable
     now
   end
 
-  def self.after_end_of_cycle?
-    current_date > CycleTimetable.reject_by_default(current_year)
-  end
-
   def self.show_apply_1_deadline_banner?(application_form)
     current_date.between?(date(:show_deadline_banner), date(:apply_1_deadline)) &&
       application_form.phase == 'apply_1' &&

--- a/app/services/send_reject_by_default_email_to_provider.rb
+++ b/app/services/send_reject_by_default_email_to_provider.rb
@@ -7,7 +7,6 @@ class SendRejectByDefaultEmailToProvider
 
   def call
     return false if do_not_send_notification?(application_choice)
-    return false unless application_choice.rejected?
 
     NotificationsList.for(application_choice, event: :application_rejected_by_default).each do |provider_user|
       can_make_decisions = provider_user.authorisation.can_make_decisions?(application_choice:,
@@ -16,7 +15,9 @@ class SendRejectByDefaultEmailToProvider
     end
   end
 
+private
+
   def do_not_send_notification?(application_choice)
-    CycleTimetable.after_end_of_cycle? && application_choice.continuous_applications?
+    application_choice.continuous_applications? || !application_choice.rejected?
   end
 end

--- a/app/services/send_reject_by_default_email_to_provider.rb
+++ b/app/services/send_reject_by_default_email_to_provider.rb
@@ -6,7 +6,7 @@ class SendRejectByDefaultEmailToProvider
   end
 
   def call
-    return false if do_not_send_notification?
+    return false if do_not_send_notification?(application_choice)
     return false unless application_choice.rejected?
 
     NotificationsList.for(application_choice, event: :application_rejected_by_default).each do |provider_user|
@@ -16,7 +16,7 @@ class SendRejectByDefaultEmailToProvider
     end
   end
 
-  def do_not_send_notification?
-    CycleTimetable.after_end_of_cycle? && FeatureFlag.active?(:continuous_applications)
+  def do_not_send_notification?(application_choice)
+    CycleTimetable.after_end_of_cycle? && application_choice.continuous_applications?
   end
 end

--- a/app/services/send_reject_by_default_email_to_provider.rb
+++ b/app/services/send_reject_by_default_email_to_provider.rb
@@ -6,6 +6,7 @@ class SendRejectByDefaultEmailToProvider
   end
 
   def call
+    return false if do_not_send_notification?
     return false unless application_choice.rejected?
 
     NotificationsList.for(application_choice, event: :application_rejected_by_default).each do |provider_user|
@@ -13,5 +14,9 @@ class SendRejectByDefaultEmailToProvider
                                                                            course_option: application_choice.current_course_option)
       ProviderMailer.application_rejected_by_default(provider_user, application_choice, can_make_decisions:).deliver_later
     end
+  end
+
+  def do_not_send_notification?
+    CycleTimetable.after_end_of_cycle? && FeatureFlag.active?(:continuous_applications)
   end
 end

--- a/spec/services/send_reject_by_default_email_to_provider_spec.rb
+++ b/spec/services/send_reject_by_default_email_to_provider_spec.rb
@@ -24,17 +24,13 @@ RSpec.describe SendRejectByDefaultEmailToProvider do
   end
 
   context 'with continuous applications feature flag active', :continuous_applications do
-    before { FeatureFlag.activate(:continuous_applications) }
+    before { advance_time_to(after_reject_by_default) }
 
-    context 'after reject by default date' do
-      before { advance_time_to(after_reject_by_default) }
+    it 'returns false' do
+      training_provider = create(:provider)
 
-      it 'returns false' do
-        training_provider = create(:provider)
-
-        application_choice = create(:application_choice, :rejected_by_default, application_form: create(:application_form, :minimum_info), course_option: course_option_for_provider(provider: training_provider))
-        expect(described_class.new(application_choice:).call).to be(false)
-      end
+      application_choice = create(:application_choice, :rejected_by_default, application_form: create(:application_form, :minimum_info), course_option: course_option_for_provider(provider: training_provider))
+      expect(described_class.new(application_choice:).call).to be(false)
     end
   end
 end

--- a/spec/services/send_reject_by_default_email_to_provider_spec.rb
+++ b/spec/services/send_reject_by_default_email_to_provider_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe SendRejectByDefaultEmailToProvider do
     expect(training_provider_email['rails-mail-template'].value).to eq('application_rejected_by_default')
   end
 
-  context 'with continuous applications feature flag active' do
+  context 'with continuous applications feature flag active', :continuous_applications do
     before { FeatureFlag.activate(:continuous_applications) }
 
     context 'after reject by default date' do

--- a/spec/services/send_reject_by_default_email_to_provider_spec.rb
+++ b/spec/services/send_reject_by_default_email_to_provider_spec.rb
@@ -22,4 +22,19 @@ RSpec.describe SendRejectByDefaultEmailToProvider do
     expect(ActionMailer::Base.deliveries.count).to eq(1)
     expect(training_provider_email['rails-mail-template'].value).to eq('application_rejected_by_default')
   end
+
+  context 'with continuous applications feature flag active' do
+    before { FeatureFlag.activate(:continuous_applications) }
+
+    context 'after reject by default date' do
+      before { advance_time_to(after_reject_by_default) }
+
+      it 'returns false' do
+        training_provider = create(:provider)
+
+        application_choice = create(:application_choice, :rejected_by_default, application_form: create(:application_form, :minimum_info), course_option: course_option_for_provider(provider: training_provider))
+        expect(described_class.new(application_choice:).call).to be(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

In line with the continuous applications work, we no longer need these emails.

## Changes proposed in this pull request

Disable the emails if

- `continuous_applications` feature flag enabled
- The date is after the end of the cycle

## Guidance to review

- Do we need the time check, given that we have the feature flag check? I assume the feature flag will only be active after the end of cycle anyways?

- Does this count as a "significant user-facing change"? What counts as significant?

## Link to Trello card

https://trello.com/c/GaV4AQ7V/487-ca-emails-disable-provider-reject-by-default-emails

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
