### PR TITLE
Introduce the 20 unsuccessful application cap

### DIFF
--- a/app/controllers/candidate_interface/after_sign_in_controller.rb
+++ b/app/controllers/candidate_interface/after_sign_in_controller.rb
@@ -14,6 +14,8 @@ module CandidateInterface
         redirect_to course_choices_page
       elsif current_application.maximum_number_of_course_choices?
         flash[:warning] = I18n.t('errors.messages.too_many_course_choices', max_applications: ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES, course_name: course_from_find.name)
+      elsif current_application.exceeded_maximum_unsuccessful_choices?
+        flash[:warning] = I18n.t('errors.messages.too_many_unsuccessful_choices', max_unsuccessful_applications: ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS)
 
         redirect_to course_choices_page
       else

--- a/app/controllers/candidate_interface/after_sign_in_controller.rb
+++ b/app/controllers/candidate_interface/after_sign_in_controller.rb
@@ -14,7 +14,8 @@ module CandidateInterface
         redirect_to course_choices_page
       elsif current_application.maximum_number_of_course_choices?
         flash[:warning] = I18n.t('errors.messages.too_many_course_choices', max_applications: ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES, course_name: course_from_find.name)
-      elsif current_application.exceeded_maximum_unsuccessful_choices?
+        redirect_to course_choices_page
+      elsif current_application.reached_maximum_unsuccessful_choices?
         flash[:warning] = I18n.t('errors.messages.too_many_unsuccessful_choices', max_unsuccessful_applications: ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS)
 
         redirect_to course_choices_page

--- a/app/controllers/candidate_interface/continuous_applications/course_choices/base_controller.rb
+++ b/app/controllers/candidate_interface/continuous_applications/course_choices/base_controller.rb
@@ -3,6 +3,7 @@ module CandidateInterface
     module CourseChoices
       class BaseController < ::CandidateInterface::ContinuousApplicationsController
         before_action :redirect_to_your_applications_if_maximum_amount_of_choices_have_been_used, only: %i[new create]
+        before_action :redirect_to_your_applications_if_maximum_amount_of_unsuccessful_applications_have_been_reached, only: %i[new create]
         before_action :redirect_to_your_applications_if_cycle_is_over
         before_action :redirect_to_your_applications_if_submitted, only: %i[edit update]
 
@@ -99,6 +100,10 @@ module CandidateInterface
 
         def redirect_to_your_applications_if_maximum_amount_of_choices_have_been_used
           redirect_to candidate_interface_continuous_applications_choices_path unless current_application.can_add_more_choices?
+        end
+
+        def redirect_to_your_applications_if_maximum_amount_of_unsuccessful_applications_have_been_reached
+          redirect_to candidate_interface_continuous_applications_choices_path if current_application.exceeded_maximum_unsuccessful_choices?
         end
       end
     end

--- a/app/controllers/candidate_interface/continuous_applications/course_choices/base_controller.rb
+++ b/app/controllers/candidate_interface/continuous_applications/course_choices/base_controller.rb
@@ -103,7 +103,7 @@ module CandidateInterface
         end
 
         def redirect_to_your_applications_if_maximum_amount_of_unsuccessful_applications_have_been_reached
-          redirect_to candidate_interface_continuous_applications_choices_path if current_application.exceeded_maximum_unsuccessful_choices?
+          redirect_to candidate_interface_continuous_applications_choices_path if current_application.reached_maximum_unsuccessful_choices?
         end
       end
     end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -47,6 +47,7 @@ class ApplicationForm < ApplicationRecord
   EQUALITY_AND_DIVERSITY_MINIMAL_ATTR = %w[sex disabilities ethnic_group].freeze
   BRITISH_OR_IRISH_NATIONALITIES = %w[GB IE].freeze
   MAXIMUM_NUMBER_OF_COURSE_CHOICES = 4
+  MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS = 20
 
   # Applications created after this date include a single personal statement
   # instead of 2 personal statement sections
