### PR TITLE
Set the start of the 2025 cycle to after October

### DIFF
--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -79,8 +79,8 @@ class CycleTimetable
       },
     },
     2025 => {
-      find_opens: Time.zone.local(2024, 10, 1, 9), # First Tuesday of October
-      apply_opens: Time.zone.local(2024, 10, 8, 9), # Second Tuesday of October
+      find_opens: Time.zone.local(2024, 11, 1, 9), # First Tuesday of October
+      apply_opens: Time.zone.local(2024, 11, 8, 9), # Second Tuesday of October
       show_summer_recruitment_banner: Time.zone.local(2025, 7, 1),
       show_deadline_banner: Time.zone.local(2025, 7, 29, 9), # 5 weeks before Apply 1 deadline
       apply_1_deadline: Time.zone.local(2025, 9, 2, 18), # 1st Tuesday of September

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -475,7 +475,7 @@ RSpec.describe CycleTimetable do
   end
 
   describe 'cycle switcher' do
-    it 'correctly sets can_add_course_choice? and can_submit? between cycles', :mid_cycle do
+    it 'correctly sets can_add_course_choice? and can_submit? between cycles', time: mid_cycle(2023) do
       SiteSetting.set(name: 'cycle_schedule', value: :today_is_mid_cycle)
 
       application_form = create(:application_form, phase: 'apply_1')
@@ -500,7 +500,7 @@ RSpec.describe CycleTimetable do
       SiteSetting.set(name: 'cycle_schedule', value: nil)
     end
 
-    context 'when cycle_schedule is set to today_is_after_find_opens', :mid_cycle do
+    context 'when cycle_schedule is set to today_is_after_find_opens', time: mid_cycle(2023) do
       it 'changes the CycleTimetable.current_year to the next year' do
         current_year = described_class.current_year
         next_year = described_class.next_year
@@ -511,7 +511,7 @@ RSpec.describe CycleTimetable do
       end
     end
 
-    context 'when cycle_schedule is set to today_is_after_apply_opens', :mid_cycle do
+    context 'when cycle_schedule is set to today_is_after_apply_opens', time: mid_cycle(2023) do
       it 'changes the CycleTimetable.current_year to the next year' do
         current_year = described_class.current_year
         next_year = described_class.next_year

--- a/spec/system/support_interface/disable_generate_applications_cycle_switcher_spec.rb
+++ b/spec/system/support_interface/disable_generate_applications_cycle_switcher_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Disable generate future applications cycle switching' do
+RSpec.feature 'Disable generate future applications cycle switching', time: CycleTimetableHelper.mid_cycle(2023) do
   include DfESignInHelpers
 
   scenario 'Cannot generate future applications when switching to next cycle' do


### PR DESCRIPTION
## Context

Now that we have entered into Oct our arbitrary dates are currently interfering with our cycle switcher if we try to jump into 2024. Set these for November to enable the switcher to work for the end of the 2023 cycle.

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="626" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/9bc0bce7-20bc-4d92-9b95-3f972e1fc709">|<img width="602" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/e6fef1a9-361f-4bc3-83af-34cf3cdf100f">|

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
