### PR TITLE
[545] Update content on `status_tag` component

### DIFF
--- a/app/components/candidate_interface/application_status_tag_component.html.erb
+++ b/app/components/candidate_interface/application_status_tag_component.html.erb
@@ -13,7 +13,7 @@
   </p>
 <% elsif @application_choice.decision_pending? && @application_choice.reject_by_default_at&.future? %>
 
-  <p class="govuk-body govuk-!-margin-top-2">Application submitted <%= days_since_submission(@application_choice.application_form) %> days ago </p>
+  <p class="govuk-!-margin-top-2">Application submitted <%= @application_choice.days_since_submission %> days ago</p>
 
   <p class="govuk-body govuk-!-margin-top-2">
    If you do not receive a response from this training provider, you can withdraw this application and apply to another provider.

--- a/app/components/candidate_interface/application_status_tag_component.html.erb
+++ b/app/components/candidate_interface/application_status_tag_component.html.erb
@@ -13,11 +13,22 @@
   </p>
 <% elsif @application_choice.decision_pending? && @application_choice.reject_by_default_at&.future? %>
 
-  <p class="govuk-!-margin-top-2">Application submitted <%= @application_choice.days_since_submission %> days ago</p>
+  <% if @application_choice.continuous_applications? %>
+
+    <p class="govuk-!-margin-top-2">Application submitted <%= @application_choice.days_since_submission %> days ago</p>
+
+    <p class="govuk-body govuk-!-margin-top-2">
+    If you do not receive a response from this training provider, you can withdraw this application and apply to another provider.
+    </p>
+
+  <% else %>
 
   <p class="govuk-body govuk-!-margin-top-2">
-   If you do not receive a response from this training provider, you can withdraw this application and apply to another provider.
-  </p>
+    You’ll get a decision on your application by <%= @application_choice.reject_by_default_at.to_fs(:govuk_date) %>.
+   </p>
+
+  <% end %>
+
 <% elsif @application_choice.withdrawn_at_candidates_request? %>
   <p class="govuk-body govuk-!-margin-top-2">
     You requested to withdraw your application. If you did not request this, email <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>.

--- a/app/components/candidate_interface/application_status_tag_component.html.erb
+++ b/app/components/candidate_interface/application_status_tag_component.html.erb
@@ -12,8 +12,11 @@
     <% end %>
   </p>
 <% elsif @application_choice.decision_pending? && @application_choice.reject_by_default_at&.future? %>
+
+  <p class="govuk-body govuk-!-margin-top-2">Application submitted <%= days_since_submission(@application_choice.application_form) %> days ago </p>
+
   <p class="govuk-body govuk-!-margin-top-2">
-   You’ll get a decision on your application by <%= @application_choice.reject_by_default_at.to_fs(:govuk_date) %>.
+   If you do not receive a response from this training provider, you can withdraw this application and apply to another provider.
   </p>
 <% elsif @application_choice.withdrawn_at_candidates_request? %>
   <p class="govuk-body govuk-!-margin-top-2">

--- a/app/components/candidate_interface/application_status_tag_component.rb
+++ b/app/components/candidate_interface/application_status_tag_component.rb
@@ -36,6 +36,8 @@ module CandidateInterface
     end
 
     def days_since_submission(application_form)
+      return if application_form.submitted_at.nil?
+
       (Time.zone.now.to_date - application_form.submitted_at.to_date).to_i
     end
 

--- a/app/components/candidate_interface/application_status_tag_component.rb
+++ b/app/components/candidate_interface/application_status_tag_component.rb
@@ -35,12 +35,6 @@ module CandidateInterface
       end
     end
 
-    def days_since_submission(application_form)
-      return if application_form.submitted_at.nil?
-
-      (Time.zone.now.to_date - application_form.submitted_at.to_date).to_i
-    end
-
   private
 
     attr_reader :application_choice

--- a/app/components/candidate_interface/application_status_tag_component.rb
+++ b/app/components/candidate_interface/application_status_tag_component.rb
@@ -35,6 +35,10 @@ module CandidateInterface
       end
     end
 
+    def days_since_submission(application_form)
+      (Time.zone.now.to_date - application_form.submitted_at.to_date).to_i
+    end
+
   private
 
     attr_reader :application_choice

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -255,6 +255,12 @@ class ApplicationChoice < ApplicationRecord
     course.primary_course?
   end
 
