### PR TITLE
Recruit with pending conditions button on manage

### DIFF
--- a/app/components/provider_interface/offer_summary_component.html.erb
+++ b/app/components/provider_interface/offer_summary_component.html.erb
@@ -22,15 +22,30 @@
   <%= render ProviderInterface::ConditionsListComponent.new(conditions) %>
 
   <% if editable %>
-    <% if @application_choice.pending_conditions? %>
-      <div class='govuk-body'>
-        <%= govuk_button_to 'Update status of conditions', update_conditions_path, form_class: 'govuk-!-display-inline-block' %>
-      </div>
-    <% end %>
-    <% if @application_choice.offer? || show_conditions_link %>
-      <div class='govuk-body'>
-        <%= govuk_link_to 'Add or change conditions', [mode, :provider_interface, @application_choice, :offer, :conditions] %>
-      </div>
-    <% end %>
+    <div class='govuk-body'>
+      <% if @application_choice.pending_conditions? %>
+        <%= govuk_button_to(
+          'Update status of conditions',
+          update_conditions_path,
+          form_class: 'govuk-!-display-inline-block',
+          method: :get,
+        ) %>
+      <% end %>
+      <% if @application_choice.offer? || show_conditions_link %>
+        <%= govuk_link_to(
+          'Add or change conditions',
+          [mode, :provider_interface, @application_choice, :offer, :conditions],
+        ) %>
+      <% end %>
+      <% if show_recruit_with_pending_conditions? %>
+        <%= govuk_button_to(
+          'Recruit candidate with pending conditions',
+          provider_interface_application_choice_new_recruit_with_pending_conditions_path(application_choice_id: @application_choice.id),
+          form_class: 'govuk-!-display-inline-block',
+          secondary: true,
+          method: :get,
+        ) %>
+      <% end %>
+    </div>
   <% end %>
 </div>

--- a/app/components/provider_interface/offer_summary_component.html.erb
+++ b/app/components/provider_interface/offer_summary_component.html.erb
@@ -40,7 +40,7 @@
       <% if show_recruit_with_pending_conditions? %>
         <%= govuk_button_to(
           'Recruit candidate with pending conditions',
-          provider_interface_application_choice_new_recruit_with_pending_conditions_path(application_choice_id: @application_choice.id),
+          new_provider_interface_application_choice_offer_recruit_with_pending_conditions_path(application_choice_id: @application_choice.id),
           form_class: 'govuk-!-display-inline-block',
           secondary: true,
           method: :get,

--- a/app/components/provider_interface/offer_summary_component.html.erb
+++ b/app/components/provider_interface/offer_summary_component.html.erb
@@ -19,19 +19,18 @@
     <% end %>
   <% end %>
 
+  <%= render ProviderInterface::ConditionsListComponent.new(conditions) %>
+
   <% if editable %>
     <% if @application_choice.pending_conditions? %>
       <div class='govuk-body'>
-        <%= govuk_link_to 'Update status of conditions', update_conditions_path %>
+        <%= govuk_button_to 'Update status of conditions', update_conditions_path, form_class: 'govuk-!-display-inline-block' %>
       </div>
     <% end %>
-
     <% if @application_choice.offer? || show_conditions_link %>
       <div class='govuk-body'>
         <%= govuk_link_to 'Add or change conditions', [mode, :provider_interface, @application_choice, :offer, :conditions] %>
       </div>
     <% end %>
   <% end %>
-
-  <%= render ProviderInterface::ConditionsListComponent.new(conditions) %>
 </div>

--- a/app/components/provider_interface/offer_summary_component.rb
+++ b/app/components/provider_interface/offer_summary_component.rb
@@ -84,6 +84,10 @@ module ProviderInterface
       edit_provider_interface_condition_statuses_path(application_choice)
     end
 
+    def show_recruit_with_pending_conditions?
+      CanRecruitWithPendingConditions.new(application_choice:).call
+    end
+
   private
 
     def accredited_body_details(course_option)

--- a/app/controllers/provider_interface/offer/recruit_with_pending_conditions_controller.rb
+++ b/app/controllers/provider_interface/offer/recruit_with_pending_conditions_controller.rb
@@ -5,9 +5,26 @@ module ProviderInterface
       before_action :confirm_application_can_be_recruited_with_pending_conditions
 
       def new
+        @recruit_with_pending_conditions_form =
+          ProviderInterface::RecruitWithPendingConditionsForm.new(
+            application_choice: @application_choice,
+          )
       end
 
       def create
+        @recruit_with_pending_conditions_form =
+          ProviderInterface::RecruitWithPendingConditionsForm.new(
+            create_params,
+          )
+
+        if @recruit_with_pending_conditions_form.save
+          flash[:success] = 'Applicant recruited with conditions pending' 
+          redirect_to(
+            provider_interface_application_choice_offer_path(application_choice_id: @application_choice.id),
+          )
+        else
+          render :new
+        end
       end
 
     private
@@ -16,6 +33,11 @@ module ProviderInterface
         return if CanRecruitWithPendingConditions.new(application_choice: @application_choice).call
 
         redirect_to(provider_interface_application_choice_path(@application_choice))
+      end
+
+      def create_params
+        form_params = params.permit(provider_interface_recruit_with_pending_conditions_form: :confirmation)[:provider_interface_recruit_with_pending_conditions_form]
+        (form_params || {}).merge(application_choice: @application_choice)
       end
     end
   end

--- a/app/controllers/provider_interface/offer/recruit_with_pending_conditions_controller.rb
+++ b/app/controllers/provider_interface/offer/recruit_with_pending_conditions_controller.rb
@@ -37,7 +37,7 @@ module ProviderInterface
 
       def create_params
         form_params = params.permit(provider_interface_recruit_with_pending_conditions_form: :confirmation)[:provider_interface_recruit_with_pending_conditions_form]
-        (form_params || {}).merge(application_choice: @application_choice)
+        (form_params || {}).merge(actor: current_user, application_choice: @application_choice)
       end
     end
   end

--- a/app/controllers/provider_interface/offer/recruit_with_pending_conditions_controller.rb
+++ b/app/controllers/provider_interface/offer/recruit_with_pending_conditions_controller.rb
@@ -18,7 +18,7 @@ module ProviderInterface
           )
 
         if @recruit_with_pending_conditions_form.save
