### PR TITLE
[469] Update offer emails

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -220,6 +220,15 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def new_offer_made(application_choice)
+    @application_choice = application_choice
+    @course = @application_choice.current_course_option.course
+    @provider_name = @course.provider.name
+    @course_name_and_code = @application_choice.current_course_option.course.name_and_code
+    @application_form = @application_choice.application_form
+    email_for_candidate(@application_form, subject: I18n.t('candidate_mailer.new_offer_made.subject', provider_name: @course.provider.name))
+  end
+
   def new_offer_single_offer(application_choice)
     new_offer(application_choice, :single_offer)
   end

--- a/app/services/send_new_offer_email_to_candidate.rb
+++ b/app/services/send_new_offer_email_to_candidate.rb
@@ -6,13 +6,21 @@ class SendNewOfferEmailToCandidate
   end
 
   def call
+    if application_choice.continuous_applications?
+      CandidateMailer.new_offer_made(application_choice).deliver_later
+    else
+      pre_continuous_applications_withdrawn_mailers
+    end
+  end
+
+private
+
+  def pre_continuous_applications_withdrawn_mailers
     CandidateMailer.send(
       "new_offer_#{mail_type(application_choice)}".to_sym,
       application_choice,
     ).deliver_later
   end
-
-private
 
   def mail_type(application_choice)
     candidate_application_choices = application_choice.self_and_siblings

--- a/app/views/candidate_mailer/new_offer_made.text.erb
+++ b/app/views/candidate_mailer/new_offer_made.text.erb
@@ -1,0 +1,13 @@
+Hello <%= @application_form.first_name %>
+
+Congratulations! You have an offer from <%= @provider_name %> to study <%= @course_name_and_code %>.
+
+<% @application_choice.offer.conditions.select(&:unmet?).each do |condition| %>
+  You will need to meet the following conditions:
+
+ - <%= condition.text %>
+<% end %>
+
+Contact <%= @provider_name %> if you have any questions about this.
+
+[Sign into your account to respond to your offer](<%= candidate_magic_link(@application_form.candidate) %>).

--- a/app/views/candidate_mailer/offer_accepted.text.erb
+++ b/app/views/candidate_mailer/offer_accepted.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>
+Hello <%= @application_form.first_name %>
 
 You’ve accepted <%= @provider_name %>’s offer to study <%= @course_name_and_code %>.
 
@@ -7,12 +7,5 @@ Your place will be confirmed when:
 - <%= @provider_name %> has received and checked your references
 - you’ve met your offer conditions
 
-Sign into your account to check the progress of your reference requests and offer conditions.
+[Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>) to check the progress of your reference requests and offer conditions..
 
-[Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>).
-
-#If you’re unable to start training in <%= @start_date %>
-
-Contact <%= @provider_name%> to find out if they’ll allow you to defer your offer. This means that you could start your course a year later. 
-
-Asking if it’s possible will not affect your existing offer.

--- a/app/views/candidate_mailer/offer_accepted.text.erb
+++ b/app/views/candidate_mailer/offer_accepted.text.erb
@@ -7,5 +7,5 @@ Your place will be confirmed when:
 - <%= @provider_name %> has received and checked your references
 - you’ve met your offer conditions
 
-[Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>) to check the progress of your reference requests and offer conditions..
+[Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>) to check the progress of your reference requests and offer conditions.
 

--- a/app/views/candidate_mailer/unconditional_offer_accepted.text.erb
+++ b/app/views/candidate_mailer/unconditional_offer_accepted.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application_form.first_name %>
+Hello <%= @application_form.first_name %>
 
 You’ve accepted <%= @provider_name %>’s offer to study <%= @course_name_and_code %>.
 
@@ -6,12 +6,4 @@ You’ve accepted <%= @provider_name %>’s offer to study <%= @course_name_and_
 
 They’ll let you know if they need further information before you can start training.
 
-Sign into your account to check the progress of your reference requests.
-
-[Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>).
-
-#If you’re unable to start training in <%= @start_date %>
-
-Contact <%= @provider_name %> to find out if they’ll allow you to defer your offer. This means that you could start your course a year later.
-
-Asking if it’s possible will not affect your existing offer.
+[Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>) to check the progress of your reference requests.

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -257,6 +257,7 @@ en:
 
         An email is sent to the candidate, the content of which depends on the state of the other application choices, whether there are other offers and whether there are pending decisions from providers.
       emails:
+        - candidate_mailer-new_offer_made
         - candidate_mailer-new_offer_single_offer
         - candidate_mailer-new_offer_multiple_offers
         - candidate_mailer-new_offer_decisions_pending
@@ -318,6 +319,7 @@ en:
 
         An email is sent to the candidate, the content of which depends on the state of the other application choices, whether there are other offers and whether there are pending decisions from providers.
       emails:
+        - candidate_mailer-new_offer_made
         - candidate_mailer-new_offer_single_offer
         - candidate_mailer-new_offer_multiple_offers
         - candidate_mailer-new_offer_decisions_pending
