### PR TITLE
Add post offer dashboard behaviour to candidate interface

### DIFF
--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -80,7 +80,7 @@ module CandidateInterface
     end
 
     def redirect_to_new_continuous_applications_if_active
-      return unless current_application.continuous_applications?
+      return unless current_application.continuous_applications? && !current_application.any_offer_accepted?
 
       completed_application_form = CandidateInterface::CompletedApplicationForm.new(
         application_form: current_application,

--- a/app/controllers/candidate_interface/continuous_applications_choices_controller.rb
+++ b/app/controllers/candidate_interface/continuous_applications_choices_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class ContinuousApplicationsChoicesController < ContinuousApplicationsController
+    before_action :redirect_to_post_offer_dashboard_if_accepted_or_recruited
+
     def index
       @application_form_presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
     end

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -8,19 +8,28 @@ class NavigationItems
     def candidate_primary_navigation(current_candidate:, current_controller:)
       return [] unless current_candidate
 
-      menu = []
-
-      menu << NavigationItem.new(
-        t('page_titles.your_details'), candidate_interface_continuous_applications_details_path,
-        !current_controller.choices_controller?
-      )
-
-      application_title = t('page_titles.continuous_applications.your_applications')
-
-      menu << NavigationItem.new(
-        application_title, candidate_interface_continuous_applications_choices_path,
-        current_controller.choices_controller?
-      )
+      if current_candidate.current_application.any_offer_accepted?
+        [
+          NavigationItem.new(
+            t('page_titles.offer_dashboard'),
+            candidate_interface_application_offer_dashboard_path,
+            true,
+          ),
+        ]
+      else
+        [
+          NavigationItem.new(
+            t('page_titles.your_details'),
+            candidate_interface_continuous_applications_details_path,
+            !current_controller.choices_controller?,
+          ),
+          NavigationItem.new(
+            t('page_titles.continuous_applications.your_applications'),
+            candidate_interface_continuous_applications_choices_path,
+            current_controller.choices_controller?,
+          ),
+        ]
+      end
     end
 
     def for_candidate_primary_nav(current_candidate, _current_controller)

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -27,6 +27,7 @@
         missing_error: missing_error,
         application_choice_error: application_choice_error,
         return_to_application_review: true,
+        display_accepted_application_choices: true,
       ),
     ) %>
   <% end %>

--- a/app/views/candidate_interface/decisions/withdraw.html.erb
+++ b/app/views/candidate_interface/decisions/withdraw.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.decisions.withdraw') %>
-<% content_for :before_content, govuk_back_link_to(application_form_path) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -12,7 +12,7 @@
         items: NavigationItems.candidate_primary_navigation(current_candidate:, current_controller: controller),
         items_right: [NavigationItems::NavigationItem.new('Sign out', candidate_interface_sign_out_path)],
       )) %>