-          flash[:success] = 'Applicant recruited with conditions pending' 
+          flash[:success] = 'Applicant recruited with conditions pending'
           redirect_to(
             provider_interface_application_choice_offer_path(application_choice_id: @application_choice.id),
           )

--- a/app/controllers/provider_interface/offer/recruit_with_pending_conditions_controller.rb
+++ b/app/controllers/provider_interface/offer/recruit_with_pending_conditions_controller.rb
@@ -1,0 +1,22 @@
+module ProviderInterface
+  module Offer
+    class RecruitWithPendingConditionsController < ProviderInterfaceController
+      before_action :set_application_choice
+      before_action :confirm_application_can_be_recruited_with_pending_conditions
+
+      def new
+      end
+
+      def create
+      end
+
+    private
+
+      def confirm_application_can_be_recruited_with_pending_conditions
+        return if CanRecruitWithPendingConditions.new(application_choice: @application_choice).call
+
+        redirect_to(provider_interface_application_choice_path(@application_choice))
+      end
+    end
+  end
+end

--- a/app/forms/provider_interface/recruit_with_pending_conditions_form.rb
+++ b/app/forms/provider_interface/recruit_with_pending_conditions_form.rb
@@ -10,10 +10,8 @@ module ProviderInterface
     def save
       return false unless valid?
 
-      # TODO: Work out whether we really need the radio buttons here and hence
-      # whether we even need the `confirmation` attribute here.
       if confirmed?
-        ConfirmOfferConditions.new(actor:, application_choice:, updated_conditions: false).save
+        ConfirmOfferWithPendingSkeConditions.new(actor:, application_choice:).save
       end
     end
 

--- a/app/forms/provider_interface/recruit_with_pending_conditions_form.rb
+++ b/app/forms/provider_interface/recruit_with_pending_conditions_form.rb
@@ -8,9 +8,7 @@ module ProviderInterface
     validates :confirmation, inclusion: { in: %w[yes no] }
 
     def save
-      return false unless valid?
-
-      if confirmed?
+      if valid? && confirmed?
         ConfirmOfferWithPendingSkeConditions.new(actor:, application_choice:).save
       end
     end

--- a/app/forms/provider_interface/recruit_with_pending_conditions_form.rb
+++ b/app/forms/provider_interface/recruit_with_pending_conditions_form.rb
@@ -2,7 +2,7 @@ module ProviderInterface
   class RecruitWithPendingConditionsForm
     include ActiveModel::Model
 
-    attr_accessor :application_choice, :confirmation
+    attr_accessor :actor, :application_choice, :confirmation
 
     validates :confirmation, presence: true
     validates :confirmation, inclusion: { in: %w[yes no] }
@@ -10,8 +10,17 @@ module ProviderInterface
     def save
       return false unless valid?
 
-      # TODO: 
-      true
+      # TODO: Work out whether we really need the radio buttons here and hence
+      # whether we even need the `confirmation` attribute here.
+      if confirmed?
+        ConfirmOfferConditions.new(actor:, application_choice:, updated_conditions: false).save
+      end
+    end
+
+  private
+
+    def confirmed?
+      confirmation.to_s == 'yes'
     end
   end
 end

--- a/app/forms/provider_interface/recruit_with_pending_conditions_form.rb
+++ b/app/forms/provider_interface/recruit_with_pending_conditions_form.rb
@@ -1,0 +1,17 @@
+module ProviderInterface
+  class RecruitWithPendingConditionsForm
+    include ActiveModel::Model
+
+    attr_accessor :application_choice, :confirmation
+
+    validates :confirmation, presence: true
+    validates :confirmation, inclusion: { in: %w[yes no] }
+
+    def save
+      return false unless valid?
+
+      # TODO: 
+      true
+    end
+  end
+end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -31,6 +31,12 @@ class Provider < ApplicationRecord
     yorkshire_and_the_humber: 'yorkshire_and_the_humber',
   }
 
+  enum provider_type: {
+    lead_school: 'lead_school',
+    scitt: 'scitt',
+    university: 'university',
+  }
+
   audited
   has_associated_audits
 

--- a/app/models/support_interface/providers_filter.rb
+++ b/app/models/support_interface/providers_filter.rb
@@ -9,10 +9,13 @@ module SupportInterface
       'dsa_signed_only' => 'With signed DSAs',
     }.freeze
 
+    LEAD_SCHOOL = 'lead_school'
+    SCITT = 'scitt'
+    UNIVERSITY = 'university'
     PROVIDER_TYPES = {
-      'lead_school' => 'School Direct',
-      'scitt' => 'SCITT',
-      'university' => 'HEI',
+      LEAD_SCHOOL => 'School Direct',
+      SCITT => 'SCITT',
+      UNIVERSITY => 'HEI',
     }.freeze
 
     RATIFIED_BY = {

--- a/app/models/support_interface/providers_filter.rb
+++ b/app/models/support_interface/providers_filter.rb
@@ -9,13 +9,10 @@ module SupportInterface
       'dsa_signed_only' => 'With signed DSAs',
     }.freeze
 