@@ -289,8 +290,12 @@ class ApplicationForm < ApplicationRecord
     continuous_applications? ? application_choices.size - count_unsuccessful_choices : application_choices.size
   end
 
-  def count_unsuccessful_choices
-    application_choices.count { |choice| ApplicationStateChange::UNSUCCESSFUL_STATES.include?(choice.status.to_sym) }
+  def count_unsuccessful_choices(count_inactive: true)
+    application_choices.count { |choice| (count_inactive || choice.status.to_sym != :inactive) && ApplicationStateChange::UNSUCCESSFUL_STATES.include?(choice.status.to_sym) }
+  end
+
+  def exceeded_maximum_unsuccessful_choices?
+    count_unsuccessful_choices(count_inactive: false) >= MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS
   end
 
   def can_submit_further_applications?

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -294,8 +294,8 @@ class ApplicationForm < ApplicationRecord
     application_choices.count { |choice| (count_inactive || choice.status.to_sym != :inactive) && ApplicationStateChange::UNSUCCESSFUL_STATES.include?(choice.status.to_sym) }
   end
 
-  def exceeded_maximum_unsuccessful_choices?
-    count_unsuccessful_choices(count_inactive: false) >= MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS
+  def reached_maximum_unsuccessful_choices?
+    count_unsuccessful_choices(count_inactive: false) == MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS
   end
 
   def can_submit_further_applications?

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -9,6 +9,7 @@ module CandidateInterface
              :candidate_has_previously_applied?,
              :can_add_more_choices?,
              :english_main_language,
+             :exceeded_maximum_unsuccessful_choices?,
              :first_name,
              :first_nationality,
              :previous_application_form,

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -9,7 +9,7 @@ module CandidateInterface
              :candidate_has_previously_applied?,
              :can_add_more_choices?,
              :english_main_language,
-             :exceeded_maximum_unsuccessful_choices?,
+             :reached_maximum_unsuccessful_choices?,
              :first_name,
              :first_nationality,
              :previous_application_form,

--- a/app/validators/can_add_more_choices_validator.rb
+++ b/app/validators/can_add_more_choices_validator.rb
@@ -4,7 +4,7 @@ class CanAddMoreChoicesValidator < ActiveModel::EachValidator
       record.errors.add(attribute, :max_course_choices, message: 'You cannot submit this application because you have already submitted the maximum number of applications.')
     end
 
-    if application_choice.application_form.exceeded_maximum_unsuccessful_choices?
+    if application_choice.application_form.reached_maximum_unsuccessful_choices?
       record.errors.add(attribute, :max_course_choices, message: "You cannot submit this application because you have #{ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS} unsuccessful applications.")
     end
   end

--- a/app/validators/can_add_more_choices_validator.rb
+++ b/app/validators/can_add_more_choices_validator.rb
@@ -3,5 +3,9 @@ class CanAddMoreChoicesValidator < ActiveModel::EachValidator
     unless application_choice.application_form.can_submit_further_applications?
       record.errors.add(attribute, :max_course_choices, message: 'You cannot submit this application because you have already submitted the maximum number of applications.')
     end
+
+    if application_choice.application_form.exceeded_maximum_unsuccessful_choices?
+      record.errors.add(attribute, :max_course_choices, message: "You cannot submit this application because you have #{ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS} unsuccessful applications.")
+    end
   end
 end

--- a/app/views/candidate_interface/continuous_applications_choices/index.html.erb
+++ b/app/views/candidate_interface/continuous_applications_choices/index.html.erb
@@ -9,57 +9,62 @@
     <% if CycleTimetable.today_is_between_apply_1_deadline_and_find_reopens? %>
       <p class="govuk-body govuk-!-margin-top-6">Applications for courses starting in September <%= RecruitmentCycle.current_year %> are closed.</p>
       <p class="govuk-body"> From <%= CycleTimetable.find_reopens.to_fs(:govuk_time_and_date) %>, you can <%= govuk_link_to(
-      'find postgraduate teacher training courses',
-      t('find_postgraduate_teacher_training.production_url'),
-    ) %> starting in September <%= RecruitmentCycle.next_year %>.</p>
+        'find postgraduate teacher training courses',
+        t('find_postgraduate_teacher_training.production_url'),
+      ) %> starting in September <%= RecruitmentCycle.next_year %>.</p>
 
