### PR TITLE
Allow references without a type do be updated

### DIFF
--- a/app/components/candidate_interface/references_review_component.rb
+++ b/app/components/candidate_interface/references_review_component.rb
@@ -149,26 +149,36 @@ module CandidateInterface
     end
 
     def reference_type_row(reference)
-      action = if reference.feedback_provided?
-                 {}
-               else
-                 {
-                   action: {
-                     href: reference_edit_type_path(
-                       application_choice: @application_choice,
-                       reference: reference,
-                       return_to: return_to_params,
-                       step: reference_workflow_step,
-                     ),
-                     visually_hidden_text: "reference type for #{reference.name}",
-                   },
-                 }
-               end
+      if reference.referee_type?
+        action = if reference.feedback_provided?
+                   {}
+                 else
+                   {
+                     action: {
+                       href: reference_edit_type_path(
+                         application_choice: @application_choice,
+                         reference: reference,
+                         return_to: return_to_params,
+                         step: reference_workflow_step,
+                       ),
+                       visually_hidden_text: "reference type for #{reference.name}",
+                     },
+                   }
+                 end
 
-      {
-        key: t('review_application.references.type.label'),
-        value: formatted_reference_type(reference),
-      }.merge(action)
+        {
+          key: t('review_application.references.type.label'),
+          value: formatted_reference_type(reference),
+        }.merge(action)
+      else
+        type_path = candidate_interface_references_edit_blank_type_path(
+          { id: reference.id }.merge(return_to_params.symbolize_keys),
+        )
+        {
+          key: t('review_application.references.type.label'),
+          value: govuk_link_to('Choose a type of referee', type_path),
+        }
+      end
     end
 
     def status_row(reference)

--- a/app/components/candidate_interface/references_review_component.rb
+++ b/app/components/candidate_interface/references_review_component.rb
@@ -171,7 +171,7 @@ module CandidateInterface
           value: formatted_reference_type(reference),
         }.merge(action)
       else
