### PR TITLE
Remove apply again copy in candidate actions

### DIFF
--- a/app/views/candidate_interface/decisions/decline_offer.html.erb
+++ b/app/views/candidate_interface/decisions/decline_offer.html.erb
@@ -9,12 +9,6 @@
 
     <%= render(CandidateInterface::OfferReviewComponent.new(course_choice: @application_choice)) %>
 
-    <% if single_application_choice? %>
-      <p class="govuk-body">If you decline this offer you can still apply again.</p>
-    <% else %>
-      <p class="govuk-body">If you decline all your offers you can still apply again.</p>
-    <% end %>
-
     <%= form_with model: @respond_to_offer, url: candidate_interface_decline_offer_path(@application_choice) do |f| %>
       <%= f.govuk_submit t('decisions.decline_offer.confirm'), warning: true %>
     <% end %>

--- a/app/views/candidate_interface/decisions/withdraw.html.erb
+++ b/app/views/candidate_interface/decisions/withdraw.html.erb
@@ -9,12 +9,6 @@
 
     <%= render(SummaryListComponent.new(rows: course_choice_rows)) %>
 
-    <% if single_application_choice? %>
-      <p class="govuk-body">If you withdraw this application you can still apply again.</p>
-    <% else %>
-      <p class="govuk-body">If you withdraw all your applications you can still apply again.</p>
-    <% end %>
-
     <p class="govuk-body">Any upcoming interviews will be cancelled.</p>
 
     <%= govuk_button_to t('decisions.withdraw.confirm'), candidate_interface_withdraw_path, warning: true %>


### PR DESCRIPTION
## Context

We have two candidate actions that can result in them reaching a negative end state:
- Withdrawing a submitted application
- Declining an offer

Both of these tell the candidate they can apply again, but only if they perform this action on all of their applications – this doesn't reflect how it now works with continuous applications.

## Changes proposed in this pull request

**Withdrawing an application:**
|Before|After|
|---|---|
|<img width="608" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/48a49f5d-275c-49cd-9103-e283109f767d">|<img width="668" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/314c7a0e-d13a-4342-b514-f17f7a373bf8">|

**Declining an offer:**
|Before|After|
|---|---|
|<img width="628" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/396b3187-24a1-4b8b-9963-60e945e5cc27">|<img width="646" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/0ee06e20-98ad-4d81-8c2d-5b005c92daa6">|

## Guidance to review

This would render for any 2023 applications who could still have an offer – small % and happy to live with them no longer seeing this content.

## Link to Trello card

https://trello.com/c/ZzXS6IKr/739-apply-review-and-remove-instances-of-apply-again-from-views

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
