### PR TITLE
Remove double full stop on 'you cannot submit this application until you've completed your details'

### DIFF
--- a/spec/services/candidate_interface/continuous_applications/application_choice_submission_spec.rb
+++ b/spec/services/candidate_interface/continuous_applications/application_choice_submission_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationChoiceSubm
 
       it 'adds errors to application choice' do
         expect(application_choice_submission).not_to be_valid
-        expect(application_choice_submission.errors[:application_choice]).to include('You cannot submit this application until you’ve completed your details.')
+        expect(application_choice_submission.errors[:application_choice]).to include('You cannot submit this application until you’ve completed your details')
         expect(application_choice_submission.errors[:application_choice]).to include('To apply for a Primary course, you need a GCSE in science at grade 4 (C) or above, or equivalent')
         expect(application_choice_submission.errors[:application_choice]).to include('<a class="govuk-link" href="/candidate/application/gcse/science">Add your science GCSE grade (or equivalent) before submitting this application</a>')
       end


### PR DESCRIPTION
## Context

Double full stop - removing.

## Changes proposed in this pull request

![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/35870975/4a000b0b-261a-4ed7-ac1b-378256f5dfa0)

I've done for the first issue, we need to do it for several more. E.g. below.

<img width="787" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/35870975/f3af368f-ccd4-4314-ab03-327a2d88a758">


## Guidance to review

Will this work? It's interesting that the en.yml file has a full stop on the value for this sentence, but only a single one. Do we have some logic somewhere that automatically appends a full stop? 

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
