### PR TITLE
Update offer deadline text

### DIFF
--- a/app/components/provider_interface/application_header_components/offer_will_be_declined_by_default_component.html.erb
+++ b/app/components/provider_interface/application_header_components/offer_will_be_declined_by_default_component.html.erb
@@ -2,5 +2,9 @@
   Waiting for candidate’s response
 </h2>
 <p class="govuk-body">
-  Your offer will be automatically declined <%= decline_by_default_text %> if the candidate does not respond.
+  <% if application_choice.continuous_applications? %>
+    <%= continuous_applications_offer_text %>
+  <% else %>
+    Your offer will be automatically declined <%= decline_by_default_text %> if the candidate does not respond.
+  <% end %>
 </p>

--- a/app/components/provider_interface/application_header_components/offer_will_be_declined_by_default_component.rb
+++ b/app/components/provider_interface/application_header_components/offer_will_be_declined_by_default_component.rb
@@ -1,6 +1,16 @@
 module ProviderInterface
   module ApplicationHeaderComponents
     class OfferWillBeDeclinedByDefaultComponent < ApplicationChoiceHeaderComponent
+      def continuous_applications_offer_text
+        time_since_offer = days_from_now.zero? ? 'today' : "#{pluralize(days_from_now, 'day')} ago"
+
+        "You made this offer #{time_since_offer}. Most candidates respond to offers within 15 working days. The candidate will receive reminders to respond."
+      end
+
+      def days_from_now
+        (Time.zone.now.beginning_of_day - application_choice.offered_at.beginning_of_day).to_i / 1.day
+      end
+
       def decline_by_default_text
         return unless offer_will_be_declined_by_default?
 

--- a/spec/components/provider_interface/application_choice_header_component_spec.rb
+++ b/spec/components/provider_interface/application_choice_header_component_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe ProviderInterface::ApplicationChoiceHeaderComponent do
       end
     end
 
-    context 'when the application has had an offer' do
+    context 'when the application has had an offer and it is not continuous applications', continuous_applications: false do
       let(:dbd_date) { nil }
       let(:application_choice) { build_stubbed(:application_choice, status: 'offer', decline_by_default_at: dbd_date) }
 
@@ -105,6 +105,28 @@ RSpec.describe ProviderInterface::ApplicationChoiceHeaderComponent do
         it 'renders the header with decline by default information' do
           expect(result.css('.govuk-inset-text > h2').text).to include('Waiting for candidate’s response')
           expect(result.css('.govuk-inset-text > p').text).to include("Your offer will be automatically declined in 3 days (#{3.days.from_now.end_of_day.to_fs(:govuk_date_and_time)}) if the candidate does not respond.")
+        end
+      end
+    end
+
+    context 'when the application has had an offer and it is continuous applications', :continuous_applications do
+      let(:application_choice) { create(:application_choice, :offered) }
+
+      context 'when the offer was made today' do
+        it 'renders the correct text' do
+          expect(result.css('.govuk-inset-text > h2').text).to include('Waiting for candidate’s response')
+          expect(result.css('.govuk-inset-text > p').text).to include('You made this offer today. Most candidates respond to offers within 15 working days. The candidate will receive reminders to respond.')
+        end
+      end
+
+      context 'when the offer was made before today' do
+        before do
+          application_choice.update(offered_at: 3.days.ago)
+        end
+
+        it 'renders the correct text' do
+          expect(result.css('.govuk-inset-text > h2').text).to include('Waiting for candidate’s response')
+          expect(result.css('.govuk-inset-text > p').text).to include('You made this offer 3 days ago. Most candidates respond to offers within 15 working days. The candidate will receive reminders to respond.')
         end
       end
     end

--- a/spec/components/provider_interface/application_header_components/offer_will_be_declined_by_default_component_spec.rb
+++ b/spec/components/provider_interface/application_header_components/offer_will_be_declined_by_default_component_spec.rb
@@ -1,7 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe ProviderInterface::ApplicationHeaderComponents::OfferWillBeDeclinedByDefaultComponent do
-  describe 'rendered component' do
+  describe 'rendered component', :continuous_applications do
+    it 'renders offer will be declined content' do
+      application_choice = build_stubbed(:application_choice, :offered)
+      result = render_inline(described_class.new(application_choice:, provider_can_respond: true))
+
+      expect(result.css('h2').text.strip).to eq('Waiting for candidate’s response')
+      expect(result.css('.govuk-body').text).to match('You made this offer today. Most candidates respond to offers within 15 working days. The candidate will receive reminders to respond.')
+    end
+  end
+
+  describe 'rendered component', continuous_applications: false do
     it 'renders offer will be declined content' do
       application_choice = build_stubbed(:application_choice, :offered)
       result = render_inline(described_class.new(application_choice:, provider_can_respond: true))
@@ -11,45 +21,69 @@ RSpec.describe ProviderInterface::ApplicationHeaderComponents::OfferWillBeDeclin
     end
   end
 