-        type_path = candidate_interface_references_edit_blank_type_path(
+        type_path = candidate_interface_references_edit_type_path(
           { id: reference.id }.merge(return_to_params.symbolize_keys),
         )
         {

--- a/app/forms/candidate_interface/reference/referee_type_form.rb
+++ b/app/forms/candidate_interface/reference/referee_type_form.rb
@@ -7,7 +7,7 @@ module CandidateInterface
     validates :referee_type, presence: true
 
     def self.build_from_reference(reference)
-      new(referee_type: reference.present? ? reference.referee_type.dasherize : nil)
+      new(referee_type: reference.present? ? reference.referee_type&.dasherize : nil)
     end
 
     def update(reference)

--- a/app/helpers/references_path_helper.rb
+++ b/app/helpers/references_path_helper.rb
@@ -8,11 +8,9 @@ module ReferencesPathHelper
   alias name_previous_path references_type_path
 
   def reference_edit_type_path(reference:, return_to:, application_choice: nil, step: nil)
-    args = [reference.referee_type, reference.id, return_to]
+    args = [reference.id, return_to]
     args.unshift(application_choice) if step == :accept_offer
-    args.shift if reference.referee_type.blank?
-    blank_type = reference.referee_type.blank? ? '_blank' : ''
-    send(:"candidate_interface#{path_segment(step)}_references_edit#{blank_type}_type_path", *args)
+    send(:"candidate_interface#{path_segment(step)}_references_edit_type_path", *args)
   end
 
   def references_name_path(referee_type:, reference_id:, application_choice: nil, step: nil)

--- a/app/helpers/references_path_helper.rb
+++ b/app/helpers/references_path_helper.rb
@@ -1,6 +1,6 @@
 module ReferencesPathHelper
-  def references_type_path(referee_type:, reference_id:, application_choice: nil, step: nil)
-    args = [referee_type, reference_id]
+  def references_type_path(referee_type:, reference_id:, return_to: nil, application_choice: nil, step: nil)
+    args = [referee_type, reference_id, return_to]
     args.unshift(application_choice) if step == :accept_offer
     send(:"candidate_interface#{path_segment(step)}_references_type_path", *args)
   end
@@ -10,7 +10,9 @@ module ReferencesPathHelper
   def reference_edit_type_path(reference:, return_to:, application_choice: nil, step: nil)
     args = [reference.referee_type, reference.id, return_to]
     args.unshift(application_choice) if step == :accept_offer
-    send(:"candidate_interface#{path_segment(step)}_references_edit_type_path", *args)
+    args.shift if reference.referee_type.blank?
+    blank_type = reference.referee_type.blank? ? '_blank' : ''
+    send(:"candidate_interface#{path_segment(step)}_references_edit#{blank_type}_type_path", *args)
   end
 
   def references_name_path(referee_type:, reference_id:, application_choice: nil, step: nil)

--- a/app/views/candidate_interface/references/type/new.html.erb
+++ b/app/views/candidate_interface/references/type/new.html.erb
@@ -9,6 +9,7 @@
         application_choice: @application_choice,
         referee_type: params[:referee_type],
         reference_id: params[:id],
+        return_to: { return_to: params[:return_to] },
         step: reference_workflow_step,
       ),
       method: :post,

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -492,18 +492,16 @@ namespace :candidate_interface, path: '/candidate' do
     scope '/references' do
       get '/start' => 'references/review#show', as: :references_start
 
-      get '/type/edit/:id' => 'references/type#edit', as: :references_edit_blank_type
+      get '/type/edit/:id' => 'references/type#edit', as: :references_edit_type
       patch '/type/edit/:id' => 'references/type#update'
       get '/type/(:referee_type)/(:id)' => 'references/type#new', as: :references_type
       post '/type/(:referee_type)/(:id)' => 'references/type#create'
-      get '/type/edit/:referee_type/:id' => 'references/type#edit', as: :references_edit_type
-      patch '/type/edit/:referee_type/:id' => 'references/type#update'
 
       scope '/accept-offer/:application_id' do
+        get '/type/edit/:id' => 'references/accept_offer/type#edit', as: :accept_offer_references_edit_type
+        patch '/type/edit/:id' => 'references/accept_offer/type#update'
         get '/type/(:referee_type)/(:id)' => 'references/accept_offer/type#new', as: :accept_offer_references_type
         post '/type/(:referee_type)/(:id)' => 'references/accept_offer/type#create'
-        get '/type/edit/:referee_type/:id' => 'references/accept_offer/type#edit', as: :accept_offer_references_edit_type
-        patch '/type/edit/:referee_type/:id' => 'references/accept_offer/type#update'
 
         scope '/name/:referee_type/(:id)', constraints: { referee_type: /(academic|professional|school-based|character)/ } do
           get '/' => 'references/accept_offer/name#new', as: :accept_offer_references_name
@@ -528,10 +526,10 @@ namespace :candidate_interface, path: '/candidate' do
 
       scope '/request-references' do
         get '/start/' => 'references/request_reference/start#new', as: :request_reference_references_start
+        get '/type/edit/:id' => 'references/request_reference/type#edit', as: :request_reference_references_edit_type
+        patch '/type/edit/:id' => 'references/request_reference/type#update'
         get '/type/(:referee_type)/(:id)' => 'references/request_reference/type#new', as: :request_reference_references_type
         post '/type/(:referee_type)/(:id)' => 'references/request_reference/type#create'
-        get '/type/edit/:referee_type/:id' => 'references/request_reference/type#edit', as: :request_reference_references_edit_type
-        patch '/type/edit/:referee_type/:id' => 'references/request_reference/type#update'
 
         scope '/name/:referee_type/(:id)', constraints: { referee_type: /(academic|professional|school-based|character)/ } do
           get '/' => 'references/request_reference/name#new', as: :request_reference_references_name

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -492,6 +492,8 @@ namespace :candidate_interface, path: '/candidate' do
     scope '/references' do
       get '/start' => 'references/review#show', as: :references_start
 
+      get '/type/edit/:id' => 'references/type#edit', as: :references_edit_blank_type
+      patch '/type/edit/:id' => 'references/type#update'
       get '/type/(:referee_type)/(:id)' => 'references/type#new', as: :references_type
       post '/type/(:referee_type)/(:id)' => 'references/type#create'
       get '/type/edit/:referee_type/:id' => 'references/type#edit', as: :references_edit_type

--- a/spec/helpers/references_path_helper_spec.rb
+++ b/spec/helpers/references_path_helper_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ReferencesPathHelper do
   describe '#reference_edit_type_path' do
     it 'is candidate_interface_references_edit_type_path' do
       expect(helper.reference_edit_type_path(reference: reference, return_to: { return_to: '/foo' })).to eq(
-        candidate_interface_references_edit_type_path(reference.referee_type, reference.id, return_to: '/foo'),
+        candidate_interface_references_edit_type_path(reference.id, return_to: '/foo'),
       )
     end
 
@@ -52,7 +52,7 @@ RSpec.describe ReferencesPathHelper do
           ),
         ).to eq(
           candidate_interface_accept_offer_references_edit_type_path(
-            application_choice, reference.referee_type, reference.id, return_to: '/foo'
+            application_choice, reference.id, return_to: '/foo'
           ),
         )
       end
@@ -63,7 +63,7 @@ RSpec.describe ReferencesPathHelper do
 
       it 'is candidate_interface_request_reference_references_edit_type_path' do
         expect(helper.reference_edit_type_path(reference: reference, return_to: { return_to: '/foo' }, step: step)).to eq(
-          candidate_interface_request_reference_references_edit_type_path(reference.referee_type, reference.id, return_to: '/foo'),
+          candidate_interface_request_reference_references_edit_type_path(reference.id, return_to: '/foo'),
         )
       end
     end

--- a/spec/system/candidate_interface/references/candidate_adding_incomplete_referees_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_adding_incomplete_referees_spec.rb
@@ -54,7 +54,7 @@ RSpec.feature 'Candidate adding incomplete referees' do
   end
 
   def then_i_see_the_choose_reference_link
