### PR TITLE
Fix GenerateTestApplications test to continuous applications

### DIFF
--- a/spec/workers/generate_test_applications_spec.rb
+++ b/spec/workers/generate_test_applications_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe GenerateTestApplications do
     expect(ApplicationForm.joins(:application_choices).where('application_choices.status': 'offer', phase: 'apply_2').where.not(previous_application_form_id: nil)).not_to be_empty
   end
 
-  it 'generates test applications for the next cycle', :sidekiq do
+  it 'generates test applications for the next cycle', :continuous_applications, :sidekiq do
     current_cycle = RecruitmentCycle.current_year
     provider = create(:provider)
 


### PR DESCRIPTION
## Context

Test has started failing in a context that will not apply after one week. Expectation is not matched when feature flags are off. Very soon, continuous applications feature flag will be permanent so this is not a case we should test.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)