### PR TITLE
Fix the bug 'Candidate is unable to navigate back to the post offer'

### DIFF
--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -51,8 +51,6 @@ module CandidateInterface
                               end
     end
 
-    delegate :continuous_applications?, to: :current_application
-
     def back_link_text
       if any_accepted_offer?
         'Back to your offer'

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -51,6 +51,17 @@ module CandidateInterface
                               end
     end
 
+    delegate :continuous_applications?, to: :current_application
+
+    def back_link_text
+      if any_accepted_offer?
+        'Back to your offer'
+      else
+        'Back to application'
+      end
+    end
+    helper_method :back_link_text
+
   private
 
     def track_adviser_offering

--- a/app/controllers/candidate_interface/references/cancel_controller.rb
+++ b/app/controllers/candidate_interface/references/cancel_controller.rb
@@ -3,6 +3,7 @@ module CandidateInterface
     class CancelController < BaseController
       before_action :set_backlink
       skip_before_action :redirect_to_dashboard_if_submitted
+      skip_before_action :redirect_to_post_offer_dashboard_if_accepted_or_recruited
 
       def new
         if @reference&.feedback_requested?

--- a/app/controllers/candidate_interface/references/reminder_controller.rb
+++ b/app/controllers/candidate_interface/references/reminder_controller.rb
@@ -2,6 +2,7 @@ module CandidateInterface
   module References
     class ReminderController < BaseController
       skip_before_action :redirect_to_dashboard_if_submitted
+      skip_before_action :redirect_to_post_offer_dashboard_if_accepted_or_recruited
 
       def new; end
 

--- a/app/controllers/candidate_interface/section_controller.rb
+++ b/app/controllers/candidate_interface/section_controller.rb
@@ -4,6 +4,8 @@ module CandidateInterface
     before_action :set_section_policy
     before_action :verify_authorized_section, except: %i[show review]
 
+    delegate :continuous_applications?, to: :current_application
+
     def show; end
     def review; end
 

--- a/app/controllers/candidate_interface/section_controller.rb
+++ b/app/controllers/candidate_interface/section_controller.rb
@@ -1,5 +1,6 @@
 module CandidateInterface
   class SectionController < CandidateInterfaceController
+    before_action :redirect_to_post_offer_dashboard_if_accepted_or_recruited, if: :continuous_applications?
     before_action :set_section_policy
     before_action :verify_authorized_section, except: %i[show review]
 

--- a/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
@@ -5,6 +5,7 @@ module CandidateInterface
     before_action :render_error_if_continuous_applications_active, only: %w[submit]
     before_action :redirect_to_new_continuous_applications_if_active, only: %w[show]
     before_action :redirect_to_carry_over, except: %w[review]
+    before_action :redirect_to_post_offer_dashboard_if_accepted_or_recruited
     before_action :set_unavailable_courses, only: %w[review submit_show]
 
     def show

--- a/app/controllers/concerns/accept_offer_confirm_references.rb
+++ b/app/controllers/concerns/accept_offer_confirm_references.rb
@@ -5,6 +5,7 @@ module AcceptOfferConfirmReferences
     skip_before_action :redirect_to_dashboard_if_submitted
     skip_before_action :redirect_to_review_page_unless_reference_is_editable, raise: false
     skip_before_action :verify_authorized_section
+    skip_before_action :redirect_to_post_offer_dashboard_if_accepted_or_recruited
     before_action :application_choice
     before_action :check_that_candidate_can_accept
     before_action :check_that_candidate_has_an_offer

--- a/app/controllers/concerns/request_reference_offer_dashboard.rb
+++ b/app/controllers/concerns/request_reference_offer_dashboard.rb
@@ -4,6 +4,7 @@ module RequestReferenceOfferDashboard
   included do
     skip_before_action :redirect_to_dashboard_if_submitted
     skip_before_action :redirect_to_review_page_unless_reference_is_editable, raise: false
+    skip_before_action :redirect_to_post_offer_dashboard_if_accepted_or_recruited
     before_action :redirect_to_completed_dashboard_if_not_accepted
   end
 

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -1,20 +1,22 @@
 module ViewHelper
   include DfE::Autocomplete::ApplicationHelper
 
-  def govuk_back_link_to(url = :back, body = 'Back')
+  def govuk_back_link_to(url = :back, body = 'Back', force_text: false)
     classes = 'govuk-!-display-none-print'
 
     url = back_link_url if url == :back
 
-    text = if url.to_s.end_with?(candidate_interface_continuous_applications_details_path)
+    text = if force_text.present?
+             body
+           elsif url.to_s.end_with?(candidate_interface_continuous_applications_details_path)
              'Back to your details'
            elsif url.to_s.end_with?(candidate_interface_continuous_applications_choices_path)
              'Back to your applications'
            elsif url.to_s.end_with?(candidate_interface_application_form_path)
              'Back to application'
-           else
-             body
            end
