### PR TITLE
Editable sections

### DIFF
--- a/app/components/candidate_interface/add_new_reference_component.html.erb
+++ b/app/components/candidate_interface/add_new_reference_component.html.erb
@@ -8,4 +8,6 @@
 </ul>
 <p class="govuk-body">They’ll be asked if they know any reason why you should not work with children.</p>
 
-<%= govuk_button_link_to t('application_form.references.add_reference', count: application_form.application_references.count), candidate_interface_references_type_path, options_for_add_reference_link %>
+<% if @editable_section.can_edit? %>
+  <%= govuk_button_link_to t('application_form.references.add_reference', count: current_application.application_references.count), candidate_interface_references_type_path, options_for_add_reference_link %>
+<% end %>

--- a/app/components/candidate_interface/add_new_reference_component.html.erb
+++ b/app/components/candidate_interface/add_new_reference_component.html.erb
@@ -8,6 +8,6 @@
 </ul>
 <p class="govuk-body">They’ll be asked if they know any reason why you should not work with children.</p>
 
-<% if @editable_section.can_edit? %>
+<% if @section_policy.can_edit? %>
   <%= govuk_button_link_to t('application_form.references.add_reference', count: current_application.application_references.count), candidate_interface_references_type_path, options_for_add_reference_link %>
 <% end %>

--- a/app/components/candidate_interface/add_new_reference_component.html.erb
+++ b/app/components/candidate_interface/add_new_reference_component.html.erb
@@ -1,12 +1,14 @@
-<p class="govuk-body">You need to give the email address of 2 people who can give a reference for you. They’ll only be contacted if you accept an offer on a course.</p>
+<% unless current_application.submitted_applications? %>
+  <p class="govuk-body">You need to give the email address of 2 people who can give a reference for you. They’ll only be contacted if you accept an offer on a course.</p>
 
-<p class="govuk-body">You should include:</p>
+  <p class="govuk-body">You should include:</p>
 
-<ul class="govuk-list govuk-list--bullet">
-  <li>an academic tutor if you graduated in the past 5 years or are still studying</li>
-  <li>the headteacher if you’ve been working in a school</li>
-</ul>
-<p class="govuk-body">They’ll be asked if they know any reason why you should not work with children.</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>an academic tutor if you graduated in the past 5 years or are still studying</li>
+    <li>the headteacher if you’ve been working in a school</li>
+  </ul>
+  <p class="govuk-body">They’ll be asked if they know any reason why you should not work with children.</p>
+<% end %>
 
 <% if @section_policy.can_edit? %>
   <%= govuk_button_link_to t('application_form.references.add_reference', count: current_application.application_references.count), candidate_interface_references_type_path, options_for_add_reference_link %>

--- a/app/components/candidate_interface/add_new_reference_component.rb
+++ b/app/components/candidate_interface/add_new_reference_component.rb
@@ -2,10 +2,12 @@ module CandidateInterface
   class AddNewReferenceComponent < ViewComponent::Base
     include AddNewReferenceHelpers
 
-    attr_reader :application_form
+    attr_reader :current_application, :editable_section
+    alias application_form current_application
 
-    def initialize(application_form)
-      @application_form = application_form
+    def initialize(current_application:, editable_section:)
+      @current_application = current_application
+      @editable_section = editable_section
     end
   end
 end

--- a/app/components/candidate_interface/add_new_reference_component.rb
+++ b/app/components/candidate_interface/add_new_reference_component.rb
@@ -2,12 +2,12 @@ module CandidateInterface
   class AddNewReferenceComponent < ViewComponent::Base
     include AddNewReferenceHelpers
 
-    attr_reader :current_application, :editable_section
+    attr_reader :current_application, :section_policy
     alias application_form current_application
 
-    def initialize(current_application:, editable_section:)
+    def initialize(current_application:, section_policy:)
       @current_application = current_application
-      @editable_section = editable_section
+      @section_policy = section_policy
     end
   end
 end

--- a/app/components/candidate_interface/complete_section_component.html.erb
+++ b/app/components/candidate_interface/complete_section_component.html.erb
@@ -1,14 +1,18 @@
 <% if @section_policy.can_edit? %>
-  <div class="govuk-!-width-two-thirds">
-    <%= form.govuk_collection_radio_buttons :completed,
-        [[true, complete_or_reviewed_radio_button_label], [false, t('application_form.incomplete_radio')]],
-        :first,
-        :last,
-        hint: { text: hint_text },
-        legend: { text: t('application_form.completed_question'), size: 'm' } %>
-  </div>
+  <% if submitted_applications? && form.object.completed.present? %>
+    <%= govuk_button_link_to 'Continue', candidate_interface_continuous_applications_details_path %>
+  <% else %>
+    <div class="govuk-!-width-two-thirds">
+      <%= form.govuk_collection_radio_buttons :completed,
+          [[true, complete_or_reviewed_radio_button_label], [false, t('application_form.incomplete_radio')]],
+          :first,
+          :last,
+          hint: { text: hint_text },
+          legend: { text: t('application_form.completed_question'), size: 'm' } %>
+    </div>
 
-  <%= form.govuk_submit t('continue') %>
+    <%= form.govuk_submit t('continue') %>
+  <% end %>
 <% else %>
   <div class="govuk-inset-text">
     Contact <%= bat_contact_mail_to %> if you need to update this section.

--- a/app/components/candidate_interface/complete_section_component.html.erb
+++ b/app/components/candidate_interface/complete_section_component.html.erb
@@ -1,8 +1,16 @@
-<div class="govuk-!-width-two-thirds">
-  <%= form.govuk_collection_radio_buttons :completed,
-      [[true, complete_or_reviewed_radio_button_label], [false, t('application_form.incomplete_radio')]],
-      :first,
-      :last,
-      hint: { text: hint_text },
-      legend: { text: t('application_form.completed_question'), size: 'm' } %>
-</div>
+<% if @editable_section.can_edit? %>
+  <div class="govuk-!-width-two-thirds">
+    <%= form.govuk_collection_radio_buttons :completed,
+        [[true, complete_or_reviewed_radio_button_label], [false, t('application_form.incomplete_radio')]],
+        :first,
+        :last,
+        hint: { text: hint_text },
+        legend: { text: t('application_form.completed_question'), size: 'm' } %>
+  </div>
+
+  <%= form.govuk_submit t('continue') %>
+<% else %>
+  <div class="govuk-inset-text">
+    Contact <%= bat_contact_mail_to %> if you need to update this section.
+  </div>
+<% end %>

--- a/app/components/candidate_interface/complete_section_component.html.erb
+++ b/app/components/candidate_interface/complete_section_component.html.erb
@@ -1,4 +1,4 @@
-<% if @editable_section.can_edit? %>
+<% if @section_policy.can_edit? %>
   <div class="govuk-!-width-two-thirds">
     <%= form.govuk_collection_radio_buttons :completed,
         [[true, complete_or_reviewed_radio_button_label], [false, t('application_form.incomplete_radio')]],

--- a/app/components/candidate_interface/complete_section_component.rb
+++ b/app/components/candidate_interface/complete_section_component.rb
@@ -1,10 +1,10 @@
 module CandidateInterface
   class CompleteSectionComponent < ViewComponent::Base
     include ViewHelper
-    attr_reader :editable_section, :form, :hint_text, :section_review
+    attr_reader :section_policy, :form, :hint_text, :section_review
 
-    def initialize(editable_section:, form:, section_review: false, hint_text: false)
-      @editable_section = editable_section
+    def initialize(section_policy:, form:, section_review: false, hint_text: false)
+      @section_policy = section_policy
       @form = form
       @section_review = section_review
       @hint_text = hint_text

--- a/app/components/candidate_interface/complete_section_component.rb
+++ b/app/components/candidate_interface/complete_section_component.rb
@@ -1,8 +1,10 @@
 module CandidateInterface
   class CompleteSectionComponent < ViewComponent::Base
-    attr_reader :form, :hint_text, :section_review
+    include ViewHelper
+    attr_reader :editable_section, :form, :hint_text, :section_review
 
-    def initialize(form:, section_review: false, hint_text: false)
+    def initialize(editable_section:, form:, section_review: false, hint_text: false)
+      @editable_section = editable_section
       @form = form
       @section_review = section_review
       @hint_text = hint_text

--- a/app/components/candidate_interface/complete_section_component.rb
+++ b/app/components/candidate_interface/complete_section_component.rb
@@ -17,5 +17,9 @@ module CandidateInterface
         t('application_form.completed_radio')
       end
     end
+
+    def submitted_applications?
+      helpers.current_application.submitted_applications?
+    end
   end
 end

--- a/app/components/candidate_interface/editable_section_warning.html.erb
+++ b/app/components/candidate_interface/editable_section_warning.html.erb
@@ -1,0 +1,3 @@
+<div class="govuk-inset-text">
+  Any changes you make will be included in applications you’ve already submitted.
+</div>

--- a/app/components/candidate_interface/editable_section_warning.rb
+++ b/app/components/candidate_interface/editable_section_warning.rb
@@ -1,0 +1,14 @@
+module CandidateInterface
+  class EditableSectionWarning < ViewComponent::Base
+    attr_accessor :editable_section, :current_application
+
+    def initialize(current_application:, editable_section:)
+      @current_application = current_application
+      @editable_section = editable_section
+    end
+
+    def render?
+      @current_application.submitted_applications? && @editable_section.can_edit?
+    end
+  end
+end

--- a/app/components/candidate_interface/editable_section_warning.rb
+++ b/app/components/candidate_interface/editable_section_warning.rb
@@ -1,14 +1,14 @@
 module CandidateInterface
   class EditableSectionWarning < ViewComponent::Base
-    attr_accessor :editable_section, :current_application
+    attr_accessor :section_policy, :current_application
 
-    def initialize(current_application:, editable_section:)
+    def initialize(current_application:, section_policy:)
       @current_application = current_application
-      @editable_section = editable_section
+      @section_policy = section_policy
     end
 
     def render?
-      @current_application.submitted_applications? && @editable_section.can_edit?
+      @current_application.submitted_applications? && @section_policy.can_edit?
     end
   end
 end

--- a/app/components/candidate_interface/other_qualifications_review_component.html.erb
+++ b/app/components/candidate_interface/other_qualifications_review_component.html.erb
@@ -7,7 +7,7 @@
     ) %>
   <% end %>
 
-  <% if !@submitting_application %>
+  <% if !@submitting_application && @editable.present? %>
     <%= govuk_button_link_to t('application_form.other_qualification.another.button'),
       candidate_interface_other_qualification_type_path,
       secondary: true %>

--- a/app/components/candidate_interface/personal_details_review_component.rb
+++ b/app/components/candidate_interface/personal_details_review_component.rb
@@ -24,6 +24,7 @@ module CandidateInterface
         application_form: @application_form,
         right_to_work_form: @right_to_work_or_study_form,
         return_to_application_review: @return_to_application_review,
+        editable: @editable,
       ).rows
     end
 

--- a/app/controllers/candidate_interface/application_choices_controller.rb
+++ b/app/controllers/candidate_interface/application_choices_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   class ApplicationChoicesController < SectionController
     before_action :redirect_to_dashboard_if_submitted
+    skip_before_action :redirect_to_your_details_non_editable_sections
 
     def confirm_destroy
       @course_choice = current_candidate.current_application.application_choices.find(params[:id])

--- a/app/controllers/candidate_interface/application_choices_controller.rb
+++ b/app/controllers/candidate_interface/application_choices_controller.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   class ApplicationChoicesController < SectionController
     before_action :redirect_to_dashboard_if_submitted
-    skip_before_action :redirect_to_your_details_non_editable_sections
+    skip_before_action :verify_authorized_section
 
     def confirm_destroy
       @course_choice = current_candidate.current_application.application_choices.find(params[:id])

--- a/app/controllers/candidate_interface/application_choices_controller.rb
+++ b/app/controllers/candidate_interface/application_choices_controller.rb
@@ -1,5 +1,5 @@
 module CandidateInterface
-  class ApplicationChoicesController < CandidateInterfaceController
+  class ApplicationChoicesController < SectionController
     before_action :redirect_to_dashboard_if_submitted
 
     def confirm_destroy

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -68,6 +68,8 @@ module CandidateInterface
     end
 
     def redirect_to_dashboard_if_submitted
+      return if current_application.continuous_applications?
+
       redirect_to candidate_interface_application_complete_path if current_application.submitted?
     end
 

--- a/app/controllers/candidate_interface/contact_details/review_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/review_controller.rb
@@ -1,5 +1,5 @@
 module CandidateInterface
-  class ContactDetails::ReviewController < CandidateInterfaceController
+  class ContactDetails::ReviewController < SectionController
     before_action :redirect_to_dashboard_if_submitted
 
     def show

--- a/app/controllers/candidate_interface/degrees/base_controller.rb
+++ b/app/controllers/candidate_interface/degrees/base_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   module Degrees
-    class BaseController < CandidateInterfaceController
+    class BaseController < SectionController
       before_action :redirect_to_dashboard_if_submitted
       before_action :render_application_feedback_component
 

--- a/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   module EnglishForeignLanguage
-    class ReviewController < CandidateInterfaceController
+    class ReviewController < SectionController
       include EflRootConcern
 
       before_action :check_for_english_proficiency

--- a/app/controllers/candidate_interface/equality_and_diversity_controller.rb
+++ b/app/controllers/candidate_interface/equality_and_diversity_controller.rb
@@ -1,5 +1,5 @@
 module CandidateInterface
-  class EqualityAndDiversityController < CandidateInterfaceController
+  class EqualityAndDiversityController < SectionController
     before_action :set_review_back_link
     before_action :check_that_candidate_should_be_asked_about_free_school_meals, only: [:edit_free_school_meals]
 

