### PR TITLE
[480] Repuprose withdrawn emails in line with continuous applications

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -143,6 +143,14 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def application_withdrawn_on_request(application_choice)
+    @course = application_choice.current_course_option.course
+    @provider_name = @course.provider.name
+    @course_name_and_code = application_choice.current_course_option.course.name_and_code
+    @application_form = application_choice.application_form
+    email_for_candidate(@application_form)
+  end
+
   def application_withdrawn_on_request_all_applications_withdrawn(application_choice)
     @course = application_choice.current_course_option.course
     @application_choice = RejectedApplicationChoicePresenter.new(application_choice)

--- a/app/services/provider_interface/send_candidate_withdrawn_on_request_email.rb
+++ b/app/services/provider_interface/send_candidate_withdrawn_on_request_email.rb
@@ -9,14 +9,16 @@ module ProviderInterface
     end
 
     def call
-      if candidate_applications.all?(&:withdrawn?)
-        CandidateMailer.application_withdrawn_on_request_all_applications_withdrawn(application_choice).deliver_later
-      elsif applications_with_offer_and_awaiting_decision?
-        CandidateMailer.application_withdrawn_on_request_one_offer_one_awaiting_decision(application_choice).deliver_later
-      elsif applications_awaiting_decision_only?
-        CandidateMailer.application_withdrawn_on_request_awaiting_decision_only(application_choice).deliver_later
-      elsif applications_with_offers_only?
-        CandidateMailer.application_withdrawn_on_request_offers_only(application_choice).deliver_later
+      unless application_choice.continuous_applications?
+        if candidate_applications.all?(&:withdrawn?)
+          CandidateMailer.application_withdrawn_on_request_all_applications_withdrawn(application_choice).deliver_later
+        elsif applications_with_offer_and_awaiting_decision?
+          CandidateMailer.application_withdrawn_on_request_one_offer_one_awaiting_decision(application_choice).deliver_later
+        elsif applications_awaiting_decision_only?
+          CandidateMailer.application_withdrawn_on_request_awaiting_decision_only(application_choice).deliver_later
+        elsif applications_with_offers_only?
+          CandidateMailer.application_withdrawn_on_request_offers_only(application_choice).deliver_later
+        end
       end
     end
   end

--- a/app/services/provider_interface/send_candidate_withdrawn_on_request_email.rb
+++ b/app/services/provider_interface/send_candidate_withdrawn_on_request_email.rb
@@ -11,16 +11,14 @@ module ProviderInterface
     def call
       if application_choice.continuous_applications?
         CandidateMailer.application_withdrawn_on_request(application_choice).deliver_later
-      else
-        if candidate_applications.all?(&:withdrawn?)
-          CandidateMailer.application_withdrawn_on_request_all_applications_withdrawn(application_choice).deliver_later
-        elsif applications_with_offer_and_awaiting_decision?
-          CandidateMailer.application_withdrawn_on_request_one_offer_one_awaiting_decision(application_choice).deliver_later
-        elsif applications_awaiting_decision_only?
-          CandidateMailer.application_withdrawn_on_request_awaiting_decision_only(application_choice).deliver_later
-        elsif applications_with_offers_only?
-          CandidateMailer.application_withdrawn_on_request_offers_only(application_choice).deliver_later
-        end
+      elsif candidate_applications.all?(&:withdrawn?)
+        CandidateMailer.application_withdrawn_on_request_all_applications_withdrawn(application_choice).deliver_later
+      elsif applications_with_offer_and_awaiting_decision?
+        CandidateMailer.application_withdrawn_on_request_one_offer_one_awaiting_decision(application_choice).deliver_later
+      elsif applications_awaiting_decision_only?
+        CandidateMailer.application_withdrawn_on_request_awaiting_decision_only(application_choice).deliver_later
+      elsif applications_with_offers_only?
+        CandidateMailer.application_withdrawn_on_request_offers_only(application_choice).deliver_later
       end
     end
   end

