### PR TITLE
Update the holidays when time travelling to other cycles

### DIFF
--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -508,4 +508,16 @@ class CycleTimetable
   end
 
   private_class_method :last_recruitment_cycle_year?
+
+  # Only use this to update the holidays for the current cycle when travelling time
+  def self.reset_holidays
+    BusinessTime::Config.holidays.clear
+    Holidays.between(Date.civil(2019, 1, 1), 2.years.from_now, :gb_eng, :observed).map do |holiday|
+      BusinessTime::Config.holidays << holiday[:date]
+    end
+
+    CycleTimetable.holidays.each_value do |date_range|
+      BusinessTime::Config.holidays += date_range.to_a
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -164,8 +164,10 @@ RSpec.configure do |config|
     if example.metadata[:continuous_applications].present?
       FeatureFlag.activate(:continuous_applications)
       set_time(mid_cycle(2024))
+      CycleTimetable.reset_holidays
     elsif example.metadata.key?(:continuous_applications) && example.metadata[:continuous_applications].blank?
       set_time(mid_cycle(2023))
+      CycleTimetable.reset_holidays
       FeatureFlag.deactivate(:continuous_applications)
     end
   end

--- a/spec/services/candidate_interface/continuous_applications/inactive_date_calculator_spec.rb
+++ b/spec/services/candidate_interface/continuous_applications/inactive_date_calculator_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe CandidateInterface::ContinuousApplications::InactiveDateCalculato
     submitted_vs_inactive_dates = [
       ['28 Oct 2023 9:00:00 AM BST', '11 Dec 2023 23:59:59 PM GMT', 'near the BST/GMT boundary'],
       ['1 Apr 2024 9:00:00 AM BST',  '15 May 2024 23:59:59 PM BST', 'safely within BST'],
-      ['4 Jan 2024 11:00:00 PM GMT', '15 Feb 2024 23:59:59 PM GMT', 'safely within GMT'],
+      ['4 Jan 2024 11:00:00 PM GMT', '19 Feb 2024 23:59:59 PM GMT', 'safely within GMT'],
       ['1 Jul 2024 11:00:00 PM BST', '29 Jul 2024 23:59:59 PM BST', 'during the 20-day summer period'],
-      ['01 Dec 2023 12:00:00 PM GMT', '17 Jan 2024 23:59:59 PM GMT', 'near the Christmas holidays'],
+      ['01 Dec 2023 12:00:00 PM GMT', '02 Feb 2024 23:59:59 PM GMT', 'near the Christmas holidays'],
       ['02 Sep 2024 0:00:00 AM BST', '25 Sep 2024 23:59:59 PM BST', '1 day before apply 1 deadline'],
       ['16 Sep 2024 0:00:00 AM BST', '25 Sep 2024 23:59:59 PM BST', '1 day before apply 2 deadline'],
     ].freeze

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -604,4 +604,23 @@ RSpec.describe CycleTimetable do
       end
     end
   end
+
+  describe 'reset_holidays' do
+    it 'updates holidays when timetravelling' do
+      travel_temporarily_to('10 Dec 2024') do
+        described_class.reset_holidays
+        expect(30.business_days.from_now).to eq(Time.zone.parse('7 Feb 2025'))
+      end
+
+      travel_temporarily_to('10 Dec 2025') do
+        described_class.reset_holidays
+        expect(30.business_days.from_now).to eq(Time.zone.parse('26 Jan 2026'))
+      end
+
+      travel_temporarily_to('10 Dec 2024') do
+        described_class.reset_holidays
+        expect(30.business_days.from_now).to eq(Time.zone.parse('7 Feb 2025'))
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

  `days.business_days` depends on the initial configuration of
  BusinessTime::Config.holidays. This is done in an initializer. When we
  artificially set the time to the next recruitment cycle in tests, the
  holidays are not updated and accounted for.

  In the process of changing cycles, we should reset the holidays so we
  get an accurate time span accounting for the holidays that exist in
  the recruitment cycle being mocked.

## Changes proposed in this pull request

Add a method on `CycleTimetable` that allows us to update the applications holidays at runtime.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
