### PR TITLE
Update location content on the course selection journey

### DIFF
--- a/app/views/candidate_interface/continuous_applications/course_choices/course_site/_form_fields.html.erb
+++ b/app/views/candidate_interface/continuous_applications/course_choices/course_site/_form_fields.html.erb
@@ -3,7 +3,12 @@
 <%= f.hidden_field(:course_id) %>
 <%= f.hidden_field(:study_mode) %>
 
-<%= f.govuk_radio_buttons_fieldset :course_option_id, legend: { text: t('page_titles.which_location'), size: 'xl', tag: 'h1' } do %>
+<h1 class="govuk-heading-xl govuk-!-margin-top-3">School placement location<h1>
+
+<p class="govuk-body">During your training, you’ll be placed in at least 2 different schools to give you experience of teaching in a real classroom.</p>
+<p class="govuk-body">You can choose which location you’re most interested in. Your training provider will do their best to place you at a location you prefer and can travel to.</p>
+
+<%= f.govuk_radio_buttons_fieldset :course_option_id, legend: { text: t('page_titles.which_location'), size: 'l', tag: 'h1' } do %>
   <% @wizard.current_step.available_sites.each_with_index do |option, i| %>
     <%= f.govuk_radio_button :course_option_id, option.id, label: { text: option.site.name }, hint: { text: option.site.full_address }, link_errors: i.zero? %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -166,7 +166,7 @@ en:
     find_a_course: Find a course
     which_provider: Which training provider are you applying to?
     which_course: Which course are you applying to?
-    which_location: Which location are you applying to?
+    which_location: Which location are you interested in?
     which_study_mode: Full time or part time?
     edit_degree: Edit degree
     edit_degree_type: Edit degree type

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_edits_course_choices_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_edits_course_choices_spec.rb
@@ -226,7 +226,8 @@ RSpec.feature 'Candidate edits course choices', :continuous_applications do
   end
 
   def and_i_am_asked_to_select_site
-    expect(page).to have_content('Which location are you applying to?')
+    expect(page).to have_content('School placement location')
+    expect(page).to have_content('Which location are you interested in?')
   end
 
   def and_i_choose_the_first_site_that_offers_part_time_study_mode

--- a/spec/system/candidate_interface/course_selection/candidate_edits_course_choices_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_edits_course_choices_spec.rb
@@ -232,7 +232,7 @@ RSpec.feature 'Candidate edits course choices' do
   end
 
   def and_i_am_asked_to_select_site
-    expect(page).to have_content('Which location are you applying to?')
+    expect(page).to have_content('Which location are you interested in?')
   end
 
   def and_i_choose_the_first_site_that_offers_part_time_study_mode


### PR DESCRIPTION
## Context

When a candidate chooses a course, for some providers that can choose a location because we ask them “Which location are you applying to?”

This is misleading because candidates think they will definitely go to this location, when really it’s just a preference.

We need to update the content of the question to show it’s a preference and explain how placements work.

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="995" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/a7cc36df-e70d-4ee4-850c-39f8f4176a82">|<img width="1042" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/a4e10b6d-6c96-43e9-bf71-35d75f77b3f9">|

## Guidance to review

**Disclaimer**: The new title and guidance text is not appearing in the current (non-continuous applications) course selection journey. This is because we have less than a week until the final deadline for the current flow (which will be deleted) and we're seeing an increased number of closed courses but happy to amend and update the current flow if we agree it's best to do so.

## Link to Trello card

https://trello.com/c/53NiNhXe/511-apply-update-content-on-the-location-question-when-a-candidate-chooses-a-course

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
