### PR TITLE
User to_date to compare dates with dates and not date with time

### DIFF
--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -435,7 +435,7 @@ class CycleTimetable
   end
 
   def self.before_apply_opens?
-    current_date.to_date < date(:apply_opens)
+    current_date.to_date < date(:apply_opens).to_date
   end
 
   def self.before_find_reopens?


### PR DESCRIPTION
## Context

This is preventing candidates to submit because it is comparing date with time.

## Link to Trello card

No card yet.