-    LEAD_SCHOOL = 'lead_school'
-    SCITT = 'scitt'
-    UNIVERSITY = 'university'
     PROVIDER_TYPES = {
-      LEAD_SCHOOL => 'School Direct',
-      SCITT => 'SCITT',
-      UNIVERSITY => 'HEI',
+      'lead_school' => 'School Direct',
+      'scitt' => 'SCITT',
+      'university' => 'HEI',
     }.freeze
 
     RATIFIED_BY = {

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -84,6 +84,7 @@ class ApplicationStateChange
 
     state :pending_conditions do
       event :confirm_conditions_met, transitions_to: :recruited
+      event :confirm_non_ske_conditions_met, transitions_to: :recruited
       event :conditions_not_met, transitions_to: :conditions_not_met
       event :withdraw, transitions_to: :withdrawn
       event :defer_offer, transitions_to: :offer_deferred

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -84,7 +84,7 @@ class ApplicationStateChange
 
     state :pending_conditions do
       event :confirm_conditions_met, transitions_to: :recruited
-      event :confirm_non_ske_conditions_met, transitions_to: :recruited
+      event :recruit_with_pending_conditions, transitions_to: :recruited
       event :conditions_not_met, transitions_to: :conditions_not_met
       event :withdraw, transitions_to: :withdrawn
       event :defer_offer, transitions_to: :offer_deferred

--- a/app/services/can_recruit_with_pending_conditions.rb
+++ b/app/services/can_recruit_with_pending_conditions.rb
@@ -25,9 +25,7 @@ private
   end
 
   def offer_has_pending_ske_conditions?
-    application_choice.offer.conditions.any? do |condition|
-      condition.is_a?(SkeCondition) && condition.pending?
-    end
+    application_choice.offer.ske_conditions.any?(&:pending?)
   end
 
   def offer_has_no_unmet_non_ske_conditions?

--- a/app/services/can_recruit_with_pending_conditions.rb
+++ b/app/services/can_recruit_with_pending_conditions.rb
@@ -19,7 +19,7 @@ private
   end
 
   def application_has_offer?
-    application_choice.offer? && application_choice.offer.present?
+    application_choice.offer.present?
   end
 
   def offer_has_pending_ske_conditions?

--- a/app/services/can_recruit_with_pending_conditions.rb
+++ b/app/services/can_recruit_with_pending_conditions.rb
@@ -9,7 +9,9 @@ class CanRecruitWithPendingConditions
     feature_flag_enabled? &&
       application_has_offer? &&
       offer_has_pending_ske_conditions? &&
-      offer_has_no_unmet_non_ske_conditions?
+      offer_has_no_unmet_non_ske_conditions? &&
+      provider_is_scitt? &&
+      course_is_within_time_limit?
   end
 
 private
@@ -32,5 +34,17 @@ private
     application_choice.offer.conditions.none? do |condition|
       !condition.is_a?(SkeCondition) && !condition.met?
     end
+  end
+
+  def provider_is_scitt?
+    application_choice.provider&.provider_type&.to_s == SupportInterface::ProvidersFilter::SCITT
+  end
+
+  def course_is_within_time_limit?
+    course_start_date.present? && course_start_date < 3.months.from_now
+  end
+
+  def course_start_date
+    application_choice.course&.start_date
   end
 end

--- a/app/services/can_recruit_with_pending_conditions.rb
+++ b/app/services/can_recruit_with_pending_conditions.rb
@@ -9,7 +9,7 @@ class CanRecruitWithPendingConditions
     feature_flag_enabled? &&
       application_has_offer? &&
       offer_has_pending_ske_conditions? &&
-      offer_has_no_unmet_non_ske_conditions? &&
+      all_non_ske_conditions_met? &&
       provider_is_scitt? &&
       course_is_within_time_limit?
   end
@@ -28,7 +28,7 @@ private
     application_choice.offer.ske_conditions.any?(&:pending?)
   end
 
-  def offer_has_no_unmet_non_ske_conditions?
+  def all_non_ske_conditions_met?
     non_ske_conditions = application_choice.offer.conditions - application_choice.offer.ske_conditions
     non_ske_conditions.all?(&:met?)
   end

--- a/app/services/can_recruit_with_pending_conditions.rb
+++ b/app/services/can_recruit_with_pending_conditions.rb
@@ -34,7 +34,7 @@ private
   end
 
   def provider_is_scitt?
-    application_choice.provider&.provider_type&.to_s == SupportInterface::ProvidersFilter::SCITT
+    application_choice.provider&.scitt?
   end
 
   def course_is_within_time_limit?

--- a/app/services/can_recruit_with_pending_conditions.rb
+++ b/app/services/can_recruit_with_pending_conditions.rb
@@ -29,9 +29,8 @@ private
   end
 
   def offer_has_no_unmet_non_ske_conditions?
-    application_choice.offer.conditions.none? do |condition|
-      !condition.is_a?(SkeCondition) && !condition.met?
-    end
+    non_ske_conditions = application_choice.offer.conditions - application_choice.offer.ske_conditions
+    non_ske_conditions.all?(&:met?)
   end
 
   def provider_is_scitt?

--- a/app/services/can_recruit_with_pending_conditions.rb
+++ b/app/services/can_recruit_with_pending_conditions.rb
@@ -1,0 +1,36 @@
+class CanRecruitWithPendingConditions
+  attr_accessor :application_choice
+
+  def initialize(application_choice:)
+    self.application_choice = application_choice
+  end
+
+  def call
+    feature_flag_enabled? &&
+      application_has_offer? &&
+      offer_has_pending_ske_conditions? &&
+      offer_has_no_unmet_non_ske_conditions?
+  end
+
+private
+
+  def feature_flag_enabled?
+    FeatureFlag.active?(:recruit_with_pending_conditions)
+  end
+
+  def application_has_offer?
+    application_choice.offer? && application_choice.offer.present?
+  end
+
+  def offer_has_pending_ske_conditions?
+    application_choice.offer.conditions.any? do |condition|
+      condition.is_a?(SkeCondition) && condition.pending?
+    end
+  end
+
+  def offer_has_no_unmet_non_ske_conditions?
+    application_choice.offer.conditions.none? do |condition|
+      !condition.is_a?(SkeCondition) && !condition.met?
+    end
+  end
+end

--- a/app/services/confirm_offer_conditions.rb
+++ b/app/services/confirm_offer_conditions.rb
@@ -2,11 +2,12 @@ class ConfirmOfferConditions
   include ActiveModel::Validations
   include ImpersonationAuditHelper
 
-  attr_reader :auth, :application_choice
+  attr_reader :auth, :application_choice, :updated_conditions
 
-  def initialize(actor:, application_choice:)
+  def initialize(actor:, application_choice:, updated_conditions: true)
     @auth = ProviderAuthorisation.new(actor:)
     @application_choice = application_choice
+    @updated_conditions = updated_conditions
   end
 
   def save
@@ -15,7 +16,7 @@ class ConfirmOfferConditions
     audit(auth.actor) do
       ApplicationStateChange.new(application_choice).confirm_conditions_met!
       application_choice.update!(recruited_at: Time.zone.now)
-      application_choice.offer.conditions.each(&:met!)
+      application_choice.offer.conditions.each(&:met!) if updated_conditions
       CandidateMailer.conditions_met(application_choice).deliver_later
     end
 

--- a/app/services/confirm_offer_conditions.rb
+++ b/app/services/confirm_offer_conditions.rb
@@ -2,12 +2,11 @@ class ConfirmOfferConditions
   include ActiveModel::Validations
   include ImpersonationAuditHelper
 
-  attr_reader :auth, :application_choice, :updated_conditions
+  attr_reader :auth, :application_choice
 
-  def initialize(actor:, application_choice:, updated_conditions: true)
+  def initialize(actor:, application_choice:)
     @auth = ProviderAuthorisation.new(actor:)
     @application_choice = application_choice
-    @updated_conditions = updated_conditions
   end
 
   def save
@@ -16,7 +15,7 @@ class ConfirmOfferConditions
     audit(auth.actor) do
       ApplicationStateChange.new(application_choice).confirm_conditions_met!
       application_choice.update!(recruited_at: Time.zone.now)
-      application_choice.offer.conditions.each(&:met!) if updated_conditions
+      application_choice.offer.conditions.each(&:met!)
       CandidateMailer.conditions_met(application_choice).deliver_later
     end
 

--- a/app/services/confirm_offer_with_pending_ske_conditions.rb
+++ b/app/services/confirm_offer_with_pending_ske_conditions.rb
@@ -6,7 +6,7 @@ class ConfirmOfferWithPendingSkeConditions < ConfirmOfferConditions
     )
 
     audit(auth.actor) do
