### PR TITLE
Do not process interviewing apps to inactive

### DIFF
--- a/app/queries/get_stale_application_choices.rb
+++ b/app/queries/get_stale_application_choices.rb
@@ -1,6 +1,11 @@
 class GetStaleApplicationChoices
   def self.call
-    scope = ApplicationChoice.decision_pending.order(:application_form_id)
+    scope = if RecruitmentCycle.current_year == 2024
+              ApplicationChoice.awaiting_provider_decision.order(:application_form_id)
+            else
+              ApplicationChoice.decision_pending.order(:application_form_id)
+            end
+
     application_choices_past_reject_by_default_at(scope)
   end
 

--- a/spec/services/process_stale_applications_spec.rb
+++ b/spec/services/process_stale_applications_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe ProcessStaleApplications do
         reject_by_default_at: 1.business_days.ago,
         recruitment_cycle_year: 2023,
       )
+
+      interviewing_application_choice = create(
+        :application_choice,
+        :interviewing,
+        reject_by_default_at: 1.business_days.ago,
+        recruitment_cycle_year: 2023,
+      )
+
       other_application_choice = create(
         :application_choice,
         :awaiting_provider_decision,
@@ -18,17 +26,19 @@ RSpec.describe ProcessStaleApplications do
       described_class.new.call
       expect(other_application_choice.reload.status).to eq('awaiting_provider_decision')
       expect(application_choice.reload.status).to eq('rejected')
+      expect(interviewing_application_choice.reload.status).to eq('rejected')
     end
   end
 
   context 'when 2024 recruitment cycle', :continuous_applications do
-    it 'rejects an application that is ready for rejection but leaves other untouched' do
+    it 'rejects an application that is ready for rejection but leaves others untouched' do
       application_choice = create(
         :application_choice,
         :awaiting_provider_decision,
         :continuous_applications,
         reject_by_default_at: 1.business_days.ago,
       )
+
       other_application_choice = create(
         :application_choice,
         :awaiting_provider_decision,
@@ -36,8 +46,16 @@ RSpec.describe ProcessStaleApplications do
         reject_by_default_at: 1.business_day.from_now,
       )
 
+      interviewing_application_choice = create(
+        :application_choice,
+        :interviewing,
+        :continuous_applications,
+        reject_by_default_at: 1.business_day.from_now,
+      )
+
       described_class.new.call
       expect(other_application_choice.reload.status).to eq('awaiting_provider_decision')
+      expect(interviewing_application_choice.reload.status).to eq('interviewing')
       expect(application_choice.reload.status).to eq('inactive')
     end
 


### PR DESCRIPTION
## Context

QA has revealed:
![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/8dfede06-1c0e-4bb7-ae26-30c406bb566f)
We should only process applications that are awaiting provider decision

## Changes proposed in this pull request

Change scoping

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
