### PR TITLE
Sort and group application choices in candidate interface

### DIFF
--- a/app/components/candidate_interface/continuous_applications/dashboard_component.html.erb
+++ b/app/components/candidate_interface/continuous_applications/dashboard_component.html.erb
@@ -1,3 +1,13 @@
+<% previous_header = '' %>
+
 <% application_choices.each do |application_choice| %>
+  <% current_header = group_header(application_choice) %>
+
+  <% if current_header != previous_header %>
+    <h2 class="govuk-heading-m grouped-application-header"><%= current_header %></h2>
+
+    <% previous_header = current_header %>
+  <% end %>
+
   <%= render CandidateInterface::ContinuousApplications::ApplicationSummaryComponent.new(application_choice:) %>
 <% end %>

--- a/app/components/candidate_interface/continuous_applications/dashboard_component.rb
+++ b/app/components/candidate_interface/continuous_applications/dashboard_component.rb
@@ -8,11 +8,17 @@ module CandidateInterface
       end
 
       def application_choices
-        @application_form
-          .application_choices
-          .includes(:course, :site, :provider, :current_course, :current_course_option, :interviews)
-          .includes(offer: :conditions)
-          .order(created_at: :desc)
+        CandidateInterface::SortApplicationChoices.call(
+          application_choices:
+            @application_form
+              .application_choices
+              .includes(:course, :site, :provider, :current_course, :current_course_option, :interviews)
+              .includes(offer: :conditions),
+        )
+      end
+
+      def group_header(application_choice)
+        t("candidate_interface.sort_application_choices.#{application_choice.application_choices_group.humanize}")
       end
     end
   end

--- a/app/services/candidate_interface/sort_application_choices.rb
+++ b/app/services/candidate_interface/sort_application_choices.rb
@@ -1,0 +1,22 @@
+module CandidateInterface
+  class SortApplicationChoices
+    def self.call(application_choices:)
+      scope = application_choices.from <<~WITH_GROUP.squish
+        (
+          SELECT application.*,
+          CASE
+            WHEN (status IN ('offer')) THEN 1
+            WHEN (status IN ('unsubmitted', 'application_not_sent', 'cancelled')) THEN 2
+            WHEN (status IN ('rejected', 'conditions_not_met')) THEN 3
+            WHEN (status IN ('interviewing', 'inactive', 'awaiting_provider_decision')) THEN 4
+            WHEN (status IN ('declined')) THEN 5
+            WHEN (status IN ('offer_withdrawn', 'withdrawn')) THEN 6
+            ELSE 10
+          END AS application_choices_group
+          FROM application_choices application
+        ) AS application_choices
+      WITH_GROUP
+      scope.order('application_choices_group ASC, application_choices.updated_at DESC')
+    end
+  end
+end

--- a/app/services/candidate_interface/sort_application_choices.rb
+++ b/app/services/candidate_interface/sort_application_choices.rb
@@ -16,7 +16,7 @@ module CandidateInterface
           FROM application_choices application
         ) AS application_choices
       WITH_GROUP
-      scope.order('application_choices_group ASC, application_choices.updated_at DESC')
+      scope.order('application_choices_group ASC, application_choices.sent_to_provider_at DESC')
     end
   end
 end

--- a/config/locales/candidate_interface/sort_application_choices.yml
+++ b/config/locales/candidate_interface/sort_application_choices.yml
@@ -1,0 +1,10 @@
+en:
+  candidate_interface:
+    sort_application_choices:
+      one: Offers received
+      two: Unsubmitted applications
+      three: Unsuccessful applications
+      four: In progress
+      five: Declined offers
+      six: Withdrawn applications
+      ten: Other applications

--- a/spec/components/candidate_interface/continuous_applications/dashboard_component_spec.rb
+++ b/spec/components/candidate_interface/continuous_applications/dashboard_component_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::ContinuousApplications::DashboardComponent do
+  let(:application_form) { create(:application_form) }
+
+  subject(:result) do
+    render_inline(described_class.new(application_form:))
+  end
+
+  before do
+    create(:application_choice, :offer_withdrawn, application_form:)
+    create(:application_choice, :withdrawn, application_form:)
+    create(:application_choice, :declined, application_form:)
+    create(:application_choice, :awaiting_provider_decision, application_form:)
+    create(:application_choice, :inactive, application_form:)
+    create(:application_choice, :interviewing, application_form:)
+    create(:application_choice, :rejected, application_form:)
+    create(:application_choice, :conditions_not_met, application_form:)
+    create(:application_choice, :unsubmitted, application_form:)
+    create(:application_choice, :application_not_sent, application_form:)
+    create(:application_choice, :cancelled, application_form:)
+    create(:application_choice, :offer, application_form:)
+  end
+
+  it 'sort group headers in the expected order' do
+    expect(result.css('h2.grouped-application-header').map(&:text)).to eq([
+      'Offers received',
+      'Unsubmitted applications',
+      'Unsuccessful applications',
+      'In progress',
+      'Declined offers',
+      'Withdrawn applications',
+    ])
+  end
+end

--- a/spec/services/candidate_interface/sort_application_choices_spec.rb
+++ b/spec/services/candidate_interface/sort_application_choices_spec.rb
@@ -94,8 +94,8 @@ RSpec.describe CandidateInterface::SortApplicationChoices do
         # --- 5
         create(:application_choice, :declined),
         # --- 4