-      ApplicationStateChange.new(application_choice).confirm_non_ske_conditions_met!
+      ApplicationStateChange.new(application_choice).recruit_with_pending_conditions!
       application_choice.update!(recruited_at: Time.zone.now)
       CandidateMailer.conditions_met(application_choice).deliver_later
     end

--- a/app/services/confirm_offer_with_pending_ske_conditions.rb
+++ b/app/services/confirm_offer_with_pending_ske_conditions.rb
@@ -1,0 +1,22 @@
+class ConfirmOfferWithPendingSkeConditions < ConfirmOfferConditions
+  def save
+    auth.assert_can_make_decisions!(
+      application_choice:,
+      course_option_id: application_choice.current_course_option.id,
+    )
+
+    audit(auth.actor) do
+      ApplicationStateChange.new(application_choice).confirm_non_ske_conditions_met!
+      application_choice.update!(recruited_at: Time.zone.now)
+      CandidateMailer.conditions_met(application_choice).deliver_later
+    end
+
+    true
+  rescue Workflow::NoTransitionAllowed
+    errors.add(
+      :base,
+      I18n.t('activerecord.errors.models.application_choice.attributes.status.invalid_transition'),
+    )
+    false
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -38,6 +38,7 @@ class FeatureFlag
     [:structured_reference_condition, 'Structured reference condition that can be added as a condition to an offer', 'Tomas Destefi'],
     [:continuous_applications, 'The new continuous applications flow', 'James Glenn'],
     [:course_has_vacancies, 'Using the new publish status to set a course as open or closed', 'Tomas & James'],
+    [:recruit_with_pending_conditions, 'Providers will be able to recruit candidates that have a SKE condition pending provided there are no other pending conditions', 'Steve Hook'],
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day

--- a/app/views/provider_interface/offer/recruit_with_pending_conditions/new.html.erb
+++ b/app/views/provider_interface/offer/recruit_with_pending_conditions/new.html.erb
@@ -1,18 +1,27 @@
 <% content_for :browser_title, t('.title') %>
 
+<h1 class="govuk-heading-xl govuk-!-margin-bottom-6">
+  <%= @application_choice.application_form.full_name %>
+  <%= render(ProviderInterface::ApplicationStatusTagComponent.new(application_choice: @application_choice)) %>
+</h1>
+
 <%= form_with(
-  model: @application_choice, #@recruit_with_pending_conditions_form,
+  model: @recruit_with_pending_conditions_form,
   url: provider_interface_application_choice_offer_recruit_with_pending_conditions_path(@application_choice),
   method: :post,
 ) do |f| %>
-  <h1 class="govuk-heading-l">
-    <span class="govuk-caption-l"><%= t('caption.make_offer', name: @application_choice.application_form.full_name) %></span>
-    <%= t('.title') %>
-  </h1>
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset(
+        :confirmation,
+        legend: { text: "Do you want to recruit the candidate with pending conditions?", size: 'm' },
+        hint: { text: "If you choose ‘yes’, the candidate will be informed by email they can start their teacher training" },
+      ) do %>
+        <%= f.govuk_radio_button :confirmation, 'yes', label: { text: 'Yes, recruit with pending SKE conditions' }, link_errors: true %>
+        <%= f.govuk_radio_button :confirmation, 'no', label: { text: 'No, do not recruit yet' } %>
+      <% end %>
 
       <%= f.govuk_submit t('.submit') %>
 

--- a/app/views/provider_interface/offer/recruit_with_pending_conditions/new.html.erb
+++ b/app/views/provider_interface/offer/recruit_with_pending_conditions/new.html.erb
@@ -1,0 +1,25 @@
+<% content_for :browser_title, t('.title') %>
+
+<%= form_with(
+  model: @application_choice, #@recruit_with_pending_conditions_form,
+  url: provider_interface_application_choice_offer_recruit_with_pending_conditions_path(@application_choice),
+  method: :post,
+) do |f| %>
+  <h1 class="govuk-heading-l">
+    <span class="govuk-caption-l"><%= t('caption.make_offer', name: @application_choice.application_form.full_name) %></span>
+    <%= t('.title') %>
+  </h1>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_submit t('.submit') %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to t('cancel'), provider_interface_application_choice_path(@application_choice.id), no_visited_state: true %>
+      </p>
+    </div>
+  </div>
+<% end %>
+

--- a/app/views/provider_interface/offer/recruit_with_pending_conditions/new.html.erb
+++ b/app/views/provider_interface/offer/recruit_with_pending_conditions/new.html.erb
@@ -16,8 +16,8 @@
 
       <%= f.govuk_radio_buttons_fieldset(
         :confirmation,
-        legend: { text: "Do you want to recruit the candidate with pending conditions?", size: 'm' },
-        hint: { text: "If you choose ‘yes’, the candidate will be informed by email they can start their teacher training" },
+        legend: { text: 'Do you want to recruit the candidate with pending conditions?', size: 'm' },
+        hint: { text: 'If you choose ‘yes’, the candidate will be informed by email they can start their teacher training' },
       ) do %>
         <%= f.govuk_radio_button :confirmation, 'yes', label: { text: 'Yes, recruit with pending SKE conditions' }, link_errors: true %>
         <%= f.govuk_radio_button :confirmation, 'no', label: { text: 'No, do not recruit yet' } %>
@@ -31,4 +31,3 @@
     </div>
   </div>
 <% end %>
-

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -439,6 +439,13 @@ en:
       emails:
         - candidate_mailer-conditions_met
 
