### PR TITLE
Add status, applied at and personal statement to application review page

### DIFF
--- a/app/components/candidate_interface/application_status_tag_component.html.erb
+++ b/app/components/candidate_interface/application_status_tag_component.html.erb
@@ -1,58 +1,60 @@
 <%= govuk_tag(text: text, colour: colour) %>
 
-<% if @application_choice.application_not_sent? %>
-  <p class="govuk-body govuk-!-margin-top-2">
-    Your application was not sent for this course because references were not given before the deadline.
-  </p>
-<% elsif @application_choice.continuous_applications? && @application_choice.unsubmitted? && @application_choice.course_available? %>
-  <p class="govuk-body govuk-!-margin-top-2">
-    <%= govuk_link_to candidate_interface_continuous_applications_course_review_path(@application_choice) do %>
-      <%= t('application_form.continuous_applications.courses.continue_application') %>
-      <span class="govuk-visually-hidden"> <%= @application_choice.current_course.provider.name %></span>
-    <% end %>
-  </p>
-<% elsif @application_choice.decision_pending? && @application_choice.reject_by_default_at&.future? %>
+<% if @display_info_text %>
+  <% if @application_choice.application_not_sent? %>
+    <p class="govuk-body govuk-!-margin-top-2">
+      Your application was not sent for this course because references were not given before the deadline.
+    </p>
+  <% elsif @application_choice.continuous_applications? && @application_choice.unsubmitted? && @application_choice.course_available? %>
+    <p class="govuk-body govuk-!-margin-top-2">
+      <%= govuk_link_to candidate_interface_continuous_applications_course_review_path(@application_choice) do %>
+        <%= t('application_form.continuous_applications.courses.continue_application') %>
+        <span class="govuk-visually-hidden"> <%= @application_choice.current_course.provider.name %></span>
+      <% end %>
+    </p>
+  <% elsif @application_choice.decision_pending? && @application_choice.reject_by_default_at&.future? %>
 
-  <% if @application_choice.continuous_applications? %>
+    <% if @application_choice.continuous_applications? %>
 
-    <p class="govuk-!-margin-top-2">Application submitted <%= @application_choice.days_since_submission %> days ago</p>
+      <p class="govuk-!-margin-top-2">Application submitted <%= @application_choice.days_since_submission %> days ago</p>
+
+      <p class="govuk-body govuk-!-margin-top-2">
+      If you do not receive a response from this training provider, you can withdraw this application and apply to another provider.
+      </p>
+
+    <% else %>
 
     <p class="govuk-body govuk-!-margin-top-2">
-    If you do not receive a response from this training provider, you can withdraw this application and apply to another provider.
+      You’ll get a decision on your application by <%= @application_choice.reject_by_default_at.to_fs(:govuk_date) %>.
     </p>
 
-  <% else %>
-
-  <p class="govuk-body govuk-!-margin-top-2">
-    You’ll get a decision on your application by <%= @application_choice.reject_by_default_at.to_fs(:govuk_date) %>.
-   </p>
-
-  <% end %>
-
-<% elsif @application_choice.withdrawn_at_candidates_request? %>
-  <p class="govuk-body govuk-!-margin-top-2">
-    You requested to withdraw your application. If you did not request this, email <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>.
-  </p>
-<% elsif  @application_choice.offer_deferred? %>
-  <p class="govuk-body govuk-!-margin-top-2">
-    Your training will now start in <%= (@application_choice.current_course_option.course.start_date + 1.year).to_fs(:month_and_year) %>.
-  </p>
-<% elsif @application_choice.pending_conditions? || @application_choice.recruited? || @application_choice.offer? %>
-    <%= govuk_details(
-      summary_text: "What to do if you’re unable to start training in #{@application_choice.current_course_option.course.start_date.to_fs(:month_and_year)}",
-      classes: 'govuk-!-margin-bottom-0 govuk-!-margin-top-2',
-    ) do %>
-      <p>
-        You can defer your offer and start your course a year later.
-      </p>
-
-      <p>
-        Contact <%= @application_choice.current_course_option.course.provider.name %> to ask if it’s possible to defer, this will not affect your existing offer.
-      </p>
-
-      <p>
-      If your provider agrees, you’ll need to accept the offer first.
-      </p>
-
     <% end %>