-        create(:application_choice, :awaiting_provider_decision),
-        create(:application_choice, :awaiting_provider_decision), # has more recent updated_at, will appear first
+        create(:application_choice, :awaiting_provider_decision, sent_to_provider_at: 1.minute.ago),
+        create(:application_choice, :awaiting_provider_decision, sent_to_provider_at: Time.zone.now), # has more recent sent_to_provider_at, will appear first
         create(:application_choice, :inactive),
         create(:application_choice, :interviewing),
         # --- 3

--- a/spec/services/candidate_interface/sort_application_choices_spec.rb
+++ b/spec/services/candidate_interface/sort_application_choices_spec.rb
@@ -1,0 +1,120 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::SortApplicationChoices do
+  describe 'decorates models with' do
+    let(:model) do
+      create(:application_choice, :awaiting_provider_decision)
+      described_class.call(application_choices: ApplicationChoice.all).first
+    end
+
+    it 'application_choices_group' do
+      expect(model).to respond_to(:application_choices_group)
+    end
+  end
+
+  describe '#application_choices_group' do
+    let(:application_choice) do
+      described_class.call(application_choices: ApplicationChoice.all).first
+    end
+
+    it 'when application has an offer' do
+      create(:application_choice, :offer)
+      expect(application_choice.application_choices_group).to eq(1)
+    end
+
+    it 'when application is unsubmitted' do
+      create(:application_choice, :unsubmitted)
+      expect(application_choice.application_choices_group).to eq(2)
+    end
+
+    it 'when application is application_not_sent' do
+      create(:application_choice, :application_not_sent)
+      expect(application_choice.application_choices_group).to eq(2)
+    end
+
+    it 'when application is cancelled' do
+      create(:application_choice, :cancelled)
+      expect(application_choice.application_choices_group).to eq(2)
+    end
+
+    it 'when application is rejected' do
+      create(:application_choice, :rejected)
+      expect(application_choice.application_choices_group).to eq(3)
+    end
+
+    it 'when application is conditions_not_met' do
+      create(:application_choice, :conditions_not_met)
+      expect(application_choice.application_choices_group).to eq(3)
+    end
+
+    it 'when application is interviewing' do
+      create(:application_choice, :interviewing)
+      expect(application_choice.application_choices_group).to eq(4)
+    end
+
+    it 'when application is inactive' do
+      create(:application_choice, :inactive)
+      expect(application_choice.application_choices_group).to eq(4)
+    end
+
+    it 'when application is awaiting_provider_decision' do
+      create(:application_choice, :awaiting_provider_decision)
+      expect(application_choice.application_choices_group).to eq(4)
+    end
+
+    it 'when application is declined' do
+      create(:application_choice, :declined)
+      expect(application_choice.application_choices_group).to eq(5)
+    end
+
+    it 'when application is withdrawn' do
+      create(:application_choice, :withdrawn)
+      expect(application_choice.application_choices_group).to eq(6)
+    end
+
+    it 'when application is offer withdrawn' do
+      create(:application_choice, :offer_withdrawn)
+      expect(application_choice.application_choices_group).to eq(6)
+    end
+
+    it 'when application status is not mapped' do
+      create(:application_choice, :recruited)
+      expect(application_choice.application_choices_group).to eq(10)
+    end
+  end
+
+  describe '.call' do
+    let(:application_choices) do
+      [
+        # --- 10
+        create(:application_choice, :recruited),
+        # --- 6
+        create(:application_choice, :offer_withdrawn),
+        create(:application_choice, :withdrawn),
+        # --- 5
+        create(:application_choice, :declined),
+        # --- 4
+        create(:application_choice, :awaiting_provider_decision),
+        create(:application_choice, :awaiting_provider_decision), # has more recent updated_at, will appear first
+        create(:application_choice, :inactive),
+        create(:application_choice, :interviewing),
+        # --- 3
+        create(:application_choice, :rejected),
+        create(:application_choice, :conditions_not_met),
+        # --- 2
+        create(:application_choice, :unsubmitted),
+        create(:application_choice, :unsubmitted), # has more recent updated_at, will appear first
+        create(:application_choice, :application_not_sent),
+        create(:application_choice, :cancelled),
+        # --- 1
+        create(:application_choice, :offer),
+      ]
+    end
+
+    it 'according to their application_choices_group and updated_at' do
+      expected = application_choices.reverse
+      result = described_class.call(application_choices: ApplicationChoice.all)
+      expect(result).to match_array(expected)
+    end
+  end
+end


### PR DESCRIPTION
## Context

This PR introduces ordering and grouping on the ‘Your applications’ tab in candidate interface following on from:

For more details about the grouping see the trello card:
https://trello.com/c/prpxDlNS/778-ca-application-headers-and-grouping-on-your-applications-tab

## Guidance to review

Does it work?
When candidate reaches the 20 max limit during the cycle, how the page looks like?
When candidate reaches many applications in different states during the cycle, how the page looks like?

## Link to Trello card

https://trello.com/c/prpxDlNS/778-ca-application-headers-and-grouping-on-your-applications-tab