-  <% else %>
+    <% else %>
       <%= render(PrimaryNavigationComponent.new(
         items: NavigationItems.for_candidate_primary_nav(current_candidate, controller),
         items_right: [NavigationItems::NavigationItem.new('Sign out', candidate_interface_sign_out_path)],

--- a/spec/helpers/navigation_items_spec.rb
+++ b/spec/helpers/navigation_items_spec.rb
@@ -4,9 +4,13 @@ RSpec.describe NavigationItems do
   let(:current_application) { current_candidate.current_application }
 
   describe '.candidate_primary_navigation', :continuous_applications do
+    let(:current_candidate) { nil }
+    let(:current_controller) { nil }
+    let(:navigation_items) { described_class.candidate_primary_navigation(current_candidate:, current_controller:).map(&:text) }
+
     context 'when no candidate is provided' do
       it 'renders the correct items' do
-        expect(described_class.candidate_primary_navigation(current_candidate: nil, current_controller: nil).map(&:text)).to eq([])
+        expect(navigation_items).to eq([])
       end
     end
 
@@ -14,12 +18,23 @@ RSpec.describe NavigationItems do
       let(:current_controller) do
         instance_double(CandidateInterface::ContinuousApplicationsDetailsController, controller_name: 'continuous_applications_details', choices_controller?: true)
       end
-      let(:current_candidate) do
-        create(:candidate, application_forms: [create(:application_form, application_choices: [build(:application_choice, :pending_conditions)])])
+
+      let(:current_candidate) { create(:candidate, application_forms: [create(:application_form, application_choices:)]) }
+
+      context 'when application choice is in unsubmitted state' do
+        let(:application_choices) { [build(:application_choice, :unsubmitted)] }
+
+        it 'renders the correct items' do
+          expect(navigation_items).to eq(['Your details', 'Your applications'])
+        end
       end
 
-      it 'renders the correct items' do
-        expect(described_class.candidate_primary_navigation(current_candidate:, current_controller:).map(&:text)).to eq(['Your details', 'Your applications'])
+      context 'when application choice is in accepted state' do
+        let(:application_choices) { [build(:application_choice, :pending_conditions)] }
+
+        it 'renders the correct items' do
+          expect(navigation_items).to eq(['Your offer'])
+        end
       end
     end
   end

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_spec.rb
@@ -82,9 +82,11 @@ RSpec.feature 'Candidate accepts an offer' do
 
     when_i_add_reference_relationship
     then_i_should_be_on_accept_offer_page
+    and_i_see_your_application_menu_item_as_active
 
     and_i_confirm_the_acceptance
     then_i_see_a_flash_message_telling_me_i_have_accepted_the_offer
+    and_i_see_your_offer_menu_item_as_active
     and_i_see_that_i_accepted_the_offer
     and_i_see_that_i_declined_the_other_offer
     and_i_see_that_i_withdrawn_from_the_third_choice
@@ -99,9 +101,19 @@ RSpec.feature 'Candidate accepts an offer' do
 
     when_i_visit_the_decline_page_of_the_accepted_offer
     then_i_see_the_page_not_found
-
     when_the_provider_marks_my_application_as_recruited
     and_i_view_my_application
+    then_i_see_the_new_dashboard_content
+
+    when_i_click_to_view_my_application
+    then_i_see_the_course_with_an_accepted_offer
+    and_i_dont_see_the_course_without_an_offer
+
+    when_i_click_back
+    then_i_see_the_new_dashboard_content
+
+    when_i_click_to_withdraw_my_application
+    and_i_click_back
     then_i_see_the_new_dashboard_content
   end
 
@@ -194,7 +206,7 @@ RSpec.feature 'Candidate accepts an offer' do
   end
 
   def and_i_click_delete_the_first_reference
-    click_on "Delete reference from #{@application_form.application_references.creation_order.first.name}"
+    click_link "Delete reference from #{@application_form.application_references.creation_order.first.name}"
   end
 
   def then_the_back_link_should_point_to_the_accept_offer_page
@@ -208,7 +220,7 @@ RSpec.feature 'Candidate accepts an offer' do
   end
 
   def and_i_confirm_delete
-    click_on 'Yes I’m sure - delete this reference'
+    click_button 'Yes I’m sure - delete this reference'
   end
 
   def then_i_should_see_an_error_message
@@ -270,7 +282,7 @@ RSpec.feature 'Candidate accepts an offer' do
   end
 
   def when_i_click_to_add_another_reference
-    click_on 'Add another reference'
+    click_link 'Add another reference'
   end
 
   def and_i_click_continue
@@ -350,12 +362,13 @@ RSpec.feature 'Candidate accepts an offer' do
   end
 
   def when_i_click_to_change_the_reference_name
-    click_on 'Change name for Gimli'
+    click_link 'Change name for Gimli'
   end
 
   def and_i_click_back
-    click_on 'Back'
+    click_link 'Back'
   end
+  alias_method :when_i_click_back, :and_i_click_back
 
   def when_i_change_the_reference_name
     fill_in 'What’s the name of the person who can give a reference?', with: 'Legolas'
@@ -367,7 +380,7 @@ RSpec.feature 'Candidate accepts an offer' do
   end
 
   def when_i_click_to_change_the_reference_type
-    click_on 'Change reference type for Legolas'
+    click_link 'Change reference type for Legolas'
   end
 
   def when_i_change_the_reference_type
@@ -380,7 +393,7 @@ RSpec.feature 'Candidate accepts an offer' do
   end
 
   def when_i_click_to_change_the_reference_email_address
-    click_on 'Change email address for Legolas'
+    click_link 'Change email address for Legolas'
   end
 
   def when_i_change_the_reference_email_address
@@ -393,7 +406,7 @@ RSpec.feature 'Candidate accepts an offer' do
   end
 
   def when_i_click_to_change_the_reference_relationship
-    click_on 'Change relationship for Legolas'
+    click_link 'Change relationship for Legolas'
   end
 
   def when_i_change_the_reference_relationship
@@ -453,7 +466,7 @@ RSpec.feature 'Candidate accepts an offer' do
   end
 
   def when_i_add_reference_relationship
-    click_on 'Enter how you know them and for how long'
+    click_link 'Enter how you know them and for how long'
     fill_in 'How do you know Aragorn and how long have you known them?', with: 'Middle earth'
     and_i_click_save_and_continue
   end
@@ -476,5 +489,35 @@ RSpec.feature 'Candidate accepts an offer' do
 
   def then_i_see_the_new_dashboard_content
     expect(page).to have_content "You’ve accepted an offer from #{@course_option.course.provider.name} to study #{@course_option.course.name_and_code}."
+  end
+
+  def and_i_see_your_application_menu_item_as_active
+    expect(page).to have_css('.govuk-link.app-primary-navigation__link[aria-current=page]', text: 'Your application')
+  end
+
+  def and_i_see_your_offer_menu_item_as_active
+    expect(page).to have_css('.govuk-link.app-primary-navigation__link[aria-current=page]', text: 'Your offer')
+  end
+
+  def when_i_click_to_view_my_application
+    click_link 'View application'
+  end
+
+  def when_i_click_to_withdraw_my_application
+    click_link 'Withdraw from the course'
+  end
+
+  def then_i_see_the_course_with_an_accepted_offer
+    expect(page).to have_content @application_choice.course.name_and_code
+  end
+
+  def and_i_dont_see_the_course_without_an_offer
+    expect(page).not_to have_content @other_application_choice.course.name_and_code
+  end
+
+  def and_the_back_link_should_point_to_the_offer_dashboard_page
+    expect(
+      back_link,
+    ).to eq(candidate_interface_application_offer_dashboard_path)
   end
 end


### PR DESCRIPTION
* Candidate can't access their choices page
* Navigation changes from 'Your application' to 'Your offer'
* 'Your details' page is hidden
* 'Your offer' page only shows the accepted offer
* Withdraw page button points to the right page

**Before:**
<img width="897" alt="Screenshot 2023-09-21 at 10 09 11" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/c596005d-ab8c-4372-a347-427f9e1ed7ec">

**After:**
<img width="897" alt="Screenshot 2023-09-21 at 10 08 52" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/18f57d17-76f5-4a47-87e2-b8591f332912">
