### PR TITLE
Only show the inset if the applications is unsubmitted and course full

### DIFF
--- a/app/components/candidate_interface/continuous_applications/application_summary_component.rb
+++ b/app/components/candidate_interface/continuous_applications/application_summary_component.rb
@@ -36,7 +36,7 @@ module CandidateInterface
       end
 
       def container_class
-        return unless @application_choice.course_full?
+        return unless @application_choice.course_full? && application_choice.unsubmitted?
 
         'govuk-inset-text app-inset-text--narrow-border app-inset-text--important govuk-!-padding-top-0 govuk-!-padding-bottom-0'
       end

--- a/spec/components/candidate_interface/continuous_applications/application_summary_component_spec.rb
+++ b/spec/components/candidate_interface/continuous_applications/application_summary_component_spec.rb
@@ -48,14 +48,31 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationSummaryCom
 
     context 'when application course is full' do
       let(:course) { create(:course, :with_no_vacancies) }
-      let(:application_choice) { create(:application_choice, :unsubmitted, course:) }
 
-      it 'renders the course full info and `Change` link without the `View application` link' do
-        expect(result.text).to include('You cannot apply to this course as there are no places left on it')
-        expect(result.text).to include('You need to either remove or change this course choice')
-        expect(result.text).to include("#{application_choice.course.provider.name} may be able to recommend an alternative course.")
-        expect(actions).not_to include('View application')
-        expect(links).to include('Change')
+      context 'when unsubmitted' do
+        let(:application_choice) { create(:application_choice, :unsubmitted, course:) }
+
+        it 'renders the course full info and `Change` link without the `View application` link' do
+          expect(result).to have_css('.govuk-inset-text')
+          expect(result.text).to include('You cannot apply to this course as there are no places left on it')
+          expect(result.text).to include('You need to either remove or change this course choice')
+          expect(result.text).to include("#{application_choice.course.provider.name} may be able to recommend an alternative course.")
+          expect(actions).not_to include('View application')
+          expect(links).to include('Change')
+        end
+      end
+
+      context 'when submitted' do
+        let(:application_choice) { create(:application_choice, :awaiting_provider_decision, course:) }
+
+        it 'renders the course full info and `Change` link without the `View application` link' do
+          expect(result).not_to have_css('.govuk-inset-text')
+          expect(result.text).not_to include('You cannot apply to this course as there are no places left on it')
+          expect(result.text).not_to include('You need to either remove or change this course choice')
+          expect(result.text).not_to include("#{application_choice.course.provider.name} may be able to recommend an alternative course.")
+          expect(actions).to include('Withdraw')
+          expect(links).not_to include('Change')
+        end
       end
     end
   end


### PR DESCRIPTION
## Context

When a candidate has added a course that becomes full (and the application is unsubmitted), we used to render some text to say that it’s full.

This made use of a blue inset text.

We appear to have ported this over to our designs, but we also appear to be rendering some sort of blue inset, regardless of the status this means that the blue inset bar is rendering for submitted apps, without any helptext.

This PR fix to remove this blue inset if the application is submitted.

How to reproduce the bug:

1. Submitted an application
2. Makes the course goes full (no vacancies)

## Guidance to review

Does it work?

## Link to Trello card

https://trello.com/c/cyet0Ofg/782-fix-blue-inset-that-appears-on-an-application-summary-card-when-course-is-full

