### PR TITLE
Change "Edit your answer" to "Edit your personal statement"

### DIFF
--- a/app/components/candidate_interface/becoming_a_teacher_review_component.html.erb
+++ b/app/components/candidate_interface/becoming_a_teacher_review_component.html.erb
@@ -11,7 +11,7 @@
   <div class="app-summary-card govuk-!-margin-bottom-6">
     <% if @editable %>
       <div class="app-summary-card__header govuk-body">
-        <%= govuk_link_to 'Edit your answer', candidate_interface_edit_becoming_a_teacher_path(return_to_params) %>
+        <%= govuk_link_to 'Edit your personal statement', candidate_interface_edit_becoming_a_teacher_path(return_to_params) %>
       </div>
     <% end %>
     <div class="app-summary-card__body">

--- a/spec/components/candidate_interface/becoming_a_teacher_review_component_spec.rb
+++ b/spec/components/candidate_interface/becoming_a_teacher_review_component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CandidateInterface::BecomingATeacherReviewComponent, type: :compo
         render_inline(described_class.new(application_form:))
 
         expect(page.text).to include(application_form.becoming_a_teacher)
-        expect(page).to have_link('Edit your answer')
+        expect(page).to have_link('Edit your personal statement')
       end
     end
 
@@ -27,7 +27,7 @@ RSpec.describe CandidateInterface::BecomingATeacherReviewComponent, type: :compo
         render_inline(described_class.new(application_form: new_application_form))
 
         expect(page).to have_text(new_application_form.becoming_a_teacher)
-        expect(page).to have_link('Edit your answer')
+        expect(page).to have_link('Edit your personal statement')
       end
     end
   end
@@ -36,7 +36,7 @@ RSpec.describe CandidateInterface::BecomingATeacherReviewComponent, type: :compo
     it 'renders component without an edit link' do
       render_inline(described_class.new(application_form:, editable: false))
 
-      expect(page).not_to have_link('Edit your answer')
+      expect(page).not_to have_link('Edit your personal statement')
     end
   end
 

--- a/spec/system/candidate_interface/apply_again/candidate_applies_again_updates_personal_statement_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_applies_again_updates_personal_statement_spec.rb
@@ -144,7 +144,7 @@ RSpec.feature 'Apply again with four choices', continuous_applications: false do
 
   def when_i_review_and_edit_my_personal_statement
     click_link 'Your personal statement'
-    click_link 'Edit your answer'
+    click_link 'Edit your personal statement'
     fill_in 'Your personal statement', with: 'I am a hardworking person'
     click_button t('continue')
   end

--- a/spec/system/candidate_interface/continuous_applications/entering_details/candidate_can_edit_some_sections_after_first_submission_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/entering_details/candidate_can_edit_some_sections_after_first_submission_spec.rb
@@ -127,7 +127,7 @@ RSpec.feature 'A candidate can edit some sections after first submission', :cont
   end
 
   def and_i_can_edit_the_section_personal_statement
-    click_link 'Edit your answer'
+    click_link 'Edit your personal statement'
     fill_in 'Your personal statement', with: 'Repellat qui et'
     click_button 'Continue'
 

--- a/spec/system/candidate_interface/entering_details/candidate_becoming_a_teacher_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_becoming_a_teacher_spec.rb
@@ -75,7 +75,7 @@ RSpec.feature 'Entering "Why do you want to be a teacher?"', continuous_applicat
   end
 
   def when_i_click_to_change_my_answer
-    click_link('Edit your answer')
+    click_link('Edit your personal statement')
   end
 
   def and_i_fill_in_a_different_answer

--- a/spec/system/candidate_interface/entering_details/candidate_personal_statement_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_personal_statement_spec.rb
@@ -113,7 +113,7 @@ RSpec.feature 'Entering "Personal statement"' do
   end
 
   def when_i_click_to_edit_my_answer
-    click_link('Edit your answer')
+    click_link('Edit your personal statement')
   end
 
   def then_i_can_check_my_revised_answers

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_statement_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_statement_section_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature 'Candidate is redirected correctly', continuous_applications: fals
 
   def when_i_click_change_on_why_i_want_to_become_a_teacher
     within('[data-qa="becoming-a-teacher"]') do
-      click_link 'Edit your answer'
+      click_link 'Edit your personal statement'
     end
   end
 


### PR DESCRIPTION
## Context

Change "Edit your answer" to "Edit your personal statement"

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="876" alt="Screenshot 2023-10-02 at 14 39 42" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/27509/d08abf11-d6c6-48cc-99ca-887a1b202852">|<img width="763" alt="Screenshot 2023-10-02 at 14 39 24" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/27509/d4326bdc-fed3-4e38-a9e9-fe9b63ee9c1f">|

## Guidance to review

Is the change working as expected?

## Link to Trello card

https://trello.com/c/LUn0SkzC/726-apply-update-edit-your-answer-wording-on-the-personal-statement-section