--- a/app/controllers/candidate_interface/gcse/base_controller.rb
+++ b/app/controllers/candidate_interface/gcse/base_controller.rb
@@ -1,5 +1,5 @@
 module CandidateInterface
-  class Gcse::BaseController < CandidateInterfaceController
+  class Gcse::BaseController < SectionController
     before_action :redirect_to_dashboard_if_submitted
     before_action :set_subject
     before_action :render_application_feedback_component

--- a/app/controllers/candidate_interface/interview_availability_controller.rb
+++ b/app/controllers/candidate_interface/interview_availability_controller.rb
@@ -1,5 +1,5 @@
 module CandidateInterface
-  class InterviewAvailabilityController < CandidateInterfaceController
+  class InterviewAvailabilityController < SectionController
     before_action :redirect_to_dashboard_if_submitted
 
     def show

--- a/app/controllers/candidate_interface/other_qualifications/base_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/base_controller.rb
@@ -1,5 +1,5 @@
 module CandidateInterface
-  class OtherQualifications::BaseController < CandidateInterfaceController
+  class OtherQualifications::BaseController < SectionController
     before_action :redirect_to_dashboard_if_submitted
     before_action :render_application_feedback_component
 

--- a/app/controllers/candidate_interface/personal_details/review_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/review_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   module PersonalDetails
-    class ReviewController < CandidateInterfaceController
+    class ReviewController < SectionController
       before_action :redirect_to_dashboard_if_submitted
 
       def show
@@ -12,6 +12,7 @@ module CandidateInterface
         @nationalities_form = NationalitiesForm.build_from_application(current_application)
         @personal_details_review = PersonalDetailsReviewComponent.new(
           application_form: current_application,
+          editable: @editable_section.can_edit?,
         )
       end
 

--- a/app/controllers/candidate_interface/personal_details/review_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/review_controller.rb
@@ -12,7 +12,7 @@ module CandidateInterface
         @nationalities_form = NationalitiesForm.build_from_application(current_application)
         @personal_details_review = PersonalDetailsReviewComponent.new(
           application_form: current_application,
-          editable: @editable_section.can_edit?,
+          editable: @section_policy.can_edit?,
         )
       end
 

--- a/app/controllers/candidate_interface/personal_statement_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement_controller.rb
@@ -1,5 +1,5 @@
 module CandidateInterface
-  class PersonalStatementController < CandidateInterfaceController
+  class PersonalStatementController < SectionController
     include AdviserStatus
 
     before_action { redirect_to_dashboard_if_submitted unless current_application.continuous_applications? }

--- a/app/controllers/candidate_interface/references/base_controller.rb
+++ b/app/controllers/candidate_interface/references/base_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   module References
-    class BaseController < CandidateInterfaceController
+    class BaseController < SectionController
       before_action :render_application_feedback_component, :set_reference, :set_edit_backlink
       before_action :redirect_to_dashboard_if_submitted
       rescue_from ActiveRecord::RecordNotFound, with: :render_404

--- a/app/controllers/candidate_interface/restructured_work_history/base_controller.rb
+++ b/app/controllers/candidate_interface/restructured_work_history/base_controller.rb
@@ -1,5 +1,5 @@
 module CandidateInterface
-  class RestructuredWorkHistory::BaseController < CandidateInterfaceController
+  class RestructuredWorkHistory::BaseController < SectionController
     before_action :redirect_to_dashboard_if_submitted
   end
 end

--- a/app/controllers/candidate_interface/safeguarding_controller.rb
+++ b/app/controllers/candidate_interface/safeguarding_controller.rb
@@ -1,5 +1,5 @@
 module CandidateInterface
-  class SafeguardingController < CandidateInterfaceController
+  class SafeguardingController < SectionController
     before_action :redirect_to_dashboard_if_submitted
 
     def show

--- a/app/controllers/candidate_interface/section_controller.rb
+++ b/app/controllers/candidate_interface/section_controller.rb
@@ -1,6 +1,9 @@
 module CandidateInterface
   class SectionController < CandidateInterfaceController
     before_action :set_editable_section
+    # rubocop:disable Rails/LexicallyScopedActionFilter
+    before_action :redirect_to_your_details_non_editable_sections, except: %i[show review]
+    # rubocop:enable Rails/LexicallyScopedActionFilter
 
     def set_editable_section
       @editable_section = EditableSection.new(
@@ -9,6 +12,10 @@ module CandidateInterface
         action_name:,
         params:,
       )
+    end
+
+    def redirect_to_your_details_non_editable_sections
+      redirect_to candidate_interface_continuous_applications_details_path unless @editable_section.can_edit?
     end
   end
 end

--- a/app/controllers/candidate_interface/section_controller.rb
+++ b/app/controllers/candidate_interface/section_controller.rb
@@ -1,12 +1,13 @@
 module CandidateInterface
   class SectionController < CandidateInterfaceController
-    before_action :set_editable_section
-    # rubocop:disable Rails/LexicallyScopedActionFilter
-    before_action :redirect_to_your_details_non_editable_sections, except: %i[show review]
-    # rubocop:enable Rails/LexicallyScopedActionFilter
+    before_action :set_section_policy
+    before_action :verify_authorized_section, except: %i[show review]
 
-    def set_editable_section
-      @editable_section = EditableSection.new(
+    def show; end
+    def review; end
+
+    def set_section_policy
+      @section_policy = SectionPolicy.new(
         current_application:,
         controller_path:,
         action_name:,
@@ -14,8 +15,11 @@ module CandidateInterface
       )
     end
 
-    def redirect_to_your_details_non_editable_sections
-      redirect_to candidate_interface_continuous_applications_details_path unless @editable_section.can_edit?
+    def verify_authorized_section
+      unless @section_policy.can_edit?
+        Rails.logger.info("Not authorized for controller '#{@section_policy.controller_path}' and action '#{@section_policy.action_name}'")
+        redirect_to candidate_interface_continuous_applications_details_path
+      end
     end
   end
 end

--- a/app/controllers/candidate_interface/section_controller.rb
+++ b/app/controllers/candidate_interface/section_controller.rb
@@ -1,0 +1,14 @@
+module CandidateInterface
+  class SectionController < CandidateInterfaceController
+    before_action :set_editable_section
+
+    def set_editable_section
+      @editable_section = EditableSection.new(
+        current_application:,
+        controller_path:,
+        action_name:,
+        params:,
+      )
+    end
+  end
+end

--- a/app/controllers/candidate_interface/subject_knowledge_controller.rb
+++ b/app/controllers/candidate_interface/subject_knowledge_controller.rb
@@ -1,5 +1,5 @@
 module CandidateInterface
-  class SubjectKnowledgeController < CandidateInterfaceController
+  class SubjectKnowledgeController < SectionController
     before_action :redirect_to_dashboard_if_submitted, :render_application_feedback_component, :redirect_to_personal_statement_if_on_the_new_personal_statement
 
     def show

--- a/app/controllers/candidate_interface/training_with_a_disability_controller.rb
+++ b/app/controllers/candidate_interface/training_with_a_disability_controller.rb
@@ -1,5 +1,5 @@
 module CandidateInterface
-  class TrainingWithADisabilityController < CandidateInterfaceController
+  class TrainingWithADisabilityController < SectionController
     before_action :redirect_to_dashboard_if_submitted
 
     def show

--- a/app/controllers/candidate_interface/volunteering/base_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/base_controller.rb
@@ -1,5 +1,5 @@
 module CandidateInterface
-  class Volunteering::BaseController < CandidateInterfaceController
+  class Volunteering::BaseController < SectionController
     before_action :redirect_to_dashboard_if_submitted
 
   private

--- a/app/controllers/candidate_interface/volunteering/review_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/review_controller.rb
@@ -1,5 +1,5 @@
 module CandidateInterface
-  class Volunteering::ReviewController < CandidateInterfaceController
+  class Volunteering::ReviewController < SectionController
     before_action :redirect_to_dashboard_if_submitted
 
     def show

--- a/app/controllers/candidate_interface/volunteering/review_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/review_controller.rb
@@ -1,5 +1,5 @@
 module CandidateInterface
-  class Volunteering::ReviewController < SectionController
+  class Volunteering::ReviewController < Volunteering::BaseController
     before_action :redirect_to_dashboard_if_submitted
 
     def show

--- a/app/controllers/concerns/accept_offer_confirm_references.rb
+++ b/app/controllers/concerns/accept_offer_confirm_references.rb
@@ -4,6 +4,7 @@ module AcceptOfferConfirmReferences
   included do
     skip_before_action :redirect_to_dashboard_if_submitted
     skip_before_action :redirect_to_review_page_unless_reference_is_editable, raise: false
+    skip_before_action :redirect_to_your_details_non_editable_sections
     before_action :application_choice
     before_action :check_that_candidate_can_accept
     before_action :check_that_candidate_has_an_offer

--- a/app/controllers/concerns/accept_offer_confirm_references.rb
+++ b/app/controllers/concerns/accept_offer_confirm_references.rb
@@ -4,7 +4,7 @@ module AcceptOfferConfirmReferences
   included do
     skip_before_action :redirect_to_dashboard_if_submitted
     skip_before_action :redirect_to_review_page_unless_reference_is_editable, raise: false
-    skip_before_action :redirect_to_your_details_non_editable_sections
+    skip_before_action :verify_authorized_section
     before_action :application_choice
     before_action :check_that_candidate_can_accept
     before_action :check_that_candidate_has_an_offer

--- a/app/services/candidate_interface/editable_section.rb
+++ b/app/services/candidate_interface/editable_section.rb
@@ -1,0 +1,34 @@
+module CandidateInterface
+  class EditableSection
+    include ActiveModel::Model
+    attr_accessor :current_application, :controller_path, :action_name, :params
+
+    Section = Struct.new(:controller, :conditions, keyword_init: true)
+
+    def self.all
+      [
+        Section.new(controller: 'CandidateInterface::PersonalDetails'),
+        Section.new(controller: 'CandidateInterface::ContactDetails'),
+        Section.new(controller: 'CandidateInterface::TrainingWithADisability'),
+        Section.new(controller: 'CandidateInterface::InterviewAvailability'),
+        Section.new(controller: 'CandidateInterface::EqualityAndDiversity'),
+        Section.new(controller: 'CandidateInterface::PersonalStatement'),
+        #      'candidate_interface/gsce/review' => { conditions: { subject: 'science', status: :unsubmitted } },
+      ]
+    end
+
+    def can_edit?
+      all_applications_unsubmitted? || editable_section?
+    end
+
+    def all_applications_unsubmitted?
+      current_application.application_choices.all?(&:unsubmitted?)
+    end
+
+    def editable_section?
+      EditableSection.all.any? do |section|
+        @controller_path.classify =~ /#{section.controller}/
+      end
+    end
+  end
+end

--- a/app/services/candidate_interface/editable_section.rb
+++ b/app/services/candidate_interface/editable_section.rb
@@ -18,8 +18,10 @@ module CandidateInterface
     end
 
     def can_edit?
-      all_applications_unsubmitted? || editable_section?
+      any_offer_accepted? || all_applications_unsubmitted? || editable_section?
     end
+
+    delegate :any_offer_accepted?, to: :current_application
 
     def all_applications_unsubmitted?
       current_application.application_choices.all?(&:unsubmitted?)

--- a/app/services/candidate_interface/section.rb
+++ b/app/services/candidate_interface/section.rb
@@ -10,9 +10,9 @@ module CandidateInterface
     def science_gcse?(policy)
       params = policy.params
       current_application = policy.current_application
+      subject = params[:subject]
 
-      params[:subject] &&
-        params[:subject] == 'science' &&
+      ((subject && subject == 'science') || policy.controller_path.include?('candidate_interface/gcse/science')) &&
         current_application
           .application_choices
           .select(&:science_gcse_needed?)

--- a/app/services/candidate_interface/section.rb
+++ b/app/services/candidate_interface/section.rb
@@ -1,0 +1,22 @@
+module CandidateInterface
+  class Section
+    attr_accessor :controller, :condition
+
+    def initialize(controller:, condition: nil)
+      @controller = controller
+      @condition = condition
+    end
+
+    def science_gcse?(policy)
+      params = policy.params
+      current_application = policy.current_application
+
+      params[:subject] &&
+        params[:subject] == 'science' &&
+        current_application
+          .application_choices
+          .select(&:science_gcse_needed?)
+          .all?(&:unsubmitted?)
+    end
+  end
+end

--- a/app/services/candidate_interface/section_policy.rb
+++ b/app/services/candidate_interface/section_policy.rb
@@ -21,6 +21,7 @@ module CandidateInterface
           controller: 'CandidateInterface::Gcse',
           condition: ->(section, policy) { section.science_gcse?(policy) },
         ),
+        Section.new(controller: 'CandidateInterface::EnglishForeignLanguage'),
       ]
     end
 

--- a/app/views/candidate_interface/application_choices/review.html.erb
+++ b/app/views/candidate_interface/application_choices/review.html.erb
@@ -22,12 +22,12 @@
         <%= render CandidateInterface::CourseChoicesReviewComponent.new(application_form: @application_form) %>
 
         <%= render(CandidateInterface::CompleteSectionComponent.new(
+          editable_section: OpenStruct.new(can_edit?: true),
           form: f,
           hint_text: if current_application.choices_left_to_make.positive?
                        t('application_form.courses.complete.hint_text', count: current_application.choices_left_to_make)
                      end,
         )) %>
-        <%= f.govuk_submit t('continue') %>
       <%# end %>
     </div>
   </div>