--- a/app/services/provider_interface/send_candidate_withdrawn_on_request_email.rb
+++ b/app/services/provider_interface/send_candidate_withdrawn_on_request_email.rb
@@ -11,7 +11,15 @@ module ProviderInterface
     def call
       if application_choice.continuous_applications?
         CandidateMailer.application_withdrawn_on_request(application_choice).deliver_later
-      elsif candidate_applications.all?(&:withdrawn?)
+      else
+        pre_continuous_applications_withdrawn_mailers
+      end
+    end
+
+  private
+
+    def pre_continuous_applications_withdrawn_mailers
+      if candidate_applications.all?(&:withdrawn?)
         CandidateMailer.application_withdrawn_on_request_all_applications_withdrawn(application_choice).deliver_later
       elsif applications_with_offer_and_awaiting_decision?
         CandidateMailer.application_withdrawn_on_request_one_offer_one_awaiting_decision(application_choice).deliver_later

--- a/app/services/provider_interface/send_candidate_withdrawn_on_request_email.rb
+++ b/app/services/provider_interface/send_candidate_withdrawn_on_request_email.rb
@@ -9,7 +9,9 @@ module ProviderInterface
     end
 
     def call
-      unless application_choice.continuous_applications?
+      if application_choice.continuous_applications?
+        CandidateMailer.application_withdrawn_on_request(application_choice).deliver_later
+      else
         if candidate_applications.all?(&:withdrawn?)
           CandidateMailer.application_withdrawn_on_request_all_applications_withdrawn(application_choice).deliver_later
         elsif applications_with_offer_and_awaiting_decision?

--- a/app/views/candidate_mailer/application_withdrawn_on_request.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request.text.erb
@@ -1,6 +1,6 @@
 Hello <%= @application_form.first_name %>,
 
-You’ve withdrawn your application for <%= @course_name_and_code %> at <%= @provider_name %>.
+At your request, <%= @provider_name %> has withdrawn your application for <%= @course_name_and_code %>.
 
 If now’s the right time for you, you can still apply for teacher training again this year.
 
@@ -12,7 +12,7 @@ All you need to do is:
 
 [Sign in to apply again](<%= candidate_magic_link(@application_form.candidate) %>)
 
-Since you withdrew your application, we’ve contacted these people to say they do not need to give a reference:
+We’ve contacted these people to say they do not need to give a reference:
 
 <% @application_form.application_references.each do |reference| %>
   -<%= reference.name %>

--- a/app/views/candidate_mailer/application_withdrawn_on_request.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request.text.erb
@@ -1,0 +1,21 @@
+Hello <%= @application_form.first_name %>,
+
+You’ve withdrawn your application for <%= @course_name_and_code %> at <%= @provider_name %>.
+
+If now’s the right time for you, you can still apply for teacher training again this year.
+
+All you need to do is:
+
+  - check that your details are still correct
+  - make sure you're happy with your personal statement
+  - find a course and submit another application
+
+[Sign in to apply again](<%= candidate_magic_link(@application_form.candidate) %>)
+
+Since you withdrew your application, we’ve contacted these people to say they do not need to give a reference:
+
+<% @application_form.application_references.each do |reference| %>
+  -<%= reference.name %>
+<% end %>
+
+You can send another request for a reference from them if you apply again.

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -281,6 +281,7 @@ en:
         The candidate makes a withdrawal decision to inform the provider that they no longer want their application to be considered. The candidate can withdraw an application at any time or ask the provider to withdraw the application on their behalf.
       emails:
         - provider_mailer-application_withdrawn
+        - candidate_mailer-application_withdrawn_on_request
         - candidate_mailer-application_withdrawn_on_request_all_applications_withdrawn
         - candidate_mailer-application_withdrawn_on_request_awaiting_decision_only
         - candidate_mailer-application_withdrawn_on_request_offers_only
@@ -341,6 +342,7 @@ en:
         The candidate makes a withdrawal decision to inform the provider that they no longer want their application to be considered. The candidate can withdraw an application at any time or ask a provider to withdraw an application on their behalf.
       emails:
         - provider_mailer-application_withdrawn
