### PR TITLE
Fix apply again bug on continuous applications

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -321,7 +321,7 @@ class ApplicationForm < ApplicationRecord
 
   def any_offer_accepted?
     application_choices.present? &&
-      application_choices.map(&:status).map(&:to_sym).any? { |status| ApplicationStateChange::ACCEPTED_STATES.include?(status) }
+      application_choices.map(&:status).map(&:to_sym).any? { |status| (ApplicationStateChange::ACCEPTED_STATES - [:conditions_not_met]).include?(status) }
   end
 
   def ended_without_success?

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -792,6 +792,14 @@ RSpec.describe ApplicationForm do
       expect(application_form.any_offer_accepted?).to be(false)
     end
 
+    it 'returns false if there is no accepted offer and there is conditions not met on any of the application choices' do
+      offer_choice = create(:application_choice, :offered)
+      other_choice = create(:application_choice, :withdrawn)
+      another_choice = create(:application_choice, :conditions_not_met)
+      application_form = create(:completed_application_form, application_choices: [offer_choice, other_choice, another_choice])
+      expect(application_form.any_offer_accepted?).to be(false)
+    end
+
     it 'returns true if there is an application choice with an accepted offer' do
       accepted_offer_choice = create(:application_choice, :accepted)
       other_choice = create(:application_choice, :rejected)

--- a/spec/system/candidate_interface/continuous_applications/submitting/candidate_is_redirected_away_from_complete_page_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/submitting/candidate_is_redirected_away_from_complete_page_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.feature 'Redirects away from complete page', :continuous_applications do
+  include CandidateHelper
+
+  scenario 'Candidate with an application' do
+    ApplicationChoice.statuses.each_value do |status|
+      @status = status
+      @candidate = create(:candidate)
+
+      given_i_am_signed_in
+      and_i_have_an_application_choice
+      when_i_visit_the_complete_page
+      then_i_should_be_redirected_away_from_complete_page
+    end
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate(candidate: @candidate)
+  end
+
+  def and_i_have_an_application_choice
+    application_form = create(:application_form, candidate: @candidate)
+    create(:application_choice, @status, application_form:)
+  end
+
+  def when_i_visit_the_complete_page
+    visit candidate_interface_application_complete_path
+  end
+
+  def then_i_should_be_redirected_away_from_complete_page
+    expect(page).to have_current_path(expected_path)
+  end
+
+  def expected_path
+    case @status.to_sym
+    when :unsubmitted, :cancelled, :awaiting_provider_decision, :inactive, :interviewing, :application_not_sent, :offer_withdrawn, :declined, :withdrawn, :conditions_not_met, :offer, :rejected
+      candidate_interface_continuous_applications_details_path
+    when :pending_conditions, :offer_deferred, :recruited
+      candidate_interface_application_offer_dashboard_path
+    end
+  end
+end


### PR DESCRIPTION
## Context

When the user is in conditions_not_met, after login it is rendered the complete page. 

The problem with this page that on this page the user can "apply again" and create a new application form and bypass any cap that we have.

We shouldn't never render the complete page whenever the status so I decided to write a system spec to guarantee that whenever is the status we never render the complete page (only for continuous applications!).

## Guidance to review

On conditions not met, does it redirect to the right place?

## Link to Trello card

https://trello.com/c/ohrxOhLE/732-apply-candidates-incorrectly-able-to-enter-apply-again-status
