### PR TITLE
[651] Update content under `Your details` tab

### DIFF
--- a/app/helpers/application_details_helper.rb
+++ b/app/helpers/application_details_helper.rb
@@ -1,0 +1,5 @@
+module ApplicationDetailsHelper
+  def completed_application_form?(application_form)
+    @completed_application_form ||= CandidateInterface::CompletedApplicationForm.new(application_form:).valid?
+  end
+end

--- a/app/views/candidate_interface/shared/_details.html.erb
+++ b/app/views/candidate_interface/shared/_details.html.erb
@@ -14,8 +14,18 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">
-      Courses can fill up quickly, so you should apply as soon as you can.
-      <%= govuk_link_to 'Read how the application process works', candidate_interface_guidance_path %></a>.
+      <% if @application_form_presenter.application_form.continuous_applications? %>
+          <% message = 'Your details will be shared with the training provider of any course you apply to.' %>
+
+          <% if completed_application_form?(@application_form_presenter.application_form) %>
+              <%= message %>
+          <% else %>
+              Complete these sections so that you can start applying to courses. <%= message %>
+          <% end %>
+      <% else %>
+          Courses can fill up quickly, so you should apply as soon as you can.
+          <%= govuk_link_to 'Read how the application process works', candidate_interface_guidance_path %>.
+      <% end %>
     </p>
     <br>
     <section class="govuk-!-margin-bottom-8">

--- a/spec/system/candidate_interface/continuous_applications/entering_details/candidate_marking_section_complete_or_incomplete_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/entering_details/candidate_marking_section_complete_or_incomplete_spec.rb
@@ -13,6 +13,32 @@ RSpec.feature 'Marking section as complete or incomplete', :continuous_applicati
     then_i_should_be_redirected_to_your_applications_page
   end
 
+  scenario 'when not all sections are complete' do
+    given_i_have_a_completed_application_form
+    when_i_sign_in
+    and_i_mark_a_section_as_incomplete
+    then_i_see_the_incomplete_text
+  end
+
+  scenario 'when all sections are complete' do
+    given_i_have_a_completed_application_form
+    when_i_sign_in
+    and_all_details_have_been_completed
+    then_i_do_not_see_the_incomplete_text
+  end
+
+  def and_i_click_on_your_details
+    click_link 'Your details'
+  end
+
+  def then_i_do_not_see_the_incomplete_text
+    expect(page).not_to have_text 'Complete these sections so that you can start applying to courses. Your details will be shared with the training provider of any course you apply to.'
+  end
+
+  def then_i_see_the_incomplete_text
+    expect(page).to have_text('Complete these sections so that you can start applying to courses. Your details will be shared with the training provider of any course you apply to.')
+  end
+
   def given_i_have_a_completed_application_form
     @application_form = create(
       :application_form,
@@ -39,6 +65,8 @@ RSpec.feature 'Marking section as complete or incomplete', :continuous_applicati
   def when_i_mark_a_section_as_complete
     mark_section(section: 'Declare any safeguarding issues', complete: true)
   end
+
+  alias_method :and_all_details_have_been_completed, :when_i_mark_a_section_as_complete
 
   def and_all_sections_are_complete
     completed_application_form = CandidateInterface::CompletedApplicationForm.new(application_form: @application_form)

--- a/spec/system/candidate_interface/navigation_tabs_spec.rb
+++ b/spec/system/candidate_interface/navigation_tabs_spec.rb
@@ -19,13 +19,6 @@ RSpec.describe 'Primary Navigation', continuous_applications: false do
     when_i_click_on_your_applications
     then_i_should_see_your_applications_as_active
 
-    when_i_click_on_link_to_guidance
-    then_i_should_see_your_applications_as_active
-
-    when_i_click_on_your_details
-    and_i_click_on_link_to_guidance
-    then_i_should_see_your_details_as_active
-
     when_i_visit_guidance_page_without_referer
     then_i_should_see_your_details_as_active
   end
@@ -42,18 +35,9 @@ RSpec.describe 'Primary Navigation', continuous_applications: false do
     click_link 'Personal information'
   end
 
-  def when_i_click_on_your_details
-    click_link 'Your details'
-  end
-
   def when_i_click_on_your_applications
     click_link 'Your applications'
   end
-
-  def when_i_click_on_link_to_guidance
-    click_link 'Read how the application process works'
-  end
-  alias_method :and_i_click_on_link_to_guidance, :when_i_click_on_link_to_guidance
 
   def then_i_should_see_your_details_as_active
     expect(page).to have_css('.govuk-link.app-primary-navigation__link[aria-current=page]', text: 'Your details')

--- a/spec/system/candidate_interface/signup_and_signin/candidate_views_guidance_from_unsubmitted_application_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_views_guidance_from_unsubmitted_application_spec.rb
@@ -10,9 +10,6 @@ RSpec.feature 'Candidate signs in and starts blank application' do
     when_i_fill_in_the_sign_in_form
     and_i_click_on_the_link_in_my_email_and_sign_in
     then_i_am_taken_to_the_application_page
-
-    when_i_click_on_the_guidance_link
-    then_i_am_taken_to_the_guidance_page
   end
 
   def given_a_course_is_available
@@ -38,13 +35,5 @@ RSpec.feature 'Candidate signs in and starts blank application' do
 
   def then_i_am_taken_to_the_application_page
     expect(page).to have_current_path(candidate_interface_continuous_applications_details_path)
-  end
-
-  def when_i_click_on_the_guidance_link
-    click_link 'Read how the application process works'
-  end
-
-  def then_i_am_taken_to_the_guidance_page
-    expect(page).to have_current_path(candidate_interface_guidance_path)
   end
 end


### PR DESCRIPTION
## Context

The content under `Your details` is still showing the old content before we split into `Your details` and `Your applications`.

## Changes proposed in this pull request

- Add helper method to check if application form has been completed.
- Use the method to render different text on the "Your details" tab
- Changes are only in play if the continuous applications flow is enabled.

## Guidance to review

### Without `continuous_applications` enabled

<img width="1117" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/50492247/ab4f3008-95b9-4bf1-af38-7f158f6df53b">

### With `continuous_applications` enabled and an incomplete section

<img width="1129" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/50492247/40c68f18-9c83-401e-bcf3-e518938d87fd">


### With `continuous_applications` enabled and all sections complete 

<img width="1121" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/50492247/e6f25b4d-cd87-4ece-aab3-f9418b5c897d">


## Link to Trello card

https://trello.com/c/Ji6CaaSm/651-update-content-on-your-details-tab-below-the-h1

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
