### PR TITLE
[487] Disable DBD and provider chaser emails

### DIFF
--- a/app/services/decline_offer_by_default.rb
+++ b/app/services/decline_offer_by_default.rb
@@ -20,12 +20,14 @@ class DeclineOfferByDefault
       end
     end
 
-    application_choices.each do |application_choice|
-      NotificationsList.for(application_choice, event: :declined_by_default, include_ratifying_provider: true).each do |provider_user|
-        ProviderMailer.declined_by_default(provider_user, application_choice).deliver_later
+    unless application_form.continuous_applications?
+      application_choices.each do |application_choice|
+        NotificationsList.for(application_choice, event: :declined_by_default, include_ratifying_provider: true).each do |provider_user|
+          ProviderMailer.declined_by_default(provider_user, application_choice).deliver_later
+        end
       end
-    end
 
-    CandidateMailer.declined_by_default(application_form).deliver_later
+      CandidateMailer.declined_by_default(application_form).deliver_later
+    end
   end
 end

--- a/app/services/send_chase_email_to_provider.rb
+++ b/app/services/send_chase_email_to_provider.rb
@@ -1,9 +1,11 @@
 class SendChaseEmailToProvider
   def self.call(application_choice:)
-    NotificationsList.for(application_choice, event: :chase_provider_decision).each do |provider_user|
-      ProviderMailer.chase_provider_decision(provider_user, application_choice).deliver_later
-    end
+    unless application_choice.continuous_applications?
+      NotificationsList.for(application_choice, event: :chase_provider_decision).each do |provider_user|
+        ProviderMailer.chase_provider_decision(provider_user, application_choice).deliver_later
+      end
 
-    ChaserSent.create!(chased: application_choice, chaser_type: :provider_decision_request)
+      ChaserSent.create!(chased: application_choice, chaser_type: :provider_decision_request)
+    end
   end
 end

--- a/spec/services/decline_offer_by_default_spec.rb
+++ b/spec/services/decline_offer_by_default_spec.rb
@@ -15,23 +15,25 @@ RSpec.describe DeclineOfferByDefault do
     expect(application_choice.withdrawn_or_declined_for_candidate_by_provider).to be false
   end
 
-  it 'sends a notification email to the training provider and ratifying provider', :sidekiq do
-    training_provider = create(:provider)
-    training_provider_user = create(:provider_user, :with_notifications_enabled, providers: [training_provider])
+  context 'with continuous applications feature flag inactive', continuous_applications: false do
+    it 'sends a notification email to the training provider and ratifying provider', :sidekiq do
+      training_provider = create(:provider)
+      training_provider_user = create(:provider_user, :with_notifications_enabled, providers: [training_provider])
 
-    ratifying_provider = create(:provider)
-    ratifying_provider_user = create(:provider_user, :with_notifications_enabled, providers: [ratifying_provider])
+      ratifying_provider = create(:provider)
+      ratifying_provider_user = create(:provider_user, :with_notifications_enabled, providers: [ratifying_provider])
 
-    course_option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: ratifying_provider)
-    application_choice = create(:application_choice, status: :offer, course_option:)
+      course_option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: ratifying_provider)
+      application_choice = create(:application_choice, status: :offer, course_option:)
 
-    described_class.new(application_form: application_choice.application_form).call
+      described_class.new(application_form: application_choice.application_form).call
 
-    training_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == training_provider_user.email_address }
-    ratifying_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == ratifying_provider_user.email_address }
+      training_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == training_provider_user.email_address }
+      ratifying_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == ratifying_provider_user.email_address }
 
-    expect(training_provider_email['rails-mail-template'].value).to eq('declined_by_default')
-    expect(ratifying_provider_email['rails-mail-template'].value).to eq('declined_by_default')
+      expect(training_provider_email['rails-mail-template'].value).to eq('declined_by_default')
+      expect(ratifying_provider_email['rails-mail-template'].value).to eq('declined_by_default')
+    end
   end
 
   context 'with continuous applications feature flag active', :continuous_applications do

--- a/spec/services/send_chase_email_to_provider_spec.rb
+++ b/spec/services/send_chase_email_to_provider_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe SendChaseEmailToProvider do
       described_class.call(application_choice:)
     end
 
