### PR TITLE
Update find to apply journey banner content

### DIFF
--- a/app/components/utility/flash_message_component.rb
+++ b/app/components/utility/flash_message_component.rb
@@ -22,12 +22,12 @@ class FlashMessageComponent < ViewComponent::Base
   end
 
   def heading
-    messages.is_a?(Array) ? messages[0] : messages
+    messages.is_a?(Array) ? messages[0].html_safe : messages.html_safe
   end
 
   def body
     if messages.is_a?(Array) && messages.count >= 2
-      tag.p(messages[1], class: 'govuk-body')
+      tag.p(messages[1].html_safe, class: 'govuk-body')
     end
   end
 

--- a/app/controllers/candidate_interface/after_sign_in_controller.rb
+++ b/app/controllers/candidate_interface/after_sign_in_controller.rb
@@ -10,10 +10,10 @@ module CandidateInterface
       if current_application.submitted? && !current_application.continuous_applications?
         redirect_to candidate_interface_application_complete_path
       elsif current_application.contains_course?(course_from_find)
-        flash[:warning] = "You have already selected #{course_from_find.name_and_code}."
+        flash[:warning] = "You have already added an application for #{course_from_find.name}. #{view_context.link_to('Find a different course to apply to', find_url, class: 'govuk-link')}."
         redirect_to course_choices_page
       elsif current_application.maximum_number_of_course_choices?
-        flash[:warning] = I18n.t('errors.messages.too_many_course_choices', course_name_and_code: course_from_find.name_and_code)
+        flash[:warning] = I18n.t('errors.messages.too_many_course_choices', max_applications: ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES, course_name: course_from_find.name)
 
         redirect_to course_choices_page
       else

--- a/app/forms/candidate_interface/pick_site_form.rb
+++ b/app/forms/candidate_interface/pick_site_form.rb
@@ -38,7 +38,7 @@ module CandidateInterface
 
       error_key = 'errors.messages.too_many_course_choices'
 
-      errors.add(:base, I18n.t!(error_key, course_name_and_code: course_option.course.name_and_code))
+      errors.add(:base, I18n.t!(error_key, max_applications: ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES, course_name: course_option.course.name_and_code))
     end
   end
 end

--- a/app/views/candidate_interface/apply_from_find/not_found.html.erb
+++ b/app/views/candidate_interface/apply_from_find/not_found.html.erb
@@ -3,12 +3,12 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      <%= service_name %>
+      There is a problem
     </h1>
 
     <p class="govuk-body">
-      We could not find the course you’re looking for – there may be a problem with the training provider and/or course code(s).
-      You can go back to <%= govuk_link_to 'Find postgraduate teacher training', I18n.t('find_postgraduate_teacher_training.production_url') %> and try selecting your course again, or choose a different course.
+      We could not find the course you’re looking for. There may be a problem with the training provider or the course.
+      <%= govuk_link_to 'Try selecting the course again or find a different course to apply to', I18n.t('find_postgraduate_teacher_training.production_url') %>.
     </p>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -543,7 +543,7 @@ en:
     messages:
       too_long: "%{attribute} must be %{count} characters or fewer"
       too_many_words: Must be %{maximum} words or less
-      too_many_course_choices: You cannot have more than 4 course choices. You must delete a choice if you want to apply to %{course_name_and_code}.
+      too_many_course_choices: You cannot have more than %{max_applications} applications. Remove an application first, and then apply to %{course_name}.
       invalid_year: Enter a real %{attribute}
       multiple_year: Enter a single %{attribute}
       invalid_date: Enter a real %{attribute}

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_not_signed_in_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_not_signed_in_spec.rb
@@ -177,7 +177,7 @@ RSpec.feature 'An existing candidate arriving from Find with a course and provid
   end
 
   def and_i_should_be_informed_i_already_have_4_courses
-    expect(page).to have_content I18n.t('errors.messages.too_many_course_choices', course_name_and_code: @course_with_multiple_sites.name_and_code)
+    expect(page).to have_content I18n.t('errors.messages.too_many_course_choices', max_applications: ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES, course_name: @course_with_multiple_sites.name)
   end
 
   def when_i_sign_out
