### PR TITLE
When user answers no we should redirect to your applications tab

### DIFF
--- a/app/forms/candidate_interface/continuous_applications/find_course_selection_step.rb
+++ b/app/forms/candidate_interface/continuous_applications/find_course_selection_step.rb
@@ -2,17 +2,27 @@ module CandidateInterface
   module ContinuousApplications
     class FindCourseSelectionStep < DfE::WizardStep
       include Concerns::CourseSelectionStepHelper
-      attr_accessor :course_id
-      validates :course_id, presence: true
+      attr_accessor :course_id, :confirm
+      validates :course_id, :confirm, presence: true
 
       delegate :find_url, :provider, :name_and_code, to: :course, prefix: true
       delegate :provider_id, to: :course
 
       def self.permitted_params
-        %i[course_id]
+        %i[course_id confirm]
+      end
+
+      def completed?
+        confirm_answer.present? && super
+      end
+
+      def exit_path
+        url_helpers.candidate_interface_continuous_applications_choices_path
       end
 
       def next_step
+        return :exit if confirm_answer.blank?
+
         return :course_review if completed?
 
         if multiple_study_modes?
@@ -38,6 +48,10 @@ module CandidateInterface
 
       def course
         Course.find(course_id)
+      end
+
+      def confirm_answer
+        ActiveModel::Type::Boolean.new.cast(confirm)
       end
     end
   end

--- a/app/forms/candidate_interface/continuous_applications/find_course_selection_step.rb
+++ b/app/forms/candidate_interface/continuous_applications/find_course_selection_step.rb
@@ -13,7 +13,7 @@ module CandidateInterface
       end
 
       def completed?
-        confirm_answer.present? && super
+        confirm_answer? && super
       end
 
       def exit_path
@@ -21,7 +21,7 @@ module CandidateInterface
       end
 
       def next_step
-        return :exit if confirm_answer.blank?
+        return :exit if !confirm_answer?
 
         return :course_review if completed?
 
@@ -50,8 +50,8 @@ module CandidateInterface
         Course.find(course_id)
       end
 
-      def confirm_answer
-        ActiveModel::Type::Boolean.new.cast(confirm)
+      def confirm_answer?
+        ActiveModel::Type::Boolean.new.cast(confirm).present?
       end
     end
   end

--- a/app/lib/dfe/wizard.rb
+++ b/app/lib/dfe/wizard.rb
@@ -90,6 +90,9 @@ module DfE
     def next_step_path
       info("Finding next step for #{current_step.step_name}")
       next_step_name = current_step.next_step
+
+      return current_step.exit_path if next_step_name == :exit
+
       next_step_klass = find_step(next_step_name)
 
       if next_step_klass.present?

--- a/app/views/candidate_interface/continuous_applications/course_choices/find_course_selection/new.html.erb
+++ b/app/views/candidate_interface/continuous_applications/course_choices/find_course_selection/new.html.erb
@@ -4,6 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @wizard.current_step, url: candidate_interface_continuous_applications_course_confirm_selection_path(@wizard.current_step.course_id), method: :post do |f| %>
       <%= f.hidden_field :course_id %>
+      <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">
         <%= t('application_form.confirm_selection.heading') %>

--- a/config/locales/candidate_interface/course_selection_wizard.yml
+++ b/config/locales/candidate_interface/course_selection_wizard.yml
@@ -22,3 +22,7 @@ en:
           attributes:
             course_option_id:
               blank: Select which location you’re applying to
+        find_course_selection:
+          attributes:
+            confirm:
+              blank: Select if you want to apply to this course.

--- a/spec/lib/dfe/wizard_spec.rb
+++ b/spec/lib/dfe/wizard_spec.rb
@@ -55,6 +55,22 @@ module TestWizard
   class TestCourseSiteSelection < DfE::WizardStep
   end
 
+  class TestFindSelection < DfE::WizardStep
+    attr_accessor :answer
+
+    def self.permitted_params
+      %i[answer]
+    end
+
+    def next_step
+      :exit if answer == 'no'
+    end
+
+    def exit_path
+      'custom_exit_path'
+    end
+  end
+
   class TestReview < DfE::WizardStep
   end
 