+
+    text ||= body
 
     render GovukComponent::BackLinkComponent.new(
       text: text,

--- a/app/models/application_dates.rb
+++ b/app/models/application_dates.rb
@@ -4,7 +4,12 @@ class ApplicationDates
   end
 
   def submitted_at
-    @application_form.submitted_at
+    if @application_form.continuous_applications?
+      @application_form.application_choices.pending_conditions.first&.sent_to_provider_at ||
+        @application_form.submitted_at
+    else
+      @application_form.submitted_at
+    end
   end
 
   def reject_by_default_at

--- a/app/models/application_dates.rb
+++ b/app/models/application_dates.rb
@@ -4,12 +4,11 @@ class ApplicationDates
   end
 
   def submitted_at
-    if @application_form.continuous_applications?
-      @application_form.application_choices.pending_conditions.first&.sent_to_provider_at ||
-        @application_form.submitted_at
-    else
-      @application_form.submitted_at
-    end
+    return @application_form.submitted_at unless @application_form.continuous_applications?
+
+    sent_to_provider_at = @application_form.application_choices.pending_conditions.first&.sent_to_provider_at
+
+    sent_to_provider_at || @application_form.submitted_at
   end
 
   def reject_by_default_at

--- a/app/views/candidate_interface/decisions/withdraw.html.erb
+++ b/app/views/candidate_interface/decisions/withdraw.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.decisions.withdraw') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, back_link_text, force_text: true) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/submitted_application_form/review_submitted.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/review_submitted.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, t('page_titles.submitted_application') %>
 
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application dashboard') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, back_link_text, force_text: true) %>
 
 <h1 class="govuk-heading-xl">
   <%= t('page_titles.submitted_application') %>

--- a/spec/models/application_dates_spec.rb
+++ b/spec/models/application_dates_spec.rb
@@ -14,8 +14,36 @@ RSpec.describe ApplicationDates do
   end
 
   describe '#submitted_at' do
-    it 'returns date that application was submitted on' do
-      expect(application_dates.submitted_at).to eql(submitted_at)
+    context 'when not continuous applications', continuous_applications: false do
+      it 'returns date that application was submitted on' do
+        expect(application_dates.submitted_at).to eql(submitted_at)
+      end
+    end
+
+    context 'when continuous applications', :continuous_applications do
+      context 'when application is submitted' do
+        let(:sent_to_provider_at) { 10.days.ago }
+
+        before do
+          create(:application_choice, :awaiting_provider_decision, application_form:, sent_to_provider_at:)
+        end
+
+        it 'returns sent to provider at' do
+          expect(application_dates.submitted_at).to eq(submitted_at)
+        end
+      end
+
+      context 'when application is accepted' do
+        let(:sent_to_provider_at) { 1.day.ago }
+
+        before do
+          create(:application_choice, :accepted, application_form:, sent_to_provider_at:)
+        end
+
+        it 'returns sent to provider at' do
+          expect(application_dates.submitted_at).to eq(sent_to_provider_at)
+        end
+      end
     end
   end
 

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_and_offer_and_is_redirected_when_tries_to_access_some_pages_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_and_offer_and_is_redirected_when_tries_to_access_some_pages_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate is redirected when tries to see your details after accepting an offer', :continuous_applications do
+  include CandidateHelper
+
+  scenario 'Candidate views their application on the post offer dashboard' do
+    given_i_am_signed_in
+    and_i_have_an_accepted_offer
+
+    when_i_visit_the_application_dashboard
+    then_i_should_see_the_post_offer_dashboard
+
+    when_i_click_to_view_my_submitted_application
+    and_i_click_back_to_my_offer
+
+    then_i_should_see_the_post_offer_dashboard
+
+    when_i_click_to_withdraw_my_application
+    and_i_click_back_to_my_offer
+
+    when_i_try_to_enter_a_specific_section
+    then_i_should_see_the_post_offer_dashboard
+  end
+
+  def given_i_am_signed_in
+    @candidate = create(:candidate)
+    login_as(@candidate)
+  end
+
+  def and_i_have_an_accepted_offer
+    @application_form = create(:completed_application_form, candidate: @candidate, recruitment_cycle_year: 2024)
+    @pending_reference = create(:reference, :feedback_requested, reminder_sent_at: nil, application_form: @application_form)
+    @completed_reference = create(:reference, :feedback_provided, application_form: @application_form)
+
+    @application_choice = create(
+      :application_choice,
+      :accepted,
+      application_form: @application_form,
+    )
+  end
+
+  def when_i_visit_the_application_dashboard
+    visit candidate_interface_application_complete_path
+  end
+
+  def then_i_should_see_the_post_offer_dashboard
+    expect(page).to have_current_path(candidate_interface_application_offer_dashboard_path)
+
+    expect(page).to have_content("Your offer for #{@application_choice.current_course.name_and_code}")
+    expect(page).to have_content("You’ve accepted an offer from #{@application_choice.course_option.course.provider.name} to study #{@application_choice.course.name_and_code}.")
+    expect(page).to have_content('References')
+    expect(page).to have_content('Offer conditions')
+    expect(page).to have_content("#{@application_choice.offer.conditions.first.text} Pending", normalize_ws: true)
+  end
+
+  def when_i_click_to_view_my_submitted_application
+    click_link 'View application'
+  end
+
+  def when_i_click_to_withdraw_my_application
+    click_link 'Withdraw from the course'
+  end
+
+  def and_i_click_back_to_my_offer
+    click_link 'Back to your offer'
+  end
+
+  def when_i_try_to_enter_a_specific_section
+    visit candidate_interface_edit_safeguarding_path
+  end
+end

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_and_offer_and_is_redirected_when_tries_to_access_some_pages_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_and_offer_and_is_redirected_when_tries_to_access_some_pages_spec.rb
@@ -12,11 +12,11 @@ RSpec.feature 'Candidate is redirected when tries to see your details after acce
 
     when_i_click_to_view_my_submitted_application
     and_i_click_back_to_my_offer
-
     then_i_should_see_the_post_offer_dashboard
 
     when_i_click_to_withdraw_my_application
     and_i_click_back_to_my_offer
+    then_i_should_see_the_post_offer_dashboard
 
     when_i_try_to_enter_a_specific_section
     then_i_should_see_the_post_offer_dashboard

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_continuous_applications_feature_enabled_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_continuous_applications_feature_enabled_spec.rb
@@ -1,0 +1,520 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate accepts an offer', :continuous_applications do
+  include CourseOptionHelpers
+
+  scenario 'Candidate views an offer and accepts' do
+    given_i_am_signed_in
+    and_i_have_2_offers_on_my_choices
+    and_1_choice_that_is_awaiting_provider_decision
+
+    when_i_visit_the_application_dashboard
+    and_i_click_on_view_and_respond_to_offer_link
+    then_i_see_the_offer
+    and_i_am_told_my_other_offer_will_be_automatically_declined
+
+    when_i_continue_without_selecting_a_response
+    then_i_see_and_error_message
+
+    when_i_accept_one_offer
+
+    then_i_should_be_seeing_my_references
+
+    and_i_delete_one_of_my_references
+    and_i_confirm_the_acceptance
+
+    then_i_should_see_an_error_message
+
+    when_i_add_another_reference
+    then_i_should_be_on_accept_offer_page
+
+    when_i_click_to_change_the_reference_name
+    then_the_back_link_should_point_to_the_accept_offer_page
+
+    when_i_change_the_reference_name
+    then_i_should_be_on_accept_offer_page
+    and_i_should_see_the_new_reference_name
+
+    when_i_click_to_change_the_reference_type
+    then_the_back_link_should_point_to_the_accept_offer_page
+
+    when_i_change_the_reference_type
+    then_i_should_be_on_accept_offer_page
+    and_i_should_see_the_new_reference_type
+
+    when_i_click_to_change_the_reference_email_address
+    then_the_back_link_should_point_to_the_accept_offer_page
+
+    when_i_change_the_reference_email_address
+    then_i_should_be_on_accept_offer_page
+    and_i_should_see_the_new_reference_email_address
+
+    when_i_click_to_change_the_reference_relationship
+    then_the_back_link_should_point_to_the_accept_offer_page
+
+    when_i_change_the_reference_relationship
+    then_i_should_be_on_accept_offer_page
+    and_i_should_see_the_new_reference_relationship
+
+    when_i_click_to_add_another_reference
+    and_i_add_a_reference_type
+    and_i_add_a_reference_name
+    and_i_add_a_reference_email_address
+
+    and_i_click_back
+    and_i_should_be_on_add_email_address_page
+
+    and_i_click_back
+    and_i_should_be_on_the_existing_add_name_page
+
+    and_i_click_back
+    and_i_should_be_on_the_existing_add_type_page
+
+    and_i_click_back
+    then_i_should_be_on_accept_offer_page
+
+    and_i_confirm_the_acceptance
+    then_i_should_see_an_error_message_about_incomplete_reference
+
+    when_i_add_reference_relationship
+    then_i_should_be_on_accept_offer_page
+    and_i_see_your_application_menu_item_as_active
+
+    and_i_confirm_the_acceptance
+    then_i_see_a_flash_message_telling_me_i_have_accepted_the_offer
+    and_i_see_your_offer_menu_item_as_active
+    and_i_see_that_i_accepted_the_offer
+    and_i_see_that_i_declined_the_other_offer
+    and_i_see_that_i_withdrawn_from_the_third_choice
+    and_the_provider_has_received_an_email
+    and_the_candidate_has_received_an_email
+
+    when_i_visit_the_offer_page_of_the_declined_offer
+    then_i_see_the_page_not_found
+
+    when_i_visit_the_accept_page_of_the_declined_offer
+    then_i_see_the_page_not_found
+
+    when_i_visit_the_decline_page_of_the_accepted_offer
+    then_i_see_the_page_not_found
+    when_the_provider_marks_my_application_as_recruited
+    and_i_view_my_application
+    then_i_see_the_new_dashboard_content
+
+    when_i_click_to_view_my_application
+    then_i_see_the_course_with_an_accepted_offer
+    and_i_dont_see_the_course_without_an_offer
+
+    when_i_click_back
+    then_i_see_the_new_dashboard_content
+
+    when_i_click_to_withdraw_my_application
+    and_i_click_back
+    then_i_see_the_new_dashboard_content
+  end
+
+  def given_i_am_signed_in
+    @candidate = create(:candidate)
+    login_as(@candidate)
+  end
+
+  def and_i_have_2_offers_on_my_choices
+    @application_form = create(
+      :completed_application_form,
+      first_name: 'Harry',
+      last_name: 'Potter',
+      candidate: @candidate,
+      submitted_at: Time.zone.now,
+      support_reference: '123A',
+      recruitment_cycle_year: 2024,
+    )
+
+    @course_option = course_option_for_provider_code(provider_code: 'ABC')
+    other_course_option = course_option_for_provider_code(provider_code: 'DEF')
+
+    @provider_user = create(:provider_user, :with_notifications_enabled, providers: [@course_option.course.provider])
+
+    @application_choice = create(
+      :application_choice,
+      :offered,
+      course_option: @course_option,
+      application_form: @application_form,
+    )
+
+    @other_application_choice = create(
+      :application_choice,
+      :offered,
+      course_option: other_course_option,
+      application_form: @application_form,
+    )
+  end
+
+  def and_1_choice_that_is_awaiting_provider_decision
+    @third_application_choice = create(
+      :application_choice,
+      status: 'awaiting_provider_decision',
+      application_form: @application_form,
+    )
+  end
+
+  def when_i_visit_the_application_dashboard
+    visit candidate_interface_application_complete_path
+  end
+
+  def and_i_click_on_view_and_respond_to_offer_link
+    click_link href: candidate_interface_offer_path(@application_choice)
+  end
+
+  def then_i_see_the_offer
+    provider = @course_option.course.provider.name
+    expect(page).to have_content(provider)
+    expect(page).to have_content(t('page_titles.decisions.offer'))
+  end
+
+  def and_i_am_told_my_other_offer_will_be_automatically_declined
+    expect(page).to have_content('If you accept this offer, your other offer will be automatically declined.')
+  end
+
+  def when_i_continue_without_selecting_a_response
+    click_button t('continue')
+  end
+
+  def then_i_see_and_error_message
+    expect(page).to have_content('Select if you want to accept or decline the offer')
+  end
+
+  def when_i_accept_one_offer
+    choose 'Accept offer and conditions'
+    click_button t('continue')
+  end
+
+  def then_i_should_be_seeing_my_references
+    @application_form.reload.application_references.creation_order.each do |reference|
+      expect(page).to have_content(reference.name)
+      expect(page).to have_content(reference.email_address)
+      expect(page).to have_content(reference.relationship)
+    end
+  end
+
+  def and_i_delete_one_of_my_references
+    and_i_click_delete_the_first_reference
+    then_the_back_link_should_point_to_the_accept_offer_page
+    and_i_confirm_delete
+  end
+
+  def and_i_click_delete_the_first_reference
+    click_link "Delete reference from #{@application_form.application_references.creation_order.first.name}"
+  end
+
+  def then_the_back_link_should_point_to_the_accept_offer_page
+    expect(
+      back_link,
+    ).to eq(candidate_interface_accept_offer_path(@application_choice))
+  end
+
+  def then_i_should_be_on_accept_offer_page
+    expect(page).to have_current_path(candidate_interface_accept_offer_path(@application_choice))
+  end
+
+  def and_i_confirm_delete
+    click_button 'Yes I’m sure - delete this reference'
+  end
+
+  def then_i_should_see_an_error_message
+    expect(page.text).to include("There is a problem\nYou need to have at least 2 references to accept an offer")
+  end
+
+  def when_i_add_another_reference
+    when_i_click_to_add_another_reference
+    then_the_back_link_should_point_to_the_accept_offer_page
+    and_i_should_be_on_the_add_type_page
+    choose 'School experience, such as from the headteacher of a school you’ve been working in'
+    and_i_click_continue
+    and_i_should_be_on_the_add_name_page
+    and_the_back_link_should_point_to_the_add_type_page
+    fill_in 'What’s the name of the person who can give a reference?', with: 'Gimli'
+    and_i_click_save_and_continue
+    and_i_should_be_on_add_email_address_page
+    and_the_back_link_should_point_to_the_add_name_page
+    fill_in 'What is Gimli’s email address?', with: 'gimli@education.gov.uk'
+    and_i_click_save_and_continue
+    and_i_should_be_on_add_relationship_page
+    and_the_back_link_should_point_to_the_add_email_address_page
+    fill_in 'How do you know Gimli and how long have you known them?', with: 'Lord of the rings'
+    and_i_click_save_and_continue
+  end
+
+  def and_the_back_link_should_point_to_the_add_type_page
+    expect(
+      back_link,
+    ).to eq(
+      candidate_interface_accept_offer_references_type_path(
+        @application_choice,
+        'school-based',
+      ),
+    )
+  end
+
+  def and_the_back_link_should_point_to_the_add_name_page
+    expect(
+      back_link,
+    ).to eq(
+      candidate_interface_accept_offer_references_name_path(
+        @application_choice,
+        'school-based',
+        @application_form.reload.application_references.creation_order.last.id,
+      ),
+    )
+  end
+
+  def and_the_back_link_should_point_to_the_add_email_address_page
+    expect(
+      back_link,
+    ).to eq(
+      candidate_interface_accept_offer_references_email_address_path(
+        @application_choice,
+        @application_form.reload.application_references.creation_order.last.id,
+      ),
+    )
+  end
+
+  def when_i_click_to_add_another_reference
+    click_link 'Add another reference'
+  end
+
+  def and_i_click_continue
+    click_button 'Continue'
+  end
+
+  def and_i_click_save_and_continue
+    click_button 'Save and continue'
+  end
+
+  def and_i_add_a_reference_type
+    choose 'Professional, such as a manager'
+    and_i_click_continue
+  end
+
+  def and_i_add_a_reference_name
+    fill_in 'What’s the name of the person who can give a reference?', with: 'Aragorn'
+    and_i_click_save_and_continue
+  end
+
+  def and_i_add_a_reference_email_address
+    fill_in 'What is Aragorn’s email address?', with: 'aragorn@education.gov.uk'
+    and_i_click_save_and_continue
+  end
+
+  def and_i_should_be_on_the_add_type_page
+    expect(page).to have_current_path(
+      candidate_interface_accept_offer_references_type_path(@application_choice),
+    )
+  end
+
+  def and_i_should_be_on_the_existing_add_type_page
+    expect(page).to have_current_path(
+      candidate_interface_accept_offer_references_type_path(
+        @application_choice,
+        'professional',
+        @application_form.reload.application_references.creation_order.last.id,
+      ),
+    )
+  end
+
+  def and_i_should_be_on_the_add_name_page
+    expect(page).to have_current_path(
+      candidate_interface_accept_offer_references_name_path(
+        @application_choice,
+        'school-based',
+      ),
+    )
+  end
+
+  def and_i_should_be_on_the_existing_add_name_page
+    expect(page).to have_current_path(
+      candidate_interface_accept_offer_references_name_path(
+        @application_choice,
+        'professional',
+        @application_form.reload.application_references.creation_order.last.id,
+      ),
+    )
+  end
+
+  def and_i_should_be_on_add_email_address_page
+    expect(page).to have_current_path(
+      candidate_interface_accept_offer_references_email_address_path(
+        @application_choice,
+        @application_form.reload.application_references.creation_order.last.id,
+      ),
+    )
+  end
+
+  def and_i_should_be_on_add_relationship_page
+    expect(page).to have_current_path(
+      candidate_interface_accept_offer_references_relationship_path(
+        @application_choice,
+        @application_form.reload.application_references.creation_order.last.id,
+      ),
+    )
+  end
+
+  def when_i_click_to_change_the_reference_name
+    click_link 'Change name for Gimli'
+  end
+
+  def and_i_click_back
+    click_link 'Back'
+  end
+  alias_method :when_i_click_back, :and_i_click_back
+
+  def when_i_change_the_reference_name
+    fill_in 'What’s the name of the person who can give a reference?', with: 'Legolas'
+    and_i_click_save_and_continue
+  end
+
+  def and_i_should_see_the_new_reference_name
+    expect(page.text).to have_content('Legolas')
+  end
+
+  def when_i_click_to_change_the_reference_type
+    click_link 'Change reference type for Legolas'
+  end
+
+  def when_i_change_the_reference_type
+    choose 'Character, such as a mentor or someone you know from volunteering'
+    and_i_click_continue
+  end
+
+  def and_i_should_see_the_new_reference_type
+    expect(page.text).to have_content('Character')
+  end
+
+  def when_i_click_to_change_the_reference_email_address
+    click_link 'Change email address for Legolas'
+  end
+
+  def when_i_change_the_reference_email_address
+    fill_in 'What is Legolas’s email address?', with: 'legolas-middle-earth@education.gov.uk'
+    and_i_click_save_and_continue
+  end
+
+  def and_i_should_see_the_new_reference_email_address
+    expect(page).to have_content('legolas-middle-earth@education.gov.uk')
+  end
+
+  def when_i_click_to_change_the_reference_relationship
+    click_link 'Change relationship for Legolas'
+  end
+
+  def when_i_change_the_reference_relationship
+    fill_in 'How do you know Legolas and how long have you known them?', with: 'The Hobbit'
+    and_i_click_save_and_continue
+  end
+
+  def and_i_should_see_the_new_reference_relationship
+    expect(page).to have_content('The Hobbit')
+  end
+
+  def and_i_confirm_the_acceptance
+    expect(page).to have_content 'Your other applications will be withdrawn and any upcoming interviews will be cancelled.'
+    click_button 'Accept offer'
+  end
+
+  def then_i_see_a_flash_message_telling_me_i_have_accepted_the_offer
+    expect(page).to have_content "You have accepted your offer for #{@application_choice.course.name_and_code} at #{@application_choice.provider.name}"
+  end
+
+  def and_i_see_that_i_accepted_the_offer
+    expect(page).to have_content "You have accepted your offer for #{@application_choice.course.name_and_code} at #{@application_choice.course.provider.name}"
+  end
+
+  def and_i_see_that_i_declined_the_other_offer
+    expect(@other_application_choice.reload.status).to eq 'declined'
+  end
+
+  def and_i_see_that_i_withdrawn_from_the_third_choice
+    expect(@third_application_choice.reload.status).to eq 'withdrawn'
+  end
+
+  def and_the_provider_has_received_an_email
+    open_email(@provider_user.email_address)
+    expect(current_email.subject).to have_content "Harry Potter accepted your offer for #{@application_choice.course.name}"
+  end
+
+  def and_the_candidate_has_received_an_email
+    open_email(@candidate.email_address)
+    expect(current_email.subject).to have_content "You’ve accepted #{@course_option.course.provider.name}’s offer to study #{@course_option.course.name_and_code}"
+  end
+
+  def when_i_visit_the_offer_page_of_the_declined_offer
+    visit candidate_interface_offer_path(@other_application_choice.id)
+  end
+
+  def when_i_visit_the_accept_page_of_the_declined_offer
+    visit candidate_interface_accept_offer_path(@other_application_choice.id)
+  end
+
+  def then_i_see_the_page_not_found
+    expect(page).to have_content('Page not found')
+  end
+
+  def when_i_visit_the_decline_page_of_the_accepted_offer
+    visit candidate_interface_decline_offer_path(@application_choice.id)
+  end
+
+  def when_i_add_reference_relationship
+    click_link 'Enter how you know them and for how long'
+    fill_in 'How do you know Aragorn and how long have you known them?', with: 'Middle earth'
+    and_i_click_save_and_continue
+  end
+
+  def then_i_should_see_an_error_message_about_incomplete_reference
+    expect(page).to have_content(I18n.t('errors.messages.incomplete_references'))
+  end
+
+  def back_link
+    find('a', text: 'Back')[:href]
+  end
+
+  def when_the_provider_marks_my_application_as_recruited
+    @application_choice.recruited!
+  end
+
+  def and_i_view_my_application
+    visit candidate_interface_application_complete_path
+  end
+
+  def then_i_see_the_new_dashboard_content
+    expect(page).to have_content "You’ve accepted an offer from #{@course_option.course.provider.name} to study #{@course_option.course.name_and_code}."
+  end
+
+  def and_i_see_your_application_menu_item_as_active
+    expect(page).to have_css('.govuk-link.app-primary-navigation__link[aria-current=page]', text: 'Your application')
+  end
+
+  def and_i_see_your_offer_menu_item_as_active
+    expect(page).to have_css('.govuk-link.app-primary-navigation__link[aria-current=page]', text: 'Your offer')
+  end
+
+  def when_i_click_to_view_my_application
+    click_link 'View application'
+  end
+
+  def when_i_click_to_withdraw_my_application
+    click_link 'Withdraw from the course'
+  end
+
+  def then_i_see_the_course_with_an_accepted_offer
+    expect(page).to have_content @application_choice.course.name_and_code
+  end
+
+  def and_i_dont_see_the_course_without_an_offer
+    expect(page).not_to have_content @other_application_choice.course.name_and_code
+  end
+
+  def and_the_back_link_should_point_to_the_offer_dashboard_page
+    expect(
+      back_link,
+    ).to eq(candidate_interface_application_offer_dashboard_path)
+  end
+end

--- a/spec/system/candidate_interface/references/candidate_request_references_continuous_applications_feature_enabled_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_request_references_continuous_applications_feature_enabled_spec.rb
@@ -1,0 +1,261 @@
+require 'rails_helper'
+
+RSpec.feature 'New References', :continuous_applications, :with_audited do
+  include CandidateHelper
+
+  scenario 'Candidate request their references on the post offer dashboard' do
+    given_i_am_signed_in
+    and_i_have_an_accepted_offer
+
+    when_i_visit_the_application_dashboard
+    then_i_should_see_the_post_offer_dashboard
+
+    when_i_click_request_another_reference
+
+    then_the_back_link_should_point_to_the_offer_dashboard_page
+    and_i_should_be_on_start_page
+    and_i_click_continue
+    and_i_should_be_on_the_add_type_page
+    and_i_choose_character
+    and_i_click_continue
+    and_i_should_be_on_the_add_name_page
+    and_the_back_link_should_point_to_the_add_type_page
+    and_i_fill_in_the_reference_name
+    and_i_click_save_and_continue
+    and_i_should_be_on_add_email_address_page
+    and_the_back_link_should_point_to_the_add_name_page
+    and_i_fill_the_email_address
+    and_i_click_save_and_continue
+    and_i_should_be_on_add_relationship_page
+    and_the_back_link_should_point_to_the_add_email_address_page
+    and_i_fill_in_the_relationship
+    and_i_click_save_and_continue
+    and_i_should_be_on_check_your_answers
+    and_the_button_request_a_reference_should_be_on_the_page
+    and_the_reference_should_be_not_sent_yet
+    and_i_return_to_the_offer_dashboard
+    and_i_click_on_my_reference
+    and_i_should_be_on_check_your_answers
+    when_i_click_to_change_the_reference_name
+    and_when_i_change_the_reference_name
+    and_i_should_be_on_check_your_answers
+    when_i_click_to_change_the_reference_type
+    and_when_i_change_the_reference_type
+    and_i_should_be_on_check_your_answers
+    when_i_click_to_change_the_reference_email_address
+    and_when_i_change_the_reference_email_address
+    and_i_should_be_on_check_your_answers
+    when_i_click_to_change_the_reference_relationship
+    and_i_change_the_reference_relationship
+    and_i_should_be_on_check_your_answers
+    and_i_click_to_request_the_reference
+    then_the_reference_should_be_requested
+    and_i_click_cancel_request_from_the_list_page
+    then_the_back_link_should_point_to_the_offer_dashboard_page
+  end
+
+  def given_i_am_signed_in
+    @candidate = create(:candidate)
+    login_as(@candidate)
+  end
+
+  def and_i_have_an_accepted_offer
+    @application_form = create(:completed_application_form, candidate: @candidate, recruitment_cycle_year: 2024)
+    @pending_reference = create(:reference, :feedback_requested, reminder_sent_at: nil, application_form: @application_form)
+    @completed_reference = create(:reference, :feedback_provided, application_form: @application_form)
+
+    @application_choice = create(
+      :application_choice,
+      :accepted,
+      application_form: @application_form,
+    )
+  end
+
+  def when_i_visit_the_application_dashboard
+    visit candidate_interface_application_complete_path
+  end
+
+  def then_i_should_see_the_post_offer_dashboard
+    expect(page).to have_content("Your offer for #{@application_choice.current_course.name_and_code}")
+    expect(page).to have_content("You’ve accepted an offer from #{@application_choice.course_option.course.provider.name} to study #{@application_choice.course.name_and_code}.")
+    expect(page).to have_content('References')
+    expect(page).to have_content('Offer conditions')
+    expect(page).to have_content("#{@application_choice.offer.conditions.first.text} Pending", normalize_ws: true)
+  end
+
+  def when_i_click_request_another_reference
+    click_link 'Request another reference'
+  end
+
+  def and_i_click_continue
+    click_button 'Continue'
+  end
+
+  def and_i_click_save_and_continue
+    click_button 'Save and continue'
+  end
+
+  def then_the_back_link_should_point_to_the_offer_dashboard_page
+    expect(
+      back_link,
+    ).to eq(candidate_interface_application_offer_dashboard_path)
+  end
+
+  def and_i_should_be_on_start_page
+    expect(page).to have_current_path(candidate_interface_request_reference_references_start_path)
+  end
+
+  def and_i_should_be_on_the_add_type_page
+    expect(page).to have_current_path(candidate_interface_request_reference_references_type_path)
+  end
+
+  def and_i_should_be_on_the_add_name_page
+    expect(page).to have_current_path(candidate_interface_request_reference_references_name_path('character'))
+  end
+
+  def and_the_back_link_should_point_to_the_add_type_page
+    expect(back_link).to eq(candidate_interface_request_reference_references_type_path('character'))
+  end
+
+  def and_i_choose_character
+    choose 'Character, such as a mentor or someone you know from volunteering'
+  end
+
+  def and_i_fill_in_the_reference_name
+    fill_in 'What’s the name of the person who can give a reference?', with: 'Aragorn'
+  end
+
+  def and_i_should_be_on_add_email_address_page
+    expect(page).to have_current_path(
+      candidate_interface_request_reference_references_email_address_path(
+        @application_form.reload.application_references.creation_order.last.id,
+      ),
+    )
+  end
+
+  def and_the_back_link_should_point_to_the_add_name_page
+    expect(back_link).to eq(
+      candidate_interface_request_reference_references_name_path(
+        'character',
+        @application_form.reload.application_references.creation_order.last.id,
+      ),
+    )
+  end
+
+  def and_i_should_be_on_add_email_address_page
+    expect(page).to have_current_path(
+      candidate_interface_request_reference_references_email_address_path(
+        @application_form.reload.application_references.creation_order.last.id,
+      ),
+    )
+  end
+
+  def and_i_fill_the_email_address
+    fill_in 'What is Aragorn’s email address?', with: 'elendil@education.gov.uk'
+  end
+
+  def and_i_should_be_on_add_relationship_page
+    expect(page).to have_current_path(
+      candidate_interface_request_reference_references_relationship_path(
+        @application_form.reload.application_references.creation_order.last.id,
+      ),
+    )
+  end
+
+  def and_the_back_link_should_point_to_the_add_email_address_page
+    expect(back_link).to eq(
+      candidate_interface_request_reference_references_email_address_path(
+        @application_form.reload.application_references.creation_order.last.id,
+      ),
+    )
+  end
+
+  def and_i_fill_in_the_relationship
+    fill_in 'How do you know Aragorn and how long have you known them?', with: 'Lord of the rings'
+  end
+
+  def and_i_should_be_on_check_your_answers
+    expect(page).to have_current_path(
+      candidate_interface_references_request_reference_review_path(
+        @application_form.reload.application_references.creation_order.last.id,
+      ),
+    )
+  end
+
+  def and_the_button_request_a_reference_should_be_on_the_page
+    expect(page.all('button').map(&:text)).to include('Send reference request')
+  end
+
+  def and_the_reference_should_be_not_sent_yet
+    expect(@application_form.reload.application_references.creation_order.last.feedback_status).to eq('not_requested_yet')
+  end
+
+  def and_i_return_to_the_offer_dashboard
+    visit candidate_interface_application_offer_dashboard_path
+  end
+
+  def and_i_click_on_my_reference
+    click_link 'Aragorn'
+  end
+
+  def when_i_click_to_change_the_reference_name
+    click_link 'Change name for Aragorn'
+  end
+
+  def when_i_click_to_change_the_reference_type
+    click_link 'Change reference type for Aragorn the Middle earth king'
+  end
+
+  def when_i_click_to_change_the_reference_email_address
+    click_link 'Change email address for Aragorn the Middle earth king'
+  end
+
+  def when_i_click_to_change_the_reference_relationship
+    click_link 'Change relationship for Aragorn the Middle earth king'
+  end
+
+  def and_when_i_change_the_reference_name
+    fill_in 'What’s the name of the person who can give a reference?', with: 'Aragorn the Middle earth king'
+    and_i_click_save_and_continue
+  end
+
+  def and_when_i_change_the_reference_type
+    choose 'Professional, such as a manager'
+    and_i_click_continue
+  end
+
+  def and_when_i_change_the_reference_email_address
+    fill_in 'What is Aragorn the Middle earth king’s email address?', with: 'aragorn.elendil@education.gov.uk'
+    and_i_click_save_and_continue
+  end
+
+  def and_i_change_the_reference_relationship
+    fill_in 'How do you know Aragorn the Middle earth king and how long have you known them?', with: 'Lord of the rings the two towers'
+    and_i_click_save_and_continue
+  end
+
+  def and_i_click_to_request_the_reference
+    click_button 'Send reference request'
+  end
+
+  def then_the_reference_should_be_requested
+    expect(@application_form.reload.application_references.creation_order.last.feedback_status).to eq('feedback_requested')
+    expect(reference_row.text).to include('Requested')
+  end
+
+  def reference_row(name = 'Aragorn the Middle earth king')
+    page.all('.app-task-list__item').find do |list|
+      list.find('a', text: name)
+    rescue StandardError
+      nil
+    end
+  end
+
+  def and_i_click_cancel_request_from_the_list_page
+    click_link 'cancel request'
+  end
+
+  def back_link
+    find('a', text: 'Back')[:href]
+  end
+end

--- a/spec/system/candidate_interface/references/candidate_views_their_references_on_the_post_offer_dashboard_continuous_applications_feature_enabled_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_views_their_references_on_the_post_offer_dashboard_continuous_applications_feature_enabled_spec.rb
@@ -1,0 +1,125 @@
+require 'rails_helper'
+
+RSpec.feature 'Post-offer references', :continuous_applications, :with_audited do
+  include CandidateHelper
+
+  scenario 'Candidate views their references on the post offer dashboard' do
+    given_i_am_signed_in
+    and_i_have_an_accepted_offer
+
+    when_i_visit_the_application_dashboard
+    then_i_should_see_the_post_offer_dashboard
+
+    when_i_click_on_my_requested_reference
+    then_i_see_my_referee_information
+    and_my_available_actions
+
+    when_i_click_send_a_reminder
+    then_i_see_the_reminder_confirmation_page
+
+    when_i_confirm_i_want_to_send_the_reminder
+    and_i_click_on_my_requested_reference
+    then_i_see_the_updated_history
+
+    when_i_go_back_to_the_dashboard
+    then_i_should_see_the_post_offer_dashboard
+    then_i_see_the_updated_history_on_the_dashboard
+    and_i_click_on_my_requested_reference
+    and_i_click_cancel_request
+    then_i_see_the_cancellation_confirmation_page
+
+    when_i_confirm_i_want_to_cancel_the_request
+    then_i_see_the_status_change
+  end
+
+  def given_i_am_signed_in
+    @candidate = create(:candidate)
+    login_as(@candidate)
+  end
+
+  def and_i_have_an_accepted_offer
+    @application_form = create(:completed_application_form, candidate: @candidate, recruitment_cycle_year: 2024)
+    @pending_reference = create(:reference, :feedback_requested, reminder_sent_at: nil, application_form: @application_form)
+    @completed_reference = create(:reference, :feedback_provided, application_form: @application_form)
+
+    @application_choice = create(
+      :application_choice,
+      :accepted,
+      application_form: @application_form,
+    )
+  end
+
+  def when_i_visit_the_application_dashboard
+    visit candidate_interface_application_complete_path
+  end
+
+  def then_i_should_see_the_post_offer_dashboard
+    expect(page).to have_content("Your offer for #{@application_choice.current_course.name_and_code}")
+    expect(page).to have_content("You’ve accepted an offer from #{@application_choice.course_option.course.provider.name} to study #{@application_choice.course.name_and_code}.")
+    expect(page).to have_content('References')
+    expect(page).to have_content('Offer conditions')
+    expect(page).to have_content("#{@application_choice.offer.conditions.first.text} Pending", normalize_ws: true)
+  end
+
+  def when_i_click_on_my_requested_reference
+    click_link @pending_reference.name
+  end
+
+  alias_method :and_i_click_on_my_requested_reference, :when_i_click_on_my_requested_reference
+
+  def then_i_see_my_referee_information
+    expect(page).to have_content(@pending_reference.name)
+    expect(page).to have_content(@pending_reference.email_address)
+    expect(page).to have_content(@pending_reference.referee_type.humanize)
+    expect(page).to have_content(@pending_reference.relationship)
+  end
+
+  def and_my_available_actions
+    expect(page).to have_content('Send a reminder')
+    expect(page).to have_content('Cancel request')
+  end
+
+  def when_i_click_send_a_reminder
+    click_link 'Send a reminder'
+  end
+
+  def then_i_see_the_reminder_confirmation_page
+    expect(page).to have_content("Would you like to send a reminder to #{@pending_reference.name}?")
+    expect(page).to have_current_path(candidate_interface_references_new_reminder_path(@pending_reference.id))
+    expect(page).to have_content("They’ll also get an automatic reminder on #{@pending_reference.next_automated_chase_at.strftime('%-d %B %Y')}.")
+  end
+
+  def when_i_confirm_i_want_to_send_the_reminder
+    click_button 'Send a reminder'
+  end
+
+  def then_i_see_the_updated_history
+    expect(page).to have_content("You sent a reminder on #{Time.zone.now.to_fs(:govuk_date)}")
+  end
+
+  def when_i_go_back_to_the_dashboard
+    click_link 'Back'
+  end
+
+  def and_i_click_cancel_request
+    click_link 'Cancel request'
+  end
+
+  def then_i_see_the_cancellation_confirmation_page
+    expect(page).to have_current_path(candidate_interface_references_confirm_cancel_reference_path(@pending_reference.id))
+    expect(page).to have_content("Are you sure you want to cancel the request for a reference from #{@pending_reference.name}?")
+    expect(page).to have_content('We’ll tell them that they no longer need to give a reference.')
+  end
+
+  def when_i_confirm_i_want_to_cancel_the_request
+    click_button 'Cancel reference request'
+  end
+
+  def then_i_see_the_status_change
+    expect(page).to have_content('Request cancelled')
+  end
+
+  def then_i_see_the_updated_history_on_the_dashboard
+    expect(page).to have_content("Reminder sent on #{Time.zone.now.to_fs(:govuk_date)}")
+  end
+end


### PR DESCRIPTION
## Context

### Before this PR 

Clicking ‘Back to application’ takes the candidate back to the old pre-continuous applications ‘Your applications’ view

A candidate should be able to view their submitted application – this is correct.

However, it should be clear, and easy, for them to get back to the post offer dashboard.

Ensure the back link takes them back to the post offer dashboard and update it to say ‘Back to your offer’

We also need to ensure the ‘Date submitted’ value is using the sent_to_provider_at attribute on the application choice, and not the submitted_at application form attribute

We should also ensure the back link on the withdrawal page correctly redirects to the post offer dashboard:

Context on slack threads:

https://ukgovernmentdfe.slack.com/archives/C05QKRWP3H8/p1695896372074619

https://ukgovernmentdfe.slack.com/archives/C05QKRWP3H8/p1695898870064039