### PR TITLE
Edit content for candidate and provider application submitted emails

### DIFF
--- a/app/views/candidate_mailer/application_submitted.text.erb
+++ b/app/views/candidate_mailer/application_submitted.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>
+Hello <%= @application_form.first_name %>
 
 <% if @application_form.application_choices.count > 1 %>
 
@@ -22,8 +22,10 @@ Dear <%= @application_form.first_name %>
 
 <% else %>
 
-  Your training provider will be in touch if they would like to organise an interview.
+  Your training provider will contact you if they would like to organise an interview.
 
 <% end %>
 
+<% if FeatureFlag.inactive?(:continuous_applications) %>
 They have until <%= @reject_by_default_date %> to make a decision on your application.
+<% end %>

--- a/app/views/provider_mailer/application_submitted.text.erb
+++ b/app/views/provider_mailer/application_submitted.text.erb
@@ -2,11 +2,17 @@ Dear <%= @provider_user_name %>
 
 <%= @application.candidate_name %> submitted an application for <%= @application.course_name_and_code %>.
 
+<% if FeatureFlag.inactive?(:continuous_applications) %>
 The application will be automatically rejected after <%= @application.rbd_days %> working days, on <%= @application.rbd_date %>.
+<% end %>
 
 View the application:
 
 <%= provider_interface_application_choice_url(@application.application_choice) %>
+
+<% if FeatureFlag.active?(:continuous_applications) %>
+If you do not respond to this application within 30 working days, <%= @application.candidate_name %> will be able to submit a further application to a different training provider.
+<% end %>
 
 <%= render 'international_relocation_payment' if @application.international_relocation_payment_eligible %>
 

--- a/app/views/provider_mailer/application_submitted_with_safeguarding_issues.text.erb
+++ b/app/views/provider_mailer/application_submitted_with_safeguarding_issues.text.erb
@@ -4,7 +4,9 @@ Dear <%= @provider_user_name %>
 
 The application contains information about criminal convictions and professional misconduct.
 
+<% if FeatureFlag.inactive?(:continuous_applications) %>
 The application will be automatically rejected after <%= @application.rbd_days %> working days, on <%= @application.rbd_date %>.
+<% end %>
 
 View the application:
 

--- a/app/views/provider_mailer/application_submitted_with_safeguarding_issues.text.erb
+++ b/app/views/provider_mailer/application_submitted_with_safeguarding_issues.text.erb
@@ -12,6 +12,10 @@ View the application:
 
 <%= provider_interface_application_choice_url(@application.application_choice) %>
 
+<% if FeatureFlag.active?(:continuous_applications) %>
+If you do not respond to this application within 30 working days, <%= @application.candidate_name %> will be able to submit a further application to a different training provider.
+<% end %>
+
 <%= render 'international_relocation_payment' if @application.international_relocation_payment_eligible %>
 
 <% content_for :additional_footer_content do %><%= render 'notification_preferences' %><% end %>

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -46,14 +46,28 @@ RSpec.describe CandidateMailer do
     }
     let(:email) { mailer.application_submitted(application_form) }
 
-    it_behaves_like(
-      'a mail with subject and content',
-      I18n.t!('candidate_mailer.application_submitted.subject'),
-      'intro' => 'You’ve submitted an application for',
-      'magic link to authenticate' => 'http://localhost:3000/candidate/sign-in/confirm?token=raw_token',
-      'dynamic paragraph' => 'Your training provider will be in touch if they would like to organise an interview',
-      'reject_by_default date' => 5.days.from_now.to_fs(:govuk_date),
-    )
+    context 'when not continuous applications', continuous_applications: false do
+      TestSuiteTimeMachine.travel_temporarily_to(mid_cycle(2023)) do
+        it_behaves_like(
+          'a mail with subject and content',
+          I18n.t!('candidate_mailer.application_submitted.subject'),
+          'intro' => 'You’ve submitted an application for',
+          'magic link to authenticate' => 'http://localhost:3000/candidate/sign-in/confirm?token=raw_token',
+          'dynamic paragraph' => 'Your training provider will contact you if they would like to organise an interview',
+          'reject_by_default date' => 5.days.from_now.to_fs(:govuk_date),
+        )
+      end
+    end
+
+    context 'when continuous applications', :continuous_applications do
+      it_behaves_like(
+        'a mail with subject and content',
+        I18n.t!('candidate_mailer.application_submitted.subject'),
+        'intro' => 'You’ve submitted an application for',
+        'magic link to authenticate' => 'http://localhost:3000/candidate/sign-in/confirm?token=raw_token',
+        'dynamic paragraph' => 'Your training provider will contact you if they would like to organise an interview',
+      )
+    end
   end
 
   describe 'Candidate decision chaser email' do

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -27,16 +27,31 @@ RSpec.describe ProviderMailer do
   describe 'Send application submitted email' do
     let(:email) { described_class.application_submitted(provider_user, application_choice) }
 