--- a/app/views/candidate_interface/application_choices/review.html.erb
+++ b/app/views/candidate_interface/application_choices/review.html.erb
@@ -22,7 +22,7 @@
         <%= render CandidateInterface::CourseChoicesReviewComponent.new(application_form: @application_form) %>
 
         <%= render(CandidateInterface::CompleteSectionComponent.new(
-          editable_section: OpenStruct.new(can_edit?: true),
+          editable_section: @editable_section,
           form: f,
           hint_text: if current_application.choices_left_to_make.positive?
                        t('application_form.courses.complete.hint_text', count: current_application.choices_left_to_make)

--- a/app/views/candidate_interface/application_choices/review.html.erb
+++ b/app/views/candidate_interface/application_choices/review.html.erb
@@ -22,7 +22,7 @@
         <%= render CandidateInterface::CourseChoicesReviewComponent.new(application_form: @application_form) %>
 
         <%= render(CandidateInterface::CompleteSectionComponent.new(
-          editable_section: @editable_section,
+          section_policy: @section_policy,
           form: f,
           hint_text: if current_application.choices_left_to_make.positive?
                        t('application_form.courses.complete.hint_text', count: current_application.choices_left_to_make)

--- a/app/views/candidate_interface/contact_details/review/show.html.erb
+++ b/app/views/candidate_interface/contact_details/review/show.html.erb
@@ -11,11 +11,11 @@
     <%= t('page_titles.contact_information') %>
   </h1>
 
-  <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application:) %>
+  <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
 
-  <%= render CandidateInterface::ContactDetailsReviewComponent.new(editable: @editable_section.can_edit?, application_form: @application_form) %>
+  <%= render CandidateInterface::ContactDetailsReviewComponent.new(editable: @section_policy.can_edit?, application_form: @application_form) %>
 
   <% if @can_complete %>
-    <%= render CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f) %>
+    <%= render CandidateInterface::CompleteSectionComponent.new(section_policy: @section_policy, form: f) %>
   <% end %>
 <% end %>

--- a/app/views/candidate_interface/contact_details/review/show.html.erb
+++ b/app/views/candidate_interface/contact_details/review/show.html.erb
@@ -11,10 +11,9 @@
     <%= t('page_titles.contact_information') %>
   </h1>
 
-  <%= render CandidateInterface::ContactDetailsReviewComponent.new(application_form: @application_form) %>
+  <%= render CandidateInterface::ContactDetailsReviewComponent.new(editable: @editable_section.can_edit?, application_form: @application_form) %>
 
   <% if @can_complete %>
-    <%= render CandidateInterface::CompleteSectionComponent.new(form: f) %>
-    <%= f.govuk_submit t('continue') %>
+    <%= render CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f) %>
   <% end %>
 <% end %>

--- a/app/views/candidate_interface/contact_details/review/show.html.erb
+++ b/app/views/candidate_interface/contact_details/review/show.html.erb
@@ -11,6 +11,8 @@
     <%= t('page_titles.contact_information') %>
   </h1>
 
+  <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application:) %>
+
   <%= render CandidateInterface::ContactDetailsReviewComponent.new(editable: @editable_section.can_edit?, application_form: @application_form) %>
 
   <% if @can_complete %>

--- a/app/views/candidate_interface/degrees/review/show.html.erb
+++ b/app/views/candidate_interface/degrees/review/show.html.erb
@@ -9,18 +9,18 @@
         <%= t('page_titles.degree') %>
       </fieldset>
 
-      <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application: @application_form) %>
+      <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application: @application_form) %>
 
       <% degree_empty_component = CandidateInterface::DegreeEmptyComponent.new(application_form: @application_form) %>
-      <% unless degree_empty_component.render? || !@editable_section.can_edit? %>
+      <% unless degree_empty_component.render? || !@section_policy.can_edit? %>
         <%= govuk_button_link_to t('application_form.degree.another.button'), candidate_interface_degree_country_path(context: :new_degree), secondary: true %>
       <% end %>
     </div>
   </div>
 
   <%= render degree_empty_component %>
-  <%= render CandidateInterface::DegreeReviewComponent.new(application_form: @application_form, editable: @editable_section.can_edit?) %>
+  <%= render CandidateInterface::DegreeReviewComponent.new(application_form: @application_form, editable: @section_policy.can_edit?) %>
   <% unless degree_empty_component.render? %>
-    <%= render CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f, hint_text: t('application_form.degree.review.complete_hint_text')) %>
+    <%= render CandidateInterface::CompleteSectionComponent.new(section_policy: @section_policy, form: f, hint_text: t('application_form.degree.review.complete_hint_text')) %>
   <% end %>
 <% end %>

--- a/app/views/candidate_interface/degrees/review/show.html.erb
+++ b/app/views/candidate_interface/degrees/review/show.html.erb
@@ -9,7 +9,7 @@
         <%= t('page_titles.degree') %>
       </fieldset>
 
-      <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application:) %>
+      <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application: @application_form) %>
 
       <% degree_empty_component = CandidateInterface::DegreeEmptyComponent.new(application_form: @application_form) %>
       <% unless degree_empty_component.render? || !@editable_section.can_edit? %>

--- a/app/views/candidate_interface/degrees/review/show.html.erb
+++ b/app/views/candidate_interface/degrees/review/show.html.erb
@@ -9,6 +9,8 @@
         <%= t('page_titles.degree') %>
       </fieldset>
 
+      <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application:) %>
+
       <% degree_empty_component = CandidateInterface::DegreeEmptyComponent.new(application_form: @application_form) %>
       <% unless degree_empty_component.render? %>
         <%= govuk_button_link_to t('application_form.degree.another.button'), candidate_interface_degree_country_path(context: :new_degree), secondary: true %>

--- a/app/views/candidate_interface/degrees/review/show.html.erb
+++ b/app/views/candidate_interface/degrees/review/show.html.erb
@@ -12,7 +12,7 @@
       <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application:) %>
 
       <% degree_empty_component = CandidateInterface::DegreeEmptyComponent.new(application_form: @application_form) %>
-      <% unless degree_empty_component.render? %>
+      <% unless degree_empty_component.render? || !@editable_section.can_edit? %>
         <%= govuk_button_link_to t('application_form.degree.another.button'), candidate_interface_degree_country_path(context: :new_degree), secondary: true %>
       <% end %>
     </div>

--- a/app/views/candidate_interface/degrees/review/show.html.erb
+++ b/app/views/candidate_interface/degrees/review/show.html.erb
@@ -17,9 +17,8 @@
   </div>
 
   <%= render degree_empty_component %>
-  <%= render CandidateInterface::DegreeReviewComponent.new(application_form: @application_form) %>
+  <%= render CandidateInterface::DegreeReviewComponent.new(application_form: @application_form, editable: @editable_section.can_edit?) %>
   <% unless degree_empty_component.render? %>
-    <%= render CandidateInterface::CompleteSectionComponent.new(form: f, hint_text: t('application_form.degree.review.complete_hint_text')) %>
-    <%= f.govuk_submit t('continue') %>
+    <%= render CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f, hint_text: t('application_form.degree.review.complete_hint_text')) %>
   <% end %>
 <% end %>

--- a/app/views/candidate_interface/english_foreign_language/review/show.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/review/show.html.erb
@@ -6,7 +6,7 @@
 
   <h1 class="govuk-heading-xl"><%= t('page_titles.efl.review') %></h1>
 
-  <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application:) %>
+  <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
   <%= render @component_instance %>
-  <%= render CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f) %>
+  <%= render CandidateInterface::CompleteSectionComponent.new(section_policy: @section_policy, form: f) %>
 <% end %>

--- a/app/views/candidate_interface/english_foreign_language/review/show.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/review/show.html.erb
@@ -7,6 +7,5 @@
   <h1 class="govuk-heading-xl"><%= t('page_titles.efl.review') %></h1>
 
   <%= render @component_instance %>
-  <%= render CandidateInterface::CompleteSectionComponent.new(form: f) %>
-  <%= f.govuk_submit t('continue') %>
+  <%= render CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f) %>
 <% end %>

--- a/app/views/candidate_interface/english_foreign_language/review/show.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/review/show.html.erb
@@ -6,6 +6,7 @@
 
   <h1 class="govuk-heading-xl"><%= t('page_titles.efl.review') %></h1>
 
+  <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application:) %>
   <%= render @component_instance %>
   <%= render CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f) %>
 <% end %>

--- a/app/views/candidate_interface/equality_and_diversity/review.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/review.html.erb
@@ -11,6 +11,7 @@
         Check your answers
       </h1>
 
+      <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application:) %>
       <%= render(CandidateInterface::EqualityAndDiversityReviewComponent.new(application_form: @current_application, editable: @editable_section.can_edit?)) %>
       <% if @current_application.equality_and_diversity_answers_provided? %>
         <%= render CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f) %>

--- a/app/views/candidate_interface/equality_and_diversity/review.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/review.html.erb
@@ -11,11 +11,10 @@
         Check your answers
       </h1>
 
-      <%= render(CandidateInterface::EqualityAndDiversityReviewComponent.new(application_form: @current_application)) %>
+      <%= render(CandidateInterface::EqualityAndDiversityReviewComponent.new(application_form: @current_application, editable: @editable_section.can_edit?)) %>
       <% if @current_application.equality_and_diversity_answers_provided? %>
-        <%= render CandidateInterface::CompleteSectionComponent.new(form: f) %>
-      <%= f.govuk_submit t('continue') %>
-    <% end %>
+        <%= render CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f) %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/equality_and_diversity/review.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/review.html.erb
@@ -11,10 +11,10 @@
         Check your answers
       </h1>
 
-      <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application:) %>
-      <%= render(CandidateInterface::EqualityAndDiversityReviewComponent.new(application_form: @current_application, editable: @editable_section.can_edit?)) %>
+      <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
+      <%= render(CandidateInterface::EqualityAndDiversityReviewComponent.new(application_form: @current_application, editable: @section_policy.can_edit?)) %>
       <% if @current_application.equality_and_diversity_answers_provided? %>
-        <%= render CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f) %>
+        <%= render CandidateInterface::CompleteSectionComponent.new(section_policy: @section_policy, form: f) %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/gcse/review/show.html.erb
+++ b/app/views/candidate_interface/gcse/review/show.html.erb
@@ -6,14 +6,14 @@
 
   <h1 class="govuk-heading-xl"><%= t("gcse_summary.page_titles.#{@subject}") %></h1>
 
-  <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application:) %>
+  <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
 
   <%= render CandidateInterface::GcseQualificationReviewComponent.new(
     application_form: @application_form,
     application_qualification: @application_qualification,
     subject: @subject,
-    editable: @editable_section.can_edit?,
+    editable: @section_policy.can_edit?,
   ) %>
 
-  <%= render CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f) %>
+  <%= render CandidateInterface::CompleteSectionComponent.new(section_policy: @section_policy, form: f) %>
 <% end %>

--- a/app/views/candidate_interface/gcse/review/show.html.erb
+++ b/app/views/candidate_interface/gcse/review/show.html.erb
@@ -10,9 +10,8 @@
     application_form: @application_form,
     application_qualification: @application_qualification,
     subject: @subject,
+    editable: @editable_section.can_edit?,
   ) %>
 
-  <%= render CandidateInterface::CompleteSectionComponent.new(form: f) %>
-
-  <%= f.govuk_submit t('continue') %>
+  <%= render CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f) %>
 <% end %>

--- a/app/views/candidate_interface/gcse/review/show.html.erb
+++ b/app/views/candidate_interface/gcse/review/show.html.erb
@@ -6,6 +6,8 @@
 
   <h1 class="govuk-heading-xl"><%= t("gcse_summary.page_titles.#{@subject}") %></h1>
 
+  <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application:) %>
+
   <%= render CandidateInterface::GcseQualificationReviewComponent.new(
     application_form: @application_form,
     application_qualification: @application_qualification,

--- a/app/views/candidate_interface/interview_availability/show.html.erb
+++ b/app/views/candidate_interface/interview_availability/show.html.erb
@@ -8,6 +8,7 @@
     <%= t('page_titles.interview_preferences.heading') %>
   </h1>
 
+  <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application:) %>
   <%= render CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: @application_form, editable: @editable_section.can_edit?) %>
   <%= render CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f) %>
 <% end %>

--- a/app/views/candidate_interface/interview_availability/show.html.erb
+++ b/app/views/candidate_interface/interview_availability/show.html.erb
@@ -8,8 +8,6 @@
     <%= t('page_titles.interview_preferences.heading') %>
   </h1>
 
-  <%= render CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: @application_form) %>
-  <%= render CandidateInterface::CompleteSectionComponent.new(form: f) %>
-
-  <%= f.govuk_submit t('continue') %>
+  <%= render CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: @application_form, editable: @editable_section.can_edit?) %>
+  <%= render CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f) %>
 <% end %>

--- a/app/views/candidate_interface/interview_availability/show.html.erb
+++ b/app/views/candidate_interface/interview_availability/show.html.erb
@@ -8,7 +8,7 @@
     <%= t('page_titles.interview_preferences.heading') %>
   </h1>
 
-  <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application:) %>
-  <%= render CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: @application_form, editable: @editable_section.can_edit?) %>
-  <%= render CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f) %>
+  <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
+  <%= render CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: @application_form, editable: @section_policy.can_edit?) %>
+  <%= render CandidateInterface::CompleteSectionComponent.new(section_policy: @section_policy, form: f) %>
 <% end %>

--- a/app/views/candidate_interface/other_qualifications/review/show.html.erb
+++ b/app/views/candidate_interface/other_qualifications/review/show.html.erb
@@ -8,8 +8,6 @@
     <%= other_qualifications_title(@application_form) %>
   </h1>
 
