### PR TITLE
Fix performance on get unsuccessfull query

### DIFF
--- a/app/queries/get_unsuccessful_and_unsubmitted_candidates.rb
+++ b/app/queries/get_unsuccessful_and_unsubmitted_candidates.rb
@@ -1,41 +1,29 @@
 class GetUnsuccessfulAndUnsubmittedCandidates
   def self.call
     Candidate
-    .joins(:application_forms)
-    .where(
-      application_forms: {
-        recruitment_cycle_year: RecruitmentCycle.previous_year,
-        id: ApplicationChoice.where(status: ApplicationStateChange::UNSUCCESSFUL_STATES).select(:application_form_id),
-      },
-    )
-    .where.not(
-      application_forms:
-      {
-        id: ApplicationChoice.where(status: ApplicationStateChange::SUCCESSFUL_STATES)
-        .select(:application_form_id),
-      },
-    )
-    .where.not(unsubscribed_from_emails: true)
-    .or(
-      Candidate.joins(:application_forms)
-      .where(application_forms:
-        {
-          submitted_at: nil,
-          recruitment_cycle_year: RecruitmentCycle.previous_year,
-        })
-      .where.not(unsubscribed_from_emails: true),
-    )
-    .or(
-      Candidate
-      .joins(:application_forms)
-      .where(application_forms:
-        {
-          recruitment_cycle_year:
-          RecruitmentCycle.current_year,
-        })
-      .where.not(unsubscribed_from_emails: true),
-    )
-    .includes(:application_choices)
-    .distinct
+      .left_outer_joins(:application_forms)
+      .left_outer_joins(application_forms: :application_choices)
+      .where(application_forms: { recruitment_cycle_year: 2023 })
+      .where(application_choices: {
+        status: %w[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn application_not_sent unsubmitted],
+      })
+      .where.not(candidates: { unsubscribed_from_emails: true })
+      .where.not(candidates: { submission_blocked: true })
+      .where.not(candidates: { account_locked: true })
+      .or(
+        Candidate
+          .where(application_forms: { submitted_at: nil, recruitment_cycle_year: 2023 })
+          .where.not(candidates: { unsubscribed_from_emails: true })
+          .where.not(candidates: { submission_blocked: true })
+          .where.not(candidates: { account_locked: true }),
+      )
+      .or(
+        Candidate
+          .where(application_forms: { recruitment_cycle_year: 2024 })
+          .where.not(candidates: { unsubscribed_from_emails: true })
+          .where.not(candidates: { submission_blocked: true })
+          .where.not(candidates: { account_locked: true }),
+      )
+      .distinct
   end
 end

--- a/app/queries/get_unsuccessful_and_unsubmitted_candidates.rb
+++ b/app/queries/get_unsuccessful_and_unsubmitted_candidates.rb
@@ -2,20 +2,15 @@ class GetUnsuccessfulAndUnsubmittedCandidates
   def self.call
     Candidate
       .left_outer_joins(:application_forms)
-      .left_outer_joins(application_forms: :application_choices)
-      .where(application_forms: { recruitment_cycle_year: 2023 })
-      .where(application_choices: {
-        status: %w[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn application_not_sent unsubmitted],
-      })
       .where.not(candidates: { unsubscribed_from_emails: true })
       .where.not(candidates: { submission_blocked: true })
       .where.not(candidates: { account_locked: true })
