### PR TITLE
Fix unpredictable date parse behaviour

### DIFF
--- a/app/helpers/date_validation_helper.rb
+++ b/app/helpers/date_validation_helper.rb
@@ -5,7 +5,7 @@ module DateValidationHelper
     date_args = [year, month, 1].map(&:to_i)
 
     if date_args[1].zero?
-      date_args[1] = Date.parse(month).month
+      date_args[1] = Date.strptime(month, '%b').month
     end
 
     Date.new(*date_args)

--- a/spec/helpers/date_validation_helper_spec.rb
+++ b/spec/helpers/date_validation_helper_spec.rb
@@ -92,11 +92,11 @@ RSpec.describe DateValidationHelper do
     end
 
     context 'when the short hand month is written in caps' do
-      let(:month) { 'JAN' }
+      let(:month) { 'FEB' }
 
       it 'returns a valid date' do
         expect(date).to be_a(Date)
-        expect(date).to have_attributes(year: year.to_i, month: 1, day: 1)
+        expect(date).to have_attributes(year: year.to_i, month: 2, day: 1)
       end
     end
 


### PR DESCRIPTION
## Context

The `Date.parse` method is not consistent in how it handles dates with ambiguous short month values.

```shell
> TestSuiteTimeMachine.travel_temporarily_to('2023-09-11 09:00:00', 'real_world') { Date.parse('FEB') }
=> Mon, 30 Jan 2023

> TestSuiteTimeMachine.travel_temporarily_to('2023-10-11 09:00:00', 'real_world') { Date.parse('FEB') }
=> Wed, 01 Mar 2023
```

## Changes proposed in this pull request

Use `Date.strptime` with a short month argument to hopefully produce better results.