+        - candidate_mailer-application_withdrawn_on_request
         - candidate_mailer-application_withdrawn_on_request_all_applications_withdrawn
         - candidate_mailer-application_withdrawn_on_request_awaiting_decision_only
         - candidate_mailer-application_withdrawn_on_request_offers_only
@@ -421,6 +423,7 @@ en:
       description: The candidate can decline the offer or ask the provider to withdraw the offered application on their behalf.
       emails:
         - provider_mailer-declined
+        - candidate_mailer-application_withdrawn_on_request
         - candidate_mailer-application_withdrawn_on_request_all_applications_withdrawn
         - candidate_mailer-application_withdrawn_on_request_awaiting_decision_only
         - candidate_mailer-application_withdrawn_on_request_offers_only
@@ -446,6 +449,7 @@ en:
       description: Candidates can withdraw at any time or ask the provider to withdraw the application on their behalf.
       emails:
         - provider_mailer-application_withdrawn
+        - candidate_mailer-application_withdrawn_on_request
         - candidate_mailer-application_withdrawn_on_request_all_applications_withdrawn
         - candidate_mailer-application_withdrawn_on_request_awaiting_decision_only
         - candidate_mailer-application_withdrawn_on_request_offers_only
@@ -457,6 +461,7 @@ en:
       description: Candidates can withdraw at any time or ask the provider to withdraw the application on their behalf.
       emails:
         - provider_mailer-application_withdrawn
+        - candidate_mailer-application_withdrawn_on_request
         - candidate_mailer-application_withdrawn_on_request_all_applications_withdrawn
         - candidate_mailer-application_withdrawn_on_request_awaiting_decision_only
         - candidate_mailer-application_withdrawn_on_request_offers_only
@@ -665,6 +670,7 @@ en:
       by: candidate
       description: Candidates can withdraw at any time or ask the provider to withdraw the application on their behalf.
       emails:
+        - candidate_mailer-application_withdrawn_on_request
         - candidate_mailer-application_withdrawn_on_request_all_applications_withdrawn
         - candidate_mailer-application_withdrawn_on_request_awaiting_decision_only
         - candidate_mailer-application_withdrawn_on_request_offers_only

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -57,6 +57,8 @@ en:
       subject: Update on your application
     application_rejected_offers_only:
       subject: Update on your application - respond by %{date}
+    application_withdrawn_on_request:
+      subject: Update on your application
     application_withdrawn_on_request_all_applications_withdrawn:
       subject: Update on your application - all decisions now made
     application_withdrawn_on_request_one_offer_one_awaiting_decision:

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -701,7 +701,7 @@ RSpec.describe CandidateMailer do
         'a mail with subject and content',
         'Update on your application',
         'greeting' => 'Hello Fred',
-        'details' => 'You’ve withdrawn your application for',
+        'details' => 'has withdrawn your application for',
         'content' => 'If now’s the right time for you, you can still apply for teacher training again this year.',
       )
     end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -693,6 +693,20 @@ RSpec.describe CandidateMailer do
     end
   end
 
+  describe '.application_withdrawn_on_request' do
+    context 'when the candidate has withdrawn or asked to be withdrawn from an application choice' do
+      let(:email) { mailer.application_withdrawn_on_request(application_form.application_choices.first) }
+
+      it_behaves_like(
+        'a mail with subject and content',
+        'Update on your application',
+        'greeting' => 'Hello Fred',
+        'details' => 'You’ve withdrawn your application for',
+        'content' => 'If now’s the right time for you, you can still apply for teacher training again this year.',
+      )
+    end
+  end
+
   describe '.nudge_unsubmitted' do
     let(:application_form) { build_stubbed(:application_form, :minimum_info, first_name: 'Fred') }
     let(:email) { mailer.nudge_unsubmitted(application_form) }

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -425,6 +425,27 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.application_rejected_offers_only(application_form.application_choices.first)
   end
 
