### PR TITLE
Application Choice submitted transaction email

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -13,6 +13,17 @@ class CandidateMailer < ApplicationMailer
   )
   include QualificationValueHelper
 
+  def application_choice_submitted(application_choice)
+    @application_choice = application_choice
+    @candidate_magic_link = candidate_magic_link(application_choice.application_form.candidate)
+    @reject_by_default_date = @application_choice.reject_by_default_at.to_fs(:govuk_date)
+
+    email_for_candidate(
+      application_choice.application_form,
+    )
+  end
+
+  # TODO: Delete after 2023 cycle completed
   def application_submitted(application_form)
     @candidate_magic_link = candidate_magic_link(application_form.candidate)
     @application_choice = application_form.application_choices.first

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -16,7 +16,6 @@ class CandidateMailer < ApplicationMailer
   def application_choice_submitted(application_choice)
     @application_choice = application_choice
     @candidate_magic_link = candidate_magic_link(application_choice.application_form.candidate)
-    @reject_by_default_date = @application_choice.reject_by_default_at.to_fs(:govuk_date)
 
     email_for_candidate(
       application_choice.application_form,

--- a/app/services/candidate_interface/continuous_applications/submit_application_choice.rb
+++ b/app/services/candidate_interface/continuous_applications/submit_application_choice.rb
@@ -19,6 +19,7 @@ module CandidateInterface
           application_choice.update!(sent_to_provider_at:)
           application_choice.update!(reject_by_default_at: inactive_date, reject_by_default_days: inactive_days)
           ApplicationStateChange.new(application_choice).send_to_provider!
+          CandidateMailer.application_choice_submitted(application_choice).deliver_later
         end
       end
 

--- a/app/services/candidate_interface/continuous_applications/submit_application_choice.rb
+++ b/app/services/candidate_interface/continuous_applications/submit_application_choice.rb
@@ -19,6 +19,8 @@ module CandidateInterface
           application_choice.update!(sent_to_provider_at:)
           application_choice.update!(reject_by_default_at: inactive_date, reject_by_default_days: inactive_days)
           ApplicationStateChange.new(application_choice).send_to_provider!
+
+          SendNewApplicationEmailToProvider.new(application_choice:).call
           CandidateMailer.application_choice_submitted(application_choice).deliver_later
         end
       end

--- a/app/views/candidate_mailer/application_choice_submitted.text.erb
+++ b/app/views/candidate_mailer/application_choice_submitted.text.erb
@@ -1,0 +1,9 @@
+Hello <%= @application_form.first_name %>
+
+
+  You’ve submitted an application for <%= @application_choice.course_option.course.name_and_code %> at <%= @application_choice.course_option.course.provider.name %>.
+
+[Sign in to your account to check the progress of your application](<%= @candidate_magic_link %>).
+
+
+  Your training provider will contact you if they would like to organise an interview.

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -2,8 +2,10 @@ en:
   candidate_mailer:
     reference_received:
       subject: "%{referee_name} has given you a reference"
-    application_submitted:
+    application_submitted: &application_submitted
       subject: "You’ve submitted your teacher training application"
+    application_choice_submitted:
+      <<: *application_submitted
     candidate_offer:
       single_offer:
         subject: "Successful application for %{provider_name}"

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -70,6 +70,24 @@ RSpec.describe CandidateMailer do
     end
   end
 
+  describe '.application_choice_submitted' do
+    let(:application_form) {
+      build_stubbed(:application_form, first_name: 'Jimbo',
+                                       candidate:,
+                                       application_choices: [])
+    }
+    let(:application_choice) { build_stubbed(:application_choice, reject_by_default_at: 5.days.from_now, application_form:) }
+    let(:email) { mailer.application_choice_submitted(application_choice) }
+
+    it_behaves_like(
+      'a mail with subject and content',
+      I18n.t!('candidate_mailer.application_choice_submitted.subject'),
+      'intro' => 'You’ve submitted an application for',
+      'magic link to authenticate' => 'http://localhost:3000/candidate/sign-in/confirm?token=raw_token',
+      'dynamic paragraph' => 'Your training provider will contact you if they would like to organise an interview',
+    )
+  end
+
   describe '.application_rejected' do
     let(:application_choice) { build_stubbed(:application_choice, :rejected, rejection_reason: 'Missing your English GCSE', course_option:) }
     let(:application_form) {

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -22,6 +22,20 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.application_choice_submitted(application_choice)
   end
 
+  def application_submitted_with_multiple_choices
+    application_form = FactoryBot.build_stubbed(
+      :completed_application_form,
+      candidate:,
+      support_reference: 'ABCDEF',
+      application_choices: [
+        FactoryBot.build_stubbed(:application_choice, :awaiting_provider_decision, course_option:),
+        FactoryBot.build_stubbed(:application_choice, :awaiting_provider_decision, course_option:),
+      ],
+    )
+
+    CandidateMailer.application_submitted(application_form)
+  end
+
   def changed_offer
     application_form = application_form_with_course_choices([application_choice_with_offer, application_choice_with_offer])
     application_choice = FactoryBot.build_stubbed(:application_choice, :awaiting_provider_decision,

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -10,6 +10,18 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.application_submitted(application_form)
   end
 
+  def application_choice_submitted
+    application_form = FactoryBot.build_stubbed(
+      :completed_application_form,
+      candidate:,
+      support_reference: 'ABCDEF',
+      application_choices: [],
+    )
+    application_choice = FactoryBot.build_stubbed(:application_choice, :awaiting_provider_decision, course_option:, application_form:)
+
+    CandidateMailer.application_choice_submitted(application_choice)
+  end
+
   def changed_offer
     application_form = application_form_with_course_choices([application_choice_with_offer, application_choice_with_offer])
     application_choice = FactoryBot.build_stubbed(:application_choice, :awaiting_provider_decision,

--- a/spec/services/candidate_interface/continuous_applications/submit_application_choice_spec.rb
+++ b/spec/services/candidate_interface/continuous_applications/submit_application_choice_spec.rb
@@ -65,6 +65,15 @@ RSpec.describe CandidateInterface::ContinuousApplications::SubmitApplicationChoi
           submit_application
         }.to have_enqueued_mail(CandidateMailer, :application_choice_submitted)
       end
+
+      it 'sends the provider an email notifying them of the submission' do
+        provider = application_choice.course.provider
+        provider.provider_users << create(:provider_user, :with_notifications_enabled)
+
+        expect {
+          submit_application
+        }.to have_enqueued_mail(ProviderMailer, :application_submitted)
+      end
     end
   end
 end

--- a/spec/services/candidate_interface/continuous_applications/submit_application_choice_spec.rb
+++ b/spec/services/candidate_interface/continuous_applications/submit_application_choice_spec.rb
@@ -59,6 +59,12 @@ RSpec.describe CandidateInterface::ContinuousApplications::SubmitApplicationChoi
         submit_application
         expect(application_choice.personal_statement).to eq application_form.becoming_a_teacher
       end
+
+      it 'sends the candidate an email notifying them of their submission' do
+        expect {
+          submit_application
+        }.to have_enqueued_mail(CandidateMailer, :application_choice_submitted)
+      end
     end
   end
 end

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -61,6 +61,7 @@ RSpec.feature 'Docs' do
       provider_mailer-permissions_updated
       provider_mailer-reference_received
       candidate_mailer-application_rejected
+      candidate_mailer-application_choice_submitted
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"


### PR DESCRIPTION
## Context

Add transactional email for when a candidate submits an application choice.

- CandidateMailer sends and email to the candidate when they make an application,
- ProviderMailer sends an email to the provider of the course when the candidate submits an application.

## Changes proposed in this pull request

There exists already `CandidateMailer.application_submitted`. This accepts an `application_form` and the only positional argument.

Instead of adding to this, I have decided to create a new mailer `application_choice_submitted`. This mailer has no need for conditionals in the template.

Also added a mailer preview for `application_submitted` when the application has more than one application choice.

## Screenshot

![Screenshot from 2023-10-03 14-55-30](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/8357509a-0842-4ccd-9840-35c010e24172)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

[Trello Ticket](https://trello.com/c/ss5YiEVU/776-apply-application-submitted-candidate-mailer)
