### PR TITLE
Conditionally display suggestion on duplicate course selection

### DIFF
--- a/app/views/candidate_interface/continuous_applications/course_choices/duplicate_course_selection/new.html.erb
+++ b/app/views/candidate_interface/continuous_applications/course_choices/duplicate_course_selection/new.html.erb
@@ -15,7 +15,7 @@
         <li>apply to a <%= govuk_link_to 'different training provider', candidate_interface_continuous_applications_provider_selection_path %></li>
       </ul>
       <% else %>
-        <p class="govuk-body">You can apply to a <%= govuk_link_to 'different training provider', candidate_interface_continuous_applications_provider_selection_path %></p>
+        <p class="govuk-body">You can apply to a <%= govuk_link_to 'different training provider', candidate_interface_continuous_applications_provider_selection_path %>.</p>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/continuous_applications/course_choices/duplicate_course_selection/new.html.erb
+++ b/app/views/candidate_interface/continuous_applications/course_choices/duplicate_course_selection/new.html.erb
@@ -7,10 +7,15 @@
       <%= t('page_titles.duplicate_application_selection', course_name: @course.name_and_code, provider_name: @course.provider.name) %>
     </h1>
 
-    <p class="govuk-body">You can:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>apply to a <%= govuk_link_to 'different course', candidate_interface_continuous_applications_which_course_are_you_applying_to_path(provider_id: @course.provider.id) %> offered by <%= @course.provider.name %></li>
-      <li>apply to a <%= govuk_link_to 'different training provider', candidate_interface_continuous_applications_provider_selection_path %></li>
-    </ul>
+    <% if @course.provider.courses.current_cycle.open_on_apply.open_for_applications.exposed_in_find.count > 1 %>
+      <p class="govuk-body">You can:</p>
+      <ul class="govuk-list govuk-list--bullet">
+
+        <li>apply to a <%= govuk_link_to 'different course', candidate_interface_continuous_applications_which_course_are_you_applying_to_path(provider_id: @course.provider.id) %> offered by <%= @course.provider.name %></li>
+        <li>apply to a <%= govuk_link_to 'different training provider', candidate_interface_continuous_applications_provider_selection_path %></li>
+      </ul>
+      <% else %>
+        <p class="govuk-body">You can apply to a <%= govuk_link_to 'different training provider', candidate_interface_continuous_applications_provider_selection_path %></p>
+    <% end %>
   </div>
 </div>


### PR DESCRIPTION
## Context

When a candidate has an open application to a course and the provider of that course only has one course available to apply to and the candidate tries to make a second application to that course, it doesn't make sense to suggest to the candidate to choose another course from the same provider.

## Changes proposed in this pull request

  Only suggest that the candidate choose another course from the
  provider if the provider has another course option available.


## Screenshot
![Screenshot from 2023-09-29 12-42-15](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/f3f67301-e2e3-4982-a103-acc41a21fd77)


## Guidance to review

Should we create a named scope on the `Course` model that selects all open and available courses in the current cycle?

### Review App

Single course added to the review app and [this user has been carried over](https://apply-review-8611.test.teacherservices.cloud/support/applications/40)

## Link to Trello card

[Trello Ticket](https://trello.com/c/tK9UOzqv/724-apply-hide-the-apply-to-a-different-course-if-the-provider-only-has-one-course)

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