-    <p class="govuk-body">You’ll be able to apply to courses from <%= CycleTimetable.apply_reopens.to_fs(:govuk_time_and_date) %>.</p>
+      <p class="govuk-body">You’ll be able to apply to courses from <%= CycleTimetable.apply_reopens.to_fs(:govuk_time_and_date) %>.</p>
 
-    <p class="govuk-body">While you wait, you can:</p>
+      <p class="govuk-body">While you wait, you can:</p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li><%= govuk_link_to('continue making changes to your details to get ready to apply', candidate_interface_continuous_applications_details_path) %></li>
-      <li><%= govuk_link_to('read about how the application process works', candidate_interface_guidance_path) %>
-      </li>
-    </ul>
+      <ul class="govuk-list govuk-list--bullet">
+        <li><%= govuk_link_to('continue making changes to your details to get ready to apply', candidate_interface_continuous_applications_details_path) %></li>
+        <li><%= govuk_link_to('read about how the application process works', candidate_interface_guidance_path) %>
+        </li>
+      </ul>
 
     <% else %>
 
-      <% unless @application_form_presenter.can_add_more_choices? %>
-        <p class="govuk-body">You cannot add any more applications.</p>
-        <p class="govuk-body">If one of your applications is unsuccessful, or you withdraw or remove it, you will be able to add another application.<p>
-            <p class="govuk-body">
-              <%= govuk_link_to 'Read how the application process works', candidate_interface_guidance_path %>
-            </p>
+      <% if @application_form_presenter.exceeded_maximum_unsuccessful_choices? %>
+        <p class="govuk-body">You cannot submit any more applications because you have <%= ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS %> unsuccessful applications.</p>
+        <p class="govuk-body">You’ll be able to apply again in <%= CycleTimetable.apply_reopens.to_fs(:month_and_year) %> when applications open for courses starting in September <%= CycleTimetable.next_year %>.</p>
+        <p class="govuk-body">Email <%= govuk_mail_to('becomingateacher@digital.education.gov.uk') %> if you need help with your applications.</p>
       <% else %>
+        <% unless @application_form_presenter.can_add_more_choices? %>
+          <p class="govuk-body">You cannot add any more applications.</p>
+          <p class="govuk-body">If one of your applications is unsuccessful, or you withdraw or remove it, you will be able to add another application.<p>
+              <p class="govuk-body">
+                <%= govuk_link_to 'Read how the application process works', candidate_interface_guidance_path %>
+              </p>
+            <% else %>
 
-        <%= render CandidateInterface::ApplicationsLeftMessageComponent.new(@application_form_presenter.application_form) %>
+              <%= render CandidateInterface::ApplicationsLeftMessageComponent.new(@application_form_presenter.application_form) %>
 
-        <div class="govuk-inset-text">
-          <p class="govuk-body">Training providers offer places on courses as people apply throughout the year. Courses stay open until they are full.</p>
+              <div class="govuk-inset-text">
+                <p class="govuk-body">Training providers offer places on courses as people apply throughout the year. Courses stay open until they are full.</p>
 
-          <p class="govuk-body">Courses can fill up quickly, so you should apply as soon as you’re ready rather than putting it off.</p>
+                <p class="govuk-body">Courses can fill up quickly, so you should apply as soon as you’re ready rather than putting it off.</p>
 
-          <p class="govuk-body">
-            <%= govuk_link_to 'Read how the application process works', candidate_interface_guidance_path %>
-          </p>
-        </div>
+                <p class="govuk-body">
+                  <%= govuk_link_to 'Read how the application process works', candidate_interface_guidance_path %>
+                </p>
+              </div>
 
