### PR TITLE
Edit content for nudge_unsubmitted emails for continuous applications

### DIFF
--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_courses.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_courses.text.erb
@@ -1,8 +1,12 @@
-Dear <%= @application_form.first_name %>
+Hello <%= @application_form.first_name %>
 
-You’ve not added courses to your teacher training application yet.
+You’ve not applied to any teacher training courses yet.
 
-[Sign in to your account to add up to 4 courses](<%= candidate_magic_link(@application_form.candidate) %>).
+<% if FeatureFlag.active?(:continuous_applications) %>
+  [Sign in to your account to add up to 4 courses](<%= candidate_magic_link(@application_form.candidate) %>).
+<% else %>
+  [Sign in to your account to add up to 4 courses](<%= candidate_magic_link(@application_form.candidate) %>).
+<% end %>
 
 # Support with your application
 

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_personal_statement.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_personal_statement.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>
+Hello <%= @application_form.first_name %>
 
 You have not marked your personal statement as complete.
 

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
@@ -1,6 +1,6 @@
-Dear <%= @application_form.first_name %>
+Hello <%= @application_form.first_name %>
 
-You have not yet completed the references section of your teacher training application.
+You have not completed the references section of your teacher training application yet.
 
 You need to give details of 2 people who can give you a reference. They’ll only be contacted if you accept an offer on a course.
 
@@ -9,6 +9,8 @@ You need to give details of 2 people who can give you a reference. They’ll onl
 # Who to choose to give you a reference
 
 You could choose someone like a manager, a university tutor or a client.
+
+[Find out more about what references you should add](<%= email_link_with_utm_params t('url_references'), 'nudge_unsubmitted_no_references', @application_form.phase %>).
 
 In their reference, they will be asked to:
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,7 @@ en:
     url_choose_your_referees: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/how-to-apply-for-teacher-training#choose-your-references
     url_if_you_dont_have_a_degree: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/if-you-dont-have-a-degree
     url_subject_knowledge_enhancement: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement
+    url_references: https://getintoteaching.education.gov.uk/how-to-apply-for-teacher-training/teacher-training-references
   train_to_teach_in_england:
     url: https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration
     url_citizen_visa: https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-if-youre-a-non-uk-citizen#visa


### PR DESCRIPTION
## Context

We need to edit some of our emails so they make sense for continuous applications.

## Changes proposed in this pull request

edited the 'nudge_unsubmitted_with_incomplete_courses
- added a link to the 'Your applications' tab

edited the 'unsubmitted_with_incomplete_references
- added a link to the new GIT referecnes page (this is not continuous application specific so I've not added a feature flag)

edited the nundge_personal_statement
- replaced 'Dear' with 'Hello'

## Guidance to review

Check the the content changes for the 'nudge_unsubmitted_with_incomplete_courses' email when the feature flag for continuous applications is on/off.

The link should change on the second line. 
- If feature flag on = link goes to 'Your applications' tab
- If feature flag off = link goes to normal sign page and the 'Your details' tab

Check link to reference page on GIT works on reference email.

## Link to Trello card

https://trello.com/c/DrAHxBnR/473-edit-content-for-existing-nudge-emails

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
