### PR TITLE
[570] Update content under `Your applications` tab between the apply1 deadline and Find reopening

### DIFF
--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -444,6 +444,10 @@ class CycleTimetable
     false
   end
 
+  def self.today_is_between_apply_1_deadline_and_find_reopens
+    current_date.between?(apply_1_deadline, find_reopens)
+  end
+
   def self.before_apply_reopens?
     current_date.to_date <= apply_reopens
   end

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -444,7 +444,7 @@ class CycleTimetable
     false
   end
 
-  def self.today_is_between_apply_1_deadline_and_find_reopens
+  def self.today_is_between_apply_1_deadline_and_find_reopens?
     current_date.between?(apply_1_deadline, find_reopens)
   end
 

--- a/app/views/candidate_interface/continuous_applications_choices/index.html.erb
+++ b/app/views/candidate_interface/continuous_applications_choices/index.html.erb
@@ -6,25 +6,46 @@
       <%= t('page_titles.continuous_applications.your_applications') %>
     </h1>
 
-    <% unless @application_form_presenter.can_add_more_choices? %>
-      <p class="govuk-body">You cannot add any more applications.</p>
-      <p class="govuk-body">If one of your applications is unsuccessful, or you withdraw or remove it, you will be able to add another application.<p>
+    <% if CycleTimetable.today_is_between_apply_1_deadline_and_find_reopens %>
+      <p class="govuk-body govuk-!-margin-top-6">Applications for courses starting in September 2023 are closed.</p>
+      <p class="govuk-body"> From <%= CycleTimetable.find_reopens.to_fs(:govuk_time_and_date) %>, you can <%= govuk_link_to(
+      'find postgraduate teacher training courses',
+      t('find_postgraduate_teacher_training.production_url'),
+    ) %> starting in September <%= RecruitmentCycle.next_year %>.</p>
+
+    <p class="govuk-body">You’ll be able to apply to courses from <%= CycleTimetable.apply_reopens.to_fs(:govuk_time_and_date) %>.</p>
+
+    <p class="govuk-body">While you wait, you can:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li><%= govuk_link_to('continue making changes to your details to get ready to apply', candidate_interface_continuous_applications_details_path) %></li>
+      <li><%= govuk_link_to('read about how the application process works', candidate_interface_guidance_path) %>
+      </li>
+    </ul>
+
+    <% else %>
+
+      <% unless @application_form_presenter.can_add_more_choices? %>
+        <p class="govuk-body">You cannot add any more applications.</p>
+        <p class="govuk-body">If one of your applications is unsuccessful, or you withdraw or remove it, you will be able to add another application.<p>
+            <p class="govuk-body">
+              <%= govuk_link_to 'Read how the application process works', candidate_interface_guidance_path %>
+            </p>
+      <% else %>
+
+        <%= render CandidateInterface::ApplicationsLeftMessageComponent.new(@application_form_presenter.application_form) %>
+
+        <div class="govuk-inset-text">
+          <p class="govuk-body">Training providers offer places on courses as people apply throughout the year. Courses stay open until they are full.</p>
+
+          <p class="govuk-body">Courses can fill up quickly, so you should apply as soon as you’re ready rather than putting it off.</p>
+
           <p class="govuk-body">
             <%= govuk_link_to 'Read how the application process works', candidate_interface_guidance_path %>
           </p>
-    <% else %>
+        </div>
 
-      <%= render CandidateInterface::ApplicationsLeftMessageComponent.new(@application_form_presenter.application_form) %>
-
-      <div class="govuk-inset-text">
-        <p class="govuk-body">Training providers offer places on courses as people apply throughout the year. Courses stay open until they are full.</p>
-
-        <p class="govuk-body">Courses can fill up quickly, so you should apply as soon as you’re ready rather than putting it off.</p>
-
-        <p class="govuk-body">
-          <%= govuk_link_to 'Read how the application process works', candidate_interface_guidance_path %>
-        </p>
-      </div>
+      <% end %>
 
       <% if CycleTimetable.can_add_course_choice?(@application_form_presenter.application_form) && @application_form_presenter.can_add_more_choices? %>
         <%= govuk_button_link_to t('section_items.add_application'), candidate_interface_continuous_applications_do_you_know_the_course_path %>

--- a/app/views/candidate_interface/continuous_applications_choices/index.html.erb
+++ b/app/views/candidate_interface/continuous_applications_choices/index.html.erb
@@ -6,7 +6,7 @@
       <%= t('page_titles.continuous_applications.your_applications') %>
     </h1>
 
