### PR TITLE
Journey from Find – reapply for previously unsuccessful courses

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -429,7 +429,7 @@ class ApplicationForm < ApplicationRecord
 
   def contains_course?(course)
     potential_course_option_ids = CourseOption.where(course_id: course.id).map(&:id)
-    current_course_option_ids = application_choices.map(&:course_option_id)
+    current_course_option_ids = application_choices.where({ status: ApplicationStateChange::NON_REAPPLY_STATUSES }).pluck(:course_option_id)
 
     potential_course_option_ids.intersect?(current_course_option_ids)
   end

--- a/spec/factories/course.rb
+++ b/spec/factories/course.rb
@@ -104,6 +104,10 @@ FactoryBot.define do
       course_options { build_list(:course_option, 2, course: instance) }
     end
 
+    trait :with_a_course_option do
+      course_options { [create(:course_option, course: instance)] }
+    end
+
     trait :with_no_vacancies do
       course_options { build_list(:course_option, 2, :no_vacancies, course: instance) }
     end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -1002,6 +1002,25 @@ RSpec.describe ApplicationForm do
     end
   end
 
+  describe '#contains_course?' do
+    let(:application_form) { create(:application_form) }
+    let(:course) { create(:course, :with_a_course_option) }
+
+    context 'when the course exists but the candidate cannot reapply for it' do
+      it 'returns true' do
+        create(:application_choice, :awaiting_provider_decision, course:, application_form:)
+        expect(application_form.contains_course?(course)).to be true
+      end
+    end
+
+    context 'when the course exists but the candidate can reapply for it' do
+      it 'returns false' do
+        create(:application_choice, :rejected, course:, application_form:)
+        expect(application_form.contains_course?(course)).to be false
+      end
+    end
+  end
+
   describe '#complete_references_information?' do
     context 'when an applications has two or more references' do
       it 'returns true' do


### PR DESCRIPTION
## Context

We allow candidates to reapply for courses provided they have been previously unsuccessful with the choice. We need to replicate this for the apply from Find journey.

## Changes proposed in this pull request

Only check for courses associated to application choices in the following states:

- awaiting_provider_decision 
- interviewing 
- pending_conditions 
- conditions_not_met 
- recruited 
- offer 
- offer_deferred 
- inactive 
- unsubmitted


|Before|After|
|---|---|
|<img width="810" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/e4af4fe9-ea46-4670-a147-85f1c0d6f51e">|<img width="582" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/9ef4ea19-ddcb-4563-8ce0-330d76ca7175">|

## Guidance to review

Aside from the Find journey, this method appears to only be used in the pre continuous applications course selection journey.

You can test locally with the following URL:
`http://localhost:3000/candidate/apply?providerCode=XXX&courseCode=XXXX`

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
