### PR TITLE
Remove the double full stops.. again..

### DIFF
--- a/app/validators/can_add_more_choices_validator.rb
+++ b/app/validators/can_add_more_choices_validator.rb
@@ -1,11 +1,11 @@
 class CanAddMoreChoicesValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, application_choice)
     unless application_choice.application_form.can_submit_further_applications?
-      record.errors.add(attribute, :max_course_choices, message: 'You cannot submit this application because you have already submitted the maximum number of applications.')
+      record.errors.add(attribute, :max_course_choices, message: 'You cannot submit this application because you have already submitted the maximum number of applications')
     end
 
     if application_choice.application_form.reached_maximum_unsuccessful_choices?
-      record.errors.add(attribute, :max_course_choices, message: "You cannot submit this application because you have #{ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS} unsuccessful applications.")
+      record.errors.add(attribute, :max_course_choices, message: "You cannot submit this application because you have #{ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS} unsuccessful applications")
     end
   end
 end

--- a/spec/services/candidate_interface/continuous_applications/application_choice_submission_spec.rb
+++ b/spec/services/candidate_interface/continuous_applications/application_choice_submission_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationChoiceSubm
       it 'adds error to application choice' do
         application_choice_submission.valid?
         expect(application_choice_submission.errors[:application_choice]).to include(
-          'You cannot submit this application because you have already submitted the maximum number of applications.',
+          'You cannot submit this application because you have already submitted the maximum number of applications',
         )
       end
     end
@@ -155,7 +155,7 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationChoiceSubm
       it 'adds error to application choice' do
         application_choice_submission.valid?
         expect(application_choice_submission.errors[:application_choice]).to include(
-          "You cannot submit this application because you have #{ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS} unsuccessful applications.",
+          "You cannot submit this application because you have #{ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS} unsuccessful applications",
         )
       end
     end


### PR DESCRIPTION
## Context

We're still rendering `..` in places.

## Changes proposed in this pull request

|Before|After
|---|---|
|![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/e8f18d6d-cbc2-4a48-a175-39c113bbfe30)|<img width="805" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/1a37b057-8658-4733-bf01-05ede71ae10a">|

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
