### PR TITLE
No need to check for current_application in CourseSelectionWizard

### DIFF
--- a/app/validators/candidate_interface/continuous_applications/course_selection_validator.rb
+++ b/app/validators/candidate_interface/continuous_applications/course_selection_validator.rb
@@ -6,8 +6,6 @@ module CandidateInterface
       ALLOWED_REAPPLICATION_LIMIT = 2
 
       def validate(record)
-        return unless record.wizard.current_application
-
         scope = scope_for_current_application(record)
 
         if reached_reapplication_limit?(scope, record)


### PR DESCRIPTION
## Context

Simple change to remove an unnecessary guard clause in the CourseSelectionWizard.
The Course Selection Wizard always has an associated `current_application`, it is passed into the wizard on every request in the base controller.

https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/app/controllers/candidate_interface/continuous_applications/course_choices/base_controller.rb

This was discovered while debugging another issue.

## Changes proposed in this pull request

Remove unnecessary guard clause

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