-  <%= render CandidateInterface::OtherQualificationsReviewComponent.new(application_form: @application_form) %>
-  <%= render CandidateInterface::CompleteSectionComponent.new(form: f) %>
-
-  <%= f.govuk_submit t('continue') %>
+  <%= render CandidateInterface::OtherQualificationsReviewComponent.new(application_form: @application_form, editable: @editable_section.can_edit?) %>
+  <%= render CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f) %>
 <% end %>

--- a/app/views/candidate_interface/other_qualifications/review/show.html.erb
+++ b/app/views/candidate_interface/other_qualifications/review/show.html.erb
@@ -8,7 +8,7 @@
     <%= other_qualifications_title(@application_form) %>
   </h1>
 
-  <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application:) %>
-  <%= render CandidateInterface::OtherQualificationsReviewComponent.new(application_form: @application_form, editable: @editable_section.can_edit?) %>
-  <%= render CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f) %>
+  <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
+  <%= render CandidateInterface::OtherQualificationsReviewComponent.new(application_form: @application_form, editable: @section_policy.can_edit?) %>
+  <%= render CandidateInterface::CompleteSectionComponent.new(section_policy: @section_policy, form: f) %>
 <% end %>

--- a/app/views/candidate_interface/other_qualifications/review/show.html.erb
+++ b/app/views/candidate_interface/other_qualifications/review/show.html.erb
@@ -8,6 +8,7 @@
     <%= other_qualifications_title(@application_form) %>
   </h1>
 
+  <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application:) %>
   <%= render CandidateInterface::OtherQualificationsReviewComponent.new(application_form: @application_form, editable: @editable_section.can_edit?) %>
   <%= render CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f) %>
 <% end %>

--- a/app/views/candidate_interface/personal_details/review/show.html.erb
+++ b/app/views/candidate_interface/personal_details/review/show.html.erb
@@ -13,7 +13,6 @@
   </h1>
 
   <%= render SummaryCardComponent.new(rows: @personal_details_review.rows) %>
-  <%= render CandidateInterface::CompleteSectionComponent.new(form: f) %>
 
-  <%= f.govuk_submit t('continue') %>
+  <%= render CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f) %>
 <% end %>

--- a/app/views/candidate_interface/personal_details/review/show.html.erb
+++ b/app/views/candidate_interface/personal_details/review/show.html.erb
@@ -12,9 +12,9 @@
     <%= t('page_titles.personal_information.heading') %>
   </h1>
 
-  <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application:) %>
+  <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
 
   <%= render SummaryCardComponent.new(rows: @personal_details_review.rows) %>
 
-  <%= render CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f) %>
+  <%= render CandidateInterface::CompleteSectionComponent.new(section_policy: @section_policy, form: f) %>
 <% end %>

--- a/app/views/candidate_interface/personal_details/review/show.html.erb
+++ b/app/views/candidate_interface/personal_details/review/show.html.erb
@@ -12,6 +12,8 @@
     <%= t('page_titles.personal_information.heading') %>
   </h1>
 
+  <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application:) %>
+
   <%= render SummaryCardComponent.new(rows: @personal_details_review.rows) %>
 
   <%= render CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f) %>

--- a/app/views/candidate_interface/personal_statement/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/show.html.erb
@@ -47,11 +47,11 @@
     </div>
   <% end %>
 
-  <%= render(CandidateInterface::BecomingATeacherReviewComponent.new(application_form: @application_form, editable: @editable_section.can_edit?)) %>
+  <%= render(CandidateInterface::BecomingATeacherReviewComponent.new(application_form: @application_form, editable: @section_policy.can_edit?)) %>
 
   <% if @becoming_a_teacher_form.valid? %>
     <%= render(CandidateInterface::CompleteSectionComponent.new(
-      editable_section: @editable_section,
+      section_policy: @section_policy,
       form: f,
       hint_text: t('application_form.personal_statement.becoming_a_teacher.complete_hint_text'),
       section_review: @application_form.reviewable?(:becoming_a_teacher),

--- a/app/views/candidate_interface/personal_statement/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/show.html.erb
@@ -47,15 +47,15 @@
     </div>
   <% end %>
 
-  <%= render(CandidateInterface::BecomingATeacherReviewComponent.new(application_form: @application_form)) %>
+  <%= render(CandidateInterface::BecomingATeacherReviewComponent.new(application_form: @application_form, editable: @editable_section.can_edit?)) %>
 
   <% if @becoming_a_teacher_form.valid? %>
     <%= render(CandidateInterface::CompleteSectionComponent.new(
+      editable_section: @editable_section,
       form: f,
       hint_text: t('application_form.personal_statement.becoming_a_teacher.complete_hint_text'),
       section_review: @application_form.reviewable?(:becoming_a_teacher),
     )) %>
-    <%= f.govuk_submit t('continue') %>
   <% else %>
     <%= govuk_button_link_to 'Continue', candidate_interface_application_form_path %>
   <% end %>

--- a/app/views/candidate_interface/references/review/show.html.erb
+++ b/app/views/candidate_interface/references/review/show.html.erb
@@ -9,22 +9,22 @@
         <%= t('page_titles.references') %>
       </h1>
 
-      <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application:) %>
+      <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
 
-      <%= render CandidateInterface::AddNewReferenceComponent.new(current_application:, editable_section: @editable_section) %>
+      <%= render CandidateInterface::AddNewReferenceComponent.new(current_application:, section_policy: @section_policy) %>
     </div>
   </div>
 
   <%= render(
     CandidateInterface::ReferencesReviewComponent.new(
       application_form: current_application,
-      editable: @editable_section.can_edit?,
+      editable: @section_policy.can_edit?,
       references: @references,
       heading_level: 3,
     ),
   ) %>
 
   <% if current_application.complete_references_information? %>
-    <%= render CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f) %>
+    <%= render CandidateInterface::CompleteSectionComponent.new(section_policy: @section_policy, form: f) %>
   <% end %>
 <% end %>

--- a/app/views/candidate_interface/references/review/show.html.erb
+++ b/app/views/candidate_interface/references/review/show.html.erb
@@ -9,6 +9,8 @@
         <%= t('page_titles.references') %>
       </h1>
 
+      <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application:) %>
+
       <%= render CandidateInterface::AddNewReferenceComponent.new(current_application) %>
     </div>
   </div>

--- a/app/views/candidate_interface/references/review/show.html.erb
+++ b/app/views/candidate_interface/references/review/show.html.erb
@@ -11,7 +11,7 @@
 
       <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application:) %>
 
-      <%= render CandidateInterface::AddNewReferenceComponent.new(current_application) %>
+      <%= render CandidateInterface::AddNewReferenceComponent.new(current_application:, editable_section: @editable_section) %>
     </div>
   </div>
 

--- a/app/views/candidate_interface/references/review/show.html.erb
+++ b/app/views/candidate_interface/references/review/show.html.erb
@@ -16,14 +16,13 @@
   <%= render(
     CandidateInterface::ReferencesReviewComponent.new(
       application_form: current_application,
-      editable: true,
+      editable: @editable_section.can_edit?,
       references: @references,
       heading_level: 3,
     ),
   ) %>
 
   <% if current_application.complete_references_information? %>
-    <%= render CandidateInterface::CompleteSectionComponent.new(form: f) %>
-    <%= f.govuk_submit t('continue') %>
+    <%= render CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f) %>
   <% end %>
 <% end %>

--- a/app/views/candidate_interface/restructured_work_history/review/show.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/review/show.html.erb
@@ -6,6 +6,8 @@
 
   <h1 class="govuk-heading-xl"><%= t('page_titles.work_history') %></h1>
 
+  <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application:) %>
+
   <% if @application_form.can_complete? %>
     <div class="govuk-!-width-two-thirds">
       <p class="govuk-body">Enter all the jobs you’ve had since you left school.</p>

--- a/app/views/candidate_interface/restructured_work_history/review/show.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/review/show.html.erb
@@ -6,7 +6,7 @@
 
   <h1 class="govuk-heading-xl"><%= t('page_titles.work_history') %></h1>
 
-  <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application:) %>
+  <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
 
   <% if @application_form.can_complete? %>
     <div class="govuk-!-width-two-thirds">
@@ -24,10 +24,10 @@
   <% end %>
 
   <% unless @application_form.can_complete? && @application_form.application_work_experiences.blank? %>
-    <%= render RestructuredWorkHistory::ReviewComponent.new(application_form: @application_form, editable: @editable_section.can_edit?) %>
+    <%= render RestructuredWorkHistory::ReviewComponent.new(application_form: @application_form, editable: @section_policy.can_edit?) %>
 
     <%= render(CandidateInterface::CompleteSectionComponent.new(
-      editable_section: @editable_section,
+      section_policy: @section_policy,
       form: f,
     )) %>
   <% end %>

--- a/app/views/candidate_interface/restructured_work_history/review/show.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/review/show.html.erb
@@ -22,13 +22,12 @@
   <% end %>
 
   <% unless @application_form.can_complete? && @application_form.application_work_experiences.blank? %>
-    <%= render RestructuredWorkHistory::ReviewComponent.new(application_form: @application_form) %>
+    <%= render RestructuredWorkHistory::ReviewComponent.new(application_form: @application_form, editable: @editable_section.can_edit?) %>
 
     <%= render(CandidateInterface::CompleteSectionComponent.new(
+      editable_section: @editable_section,
       form: f,
     )) %>
-
-    <%= f.govuk_submit t('continue') %>
   <% end %>
 
 <% end %>

--- a/app/views/candidate_interface/safeguarding/show.html.erb
+++ b/app/views/candidate_interface/safeguarding/show.html.erb
@@ -8,7 +8,7 @@
     <%= t('page_titles.suitability_to_work_with_children') %>
   </h1>
 
-  <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application:) %>
-  <%= render CandidateInterface::SafeguardingReviewComponent.new(application_form: @current_application, editable: @editable_section.can_edit?) %>
-  <%= render CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f) %>
+  <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
+  <%= render CandidateInterface::SafeguardingReviewComponent.new(application_form: @current_application, editable: @section_policy.can_edit?) %>
+  <%= render CandidateInterface::CompleteSectionComponent.new(section_policy: @section_policy, form: f) %>
 <% end %>

--- a/app/views/candidate_interface/safeguarding/show.html.erb
+++ b/app/views/candidate_interface/safeguarding/show.html.erb
@@ -8,7 +8,6 @@
     <%= t('page_titles.suitability_to_work_with_children') %>
   </h1>
 
-  <%= render CandidateInterface::SafeguardingReviewComponent.new(application_form: @current_application) %>
-  <%= render CandidateInterface::CompleteSectionComponent.new(form: f) %>
-  <%= f.govuk_submit t('continue') %>
+  <%= render CandidateInterface::SafeguardingReviewComponent.new(application_form: @current_application, editable: @editable_section.can_edit?) %>
+  <%= render CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f) %>
 <% end %>

--- a/app/views/candidate_interface/safeguarding/show.html.erb
+++ b/app/views/candidate_interface/safeguarding/show.html.erb
@@ -8,6 +8,7 @@
     <%= t('page_titles.suitability_to_work_with_children') %>
   </h1>
 
+  <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application:) %>
   <%= render CandidateInterface::SafeguardingReviewComponent.new(application_form: @current_application, editable: @editable_section.can_edit?) %>
   <%= render CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f) %>
 <% end %>

--- a/app/views/candidate_interface/subject_knowledge/show.html.erb
+++ b/app/views/candidate_interface/subject_knowledge/show.html.erb
@@ -41,11 +41,11 @@
 
   <% if @subject_knowledge_form.valid? %>
     <%= render(CandidateInterface::CompleteSectionComponent.new(
+      editable_section: @editable_section,
       form: f,
       section_review: @application_form.reviewable?(:subject_knowledge),
       hint_text: t('application_form.personal_statement.subject_knowledge.complete_hint_text'),
     )) %>
-    <%= f.govuk_submit t('continue') %>
   <% else %>
     <%= govuk_button_link_to 'Continue', candidate_interface_application_form_path %>
   <% end %>

--- a/app/views/candidate_interface/subject_knowledge/show.html.erb
+++ b/app/views/candidate_interface/subject_knowledge/show.html.erb
@@ -41,7 +41,7 @@
 
   <% if @subject_knowledge_form.valid? %>
     <%= render(CandidateInterface::CompleteSectionComponent.new(
-      editable_section: @editable_section,
+      section_policy: @section_policy,
       form: f,
       section_review: @application_form.reviewable?(:subject_knowledge),
       hint_text: t('application_form.personal_statement.subject_knowledge.complete_hint_text'),

--- a/app/views/candidate_interface/training_with_a_disability/show.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/show.html.erb
@@ -8,6 +8,7 @@
     <%= t('page_titles.training_with_a_disability') %>
   </h1>
 
+  <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application:) %>
   <%= render CandidateInterface::TrainingWithADisabilityReviewComponent.new(editable: @editable_section.can_edit?, application_form: @application_form) %>
   <%= render CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f) %>
 <% end %>

--- a/app/views/candidate_interface/training_with_a_disability/show.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/show.html.erb
@@ -8,8 +8,6 @@
     <%= t('page_titles.training_with_a_disability') %>
   </h1>
 
-  <%= render CandidateInterface::TrainingWithADisabilityReviewComponent.new(application_form: @application_form) %>
-  <%= render CandidateInterface::CompleteSectionComponent.new(form: f) %>
-
-  <%= f.govuk_submit t('continue') %>
+  <%= render CandidateInterface::TrainingWithADisabilityReviewComponent.new(editable: @editable_section.can_edit?, application_form: @application_form) %>
+  <%= render CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f) %>
 <% end %>

--- a/app/views/candidate_interface/training_with_a_disability/show.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/show.html.erb
@@ -8,7 +8,7 @@
     <%= t('page_titles.training_with_a_disability') %>
   </h1>
 