-    it 'sends a chaser email to the provider' do
+    it 'sends a chaser email to the provider', continuous_applications: false do
       expect(application_choice.chasers_sent.provider_decision_request.count).to eq(1)
     end
 

--- a/spec/services/send_chase_email_to_provider_spec.rb
+++ b/spec/services/send_chase_email_to_provider_spec.rb
@@ -19,5 +19,11 @@ RSpec.describe SendChaseEmailToProvider do
     it 'sends a chaser email to the provider' do
       expect(application_choice.chasers_sent.provider_decision_request.count).to eq(1)
     end
+
+    context 'with continuous applications feature flag active', :continuous_applications do
+      it 'does not send a chaser email to the provider' do
+        expect(application_choice.chasers_sent.provider_decision_request.count).to eq(0)
+      end
+    end
   end
 end

--- a/spec/system/decline_by_default_spec.rb
+++ b/spec/system/decline_by_default_spec.rb
@@ -1,28 +1,15 @@
 require 'rails_helper'
 
 RSpec.feature 'Decline by default' do
-  include CourseOptionHelpers
-  include CandidateHelper
-
-  scenario 'An application is declined by default' do
+  scenario 'An application is declined by default', :continuous_applications do
     when_i_have_an_offer_waiting_for_my_decision
-    and_the_time_limit_before_decline_by_default_date_has_been_exceeded
-    then_i_receive_an_email_to_make_a_decision
-
     and_when_the_decline_by_default_limit_has_been_exceeded
     then_the_application_choice_is_declined
-    and_the_candidate_receives_a_decline_by_default_email
-    and_the_provider_receives_an_email
 
     when_i_have_an_offer_waiting_for_my_decision
     and_i_have_a_rejection
-    and_the_time_limit_before_decline_by_default_date_has_been_exceeded
-    then_i_receive_an_email_to_make_a_decision
-
     and_when_the_decline_by_default_limit_has_been_exceeded
     then_the_application_choice_is_declined
-    and_the_candidate_receives_a_decline_by_default_email
-    and_the_provider_receives_an_email
   end
 
   def when_i_have_an_offer_waiting_for_my_decision
@@ -30,24 +17,6 @@ RSpec.feature 'Decline by default' do
     @application_choice = create(:application_choice, status: :offer, application_form: @application_form, sent_to_provider_at: Time.zone.now, decline_by_default_at: 10.days.from_now)
 
     @provider_user = create(:provider_user, :with_notifications_enabled, providers: [@application_choice.provider])
-  end
-
-  def and_the_time_limit_before_decline_by_default_date_has_been_exceeded
-    time_limit_in_business_days = TimeLimitConfig.limits_for(:chase_candidate_before_dbd).first.limit
-    decline_by_default_at = @application_form.application_choices.first.decline_by_default_at
-
-    travel_temporarily_to(time_limit_in_business_days.days.before(decline_by_default_at)) do
-      SendChaseEmailToCandidatesWorker.perform_async
-    end
-  end
-
-  def then_i_receive_an_email_to_make_a_decision
-    open_email(@application_form.candidate.email_address)
-
-    expected_subject = I18n.t('candidate_mailer.chase_candidate_decision.subject_singular')
-    expect(current_email.subject).to include(expected_subject)
-
-    expect(current_email.body).to include('http://localhost:3000/candidate/sign-in/confirm')
   end
 
   def and_when_the_decline_by_default_limit_has_been_exceeded
@@ -60,19 +29,6 @@ RSpec.feature 'Decline by default' do
     @application_choice.reload
 
     expect(@application_choice.reload.status).to eql('declined')
-  end
-
-  def and_the_provider_receives_an_email
-    open_email(@provider_user.email_address)
-
-    expect(current_email.subject).to include("Harry Potter’s offer for #{@application_choice.current_course.name} was automatically declined")
-  end
-
-  def and_the_candidate_receives_a_decline_by_default_email
-    open_email(@application_form.candidate.email_address)
-
-    expect(current_email.subject).to include('You did not respond to your offer: next steps')
-    expect(current_email.text).to include('Your last application is saved. All you need to do is:')
   end
 
   def and_i_have_a_rejection