+
+  <% elsif @application_choice.withdrawn_at_candidates_request? %>
+    <p class="govuk-body govuk-!-margin-top-2">
+      You requested to withdraw your application. If you did not request this, email <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>.
+    </p>
+  <% elsif  @application_choice.offer_deferred? %>
+    <p class="govuk-body govuk-!-margin-top-2">
+      Your training will now start in <%= (@application_choice.current_course_option.course.start_date + 1.year).to_fs(:month_and_year) %>.
+    </p>
+  <% elsif @application_choice.pending_conditions? || @application_choice.recruited? || @application_choice.offer? %>
+      <%= govuk_details(
+        summary_text: "What to do if you’re unable to start training in #{@application_choice.current_course_option.course.start_date.to_fs(:month_and_year)}",
+        classes: 'govuk-!-margin-bottom-0 govuk-!-margin-top-2',
+      ) do %>
+        <p>
+          You can defer your offer and start your course a year later.
+        </p>
+
+        <p>
+          Contact <%= @application_choice.current_course_option.course.provider.name %> to ask if it’s possible to defer, this will not affect your existing offer.
+        </p>
+
+        <p>
+        If your provider agrees, you’ll need to accept the offer first.
+        </p>
+
+      <% end %>
+  <% end %>
 <% end %>

--- a/app/components/candidate_interface/application_status_tag_component.rb
+++ b/app/components/candidate_interface/application_status_tag_component.rb
@@ -2,8 +2,9 @@ module CandidateInterface
   class ApplicationStatusTagComponent < ViewComponent::Base
     delegate :status, to: :application_choice
 
-    def initialize(application_choice:)
+    def initialize(application_choice:, display_info_text: true)
       @application_choice = application_choice
+      @display_info_text = display_info_text
     end
 
     def text

--- a/app/components/candidate_interface/continuous_applications/application_review_component.html.erb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.html.erb
@@ -1,1 +1,16 @@
 <%= render SummaryListComponent.new(rows: rows) %>
+
+<% if @application_choice.personal_statement.present? %>
+  <div class="app-summary-card govuk-!-margin-bottom-6">
+    <div class="app-summary-card__header govuk-body">
+      Personal statement
+    </div>
+    <div class="app-summary-card__body">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-three-quarters-from-desktop">
+          <%= simple_format(@application_choice.personal_statement, class: 'govuk-body') %>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/components/candidate_interface/continuous_applications/application_review_component.rb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.rb
@@ -10,10 +10,27 @@ module CandidateInterface
 
       def rows
         [
+          status_row,
+          submitted_at_row,
           course_info_row,
           study_mode_row,
           location_row,
-        ]
+        ].compact
+      end
+
+      def status_row
+        return unless application_choice.sent_to_provider_at
+
+        {
+          key: 'Status',
+          value: render(ApplicationStatusTagComponent.new(application_choice:, display_info_text: false)),
+        }
+      end
+
+      def submitted_at_row
+        return unless application_choice.sent_to_provider_at
+
+        { key: 'Application submitted', value: application_choice.sent_to_provider_at.to_fs(:govuk_date_and_time) }
       end
 
       def course_info_row

--- a/app/components/candidate_interface/continuous_applications/application_summary_component.html.erb
+++ b/app/components/candidate_interface/continuous_applications/application_summary_component.html.erb
@@ -16,7 +16,7 @@
         <%= title %>
       </h2>
       <ul class="govuk-summary-card__actions">
-        <% unless application_choice.course_full? && application_choice.unsubmitted? %>
+        <% if application_choice.course_available? && !application_choice.unsubmitted? %>
           <li class="govuk-summary-card__action">
             <%= govuk_link_to candidate_interface_continuous_applications_course_review_path(application_choice) do %>
               <%= t('application_form.continuous_applications.courses.view_application') %>

--- a/spec/components/candidate_interface/continuous_applications/application_summary_component_spec.rb
+++ b/spec/components/candidate_interface/continuous_applications/application_summary_component_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationSummaryCom
         expect(result.text).not_to include('You cannot apply to this course as there are no places left on it')
         expect(result.text).not_to include('You need to either remove or change this course choice')
         expect(result.text).not_to include('may be able to recommend an alternative course')
-        expect(actions).to include('View application')
+        expect(actions).not_to include('View application')
         expect(links).not_to include('Change')
       end
     end

--- a/spec/system/candidate_interface/continuous_applications/submitting/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/submitting/candidate_submitting_application_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'Candidate submits the application', :continuous_applications do
     given_i_am_signed_in
 
     when_i_have_completed_my_application_and_added_primary_as_course_choice
-    and_i_review_my_application
+    and_i_continue_with_my_application
     and_i_submit_the_application
 
     then_i_should_see_an_error_message_that_i_should_choose_an_option