+    pending_conditions-recruit_with_pending_conditions:
+      name: Provider confirms all conditions except SKE conditions are met
+      by: provider
+      description: The provider confirms that the candidate has met the conditions set out in the offer with the exception of any SKE conditions.
+      emails:
+        - candidate_mailer-conditions_met
+
     pending_conditions-conditions_not_met:
       name: Providers marks conditions as not met
       by: provider

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -127,3 +127,7 @@ en:
               other_offer_already_accepted: You cannot make an offer because the candidate has already accepted one
               application_rejected_by_default: You cannot make an offer because the application has been automatically rejected
               only_latest_application_rejection_can_be_reverted_on_apply_2: You cannot make an offer because you can only do so for the most recent application
+        provider_interface/recruit_with_pending_conditions_form:
+          attributes:
+            confirmation:
+              blank: Select whether you want to recruit the candidate with pending conditions

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -63,6 +63,10 @@ en:
         edit:
           title: Check and send new offer
           submit: Send new offer
+      recruit_with_pending_conditions:
+        new:
+          title: Do you want to recruit the candidate with pending conditions?
+          submit: Continue
     offers:
       failure: Sorry, there is a problem with the service.
       create:

--- a/config/routes/provider.rb
+++ b/config/routes/provider.rb
@@ -63,6 +63,9 @@ namespace :provider_interface, path: '/provider' do
     get '/offer/defer' => 'decisions#new_defer_offer', as: :application_choice_new_defer_offer
     post '/offer/defer' => 'decisions#defer_offer', as: :application_choice_defer_offer
 
+    get '/offer/recruit_with_pending_conditions', as: :application_choice_new_recruit_with_pending_conditions
+    post '/offer/recruit_with_pending_conditions', as: :application_choice_recruit_with_pending_conditions
+
     resource :decision, only: %i[new create], as: :application_choice_decision
 
     resource :offers, only: %i[new edit create show update], as: :application_choice_offer

--- a/config/routes/provider.rb
+++ b/config/routes/provider.rb
@@ -63,9 +63,6 @@ namespace :provider_interface, path: '/provider' do
     get '/offer/defer' => 'decisions#new_defer_offer', as: :application_choice_new_defer_offer
     post '/offer/defer' => 'decisions#defer_offer', as: :application_choice_defer_offer
 
-    get '/offer/recruit_with_pending_conditions', as: :application_choice_new_recruit_with_pending_conditions
-    post '/offer/recruit_with_pending_conditions', as: :application_choice_recruit_with_pending_conditions
-
     resource :decision, only: %i[new create], as: :application_choice_decision
 
     resource :offers, only: %i[new edit create show update], as: :application_choice_offer
@@ -83,6 +80,7 @@ namespace :provider_interface, path: '/provider' do
       resource :ske_requirements, only: %i[new create update edit], path: 'ske-requirements'
       resource :ske_reason, only: %i[new create update edit], path: 'ske-reason'
       resource :ske_length, only: %i[new create update edit], path: 'ske-length'
+      resource :recruit_with_pending_conditions, only: %i[new create], path: 'recruit-with-pending-conditions'
     end
 
     namespace :courses, as: :application_choice_course do

--- a/spec/components/provider_interface/offer_summary_component_spec.rb
+++ b/spec/components/provider_interface/offer_summary_component_spec.rb
@@ -188,7 +188,22 @@ RSpec.describe ProviderInterface::OfferSummaryComponent do
         let(:application_choice) { build_stubbed(:application_choice, :accepted) }
 
         it 'displays the update condition link' do
-          expect(render.css('.govuk-body').css('a').first.attr('href')).to eq(edit_provider_interface_condition_statuses_path(application_choice))
+          expect(render.css('.govuk-body').css('form').first.attr('action')).to eq(edit_provider_interface_condition_statuses_path(application_choice))
+        end
+      end
+
+      context 'when application is in condititions_pending state but only SKE conditions are pending' do
+        let(:application_choice) { build_stubbed(:application_choice, :accepted) }
+
+        before { allow(CanRecruitWithPendingConditions).to receive(:new).and_return(instance_double(CanRecruitWithPendingConditions, call: true)) }
+
+        it 'displays the update condition link' do
+          expect(render.css('.govuk-body').css('form').first.attr('action')).to eq(
+            edit_provider_interface_condition_statuses_path(application_choice),
+          )
+          expect(render.css('.govuk-body').css('form')[1].attr('action')).to eq(
+            new_provider_interface_application_choice_offer_recruit_with_pending_conditions_path(application_choice_id: application_choice.id),
+          )
         end
       end
     end

--- a/spec/services/can_recruit_with_pending_conditions_spec.rb
+++ b/spec/services/can_recruit_with_pending_conditions_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe CanRecruitWithPendingConditions do
+  let(:offer) { create(:offer) }
+  subject(:service) { described_class.new(application_choice: offer.application_choice) }
+
+  context 'when feature flag is off' do
+    let(:offer) { create(:offer, :with_ske_conditions) }
+
+    before do
+      FeatureFlag.deactivate(:recruit_with_pending_conditions)
+      offer.conditions.select { |condition| !condition.is_a?(SkeCondition) }.each do |condition|
+        condition.update!(status: :met)
+      end
+    end
+
+    it 'returns false' do
+      expect(service.call).to be(false)
+    end 
+  end
+
+  context 'when feature flag is on' do
+    before { FeatureFlag.activate(:recruit_with_pending_conditions) }
+
+    context 'when there are various pending conditions' do
+      let(:offer) { create(:offer, :with_unmet_conditions) }
+
+      it 'returns false' do
+        expect(service.call).to be(false)
+      end 
+    end
+
+    context 'when there is a pending SKE condition and other met conditions' do
+      let(:offer) { create(:offer, :with_ske_conditions) }
+
+      before do
+        offer.conditions.select { |condition| !condition.is_a?(SkeCondition) }.each do |condition|
+          condition.update!(status: :met)
+        end
+      end
+
+      it 'returns true' do
+        expect(service.call).to be(true)
+      end 
+    end
+  end
+end

--- a/spec/services/can_recruit_with_pending_conditions_spec.rb
+++ b/spec/services/can_recruit_with_pending_conditions_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe CanRecruitWithPendingConditions do
   let(:offer) { create(:offer) }
+
   subject(:service) { described_class.new(application_choice: offer.application_choice) }
 
   context 'when feature flag is off' do
