### PR TITLE
Render content for an inactive application

### DIFF
--- a/app/components/candidate_interface/application_status_tag_component.html.erb
+++ b/app/components/candidate_interface/application_status_tag_component.html.erb
@@ -12,7 +12,7 @@
         <span class="govuk-visually-hidden"> <%= @application_choice.current_course.provider.name %></span>
       <% end %>
     </p>
-  <% elsif @application_choice.decision_pending? && @application_choice.reject_by_default_at&.future? %>
+  <% elsif (@application_choice.decision_pending? || @application_choice.inactive?) && @application_choice.reject_by_default_at&.future? %>
 
     <% if @application_choice.continuous_applications? %>
 
@@ -28,7 +28,11 @@
       <% end %>
 
       <p class="govuk-body govuk-!-margin-top-2">
-        If you do not receive a response from this training provider, you can withdraw this application and apply to another provider.
+        <% if @application_choice.inactive? && @application_choice.application_form.can_add_more_choices? %>
+          You can add an application for a different training provider while you wait for a decision on this application.
+        <% else %>
+            If you do not receive a response from this training provider, you can withdraw this application and apply to another provider.
+          <% end %>
       </p>
 
     <% else %>


### PR DESCRIPTION
## Context

The functionality for an inactive application is working but we're not rendering any copy once an application switches from `awaiting_provider_decision` to `inactive`.

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="759" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/3045b187-8bc9-433c-b621-4ad52feb3184">|<img width="783" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/336e6b9f-b39c-4998-afa5-3a7385e1c7df">|

For context, this is an application that is `awaiting_provider_decision`:
||
|---|
|<img width="768" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/6cafcbb3-f95a-456a-8406-f303ab6bd660">|

## Guidance to review

This is per the [prototype](https://apply-beta-prototype.herokuapp.com/applications):
<img width="757" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/5f846aff-36e2-498f-b702-648a49e64da0">

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