-  <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application:) %>
-  <%= render CandidateInterface::TrainingWithADisabilityReviewComponent.new(editable: @editable_section.can_edit?, application_form: @application_form) %>
-  <%= render CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f) %>
+  <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
+  <%= render CandidateInterface::TrainingWithADisabilityReviewComponent.new(editable: @section_policy.can_edit?, application_form: @application_form) %>
+  <%= render CandidateInterface::CompleteSectionComponent.new(section_policy: @section_policy, form: f) %>
 <% end %>

--- a/app/views/candidate_interface/volunteering/review/show.html.erb
+++ b/app/views/candidate_interface/volunteering/review/show.html.erb
@@ -9,8 +9,6 @@
     <%= govuk_button_link_to(t('application_form.volunteering.another.button'), candidate_interface_new_volunteering_role_path, secondary: true) %>
   <% end %>
 
-  <%= render CandidateInterface::VolunteeringReviewComponent.new(application_form: @application_form, show_experience_advice: true) %>
-  <%= render(CandidateInterface::CompleteSectionComponent.new(form: f)) %>
-
-  <%= f.govuk_submit t('continue') %>
+  <%= render CandidateInterface::VolunteeringReviewComponent.new(application_form: @application_form, show_experience_advice: true, editable: @editable_section.can_edit?) %>
+  <%= render(CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f)) %>
 <% end %>

--- a/app/views/candidate_interface/volunteering/review/show.html.erb
+++ b/app/views/candidate_interface/volunteering/review/show.html.erb
@@ -6,12 +6,12 @@
 
   <h1 class="govuk-heading-xl"><%= t('page_titles.volunteering.short') %></h1>
 
-  <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application:) %>
+  <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
 
-  <% if @application_form.application_volunteering_experiences.any? && @editable_section.can_edit? %>
+  <% if @application_form.application_volunteering_experiences.any? && @section_policy.can_edit? %>
     <%= govuk_button_link_to(t('application_form.volunteering.another.button'), candidate_interface_new_volunteering_role_path, secondary: true) %>
   <% end %>
 
-  <%= render CandidateInterface::VolunteeringReviewComponent.new(application_form: @application_form, show_experience_advice: true, editable: @editable_section.can_edit?) %>
-  <%= render(CandidateInterface::CompleteSectionComponent.new(editable_section: @editable_section, form: f)) %>
+  <%= render CandidateInterface::VolunteeringReviewComponent.new(application_form: @application_form, show_experience_advice: true, editable: @section_policy.can_edit?) %>
+  <%= render(CandidateInterface::CompleteSectionComponent.new(section_policy: @section_policy, form: f)) %>
 <% end %>

--- a/app/views/candidate_interface/volunteering/review/show.html.erb
+++ b/app/views/candidate_interface/volunteering/review/show.html.erb
@@ -8,7 +8,7 @@
 
   <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application:) %>
 
-  <% if @application_form.application_volunteering_experiences.any? %>
+  <% if @application_form.application_volunteering_experiences.any? && @editable_section.can_edit? %>
     <%= govuk_button_link_to(t('application_form.volunteering.another.button'), candidate_interface_new_volunteering_role_path, secondary: true) %>
   <% end %>
 

--- a/app/views/candidate_interface/volunteering/review/show.html.erb
+++ b/app/views/candidate_interface/volunteering/review/show.html.erb
@@ -5,6 +5,9 @@
   <%= f.govuk_error_summary %>
 
   <h1 class="govuk-heading-xl"><%= t('page_titles.volunteering.short') %></h1>
+
+  <%= render CandidateInterface::EditableSectionWarning.new(editable_section: @editable_section, current_application:) %>
+
   <% if @application_form.application_volunteering_experiences.any? %>
     <%= govuk_button_link_to(t('application_form.volunteering.another.button'), candidate_interface_new_volunteering_role_path, secondary: true) %>
   <% end %>

--- a/docs/editable_sections.md
+++ b/docs/editable_sections.md
@@ -1,4 +1,4 @@
-# Sections
+# Editable Sections ideas
 
 Hard coded approach:
 

--- a/sections.md
+++ b/sections.md
@@ -1,7 +1,8 @@
 # Sections
 
-1. Approach hard coded sections
+Hard coded approach:
 
+```ruby
 class EditableSections
   EDITABLE_SECTIONS = {
     'candidate_interface/personal_details' => {},
@@ -20,24 +21,24 @@ class EditableSections
     # ...
   end
 end
+```
 
-views / components
+## Views / components
 
 Makes  CandidateInterface::CompleteSectionComponent to use editable params that
 calls the EditableSections class
 
 Also uses the same to not render the change links on the review pages of
 sections
-
+```
 if this_section_is_editable?
   show the section complete
 else
   show the contact support content
 end
+```
 
-controllers
-
-Uses the same to not render the change
+## Controllers
 
 But we need how to add the filter:
 
@@ -49,10 +50,13 @@ dashboard)
 and add to the ones that doesn't contain base controllers
 3. Create a SectionController and inherit all base controllers and etc (problem more inheritance)
 
-before filters that if
-the candidate submitted and the they trying to go mannually and edit we should
-redirect (maybe checking for the section name && the action name because we
-should allow the show action for all sections)
+before filters that if:
+
+* the candidate submitted and
+* they trying to go mannually and edit
+
+Maybe checking for the section name && the action name because we
+should allow the show action for all sections
 
 ## Editable sections
 

--- a/sections.md
+++ b/sections.md
@@ -6,7 +6,7 @@ class EditableSections
   EDITABLE_SECTIONS = {
     'candidate_interface/personal_details' => {},
     'candidate_interface/contact_details' => {},
-    'candidate_interface/gsce/review' => { params: { subject: 'science' } } },
+    'candidate_interface/gsce/review' => { conditions: { subject: 'science' } } },
   }
 
   def initialize(application_form:, controller_path:, action:, params: {})
@@ -53,11 +53,6 @@ before filters that if
 the candidate submitted and the they trying to go mannually and edit we should
 redirect (maybe checking for the section name && the action name because we
 should allow the show action for all sections)
-
-# Edge case
-
-Science GSCE
-We might need to the normal checks BUT also the params[:subject]
 
 ## Editable sections
 
@@ -167,6 +162,9 @@ CandidateInterface::Degrees::ReviewController#complete
 
 ## Edge cases
 
-app/controllers/candidate_interface/references/accept_offer/
-Adding references after accepting an offer should not have any filter to
-editable sections
+* Adding references after accepting an offer should not have any filter to
+    app/controllers/candidate_interface/references/accept_offer/
+    editable sections
+
+* Science GSCE
+    We might need to the normal checks BUT also the params[:subject]

--- a/sections.md
+++ b/sections.md
@@ -1,28 +1,33 @@
 # Sections
 
-
 1. Approach hard coded sections
 
-class or module EditableSections
+class EditableSections
+  EDITABLE_SECTIONS = {
+    'candidate_interface/personal_details' => {},
+    'candidate_interface/contact_details' => {},
+    'candidate_interface/gsce/review' => { params: { subject: 'science' } } },
+  }
 
-def initialize(application_form:, controller_name:)
-  can :edit, sections: [
-    CandidateInterface::PersonalDetails,
-    CandidateInterface::ContactDetails,
-  ]
-  can :edit, section: CandidateInterface::ContactDetails
-end
+  def initialize(application_form:, controller_path:, action:, params: {})
+  end
 
-editable_sections = {
-  personal_details: CandidateInterface::PersonalDetails,
-  contact_information: CandidateInterface::ContactDetails,
-}
+  def can_edit?
+    # this handles all non continuous applications and continuous applications?
+    return true if all_applications_unsubmitted?
 
-def can_edit?()
-end
+    # EDITABLE_SECTIONS[controller_path]
+    # ...
+  end
 end
 
 views / components
+
+Makes  CandidateInterface::CompleteSectionComponent to use editable params that
+calls the EditableSections class
+
+Also uses the same to not render the change links on the review pages of
+sections
 
 if this_section_is_editable?
   show the section complete
@@ -31,6 +36,18 @@ else
 end
 
 controllers
+
+Uses the same to not render the change
+
+But we need how to add the filter:
+
+1. Having the filter in Candidate interface controller might result in a problem
+because there are paths and actions not related to the sections (example: your
+applications tab, responding to an offer, accepting an offer, post offer
+dashboard)
+2. Add a mixin and include them in Base controllers as much as possible and
+and add to the ones that doesn't contain base controllers
+3. Create a SectionController and inherit all base controllers and etc (problem more inheritance)
 
 before filters that if
 the candidate submitted and the they trying to go mannually and edit we should
@@ -128,6 +145,8 @@ CandidateInterface::Gcse::ReviewController#show as HTML
 Parameters: {"subject"=>"maths"}
 CandidateInterface::Gcse::ReviewController#complete as HTML
 Parameters: {"candidate_interface_section_complete_form"=>{"completed"=>"true"}, "subject"=>"maths"}
+CandidateInterface::Gcse::ReviewController#edit as HTML
+Parameters: {"subject"=>"maths"}
 
 #### Science GCSE
 
@@ -145,3 +164,9 @@ CandidateInterface::OtherQualifications::ReviewController#complete
 
 CandidateInterface::Degrees::ReviewController#show
 CandidateInterface::Degrees::ReviewController#complete
+
+## Edge cases
+
+app/controllers/candidate_interface/references/accept_offer/
+Adding references after accepting an offer should not have any filter to
+editable sections

--- a/sections.md
+++ b/sections.md
@@ -1,0 +1,147 @@
+# Sections
+
+
+1. Approach hard coded sections
+
+class or module EditableSections
+
+def initialize(application_form:, controller_name:)
+  can :edit, sections: [
+    CandidateInterface::PersonalDetails,
+    CandidateInterface::ContactDetails,
+  ]
+  can :edit, section: CandidateInterface::ContactDetails
+end
+
+editable_sections = {
+  personal_details: CandidateInterface::PersonalDetails,
+  contact_information: CandidateInterface::ContactDetails,
+}
+
+def can_edit?()
+end
+end
+
+views / components
+
+if this_section_is_editable?
+  show the section complete
+else
+  show the contact support content
+end
+
+controllers
+
+before filters that if
+the candidate submitted and the they trying to go mannually and edit we should
+redirect (maybe checking for the section name && the action name because we
+should allow the show action for all sections)
+
+# Edge case
+
+Science GSCE
+We might need to the normal checks BUT also the params[:subject]
+
+## Editable sections
+
+### Personal details
+
+CandidateInterface::PersonalDetails::ReviewController#show
+CandidateInterface::PersonalDetails::NameAndDobController#edit
+CandidateInterface::PersonalDetails::ReviewController#complete
+
+### Contact information
+
+CandidateInterface::ContactDetails::ReviewController#show
+CandidateInterface::ContactDetails::PhoneNumberController#edit
+CandidateInterface::ContactDetails::AddressTypeController#edit
+CandidateInterface::ContactDetails::AddressController#edit
+CandidateInterface::ContactDetails::ReviewController#complete
+
+### Ask for support if you are disabled
+
+CandidateInterface::TrainingWithADisabilityController#show
+CandidateInterface::TrainingWithADisabilityController#edit
+CandidateInterface::TrainingWithADisabilityController#update
+CandidateInterface::TrainingWithADisabilityController#complete
+
+### Interview availability
+
+CandidateInterface::InterviewAvailabilityController#show
+CandidateInterface::InterviewAvailabilityController#edit
+CandidateInterface::InterviewAvailabilityController#update
+CandidateInterface::InterviewAvailabilityController#complete
+
+### Equality and diversity
+
+CandidateInterface::EqualityAndDiversityController#review
+CandidateInterface::EqualityAndDiversityController#edit_sex
+CandidateInterface::EqualityAndDiversityController#edit_disabilities
+CandidateInterface::EqualityAndDiversityController#edit_ethnic_group
+
+### Personal statement
+
+CandidateInterface::PersonalStatementController#show
+CandidateInterface::PersonalStatementController#edit
+CandidateInterface::PersonalStatementController#complete
+
+## Non editable
+
+### Declare any safeguarding issues
+
+CandidateInterface::SafeguardingController#show
+CandidateInterface::SafeguardingController#edit
+CandidateInterface::SafeguardingController#complete
+
+### References
+
+CandidateInterface::References::ReviewController#show
+CandidateInterface::References::TypeController#new
+CandidateInterface::References::NameController#new
+CandidateInterface::References::EmailAddressController#new
+CandidateInterface::References::RelationshipController#new
+CandidateInterface::References::ReviewController#complete
+
+### Unpaid experience
+
+CandidateInterface::Volunteering::ReviewController#show
+CandidateInterface::Volunteering::RoleController#edit
+
+### Work history
+
+CandidateInterface::RestructuredWorkHistory::ReviewController#show
+CandidateInterface::RestructuredWorkHistory::ReviewController#complete
+
+### Qualifications
+
+#### English GCSE
+
+CandidateInterface::Gcse::ReviewController#show
+Parameters: {"subject"=>"english"}
+
+CandidateInterface::Gcse::ReviewController#complete as HTML
+Parameters: {"candidate_interface_section_complete_form"=>{"completed"=>"true"}, "subject"=>"english"}
+
+#### Maths GCSE
+
+CandidateInterface::Gcse::ReviewController#show as HTML
+Parameters: {"subject"=>"maths"}
+CandidateInterface::Gcse::ReviewController#complete as HTML
+Parameters: {"candidate_interface_section_complete_form"=>{"completed"=>"true"}, "subject"=>"maths"}
+
+#### Science GCSE
+
+CandidateInterface::Gcse::ReviewController#show as HTML
+Parameters: {"subject"=>"science"}
+CandidateInterface::Gcse::ReviewController#complete as HTML
+Parameters: {"candidate_interface_section_complete_form"=>{"completed"=>"true"}, "subject"=>"science"}
+
+### A levels
+
+CandidateInterface::OtherQualifications::ReviewController#show
+CandidateInterface::OtherQualifications::ReviewController#complete
+
+### Degrees
+
+CandidateInterface::Degrees::ReviewController#show
+CandidateInterface::Degrees::ReviewController#complete

