### PR TITLE
Remove references to cancelled references

### DIFF
--- a/app/views/candidate_mailer/application_withdrawn_on_request.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request.text.erb
@@ -11,11 +11,3 @@ All you need to do is:
   - find a course and submit another application
 
 [Sign in to apply again](<%= candidate_magic_link(@application_form.candidate) %>)
-
-We’ve contacted these people to say they do not need to give a reference:
-
-<% @application_form.application_references.each do |reference| %>
-  -<%= reference.name %>
-<% end %>
-
-You can send another request for a reference from them if you apply again.

--- a/app/views/candidate_mailer/withdraw_last_application_choice.text.erb
+++ b/app/views/candidate_mailer/withdraw_last_application_choice.text.erb
@@ -3,11 +3,3 @@ Hello <%= @application_form.first_name %>
 You’ve withdrawn your <%= 'application'.pluralize(@withdrawn_course_names.size) %> for <%= @withdrawn_course_names.to_sentence %>.
 
 <%= render 'still_interested_content' %>
-
-Since you withdrew your application, we’ve contacted these people to say they do not need to give a reference:
-
-<% @application_form.application_references.feedback_requested.each do |reference| %>
-  -<%= reference.name %>
-<% end %>
-
-You can send another request for a reference from them if you apply again.

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -286,7 +286,6 @@ RSpec.describe CandidateMailer do
         'You’ve withdrawn your application',
         'heading' => 'Hello Fred',
         'application_withdrawn' => 'You’ve withdrawn your application',
-        'reference details' => 'we’ve contacted these people to say they do not need to give a reference:',
         'first referee' => 'Jenny',
         'second referee' => 'Luke',
       )

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -286,8 +286,6 @@ RSpec.describe CandidateMailer do
         'You’ve withdrawn your application',
         'heading' => 'Hello Fred',
         'application_withdrawn' => 'You’ve withdrawn your application',
-        'first referee' => 'Jenny',
-        'second referee' => 'Luke',
       )
     end
 


### PR DESCRIPTION
## Context

- Follows on from a change that prevents cancellation of references when in a post-offer state.

## Changes proposed in this pull request

- Remove the references to references in emails where a candidate withdraws/moves from a successful 
 
## Guidance to review

- We should test this in the review app to ensure the emails look right. You'll need to accept an offer and then withdraw.

## Link to Trello card

https://trello.com/c/w4DzKH8F/801-remove-mention-of-cancelling-references-in-withdrawn-emails

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