@@ -80,6 +96,7 @@ module TestWizard
           test_course_name_selection: TestCourseNameSelection,
           test_course_study_mode_selection: TestCourseStudyModeSelection,
           test_course_site_selection: TestCourseSiteSelection,
+          test_find_selection: TestFindSelection,
           test_review: TestReview,
         },
       ]
@@ -134,6 +151,7 @@ RSpec.describe DfE::Wizard do
         test_course_name_selection: TestWizard::TestCourseNameSelection,
         test_course_study_mode_selection: TestWizard::TestCourseStudyModeSelection,
         test_course_site_selection: TestWizard::TestCourseSiteSelection,
+        test_find_selection: TestWizard::TestFindSelection,
         test_review: TestWizard::TestReview,
       },
     ]
@@ -320,6 +338,17 @@ RSpec.describe DfE::Wizard do
         expect {
           wizard.next_step_path
         }.to raise_error(DfE::Wizard::MissingStepError, 'Next step for TestGoToFind missing.')
+      end
+    end
+
+    context 'when exiting the wizard' do
+      let(:current_step) { :test_find_selection }
+      let(:step_params) do
+        { test_find_selection: { answer: 'no' } }
+      end
+
+      it 'assigns attributes to the current step' do
+        expect(wizard.next_step_path).to eq('custom_exit_path')
       end
     end
 

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_and_says_no_to_course_choice_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_and_says_no_to_course_choice_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate arrives from Find with provider and course params', :continuous_applications do
+  include CandidateHelper
+
+  scenario 'The provider is only accepting applications on the Apply service' do
+    given_there_is_a_provider_with_a_course_that_is_only_accepting_applications_on_apply
+
+    when_i_follow_a_link_from_find
+    then_i_am_redirected_to_the_create_account_or_sign_in_path
+
+    given_i_am_signed_in
+
+    when_i_follow_a_link_from_find
+    then_i_am_redirected_to_the_course_confirm_selection_page
+
+    when_i_dont_answer
+    then_i_should_see_an_error_message
+
+    when_i_say_no
+    then_i_should_be_redirected_to_your_applications_tab
+  end
+
+  def given_there_is_a_provider_with_a_course_that_is_only_accepting_applications_on_apply
+    @provider = create(:provider, code: '8N5', name: 'Snape University')
+    @course = create(:course, :open_on_apply, name: 'Potions', provider: @provider, recruitment_cycle_year: 2024)
+    create(:course_option, course: @course)
+  end
+
+  def when_i_follow_a_link_from_find
+    visit candidate_interface_apply_from_find_path(
+      providerCode: @course.provider.code,
+      courseCode: @course.code,
+    )
+  end
+
+  def then_i_am_redirected_to_the_create_account_or_sign_in_path
+    expect(page).to have_current_path candidate_interface_create_account_or_sign_in_path(
+      providerCode: @provider.code,
+      courseCode: @course.code,
+    )
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def then_i_am_redirected_to_the_course_confirm_selection_page
+    expect(page).to have_current_path(
+      candidate_interface_continuous_applications_course_confirm_selection_path(@course.id),
+    )
+  end
+
+  def when_i_dont_answer
+    click_on 'Continue'
+  end
+
+  def then_i_should_see_an_error_message
+    expect(page).to have_content(
+      I18n.t('activemodel.errors.models.find_course_selection.attributes.confirm.blank'),
+    )
+  end
+
+  def when_i_say_no
+    choose 'No'
+    click_on 'Continue'
+  end
+
+  def then_i_should_be_redirected_to_your_applications_tab
+    expect(page).to have_current_path(
+      candidate_interface_continuous_applications_choices_path,
+    )
+  end
+end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_not_signed_in_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_not_signed_in_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'An existing candidate arriving from Find with a course and provid
 
   scenario 'candidate is not signed in and retains their course selection through the sign in process' do
     # Single site course
-    and_i_am_an_existing_candidate_on_apply
+    given_i_am_an_existing_candidate_on_apply
     and_i_have_less_than_4_application_options
     and_the_course_i_selected_only_has_one_site
     when_i_arrive_at_the_apply_from_find_page_with_the_single_site_course_params
@@ -62,6 +62,7 @@ RSpec.feature 'An existing candidate arriving from Find with a course and provid
     @email = "#{SecureRandom.hex}@example.com"
     @candidate = create(:candidate, email_address: @email)
   end