--- a/spec/system/decline_by_default_with_continuous_applications_disabled_spec.rb
+++ b/spec/system/decline_by_default_with_continuous_applications_disabled_spec.rb
@@ -1,0 +1,84 @@
+# This file can be deleted with the continuous applications feature flag. The remaining functionality is tested in
+# 'decline_by_default_spec.rb'
+
+require 'rails_helper'
+
+RSpec.feature 'Decline by default' do
+  include CourseOptionHelpers
+  include CandidateHelper
+
+  scenario 'An application is declined by default', continuous_applications: false do
+    when_i_have_an_offer_waiting_for_my_decision
+    and_the_time_limit_before_decline_by_default_date_has_been_exceeded
+    then_i_receive_an_email_to_make_a_decision
+
+    and_when_the_decline_by_default_limit_has_been_exceeded
+    then_the_application_choice_is_declined
+    and_the_candidate_receives_a_decline_by_default_email
+    and_the_provider_receives_an_email
+
+    when_i_have_an_offer_waiting_for_my_decision
+    and_i_have_a_rejection
+    and_the_time_limit_before_decline_by_default_date_has_been_exceeded
+    then_i_receive_an_email_to_make_a_decision
+
+    and_when_the_decline_by_default_limit_has_been_exceeded
+    then_the_application_choice_is_declined
+    and_the_candidate_receives_a_decline_by_default_email
+    and_the_provider_receives_an_email
+  end
+
+  def when_i_have_an_offer_waiting_for_my_decision
+    @application_form = create(:completed_application_form, first_name: 'Harry', last_name: 'Potter')
+    @application_choice = create(:application_choice, status: :offer, application_form: @application_form, sent_to_provider_at: Time.zone.now, decline_by_default_at: 10.days.from_now)
+
+    @provider_user = create(:provider_user, :with_notifications_enabled, providers: [@application_choice.provider])
+  end
+
+  def and_the_time_limit_before_decline_by_default_date_has_been_exceeded
+    time_limit_in_business_days = TimeLimitConfig.limits_for(:chase_candidate_before_dbd).first.limit
+    decline_by_default_at = @application_form.application_choices.first.decline_by_default_at
+
+    travel_temporarily_to(time_limit_in_business_days.days.before(decline_by_default_at)) do
+      SendChaseEmailToCandidatesWorker.perform_async
+    end
+  end
+
+  def then_i_receive_an_email_to_make_a_decision
+    open_email(@application_form.candidate.email_address)
+
+    expected_subject = I18n.t('candidate_mailer.chase_candidate_decision.subject_singular')
+    expect(current_email.subject).to include(expected_subject)
+
+    expect(current_email.body).to include('http://localhost:3000/candidate/sign-in/confirm')
+  end
+
+  def and_when_the_decline_by_default_limit_has_been_exceeded
+    travel_temporarily_to(30.days.from_now) do
+      DeclineOffersByDefaultWorker.perform_async
+    end
+  end
+
+  def then_the_application_choice_is_declined
+    @application_choice.reload
+
+    expect(@application_choice.reload.status).to eql('declined')
+  end
+
+  def and_the_provider_receives_an_email
+    open_email(@provider_user.email_address)
+
+    expect(current_email.subject).to include("Harry Potter’s offer for #{@application_choice.current_course.name} was automatically declined")
+  end
+
+  def and_the_candidate_receives_a_decline_by_default_email
+    open_email(@application_form.candidate.email_address)
+
+    expect(current_email.subject).to include('You did not respond to your offer: next steps')
+    expect(current_email.text).to include('Your last application is saved. All you need to do is:')
+  end
+
+  def and_i_have_a_rejection
+    create(:application_choice, status: :rejected, application_form: @application_form)
+  end
+end


### PR DESCRIPTION
## Context

In line with the continuous applications work, we no longer need these emails.

## Changes proposed in this pull request

Disable RBD emails to training provider, ratifying provider and candidate If the `continuous_applications` feature flag is enabled.


## Guidance to review

Comment in line which requires clarification/confirmation

## Link to Trello card

https://trello.com/c/BqnlAGRA/488-ca-emails-remove-provider-make-a-decision-and-decline-by-default-emails

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
