### PR TITLE
Do not cancel outstanding references on continuous applications

### DIFF
--- a/app/services/cancel_outstanding_references.rb
+++ b/app/services/cancel_outstanding_references.rb
@@ -8,6 +8,8 @@ class CancelOutstandingReferences
   end
 
   def call!
+    return if @application_form.continuous_applications?
+
     application_references.feedback_requested.each do |reference|
       CancelReferee.new.call(reference: reference)
     end

--- a/spec/services/cancel_outstanding_references_spec.rb
+++ b/spec/services/cancel_outstanding_references_spec.rb
@@ -7,16 +7,28 @@ RSpec.describe CancelOutstandingReferences, :sidekiq do
   let!(:requested_reference) { create(:reference, :feedback_requested, application_form: application_form) }
   let!(:provided_reference) { create(:reference, :feedback_provided, application_form: application_form) }
 
-  it 'cancel the requested references' do
-    service.call!
+  context 'when not continuous applications', continuous_applications: false do
+    it 'cancel the requested references' do
+      service.call!
 
-    expect(requested_reference.reload.feedback_status).to eq('cancelled')
-    expect(provided_reference.reload.feedback_status).to eq('feedback_provided')
+      expect(requested_reference.reload.feedback_status).to eq('cancelled')
+      expect(provided_reference.reload.feedback_status).to eq('feedback_provided')
+    end
+
+    it 'deliver email to requested references' do
+      service.call!
+
+      expect(ActionMailer::Base.deliveries.map(&:to).flatten).to contain_exactly(requested_reference.email_address)
+    end
   end
 
-  it 'deliver email to requested references' do
-    service.call!
+  context 'when continuous applications', :continuous_applications do
+    it 'do not cancel outstanding references' do
+      service.call!
 
-    expect(ActionMailer::Base.deliveries.map(&:to).flatten).to contain_exactly(requested_reference.email_address)
+      expect(requested_reference.reload.feedback_status).to eq('feedback_requested')
+      expect(provided_reference.reload.feedback_status).to eq('feedback_provided')
+      expect(ActionMailer::Base.deliveries.map(&:to).flatten).to be_empty
+    end
   end
 end


### PR DESCRIPTION
## Context

Because continuous applications doesn't have the apply again concept and we use the same application form to attach references if we cancel references it will make a blocking process for the candidates when they are marked inactive, rejected or withdrawn an application

## Guidance to review

#### Scenario 1: Marking as conditions not met

1. Mark one application as conditions not met
2. The candidate should not have any references changed to cancelled

#### Scenario 2: Reject an application

1. Reject an application (after candidate has requested references!)
2. The candidate should not have any references changed to cancelled

#### Scenario 3: Withdrawn an application

1. Candidate withdraws an application after accepting an offer (and after candidate has requested references!)
2. The candidate should not have any references changed to cancelled

## Link to Trello card

We need to create one