+  alias_method :given_i_am_an_existing_candidate_on_apply, :and_i_am_an_existing_candidate_on_apply
 
   def when_i_arrive_at_the_apply_from_find_page_with_the_single_site_course_params
     visit candidate_interface_apply_from_find_path(

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_not_signed_in_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_not_signed_in_spec.rb
@@ -1,0 +1,207 @@
+require 'rails_helper'
+
+RSpec.feature 'An existing candidate arriving from Find with a course and provider code (with course selection page)', :continuous_applications do
+  include CourseOptionHelpers
+  include SignInHelper
+  include CandidateHelper
+
+  scenario 'candidate is not signed in and retains their course selection through the sign in process' do
+    # Single site course
+    and_i_am_an_existing_candidate_on_apply
+    and_i_have_less_than_4_application_options
+    and_the_course_i_selected_only_has_one_site
+    when_i_arrive_at_the_apply_from_find_page_with_the_single_site_course_params
+    and_i_go_to_sign_in
+    then_i_should_see_the_course_selection_page
+    and_i_should_see_a_link_to_the_course_on_find
+
+    when_i_say_yes
+    then_i_should_see_the_courses_review_page
+    and_i_should_see_the_course_name_and_code
+    and_my_course_from_find_id_should_be_set_to_nil
+    when_i_sign_out
+    when_i_arrive_at_the_apply_from_find_page_with_the_single_site_course_params
+    and_i_go_to_sign_in
+    and_i_should_be_informed_i_have_already_selected_that_course
+
+    # Multi-site course
+    given_i_am_signed_out
+    given_the_course_i_selected_has_multiple_sites
+    and_i_am_an_existing_candidate_on_apply
+    and_i_have_less_than_4_application_options
+    when_i_arrive_at_the_apply_from_find_page_with_the_multi_site_course_params
+    and_i_go_to_sign_in
+    then_i_should_see_the_multi_site_course_selection_page
+    when_i_say_yes
+    and_i_select_the_part_time_study_mode
+    then_i_should_see_the_course_choices_site_page
+    and_i_see_the_form_to_pick_a_location
+    and_my_course_from_find_id_should_be_set_to_nil
+
+    given_i_am_signed_out
+    and_the_course_i_selected_only_has_one_site
+    and_i_am_an_existing_candidate_on_apply
+    and_i_have_4_application_options
+    when_i_arrive_at_the_apply_from_find_page_with_the_multi_site_course_params
+    and_i_go_to_sign_in
+    and_my_course_from_find_id_should_be_set_to_nil
+    and_i_should_be_informed_i_already_have_4_courses
+  end
+
+  def given_i_am_signed_out
+    when_i_sign_out
+  end
+
+  def and_the_course_i_selected_only_has_one_site
+    @course = create(:course, :open_on_apply, name: 'Potions')
+    @site = create(:site, provider: @course.provider)
+    create(:course_option, site: @site, course: @course)
+  end
+
+  def and_i_am_an_existing_candidate_on_apply
+    @email = "#{SecureRandom.hex}@example.com"
+    @candidate = create(:candidate, email_address: @email)
+  end
+
+  def when_i_arrive_at_the_apply_from_find_page_with_the_single_site_course_params
+    visit candidate_interface_apply_from_find_path(
+      providerCode: @course.provider.code,
+      courseCode: @course.code,
+    )
+  end
+
+  def when_i_arrive_at_the_apply_from_find_page_with_the_multi_site_course_params
+    visit candidate_interface_apply_from_find_path(
+      providerCode: @course_with_multiple_sites.provider.code,
+      courseCode: @course_with_multiple_sites.code,
+    )
+  end
+
+  def and_i_go_to_sign_in
+    choose 'Yes, sign in'
+    fill_in 'Email', with: @email
+    click_button t('continue')
+
+    open_email(@email)
+    click_magic_link_in_email
+    confirm_sign_in
+  end
+
+  def and_i_have_less_than_4_application_options
+    application_form = create(:application_form, candidate: @candidate)
+    create(:application_choice, application_form:)
+  end
+
+  def and_i_have_4_application_options
+    application_choice_for_candidate(candidate: @candidate, application_choice_count: 4)
+  end
+
+  def then_i_should_see_the_course_selection_page
+    expect(page).to have_content('You selected a course')
+    expect(page).to have_content(@course.provider.name)
+    expect(page).to have_content(@course.name_and_code)
+  end
+
+  def then_i_should_see_the_multi_site_course_selection_page
+    expect(page).to have_content('You selected a course')
+    expect(page).to have_content(@course_with_multiple_sites.provider.name)
+    expect(page).to have_content(@course_with_multiple_sites.name_and_code)
+  end
+
+  def when_i_say_yes
+    choose 'Yes'
+    click_on t('continue')
+  end
+
+  def then_i_should_see_the_courses_review_page
+    expect(page).to have_current_path(
+      candidate_interface_continuous_applications_course_review_path(
+        application_choice_id: @candidate.current_application.application_choices.last.id,
+      ),
+    )
+  end
+
+  def and_i_should_see_the_course_name_and_code
+    expect(page).to have_content "#{@course.name} (#{@course.code})"
+  end
+
+  def and_i_see_the_form_to_pick_a_location
+    expect(page).to have_content @site2.name
+    expect(page).to have_content @site2.address_line1
+    expect(page).to have_content @site2.address_line2
+    expect(page).to have_content @site2.address_line3
+    expect(page).to have_content @site2.address_line4
+    expect(page).to have_content @site2.postcode
+    expect(page).to have_content @site3.name
+    expect(page).to have_content @site3.address_line1
+    expect(page).to have_content @site3.address_line2
+    expect(page).to have_content @site3.address_line3
+    expect(page).to have_content @site3.address_line4
+    expect(page).to have_content @site3.postcode
+  end
+
+  def and_my_course_from_find_id_should_be_set_to_nil
+    candidate = Candidate.find_by!(email_address: @email)
+    expect(candidate.course_from_find_id).to be_nil
+  end
+
+  def given_the_course_i_selected_has_multiple_sites
+    @course_with_multiple_sites = create(
+      :course,
+      :open_on_apply,
+      :with_both_study_modes,
+      name: 'Herbology',
+    )
+    @site1 = create(:site, provider: @course_with_multiple_sites.provider)
+    @site2 = create(:site, provider: @course_with_multiple_sites.provider)
+    @site3 = create(:site, provider: @course_with_multiple_sites.provider)
+    create(:course_option, :full_time, site: @site1, course: @course_with_multiple_sites)
+    create(:course_option, :part_time, site: @site2, course: @course_with_multiple_sites)
+    create(:course_option, :part_time, site: @site3, course: @course_with_multiple_sites)
+  end
+
+  def and_i_select_the_part_time_study_mode
+    choose 'Part time'
+    click_button t('continue')
+  end
+
+  def then_i_should_see_the_course_choices_site_page
+    expect(page).to have_current_path(
+      candidate_interface_continuous_applications_course_site_path(
+        @course_with_multiple_sites.provider.id,
+        @course_with_multiple_sites.id,
+        :part_time,
+      ),
+    )
+  end
+
+  def and_i_should_be_informed_i_already_have_4_courses
+    expect(page).to have_content I18n.t('errors.messages.too_many_course_choices', course_name_and_code: @course_with_multiple_sites.name_and_code)
+  end
+
+  def when_i_sign_out
+    click_link 'Sign out'
+  end
+
+  def and_i_should_be_informed_i_have_already_selected_that_course
+    expect(page).to have_content "You have already selected #{@course.name_and_code}."
+  end
+
+  def and_i_should_see_a_link_to_the_course_on_find
+    expect(page).to have_link(
+      "#{@course.provider.name} #{@course.name_and_code}",
+      href: "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{@course.provider.code}/#{@course.code}",
+    )
+  end
+
+private
+
+  def application_choice_for_candidate(candidate:, application_choice_count:)
+    provider = create(:provider)
+    application_form = create(:application_form, candidate:)
+    application_choice_count.times { course_option_for_provider(provider:) }
+    provider.courses.each do |course|
+      create(:application_choice, application_form:, course_option: course.course_options.first)
+    end
+  end
+end


### PR DESCRIPTION
## Context

When candidates answer "No" when adding a courses from Find, we should redirect them to Your applications tab

I created a special step in the wizard library called :exit 

When a step returns `:exit` the convention will be call `exit_path` to the current step!
