### PR TITLE
Allow interviews to be scheduled after the RBD date

### DIFF
--- a/app/services/interview_validations.rb
+++ b/app/services/interview_validations.rb
@@ -16,7 +16,6 @@ class InterviewValidations
   validate :require_training_or_ratifying_provider, on: %i[create update], if: -> { application_choice }
   validate :create_interview_in_the_past, on: :create
   validate :updates_to_date_and_time, on: :update
-  validate :keep_date_and_time_before_rbd, if: -> { date_and_time && rbd_date }
 
   def initialize(interview:)
     @interview = interview
@@ -53,9 +52,5 @@ class InterviewValidations
         errors.add :date_and_time, :in_the_past
       end
     end
-  end
-
-  def keep_date_and_time_before_rbd
-    errors.add :date_and_time, :past_rbd_date if date_and_time > rbd_date
   end
 end

--- a/config/locales/interview_validations.yml
+++ b/config/locales/interview_validations.yml
@@ -8,7 +8,6 @@ en:
               blank: Date and time of interview must be supplied
               in_the_past: Cannot schedule interview in the past
               moving_interview_to_the_past: Cannot re-schedule interview in the past
-              past_rbd_date: The interview date must be no later than the automatic rejection of the application
             application_choice:
               blank: Application choice must be supplied
             provider:

--- a/spec/services/interview_validations_spec.rb
+++ b/spec/services/interview_validations_spec.rb
@@ -88,14 +88,6 @@ RSpec.describe InterviewValidations do
 
       expect(interview_validations).to be_valid(:create)
     end
-
-    it 'with a date_and_time past the RBD date is not valid' do
-      rbd_date = application_choice.reject_by_default_at
-      interview.date_and_time = rbd_date + 1.second
-
-      expect(interview_validations).not_to be_valid(:create)
-      expect(errors).to contain_exactly(error_message('date_and_time.past_rbd_date'))
-    end
   end
 
   context 'update interview' do
@@ -208,8 +200,7 @@ RSpec.describe InterviewValidations do
           rbd_date = application_choice.reject_by_default_at
           interview.date_and_time = rbd_date + 1.second
 
-          expect(interview_validations).not_to be_valid(:update)
-          expect(errors).to contain_exactly(error_message('date_and_time.past_rbd_date'))
+          expect(interview_validations).to be_valid(:update)
         end
       end
     end


### PR DESCRIPTION
Removes the validation that prevents interviews from being scheduled after the reject by default date. 