+  def application_withdrawn_on_request
+    application_form_with_provided_references = FactoryBot.build_stubbed(
+      :application_form,
+      first_name: 'Fred',
+      application_references: [
+        FactoryBot.build_stubbed(:reference, feedback_status: :feedback_requested),
+        FactoryBot.build_stubbed(:reference, feedback_status: :feedback_requested),
+      ],
+    )
+
+    application_choice = FactoryBot.build_stubbed(
+      :application_choice,
+      application_form: application_form_with_provided_references,
+      course_option:,
+      status: :withdrawn,
+      withdrawn_at: Time.zone.now,
+    )
+
+    CandidateMailer.application_withdrawn_on_request(application_choice)
+  end
+
   def application_withdrawn_on_request_all_applications_withdrawn
     application_choice = FactoryBot.build_stubbed(
       :application_choice,

--- a/spec/services/provider_interface/send_candidate_withdrawn_on_request_email_spec.rb
+++ b/spec/services/provider_interface/send_candidate_withdrawn_on_request_email_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe ProviderInterface::SendCandidateWithdrawnOnRequestEmail do
+RSpec.describe ProviderInterface::SendCandidateWithdrawnOnRequestEmail, continuous_applications: false do
   describe '#call' do
     let(:mailer) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
 
@@ -36,6 +36,19 @@ RSpec.describe ProviderInterface::SendCandidateWithdrawnOnRequestEmail do
       described_class.new(application_choice: offered).call
 
       expect(CandidateMailer).to have_received(:application_withdrawn_on_request_one_offer_one_awaiting_decision)
+    end
+
+    context 'when continuous_applications flag is turned on', :continuous_applications do
+      it 'does not send any emails' do
+        allow(CandidateMailer).to receive_messages(application_withdrawn_on_request_all_applications_withdrawn: mailer, application_withdrawn_on_request_awaiting_decision_only: mailer, application_withdrawn_on_request_offers_only: mailer, application_withdrawn_on_request_one_offer_one_awaiting_decision: mailer)
+
+        described_class.new(application_choice: create(:application_choice, :withdrawn)).call
+
+        expect(CandidateMailer).not_to have_received(:application_withdrawn_on_request_all_applications_withdrawn)
+        expect(CandidateMailer).not_to have_received(:application_withdrawn_on_request_awaiting_decision_only)
+        expect(CandidateMailer).not_to have_received(:application_withdrawn_on_request_offers_only)
+        expect(CandidateMailer).not_to have_received(:application_withdrawn_on_request_one_offer_one_awaiting_decision)
+      end
     end
   end
 end

--- a/spec/services/provider_interface/send_candidate_withdrawn_on_request_email_spec.rb
+++ b/spec/services/provider_interface/send_candidate_withdrawn_on_request_email_spec.rb
@@ -1,54 +1,41 @@
 require 'rails_helper'
 
-RSpec.describe ProviderInterface::SendCandidateWithdrawnOnRequestEmail, continuous_applications: false do
+RSpec.describe ProviderInterface::SendCandidateWithdrawnOnRequestEmail, :continuous_applications do
   describe '#call' do
     let(:mailer) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
 
-    it 'calls CandidateMailer.application_withdrawn_on_request_all_applications_withdrawn when all applications are withdrawn' do
-      allow(CandidateMailer).to receive(:application_withdrawn_on_request_all_applications_withdrawn).and_return(mailer)
+    it 'calls CandidateMailer.application_withdrawn_on_request when all applications are withdrawn' do
+      allow(CandidateMailer).to receive(:application_withdrawn_on_request).and_return(mailer)
 
       described_class.new(application_choice: create(:application_choice, :withdrawn)).call
 
-      expect(CandidateMailer).to have_received(:application_withdrawn_on_request_all_applications_withdrawn)
+      expect(CandidateMailer).to have_received(:application_withdrawn_on_request)
     end
 
-    it 'calls CandidateMailer.application_withdrawn_on_request_awaiting_decision_only when all applications are awaiting decision' do
-      allow(CandidateMailer).to receive(:application_withdrawn_on_request_awaiting_decision_only).and_return(mailer)
+    it 'calls CandidateMailer.application_withdrawn_on_request when all applications are awaiting decision' do
+      allow(CandidateMailer).to receive(:application_withdrawn_on_request).and_return(mailer)
 
       described_class.new(application_choice: create(:application_choice, :awaiting_provider_decision)).call
 
-      expect(CandidateMailer).to have_received(:application_withdrawn_on_request_awaiting_decision_only)
+      expect(CandidateMailer).to have_received(:application_withdrawn_on_request)
     end
 
-    it 'calls CandidateMailer.application_withdrawn_on_request_offers_only when all applications have offers' do
-      allow(CandidateMailer).to receive(:application_withdrawn_on_request_offers_only).and_return(mailer)
+    it 'calls CandidateMailer.application_withdrawn_on_request when all applications have offers' do
+      allow(CandidateMailer).to receive(:application_withdrawn_on_request).and_return(mailer)
 
       described_class.new(application_choice: create(:application_choice, :offered)).call
 
-      expect(CandidateMailer).to have_received(:application_withdrawn_on_request_offers_only)
+      expect(CandidateMailer).to have_received(:application_withdrawn_on_request)
     end
 
-    it 'calls CandidateMailer.application_withdrawn_on_request_one_offer_one_awaiting_decision when one application has an offer and another is awaiting decision' do
-      allow(CandidateMailer).to receive(:application_withdrawn_on_request_one_offer_one_awaiting_decision).and_return(mailer)
+    it 'calls CandidateMailer.application_withdrawn_on_request when one application has an offer and another is awaiting decision' do
+      allow(CandidateMailer).to receive(:application_withdrawn_on_request).and_return(mailer)
       offered = create(:application_choice, :offered)
       create(:application_choice, :awaiting_provider_decision, application_form: offered.application_form)
 
       described_class.new(application_choice: offered).call
 
-      expect(CandidateMailer).to have_received(:application_withdrawn_on_request_one_offer_one_awaiting_decision)
-    end
-
-    context 'when continuous_applications flag is turned on', :continuous_applications do
-      it 'does not send any emails' do
-        allow(CandidateMailer).to receive_messages(application_withdrawn_on_request_all_applications_withdrawn: mailer, application_withdrawn_on_request_awaiting_decision_only: mailer, application_withdrawn_on_request_offers_only: mailer, application_withdrawn_on_request_one_offer_one_awaiting_decision: mailer)
-
-        described_class.new(application_choice: create(:application_choice, :withdrawn)).call
-
-        expect(CandidateMailer).not_to have_received(:application_withdrawn_on_request_all_applications_withdrawn)
-        expect(CandidateMailer).not_to have_received(:application_withdrawn_on_request_awaiting_decision_only)
-        expect(CandidateMailer).not_to have_received(:application_withdrawn_on_request_offers_only)
-        expect(CandidateMailer).not_to have_received(:application_withdrawn_on_request_one_offer_one_awaiting_decision)
-      end
+      expect(CandidateMailer).to have_received(:application_withdrawn_on_request)
     end
   end
 end

--- a/spec/services/provider_interface/send_candidate_withdrawn_on_request_email_with_continuous_applications_flow_inactive_spec.rb
+++ b/spec/services/provider_interface/send_candidate_withdrawn_on_request_email_with_continuous_applications_flow_inactive_spec.rb
@@ -1,0 +1,57 @@
+# This file can be deleted with the continuous applications feature flag. The remaining functionality is tested in
+# 'send_candidate_withdrawn_on_request_email_spec.rb'
+
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::SendCandidateWithdrawnOnRequestEmail, continuous_applications: false do
+  describe '#call' do
+    let(:mailer) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+
+    it 'calls CandidateMailer.application_withdrawn_on_request_all_applications_withdrawn when all applications are withdrawn' do
+      allow(CandidateMailer).to receive(:application_withdrawn_on_request_all_applications_withdrawn).and_return(mailer)
+
+      described_class.new(application_choice: create(:application_choice, :withdrawn)).call
+
+      expect(CandidateMailer).to have_received(:application_withdrawn_on_request_all_applications_withdrawn)
+    end
+
+    it 'calls CandidateMailer.application_withdrawn_on_request_awaiting_decision_only when all applications are awaiting decision' do
+      allow(CandidateMailer).to receive(:application_withdrawn_on_request_awaiting_decision_only).and_return(mailer)
+
+      described_class.new(application_choice: create(:application_choice, :awaiting_provider_decision)).call
+
+      expect(CandidateMailer).to have_received(:application_withdrawn_on_request_awaiting_decision_only)
+    end
+
+    it 'calls CandidateMailer.application_withdrawn_on_request_offers_only when all applications have offers' do
+      allow(CandidateMailer).to receive(:application_withdrawn_on_request_offers_only).and_return(mailer)
+
+      described_class.new(application_choice: create(:application_choice, :offered)).call
+
+      expect(CandidateMailer).to have_received(:application_withdrawn_on_request_offers_only)
+    end
+
+    it 'calls CandidateMailer.application_withdrawn_on_request_one_offer_one_awaiting_decision when one application has an offer and another is awaiting decision' do
+      allow(CandidateMailer).to receive(:application_withdrawn_on_request_one_offer_one_awaiting_decision).and_return(mailer)
+      offered = create(:application_choice, :offered)
+      create(:application_choice, :awaiting_provider_decision, application_form: offered.application_form)
+
+      described_class.new(application_choice: offered).call
+
+      expect(CandidateMailer).to have_received(:application_withdrawn_on_request_one_offer_one_awaiting_decision)
+    end
+
+    context 'when continuous_applications flag is turned on', :continuous_applications do
+      it 'does not send any emails' do
+        allow(CandidateMailer).to receive_messages(application_withdrawn_on_request_all_applications_withdrawn: mailer, application_withdrawn_on_request_awaiting_decision_only: mailer, application_withdrawn_on_request_offers_only: mailer, application_withdrawn_on_request_one_offer_one_awaiting_decision: mailer)
+
+        described_class.new(application_choice: create(:application_choice, :withdrawn)).call
+
+        expect(CandidateMailer).not_to have_received(:application_withdrawn_on_request_all_applications_withdrawn)
+        expect(CandidateMailer).not_to have_received(:application_withdrawn_on_request_awaiting_decision_only)
+        expect(CandidateMailer).not_to have_received(:application_withdrawn_on_request_offers_only)
+        expect(CandidateMailer).not_to have_received(:application_withdrawn_on_request_one_offer_one_awaiting_decision)
+      end
+    end
+  end
+end

--- a/spec/system/provider_interface/withdraw_an_application_at_candidates_request_spec.rb
+++ b/spec/system/provider_interface/withdraw_an_application_at_candidates_request_spec.rb
@@ -74,7 +74,12 @@ RSpec.describe "withdrawing an application at the candidate's request", type: :f
 
   def and_the_candidate_receives_an_email_about_the_withdrawal
     open_email(@application_choice.application_form.candidate.email_address)
-    expect(current_email.subject).to have_content 'Update on your application - all decisions now made'
+
+    if @application_choice.continuous_applications?
+      expect(current_email.subject).to have_content 'Update on your application'
+    else
+      expect(current_email.subject).to have_content 'Update on your application - all decisions now made'
+    end
   end
 
   def and_the_interview_has_been_cancelled


### PR DESCRIPTION
## Context

In line with the continuous applications flow, we need to repurpose our withdrawn emails, so that they still make sense.

## Changes proposed in this pull request

- Disable existing withdrawn emails when continuous applications flow active.

- Add new `CandidateMailer` email, `application_withdrawn_on_request`(this will replace the disabled emails in the continuous applications flow).

## Guidance to review

Per commit


## Screenshots

<img width="460" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/50492247/5abd9917-20d5-4b5e-99d5-f2ff14f67b44">



## Link to Trello card

https://trello.com/c/lotp4DWO/480-ca-emails-design-and-implement-new-withdrawn-email

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
