### PR TITLE
Add course selection journey for courses with no vacancies

### DIFF
--- a/app/controllers/candidate_interface/continuous_applications/course_choices/full_course_selection_controller.rb
+++ b/app/controllers/candidate_interface/continuous_applications/course_choices/full_course_selection_controller.rb
@@ -1,0 +1,28 @@
+module CandidateInterface
+  module ContinuousApplications
+    module CourseChoices
+      class FullCourseSelectionController < BaseController
+        before_action :set_course
+        skip_before_action :redirect_to_your_applications_if_maximum_amount_of_choices_have_been_used
+
+      private
+
+        def step_params
+          params[current_step] = {
+            provider_id: params.delete(:provider_id),
+            course_id: params.delete(:course_id),
+          }
+          params
+        end
+
+        def current_step
+          :full_course_selection
+        end
+
+        def set_course
+          @course = Course.find(params[:course_id])
+        end
+      end
+    end
+  end
+end

--- a/app/forms/candidate_interface/continuous_applications/course_selection_wizard.rb
+++ b/app/forms/candidate_interface/continuous_applications/course_selection_wizard.rb
@@ -11,6 +11,7 @@ module CandidateInterface
           { provider_selection: ProviderSelectionStep },
           { which_course_are_you_applying_to: WhichCourseAreYouApplyingToStep },
           { duplicate_course_selection: DuplicateCourseSelectionStep },
+          { full_course_selection: FullCourseSelectionStep },
           { course_study_mode: CourseStudyModeStep },
           { course_site: CourseSiteStep },
           { find_course_selection: FindCourseSelectionStep },

--- a/app/forms/candidate_interface/continuous_applications/full_course_selection_step.rb
+++ b/app/forms/candidate_interface/continuous_applications/full_course_selection_step.rb
@@ -1,0 +1,23 @@
+module CandidateInterface
+  module ContinuousApplications
+    class FullCourseSelectionStep < DfE::WizardStep
+      include Concerns::CourseSelectionStepHelper
+      attr_accessor :provider_id, :course_id
+      validates :provider_id, :course_id, presence: true
+
+      def self.permitted_params
+        %i[provider_id course_id]
+      end
+
+      def previous_step
+        :which_course_are_you_applying_to
+      end
+
+      def next_step; end
+
+      def previous_step_path_arguments
+        { provider_id: provider_id }
+      end
+    end
+  end
+end

--- a/app/views/candidate_interface/continuous_applications/course_choices/full_course_selection/new.html.erb
+++ b/app/views/candidate_interface/continuous_applications/course_choices/full_course_selection/new.html.erb
@@ -1,0 +1,20 @@
+<% content_for :title, t('page_titles.full_course') %>
+<% content_for(:before_content, govuk_back_link_to(@wizard.previous_step_path)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.full_course', course_name: @course.name_and_code) %>
+    </h1>
+
+    <% if @course.provider.course_options.available.any? %>
+      <p class="govuk-body">You can:</p>
+      <ul class="govuk-list govuk-list--bullet govuk-!-padding-bottom-8">
+        <li>apply to a <%= govuk_link_to 'different course', candidate_interface_continuous_applications_which_course_are_you_applying_to_path(provider_id: @course.provider.id) %> offered by <%= @course.provider.name %></li>
+        <li>apply to a <%= govuk_link_to 'different training provider', candidate_interface_continuous_applications_provider_selection_path %></li>
+      </ul>
+    <% else %>
+      <p class="govuk-body">You can apply to a <%= govuk_link_to 'different training provider', candidate_interface_continuous_applications_provider_selection_path %>.</p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/continuous_applications/course_choices/which_course_are_you_applying_to/_form_fields.html.erb
+++ b/app/views/candidate_interface/continuous_applications/course_choices/which_course_are_you_applying_to/_form_fields.html.erb
@@ -12,10 +12,8 @@
   ) %>
 <% else %>
   <%= f.govuk_radio_buttons_fieldset :course_id, legend: { size: 'xl', text: t('page_titles.which_course'), tag: 'h1' } do %>
-    <% @wizard.current_step.available_courses.each_with_index do |course, i| %>
-      <% if course.course_options.available.any? %>
-        <%= f.govuk_radio_button :course_id, course.id, label: { text: "#{course.name} (#{course.code})" }, hint: { text: course.description }, link_errors: i.zero? %>
-      <% end %>
+    <% @wizard.current_step.radio_available_courses.each_with_index do |course, i| %>
+      <%= f.govuk_radio_button :course_id, course.id, label: { text: course.label }, hint: { text: course.hint }, link_errors: i.zero? %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/candidate_interface/course_choices/course_selection/_form_fields.html.erb
+++ b/app/views/candidate_interface/course_choices/course_selection/_form_fields.html.erb
@@ -10,11 +10,7 @@
 <% else %>
   <%= f.govuk_radio_buttons_fieldset :course_id, legend: { size: 'xl', text: t('page_titles.which_course'), tag: 'h1' } do %>
     <% @pick_course.radio_available_courses.each_with_index do |course, i| %>
