### PR TITLE
[470] Disable candidate chaser emails

### DIFF
--- a/app/services/send_chase_email_to_candidate.rb
+++ b/app/services/send_chase_email_to_candidate.rb
@@ -1,6 +1,8 @@
 class SendChaseEmailToCandidate
   def self.call(application_form:)
-    CandidateMailer.chase_candidate_decision(application_form).deliver_later
-    ChaserSent.create!(chased: application_form, chaser_type: :candidate_decision_request)
+    unless application_form.continuous_applications?
+      CandidateMailer.chase_candidate_decision(application_form).deliver_later
+      ChaserSent.create!(chased: application_form, chaser_type: :candidate_decision_request)
+    end
   end
 end

--- a/config/rubocop/config/rspec.yml
+++ b/config/rubocop/config/rspec.yml
@@ -80,6 +80,10 @@ RSpec/EmptyExampleGroup:
   Exclude:
     - "spec/factory_specs/**/*"
 
+RSpec/SortMetadata:
+  Exclude:
+    - "spec/services/revert_rejected_by_default_spec.rb"
+
 RSpec/IndexedLet:
   Enabled: false
 

--- a/spec/services/send_chase_email_to_candidate_spec.rb
+++ b/spec/services/send_chase_email_to_candidate_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SendChaseEmailToCandidate do
     end
 
     context 'with continuous applications feature flag active', :continuous_applications do
-      it 'sends a chaser email to the provider' do
+      it 'does not send a chaser email to the provider' do
         expect(application_form.chasers_sent.candidate_decision_request.count).to eq(0)
       end
     end

--- a/spec/services/send_chase_email_to_candidate_spec.rb
+++ b/spec/services/send_chase_email_to_candidate_spec.rb
@@ -12,8 +12,16 @@ RSpec.describe SendChaseEmailToCandidate do
       described_class.call(application_form:)
     end
 
-    it 'sends a chaser email to the provider' do
-      expect(application_form.chasers_sent.candidate_decision_request.count).to eq(1)
+    context 'with continuous applications feature flag inactive', continuous_applications: false do
+      it 'sends a chaser email to the provider' do
+        expect(application_form.chasers_sent.candidate_decision_request.count).to eq(1)
+      end
+    end
+
+    context 'with continuous applications feature flag active', :continuous_applications do
+      it 'sends a chaser email to the provider' do
+        expect(application_form.chasers_sent.candidate_decision_request.count).to eq(0)
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

In line with the continuous applications work, we no longer need these emails.

## Changes proposed in this pull request

- Disable candidate chaser emails when the `continuous_applications` flow is active.
- Rework specs to enable them to pass in CI and for ease of deletion once we delete the `continuous_applications` feature flag

## Guidance to review

~[This commit](https://github.com/DFE-Digital/apply-for-teacher-training/pull/8551/commits/9d167cfa0ae0b8cc2161342e86d6422281c6267d) is identical to [this commit on my previous PR](https://github.com/DFE-Digital/apply-for-teacher-training/pull/8549/commits/5ae9244689117d42ddbf4be6770725512170a9c4). Once that is merged in we will rebase and this commit will be dropped.~ 

**Edit:** This has now happened

## Link to Trello card

https://trello.com/c/C1FrZHLp/470-ca-emails-disable-candidate-chaser-emails

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