@@ -9,14 +10,14 @@ RSpec.describe CanRecruitWithPendingConditions do
 
     before do
       FeatureFlag.deactivate(:recruit_with_pending_conditions)
-      offer.conditions.select { |condition| !condition.is_a?(SkeCondition) }.each do |condition|
+      offer.conditions.reject { |condition| condition.is_a?(SkeCondition) }.each do |condition|
         condition.update!(status: :met)
       end
     end
 
     it 'returns false' do
       expect(service.call).to be(false)
-    end 
+    end
   end
 
   context 'when feature flag is on' do
@@ -27,21 +28,21 @@ RSpec.describe CanRecruitWithPendingConditions do
 
       it 'returns false' do
         expect(service.call).to be(false)
-      end 
+      end
     end
 
     context 'when there is a pending SKE condition and other met conditions' do
       let(:offer) { create(:offer, :with_ske_conditions) }
 
       before do
-        offer.conditions.select { |condition| !condition.is_a?(SkeCondition) }.each do |condition|
+        offer.conditions.reject { |condition| condition.is_a?(SkeCondition) }.each do |condition|
           condition.update!(status: :met)
         end
       end
 
       it 'returns true' do
         expect(service.call).to be(true)
-      end 
+      end
     end
   end
 end

--- a/spec/services/can_recruit_with_pending_conditions_spec.rb
+++ b/spec/services/can_recruit_with_pending_conditions_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe CanRecruitWithPendingConditions do
         offer.conditions.reject { |condition| condition.is_a?(SkeCondition) }.each do |condition|
           condition.update!(status: :met)
         end
-        offer.application_choice.provider.update(provider_type: SupportInterface::ProvidersFilter::SCITT)
+        offer.application_choice.provider.update(provider_type: :scitt)
         offer.application_choice.course.update(start_date: 2.months.from_now)
       end
 
@@ -50,7 +50,7 @@ RSpec.describe CanRecruitWithPendingConditions do
 
       context 'when the provider is NOT a SCITT and the course start date is within 3 months' do
         before do
-          offer.application_choice.provider.update(provider_type: SupportInterface::ProvidersFilter::UNIVERSITY)
+          offer.application_choice.provider.update(provider_type: :university)
         end
 
         it 'returns false' do

--- a/spec/services/can_recruit_with_pending_conditions_spec.rb
+++ b/spec/services/can_recruit_with_pending_conditions_spec.rb
@@ -38,10 +38,34 @@ RSpec.describe CanRecruitWithPendingConditions do
         offer.conditions.reject { |condition| condition.is_a?(SkeCondition) }.each do |condition|
           condition.update!(status: :met)
         end
+        offer.application_choice.provider.update(provider_type: SupportInterface::ProvidersFilter::SCITT)
+        offer.application_choice.course.update(start_date: 2.months.from_now)
       end
 
-      it 'returns true' do
-        expect(service.call).to be(true)
+      context 'when the provider is a SCITT and the course start date is within 3 months' do
+        it 'returns true' do
+          expect(service.call).to be(true)
+        end
+      end
+
+      context 'when the provider is NOT a SCITT and the course start date is within 3 months' do
+        before do
+          offer.application_choice.provider.update(provider_type: SupportInterface::ProvidersFilter::UNIVERSITY)
+        end
+
+        it 'returns false' do
+          expect(service.call).to be(false)
+        end
+      end
+
+      context 'when the provider is a SCITT and the course start date is NOT within 3 months' do
+        before do
+          offer.application_choice.course.update(start_date: 4.months.from_now)
+        end
+
+        it 'returns false' do
+          expect(service.call).to be(false)
+        end
       end
     end
   end

--- a/spec/services/confirm_offer_with_pending_ske_conditions_spec.rb
+++ b/spec/services/confirm_offer_with_pending_ske_conditions_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe ConfirmOfferWithPendingSkeConditions do
+  it 'raises an error if the user is not authorised' do
+    application_choice = create(:application_choice, status: :pending_conditions)
+    provider_user = create(:provider_user)
+    provider_user.providers << application_choice.current_course.provider
+
+    service = described_class.new(
+      actor: provider_user,
+      application_choice:,
+    )
+
+    expect { service.save }.to raise_error(ProviderAuthorisation::NotAuthorisedError)
+
+    expect(application_choice.reload.status).to eq 'pending_conditions'
+  end
+
+  it 'does not alter the status of any offer conditions' do
+    application_choice = create(:application_choice, :offered, status: :pending_conditions)
+    offer = Offer.find_by(application_choice:)
+
+    expect {
+      described_class.new(
+        actor: create(:support_user),
+        application_choice:,
+      ).save
+    }.not_to change { offer.conditions.first.status }
+  end
+
+  it 'changes the status to recruited' do
+    application_choice = create(:application_choice, :offered, status: :pending_conditions)
+
+    described_class.new(
+      actor: create(:support_user),
+      application_choice:,
+    ).save
+
+    expect(application_choice.reload.recruited?).to be(true)
+  end
+end

--- a/spec/services/confirm_offer_with_pending_ske_conditions_spec.rb
+++ b/spec/services/confirm_offer_with_pending_ske_conditions_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ConfirmOfferWithPendingSkeConditions do
         actor: create(:support_user),
         application_choice:,
       ).save
-    }.not_to change { offer.conditions.first.status }
+    }.not_to(change { offer.conditions.first.status })
   end
 
   it 'changes the status to recruited' do

--- a/spec/system/provider_interface/provider_can_recruit_with_pending_ske_condition_spec.rb
+++ b/spec/system/provider_interface/provider_can_recruit_with_pending_ske_condition_spec.rb
@@ -32,7 +32,10 @@ RSpec.feature 'Confirm conditions met' do
     when_i_click_recruit_with_pending_conditions
     then_i_see_the_recruit_with_pending_conditions_confirmation_page
 
-    when_i_click_continue
+    # when_i_click_continue
+    # then_i_see_a_validation_error
+
+    when_i_select_yes_and_click_continue
     then_i_see_the_offer_page_with_a_flash_message
     and_the_application_is_now_recruited
   end
@@ -132,6 +135,28 @@ RSpec.feature 'Confirm conditions met' do
 
   def and_the_candidate_is_still_pending_conditions
     expect(@application_choice.reload.pending_conditions?).to be_truthy