-      <% if course.course_options.available.blank? %>
-        <%= f.govuk_radio_button :course_id, course.id, label: { text: "#{course.name} (#{course.code}) – No vacancies" }, hint: { text: course.description }, link_errors: i.zero? %>
-      <% else %>
-        <%= f.govuk_radio_button :course_id, course.id, label: { text: "#{course.name} (#{course.code})" }, hint: { text: course.description }, link_errors: i.zero? %>
-      <% end %>
+      <%= f.govuk_radio_button :course_id, course.id, label: { text: course.label }, hint: { text: course.hint }, link_errors: i.zero? %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/candidate_interface/course_choices/course_selection/full.html.erb
+++ b/app/views/candidate_interface/course_choices/course_selection/full.html.erb
@@ -4,10 +4,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      <%= t('page_titles.full_course') %>
+      <%= t('page_titles.full_course', course_name: @course.name_and_code) %>
     </h1>
 
-    <p class="govuk-body">The course ‘<%= @course.name_and_code %>’ is full.</p>
     <p class="govuk-body">You can:</p>
     <ul class="govuk-list govuk-list--bullet govuk-!-padding-bottom-8">
       <li>
@@ -19,7 +18,7 @@
       <li>
         contact
         <%= govuk_link_to @course.provider.name, "#{@course.find_url}#section-contact" %>
-      to see if the course will re-open or discuss alternatives
+        to see if the course will re-open or discuss alternatives
       </li>
     </ul>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -161,7 +161,7 @@ en:
     choose_course: Choose your course
     courses: Courses
     course_choices: Course choices
-    full_course: You cannot apply to this course because it has no vacancies
+    full_course: Unfortunately, you cannot apply to %{course_name} because it’s now full
     destroy_course_choice: Are you sure you want to delete this choice?
     continuous_applications_destroy_course_choice: Are you sure you want to remove this draft application?
     do_you_know: Do you know which course you want to apply to?

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -361,7 +361,8 @@ namespace :candidate_interface, path: '/candidate' do
       post '/provider/:provider_id/course' => 'continuous_applications/course_choices/which_course_are_you_applying_to#create'
       get '/:application_choice_id/review' => 'continuous_applications/course_choices/review#show', as: :continuous_applications_course_review
 
-      get '/provider/:provider_id/course/:course_id/duplicate' => 'continuous_applications/course_choices/duplicate_course_selection#new', as: :continuous_applications_duplicate_course_selection
+      get '/provider/:provider_id/courses/:course_id/duplicate' => 'continuous_applications/course_choices/duplicate_course_selection#new', as: :continuous_applications_duplicate_course_selection
+      get '/provider/:provider_id/courses/:course_id/full' => 'continuous_applications/course_choices/full_course_selection#new', as: :continuous_applications_full_course_selection
 
       get '/provider/:provider_id/courses/:course_id' => 'continuous_applications/course_choices/course_study_mode#new', as: :continuous_applications_course_study_mode
       post '/provider/:provider_id/courses/:course_id' => 'continuous_applications/course_choices/course_study_mode#create'

--- a/spec/forms/candidate_interface/continuous_applications/which_course_are_you_applying_to_step_spec.rb
+++ b/spec/forms/candidate_interface/continuous_applications/which_course_are_you_applying_to_step_spec.rb
@@ -113,7 +113,17 @@ RSpec.describe CandidateInterface::ContinuousApplications::WhichCourseAreYouAppl
       end
     end
 
+    context 'when course has no course availability' do
+      it 'returns :full_course_selection' do
+        expect(which_course_are_you_applying_to_step.next_step).to be(:full_course_selection)
+      end
+    end
+
     context 'when course has single site and single study mode' do
+      before do
+        create(:course_option, course:)
+      end
+
       it 'returns :course_review' do
         expect(which_course_are_you_applying_to_step.next_step).to be(:course_review)
       end
@@ -150,6 +160,14 @@ RSpec.describe CandidateInterface::ContinuousApplications::WhichCourseAreYouAppl
 
       it 'returns :duplicate_course_selection' do
         expect(wizard.current_step.next_step).to be(:duplicate_course_selection)
+      end
+    end
+
+    context 'when course choice has no availability' do
+      let(:application_choice) { create(:application_choice) }
+
+      it 'returns :duplicate_course_selection' do
+        expect(wizard.current_step.next_step).to be(:full_course_selection)
       end
     end
   end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_that_is_full_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_that_is_full_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.feature 'Selecting a course', :continuous_applications do
