### PR TITLE
Make sure we have a bachelor degree on spec to avoid flaky specs

### DIFF
--- a/spec/system/candidate_interface/continuous_applications/entering_details/candidate_can_not_edit_some_sections_after_first_submission_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/entering_details/candidate_can_not_edit_some_sections_after_first_submission_spec.rb
@@ -41,6 +41,17 @@ RSpec.feature 'A candidate can not edit some sections after first submission', :
       volunteering_experiences_count: 1,
       candidate: current_candidate,
     )
+    create(
+      :application_qualification,
+      application_form:,
+      level: 'degree',
+      qualification_type: 'Bachelor of Science',
+      subject: 'Accountancy',
+      grade: 'First-class honours',
+      predicted_grade: false,
+      award_year: '2020',
+      institution_name: 'AA School of Architecture',
+    )
     create(:application_choice, :awaiting_provider_decision, application_form:)
   end
 


### PR DESCRIPTION
## Context

If a degree only has foundation the spec fails.

So if the factory randomly generates the foundation degree instead of bachelor the test explodes :boom:

We need to be aware of this issue. We might need to review the degrees factory at some point