-    expect(page).to have_content 'Conditions pending'
+    expect(page).to have_content('Conditions pending')
+  end
+
+  def then_i_see_the_recruit_with_pending_conditions_confirmation_page
+    expect(page).to have_content('Do you want to recruit the candidate with pending conditions?')
+  end
+
+  def when_i_click_continue
+    click_button('Continue')
+  end
+
+  def when_i_select_yes_and_click_continue
+    choose('Yes')
+    when_i_click_continue
+  end
+
+  def then_i_see_the_offer_page_with_a_flash_message
+    expect(page).to have_current_path(provider_interface_application_choice_offer_path(application_choice_id: @application_choice.id))
+    expect(page).to have_content('Applicant recruited with conditions pending')
+  end
+
+  def and_the_application_is_now_recruited
+    expect(@application_choice.reload.recruited?).to be_truthy
   end
 end

--- a/spec/system/provider_interface/provider_can_recruit_with_pending_ske_condition_spec.rb
+++ b/spec/system/provider_interface/provider_can_recruit_with_pending_ske_condition_spec.rb
@@ -1,0 +1,138 @@
+require 'rails_helper'
+
+RSpec.feature 'Confirm conditions met' do
+  include CourseOptionHelpers
+  include DfESignInHelpers
+  include ProviderUserPermissionsHelper
+
+  NUMBER_OF_TEXT_CONDITIONS = 3
+
+  scenario 'Provider user confirms offer conditions have been met by the candidate' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_the_feature_flag_is_enabled
+    and_i_am_an_authorised_provider_user
+    and_i_can_access_the_provider_interface
+
+    when_i_navigate_to_an_offer_accepted_by_the_candidate
+    and_i_navigate_to_the_offer_tab
+    then_i_should_not_see_button_to_recruit_with_pending_conditions
+
+    when_i_click_on_confirm_conditions
+    then_i_should_see_a_summary_of_the_conditions
+
+    when_i_change_the_status_of_the_text_conditions_to_met
+    and_confirm_my_selection_in_the_next_page
+
+    then_i_get_feedback_that_my_action_succeeded
+
+    when_i_revisit_the_offer
+    and_i_navigate_to_the_offer_tab
+    save_and_open_page
+    then_i_should_see_button_to_recruit_with_pending_conditions
+
+    when_i_click_recruit_with_pending_conditions
+    then_i_see_the_recruit_with_pending_conditions_confirmation_page
+
+    when_i_click_continue
+    then_i_see_the_offer_page_with_a_flash_message
+    and_the_application_is_now_recruited
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_i_am_an_authorised_provider_user
+    @provider = create(:provider)
+    create(:provider_user, providers: [@provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+    permit_make_decisions!
+  end
+
+  def and_i_can_access_the_provider_interface
+    provider_signs_in_using_dfe_sign_in
+    visit provider_interface_applications_path
+    expect(page).to have_current_path provider_interface_applications_path
+  end
+
+  def and_the_feature_flag_is_enabled
+    FeatureFlag.activate(:recruit_with_pending_conditions)
+  end
+
+  def when_i_navigate_to_an_offer_accepted_by_the_candidate
+    course_option = course_option_for_provider_code(provider_code: @provider.code)
+    @application_form = create(
+      :completed_application_form,
+      first_name: 'John',
+      last_name: 'Smith',
+    )
+    @conditions = create_list(:text_condition, NUMBER_OF_TEXT_CONDITIONS)
+    @conditions << create(:ske_condition)
+    @application_choice = create(
+      :application_choice,
+      :accepted,
+      offer: create(:offer, conditions: @conditions),
+      current_course_option: course_option,
+      application_form: @application_form,
+    )
+    visit provider_interface_application_choice_path(@application_choice)
+  end
+
+  def when_i_revisit_the_offer
+    visit provider_interface_application_choice_path(@application_choice)
+  end
+
+  def and_i_navigate_to_the_offer_tab
+    click_link 'Offer'
+  end
+
+  def then_i_should_not_see_button_to_recruit_with_pending_conditions
+    expect(page).not_to have_button('Recruit candidate with pending conditions')
+  end
+
+  def then_i_should_see_button_to_recruit_with_pending_conditions
+    expect(page).to have_button('Recruit candidate with pending conditions')
+  end
+
+  def when_i_click_on_confirm_conditions
+    click_on 'Update status of conditions'
+  end
+
+  def when_i_click_recruit_with_pending_conditions
+    click_on 'Recruit candidate with pending conditions'
+  end
+
+  def then_i_should_see_a_summary_of_the_conditions
+    within '.app-box' do
+      @conditions.each do |condition|
+        expect(page).to have_content(condition.text)
+      end
+    end
+  end
+
+  def when_i_change_the_status_of_the_text_conditions_to_met
+    @conditions.take(NUMBER_OF_TEXT_CONDITIONS).each do |condition|
+      within_fieldset(condition.text) do
+        choose 'Met'
+      end
+    end
+
+    click_button t('continue')
+  end
+
+  def and_confirm_my_selection_in_the_next_page
+    click_button 'Update status'
+  end
+
+  def then_i_get_feedback_that_my_action_succeeded
+    expect(page).to have_content 'Status of conditions updated'
+  end
+
+  def and_i_am_back_on_the_application_page
+    expect(page).to have_current_path provider_interface_application_choice_path(@application_choice)
+  end
+
+  def and_the_candidate_is_still_pending_conditions
+    expect(@application_choice.reload.pending_conditions?).to be_truthy
+    expect(page).to have_content 'Conditions pending'
+  end
+end

--- a/spec/system/provider_interface/provider_can_recruit_with_pending_ske_condition_spec.rb
+++ b/spec/system/provider_interface/provider_can_recruit_with_pending_ske_condition_spec.rb
@@ -32,8 +32,9 @@ RSpec.feature 'Confirm conditions met' do
     when_i_click_recruit_with_pending_conditions
     then_i_see_the_recruit_with_pending_conditions_confirmation_page
 
-    # when_i_click_continue
-    # then_i_see_a_validation_error
+    when_i_click_continue
+    then_i_see_a_validation_error
+    and_the_candidate_is_still_pending_conditions
 
     when_i_select_yes_and_click_continue
     then_i_see_the_offer_page_with_a_flash_message
@@ -144,6 +145,17 @@ RSpec.feature 'Confirm conditions met' do
 
   def when_i_click_continue
     click_button('Continue')
+  end
+
+  def then_i_see_a_validation_error
+    expect(page).to have_current_path(
+      provider_interface_application_choice_offer_recruit_with_pending_conditions_path(
+        application_choice_id: @application_choice.id,
+      ),
+    )
+    expect(page).to have_content(
+      'Select whether you want to recruit the candidate with pending conditions',
+    )
   end
 
   def when_i_select_yes_and_click_continue

--- a/spec/system/provider_interface/provider_can_recruit_with_pending_ske_condition_spec.rb
+++ b/spec/system/provider_interface/provider_can_recruit_with_pending_ske_condition_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
+NUMBER_OF_TEXT_CONDITIONS = 3
+
 RSpec.feature 'Confirm conditions met' do
   include CourseOptionHelpers
   include DfESignInHelpers
   include ProviderUserPermissionsHelper
-
-  NUMBER_OF_TEXT_CONDITIONS = 3
 
   scenario 'Provider user confirms offer conditions have been met by the candidate' do
     given_i_am_a_provider_user_with_dfe_sign_in
@@ -97,11 +97,11 @@ RSpec.feature 'Confirm conditions met' do
   end
 
   def when_i_click_on_confirm_conditions
-    click_on 'Update status of conditions'
+    click_button 'Update status of conditions'
   end
 
   def when_i_click_recruit_with_pending_conditions
-    click_on 'Recruit candidate with pending conditions'
+    click_button 'Recruit candidate with pending conditions'
   end
 
   def then_i_should_see_a_summary_of_the_conditions

--- a/spec/system/provider_interface/provider_can_recruit_with_pending_ske_condition_spec.rb
+++ b/spec/system/provider_interface/provider_can_recruit_with_pending_ske_condition_spec.rb
@@ -77,6 +77,8 @@ RSpec.feature 'Confirm conditions met' do
       current_course_option: course_option,
       application_form: @application_form,
     )
+    @application_choice.provider.update(provider_type: SupportInterface::ProvidersFilter::SCITT)
+    @application_choice.course.update(start_date: 2.months.from_now)
     visit provider_interface_application_choice_path(@application_choice)
   end
 

--- a/spec/system/provider_interface/provider_can_recruit_with_pending_ske_condition_spec.rb
+++ b/spec/system/provider_interface/provider_can_recruit_with_pending_ske_condition_spec.rb
@@ -27,7 +27,6 @@ RSpec.feature 'Confirm conditions met' do
 
     when_i_revisit_the_offer
     and_i_navigate_to_the_offer_tab
-    save_and_open_page
     then_i_should_see_button_to_recruit_with_pending_conditions
 
     when_i_click_recruit_with_pending_conditions

--- a/spec/system/provider_interface/provider_can_recruit_with_pending_ske_condition_spec.rb
+++ b/spec/system/provider_interface/provider_can_recruit_with_pending_ske_condition_spec.rb
@@ -77,7 +77,7 @@ RSpec.feature 'Confirm conditions met' do
       current_course_option: course_option,
       application_form: @application_form,
     )