@@ -15,8 +15,7 @@ RSpec.feature 'Candidate submits the application', :continuous_applications do
     when_i_choose_no
     and_i_am_redirected_to_the_application_dashboard
     and_my_application_is_still_unsubmitted
-
-    and_i_review_my_application
+    and_i_continue_with_my_application
     when_i_choose_to_submit
     and_i_click_continue
 
@@ -26,6 +25,11 @@ RSpec.feature 'Candidate submits the application', :continuous_applications do
     then_i_can_see_my_submitted_application
     and_i_can_see_i_have_three_choices_left
     # and_i_receive_an_email_confirmation
+
+    when_i_click_view_application
+    then_i_can_review_my_submitted_application
+
+    when_i_go_back_to_the_dashboard
 
     when_i_have_three_further_draft_choices
     then_i_can_no_longer_add_more_course_choices
@@ -42,7 +46,7 @@ RSpec.feature 'Candidate submits the application', :continuous_applications do
 
     when_i_have_completed_my_application_and_added_primary_as_course_choice
     when_i_have_not_completed_science_gcse
-    and_i_review_my_application
+    and_i_continue_with_my_application
     then_i_should_see_an_error_message_that_i_should_complete_the_science_gcse
   end
 
@@ -74,9 +78,14 @@ RSpec.feature 'Candidate submits the application', :continuous_applications do
     @application_choice.application_form.update!(science_gcse_completed: false)
   end
 
+  def and_i_continue_with_my_application
+    visit candidate_interface_continuous_applications_choices_path
+    click_link 'Continue application', match: :first
+  end
+
   def and_i_review_my_application
     visit candidate_interface_continuous_applications_choices_path
-    click_on 'View application', match: :first
+    click_link 'View application', match: :first
   end
 
   def and_i_submit_the_application
@@ -124,9 +133,7 @@ RSpec.feature 'Candidate submits the application', :continuous_applications do
   end
 
   def when_i_click_view_application
-    within '.app-summary-card__actions' do
-      click_link 'View application'
-    end
+    click_link 'View application', match: :first
   end
 
   def and_my_application_is_submitted
@@ -139,6 +146,17 @@ RSpec.feature 'Candidate submits the application', :continuous_applications do
     expect(page).to have_content 'Primary (2XT2)'
     expect(page).to have_content 'PGCE with QTS full time'
     expect(page).to have_content 'Awaiting decision'
+  end
+
+  def then_i_can_review_my_submitted_application
+    expect(@current_candidate.current_application.application_choices).to contain_exactly(@application_choice)
+    expect(page).to have_content 'Gorse SCITT'
+    expect(page).to have_content 'Awaiting decision'
+    expect(page).to have_content @application_choice.sent_to_provider_at.to_fs(:govuk_date_and_time)
+    expect(page).to have_content 'Primary (2XT2)'
+    expect(page).to have_content 'Full time'
+    expect(page).to have_content 'Main site'
+    expect(page).to have_content @application_choice.personal_statement
   end
 
   def and_i_can_see_i_have_three_choices_left
@@ -157,7 +175,7 @@ RSpec.feature 'Candidate submits the application', :continuous_applications do
   alias_method :then_i_still_cannot_add_course_choices, :then_i_can_no_longer_add_more_course_choices
 
   def when_i_submit_one_of_my_draft_applications
-    click_on 'Continue application', match: :first
+    click_link 'Continue application', match: :first
     choose 'Yes, submit it now'
     click_button t('continue')
   end
@@ -169,5 +187,9 @@ RSpec.feature 'Candidate submits the application', :continuous_applications do
   def then_i_am_able_to_add_another_choice
     visit current_path
     expect(page).to have_content 'You can add 1 more application.'
+  end
+
+  def when_i_go_back_to_the_dashboard
+    click_link 'Back'
   end
 end


### PR DESCRIPTION
Also hides the link for unsubmitted applications.

I am using the status tag component, but because I had to hide the text underneath, I added the `@display_info_text` argument. I thought about taking the `colour` method out of the `ApplicationStatusTagComponent` component and maybe putting it in a helper so I can call it directly, but not sure it's worth it. Feedback is welcome.

<table>
   <tr>
      <td>
         <img width="827" alt="Screenshot 2023-09-25 at 13 41 28" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/d1961fb0-3a44-4560-a818-a4ae15f53c30">
      </td>
   </tr>
   <tr>
      <td><img width="788" alt="Screenshot 2023-09-25 at 13 41 46" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/5136b9cd-13f1-44ea-b2c2-a206ecc50727"></td>
   </tr>
</table>
