### PR TITLE
Remove line from course details

### DIFF
--- a/app/components/candidate_interface/continuous_applications/application_summary_component.rb
+++ b/app/components/candidate_interface/continuous_applications/application_summary_component.rb
@@ -64,7 +64,6 @@ module CandidateInterface
       def course_details
         [
           DisplayCourseLength.call(course_length:),
-          current_course_option.study_mode.humanize,
         ].compact.join(' ')
       end
 


### PR DESCRIPTION
## Context

See this slack thread for more context:
https://ukgovernmentdfe.slack.com/archives/C05CFF8M8KA/p1696009712049969



## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="672" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/286e5ed2-7810-470b-8e4c-d09d2ae50952">|<img width="660" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/8995f9c5-ddeb-4afb-acee-425f242e8744">|

## Trello ticket

https://trello.com/c/3Nl3Aawf/742-apply-review-how-we-display-study-mode-full-part-time-information-on-course