@@ -185,7 +185,7 @@ RSpec.feature 'An existing candidate arriving from Find with a course and provid
   end
 
   def and_i_should_be_informed_i_have_already_selected_that_course
-    expect(page).to have_content "You have already selected #{@course.name_and_code}."
+    expect(page).to have_content "You have already added an application for #{@course.name}."
   end
 
   def and_i_should_see_a_link_to_the_course_on_find

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_duplicate_application_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_duplicate_application_spec.rb
@@ -58,6 +58,6 @@ RSpec.feature 'Candidate arrives from Find with provider and course that is alre
   end
 
   def and_i_see_a_message_about_the_duplication
-    expect(page).to have_content('You have already selected Potions (D75F)')
+    expect(page).to have_content('You have already added an application for Potions.')
   end
 end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_max_applications_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_max_applications_spec.rb
@@ -55,6 +55,6 @@ RSpec.feature 'Candidate arrives from Find with provider and course that is alre
   end
 
   def and_i_see_a_message_about_the_limit
-    expect(page).to have_content('You cannot have more than 4 course choices. You must delete a choice if you want to apply to Potions (D75F)')
+    expect(page).to have_content('You cannot have more than 4 applications. Remove an application first, and then apply to Potions.')
   end
 end

--- a/spec/system/candidate_interface/course_selection/candidate_existing_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_existing_user_with_course_params_spec.rb
@@ -173,7 +173,7 @@ RSpec.feature 'An existing candidate arriving from Find with a course and provid
   end
 
   def and_i_should_be_informed_i_already_have_4_courses
-    expect(page).to have_content I18n.t('errors.messages.too_many_course_choices', course_name_and_code: @course_with_multiple_sites.name_and_code)
+    expect(page).to have_content I18n.t('errors.messages.too_many_course_choices', max_applications: ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES, course_name: @course_with_multiple_sites.name)
   end
 
   def when_i_sign_out
@@ -181,7 +181,7 @@ RSpec.feature 'An existing candidate arriving from Find with a course and provid
   end
 
   def and_i_should_be_informed_i_have_already_selected_that_course
-    expect(page).to have_content "You have already selected #{@course.name_and_code}."
+    expect(page).to have_content "You have already added an application for #{@course.name}."
   end
 
   def and_i_should_see_a_link_to_the_course_on_find

--- a/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_spec.rb
@@ -167,7 +167,7 @@ RSpec.feature 'An existing candidate arriving from Find with a course and provid
   end
 
   def and_i_should_be_informed_i_already_have_4_courses
-    expect(page).to have_content I18n.t('errors.messages.too_many_course_choices', course_name_and_code: @course.name_and_code)
+    expect(page).to have_content I18n.t('errors.messages.too_many_course_choices', max_applications: ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES, course_name: @course.name)
   end
 
   def when_i_sign_out
@@ -179,7 +179,7 @@ RSpec.feature 'An existing candidate arriving from Find with a course and provid
   end
 
   def and_i_should_be_informed_i_have_already_selected_that_course
-    expect(page).to have_content "You have already selected #{@course.name_and_code}."
+    expect(page).to have_content "You have already added an application for #{@course.name}."
   end
 
   def and_i_am_applying_again


### PR DESCRIPTION
## Context

We’ve been working on the journey from Apply to Find to apply for courses. We noticed there are some old banners we use and the content should be updated.

## Changes proposed in this pull request

|Invalid code combination|
|---|
|<img width="725" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/31fa6368-6157-49a9-8e42-9cd437465da3">|

|Already at max applications|
|---|
|<img width="1043" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/b1970dd4-1979-4dd6-beb2-b53f9fd2a3bc">|

|Course has already been added|
|---|
|<img width="1040" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/677e2a34-73d7-49fc-8d6a-c43dce5ef70f">|



## Guidance to review

In order to get this design to work I've had to update our flash message component to set all messages to .`html_safe`. This isn't really a design pattern that we've followed before, so interested to hear thoughts on this.

## Link to Trello card

https://trello.com/c/k2EFnnJP/646-update-content-for-warning-when-candidates-apply-for-a-course-via-find

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
