### PR TITLE
New rejection emails

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -94,6 +94,14 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def application_rejected(application_choice)
+    @course = application_choice.current_course_option.course
+    @application_choice = RejectedApplicationChoicePresenter.new(application_choice)
+    @candidate_magic_link = candidate_magic_link(@application_choice.application_form.candidate)
+
+    email_for_candidate(application_choice.application_form)
+  end
+
   def application_rejected_all_applications_rejected(application_choice)
     @course = application_choice.current_course_option.course
     @application_choice = RejectedApplicationChoicePresenter.new(application_choice)

--- a/app/services/send_candidate_rejection_email.rb
+++ b/app/services/send_candidate_rejection_email.rb
@@ -8,6 +8,16 @@ class SendCandidateRejectionEmail
   end
 
   def call
+    if application_choice.continuous_applications?
+      CandidateMailer.application_rejected(application_choice).deliver_later
+    else
+      pre_continuous_applications_rejection_mailers
+    end
+  end
+
+private
+
+  def pre_continuous_applications_rejection_mailers
     if applications_with_offer_and_awaiting_decision?
       CandidateMailer.application_rejected_one_offer_one_awaiting_decision(application_choice).deliver_later
     elsif applications_awaiting_decision_only?

--- a/app/views/candidate_mailer/_reasons_for_rejection_intro.text.erb
+++ b/app/views/candidate_mailer/_reasons_for_rejection_intro.text.erb
@@ -1,6 +1,8 @@
 <% unless @application_choice.rejected_by_default? %>
 
-  Thank you for your application to study <%= @course.name_and_code %> at <%= @course.provider.name %>.
+  <% course = @application_choice.continuous_applications? ? @course.name : @course.name_and_code %>
+
+  Thank you for your application to study <%= course %> at <%= @course.provider.name %>.
 
   On this occasion, the provider is not offering you a place on this course.
 

--- a/app/views/candidate_mailer/application_rejected.text.erb
+++ b/app/views/candidate_mailer/application_rejected.text.erb
@@ -1,0 +1,22 @@
+Hello <%= @application_form.first_name %>
+
+<%= render 'reasons_for_rejection_intro' %>
+<%= render 'reasons_for_rejection' %>
+
+Contact <%= @course.provider.name %> if you would like to talk about their feedback.
+
+<% if CycleTimetable.can_submit?(@application_form) %>
+ 
+  # You can apply again
+
+  You can apply again for courses starting in the <%= "#{RecruitmentCycle.current_year} to #{RecruitmentCycle.next_year}" %> academic year.
+
+  All you need to do is:
+  - check that your details are still correct
+  - make sure you’re happy with your personal statement
+  - find a course and submit another application
+
+
+  [Sign in to apply again](<%= @candidate_magic_link %>).
+
+<% end %>

--- a/app/views/candidate_mailer/application_rejected.text.erb
+++ b/app/views/candidate_mailer/application_rejected.text.erb
@@ -4,19 +4,16 @@ Hello <%= @application_form.first_name %>
 <%= render 'reasons_for_rejection' %>
 
 Contact <%= @course.provider.name %> if you would like to talk about their feedback.
-
-<% if CycleTimetable.can_submit?(@application_form) %>
  
-  # You can apply again
+# You can apply again
 
-  You can apply again for courses starting in the <%= "#{RecruitmentCycle.current_year} to #{RecruitmentCycle.next_year}" %> academic year.
+You can apply again for courses starting in the <%= "#{RecruitmentCycle.current_year} to #{RecruitmentCycle.next_year}" %> academic year.
 
-  All you need to do is:
-  - check that your details are still correct
-  - make sure you’re happy with your personal statement
-  - find a course and submit another application
+All you need to do is:
+- check that your details are still correct
+- make sure you’re happy with your personal statement
+- find a course and submit another application
 
 
-  [Sign in to apply again](<%= @candidate_magic_link %>).
+[Sign in to apply again](<%= @candidate_magic_link %>).
 
-<% end %>

--- a/app/views/layouts/candidate_email_with_support_footer.text.erb
+++ b/app/views/layouts/candidate_email_with_support_footer.text.erb
@@ -2,6 +2,6 @@
 
 # Get help
 
-Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'support_footer_on_all_emails', @application_form.phase %>)
+If you need support with your application, you can speak to a teacher training adviser before applying again. Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'support_footer_on_all_emails', @application_form.phase %>)
 
 <%= t('get_into_teaching.opening_times') %>.

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -49,6 +49,8 @@ en:
       subject:
         one: "You did not respond to your offer: next steps"
         other: "You did not respond to your offers: next steps"
+    application_rejected:
+      subject: Update on your application
     application_rejected_all_applications_rejected:
       subject: Update on your application - all decisions now made
     application_rejected_one_offer_one_awaiting_decision:

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe CandidateMailer do
       )
     end
 