-      <% end %>
+              <% if CycleTimetable.can_add_course_choice?(@application_form_presenter.application_form) && @application_form_presenter.can_add_more_choices? %>
+                <%= govuk_button_link_to t('section_items.add_application'), candidate_interface_continuous_applications_do_you_know_the_course_path %>
+              <% else %>
+                <div class="govuk-grid-row">
+                  <section class="govuk-!-margin-bottom-8">
+                    <p class="govuk-body">
+                      You can find courses from 9am on <%= CycleTimetable.find_reopens.to_fs(:govuk_date) %>. You can keep making changes to your application until then.
+                    </p>
+                  </section>
+                </div>
+              <% end %>
+            <% end %>
+          <% end %>
 
-      <% if CycleTimetable.can_add_course_choice?(@application_form_presenter.application_form) && @application_form_presenter.can_add_more_choices? %>
-        <%= govuk_button_link_to t('section_items.add_application'), candidate_interface_continuous_applications_do_you_know_the_course_path %>
-      <% else %>
-        <div class="govuk-grid-row">
-          <section class="govuk-!-margin-bottom-8">
-            <p class="govuk-body">
-              You can find courses from 9am on <%= CycleTimetable.find_reopens.to_fs(:govuk_date) %>. You can keep making changes to your application until then.
-            </p>
-          </section>
-        </div>
-      <% end %>
-    <% end %>
-
-    <%= render CandidateInterface::ContinuousApplications::DashboardComponent.new(application_form: @application_form_presenter.application_form) %>
+          <%= render CandidateInterface::ContinuousApplications::DashboardComponent.new(application_form: @application_form_presenter.application_form) %>
+        <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/continuous_applications_choices/index.html.erb
+++ b/app/views/candidate_interface/continuous_applications_choices/index.html.erb
@@ -25,7 +25,7 @@
 
     <% else %>
 
-      <% if @application_form_presenter.exceeded_maximum_unsuccessful_choices? %>
+      <% if @application_form_presenter.reached_maximum_unsuccessful_choices? %>
         <p class="govuk-body">You cannot submit any more applications because you have <%= ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS %> unsuccessful applications.</p>
         <p class="govuk-body">You’ll be able to apply again in <%= CycleTimetable.apply_reopens.to_fs(:month_and_year) %> when applications open for courses starting in September <%= CycleTimetable.next_year %>.</p>
         <p class="govuk-body">Email <%= govuk_mail_to('becomingateacher@digital.education.gov.uk') %> if you need help with your applications.</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -544,6 +544,7 @@ en:
       too_long: "%{attribute} must be %{count} characters or fewer"
       too_many_words: Must be %{maximum} words or less
       too_many_course_choices: You cannot have more than %{max_applications} applications. Remove an application first, and then apply to %{course_name}.
+      too_many_unsuccessful_choices: You cannot apply to any more courses because you have %{max_unsuccessful_applications} unsuccessful applications.
       invalid_year: Enter a real %{attribute}
       multiple_year: Enter a single %{attribute}
       invalid_date: Enter a real %{attribute}

--- a/spec/services/candidate_interface/continuous_applications/application_choice_submission_spec.rb
+++ b/spec/services/candidate_interface/continuous_applications/application_choice_submission_spec.rb
@@ -147,6 +147,19 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationChoiceSubm
       end
     end
 
+    context 'when the candidate has reached the maximum number of unsuccessful choices' do
+      before do
+        application_form.application_choices << build_list(:application_choice, 20, status: :rejected)
+      end
+
+      it 'adds error to application choice' do
+        application_choice_submission.valid?
+        expect(application_choice_submission.errors[:application_choice]).to include(
+          "You cannot submit this application because you have #{ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS} unsuccessful applications.",
+        )
+      end
+    end
+
     context 'when application is ready for submit' do
       let(:application_form) { create(:application_form, :completed, course_choices_completed: false) }
       let(:application_choice) { create(:application_choice, :unsubmitted, application_form:) }

