### PR TITLE
Fix `before_apply_opens? in CycleTimetable

### DIFF
--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -435,7 +435,7 @@ class CycleTimetable
   end
 
   def self.before_apply_opens?
-    current_date.to_date < date(:apply_opens)
+    current_date < date(:apply_opens)
   end
 
   def self.before_find_reopens?

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -605,6 +605,24 @@ RSpec.describe CycleTimetable do
     end
   end
 
+  describe '.before_apply_opens?' do
+    context 'one second until apply_opens' do
+      it 'opens at exactly the right time' do
+        travel_temporarily_to(1.second.until(described_class.apply_opens)) do
+          expect(described_class.before_apply_opens?).to be(true)
+        end
+      end
+    end
+
+    context 'one second after apply_opens' do
+      it 'opens at exactly the right time' do
+        travel_temporarily_to(1.second.after(described_class.apply_opens)) do
+          expect(described_class.before_apply_opens?).to be(false)
+        end
+      end
+    end
+  end
+
   describe 'reset_holidays' do
     it 'updates holidays when timetravelling' do
       travel_temporarily_to('10 Dec 2024') do


### PR DESCRIPTION
## Context

In the CycleTimetable the exact date and time for when apply opens is set. In order to determine at the current moment if apply is open we need to compare Time with Time.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