-    describe '.application_rejected_all_applications_rejected' do
+    describe '.application_rejected_all_applications_rejected', continuous_applications: false do
       let(:email) { mailer.application_rejected_all_applications_rejected(application_choices.first) }
 
       let(:application_choices) { [rejected] }
@@ -233,36 +233,40 @@ RSpec.describe CandidateMailer do
       end
     end
 
-    describe '.application_rejected_awaiting_decision_only' do
+    describe '.application_rejected_awaiting_decision_only', continuous_applications: false do
       let(:email) { mailer.application_rejected_awaiting_decision_only(application_choices.first) }
       let(:application_choices) { [rejected, awaiting_decision, interviewing] }
 
-      it_behaves_like(
-        'a mail with subject and content',
-        I18n.t!('candidate_mailer.application_rejected_awaiting_decision_only.subject'),
-        'heading' => 'Dear Bob',
-        'course name and code' => 'Forensic Science (E0FO)',
-        'rejection reasons' => 'Bad qualifications',
-        'other application details' => 'You’re waiting for decisions',
-        'first application' => 'Falconholt Technical College to study Forensic Science',
-        'decision day' => "They should make their decisions by #{40.business_days.from_now.to_fs(:govuk_date)}",
-      )
+      TestSuiteTimeMachine.travel_temporarily_to(mid_cycle(2023)) do
+        it_behaves_like(
+          'a mail with subject and content',
+          I18n.t!('candidate_mailer.application_rejected_awaiting_decision_only.subject'),
+          'heading' => 'Dear Bob',
+          'course name and code' => 'Forensic Science (E0FO)',
+          'rejection reasons' => 'Bad qualifications',
+          'other application details' => 'You’re waiting for decisions',
+          'first application' => 'Falconholt Technical College to study Forensic Science',
+          'decision day' => "They should make their decisions by #{40.business_days.from_now.to_fs(:govuk_date)}",
+        )
+      end
     end
 
-    describe '.application_rejected_offers_only' do
+    describe '.application_rejected_offers_only', continuous_applications: false do
       let(:email) { mailer.application_rejected_offers_only(application_choices.first) }
       let(:application_choices) { [rejected, application_choice_with_offer, application_choice_with_offer] }
 
-      it_behaves_like(
-        'a mail with subject and content',
-        I18n.t!('candidate_mailer.application_rejected_offers_only.subject', date: 10.business_days.from_now.to_fs(:govuk_date)),
-        'heading' => 'Dear Bob',
-        'course name and code' => 'Forensic Science (E0FO)',
-        'rejection reasons' => 'Do not refer to yourself in the third person',
-        'other application details' => 'You’re not waiting for any other decisions.',
-        'first application details' => 'Brighthurst Technical College to study Applied Science (Psychology)',
-        'respond by date' => "will be automatically declined if you do not respond by #{10.business_days.from_now.to_fs(:govuk_date)}",
-      )
+      TestSuiteTimeMachine.travel_temporarily_to(mid_cycle(2023)) do
+        it_behaves_like(
+          'a mail with subject and content',
+          I18n.t!('candidate_mailer.application_rejected_offers_only.subject', date: 10.business_days.from_now.to_fs(:govuk_date)),
+          'heading' => 'Dear Bob',
+          'course name and code' => 'Forensic Science (E0FO)',
+          'rejection reasons' => 'Do not refer to yourself in the third person',
+          'other application details' => 'You’re not waiting for any other decisions.',
+          'first application details' => 'Brighthurst Technical College to study Applied Science (Psychology)',
+          'respond by date' => "will be automatically declined if you do not respond by #{10.business_days.from_now.to_fs(:govuk_date)}",
+        )
+      end
     end
   end
 

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -70,6 +70,27 @@ RSpec.describe CandidateMailer do
     end
   end
 
+  describe '.application_rejected' do
+    let(:application_choice) { build_stubbed(:application_choice, :rejected, rejection_reason: 'Missing your English GCSE', course_option:) }
+    let(:application_form) {
+      build_stubbed(:application_form,
+                    candidate:,
+                    application_choices: [application_choice])
+    }
+    let(:email) { mailer.application_rejected(application_choice) }
+
+    before { allow(EmailLogInterceptor).to receive(:generate_reference).and_return('fake-ref-123') }
+
+    context 'when the candidate receives a rejection and continuous applications', :continuous_applications do
+      it_behaves_like(
+        'a mail with subject and content',
+        I18n.t!('candidate_mailer.application_rejected.subject'),
+        'intro' => 'Thank you for your application to study Mathematics at Arithmetic College',
+        'rejection reasons' => 'Missing your English GCSE',
+      )
+    end
+  end
+
   describe 'Candidate decision chaser email' do
     let(:email) { mailer.chase_candidate_decision(application_form) }
     let(:offer) do

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -181,6 +181,25 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.new_offer_decisions_pending(application_choice)
   end
 