--- a/spec/system/candidate_interface/continuous_applications/submitting/candidate_tries_to_submit_after_exceeding_the_maximum_amount_of_unsuccessful_choices_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/submitting/candidate_tries_to_submit_after_exceeding_the_maximum_amount_of_unsuccessful_choices_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate submits the application', :continuous_applications do
+  include CandidateHelper
+
+  scenario 'Candidate with more than the max unsuccessful apps' do
+    given_i_am_signed_in
+    and_i_have_19_unsuccessful_applications
+
+    when_i_have_completed_my_application_and_added_primary_as_course_choice
+    and_i_go_to_submit_my_application
+    and_i_click_continue
+    then_i_can_see_my_application_has_been_successfully_submitted
+    and_i_can_see_i_have_three_choices_left
+
+    when_my_application_is_rejected
+    then_i_am_unable_to_add_any_further_choices
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_have_19_unsuccessful_applications
+    current_candidate.application_forms.delete_all
+    current_candidate.application_forms << build(:application_form, :completed)
+    current_candidate.current_application.application_choices << build_list(:application_choice, 19, :withdrawn)
+  end
+
+  def when_i_have_completed_my_application_and_added_primary_as_course_choice
+    @provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
+    site = create(
+      :site,
+      name: 'Main site',
+      code: '-',
+      provider: @provider,
+      address_line1: 'Gorse SCITT',
+      address_line2: 'C/O The Bruntcliffe Academy',
+      address_line3: 'Bruntcliffe Lane',
+      address_line4: 'MORLEY, lEEDS',
+      postcode: 'LS27 0LZ',
+    )
+    @course = create(:course, :open_on_apply, name: 'Primary', code: '2XT2', provider: @provider)
+    @course_option = create(:course_option, site:, course: @course)
+    @application_choice = create(:application_choice, :unsubmitted, course_option: @course_option, application_form: current_candidate.current_application)
+  end
+
+  def and_i_go_to_submit_my_application
+    visit candidate_interface_continuous_applications_choices_path
+    click_on 'Continue application', match: :first
+    choose 'Yes, submit it now'
+  end
+
+  def and_i_click_continue
+    click_button t('continue')
+  end
+
+  def and_my_application_is_still_unsubmitted
+    expect(@application_choice.reload).to be_unsubmitted
+  end
+
+  def then_i_can_see_my_application_has_been_successfully_submitted
+    expect(page).to have_content 'Application submitted'
+  end
+
+  def and_i_am_redirected_to_the_application_dashboard
+    expect(page).to have_content t('page_titles.application_dashboard')
+    expect(page).to have_content 'Gorse SCITT'
+  end
+
+  def and_my_application_is_submitted
+    expect(@application_choice.reload).to be_awaiting_provider_decision
+  end
+
+  def and_i_can_see_i_have_three_choices_left
+    expect(page).to have_content 'You can add 3 more applications.'
+  end
+
+  def when_my_application_is_rejected
+    ApplicationStateChange.new(@application_choice.reload).reject!
+  end
+
+  def then_i_am_unable_to_add_any_further_choices
+    visit current_path
+    expect(page).to have_content "You cannot submit any more applications because you have #{ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS} unsuccessful applications."
+  end
+end