--- a/spec/components/candidate_interface/complete_section_component_spec.rb
+++ b/spec/components/candidate_interface/complete_section_component_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe CandidateInterface::CompleteSectionComponent do
   let(:assigns) { {} }
   let(:controller) { ActionController::Base.new }
-  let(:lookup_context) { ActionView::LookupContext.new(nil) }
+  let(:lookup_context) { ActionView::LookupContext.new(controller) }
   let(:helper) { ActionView::Base.new(lookup_context, assigns, controller) }
   let(:section_complete_form) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(
@@ -17,6 +17,14 @@ RSpec.describe CandidateInterface::CompleteSectionComponent do
   let(:application_form) { build_stubbed(:application_form, :minimum_info) }
   let(:field_name) { 'completed' }
   let(:hint_text) { 'hints' }
+
+  before do
+    # rubocop:disable RSpec/AnyInstance
+    without_partial_double_verification do
+      allow_any_instance_of(ActionView::Base).to receive(:current_application).and_return(application_form)
+    end
+    # rubocop:enable RSpec/AnyInstance
+  end
 
   it 'renders successfully' do
     result = render_inline(described_class.new(form: section_complete_form, section_policy:))

--- a/spec/components/candidate_interface/complete_section_component_spec.rb
+++ b/spec/components/candidate_interface/complete_section_component_spec.rb
@@ -13,12 +13,13 @@ RSpec.describe CandidateInterface::CompleteSectionComponent do
       {},
     )
   end
+  let(:editable_section) { instance_double(CandidateInterface::EditableSection, can_edit?: true) }
   let(:application_form) { build_stubbed(:application_form, :minimum_info) }
   let(:field_name) { 'completed' }
   let(:hint_text) { 'hints' }
 
   it 'renders successfully' do
-    result = render_inline(described_class.new(form: section_complete_form))
+    result = render_inline(described_class.new(form: section_complete_form, editable_section:))
 
     expect(result.css('.govuk-form-group').text).to include t('application_form.completed_radio')
     expect(result.css('.govuk-form-group').text).to include t('application_form.incomplete_radio')