-  describe '#decline_by_default_text' do
-    it 'returns nil if the application is not in the offer state' do
-      application_choice = build_stubbed(:application_choice, status: 'awaiting_provider_decision')
+  context 'when not continuous applications', continuous_applications: false do
+    describe '#decline_by_default_text' do
+      it 'returns nil if the application is not in the offer state' do
+        application_choice = build_stubbed(:application_choice, status: 'awaiting_provider_decision')
 
-      expect(described_class.new(application_choice:).decline_by_default_text).to be_nil
+        expect(described_class.new(application_choice:).decline_by_default_text).to be_nil
+      end
+
+      describe 'returns the correct text when' do
+        it 'the dbd is today' do
+          application_choice = build_stubbed(
+            :application_choice,
+            status: 'offer',
+            decline_by_default_at: Time.zone.now.end_of_day,
+          )
+
+          expected_text = "at the end of today (#{application_choice.decline_by_default_at.to_fs(:govuk_date_and_time)})"
+          expect(described_class.new(application_choice:).decline_by_default_text).to eq(expected_text)
+        end
+
+        it 'the dbd is tomorrow' do
+          application_choice = build_stubbed(
+            :application_choice,
+            status: 'offer',
+            decline_by_default_at: 1.day.from_now.end_of_day,
+          )
+
+          expected_text = "at the end of tomorrow (#{application_choice.decline_by_default_at.to_fs(:govuk_date_and_time)})"
+          expect(described_class.new(application_choice:).decline_by_default_text).to eq(expected_text)
+        end
+
+        it 'the dbd is after tomorrow' do
+          application_choice = build_stubbed(
+            :application_choice,
+            status: 'offer',
+            decline_by_default_at: 3.days.from_now.end_of_day,
+          )
+
+          expected_text = "in 3 days (#{application_choice.decline_by_default_at.to_fs(:govuk_date_and_time)})"
+          expect(described_class.new(application_choice:).decline_by_default_text).to eq(expected_text)
+        end
+      end
     end
+  end
 
-    describe 'returns the correct text when' do
-      it 'the dbd is today' do
-        application_choice = build_stubbed(
-          :application_choice,
-          status: 'offer',
-          decline_by_default_at: Time.zone.now.end_of_day,
-        )
+  context 'when continuous applications', :continuous_applications do
+    describe '#continuous_applications_offer_text' do
+      context 'when the offer was made today' do
+        it 'renders the correct text' do
+          application_choice = build_stubbed(:application_choice, :continuous_applications, :offered)
 
-        expected_text = "at the end of today (#{application_choice.decline_by_default_at.to_fs(:govuk_date_and_time)})"
-        expect(described_class.new(application_choice:).decline_by_default_text).to eq(expected_text)
+          expected_text = 'You made this offer today. Most candidates respond to offers within 15 working days. The candidate will receive reminders to respond.'
+          expect(described_class.new(application_choice:).continuous_applications_offer_text).to eq(expected_text)
+        end
       end
 
-      it 'the dbd is tomorrow' do
-        application_choice = build_stubbed(
-          :application_choice,
-          status: 'offer',
-          decline_by_default_at: 1.day.from_now.end_of_day,
-        )
+      context 'when the offer was made before today' do
+        it 'renders the correct text' do
+          application_choice = build_stubbed(:application_choice, :continuous_applications, :offered, offered_at: 3.days.ago)
 
-        expected_text = "at the end of tomorrow (#{application_choice.decline_by_default_at.to_fs(:govuk_date_and_time)})"
-        expect(described_class.new(application_choice:).decline_by_default_text).to eq(expected_text)
-      end
-
-      it 'the dbd is after tomorrow' do
-        application_choice = build_stubbed(
-          :application_choice,
-          status: 'offer',
-          decline_by_default_at: 3.days.from_now.end_of_day,
-        )
-
-        expected_text = "in 3 days (#{application_choice.decline_by_default_at.to_fs(:govuk_date_and_time)})"
-        expect(described_class.new(application_choice:).decline_by_default_text).to eq(expected_text)
+          expected_text = 'You made this offer 3 days ago. Most candidates respond to offers within 15 working days. The candidate will receive reminders to respond.'
+          expect(described_class.new(application_choice:).continuous_applications_offer_text).to eq(expected_text)
+        end
       end
     end
   end


### PR DESCRIPTION
## Context

We're removing the concept of decline by default, so for the 2024 cycle it's no longer appropriate to make reference to a date at which a candidates offer will be automatically declined.

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="691" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/f842b327-525c-4ca4-bf53-54f882f81b7a">|<img width="787" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/8d1d142b-fef3-4bca-a207-400c88dbe7e6">|

Viewing the application on the day of making the offer:
<img width="664" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/d9f55823-caf6-45f0-8f57-979b3cf4fd00">


## Guidance to review

Per [prototype](https://manage-applications-beta.herokuapp.com/applications/78562646)

I've used this component, rather than making a new one as we still make use of declined_by_default with `SetDeclineByDefaultToEndOfCycle` and there's still a possibility that candidates from the 2023 cycle could be sitting on offers – hence the use of `.continuous_applications?`.

## Link to Trello card

https://trello.com/c/h1ELnt0H/748-manage-update-waiting-for-candidates-response-content-to-match-prototype

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
