### PR TITLE
Fix specs that fails between rbd and find opens

### DIFF
--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -475,7 +475,7 @@ RSpec.describe CycleTimetable do
   end
 
   describe 'cycle switcher' do
-    it 'correctly sets can_add_course_choice? and can_submit? between cycles' do
+    it 'correctly sets can_add_course_choice? and can_submit? between cycles', :mid_cycle do
       SiteSetting.set(name: 'cycle_schedule', value: :today_is_mid_cycle)
 
       application_form = create(:application_form, phase: 'apply_1')
@@ -500,7 +500,7 @@ RSpec.describe CycleTimetable do
       SiteSetting.set(name: 'cycle_schedule', value: nil)
     end
 
-    context 'when cycle_schedule is set to today_is_after_find_opens' do
+    context 'when cycle_schedule is set to today_is_after_find_opens', :mid_cycle do
       it 'changes the CycleTimetable.current_year to the next year' do
         current_year = described_class.current_year
         next_year = described_class.next_year
@@ -511,7 +511,7 @@ RSpec.describe CycleTimetable do
       end
     end
 
-    context 'when cycle_schedule is set to today_is_after_apply_opens' do
+    context 'when cycle_schedule is set to today_is_after_apply_opens', :mid_cycle do
       it 'changes the CycleTimetable.current_year to the next year' do
         current_year = described_class.current_year
         next_year = described_class.next_year

--- a/spec/workers/update_out_of_date_provider_ids_on_application_choices_spec.rb
+++ b/spec/workers/update_out_of_date_provider_ids_on_application_choices_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe UpdateOutOfDateProviderIdsOnApplicationChoices, :sidekiq, :with_a
       end
     end
 
-    context 'when application choice in current cycle provider ids are out of date' do
+    context 'when application choice in current cycle provider ids are out of date', :mid_cycle do
       before { application_choice.update!(provider_ids: [wrong_provider.id]) }
 
       it 'updates application provider ids' do


### PR DESCRIPTION
## Context

Tests are failing for the period between RBD date (September 28th) and find opens (October 3rd).

This is an attempt to fix them