-    href = candidate_interface_references_edit_blank_type_path(@reference.id, return_to: 'review')
+    href = candidate_interface_references_edit_type_path(@reference.id, return_to: 'review')
     expect(page).to have_link('Choose a type of referee', href:)
   end
 

--- a/spec/system/candidate_interface/references/candidate_adding_incomplete_referees_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_adding_incomplete_referees_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Candidate adding incomplete referees' do
   include CandidateHelper
 
-  it 'Candidate adds incomplete referees and then completes them' do
+  it 'Candidate adds incomplete referees and then completes them', :continuous_applications do
     given_i_am_signed_in
     and_i_have_provided_my_personal_details
 
@@ -21,6 +21,62 @@ RSpec.feature 'Candidate adding incomplete referees' do
     and_i_provide_a_valid_relationship_to_referee
     then_i_am_redirected_to_the_review_page
     and_i_see_that_referee_is_now_complete
+
+    when_the_reference_doesnt_have_a_referee_type
+    and_the_references_are_ready_to_be_submitted
+    when_i_visit_the_references_review_page
+    then_i_see_the_choose_reference_link
+
+    when_i_try_to_complete_the_section
+    then_i_see_a_validation_error_message
+
+    when_i_click_on_the_choose_reference_link
+    and_i_select_a_referee_type
+    then_i_am_redirected_to_the_review_page
+    and_i_cant_see_the_choose_reference_link
+
+    when_i_try_to_complete_the_section
+    then_i_get_redirected_to_the_application_page
+  end
+
+  def when_the_reference_doesnt_have_a_referee_type
+    @reference = @candidate.current_application.application_references.first
+    @candidate.current_application.update(references_completed: nil, references_completed_at: nil)
+    @reference.update(referee_type: nil)
+  end
+
+  def and_the_references_are_ready_to_be_submitted
+    create(:reference, :feedback_provided, application_form: @candidate.current_application)
+  end
+
+  def when_i_visit_the_references_review_page
+    visit candidate_interface_references_review_path
+  end
+
+  def then_i_see_the_choose_reference_link
+    href = candidate_interface_references_edit_blank_type_path(@reference.id, return_to: 'review')
+    expect(page).to have_link('Choose a type of referee', href:)
+  end
+
+  def when_i_click_on_the_choose_reference_link
+    click_link 'Choose a type of referee'
+  end
+
+  def when_i_try_to_complete_the_section
+    choose 'Yes, I have completed this section'
+    click_button 'Continue'
+  end
+
+  def then_i_see_a_validation_error_message
+    expect(page).to have_content 'Enter all required fields for each reference added'
+  end
+
+  def and_i_cant_see_the_choose_reference_link
+    expect(page).not_to have_link('Choose a type of referee')
+  end
+
+  def then_i_get_redirected_to_the_application_page
+    expect(page).to have_current_path candidate_interface_continuous_applications_details_path
   end
 
   def given_i_am_signed_in
@@ -35,6 +91,10 @@ RSpec.feature 'Candidate adding incomplete referees' do
   def when_i_provide_a_referee_type_only
     visit candidate_interface_references_start_path
     click_link 'Add reference'
+    and_i_select_a_referee_type
+  end
+
+  def and_i_select_a_referee_type
     choose 'Academic'
     click_button t('continue')
   end

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_references_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_references_spec.rb
@@ -125,7 +125,7 @@ RSpec.feature 'Candidate is redirected correctly', continuous_applications: fals
 
   def then_i_should_see_the_references_type_form
     expect(page).to have_current_path(
-      candidate_interface_references_edit_type_path(@first_reference.referee_type, @first_reference.id, return_to: 'application-review'),
+      candidate_interface_references_edit_type_path(@first_reference.id, return_to: 'application-review'),
     )
   end
 


### PR DESCRIPTION
This prevents the page from crashing if there is no reference type selected.

Fixes exception `Translation missing: en.application_form.references.referee_type.label`

**Update:** I have changed the initial approach from adding separate paths for editing references without a type to removing the type URL argument from all the edit paths: https://github.com/DFE-Digital/apply-for-teacher-training/pull/8659/commits/86b9c80c9267191e114582ef7ced6287fceb1cab

![](https://github.trello.services/images/mini-trello-icon.png) [Error raised by candidate reviewing the references without selecting the type](https://trello.com/c/1CimH5Jq/806-error-raised-by-candidate-reviewing-the-references-without-selecting-the-type)

### Example of the previous URL
<img width="905" alt="Screenshot 2023-10-10 at 15 15 39" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/8d11a08c-b7a9-4575-8040-e516017ba1ef">

### Example of a reference without a type
<img width="994" alt="Screenshot 2023-10-10 at 16 50 28" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/728728e7-5d8d-4e03-960e-3a2ee0ff3235">

### Trying to submit without selecting a type
<img width="698" alt="Screenshot 2023-10-10 at 16 50 34" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/f95835d4-421c-46ff-86e5-b17555413678">