### PR TITLE
Update the personal statement inset text

### DIFF
--- a/app/components/candidate_interface/editable_section_warning.html.erb
+++ b/app/components/candidate_interface/editable_section_warning.html.erb
@@ -1,3 +1,7 @@
 <div class="govuk-inset-text">
-  Any changes you make will be included in applications you’ve already submitted.
+  <% if @section_policy.personal_statement? %>
+    Any changes you make to your personal statement will not be included in applications you have already submitted.
+  <% else %>
+    Any changes you make will be included in applications you’ve already submitted.
+  <% end %>
 </div>

--- a/app/services/candidate_interface/section_policy.rb
+++ b/app/services/candidate_interface/section_policy.rb
@@ -29,6 +29,10 @@ module CandidateInterface
       any_offer_accepted? || all_applications_unsubmitted? || editable_section?
     end
 
+    def personal_statement?
+      @controller_path.classify.eql?('CandidateInterface::PersonalStatement')
+    end
+
   private
 
     delegate :any_offer_accepted?, to: :current_application

--- a/app/views/candidate_interface/personal_statement/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/show.html.erb
@@ -47,6 +47,8 @@
     </div>
   <% end %>
 
+  <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
+
   <%= render(CandidateInterface::BecomingATeacherReviewComponent.new(application_form: @application_form, editable: @section_policy.can_edit?)) %>
 
   <% if @becoming_a_teacher_form.valid? %>

--- a/spec/components/candidate_interface/editable_section_warning_spec.rb
+++ b/spec/components/candidate_interface/editable_section_warning_spec.rb
@@ -11,17 +11,27 @@ RSpec.describe CandidateInterface::EditableSectionWarning do
     let(:current_application) { create(:application_form, :completed, submitted_application_choices_count: 1) }
 
     context 'when candidate can edit the section' do
-      let(:section_policy) { instance_double(CandidateInterface::SectionPolicy, can_edit?: true) }
+      let(:section_policy) { instance_double(CandidateInterface::SectionPolicy, can_edit?: true, personal_statement?: false) }
 
       it 'renders message' do
         expect(result.text).to include(
           'Any changes you make will be included in applications you’ve already submitted.',
         )
       end
+
+      context 'when the canidate can edit the section and it is the personal statement' do
+        let(:section_policy) { instance_double(CandidateInterface::SectionPolicy, can_edit?: true, personal_statement?: true) }
+
+        it 'renders message' do
+          expect(result.text).to include(
+            'Any changes you make to your personal statement will not be included in applications you have already submitted.',
+          )
+        end
+      end
     end
 
     context 'when candidate can not edit the section' do
-      let(:section_policy) { instance_double(CandidateInterface::SectionPolicy, can_edit?: false) }
+      let(:section_policy) { instance_double(CandidateInterface::SectionPolicy, can_edit?: false, personal_statement?: false) }
 
       it 'renders nothing' do
         expect(result.text).to be_blank
@@ -30,7 +40,7 @@ RSpec.describe CandidateInterface::EditableSectionWarning do
   end
 
   context 'when candidate did not submitted yet' do
-    let(:section_policy) { instance_double(CandidateInterface::SectionPolicy, can_edit?: true) }
+    let(:section_policy) { instance_double(CandidateInterface::SectionPolicy, can_edit?: true, personal_statement?: false) }
     let(:current_application) { create(:application_form) }
 
     it 'renders nothing' do


### PR DESCRIPTION
## Context

After a candidate has submitted an application choice we allow them to change their personal statement for future applications. 

We need to render guidance to inform them that this change will not apply to previous application choices.

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="1021" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/9b15ea0c-3f75-41e2-b753-ae54dd6a3a68">|<img width="1046" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/09085958-83b8-4bbf-9ec4-bbbd85dc8005">|

## Guidance to review

- Check the personal statement section – there should be no inset text
- Submit an application
- View the personal statement section again – personal statement specific text should appear
- Check other sections – should be the standard inset text

## Link to Trello card

https://trello.com/c/u6JRkHFn/737-apply-missing-inset-when-editing-a-personal-statement-post-submission

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