@@ -379,6 +381,7 @@ en:
       description: |
         The provider is able to update their offer at any time before the candidate has accepted it. An updated offer may have different conditions or be for a different course.
       emails:
+        - candidate_mailer-new_offer_made
         - candidate_mailer-new_offer_single_offer
         - candidate_mailer-new_offer_multiple_offers
         - candidate_mailer-new_offer_decisions_pending
@@ -479,6 +482,7 @@ en:
       by: provider
       description: ""
       emails:
+        - candidate_mailer-new_offer_made
         - candidate_mailer-new_offer_single_offer
         - candidate_mailer-new_offer_multiple_offers
         - candidate_mailer-new_offer_decisions_pending
@@ -488,6 +492,7 @@ en:
       by: provider
       description: ""
       emails:
+        - candidate_mailer-new_offer_made
         - candidate_mailer-new_offer_single_offer
         - candidate_mailer-new_offer_multiple_offers
         - candidate_mailer-new_offer_decisions_pending

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -11,6 +11,8 @@ en:
         subject: "Successful application for %{provider_name}"
       decisions_pending:
         subject: "Successful application for %{provider_name}"
+    new_offer_made:
+      subject: "Successful application for %{provider_name}"
     chase_candidate_decision:
       subject_singular: Make a decision on your teacher training application
       subject_plural: Make a decision on your teacher training applications

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -362,9 +362,9 @@ RSpec.describe CandidateMailer do
     it_behaves_like(
       'a mail with subject and content',
       'You’ve accepted Arithmetic College’s offer to study Mathematics (M101)',
-      'greeting' => 'Dear Fred',
+      'greeting' => 'Hello Fred',
       'offer_details' => 'You’ve accepted Arithmetic College’s offer to study Mathematics (M101)',
-      'course start' => 'September 2021',
+      'sign in link' => 'Sign into your account',
     )
 
     it 'includes reference text' do

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -536,6 +536,27 @@ RSpec.describe CandidateMailer do
     end
   end
 