+  def application_rejected(reasons = :rejection_reasons)
+    SiteSetting.set(name: 'cycle_schedule', value: 'today_is_mid_cycle')
+    application_choice = FactoryBot.build_stubbed(
+      :application_choice,
+      application_form:,
+      course_option:,
+      status: :rejected,
+      structured_rejection_reasons: send(reasons),
+      rejection_reasons_type: reasons.to_s,
+    )
+    CandidateMailer.application_rejected(application_choice)
+  ensure
+    SiteSetting.set(name: 'real', value: 'real')
+  end
+
+  def application_rejected_via_api
+    application_rejected(:vendor_api_rejection_reasons)
+  end
+
   def application_rejected_all_applications_rejected_mid_cycle(reasons = :rejection_reasons)
     SiteSetting.set(name: 'cycle_schedule', value: 'today_is_mid_cycle')
     application_choice = FactoryBot.build_stubbed(

--- a/spec/services/send_candidate_rejection_email_spec.rb
+++ b/spec/services/send_candidate_rejection_email_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SendCandidateRejectionEmail do
     let(:application_choice_offer_deferred) { create(:application_choice, status: :offer_deferred, application_form:) }
     let(:mail) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
 
-    context 'when an application choice is rejected' do
+    context 'when an application choice is rejected and it is not continous applications', continuous_applications: false do
       describe 'when all application choices have been rejected' do
         before do
           allow(CandidateMailer).to receive(:application_rejected_all_applications_rejected).and_return(mail)
@@ -134,6 +134,17 @@ RSpec.describe SendCandidateRejectionEmail do
         it 'sends the all_applications_rejected email to the candidate' do
           expect(CandidateMailer).to have_received(:application_rejected_all_applications_rejected).with(application_choice)
         end
+      end
+    end
+
+    context 'when an application is rejected and it is continuous applications', :continuous_applications do
+      before do
+        allow(CandidateMailer).to receive(:application_rejected).and_return(mail)
+        described_class.new(application_choice:).call
+      end
+
+      it 'the applications_rejected email is sent to the candidate' do
+        expect(CandidateMailer).to have_received(:application_rejected).with(application_choice)
       end
     end
   end

--- a/spec/system/candidate_interface/continuous_applications/rejections/candidate_receives_rejection_email_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/rejections/candidate_receives_rejection_email_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.feature 'Receives rejection email', :continuous_applications do
+  include CandidateHelper
+
+  scenario 'Receives rejection email' do
+    when_i_have_submitted_an_application
+    and_a_provider_rejects_my_application
+    then_i_receive_the_application_rejected_email
+    and_it_includes_details_of_my_application
+  end
+
+  def when_i_have_submitted_an_application
+    @application_form = create(:completed_application_form)
+    @application_choice = create(:application_choice, status: :awaiting_provider_decision, application_form: @application_form)
+  end
+
+  def and_a_provider_rejects_my_application
+    RejectApplication.new(
+      actor: create(:support_user),
+      application_choice: @application_choice,
+      rejection_reason: 'No experience working with children.',
+    ).save
+  end
+
+  def then_i_receive_the_application_rejected_email
+    open_email(@application_form.candidate.email_address)
+
+    expect(current_email.subject).to include(I18n.t!('candidate_mailer.application_rejected.subject'))
+  end
+
+  def and_it_includes_details_of_my_application
+    expect(current_email.text).to include(@application_choice.course.provider.name)
+    expect(current_email.text).to include(@application_choice.course.name)
+    expect(current_email.text).to include('No experience working with children.')
+  end
+end

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_receives_rejection_email_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_receives_rejection_email_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Receives rejection email' do
+RSpec.feature 'Receives rejection email', continuous_applications: false do
   include CandidateHelper
 
   scenario 'Receives rejection email' do

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -60,6 +60,7 @@ RSpec.feature 'Docs' do
       provider_mailer-permissions_removed
       provider_mailer-permissions_updated
       provider_mailer-reference_received
+      candidate_mailer-application_rejected
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"


### PR DESCRIPTION
## Context

We need to ensure the emails sent to candidates still make sense regarding continuous applications.

Currently we have 14 rejection emails, some for API users and some for Manage users. But they are all very similar and trying to tell candidates too many things at once.

There will now be only two rejection emails:

One triggered in Manage

The other triggered for API users

When a candidate receives a Rejection they will receive 1 email per rejected application.

Previously we had a number or emails for rejections depending on what states the candidate’s other applications were in.

Therefore there are some existing emails that will no longer be needed. These must be disabled (and removed later)

## Changes proposed in this pull request

|New rejection email|
|---|
|<img width="603" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/dc875401-3813-485d-999b-4390bdade712">
<img width="608" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/1c6c147a-64e9-49d4-9861-245850d79b78">|


## Guidance to review

Refer to the word doc attached to the trello ticket for content.

You can preview the email at `apply-review-XXXX.test.teacherservices.cloud/rails/mailers/candidate_mailer/application_rejected`


## Link to Trello card

https://trello.com/c/rHKGQeEf/462-ca-emails-design-and-implement-new-rejection-emails

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