-    <% if CycleTimetable.today_is_between_apply_1_deadline_and_find_reopens %>
+    <% if CycleTimetable.today_is_between_apply_1_deadline_and_find_reopens? %>
       <p class="govuk-body govuk-!-margin-top-6">Applications for courses starting in September 2023 are closed.</p>
       <p class="govuk-body"> From <%= CycleTimetable.find_reopens.to_fs(:govuk_time_and_date) %>, you can <%= govuk_link_to(
       'find postgraduate teacher training courses',

--- a/app/views/candidate_interface/continuous_applications_choices/index.html.erb
+++ b/app/views/candidate_interface/continuous_applications_choices/index.html.erb
@@ -7,7 +7,7 @@
     </h1>
 
     <% if CycleTimetable.today_is_between_apply_1_deadline_and_find_reopens? %>
-      <p class="govuk-body govuk-!-margin-top-6">Applications for courses starting in September 2023 are closed.</p>
+      <p class="govuk-body govuk-!-margin-top-6">Applications for courses starting in September <%= RecruitmentCycle.current_year %> are closed.</p>
       <p class="govuk-body"> From <%= CycleTimetable.find_reopens.to_fs(:govuk_time_and_date) %>, you can <%= govuk_link_to(
       'find postgraduate teacher training courses',
       t('find_postgraduate_teacher_training.production_url'),

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -26,6 +26,11 @@ Time::DATE_FORMATS[:govuk_date_and_time] = lambda do |time|
   time.strftime(format).squish
 end
 
+Time::DATE_FORMATS[:govuk_time_and_date] = lambda do |time|
+  format = '%-l%P on %-e %B %Y'
+  time.strftime(format)
+end
+
 Time::DATE_FORMATS[:govuk_time] = lambda do |time|
   format = if time >= time.midday && time <= time.midday.end_of_minute
              '%l%P (midday)'

--- a/spec/config/initializers/date_formats_spec.rb
+++ b/spec/config/initializers/date_formats_spec.rb
@@ -32,4 +32,11 @@ RSpec.describe 'Time::DATE_FORMATS' do
       expect(date_and_time.to_fs(:govuk_time)).to eq('6:10am')
     end
   end
+
+  describe 'govuk_time_and_date' do
+    it 'formats time and date in the correct format' do
+      date_and_time = Time.zone.local(2020, 12, 5, 6)
+      expect(date_and_time.to_fs(:govuk_time_and_date)).to eq('6am on 5 December 2020')
+    end
+  end
 end

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe CycleTimetable do
   let(:one_hour_before_find_closes) { described_class.find_closes(this_year) - 1.hour }
   let(:one_hour_after_find_closes) { described_class.find_closes(this_year) + 1.hour }
   let(:one_hour_after_find_opens) { described_class.find_opens(this_year) + 1.hour }
+  let(:one_hour_after_find_reopens) { described_class.find_reopens(this_year) + 1.hour }
   let(:three_days_before_find_reopens) { described_class.find_reopens(this_year) - 3.days }
   let(:twenty_days_after_next_year_cycle_opens) { 20.business_days.after(described_class.apply_opens(next_year)).end_of_day }
   let(:one_hour_before_show_summer_recruitment_banner) { described_class::CYCLE_DATES[next_next_year][:show_summer_recruitment_banner] - 1.hour }
@@ -198,6 +199,26 @@ RSpec.describe CycleTimetable do
     it 'returns false after the new cycle opens' do
       travel_temporarily_to(one_hour_after_next_year_cycle_opens) do
         expect(described_class.between_cycles_apply_1?).to be false
+      end
+    end
+  end
+
+  describe '.between_apply_1_deadline_and_find_closes?' do
+    it 'returns false before the configured date' do
+      travel_temporarily_to(one_hour_before_apply1_deadline) do
+        expect(described_class.between_apply_1_deadline_and_find_closes?).to be false
+      end
+    end
+
+    it 'returns true during the configured date' do
+      travel_temporarily_to(one_hour_after_apply1_deadline) do
+        expect(described_class.between_apply_1_deadline_and_find_closes?).to be true
+      end
+    end
+
+    it 'returns false after the configured date' do
+      travel_temporarily_to(one_hour_after_find_reopens) do
+        expect(described_class.between_apply_1_deadline_and_find_closes?).to be false
       end
     end
   end

--- a/spec/system/candidate_interface/continuous_applications/carry_over/candidate_carries_over_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/carry_over/candidate_carries_over_spec.rb
@@ -274,7 +274,7 @@ private
 
   def then_i_should_not_see_the_add_course_button
     expect(page).not_to have_content('Add application')
-    expect(page).to have_content('You can find courses from 9am on 3 October 2023. You can keep making changes to your application until then.')
+    expect(page).to have_content("Applications for courses starting in September #{RecruitmentCycle.current_year} are closed.")
   end
 
   def and_i_should_not_see_previous_applications_heading


### PR DESCRIPTION
## Context

At the moment, we’re rendering content that isn’t congruent with the time period after the apply 1 deadline and before Find opens.

## Changes proposed in this pull request

- Update the content if the time is between the apply1 deadline and find reopening.

## Guidance to review

### Before

<img width="1099" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/50492247/ba09adb9-2877-4e40-aaa1-5ff41341428f">


### After

<img width="1050" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/50492247/dd9ed85f-ac86-4200-980b-f4df64a42dfc">


## Link to Trello card

https://trello.com/c/yzdX0Fyl/570-provide-clarity-guidance-on-after-completing-your-details-until-find-opens

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