-      .or(
-        Candidate
-          .where(application_forms: { submitted_at: nil, recruitment_cycle_year: 2023 })
-          .where.not(candidates: { unsubscribed_from_emails: true })
-          .where.not(candidates: { submission_blocked: true })
-          .where.not(candidates: { account_locked: true }),
+      .where(
+        '(application_forms.recruitment_cycle_year = 2023 AND NOT EXISTS (:successful))',
+        successful: ApplicationChoice
+            .select(1)
+            .where(status: %w[recruited pending_conditions offer offer_deferred])
+            .where('application_choices.application_form_id = application_forms.id'),
       )
       .or(
         Candidate

--- a/spec/queries/get_unsuccessful_and_unsubmitted_candidates_spec.rb
+++ b/spec/queries/get_unsuccessful_and_unsubmitted_candidates_spec.rb
@@ -34,7 +34,9 @@ RSpec.describe GetUnsuccessfulAndUnsubmittedCandidates do
       application_form_previous_year = create(:application_form, submitted_at: 1.year.ago, recruitment_cycle_year: RecruitmentCycle.previous_year)
 
       create(:application_choice, :rejected, application_form: application_form_previous_year)
-      create(:application_choice, :recruited, application_form: application_form_previous_year)
+
+      another_application_form_from_previous_year = create(:application_form, submitted_at: 1.year.ago, recruitment_cycle_year: RecruitmentCycle.previous_year)
+      create(:application_choice, :recruited, application_form: another_application_form_from_previous_year)
 
       rejected_application_choice_from_previous_cycle = create(:application_choice, :rejected, :previous_year, application_form: application_form_previous_year)
       unsubmitted_application_from_previous_cycle = create(:application_form, submitted_at: nil, recruitment_cycle_year: RecruitmentCycle.previous_year)

--- a/spec/queries/get_unsuccessful_and_unsubmitted_candidates_spec.rb
+++ b/spec/queries/get_unsuccessful_and_unsubmitted_candidates_spec.rb
@@ -3,6 +3,17 @@ require 'rails_helper'
 RSpec.describe GetUnsuccessfulAndUnsubmittedCandidates do
   describe '.call' do
     it 'returns unsuccessful and unsubmitted applications from the previous cycle' do
+      candidate_with_submission_blocked = create(:candidate, submission_blocked: true)
+      candidate_with_account_locked = create(:candidate, account_locked: true)
+      candidate_unsubscribed_from_emails = create(:candidate, unsubscribed_from_emails: true)
+
+      accepted_application_form_from_previous_cycle = create(:application_form, :submitted, recruitment_cycle_year: RecruitmentCycle.previous_year)
+      create(:application_choice, :accepted, application_form: accepted_application_form_from_previous_cycle)
+
+      create(:application_form, candidate: candidate_with_submission_blocked, recruitment_cycle_year: RecruitmentCycle.previous_year)
+      create(:application_form, candidate: candidate_with_account_locked, recruitment_cycle_year: RecruitmentCycle.previous_year)
+      create(:application_form, candidate: candidate_unsubscribed_from_emails, recruitment_cycle_year: RecruitmentCycle.previous_year)
+
       rejected_application_form_from_previous_cycle = create(
         :application_form,
         :minimum_info,
@@ -25,18 +36,18 @@ RSpec.describe GetUnsuccessfulAndUnsubmittedCandidates do
       create(:application_choice, :rejected, application_form: application_form_previous_year)
       create(:application_choice, :recruited, application_form: application_form_previous_year)
 
-      rejected_application_choice_from_previous_cycle = create(:application_choice, :rejected, :previous_year)
+      rejected_application_choice_from_previous_cycle = create(:application_choice, :rejected, :previous_year, application_form: application_form_previous_year)
       unsubmitted_application_from_previous_cycle = create(:application_form, submitted_at: nil, recruitment_cycle_year: RecruitmentCycle.previous_year)
 
       unsuccessful_and_unsubmitted_applications = described_class.call
 
       expect(unsuccessful_and_unsubmitted_applications.count).to eq(4)
-      expect(unsuccessful_and_unsubmitted_applications.map(&:id))
+      expect(unsuccessful_and_unsubmitted_applications)
         .to contain_exactly(
-          carried_over_application_form.candidate.id,
-          application_form_current_year.candidate.id,
-          unsubmitted_application_from_previous_cycle.candidate.id,
-          rejected_application_choice_from_previous_cycle.application_form.candidate.id,
+          carried_over_application_form.candidate,
+          application_form_current_year.candidate,
+          unsubmitted_application_from_previous_cycle.candidate,
+          rejected_application_choice_from_previous_cycle.application_form.candidate,
         )
     end
 


### PR DESCRIPTION
## Context

The "find has opened" email was not sent to the candidate at midday because the query took 48 minutes before to complete  and didn't finished and also was taking 100% of CPU in the DB.

@JR-G and I refactor (rewrote!) the whole query to be more performatic:

This query should return unique candidates which has/had:

1. All applications unsubmitted or unsuccessful from previous cycle
2. All applications from current cycle
3. Not unsubscribe from emails
4. Not account locked
5. Not submission blocked

We tested this is QA and locally and also run the same query on blazer in production and it took only some milliseconds
