### PR TITLE
Update candidate footer emails to include full stop around chat online

### DIFF
--- a/app/views/candidate_mailer/find_has_opened.erb
+++ b/app/views/candidate_mailer/find_has_opened.erb
@@ -18,6 +18,6 @@ Training providers offer places on courses as people apply throughout the year. 
 
 # Get help
 
-Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'find_has_opened', @application_form.phase %>)
+Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'find_has_opened', @application_form.phase %>).
 
 <%= t('get_into_teaching.opening_times') %>.

--- a/app/views/candidate_mailer/new_cycle_has_started.erb
+++ b/app/views/candidate_mailer/new_cycle_has_started.erb
@@ -22,6 +22,6 @@ All our advisers are experienced former teachers who provide free, one-to-one su
 
 # Get help
 
-Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'find_has_opened', @application_form.phase %>)
+Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'find_has_opened', @application_form.phase %>).
 
 <%= t('get_into_teaching.opening_times') %>.

--- a/app/views/candidate_mailer/nudge_unsubmitted.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted.text.erb
@@ -8,6 +8,6 @@ A teacher training adviser could help with your application, if something is hol
 
 [Get a teacher training adviser](<%= email_link_with_utm_params t('get_into_teaching.url_get_an_adviser_start'), 'nudge_unsubmitted', @application_form.phase %>)
 
-Alternatively, call 0800 389 2500 or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted', @application_form.phase %>)
+Alternatively, call 0800 389 2500 or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted', @application_form.phase %>).
 
 Monday to Friday, 8:30am to 5:30pm (except public holidays).

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_courses.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_courses.text.erb
@@ -14,6 +14,6 @@ If you’re training to teach certain secondary subjects (or primary mathematics
 
 [Find out about subject knowledge enhancement courses](<%= email_link_with_utm_params t('get_into_teaching.url_subject_knowledge_enhancement'), 'nudge_unsubmitted_with_incomplete_courses', @application_form.phase %>)
 
-Alternatively, call 0800 389 2500 or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_with_incomplete_courses', @application_form.phase %>)
+Alternatively, call 0800 389 2500 or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_with_incomplete_courses', @application_form.phase %>).
 
 Monday to Friday, 8:30am to 5:30pm (except public holidays).

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_personal_statement.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_personal_statement.text.erb
@@ -8,6 +8,6 @@ A teacher training adviser can help you understand what to put in your personal 
 
 [Get a teacher training adviser](<%= email_link_with_utm_params t('get_into_teaching.url_get_an_adviser_start'), 'nudge_unsubmitted_with_incomplete_personal_statement', @application_form.phase %>)
 
-Alternatively, call 0800 389 2500 or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_with_incomplete_personal_statement', @application_form.phase %>)
+Alternatively, call 0800 389 2500 or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_with_incomplete_personal_statement', @application_form.phase %>).
 
 Monday to Friday, 8:30am to 5:30pm (except public holidays).

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
@@ -24,6 +24,6 @@ A teacher training adviser can give advice on references:
 
 [Get a teacher training adviser](<%= email_link_with_utm_params t('get_into_teaching.url_get_an_adviser_start'), 'nudge_unsubmitted_no_references', @application_form.phase %>)
 
-Alternatively, call 0800 389 2500 or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_no_references', @application_form.phase %>)
+Alternatively, call 0800 389 2500 or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_no_references', @application_form.phase %>).
 
 Monday to Friday, 8:30am to 5:30pm (except public holidays).

--- a/app/views/layouts/candidate_email_with_support_footer.text.erb
+++ b/app/views/layouts/candidate_email_with_support_footer.text.erb
@@ -2,6 +2,6 @@
 
 # Get help
 
-If you need support with your application, you can speak to a teacher training adviser before applying again. Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'support_footer_on_all_emails', @application_form.phase %>)
+If you need support with your application, you can speak to a teacher training adviser before applying again. Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'support_footer_on_all_emails', @application_form.phase %>).
 
 <%= t('get_into_teaching.opening_times') %>.


### PR DESCRIPTION
## Context

We did some testing and it appears this mailer is missing a full stop. It appears there are other sentences we could fix, but keeping this to this chat online sentence.

## Changes proposed in this pull request

Add full stops

![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/35870975/a8a18532-f2eb-465d-94da-6af542178e3a)


## Guidance to review

Does this work?

## Link to Trello card

n/a

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