+  include CandidateHelper
+
+  it 'Candidate selects a course that is full' do
+    given_i_am_signed_in
+    and_the_course_has_no_course_options
+
+    when_i_visit_the_site
+    and_i_click_on_course_choices
+    and_i_choose_that_i_know_where_i_want_to_apply
+    and_i_choose_a_provider
+    then_i_should_see_a_course_and_its_description
+
+    and_i_choose_a_course_with_no_vacancies
+    then_i_should_be_on_the_application_choice_duplicate_page
+    and_i_see_that_i_can_apply_to_a_different_provider
+
+    when_the_provider_adds_more_vacancies
+    then_i_see_that_i_can_apply_to_another_course
+
+    when_i_click_back
+    then_i_should_be_on_the_course_choice_page
+  end
+
+  def given_i_am_signed_in
+    @candidate = create(:candidate)
+    create_and_sign_in_candidate(candidate: @candidate)
+  end
+
+  def and_the_course_has_no_course_options
+    @provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
+    @course = create(:course, :open_on_apply, :with_no_vacancies, name: 'Primary', code: '2XT2', provider: @provider)
+  end
+
+  def when_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def and_i_click_on_course_choices
+    click_link 'Your application'
+    click_link 'Add application'
+  end
+
+  def and_i_choose_that_i_know_where_i_want_to_apply
+    choose 'Yes, I know where I want to apply'
+    click_button t('continue')
+  end
+
+  def and_i_choose_a_provider
+    select 'Gorse SCITT (1N1)'
+    click_button t('continue')
+  end
+
+  def then_i_should_see_a_course_and_its_description
+    expect(page).to have_content(@course.name_and_code)
+    expect(page).to have_content(@course.description)
+  end
+
+  def and_i_choose_a_course_with_no_vacancies
+    choose 'Primary (2XT2)'
+    click_button t('continue')
+  end
+
+  def then_i_should_be_on_the_application_choice_duplicate_page
+    expect(page).to have_content('Unfortunately, you cannot apply to Primary (2XT2) because it’s now full')
+  end
+
+  def and_i_see_that_i_can_apply_to_a_different_provider
+    expect(page).not_to have_content('apply to a different course offered by Gorse SCITT')
+    expect(page).to have_content('You can apply to a different training provider.')
+  end
+
+  def when_the_provider_adds_more_vacancies
+    create(:course, :open_on_apply, :with_course_options, provider: @provider)
+  end
+
+  def then_i_see_that_i_can_apply_to_another_course
+    visit current_path
+
+    expect(page).to have_content('apply to a different course offered by Gorse SCITT')
+    expect(page).to have_content('apply to a different training provider')
+  end
+
+  def when_i_click_back
+    click_link 'Back'
+  end
+
+  def then_i_should_be_on_the_course_choice_page
+    expect(page.current_url).to end_with(candidate_interface_continuous_applications_which_course_are_you_applying_to_path(provider_id: @provider.id))
+  end
+end

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_full_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_full_spec.rb
@@ -40,8 +40,7 @@ RSpec.feature 'Selecting a full course', continuous_applications: false do
   end
 
   def then_i_see_a_page_telling_me_i_cannot_apply
-    expect(page).to have_text('You cannot apply to this course because it has no vacancies')
-    expect(page).to have_text("The course ‘#{@course.name_and_code}’ is full")
+    expect(page).to have_text("Unfortunately, you cannot apply to #{@course.name_and_code} because it’s now full")
   end
 
   def and_i_click_the_choose_another_course_link


### PR DESCRIPTION
This PR adds a new step to the course selection wizard that allows candidates to select a course that is full, but redirects them to a page that explains that they can't apply to this course and what actions they can take next.

### Shows the full courses on the radio buttons as well:
<hr/>
<img width="450" alt="Screenshot 2023-09-28 at 13 53 59" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/33ed0148-c4d6-4dba-ba7a-074b21161633">
<hr/>

### And adds the full corse page:
<img width="450" alt="Screenshot 2023-09-28 at 17 06 13" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/4638dfdd-cdba-42a8-8ebb-e3ba6dc9a7f8">
<hr/>

### And if the provider has no more available courses:
<img width="450" alt="Screenshot 2023-09-28 at 17 05 23" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/22bbd93e-3cd8-4a6e-bb0c-3374ab50272a">
<hr/>

@MaeveRoseveare I did mention this on Trello, should we keep the wording consistent to the [duplicates page](https://user-images.githubusercontent.com/135042929/270358362-671236fe-7b1d-4f70-bff1-79be1a610231.png).