-    @application_choice.provider.update(provider_type: SupportInterface::ProvidersFilter::SCITT)
+    @application_choice.provider.update(provider_type: :scitt)
     @application_choice.course.update(start_date: 2.months.from_now)
     visit provider_interface_application_choice_path(@application_choice)
   end

--- a/spec/system/provider_interface/provider_edits_condition_statuses_spec.rb
+++ b/spec/system/provider_interface/provider_edits_condition_statuses_spec.rb
@@ -62,7 +62,7 @@ RSpec.feature 'Confirm conditions met' do
   end
 
   def and_click_on_confirm_conditions
-    click_link 'Update status of conditions'
+    click_button 'Update status of conditions'
   end
 
   def then_i_should_see_a_summary_of_the_conditions

--- a/spec/system/provider_interface/provider_marks_conditions_as_met_spec.rb
+++ b/spec/system/provider_interface/provider_marks_conditions_as_met_spec.rb
@@ -74,7 +74,7 @@ RSpec.feature 'Confirm conditions met' do
   end
 
   def when_i_click_on_confirm_conditions
-    click_link 'Update status of conditions'
+    click_button 'Update status of conditions'
   end
 
   def then_i_should_see_a_summary_of_the_standard_conditions

--- a/spec/system/provider_interface/provider_marks_conditions_as_not_met_spec.rb
+++ b/spec/system/provider_interface/provider_marks_conditions_as_not_met_spec.rb
@@ -63,7 +63,7 @@ RSpec.feature 'Confirm conditions met' do
   end
 
   def and_click_on_confirm_conditions
-    click_link 'Update status of conditions'
+    click_button 'Update status of conditions'
   end
 
   def then_i_should_see_a_summary_of_the_conditions


### PR DESCRIPTION
## Context
It would be beneficial to SCITT providers if we allowed them to move a candidate who was only pending SKE conditions to ‘Recruited’ as this would automatically import their record into Register saving them from having to manually create it. This is particularly useful for providers (and DfE) who are busy getting their ITT data ready for the ITT census deadline in October.

Implementing this will move a candidate to ‘Recruited’ status, meaning that they will be included in the next import from Apply to Register (a job that currently runs at 4am every day).

## Changes proposed in this pull request

- [x] A new _Recruit candidate with pending conditions_ button on the offer page:
![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/450843/8a47b2ee-96e6-43c6-a8d4-bf037a5fce3a)

- [x] The new button above leads to a new _Do you want to recruit the candidate with pending conditions?_ page.
![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/450843/c482b875-6cd5-4314-b338-79a23170faff)

- [x] If the use confirms the action the candidate is moved on the the `recruited` state. We display a flash message.

### To be covered in a follow up PR
- We need to display a _SKE pending conditions_ tag next to _Recruited_ tag wherever we display it.
![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/450843/6c926713-4631-4bf9-bc91-39b3e0e9fcbc)

## Guidance to review
- This PR _kind of_ introduces a new _Recruited with pending SKE conditions_ 'virtual status'. However we are modelling such applications using the existing _Recruited_ status - there is no new status value.
- For now we've avoided making any DB schema changes (to add a dedicated `recruited_with_pending_ske_conditions` flag). Instead we are going to work this out using existing data (the offer conditions and their status). If performance is an issue we may revisit this.
- Are the tests sufficient?

## Link to Trello card

[<!-- http://trello.com/123-example-card -->](https://trello.com/c/0V9VGfjL/6161-recruit-with-pending-conditions-button-on-manage)

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
