### PR TITLE
Amend copy for days since submission

### DIFF
--- a/app/components/candidate_interface/application_status_tag_component.html.erb
+++ b/app/components/candidate_interface/application_status_tag_component.html.erb
@@ -16,17 +16,26 @@
 
     <% if @application_choice.continuous_applications? %>
 
-      <p class="govuk-!-margin-top-2">Application submitted <%= @application_choice.days_since_submission %> days ago</p>
+      <% unless @application_choice.days_since_submission.nil? %>
+        <% days_since_submission = @application_choice.days_since_submission %>
+        <p class="govuk-!-margin-top-2">
+          <% if days_since_submission.zero? %>
+            Application submitted today.
+          <% else %>
+            Application submitted <%= days_since_submission %> <%= 'day'.pluralize(days_since_submission) %> ago.
+          <% end %>
+        </p>
+      <% end %>
 
       <p class="govuk-body govuk-!-margin-top-2">
-      If you do not receive a response from this training provider, you can withdraw this application and apply to another provider.
+        If you do not receive a response from this training provider, you can withdraw this application and apply to another provider.
       </p>
 
     <% else %>
 
-    <p class="govuk-body govuk-!-margin-top-2">
-      You’ll get a decision on your application by <%= @application_choice.reject_by_default_at.to_fs(:govuk_date) %>.
-    </p>
+      <p class="govuk-body govuk-!-margin-top-2">
+        You’ll get a decision on your application by <%= @application_choice.reject_by_default_at.to_fs(:govuk_date) %>.
+      </p>
 
     <% end %>
 

--- a/spec/components/candidate_interface/application_status_tag_component_spec.rb
+++ b/spec/components/candidate_interface/application_status_tag_component_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe CandidateInterface::ApplicationStatusTagComponent, :continuous_ap
       application_choice = create(
         :application_choice,
         :awaiting_provider_decision,
+        sent_to_provider_at: Time.zone.now,
         reject_by_default_at: 14.days.from_now,
       )
       result = render_inline(described_class.new(application_choice:))
@@ -44,6 +45,33 @@ RSpec.describe CandidateInterface::ApplicationStatusTagComponent, :continuous_ap
       expect(result.text).to include(
         'If you do not receive a response from this training provider, you can withdraw this application and apply to another provider.',
       )
+      expect(result.text).to include('Application submitted today.')
+    end
+
+    context 'when the application was submitted 1 day ago' do
+      it 'renders the correct content' do
+        application_choice = create(
+          :application_choice,
+          :awaiting_provider_decision,
+          sent_to_provider_at: 1.day.ago,
+        )
+        result = render_inline(described_class.new(application_choice:))
+
+        expect(result.text).to include('Application submitted 1 day ago.')
+      end
+    end
+
+    context 'when the application was submitted more than a day ago' do
+      it 'renders the correct content' do
+        application_choice = create(
+          :application_choice,
+          :awaiting_provider_decision,
+          sent_to_provider_at: 3.days.ago,
+        )
+        result = render_inline(described_class.new(application_choice:))
+
+        expect(result.text).to include('Application submitted 3 days ago.')
+      end
     end
 
     it 'handles nil values for `reject_by_default_at`' do


### PR DESCRIPTION
## Context

On Your Applications, if a candidate submits an application, and it is the same day as the submission, we should render:

```
Application submitted today.
```
instead of

```
Application submitted 0 days ago
```

We also need to add a full stop to the end of the line (as per the code block above). This full stop should exist at all times, not just when it is rendering ‘today’.

We also need to change the pluralisation if it was only submitted 1 day ago, to prevent it saying “days” ago
```
Application submitted 1 day ago
```
## Changes proposed in this pull request

|Current|
|---|
|![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/d7c5dcbc-1d63-46d1-b4b3-aff4c5198023)|
|Today|
|<img width="751" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/31cfbdcd-8733-475f-a1ca-bce2c16fef57">|
|1 day since submission|
|<img width="724" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/f04084ab-d445-4a67-b5c9-6034dec5e179">|
|More than a day since submission|
|<img width="729" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/6c0750af-411d-488b-8361-9927e0b77f12">|



## Guidance to review

Submit on the review app and change the `sent_to_provider_at` date

## Link to Trello card

https://trello.com/c/6GWuyl0O/688-amend-copy-when-a-candidate-has-submitted-an-application-on-the-current-day

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