@@ -28,6 +29,7 @@ RSpec.describe CandidateInterface::CompleteSectionComponent do
   it 'renders a hint if specified' do
     result = render_inline(
       described_class.new(
+        editable_section:,
         form: section_complete_form,
         hint_text:,
       ),
@@ -39,6 +41,7 @@ RSpec.describe CandidateInterface::CompleteSectionComponent do
   it 'renders a review radio button label if specified' do
     result = render_inline(
       described_class.new(
+        editable_section:,
         form: section_complete_form,
         section_review: true,
       ),

--- a/spec/components/candidate_interface/complete_section_component_spec.rb
+++ b/spec/components/candidate_interface/complete_section_component_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe CandidateInterface::CompleteSectionComponent do
       {},
     )
   end
-  let(:editable_section) { instance_double(CandidateInterface::EditableSection, can_edit?: true) }
+  let(:section_policy) { instance_double(CandidateInterface::SectionPolicy, can_edit?: true) }
   let(:application_form) { build_stubbed(:application_form, :minimum_info) }
   let(:field_name) { 'completed' }
   let(:hint_text) { 'hints' }
 
   it 'renders successfully' do
-    result = render_inline(described_class.new(form: section_complete_form, editable_section:))
+    result = render_inline(described_class.new(form: section_complete_form, section_policy:))
 
     expect(result.css('.govuk-form-group').text).to include t('application_form.completed_radio')
     expect(result.css('.govuk-form-group').text).to include t('application_form.incomplete_radio')
@@ -29,7 +29,7 @@ RSpec.describe CandidateInterface::CompleteSectionComponent do
   it 'renders a hint if specified' do
     result = render_inline(
       described_class.new(
-        editable_section:,
+        section_policy:,
         form: section_complete_form,
         hint_text:,
       ),
@@ -41,7 +41,7 @@ RSpec.describe CandidateInterface::CompleteSectionComponent do
   it 'renders a review radio button label if specified' do
     result = render_inline(
       described_class.new(
-        editable_section:,
+        section_policy:,
         form: section_complete_form,
         section_review: true,
       ),

--- a/spec/components/candidate_interface/editable_section_warning_spec.rb
+++ b/spec/components/candidate_interface/editable_section_warning_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::EditableSectionWarning do
+  subject(:result) do
+    render_inline(
+      described_class.new(current_application:, editable_section:),
+    )
+  end
+
+  context 'when candidate has submitted applications' do
+    let(:current_application) { create(:application_form, :completed, submitted_application_choices_count: 1) }
+
+    context 'when candidate can edit the section' do
+      let(:editable_section) { instance_double(EditableSection, can_edit?: true) }
+
+      it 'renders message' do
+        expect(result.text).to include(
+          'Any changes you make will be included in applications you’ve already submitted.',
+        )
+      end
+    end
+
+    context 'when candidate can not edit the section' do
+      let(:editable_section) { instance_double(EditableSection, can_edit?: false) }
+
+      it 'renders nothing' do
+        expect(result.text).to be_blank
+      end
+    end
+  end
+
+  context 'when candidate did not submitted yet' do
+    let(:editable_section) { instance_double(EditableSection, can_edit?: true) }
+    let(:current_application) { create(:application_form) }
+
+    it 'renders nothing' do
+      expect(result.text).to be_blank
+    end
+  end
+end

--- a/spec/components/candidate_interface/editable_section_warning_spec.rb
+++ b/spec/components/candidate_interface/editable_section_warning_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe CandidateInterface::EditableSectionWarning do
   subject(:result) do
     render_inline(
-      described_class.new(current_application:, editable_section:),
+      described_class.new(current_application:, section_policy:),
     )
   end
 
@@ -11,7 +11,7 @@ RSpec.describe CandidateInterface::EditableSectionWarning do
     let(:current_application) { create(:application_form, :completed, submitted_application_choices_count: 1) }
 
     context 'when candidate can edit the section' do
-      let(:editable_section) { instance_double(CandidateInterface::EditableSection, can_edit?: true) }
+      let(:section_policy) { instance_double(CandidateInterface::SectionPolicy, can_edit?: true) }
 
       it 'renders message' do
         expect(result.text).to include(
@@ -21,7 +21,7 @@ RSpec.describe CandidateInterface::EditableSectionWarning do
     end
 
     context 'when candidate can not edit the section' do
-      let(:editable_section) { instance_double(CandidateInterface::EditableSection, can_edit?: false) }
+      let(:section_policy) { instance_double(CandidateInterface::SectionPolicy, can_edit?: false) }
 
       it 'renders nothing' do
         expect(result.text).to be_blank
@@ -30,7 +30,7 @@ RSpec.describe CandidateInterface::EditableSectionWarning do
   end
 
   context 'when candidate did not submitted yet' do
-    let(:editable_section) { instance_double(CandidateInterface::EditableSection, can_edit?: true) }
+    let(:section_policy) { instance_double(CandidateInterface::SectionPolicy, can_edit?: true) }
     let(:current_application) { create(:application_form) }
 
     it 'renders nothing' do

--- a/spec/components/candidate_interface/editable_section_warning_spec.rb
+++ b/spec/components/candidate_interface/editable_section_warning_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CandidateInterface::EditableSectionWarning do
     let(:current_application) { create(:application_form, :completed, submitted_application_choices_count: 1) }
 
     context 'when candidate can edit the section' do
-      let(:editable_section) { instance_double(EditableSection, can_edit?: true) }
+      let(:editable_section) { instance_double(CandidateInterface::EditableSection, can_edit?: true) }
 
       it 'renders message' do
         expect(result.text).to include(
@@ -21,7 +21,7 @@ RSpec.describe CandidateInterface::EditableSectionWarning do
     end
 
     context 'when candidate can not edit the section' do
-      let(:editable_section) { instance_double(EditableSection, can_edit?: false) }
+      let(:editable_section) { instance_double(CandidateInterface::EditableSection, can_edit?: false) }
 
       it 'renders nothing' do
         expect(result.text).to be_blank
@@ -30,7 +30,7 @@ RSpec.describe CandidateInterface::EditableSectionWarning do
   end
 
   context 'when candidate did not submitted yet' do
-    let(:editable_section) { instance_double(EditableSection, can_edit?: true) }
+    let(:editable_section) { instance_double(CandidateInterface::EditableSection, can_edit?: true) }
     let(:current_application) { create(:application_form) }
 
     it 'renders nothing' do

--- a/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
+++ b/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
@@ -179,6 +179,14 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
   end
 
   context 'when other qualifications are not editable' do
+    let(:application_form) { create(:application_form, :completed, :with_a_levels) }
+
+    it 'do not render the add other qualification button' do
+      result = render_inline(described_class.new(application_form:, editable: false))
+
+      expect(result.text).not_to include('Add another qualification')
+    end
+
     it 'renders component without an edit link' do
       result = render_inline(described_class.new(application_form:, editable: false))
 

--- a/spec/services/candidate_interface/editable_section_spec.rb
+++ b/spec/services/candidate_interface/editable_section_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::EditableSection do
+  subject(:editable_section) do
+    described_class.new(current_application:, controller_path:, action_name:, params:)
+  end
+
+  let(:current_application) { create(:application_form) }
+  let(:controller_path) { '' }
+  let(:action_name) { '' }
+  let(:params) { {} }
+
+  describe '#can_edit?' do
+    context 'when candidate accepted an offer' do
+      before do
+        create(:application_choice, :accepted, application_form: current_application)
+      end
+
+      it 'returns true' do
+        expect(editable_section.can_edit?).to be true
+      end
+    end
+
+    context 'when candidate did not submitted yet' do
+      it 'returns true' do
+        expect(editable_section.can_edit?).to be true
+      end
+    end
+
+    context 'when candidate already submitted at least once' do
+      let(:application_form) { create(:application_form) }
+
+      before do
+        create(:application_choice, :awaiting_provider_decision, application_form: current_application)
+      end
+
+      context 'when accessing an editable section' do
+        let(:controller_path) { 'candidate_interface/personal_details/review' }
+
+        it 'returns true' do
+          expect(editable_section.can_edit?).to be true
+        end
+      end
+
+      context 'when accessing an non editable section' do
+        let(:controller_path) { 'some-non-editable/controller' }
+
+        it 'returns false' do
+          expect(editable_section.can_edit?).to be false
+        end
+      end
+    end
+  end
+end

--- a/spec/services/candidate_interface/editable_section_spec.rb
+++ b/spec/services/candidate_interface/editable_section_spec.rb
@@ -50,5 +50,44 @@ RSpec.describe CandidateInterface::EditableSection do
         end
       end
     end
+
+    context 'when candidates already submitted and adds a primary course choice and visits science GCSE' do
+      let(:primary) { create(:course, level: 'primary') }
+      let(:secondary) { create(:course, level: 'secondary') }
+      let(:controller_path) { 'candidate_interface/gcse/review' }
+      let(:params) { { subject: 'science' } }
+
+      before do
+        create(:application_choice, :awaiting_provider_decision, course_option: create(:course_option, course: secondary), application_form: current_application)
+      end
+
+      context 'when primary choice is submitted' do
+        before do
+          create(:application_choice, :awaiting_provider_decision, course_option: create(:course_option, course: primary), application_form: current_application)
+        end
+
+        it 'returns false' do
+          expect(editable_section.can_edit?).to be false
+        end
+      end
+
+      context 'when primary choice is unsubmitted' do
+        before do
+          create(:application_choice, :unsubmitted, course_option: create(:course_option, course: primary), application_form: current_application)
+        end
+
+        it 'returns true' do
+          expect(editable_section.can_edit?).to be true
+        end
+      end
+
+      context 'when candidates visit another gcse page' do
+        let(:params) { { subject: 'maths' } }
+
+        it 'returns false' do
+          expect(editable_section.can_edit?).to be false
+        end
+      end
+    end
   end
 end

--- a/spec/services/candidate_interface/section_policy_spec.rb
+++ b/spec/services/candidate_interface/section_policy_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe CandidateInterface::EditableSection do
-  subject(:editable_section) do
+RSpec.describe CandidateInterface::SectionPolicy do
+  subject(:section_policy) do
     described_class.new(current_application:, controller_path:, action_name:, params:)
   end
 
@@ -17,13 +17,13 @@ RSpec.describe CandidateInterface::EditableSection do
       end
 
       it 'returns true' do
-        expect(editable_section.can_edit?).to be true
+        expect(section_policy.can_edit?).to be true
       end
     end
 
     context 'when candidate did not submitted yet' do
       it 'returns true' do
-        expect(editable_section.can_edit?).to be true
+        expect(section_policy.can_edit?).to be true
       end
     end
 
@@ -38,7 +38,7 @@ RSpec.describe CandidateInterface::EditableSection do
         let(:controller_path) { 'candidate_interface/personal_details/review' }
 
         it 'returns true' do
-          expect(editable_section.can_edit?).to be true
+          expect(section_policy.can_edit?).to be true
         end
       end
 
@@ -46,7 +46,7 @@ RSpec.describe CandidateInterface::EditableSection do
         let(:controller_path) { 'some-non-editable/controller' }
 
         it 'returns false' do
-          expect(editable_section.can_edit?).to be false
+          expect(section_policy.can_edit?).to be false
         end
       end
     end
@@ -67,7 +67,7 @@ RSpec.describe CandidateInterface::EditableSection do
         end
 
         it 'returns false' do
-          expect(editable_section.can_edit?).to be false
+          expect(section_policy.can_edit?).to be false
         end
       end
 
@@ -77,7 +77,7 @@ RSpec.describe CandidateInterface::EditableSection do
         end
 
         it 'returns true' do
-          expect(editable_section.can_edit?).to be true
+          expect(section_policy.can_edit?).to be true
         end
       end
 
@@ -85,7 +85,7 @@ RSpec.describe CandidateInterface::EditableSection do
         let(:params) { { subject: 'maths' } }
 
         it 'returns false' do
-          expect(editable_section.can_edit?).to be false
+          expect(section_policy.can_edit?).to be false
         end
       end
     end

--- a/spec/services/candidate_interface/section_policy_spec.rb
+++ b/spec/services/candidate_interface/section_policy_spec.rb
@@ -81,6 +81,19 @@ RSpec.describe CandidateInterface::SectionPolicy do
         end
       end
 
+      context 'when primary choice is unsubmitted and user wants to edit grade' do
+        let(:controller_path) { 'candidate_interface/gcse/science/grade' }
+        let(:params) { {} }
+
+        before do
+          create(:application_choice, :unsubmitted, course_option: create(:course_option, course: primary), application_form: current_application)
+        end
+
+        it 'returns true' do
+          expect(section_policy.can_edit?).to be true
+        end
+      end
+
       context 'when candidates visit another gcse page' do
         let(:params) { { subject: 'maths' } }
 

--- a/spec/system/candidate_interface/continuous_applications/entering_details/candidate_can_edit_some_sections_after_first_submission_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/entering_details/candidate_can_edit_some_sections_after_first_submission_spec.rb
@@ -26,8 +26,9 @@ RSpec.feature 'A candidate can edit some sections after first submission', :cont
       then_i_can_see_that_is_editable
       and_i_can_edit_the_section
       and_the_section_should_still_be_complete
-      and_i_can_mark_the_section_incomplete
-      and_i_can_mark_the_section_complete
+      when_i_click_on_the_section_in_your_details_page
+      when_i_click_continue
+      then_the_section_should_still_be_complete
     end
   end
 
@@ -45,9 +46,7 @@ RSpec.feature 'A candidate can edit some sections after first submission', :cont
   end
 
   def then_i_can_see_that_is_editable
-    expect(page).to have_content('Have you completed this section?')
-    expect(page).to have_content('Yes, I have completed this section')
-    expect(page.all('button').map(&:text)).to include('Continue')
+    expect(page.all('a').map(&:text)).to include('Continue')
   end
 
   def and_i_can_edit_the_section
@@ -68,6 +67,7 @@ RSpec.feature 'A candidate can edit some sections after first submission', :cont
       section_status,
     ).to eq("#{@section.title} Completed")
   end
+  alias_method :then_the_section_should_still_be_complete, :and_the_section_should_still_be_complete
 
   def and_i_can_edit_the_section_personal_information
     click_on 'Change name'
@@ -86,6 +86,10 @@ RSpec.feature 'A candidate can edit some sections after first submission', :cont
 
   def when_i_save_and_continue
     click_on 'Save and continue'
+  end
+
+  def when_i_click_continue
+    click_on 'Continue'
   end
 
   def and_i_can_edit_the_section_contact_information
@@ -128,25 +132,6 @@ RSpec.feature 'A candidate can edit some sections after first submission', :cont
     click_on 'Continue'
 
     expect(current_candidate.current_application.reload.becoming_a_teacher).to eq('Repellat qui et')
-  end
-
-  def and_i_can_mark_the_section_incomplete
-    and_i_visit_your_details_page
-    click_on @section.title
-    choose 'No, I’ll come back to it later'
-    click_on 'Continue'
-
-    expect(section_status).to eq("#{@section.title} Incomplete")
-  end
-
-  def and_i_can_mark_the_section_complete
-    and_i_visit_your_details_page
-    click_on @section.title
-    choose 'Yes, I have completed this section'
-    click_on 'Continue'
-
-    and_i_visit_your_details_page
-    expect(section_status).to eq("#{@section.title} Completed")
   end
 
   def section_status

--- a/spec/system/candidate_interface/continuous_applications/entering_details/candidate_can_edit_some_sections_after_first_submission_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/entering_details/candidate_can_edit_some_sections_after_first_submission_spec.rb
@@ -19,14 +19,15 @@ RSpec.feature 'A candidate can edit some sections after first submission', :cont
     TestSection.new(:personal_statement, 'Your personal statement'),
   ].each do |section|
     scenario "candidate can edit section '#{section.title}' after submission" do
+      @section = section
       given_i_already_have_one_submitted_application
       and_i_visit_your_details_page
-      when_i_click_on_the_section_in_your_details_page(section:)
+      when_i_click_on_the_section_in_your_details_page
       then_i_can_see_that_is_editable
-      and_i_can_edit_the_section(section:)
-      and_the_section_should_still_be_complete(section:)
-      and_i_can_mark_the_section_incomplete(section:)
-      and_i_can_mark_the_section_complete(section:)
+      and_i_can_edit_the_section
+      and_the_section_should_still_be_complete
+      and_i_can_mark_the_section_incomplete
+      and_i_can_mark_the_section_complete
     end
   end
 
@@ -39,8 +40,8 @@ RSpec.feature 'A candidate can edit some sections after first submission', :cont
     visit candidate_interface_continuous_applications_details_path
   end
 
-  def when_i_click_on_the_section_in_your_details_page(section:)
-    click_on section.title
+  def when_i_click_on_the_section_in_your_details_page
+    click_on @section.title
   end
 
   def then_i_can_see_that_is_editable
@@ -49,9 +50,9 @@ RSpec.feature 'A candidate can edit some sections after first submission', :cont
     expect(page.all('button').map(&:text)).to include('Continue')
   end
 
-  def and_i_can_edit_the_section(section:)
-    expect(page).to have_content('Any changes you make will be included in applications you’ve already submitted.') unless section.identifier == :personal_statement
-    method_name = "and_i_can_edit_the_section_#{section.identifier}"
+  def and_i_can_edit_the_section
+    expect(page).to have_content('Any changes you make will be included in applications you’ve already submitted.') unless @section.identifier == :personal_statement
+    method_name = "and_i_can_edit_the_section_#{@section.identifier}"
 
     if respond_to?(method_name)
       public_send(method_name)
@@ -60,12 +61,12 @@ RSpec.feature 'A candidate can edit some sections after first submission', :cont
     end
   end
 
-  def and_the_section_should_still_be_complete(section:)
+  def and_the_section_should_still_be_complete
     click_on 'Your details'
 
     expect(
-      section_status(section:),
-    ).to eq("#{section.title} Completed")
+      section_status,
+    ).to eq("#{@section.title} Completed")
   end
 
   def and_i_can_edit_the_section_personal_information
@@ -129,26 +130,26 @@ RSpec.feature 'A candidate can edit some sections after first submission', :cont
     expect(current_candidate.current_application.reload.becoming_a_teacher).to eq('Repellat qui et')
   end
 
-  def and_i_can_mark_the_section_incomplete(section:)
+  def and_i_can_mark_the_section_incomplete
     and_i_visit_your_details_page
-    click_on section.title
+    click_on @section.title
     choose 'No, I’ll come back to it later'
     click_on 'Continue'
 
-    expect(section_status(section:)).to eq("#{section.title} Incomplete")
+    expect(section_status).to eq("#{@section.title} Incomplete")
   end
 
-  def and_i_can_mark_the_section_complete(section:)
+  def and_i_can_mark_the_section_complete
     and_i_visit_your_details_page
-    click_on section.title
+    click_on @section.title
     choose 'Yes, I have completed this section'
     click_on 'Continue'
 
     and_i_visit_your_details_page
-    expect(section_status(section:)).to eq("#{section.title} Completed")
+    expect(section_status).to eq("#{@section.title} Completed")
   end
 
-  def section_status(section:)
-    page.find(:xpath, "//a[contains(text(),'#{section.title}')]/..").text
+  def section_status
+    page.find(:xpath, "//a[contains(text(),'#{@section.title}')]/..").text
   end
 end

--- a/spec/system/candidate_interface/continuous_applications/entering_details/candidate_can_edit_some_sections_after_first_submission_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/entering_details/candidate_can_edit_some_sections_after_first_submission_spec.rb
@@ -1,0 +1,153 @@
+require 'rails_helper'
+
+TestSection = Struct.new(:identifier, :title)
+RSpec.feature 'A candidate can edit some sections after first submission', :continuous_applications do
+  include SignInHelper
+  include CandidateHelper
+
+  before do
+    FeatureFlag.activate(:one_personal_statement)
+    create_and_sign_in_candidate
+  end
+
+  [
+    TestSection.new(:personal_information, 'Personal information'),
+    TestSection.new(:contact_information, 'Contact information'),
+    TestSection.new(:ask_for_support_if_you_are_disabled, 'Ask for support if you’re disabled'),
+    TestSection.new(:interview_availability, 'Interview availability'),
+    TestSection.new(:equality_and_diversity_information, 'Equality and diversity questions'),
+    TestSection.new(:personal_statement, 'Your personal statement'),
+  ].each do |section|
+    scenario "candidate can edit section '#{section.title}' after submission" do
+      given_i_already_have_one_submitted_application
+      and_i_visit_your_details_page
+      when_i_click_on_the_section_in_your_details_page(section:)
+      then_i_can_see_that_is_editable
+      and_i_can_edit_the_section(section:)
+      and_the_section_should_still_be_complete(section:)
+      and_i_can_mark_the_section_incomplete(section:)
+      and_i_can_mark_the_section_complete(section:)
+    end
+  end
+
+  def given_i_already_have_one_submitted_application
+    application_form = create(:application_form, :completed, candidate: current_candidate)
+    create(:application_choice, :awaiting_provider_decision, application_form:)
+  end
+
+  def and_i_visit_your_details_page
+    visit candidate_interface_continuous_applications_details_path
+  end
+
+  def when_i_click_on_the_section_in_your_details_page(section:)
+    click_on section.title
+  end
+
+  def then_i_can_see_that_is_editable
+    expect(page).to have_content('Have you completed this section?')
+    expect(page).to have_content('Yes, I have completed this section')
+    expect(page.all('button').map(&:text)).to include('Continue')
+  end
+
+  def and_i_can_edit_the_section(section:)
+    method_name = "and_i_can_edit_the_section_#{section.identifier}"
+
+    if respond_to?(method_name)
+      public_send(method_name)
+    else
+      raise "Method #{method_name} needs to be implemented in the spec"
+    end
+  end
+
+  def and_the_section_should_still_be_complete(section:)
+    click_on 'Your details'
+
+    expect(
+      section_status(section:),
+    ).to eq("#{section.title} Completed")
+  end
+
+  def and_i_can_edit_the_section_personal_information
+    click_on 'Change name'
+    fill_in 'First name', with: 'Robert'
+    fill_in 'Last name', with: 'Frank'
+    when_i_save_and_continue
+
+    expect(current_candidate.current_application.reload.full_name).to eq('Robert Frank')
+
+    click_on 'Change nationality'
+    check 'Irish'
+    when_i_save_and_continue
+
+    expect(current_candidate.current_application.reload.nationalities).to include('Irish')
+  end
+
+  def when_i_save_and_continue
+    click_on 'Save and continue'
+  end
+
+  def and_i_can_edit_the_section_contact_information
+    click_on 'Change phone number'
+    fill_in 'Phone number', with: '707070707070'
+    when_i_save_and_continue
+
+    expect(current_candidate.current_application.reload.phone_number).to eq('707070707070')
+  end
+
+  def and_i_can_edit_the_section_ask_for_support_if_you_are_disabled
+    click_on 'Change whether you want to ask for help'
+    choose 'Yes, I want to share information about myself so my provider can take steps to support me'
+    fill_in 'Give any relevant information', with: 'Rerum qui maxime.'
+    click_on 'Continue'
+
+    expect(current_candidate.current_application.reload.disability_disclosure).to eq('Rerum qui maxime.')
+  end
+
+  def and_i_can_edit_the_section_interview_availability
+    click_on 'Change interview availability', match: :first
+    choose 'Yes'
+    fill_in 'Give details of your interview availability', with: 'Quis et enim.'
+    when_i_save_and_continue
+
+    expect(current_candidate.current_application.reload.interview_preferences).to eq('Quis et enim.')
+  end
+
+  def and_i_can_edit_the_section_equality_and_diversity_information
+    click_on 'Change sex'
+    choose 'Male'
+    click_on 'Continue'
+
+    expect(current_candidate.current_application.reload.equality_and_diversity).to include('sex' => 'male')
+  end
+
+  def and_i_can_edit_the_section_personal_statement
+    click_on 'Edit your answer'
+    fill_in 'Your personal statement', with: 'Repellat qui et'
+    click_on 'Continue'
+
+    expect(current_candidate.current_application.reload.becoming_a_teacher).to eq('Repellat qui et')
+  end
+
+  def and_i_can_mark_the_section_incomplete(section:)
+    and_i_visit_your_details_page
+    click_on section.title
+    choose 'No, I’ll come back to it later'
+    click_on 'Continue'
+
+    expect(section_status(section:)).to eq("#{section.title} Incomplete")
+  end
+
+  def and_i_can_mark_the_section_complete(section:)
+    and_i_visit_your_details_page
+    click_on section.title
+    choose 'Yes, I have completed this section'
+    click_on 'Continue'
+
+    and_i_visit_your_details_page
+    expect(section_status(section:)).to eq("#{section.title} Completed")
+  end
+
+  def section_status(section:)
+    page.find(:xpath, "//a[contains(text(),'#{section.title}')]/..").text
+  end
+end

--- a/spec/system/candidate_interface/continuous_applications/entering_details/candidate_can_edit_some_sections_after_first_submission_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/entering_details/candidate_can_edit_some_sections_after_first_submission_spec.rb
@@ -50,6 +50,7 @@ RSpec.feature 'A candidate can edit some sections after first submission', :cont
   end
 
   def and_i_can_edit_the_section(section:)
+    expect(page).to have_content('Any changes you make will be included in applications you’ve already submitted.') unless section.identifier == :personal_statement
     method_name = "and_i_can_edit_the_section_#{section.identifier}"
 
     if respond_to?(method_name)

--- a/spec/system/candidate_interface/continuous_applications/entering_details/candidate_can_not_edit_some_sections_after_first_submission_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/entering_details/candidate_can_not_edit_some_sections_after_first_submission_spec.rb
@@ -80,6 +80,8 @@ RSpec.feature 'A candidate can not edit some sections after first submission', :
   end
 
   def and_i_can_not_edit_the_section_unpaid_experience
+    expect(page).not_to have_content('Add another role')
+
     visit candidate_interface_edit_volunteering_role_path(
       current_candidate.current_application.application_volunteering_experiences.last,
     )
@@ -96,6 +98,7 @@ RSpec.feature 'A candidate can not edit some sections after first submission', :
   end
 
   def and_i_can_not_edit_the_section_degree
+    expect(page).not_to have_content('Add another degree')
     visit candidate_interface_degree_country_path
 
     and_i_should_be_redirected_to_your_details_page
@@ -120,6 +123,8 @@ RSpec.feature 'A candidate can not edit some sections after first submission', :
   end
 
   def and_i_can_not_edit_the_section_references
+    expect(page).not_to have_content('Add another reference')
+
     visit candidate_interface_references_edit_name_path(
       current_candidate.current_application.application_references.last,
     )

--- a/spec/system/candidate_interface/continuous_applications/entering_details/candidate_can_not_edit_some_sections_after_first_submission_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/entering_details/candidate_can_not_edit_some_sections_after_first_submission_spec.rb
@@ -55,6 +55,7 @@ RSpec.feature 'A candidate can not edit some sections after first submission', :
     expect(page).not_to have_content('Have you completed this section?')
     expect(page).not_to have_content('Yes, I have completed this section')
     expect(page).not_to have_content('Change')
+    expect(page).not_to have_content('Any changes you make will be included in applications you’ve already submitted.')
     expect(page.all('button').map(&:text)).not_to include('Continue')
 
     expect(page).to have_content('Contact becomingateacher@digital.education.gov.uk if you need to update this section.')

--- a/spec/system/candidate_interface/continuous_applications/entering_details/candidate_can_not_edit_some_sections_after_first_submission_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/entering_details/candidate_can_not_edit_some_sections_after_first_submission_spec.rb
@@ -1,0 +1,158 @@
+require 'rails_helper'
+
+NonEditableSection = Struct.new(:identifier, :title)
+RSpec.feature 'A candidate can not edit some sections after first submission', :continuous_applications do
+  include SignInHelper
+  include CandidateHelper
+
+  before do
+    FeatureFlag.activate(:one_personal_statement)
+    create_and_sign_in_candidate
+  end
+
+  [
+    NonEditableSection.new(:english_gcse, 'English GCSE or equivalent'),
+    NonEditableSection.new(:maths_gcse, 'Maths GCSE or equivalent'),
+    NonEditableSection.new(:other_qualifications, 'A levels and other qualifications'),
+    NonEditableSection.new(:degree, 'Degree'),
+    NonEditableSection.new(:references, 'References to be requested if you accept an offer'),
+    NonEditableSection.new(:safeguarding, 'Declare any safeguarding issues'),
+    NonEditableSection.new(:work_history, 'Work history'),
+    NonEditableSection.new(:unpaid_experience, 'Unpaid experience'),
+  ].each do |section|
+    scenario "candidate can not edit section '#{section.title}' after submission" do
+      given_i_already_have_one_submitted_application
+      and_i_visit_your_details_page
+      when_i_click_on_the_section_in_your_details_page(section:)
+      then_i_can_see_that_is_not_editable
+      and_i_can_not_the_section(section:)
+      and_the_section_should_still_be_complete(section:)
+      and_i_can_mark_the_section_incomplete(section:)
+      and_i_can_mark_the_section_complete(section:)
+    end
+  end
+
+  def given_i_already_have_one_submitted_application
+    application_form = create(:application_form, :completed, :with_a_levels, candidate: current_candidate)
+    create(:application_choice, :awaiting_provider_decision, application_form:)
+  end
+
+  def and_i_visit_your_details_page
+    visit candidate_interface_continuous_applications_details_path
+  end
+
+  def when_i_click_on_the_section_in_your_details_page(section:)
+    click_on section.title
+  end
+
+  def then_i_can_see_that_is_not_editable
+    expect(page).not_to have_content('Have you completed this section?')
+    expect(page).not_to have_content('Yes, I have completed this section')
+    expect(page).not_to have_content('Change')
+    expect(page.all('button').map(&:text)).not_to include('Continue')
+
+    expect(page).to have_content('Contact becomingateacher@digital.education.gov.uk if you need to update this section.')
+  end
+
+  def and_i_can_not_edit_the_section(section:)
+    method_name = "and_i_can_not_the_section_#{section.identifier}"
+
+    if respond_to?(method_name)
+      public_send(method_name)
+    else
+      raise "Method #{method_name} needs to be implemented in the spec"
+    end
+  end
+
+  def and_the_section_should_still_be_complete(section:)
+    click_on 'Your details'
+
+    expect(
+      section_status(section:),
+    ).to eq("#{section.title} Completed")
+  end
+
+  def and_i_can_not_the_section_personal_information
+    click_on 'Change name'
+    fill_in 'First name', with: 'Robert'
+    fill_in 'Last name', with: 'Frank'
+    when_i_save_and_continue
+
+    expect(current_candidate.current_application.reload.full_name).to eq('Robert Frank')
+
+    click_on 'Change nationality'
+    check 'Irish'
+    when_i_save_and_continue
+
+    expect(current_candidate.current_application.reload.nationalities).to include('Irish')
+  end
+
+  def when_i_save_and_continue
+    click_on 'Save and continue'
+  end
+
+  def and_i_can_not_the_section_contact_information
+    click_on 'Change phone number'
+    fill_in 'Phone number', with: '707070707070'
+    when_i_save_and_continue
+
+    expect(current_candidate.current_application.reload.phone_number).to eq('707070707070')
+  end
+
+  def and_i_can_not_the_section_ask_for_support_if_you_are_disabled
+    click_on 'Change whether you want to ask for help'
+    choose 'Yes, I want to share information about myself so my provider can take steps to support me'
+    fill_in 'Give any relevant information', with: 'Rerum qui maxime.'
+    click_on 'Continue'
+
+    expect(current_candidate.current_application.reload.disability_disclosure).to eq('Rerum qui maxime.')
+  end
+
+  def and_i_can_not_the_section_interview_availability
+    click_on 'Change interview availability', match: :first
+    choose 'Yes'
+    fill_in 'Give details of your interview availability', with: 'Quis et enim.'
+    when_i_save_and_continue
+
+    expect(current_candidate.current_application.reload.interview_preferences).to eq('Quis et enim.')
+  end
+
+  def and_i_can_not_the_section_equality_and_diversity_information
+    click_on 'Change sex'
+    choose 'Male'
+    click_on 'Continue'
+
+    expect(current_candidate.current_application.reload.equality_and_diversity).to include('sex' => 'male')
+  end
+
+  def and_i_can_not_the_section_personal_statement
+    click_on 'Edit your answer'
+    fill_in 'Your personal statement', with: 'Repellat qui et'
+    click_on 'Continue'
+
+    expect(current_candidate.current_application.reload.becoming_a_teacher).to eq('Repellat qui et')
+  end
+
+  def and_i_can_mark_the_section_incomplete(section:)
+    and_i_visit_your_details_page
+    click_on section.title
+    choose 'No, I’ll come back to it later'
+    click_on 'Continue'
+
+    expect(section_status(section:)).to eq("#{section.title} Incomplete")
+  end
+
+  def and_i_can_mark_the_section_complete(section:)
+    and_i_visit_your_details_page
+    click_on section.title
+    choose 'Yes, I have completed this section'
+    click_on 'Continue'
+
+    and_i_visit_your_details_page
+    expect(section_status(section:)).to eq("#{section.title} Completed")
+  end
+
+  def section_status(section:)
+    page.find(:xpath, "//a[contains(text(),'#{section.title}')]/..").text
+  end
+end

--- a/spec/system/candidate_interface/continuous_applications/entering_details/candidate_can_not_edit_some_sections_after_first_submission_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/entering_details/candidate_can_not_edit_some_sections_after_first_submission_spec.rb
@@ -21,12 +21,13 @@ RSpec.feature 'A candidate can not edit some sections after first submission', :
     NonEditableSection.new(:unpaid_experience, 'Unpaid experience'),
   ].each do |section|
     scenario "candidate can not edit section '#{section.title}' after submission" do
+      @section = section
       given_i_already_have_one_submitted_application
       and_i_visit_your_details_page
-      when_i_click_on_the_section_in_your_details_page(section:)
+      when_i_click_on_the_section_in_your_details_page
       then_i_can_see_that_is_not_editable
-      and_i_can_not_edit_the_section(section:)
-      and_the_section_should_still_be_complete(section:)
+      and_i_can_not_edit_the_section
+      and_the_section_should_still_be_complete
     end
   end
 
@@ -47,8 +48,8 @@ RSpec.feature 'A candidate can not edit some sections after first submission', :
     visit candidate_interface_continuous_applications_details_path
   end
 
-  def when_i_click_on_the_section_in_your_details_page(section:)
-    click_on section.title
+  def when_i_click_on_the_section_in_your_details_page
+    click_on @section.title
   end
 
   def then_i_can_see_that_is_not_editable
@@ -61,8 +62,8 @@ RSpec.feature 'A candidate can not edit some sections after first submission', :
     expect(page).to have_content('Contact becomingateacher@digital.education.gov.uk if you need to update this section.')
   end
 
-  def and_i_can_not_edit_the_section(section:)
-    method_name = "and_i_can_not_edit_the_section_#{section.identifier}"
+  def and_i_can_not_edit_the_section
+    method_name = "and_i_can_not_edit_the_section_#{@section.identifier}"
 
     if respond_to?(method_name)
       public_send(method_name)
@@ -71,12 +72,12 @@ RSpec.feature 'A candidate can not edit some sections after first submission', :
     end
   end
 
-  def and_the_section_should_still_be_complete(section:)
+  def and_the_section_should_still_be_complete
     click_on 'Your details'
 
     expect(
-      section_status(section:),
-    ).to eq("#{section.title} Completed")
+      section_status,
+    ).to eq("#{@section.title} Completed")
   end
 
   def and_i_can_not_edit_the_section_unpaid_experience