-    it_behaves_like('a mail with subject and content',
-                    'Harry Potter submitted an application for Computer Science - manage teacher training applications',
-                    'provider name' => 'Dear Johny English',
-                    'candidate name' => 'Harry Potter',
-                    'course name and code' => 'Computer Science (6IND)',
-                    'reject by default days' => 'after 123 working days',
-                    'reject by default date' => 40.days.from_now.to_fs(:govuk_date),
-                    'link to application' => /http:\/\/localhost:3000\/provider\/applications\/\d+/,
-                    'notification settings' => 'You can change your email notification settings',
-                    'footer' => 'Get help, report a problem or give feedback')
+    context 'when not continuous applications', continuous_applications: false do
+      TestSuiteTimeMachine.travel_temporarily_to(mid_cycle(2023)) do
+        it_behaves_like('a mail with subject and content',
+                        'Harry Potter submitted an application for Computer Science - manage teacher training applications',
+                        'provider name' => 'Dear Johny English',
+                        'candidate name' => 'Harry Potter',
+                        'course name and code' => 'Computer Science (6IND)',
+                        'reject by default days' => 'after 123 working days',
+                        'reject by default date' => 40.days.from_now.to_fs(:govuk_date),
+                        'link to application' => /http:\/\/localhost:3000\/provider\/applications\/\d+/,
+                        'notification settings' => 'You can change your email notification settings',
+                        'footer' => 'Get help, report a problem or give feedback')
+      end
+    end
+
+    context 'when continuous applications', :continuous_applications do
+      it_behaves_like('a mail with subject and content',
+                      'Harry Potter submitted an application for Computer Science - manage teacher training applications',
+                      'provider name' => 'Dear Johny English',
+                      'candidate name' => 'Harry Potter',
+                      'course name and code' => 'Computer Science (6IND)',
+                      'link to application' => /http:\/\/localhost:3000\/provider\/applications\/\d+/,
+                      'notification settings' => 'You can change your email notification settings',
+                      'footer' => 'Get help, report a problem or give feedback')
+    end
 
     context 'eligible for international relocation payment' do
       before do
@@ -54,17 +69,33 @@ RSpec.describe ProviderMailer do
   describe 'Send application submitted with safeguarding issues email' do
     let(:email) { described_class.application_submitted_with_safeguarding_issues(provider_user, application_choice) }
 
-    it_behaves_like('a mail with subject and content',
-                    'Safeguarding issues - Harry Potter submitted an application for Computer Science - manage teacher training applications',
-                    'provider name' => 'Dear Johny English',
-                    'candidate name' => 'Harry Potter',
-                    'course name and code' => 'Computer Science (6IND)',
-                    'safeguarding warning' => 'The application contains information about criminal convictions and professional misconduct.',
-                    'reject by default days' => 'after 123 working days',
-                    'reject by default date' => 40.days.from_now.to_fs(:govuk_date),
-                    'link to application' => /http:\/\/localhost:3000\/provider\/applications\/\d+/,
-                    'notification settings' => 'You can change your email notification settings',
-                    'footer' => 'Get help, report a problem or give feedback')
+    context 'when not continuous applications', continuous_applications: false do
+      TestSuiteTimeMachine.travel_temporarily_to(mid_cycle(2023)) do
+        it_behaves_like('a mail with subject and content',
+                        'Safeguarding issues - Harry Potter submitted an application for Computer Science - manage teacher training applications',
+                        'provider name' => 'Dear Johny English',
+                        'candidate name' => 'Harry Potter',
+                        'course name and code' => 'Computer Science (6IND)',
+                        'safeguarding warning' => 'The application contains information about criminal convictions and professional misconduct.',
+                        'reject by default days' => 'after 123 working days',
+                        'reject by default date' => 40.days.from_now.to_fs(:govuk_date),
+                        'link to application' => /http:\/\/localhost:3000\/provider\/applications\/\d+/,
+                        'notification settings' => 'You can change your email notification settings',
+                        'footer' => 'Get help, report a problem or give feedback')
+      end
+    end
+
+    context 'when continuous applications', :continuous_applications do
+      it_behaves_like('a mail with subject and content',
+                      'Safeguarding issues - Harry Potter submitted an application for Computer Science - manage teacher training applications',
+                      'provider name' => 'Dear Johny English',
+                      'candidate name' => 'Harry Potter',
+                      'course name and code' => 'Computer Science (6IND)',
+                      'safeguarding warning' => 'The application contains information about criminal convictions and professional misconduct.',
+                      'link to application' => /http:\/\/localhost:3000\/provider\/applications\/\d+/,
+                      'notification settings' => 'You can change your email notification settings',
+                      'footer' => 'Get help, report a problem or give feedback')
+    end
 
     context 'eligible for international relocation payment' do
       before do


### PR DESCRIPTION
## Context

we need to update our mailers to they make sense for continuous applications.

## Changes proposed in this pull request

In this PR, I've edited the mailers:
- candidates receive when they submit an application – added a feature flag to hide the RBD text
- providers receive when an application is submitted to their organisation – added a feature flag to hide the RBD date and tell providers about the 30 working day rule

| Before candidate submitted email      | After canddiate submitted emails |
| ----------- | ----------- |
| <img width="629" alt="Screenshot 2023-09-20 at 10 13 38" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/68232608/f9455a36-5fbf-47f2-8f4b-53a68b5c09d0"> | <img width="617" alt="Screenshot 2023-09-20 at 10 15 10" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/68232608/5a64122e-f8dc-4684-88b4-6a4453686706"> |

| Before provider submitted email      | After provider submitted emails |
| ----------- | ----------- |
| <img width="573" alt="Screenshot 2023-09-20 at 10 11 53" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/68232608/f7f993bb-6b16-4c77-abf2-5c922fe93300"> | <img width="603" alt="Screenshot 2023-09-20 at 10 16 45" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/68232608/c8a13c2c-b3b4-4d79-92d1-9215956565b8"> |

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

- Make sure the correct content renders when the 'continuous application' feature flag is on/off
- Check any failing tests that may have been caused by content changes

## Link to Trello card

Provider mailer ticket: https://trello.com/c/eSamqUw8/485-edit-content-for-application-submitted-emails

Candidate mailer ticket: https://trello.com/c/rwkFX8gd/476-edit-content-of-submitted-email

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