--- a/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_with_the_maximum_amount_of_unsuccessful_choices_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_with_the_maximum_amount_of_unsuccessful_choices_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate arrives from Find with provider and course params', :continuous_applications do
+  include CandidateHelper
+
+  scenario 'The candidate has hit the maximum amount of unsuccessful choices per cycle' do
+    given_there_is_a_provider_with_a_course_that_is_only_accepting_applications_on_apply
+
+    when_i_follow_a_link_from_find
+    then_i_am_redirected_to_the_create_account_or_sign_in_path
+
+    given_i_am_signed_in
+
+    when_i_follow_a_link_from_find
+    then_i_am_redirected_to_the_course_confirm_selection_page
+  end
+
+  def given_there_is_a_provider_with_a_course_that_is_only_accepting_applications_on_apply
+    @provider = create(:provider, code: '8N5')
+    @course = create(:course, :open_on_apply, name: 'Potions', provider: @provider)
+  end
+
+  def when_i_follow_a_link_from_find
+    visit candidate_interface_apply_from_find_path(providerCode: @course.provider.code, courseCode: @course.code)
+  end
+
+  def then_i_am_redirected_to_the_create_account_or_sign_in_path
+    expect(page).to have_current_path candidate_interface_create_account_or_sign_in_path(providerCode: @provider.code, courseCode: @course.code)
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+    current_candidate.application_forms << build(:application_form, :completed)
+    current_candidate.current_application.application_choices << build_list(:application_choice, 20, :withdrawn)
+  end
+
+  def then_i_am_redirected_to_the_course_confirm_selection_page
+    expect(page).to have_content I18n.t('errors.messages.too_many_unsuccessful_choices', max_unsuccessful_applications: ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS)
+  end
+end

--- a/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_with_the_maximum_amount_of_unsuccessful_choices_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_with_the_maximum_amount_of_unsuccessful_choices_spec.rb
@@ -9,10 +9,10 @@ RSpec.feature 'Candidate arrives from Find with provider and course params', :co
     when_i_follow_a_link_from_find
     then_i_am_redirected_to_the_create_account_or_sign_in_path
 
-    given_i_am_signed_in
+    given_i_am_at_the_maximum_limit_of_unsuccessful_applications
 
     when_i_follow_a_link_from_find
-    then_i_am_redirected_to_the_course_confirm_selection_page
+    then_i_am_presented_with_an_error_message
   end
 
   def given_there_is_a_provider_with_a_course_that_is_only_accepting_applications_on_apply
@@ -28,13 +28,13 @@ RSpec.feature 'Candidate arrives from Find with provider and course params', :co
     expect(page).to have_current_path candidate_interface_create_account_or_sign_in_path(providerCode: @provider.code, courseCode: @course.code)
   end
 
-  def given_i_am_signed_in
+  def given_i_am_at_the_maximum_limit_of_unsuccessful_applications
     create_and_sign_in_candidate
     current_candidate.application_forms << build(:application_form, :completed)
     current_candidate.current_application.application_choices << build_list(:application_choice, 20, :withdrawn)
   end
 
-  def then_i_am_redirected_to_the_course_confirm_selection_page
+  def then_i_am_presented_with_an_error_message
     expect(page).to have_content I18n.t('errors.messages.too_many_unsuccessful_choices', max_unsuccessful_applications: ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS)
   end
 end


### PR DESCRIPTION
## Context

With continuous applications,  if there’s no upper application limit in place, we allow for the possibility of an unsuccessful candidates to enter a state of unlimited application choices (i.e. rejected/withdraws adds another.. repeat).

This can cause technical and performance problems in the apply application (also in the performance of the Vendor API or in the monthly report).

To prevent this we need to limit the total number of application choices that a candidate could have during the whole cycle.

## Changes proposed in this pull request

- introduce limit
- prevent submission if the candidate is at this limit
- prevent candidate from adding a course choice on the find-to-apply journey

|Hitting the limit|
|---|
|<img width="702" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/a99f104d-2796-4b9b-befd-0961cc94c68c">|

|Landing from find|
|---|
|<img width="1067" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/0c1c2081-2102-494c-80a0-c7a85d14ab85">|

## Guidance to review

served as a reminder about the inconsistency between calling things "choices" or "applications" so opted to follow any existing convention. 

## Link to Trello card

https://trello.com/c/qLILAMqE/447-ca-limit-and-validate-the-maximum-number-of-applications-within-a-cycle

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
