### PR TITLE
Edit content for candidate withdrawal mailer

### DIFF
--- a/app/views/candidate_mailer/_still_interested_content.text.erb
+++ b/app/views/candidate_mailer/_still_interested_content.text.erb
@@ -2,20 +2,20 @@
 
 You can apply again for courses starting in the <%= "#{RecruitmentCycle.next_year} to #{RecruitmentCycle.next_year + 1}" %> academic year.
 
-Your last application is saved. All you need to do is:
+All you need to do is:
 
-- make any changes
+- check your details are still correct  
 - submit from <%= CycleTimetable.apply_reopens.to_fs(:govuk_time) %> on <%= CycleTimetable.apply_reopens.to_fs(:govuk_date) %>
 
 <% else %>
 
 If now’s the right time for you, you can still apply for teacher training again this year.
 
-Your last application is saved. All you need to do is:
+All you need to do is:
 
-  - make any changes
-  - choose up to 4 courses
-  - submit
+- check your details are still correct  
+- make sure you’re happy with your personal statement  
+- find a course and submit another application 
 
 <% end %>
 

--- a/app/views/candidate_mailer/_still_interested_content.text.erb
+++ b/app/views/candidate_mailer/_still_interested_content.text.erb
@@ -19,4 +19,4 @@ All you need to do is:
 
 <% end %>
 
-[Sign in](<%= @candidate_magic_link %>) to apply again.
+[Sign in to apply again](<%= @candidate_magic_link %>).

--- a/app/views/candidate_mailer/withdraw_last_application_choice.text.erb
+++ b/app/views/candidate_mailer/withdraw_last_application_choice.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>
+Hello <%= @application_form.first_name %>
 
 You’ve withdrawn your <%= 'application'.pluralize(@withdrawn_course_names.size) %> for <%= @withdrawn_course_names.to_sentence %>.
 

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe CandidateMailer do
 
         it 'informs the candidate they can apply again next year' do
           expect(email.body).to include("You can apply again for courses starting in the #{RecruitmentCycle.next_year} to #{RecruitmentCycle.next_year + 1} academic year.")
-          expect(email.body).to include('Your last application is saved. All you need to do is:')
+          expect(email.body).to include('All you need to do is:')
           expect(email.body).to include("9am on 12 October #{RecruitmentCycle.current_year}")
         end
       end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe CandidateMailer do
       it_behaves_like(
         'a mail with subject and content',
         'You’ve withdrawn your application',
-        'heading' => 'Dear Fred',
+        'heading' => 'Hello Fred',
         'application_withdrawn' => 'You’ve withdrawn your application',
       )
     end
@@ -245,7 +245,7 @@ RSpec.describe CandidateMailer do
       it_behaves_like(
         'a mail with subject and content',
         'You’ve withdrawn your application',
-        'heading' => 'Dear Fred',
+        'heading' => 'Hello Fred',
         'application_withdrawn' => 'You’ve withdrawn your application',
         'reference details' => 'we’ve contacted these people to say they do not need to give a reference:',
         'first referee' => 'Jenny',

--- a/spec/system/decline_by_default_with_continuous_applications_disabled_spec.rb
+++ b/spec/system/decline_by_default_with_continuous_applications_disabled_spec.rb
@@ -75,7 +75,7 @@ RSpec.feature 'Decline by default' do
     open_email(@application_form.candidate.email_address)
 
     expect(current_email.subject).to include('You did not respond to your offer: next steps')
-    expect(current_email.text).to include('Your last application is saved. All you need to do is:')
+    expect(current_email.text).to include('All you need to do is:')
   end
 
   def and_i_have_a_rejection


### PR DESCRIPTION
## Context

We need to make sure our emails make sense for continuous applications.

we have an email that gets sent when a candidate withdraws their application themselves.

## Changes proposed in this pull request

Changes to this mailer include:

- replacing 'dear' with 'hello'
- updating the 'still_interested_content' - I've not put this under a feature flag as I don't think it needs it, but perhaps I'm wrong?
- updating the candidate_mailer_spec - again not feature flag needed as it's just the 'hello' part

| Before withdraw mailer     | After |
| ----------- | ----------- |
| <img width="582" alt="Screenshot 2023-09-20 at 16 50 31" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/68232608/2332970d-d4d8-489b-b9f4-ffd9d8e75b94"> | <img width="573" alt="Screenshot 2023-09-20 at 16 52 48" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/68232608/f2c3c573-079e-4bba-afad-2dc76b062848">
 |

## Guidance to review

Could someone make sure the tests are working and check that the 'still_interested_content' looks ok as this renders across multiple emails, but I think it still makes sense if we don't use the continuous application feature flag.

## Link to Trello card

https://trello.com/c/fhgm3cLI/475-edit-content-for-email-when-candidate-withdraws-their-own-application

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