@@ -190,7 +191,7 @@ RSpec.feature 'A candidate can not edit some sections after first submission', :
     expect(page).to have_current_path candidate_interface_continuous_applications_details_path
   end
 
-  def section_status(section:)
-    page.find(:xpath, "//a[contains(text(),'#{section.title}')]/..").text
+  def section_status
+    page.find(:xpath, "//a[contains(text(),'#{@section.title}')]/..").text
   end
 end

--- a/spec/views/degrees/show.html.erb_spec.rb
+++ b/spec/views/degrees/show.html.erb_spec.rb
@@ -5,6 +5,13 @@ RSpec.describe 'candidate_interface/degrees/review/show' do
     assign(:application_form, application_form)
     assign(:section_policy, CandidateInterface::SectionPolicy.new(current_application: application_form, controller_path: 'candidate_interface/degrees/review', action_name: 'show', params: {}))
     assign(:section_complete_form, CandidateInterface::SectionCompleteForm.new(completed: 'No'))
+
+    # rubocop:disable RSpec/AnyInstance
+    without_partial_double_verification do
+      allow_any_instance_of(ActionView::Base).to receive(:current_application).and_return(application_form)
+    end
+    # rubocop:enable RSpec/AnyInstance
+
     render
   end
 

--- a/spec/views/degrees/show.html.erb_spec.rb
+++ b/spec/views/degrees/show.html.erb_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe 'candidate_interface/degrees/review/show' do
   before do
     assign(:application_form, application_form)
+    assign(:editable_section, CandidateInterface::EditableSection.new(current_application: application_form, controller_path: 'candidate_interface/degrees/review'))
     assign(:section_complete_form, CandidateInterface::SectionCompleteForm.new(completed: 'No'))
     render
   end

--- a/spec/views/degrees/show.html.erb_spec.rb
+++ b/spec/views/degrees/show.html.erb_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'candidate_interface/degrees/review/show' do
   before do
     assign(:application_form, application_form)
-    assign(:editable_section, CandidateInterface::EditableSection.new(current_application: application_form, controller_path: 'candidate_interface/degrees/review'))
+    assign(:section_policy, CandidateInterface::SectionPolicy.new(current_application: application_form, controller_path: 'candidate_interface/degrees/review', action_name: 'show', params: {}))
     assign(:section_complete_form, CandidateInterface::SectionCompleteForm.new(completed: 'No'))
     render
   end


### PR DESCRIPTION
## Context

With continuous applications we’re going to allow candidates to edit most of their application form sections after submitting an application choice.

We’re doing this to enable candidates to action feedback that they may receive on rejected applications and also to alleviate support burden for tasks like updating an address (which candidates can’t currently do themselves).