### PR TITLE
Include the provider when candidate goes back when adding a course

### DIFF
--- a/app/controllers/candidate_interface/continuous_applications/course_choices/provider_selection_controller.rb
+++ b/app/controllers/candidate_interface/continuous_applications/course_choices/provider_selection_controller.rb
@@ -5,9 +5,7 @@ module CandidateInterface
       private
 
         def step_params
-          return provider_params if params[:provider_id].present?
-
-          params
+          params[:provider_id].present? ? provider_params : params
         end
 
         def provider_params

--- a/app/controllers/candidate_interface/continuous_applications/course_choices/provider_selection_controller.rb
+++ b/app/controllers/candidate_interface/continuous_applications/course_choices/provider_selection_controller.rb
@@ -5,7 +5,15 @@ module CandidateInterface
       private
 
         def step_params
+          return provider_params if params[:provider_id].present?
+
           params
+        end
+
+        def provider_params
+          ActionController::Parameters.new({
+            current_step => { provider_id: params[:provider_id] },
+          })
         end
 
         def current_step

--- a/app/forms/candidate_interface/continuous_applications/concerns/course_selection_step_helper.rb
+++ b/app/forms/candidate_interface/continuous_applications/concerns/course_selection_step_helper.rb
@@ -24,6 +24,10 @@ module CandidateInterface
 
         delegate :multiple_sites?, to: :course
 
+        def provider_exists?
+          Provider.exists?(provider_id)
+        end
+
         def provider
           @provider ||= Provider.find(provider_id)
         end

--- a/app/forms/candidate_interface/continuous_applications/provider_selection_step.rb
+++ b/app/forms/candidate_interface/continuous_applications/provider_selection_step.rb
@@ -27,6 +27,14 @@ module CandidateInterface
       def next_step_path_arguments
         { provider_id: }
       end
+
+      def provider_exists?
+        provider_id.present? && Provider.exists?(provider_id)
+      end
+
+      def provider
+        Provider.find(provider_id)
+      end
     end
   end
 end

--- a/app/forms/candidate_interface/continuous_applications/provider_selection_step.rb
+++ b/app/forms/candidate_interface/continuous_applications/provider_selection_step.rb
@@ -27,14 +27,6 @@ module CandidateInterface
       def next_step_path_arguments
         { provider_id: }
       end
-
-      def provider_exists?
-        provider_id.present? && Provider.exists?(provider_id)
-      end
-
-      def provider
-        Provider.find(provider_id)
-      end
     end
   end
 end

--- a/app/forms/candidate_interface/continuous_applications/which_course_are_you_applying_to_step.rb
+++ b/app/forms/candidate_interface/continuous_applications/which_course_are_you_applying_to_step.rb
@@ -27,6 +27,10 @@ module CandidateInterface
         :provider_selection
       end
 
+      def previous_step_path_arguments
+        { provider_id: }
+      end
+
       def next_step
         return :course_review if completed?
 

--- a/app/views/candidate_interface/continuous_applications/course_choices/course_site/_form_fields.html.erb
+++ b/app/views/candidate_interface/continuous_applications/course_choices/course_site/_form_fields.html.erb
@@ -3,6 +3,12 @@
 <%= f.hidden_field(:course_id) %>
 <%= f.hidden_field(:study_mode) %>
 
+<% if @wizard.current_step.provider_exists? %>
+  <p class="govuk-caption-xl govuk-!-margin-top-0">
+    <%= @wizard.current_step.provider.name %>
+  </p>
+<% end %>
+
 <h1 class="govuk-heading-xl govuk-!-margin-top-3">School placement location<h1>
 
 <p class="govuk-body">During your training, you’ll be placed in at least 2 different schools to give you experience of teaching in a real classroom.</p>

--- a/app/views/candidate_interface/continuous_applications/course_choices/course_study_mode/_form_fields.html.erb
+++ b/app/views/candidate_interface/continuous_applications/course_choices/course_study_mode/_form_fields.html.erb
@@ -2,6 +2,12 @@
 <%= f.hidden_field(:provider_id) %>
 <%= f.hidden_field(:course_id) %>
 
