### PR TITLE
Candidate shouldn't see personal statement on their draft application

### DIFF
--- a/app/components/candidate_interface/continuous_applications/application_review_component.html.erb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.html.erb
@@ -1,6 +1,6 @@
 <%= render SummaryListComponent.new(rows: rows) %>
 
-<% if @application_choice.personal_statement.present? %>
+<% if show_personal_statement? %>
   <div class="app-summary-card govuk-!-margin-bottom-6">
     <div class="app-summary-card__header govuk-body">
       Personal statement

--- a/app/components/candidate_interface/continuous_applications/application_review_component.rb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.rb
@@ -8,6 +8,10 @@ module CandidateInterface
         @application_choice = application_choice
       end
 
+      def show_personal_statement?
+        @application_choice.submitted? && @application_choice.personal_statement.present?
+      end
+
       def rows
         [
           status_row,

--- a/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
+++ b/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
@@ -6,19 +6,24 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
   end
 
   let(:application_choice) do
-    create(:application_choice, :awaiting_provider_decision)
+    create(:application_choice, :awaiting_provider_decision, personal_statement:)
   end
   let(:course) { application_choice.current_course }
   let(:provider) { application_choice.current_provider }
   let(:links) { result.css('a').map(&:text) }
+  let(:personal_statement) { 'some personal statement' }
 
   context 'when application is unsubmitted' do
     let(:application_choice) do
-      create(:application_choice, :unsubmitted)
+      create(:application_choice, :unsubmitted, personal_statement:)
     end
 
     it 'shows change course link' do
       expect(links).to include("Change course for #{application_choice.current_course.name_and_code}")
+    end
+
+    it 'does not show the personal statement' do
+      expect(result.text).not_to include(personal_statement)
     end
 
     context 'when course has multiple study modes' do
@@ -55,6 +60,10 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
   context 'when application is submitted' do
     it 'does not show change links' do
       expect(result.css('a')).to be_empty
+    end
+
+    it 'shows personal statement' do
+      expect(result.text).to include(personal_statement)
     end
 
     context 'when course has multiple study modes' do


### PR DESCRIPTION
## Context

They should only see it once they have submitted their application.

## Guidance to review

1. Does it work?

## Link to Trello card

https://trello.com/c/gef1EtNP/745-remove-the-personal-statement-view-on-draft-applications
