### PR TITLE
Align dates deadlines page with recruitment process

### DIFF
--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -79,8 +79,8 @@ class CycleTimetable
       },
     },
     2025 => {
-      find_opens: Time.zone.local(2024, 11, 1, 9), # First Tuesday of October
-      apply_opens: Time.zone.local(2024, 11, 8, 9), # Second Tuesday of October
+      find_opens: Time.zone.local(2024, 10, 1, 9), # First Tuesday of October
+      apply_opens: Time.zone.local(2024, 10, 8, 9), # Second Tuesday of October
       show_summer_recruitment_banner: Time.zone.local(2025, 7, 1),
       show_deadline_banner: Time.zone.local(2025, 7, 29, 9), # 5 weeks before Apply 1 deadline
       apply_1_deadline: Time.zone.local(2025, 9, 2, 18), # 1st Tuesday of September

--- a/app/views/content/dates_and_deadlines.md
+++ b/app/views/content/dates_and_deadlines.md
@@ -1,13 +1,9 @@
 ### <%= RecruitmentCycle.cycle_name(RecruitmentCycle.current_year) %> recruitment cycle – current
 | **Date and time** | **What happens** |
 | --- | --- |
-| <%= CycleTimetable.apply_opens.to_fs(:govuk_date_and_time) %> | Start of <%= RecruitmentCycle.cycle_name(RecruitmentCycle.current_year) %> recruitment cycle - candidates can apply for courses. |
-| <%= holidays[:christmas][:begins].to_fs(:govuk_date) %> to <%= holidays[:christmas][:ends].to_fs(:govuk_date) %> | This period is not counted as working days when calculating time to make a decision. |
-| <%= holidays[:easter][:begins].to_fs(:day_and_month) %> to <%= holidays[:easter][:ends].to_fs(:govuk_date) %> | This period is not counted as working days when calculating time to make a decision. |
-| <%= CycleTimetable.show_summer_recruitment_banner.to_fs(:govuk_date) %> | Time to make a decision is reduced from 40 working days to 20 working days. |
-| <%= CycleTimetable.apply_1_deadline.to_fs(:govuk_date_and_time) %> | Candidates can no longer apply for courses, unless they have already applied within this recruitment cycle. |
-| <%= CycleTimetable.apply_2_deadline.to_fs(:govuk_date_and_time) %> | Candidates can no longer apply for courses. |
-| <%= CycleTimetable.reject_by_default.to_fs(:govuk_date_and_time) %> | End of <%= RecruitmentCycle.cycle_name(RecruitmentCycle.current_year) %> recruitment cycle - applications awaiting decisions are automatically rejected. |
+| <%= CycleTimetable.apply_opens.to_fs(:govuk_date_and_time) %> | Start of <%= RecruitmentCycle.cycle_name(RecruitmentCycle.current_year) %> recruitment cycle. Candidates can apply for courses. |
+| <%= CycleTimetable.apply_2_deadline.to_fs(:govuk_date_and_time) %> | The last day for all candidates to apply for courses. |
+| <%= CycleTimetable.reject_by_default.to_fs(:govuk_date_and_time) %> | End of <%= RecruitmentCycle.cycle_name(RecruitmentCycle.current_year) %> recruitment cycle. Applications awaiting decisions are automatically rejected. |
 
 
 ### <%= RecruitmentCycle.cycle_name(RecruitmentCycle.next_year) %> recruitment cycle

--- a/app/views/content/dates_and_deadlines.md
+++ b/app/views/content/dates_and_deadlines.md
@@ -1,6 +1,7 @@
 ### <%= RecruitmentCycle.cycle_name(RecruitmentCycle.current_year) %> recruitment cycle – current
 | **Date and time** | **What happens** |
 | --- | --- |
+| <%= CycleTimetable.find_opens.to_fs(:govuk_date_and_time) %> | Candidates can find courses for the <%= RecruitmentCycle.cycle_name(RecruitmentCycle.current_year) %> recruitment cycle on GOV.UK. |
 | <%= CycleTimetable.apply_opens.to_fs(:govuk_date_and_time) %> | Start of <%= RecruitmentCycle.cycle_name(RecruitmentCycle.current_year) %> recruitment cycle. Candidates can apply for courses. |
 | <%= CycleTimetable.apply_2_deadline.to_fs(:govuk_date_and_time) %> | The last day for all candidates to apply for courses. |
 | <%= CycleTimetable.reject_by_default.to_fs(:govuk_date_and_time) %> | End of <%= RecruitmentCycle.cycle_name(RecruitmentCycle.current_year) %> recruitment cycle. Applications awaiting decisions are automatically rejected. |

--- a/app/views/content/dates_and_deadlines.md
+++ b/app/views/content/dates_and_deadlines.md
@@ -8,12 +8,6 @@
 
 ### <%= RecruitmentCycle.cycle_name(RecruitmentCycle.next_year) %> recruitment cycle
 
-In the <%= RecruitmentCycle.cycle_name(RecruitmentCycle.next_year) %> recruitment cycle, training providers will have more time to make decisions on applications.
-
-Applications from candidates will not be rejected after 40 working days. Instead, if candidates do not receive a decision on an application within 30 working days, they’ll be able to apply for another course.
-
-Training providers will still be able to make a decision after 30 working days on all applications.
-
 | **Date and time** | **What happens** |
 | --- | --- |
 | <%= CycleTimetable.find_opens(CycleTimetable.next_year).to_fs(:govuk_date_and_time) %> | Candidates can find courses for the <%= RecruitmentCycle.cycle_name(RecruitmentCycle.next_year) %> recruitment cycle on GOV.UK. |


### PR DESCRIPTION
## Context

Our [dates and deadlines page](https://www.apply-for-teacher-training.service.gov.uk/provider/service-guidance/dates-and-deadlines) is out of date. We created a new page, [the application process page](https://www.apply-for-teacher-training.service.gov.uk/candidate/about-the-teacher-training-application-process), which is candidate focussed and does a similar job. This brings both pages into better alignment.

Q: I've removed copy that we had sitting in 2024-2025 about 30 working days etc. Should we include this in 'current' cycle copy now?

## Changes proposed in this pull request

Before:
![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/35870975/b0608f0d-ff6e-4bd4-8bfa-30c4cbc18a58)

After: 
![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/35870975/507ec1a6-4a89-452f-83b7-c0712640d33e)


## Guidance to review

Are we happy the dates for next cycle are now correct (we can always amend, but they should at least look right on first glance, unlike they do now).

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