+<% if @wizard.current_step.provider_exists? %>
+  <p class="govuk-caption-xl govuk-!-margin-top-0">
+    <%= @wizard.current_step.provider.name %>
+  </p>
+<% end %>
+
 <%= f.govuk_radio_buttons_fieldset :study_mode, legend: { text: t('page_titles.which_study_mode'), size: 'xl', tag: 'h1' } do %>
   <%= f.govuk_radio_button :study_mode, :full_time, label: { text: 'Full time' }, link_errors: true %>
   <%= f.govuk_radio_button :study_mode, :part_time, label: { text: 'Part time' } %>

--- a/app/views/candidate_interface/continuous_applications/course_choices/provider_selection/new.html.erb
+++ b/app/views/candidate_interface/continuous_applications/course_choices/provider_selection/new.html.erb
@@ -6,6 +6,12 @@
     <%= form_with model: @wizard.current_step, url: @wizard.current_step_path do |f| %>
       <%= f.govuk_error_summary %>
 
+      <% if @wizard.current_step.provider_exists? %>
+        <p class="govuk-caption-xl govuk-!-margin-top-0">
+          <%= @wizard.current_step.provider.name %>
+        </p>
+      <% end %>
+
       <% cache @wizard.current_step.provider_cache_key do %>
         <%= f.govuk_collection_select(
               :provider_id,

--- a/app/views/candidate_interface/continuous_applications/course_choices/provider_selection/new.html.erb
+++ b/app/views/candidate_interface/continuous_applications/course_choices/provider_selection/new.html.erb
@@ -6,13 +6,7 @@
     <%= form_with model: @wizard.current_step, url: @wizard.current_step_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <% if @wizard.current_step.provider_exists? %>
-        <p class="govuk-caption-xl govuk-!-margin-top-0">
-          <%= @wizard.current_step.provider.name %>
-        </p>
-      <% end %>
-
-      <% cache @wizard.current_step.provider_cache_key do %>
+     <% cache @wizard.current_step.provider_cache_key do %>
         <%= f.govuk_collection_select(
               :provider_id,
               select_provider_options(@wizard.current_step.available_providers),

--- a/app/views/candidate_interface/continuous_applications/course_choices/which_course_are_you_applying_to/_form_fields.html.erb
+++ b/app/views/candidate_interface/continuous_applications/course_choices/which_course_are_you_applying_to/_form_fields.html.erb
@@ -1,6 +1,12 @@
 <%= f.govuk_error_summary %>
 <%= f.hidden_field(:provider_id) %>
 
+<% if @wizard.current_step.provider_exists? %>
+  <p class="govuk-caption-xl govuk-!-margin-top-0">
+    <%= @wizard.current_step.provider.name %>
+  </p>
+<% end %>
+
 <% if @wizard.current_step.available_courses.count > 20 %>
   <%= f.govuk_collection_select(
     :course_id,

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_with_multiple_study_modes_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_with_multiple_study_modes_spec.rb
@@ -17,15 +17,18 @@ RSpec.feature 'Candidate arrives from Find with provider and course with multipl
     when_i_confirm_the_course
     then_i_should_be_redirect_to_the_course_study_mode_path
 
+    then_i_should_see_the_provider_name_in_caption
     when_i_choose_the_study_mode
     then_i_should_be_redirected_to_the_course_site_path
+
+    then_i_should_see_the_provider_name_in_caption
 
     when_i_choose_a_location
     then_i_should_be_redirected_to_the_course_review_path
   end
 
   def given_there_is_a_provider_with_a_course_that_is_only_accepting_applications_on_apply
-    @provider = create(:provider)
+    @provider = create(:provider, name: 'Vim masters')
 
     @first_site = create(:site, provider: @provider, name: 'Site 1')
     @second_site = create(:site, provider: @provider, name: 'Site 2')
@@ -119,5 +122,9 @@ RSpec.feature 'Candidate arrives from Find with provider and course with multipl
     expect(page).to have_current_path(
       candidate_interface_continuous_applications_course_review_path(application_choice_id: application_choice.id),
     )
+  end
+
+  def then_i_should_see_the_provider_name_in_caption
+    expect(page.first('.govuk-caption-xl').text).to eq('Vim masters')
   end
 end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_spec.rb
@@ -19,6 +19,10 @@ RSpec.feature 'Selecting a course', :continuous_applications do
     and_i_choose_a_provider
     then_i_should_see_a_course_and_its_description
 
+    and_i_click_the_back_link
+    then_i_should_see_the_provider_chosen_selected
+    and_i_click_continue
+
     when_submit_without_choosing_a_course
     then_i_should_see_an_error
     and_i_choose_a_course
@@ -163,5 +167,13 @@ RSpec.feature 'Selecting a course', :continuous_applications do
   def and_i_can_change_the_course
     click_link 'Change'
     expect(page).to have_content('Which course are you applying to?')
+  end
+
+  def and_i_click_the_back_link
+    click_link 'Back'
+  end
+
+  def then_i_should_see_the_provider_chosen_selected
+    expect(page).to have_select('Which training provider are you applying to?', selected: 'Gorse SCITT (1N1)')
   end
 end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_spec.rb
@@ -22,6 +22,7 @@ RSpec.feature 'Selecting a course', :continuous_applications do
     and_i_click_the_back_link
     then_i_should_see_the_provider_chosen_selected
     and_i_click_continue
+    then_i_should_see_the_provider_name_in_caption
 
     when_submit_without_choosing_a_course
     then_i_should_see_an_error
@@ -40,6 +41,7 @@ RSpec.feature 'Selecting a course', :continuous_applications do
     and_i_click_on_course_choices
     when_i_choose_that_i_know_where_i_want_to_apply
     and_i_choose_a_provider
+    then_i_should_see_the_provider_name_in_caption
     then_the_course_choices_should_be_a_dropdown
     and_the_select_box_has_no_value_selected
   end
@@ -174,7 +176,10 @@ RSpec.feature 'Selecting a course', :continuous_applications do
   end
 
   def then_i_should_see_the_provider_chosen_selected
-    expect(page.first('.govuk-caption-xl').text).to eq('Gorse SCITT')
     expect(page).to have_select('Which training provider are you applying to?', selected: 'Gorse SCITT (1N1)')
+  end
+
+  def then_i_should_see_the_provider_name_in_caption
+    expect(page.first('.govuk-caption-xl').text).to eq('Gorse SCITT')
   end
 end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_spec.rb
@@ -174,6 +174,7 @@ RSpec.feature 'Selecting a course', :continuous_applications do
   end
 
   def then_i_should_see_the_provider_chosen_selected
+    expect(page.first('.govuk-caption-xl').text).to eq('Gorse SCITT')
     expect(page).to have_select('Which training provider are you applying to?', selected: 'Gorse SCITT (1N1)')
   end
 end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_study_mode_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_study_mode_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature 'Selecting a study mode', :continuous_applications do
   end
 
   def and_there_are_course_options
-    @provider = create(:provider)
+    @provider = create(:provider, name: 'University of Alien Dance')
 
     @first_site = create(:site, provider: @provider, name: 'Site 1')
     @second_site = create(:site, provider: @provider, name: 'Site 2')
@@ -154,5 +154,9 @@ RSpec.feature 'Selecting a study mode', :continuous_applications do
 
   def application_choice
     current_candidate.current_application.application_choices.last
+  end
+
+  def then_i_should_see_the_provider_name_in_caption
+    expect(page.first('.govuk-caption-xl').text).to eq('University of Alien Dance')
   end
 end


### PR DESCRIPTION
## Context

A suggestion was made to include the provider name on the course selection page: See slack threads from the Trello card - for more details

Steps to replicate:

1. Go to course selection
2. Selects a provider
3. Click next
4. Go back
5. The provider you chosen should be selected
