### PR TITLE
Stop submission labels from being bold

### DIFF
--- a/app/components/candidate_interface/continuous_applications/application_submit_component.html.erb
+++ b/app/components/candidate_interface/continuous_applications/application_submit_component.html.erb
@@ -4,6 +4,7 @@
       :answer,
       :name,
       :description,
+      bold_labels: false,
       legend: { text: t('application_form.continuous_applications.courses.submit'), size: 'm' }, link_errors: true %>
 
   <%= form.govuk_submit t('continue') %>


### PR DESCRIPTION
## Context

We don't want these labels to be bold as per the prototype

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="844" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/20d69aa6-b2bf-43a5-b81a-b8f5211c3820">|<img width="849" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/5a46afd5-5518-4122-9406-668d52351c71">|

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/ZJmTrGQx/543-apply-question-for-submitting-at-application-the-yes-no-options-are-in-bold

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
