### PR TITLE
Update error messages in course selection flow

### DIFF
--- a/config/locales/candidate_interface/course_selection_wizard.yml
+++ b/config/locales/candidate_interface/course_selection_wizard.yml
@@ -5,7 +5,7 @@ en:
         do_you_know_the_course:
           attributes:
             answer:
-              blank: Select if you have chosen a course or not
+              blank: Select if you know which course you want to apply to
         provider_selection:
           attributes:
             provider_id:
@@ -21,7 +21,7 @@ en:
         course_site:
           attributes:
             course_option_id:
-              blank: Select which location you’re applying to
+              blank: Select which location you’re interested in
         find_course_selection:
           attributes:
             confirm:

--- a/config/locales/candidate_interface/courses.yml
+++ b/config/locales/candidate_interface/courses.yml
@@ -38,11 +38,11 @@ en:
         candidate_interface/pick_site_form:
           attributes:
             course_option_id:
-              blank: Select which location you’re applying to
+              blank: Select which location you’re interested in
         candidate_interface/course_chosen_form:
           attributes:
             choice:
-              blank: Select if you have chosen a course or not
+              blank: Select if you know which course you want to apply to
         candidate_interface/pick_course_form:
           attributes:
             course_id:

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_spec.rb
@@ -71,7 +71,7 @@ RSpec.feature 'Selecting a course', :continuous_applications do
   end
 
   def then_i_should_see_an_error_message_about_to_select_if_i_know_which_course
-    expect(page).to have_content('Select if you have chosen a course or not')
+    expect(page).to have_content('Select if you know which course you want to apply to')
   end
 
   def and_i_choose_that_i_know_where_i_want_to_apply

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_with_multiple_sites_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_with_multiple_sites_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature 'Selecting a course with multiple sites', :continuous_applications
   end
 
   def then_i_should_see_an_error_message_about_to_select_if_i_know_which_course
-    expect(page).to have_content('Select if you have chosen a course or not')
+    expect(page).to have_content('Select if you know which course you want to apply to')
   end
 
   def and_i_choose_that_i_know_where_i_want_to_apply
@@ -185,7 +185,7 @@ RSpec.feature 'Selecting a course with multiple sites', :continuous_applications
 
   def then_i_should_be_seeing_an_error_message
     expect(page).to have_content('There is a problem')
-    expect(page).to have_content('Select which location you’re applying to')
+    expect(page).to have_content('Select which location you’re interested in')
   end
 
   def application_choice


### PR DESCRIPTION
## Context

This is a quick draft PR that I'm using for reference (which can close if content designers decide the best approach is to give this more thought, and to keep repo tidy)

## Changes proposed in this pull request

Updating error messages to reflect the questions.

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/35870975/fa1ef96d-0aff-4505-9df1-bec5dbb4b336) |  ![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/35870975/649dcb85-ad8c-4421-b8d9-f2264e54d029) |
| ![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/35870975/1f37d360-58b0-4ec6-be69-404bf37ab198) | No 2024 courses on review app, so unable to generate |

## Guidance to review

Does this work?

## Link to Trello card

https://trello.com/c/Vx7vVCfu/720-apply-ensure-consistency-with-error-messages-and-the-questions

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