+  describe '.new_offer_made' do
+    let(:email) { described_class.new_offer_made(application_form.application_choices.first) }
+    let(:application_choices) do
+      [build_stubbed(
+        :application_choice,
+        :offered,
+        status: 'offer',
+        current_course_option: course_option,
+      )]
+    end
+
+    it_behaves_like(
+      'a mail with subject and content',
+      'Successful application for Arithmetic College',
+      'greeting' => 'Hello Fred',
+      'offer_details' => 'Congratulations! You have an offer from Arithmetic College to study Mathematics (M101)',
+      'contact' => 'Contact Arithmetic College if you have any questions about this',
+      'sign in link' => 'Sign into your account to respond to your offer',
+    )
+  end
+
   describe '.change_course' do
     let(:application_choice) do
       create(

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -441,9 +441,9 @@ RSpec.describe CandidateMailer do
     it_behaves_like(
       'a mail with subject and content',
       'You’ve accepted Arithmetic College’s offer to study Mathematics (M101)',
-      'greeting' => 'Dear Fred',
+      'greeting' => 'Hello Fred',
       'offer_details' => 'You’ve accepted Arithmetic College’s offer to study Mathematics (M101)',
-      'course start' => 'September 2021',
+      'sign in link' => 'Sign into your account',
     )
   end
 

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -107,6 +107,22 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.chase_candidate_decision(application_form)
   end
 
+  def new_offer_made
+    application_form_with_name = FactoryBot.build_stubbed(
+      :application_form,
+      first_name: 'Bob',
+    )
+
+    application_choice = FactoryBot.build_stubbed(
+      :application_choice,
+      application_form: application_form_with_name,
+      course_option:,
+      offer: FactoryBot.build(:offer, :with_unmet_conditions),
+    )
+
+    CandidateMailer.new_offer_made(application_choice)
+  end
+
   def new_offer_single_offer
     conditions = [FactoryBot.build(:text_condition, description: 'DBS check'),
                   FactoryBot.build(:text_condition, description: 'Pass exams')]

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -664,7 +664,12 @@ class CandidateMailerPreview < ActionMailer::Preview
   end
 
   def offer_accepted
-    application_choice = FactoryBot.build_stubbed(:application_choice)
+    application_form_with_name = FactoryBot.build_stubbed(
+      :application_form,
+      first_name: 'Bob',
+    )
+
+    application_choice = FactoryBot.build_stubbed(:application_choice, application_form: application_form_with_name)
     CandidateMailer.offer_accepted(application_choice)
   end
 

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -880,7 +880,11 @@ class CandidateMailerPreview < ActionMailer::Preview
   end
 
   def unconditional_offer_accepted
-    application_choice = FactoryBot.build_stubbed(:application_choice)
+    application_form_with_name = FactoryBot.build_stubbed(
+      :application_form,
+      first_name: 'Bob',
+    )
+    application_choice = FactoryBot.build_stubbed(:application_choice, application_form: application_form_with_name)
     CandidateMailer.unconditional_offer_accepted(application_choice)
   end
 

--- a/spec/services/send_new_offer_email_to_candidate_with_continuous_applications_disabled_spec.rb
+++ b/spec/services/send_new_offer_email_to_candidate_with_continuous_applications_disabled_spec.rb
@@ -1,6 +1,8 @@
+# This file can be dropped along with the continuous applications feature flag. The new functionality is tested in `send_new_offer_email_to_candidate_spec.rb`
+
 require 'rails_helper'
 
-RSpec.describe SendNewOfferEmailToCandidate, :continuous_applications do
+RSpec.describe SendNewOfferEmailToCandidate, continuous_applications: false do
   describe '#call' do
     def setup_application
       @candidate = create(:candidate)
@@ -21,20 +23,20 @@ RSpec.describe SendNewOfferEmailToCandidate, :continuous_applications do
     context 'when there is a single offer' do
       before do
         mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
-        allow(CandidateMailer).to receive(:new_offer_made).and_return(mail)
+        allow(CandidateMailer).to receive(:new_offer_single_offer).and_return(mail)
         setup_application
       end
 
-      it 'sends new offer accepted email' do
+      it 'sends new offer email for single offer case' do
         described_class.new(application_choice: @application_choice).call
-        expect(CandidateMailer).to have_received(:new_offer_made).with(@application_choice)
+        expect(CandidateMailer).to have_received(:new_offer_single_offer).with(@application_choice)
       end
     end
 
     context 'when there are multiple offers' do
       before do
         mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
-        allow(CandidateMailer).to receive(:new_offer_made).and_return(mail)
+        allow(CandidateMailer).to receive(:new_offer_multiple_offers).and_return(mail)
         setup_application
         other_course_option = create(:course_option)
         @application_form.application_choices.create(
@@ -46,16 +48,16 @@ RSpec.describe SendNewOfferEmailToCandidate, :continuous_applications do
         )
       end
 
-      it 'sends new offer accepted email' do
+      it 'sends new offer email for multiple offers case' do
         described_class.new(application_choice: @application_choice).call
-        expect(CandidateMailer).to have_received(:new_offer_made).with(@application_choice)
+        expect(CandidateMailer).to have_received(:new_offer_multiple_offers).with(@application_choice)
       end
     end
 
     context 'when there are other choices in the awaiting_provider_decision state' do
       before do
         mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
-        allow(CandidateMailer).to receive(:new_offer_made).and_return(mail)
+        allow(CandidateMailer).to receive(:new_offer_decisions_pending).and_return(mail)
         setup_application
         other_course_option = create(:course_option)
         @application_form.application_choices.create(
@@ -67,16 +69,16 @@ RSpec.describe SendNewOfferEmailToCandidate, :continuous_applications do
         )
       end
 
-      it 'sends new offer accepted email' do
+      it 'sends new offer email for pending decision case' do
         described_class.new(application_choice: @application_choice).call
-        expect(CandidateMailer).to have_received(:new_offer_made).with(@application_choice)
+        expect(CandidateMailer).to have_received(:new_offer_decisions_pending).with(@application_choice)
       end
     end
 
     context 'when there are other choices in the interviewing state' do
       before do
         mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
-        allow(CandidateMailer).to receive(:new_offer_made).and_return(mail)
+        allow(CandidateMailer).to receive(:new_offer_decisions_pending).and_return(mail)
         setup_application
         other_course_option = create(:course_option)
         @application_form.application_choices.create(
@@ -88,9 +90,9 @@ RSpec.describe SendNewOfferEmailToCandidate, :continuous_applications do
         )
       end
 
-      it 'sends new offer accepted email' do
+      it 'sends new offer email for pending decision case' do
         described_class.new(application_choice: @application_choice).call
-        expect(CandidateMailer).to have_received(:new_offer_made).with(@application_choice)
+        expect(CandidateMailer).to have_received(:new_offer_decisions_pending).with(@application_choice)
       end
     end
   end


### PR DESCRIPTION
## Context

Re-jigging offer emails in line with continious applications.

## Changes proposed in this pull request

- Update content on `unconditional_offer_accepted` email and add name to preview.

<img width="417" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/50492247/80898022-9954-4b18-8bc6-c38e8333d4bf">


- Update content on `offer_accepted` email and add name to preview.

<img width="476" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/50492247/8ab6f840-737a-4426-8366-86199a0ba0c5">


- Create a `new_offer_made` email which will be used instead of the following emails during continuous applications:`new_offer_conditions_pending`, `new_offer_multiple_offers`, `new_offer_single_offer` and `new_unconditional_offer_decisions_pending`.

<img width="475" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/50492247/438dd133-0a32-44c3-ac72-0ba01232fe69">


## Guidance to review

🚢 

## Link to Trello card

https://trello.com/c/XfOZg3Bx/469-ca-emails-design-and-implement-new-offer-emails

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
