### PR TITLE
Prevent conditions from rendering for unsuccessful applications

### DIFF
--- a/app/components/candidate_interface/application_dashboard_course_choices_component.rb
+++ b/app/components/candidate_interface/application_dashboard_course_choices_component.rb
@@ -98,6 +98,7 @@ module CandidateInterface
     end
 
     def ske_conditions_row(application_choice)
+      return unless successful_application?(application_choice)
       return if (ske_conditions = application_choice.offer&.ske_conditions).blank?
 
       {
@@ -107,6 +108,7 @@ module CandidateInterface
     end
 
     def reference_conditions_row(application_choice)
+      return unless successful_application?(application_choice)
       return if (reference_condition = application_choice.offer&.reference_condition).blank?
 
       {
@@ -116,7 +118,7 @@ module CandidateInterface
     end
 
     def conditions_row(application_choice)
-      return unless application_choice.pending_conditions? || application_choice.offer?
+      return unless successful_application?(application_choice)
       return unconditional_offer_row if application_choice.unconditional_offer?
 
       {
@@ -129,6 +131,10 @@ module CandidateInterface
           ),
         ),
       }
+    end
+
+    def successful_application?(application_choice)
+      application_choice.pending_conditions? || application_choice.offer? || application_choice.offer_deferred?
     end
 
     def unconditional_offer_row

--- a/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
+++ b/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
@@ -371,6 +371,21 @@ RSpec.describe CandidateInterface::ApplicationDashboardCourseChoicesComponent, t
     end
   end
 
+  context 'when there is an offer that has been withdrawn' do
+    let(:application_form) { application_choice.application_form }
+    let(:application_choice) { create(:application_choice, :offer_withdrawn) }
+
+    it 'renders the references section with a default content' do
+      rendered_component = render_inline(
+        described_class.new(application_form:, editable: false, show_status: true),
+      )
+      expect(rendered_component).not_to summarise(
+        key: 'References',
+        value: "The provider will confirm your place once they've checked your references.",
+      )
+    end
+  end
+
   context 'when there is an offer with reference condition with description' do
     let(:application_form) { application_choice.application_form }
     let(:application_choice) { create(:application_choice, :offered, offer:) }


### PR DESCRIPTION
## Context

We're rendering the offer conditions for applications that enter a negative end state following an offer. Whilst we still decide what to do with the 'View application' page we should hide these rides for now, mainly because the content refers to the conditions being met if the candidate ends up being successful.

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="752" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/ff297726-26ba-4785-ba8e-01d1d582b3a9">|<img width="752" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/b968327a-bfcb-4628-93f4-e3d1517c30e3">|

## Guidance to review

- As a provider make an offer to a candidate
- Accept the offer (you will see the conditions)
- As the provider withdraw the offer
- The conditions will no longer be visible

## Link to Trello card

https://trello.com/c/MvgwZIeG/760-apply-references-section-incorrectly-appearing-when-an-application-is-unsuccessful

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