+  def days_since_submission
+    return if sent_to_provider_at.nil?
+
+    (Time.zone.now.to_date - sent_to_provider_at.to_date).to_i
+  end
+
 private
 
   def set_initial_status

--- a/spec/components/candidate_interface/application_status_tag_component_with_continuous_applications_disabled_spec.rb
+++ b/spec/components/candidate_interface/application_status_tag_component_with_continuous_applications_disabled_spec.rb
@@ -1,6 +1,9 @@
+# This file can be deleted with the continuous applications feature flag. The remaining functionality is tested in
+# 'application_status_tag_component_spec.rb'
+
 require 'rails_helper'
 
-RSpec.describe CandidateInterface::ApplicationStatusTagComponent, :continuous_applications do
+RSpec.describe CandidateInterface::ApplicationStatusTagComponent, continuous_applications: false do
   let(:course) { create(:course) }
 
   ApplicationStateChange.valid_states.each do |state_name|
@@ -18,7 +21,7 @@ RSpec.describe CandidateInterface::ApplicationStatusTagComponent, :continuous_ap
   end
 
   context 'when the application choice is in the `interviewing` state' do
-    it 'renders the correct content' do
+    it 'tells the candidate when the reject by default date will be' do
       application_choice = create(
         :application_choice,
         :interviewing,
@@ -27,13 +30,13 @@ RSpec.describe CandidateInterface::ApplicationStatusTagComponent, :continuous_ap
       result = render_inline(described_class.new(application_choice:))
 
       expect(result.text).to include(
-        'If you do not receive a response from this training provider, you can withdraw this application and apply to another provider.',
+        "You’ll get a decision on your application by #{5.days.from_now.to_fs(:govuk_date)}.",
       )
     end
   end
 
   context 'when the application choice is in the `awaiting_provider_decision` state' do
-    it 'renders the correct content' do
+    it 'tells the candidate when the reject by default date will be' do
       application_choice = create(
         :application_choice,
         :awaiting_provider_decision,
@@ -42,7 +45,7 @@ RSpec.describe CandidateInterface::ApplicationStatusTagComponent, :continuous_ap
       result = render_inline(described_class.new(application_choice:))
 
       expect(result.text).to include(
-        'If you do not receive a response from this training provider, you can withdraw this application and apply to another provider.',
+        "You’ll get a decision on your application by #{14.days.from_now.to_fs(:govuk_date)}.",
       )
     end
 
@@ -131,25 +134,6 @@ RSpec.describe CandidateInterface::ApplicationStatusTagComponent, :continuous_ap
       result = render_inline(described_class.new(application_choice:))
 
       expect(result.text).not_to include('You’ll get a decision on your application by')
-    end
-  end
-
-  context 'when the unsubmitted application choice is from a continuous application' do
-    let(:application_choice) { create(:application_choice, :continuous_applications, :unsubmitted, course:) }
-    let(:result) { render_inline(described_class.new(application_choice:)) }
-
-    context 'when the course has availability' do
-      it 'renders the `Continue application` link' do
-        expect(result.text).to include('Continue application')
-      end
-    end
-
-    context 'then the course has no availability' do
-      let(:course) { create(:course, :with_no_vacancies) }
-
-      it 'does not render the `Continue application` link' do
-        expect(result.text).not_to include('Continue application')
-      end
     end
   end
 end

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -450,4 +450,24 @@ RSpec.describe ApplicationChoice do
       expect(application_choice.science_gcse_needed?).to be false
     end
   end
+
+  describe '#days_since_submission' do
+    let(:application_choice) { create(:application_choice, sent_to_provider_at: sent_to_provider_at) }
+
+    context 'when sent_to_provider_at is nil' do
+      let(:sent_to_provider_at) { nil }
+
+      it 'returns nil' do
+        expect(application_choice.days_since_submission).to be_nil
+      end
+    end
+
+    context 'when sent_to_provider_at is a valid date' do
+      let(:sent_to_provider_at) { 5.days.ago }
+
+      it 'returns the number of days since the submission' do
+        expect(application_choice.days_since_submission).to eq(5)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

We are updating content which still mentions a deadline when a candidate submits an application. In line with the new continuous applications flow, this deadline is misleading and confusing.

## Changes proposed in this pull request

Remove the deadline and re-word the text.

## Guidance to review

- Go and find a candidate in that state using the review app.
- Ensure the days since submission is correct for each one.

## Link to Trello card

https://trello.com/c/rZCYTMZe/545-apply-content-still-mentions-a-deadline-when-candidate-submits-an-application

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
