### PR TITLE
Implement flight check blocking pattern for visa sponsorship

### DIFF
--- a/app/components/candidate_interface/continuous_applications/application_submit_component.html.erb
+++ b/app/components/candidate_interface/continuous_applications/application_submit_component.html.erb
@@ -20,7 +20,7 @@
         <% end %>
 
         <p class="govuk-body">
-          <%= govuk_link_to 'Find a course that has visa sponsorship', find_url %>.
+          <%= govuk_link_to 'Find a course that has visa sponsorship', find_url, target: '_blank', rel: 'nofollow' %>.
         </p>
       <% else %>
         <%= error.message.html_safe %>.

--- a/app/components/candidate_interface/continuous_applications/application_submit_component.html.erb
+++ b/app/components/candidate_interface/continuous_applications/application_submit_component.html.erb
@@ -20,7 +20,7 @@
         <% end %>
 
         <p class="govuk-body">
-          <%= govuk_link_to 'Find a course that has visa sponsorship.', find_url %>
+          <%= govuk_link_to 'Find a course that has visa sponsorship', find_url %>.
         </p>
       <% else %>
         <%= error.message.html_safe %>.

--- a/app/components/candidate_interface/continuous_applications/application_submit_component.html.erb
+++ b/app/components/candidate_interface/continuous_applications/application_submit_component.html.erb
@@ -14,6 +14,14 @@
       <% if error.type == :incomplete_details %>
         <p class="govuk-body">You need to <%= govuk_link_to('complete your details', candidate_interface_continuous_applications_details_path) %> before you can submit this application.</p>
         <p class="govuk-body">This application will be saved as a draft while you finish your details.</p>
+      <% elsif error.type == :immigration_status %>
+        <%= govuk_warning_text do %>
+          <%= error.message %>.
+        <% end %>
+
+        <p class="govuk-body">
+          <%= govuk_link_to 'Find a course that has visa sponsorship', find_url %>
+        </p>
       <% else %>
         <%= error.message.html_safe %>.
       <% end %>

--- a/app/components/candidate_interface/continuous_applications/application_submit_component.html.erb
+++ b/app/components/candidate_interface/continuous_applications/application_submit_component.html.erb
@@ -20,7 +20,7 @@
         <% end %>
 
         <p class="govuk-body">
-          <%= govuk_link_to 'Find a course that has visa sponsorship', find_url %>
+          <%= govuk_link_to 'Find a course that has visa sponsorship.', find_url %>
         </p>
       <% else %>
         <%= error.message.html_safe %>.

--- a/app/components/candidate_interface/continuous_applications/application_submit_component.rb
+++ b/app/components/candidate_interface/continuous_applications/application_submit_component.rb
@@ -1,6 +1,8 @@
 module CandidateInterface
   module ContinuousApplications
     class ApplicationSubmitComponent < ViewComponent::Base
+      include ApplicationHelper
+
       attr_reader :application_choice, :form, :submit_application_form, :application_choice_submission
       delegate :errors, to: :application_choice_submission
       delegate :unsubmitted?, :current_course, :current_course_option, to: :application_choice

--- a/app/components/candidate_interface/continuous_applications/application_submit_component.rb
+++ b/app/components/candidate_interface/continuous_applications/application_submit_component.rb
@@ -21,6 +21,18 @@ module CandidateInterface
       def application_can_submit?
         @application_choice_submission.valid?
       end
+
+      def errors
+        return [immigration_status_error] if immigration_status_error.present?
+
+        application_choice_submission.errors
+      end
+
+      def immigration_status_error
+        application_choice_submission.errors.find do |error|
+          error.type == :immigration_status
+        end
+      end
     end
   end
 end

--- a/app/services/candidate_interface/continuous_applications/application_choice_submission.rb
+++ b/app/services/candidate_interface/continuous_applications/application_choice_submission.rb
@@ -11,7 +11,8 @@ module CandidateInterface
                 submission_availability: true,
                 open_for_applications: true,
                 course_availability: true,
-                can_add_more_choices: true
+                can_add_more_choices: true,
+                immigration_status: true
     end
   end
 end

--- a/app/validators/immigration_status_validator.rb
+++ b/app/validators/immigration_status_validator.rb
@@ -1,6 +1,8 @@
 class ImmigrationStatusValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, application_choice)
-    return if did_not_add_nationality_yet?(application_choice) || immigration_right_to_work?(application_choice) || course_can_sponsor_visa?(application_choice)
+    return if did_not_add_nationality_yet?(application_choice) ||
+              immigration_right_to_work?(application_choice) ||
+              course_can_sponsor_visa?(application_choice)
 
     record.errors.add(attribute, :immigration_status)
   end
@@ -15,11 +17,7 @@ class ImmigrationStatusValidator < ActiveModel::EachValidator
   end
 
   def course_can_sponsor_visa?(application_choice)
-    (
-      application_choice.course.salary? && application_choice.course.can_sponsor_skilled_worker_visa?
-    ) ||
-      (
-        !application_choice.course.salary? && application_choice.course.can_sponsor_student_visa?
-      )
+    (application_choice.course.salary? && application_choice.course.can_sponsor_skilled_worker_visa?) ||
+      (!application_choice.course.salary? && application_choice.course.can_sponsor_student_visa?)
   end
 end

--- a/app/validators/immigration_status_validator.rb
+++ b/app/validators/immigration_status_validator.rb
@@ -1,0 +1,25 @@
+class ImmigrationStatusValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, application_choice)
+    return if did_not_add_nationality_yet?(application_choice) || immigration_right_to_work?(application_choice) || course_can_sponsor_visa?(application_choice)
+
+    record.errors.add(attribute, :immigration_status)
+  end
+
+  def did_not_add_nationality_yet?(application_choice)
+    application_choice.application_form.nationalities.blank?
+  end
+
+  def immigration_right_to_work?(application_choice)
+    application_choice.application_form.british_or_irish? ||
+      application_choice.application_form.right_to_work_or_study_yes?
+  end
+
+  def course_can_sponsor_visa?(application_choice)
+    (
+      application_choice.course.salary? && application_choice.course.can_sponsor_skilled_worker_visa?
+    ) ||
+      (
+        !application_choice.course.salary? && application_choice.course.can_sponsor_student_visa?
+      )
+  end
+end

--- a/config/locales/candidate_interface/submit_application.yml
+++ b/config/locales/candidate_interface/submit_application.yml
@@ -16,6 +16,7 @@ en:
               remove_or_change_application: You need to either remove this application or change your course
               science_gcse_missing: To apply for a Primary course, you need a GCSE in science at grade 4 (C) or above, or equivalent
               science_gcse_missing_guide: Add your science GCSE grade (or equivalent) before submitting this application
+              immigration_status: Visa sponsorship is not available for this course
   application_form:
     submit_application:
       title: Send application to training providers

--- a/spec/components/candidate_interface/continuous_applications/application_submit_component_spec.rb
+++ b/spec/components/candidate_interface/continuous_applications/application_submit_component_spec.rb
@@ -22,6 +22,43 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationSubmitComp
     end
   end
 
+  context 'when immigration status is invalid' do
+    let(:course_option) do
+      create(
+        :course_option,
+        course: create(
+          :course,
+          funding_type: 'fee',
+          can_sponsor_student_visa: false,
+          can_sponsor_skilled_worker_visa: false,
+        ),
+      )
+    end
+    let(:application_choice) { create(:application_choice, :unsubmitted, application_form:, course_option:) }
+    let(:application_form) do
+      create(
+        :application_form,
+        :minimum_info,
+        first_nationality: 'Indian',
+        second_nationality: nil,
+        right_to_work_or_study: 'no',
+      )
+    end
+
+    it 'only shows the immigrattion status message' do
+      expect(result.text).to include(
+        'Visa sponsorship is not available for this course.',
+        'Find a course that has visa sponsorship.',
+      )
+      expect(result.text).not_to include(
+        'You need to complete your details before you can submit this application.',
+        'This application will be saved as a draft while you finish your details.',
+        'To apply for a Primary course, you need a GCSE in science at grade 4 (C) or above, or equivalent.',
+        'Add your science GCSE grade (or equivalent) before submitting this application.',
+      )
+    end
+  end
+
   context 'when application is not submitted' do
     let(:application_choice) { create(:application_choice, :unsubmitted, application_form:) }
 

--- a/spec/system/candidate_interface/continuous_applications/submitting/candidate_with_no_right_to_work_tries_to_submit_course_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/submitting/candidate_with_no_right_to_work_tries_to_submit_course_spec.rb
@@ -1,0 +1,165 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate with no right to work or study', :continuous_applications do
+  include CandidateHelper
+
+  before do
+    given_i_am_signed_in
+    and_there_are_course_options
+  end
+
+  scenario 'when candidate did not add their nationality yet neither right to work study' do
+    and_i_add_a_course_that_can_not_sponsor_student_visa
+    then_i_should_not_see_an_error_message_that_the_course_does_not_sponsor_visa
+  end
+
+  scenario 'when submit a course that can not sponsor student visa' do
+    when_i_have_completed_my_foreign_application
+    and_i_add_a_course_that_can_not_sponsor_student_visa
+    then_i_should_see_an_error_message_that_the_course_does_not_sponsor_visa
+  end
+
+  scenario 'when submit a course that can not sponsor skilled worker visa' do
+    when_i_have_completed_my_foreign_application
+    and_i_add_a_course_that_can_not_sponsor_skilled_worker
+    then_i_should_see_an_error_message_that_the_course_does_not_sponsor_visa
+  end
+
+  scenario 'when submit a course that can sponsor student visa' do
+    when_i_have_completed_my_foreign_application
+    and_i_add_a_course_that_can_sponsor_student_visa
+    then_i_should_not_see_an_error_message_that_the_course_does_not_sponsor_visa
+    and_i_submit_the_application
+    then_i_can_see_my_application_has_been_successfully_submitted
+  end
+
+  scenario 'when submit a course that can sponsor skilled worker visa' do
+    when_i_have_completed_my_foreign_application
+    and_i_add_a_course_that_can_sponsor_skilled_worker
+    then_i_should_not_see_an_error_message_that_the_course_does_not_sponsor_visa
+    and_i_submit_the_application
+    then_i_can_see_my_application_has_been_successfully_submitted
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_there_are_course_options
+    @provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
+    @course_can_sponsor_student_visa = create(
+      :course,
+      :open_on_apply,
+      name: 'Modern Languages',
+      code: 'S397',
+      provider: @provider,
+      can_sponsor_skilled_worker_visa: false,
+      can_sponsor_student_visa: true,
+      funding_type: 'fee',
+    )
+    @course_can_not_sponsor_student_visa = create(
+      :course,
+      :open_on_apply,
+      name: 'English',
+      code: 'Q3X1',
+      provider: @provider,
+      can_sponsor_skilled_worker_visa: false,
+      can_sponsor_student_visa: false,
+      funding_type: 'fee',
+    )
+    @course_can_sponsor_skilled_worker_visa = create(
+      :course,
+      :open_on_apply,
+      name: 'History',
+      code: 'V1X1',
+      provider: @provider,
+      can_sponsor_skilled_worker_visa: true,
+      can_sponsor_student_visa: false,
+      funding_type: 'salary',
+    )
+    @course_can_not_sponsor_skilled_worker_visa = create(
+      :course,
+      :open_on_apply,
+      name: 'Physics',
+      code: 'F3X1',
+      provider: @provider,
+      can_sponsor_skilled_worker_visa: false,
+      can_sponsor_student_visa: false,
+      funding_type: 'salary',
+    )
+    create(:course_option, course: @course_can_sponsor_student_visa)
+    create(:course_option, course: @course_can_not_sponsor_student_visa)
+    create(:course_option, course: @course_can_sponsor_skilled_worker_visa)
+    create(:course_option, course: @course_can_not_sponsor_skilled_worker_visa)
+  end
+
+  def when_i_have_completed_my_foreign_application
+    create(
+      :application_form,
+      :completed,
+      candidate: current_candidate,
+      first_nationality: 'Indian',
+      second_nationality: nil,
+      right_to_work_or_study: 'no',
+      efl_completed: true,
+    )
+  end
+
+  def and_i_add_a_course_that_can_not_sponsor_student_visa
+    when_i_choose_a_provider
+    choose @course_can_not_sponsor_student_visa.name
+    and_i_click_continue
+  end
+
+  def and_i_add_a_course_that_can_not_sponsor_skilled_worker
+    when_i_choose_a_provider
+    choose @course_can_not_sponsor_skilled_worker_visa.name
+    and_i_click_continue
+  end
+
+  def and_i_add_a_course_that_can_sponsor_student_visa
+    when_i_choose_a_provider
+    choose @course_can_sponsor_student_visa.name
+    and_i_click_continue
+  end
+
+  def and_i_add_a_course_that_can_sponsor_skilled_worker
+    when_i_choose_a_provider
+    choose @course_can_sponsor_skilled_worker_visa.name
+    and_i_click_continue
+  end
+
+  def when_i_choose_a_provider
+    visit candidate_interface_application_form_path
+    click_link 'Your application'
+    click_link 'Add application'
+    choose 'Yes, I know where I want to apply'
+    and_i_click_continue
+    select 'Gorse SCITT (1N1)'
+    and_i_click_continue
+  end
+
+  def and_i_click_continue
+    click_button t('continue')
+  end
+
+  def then_i_should_see_an_error_message_that_the_course_does_not_sponsor_visa
+    expect(page).to have_content('Visa sponsorship is not available for this course.')
+    expect(page).to have_content('Find a course that has visa sponsorship')
+  end
+
+  def then_i_should_not_see_an_error_message_that_the_course_does_not_sponsor_visa
+    expect(page).not_to have_content('Visa sponsorship is not available for this course.')
+    expect(page).not_to have_content('Find a course that has visa sponsorship')
+  end
+
+  def and_i_submit_the_application
+    expect(page).to have_content('Yes, submit it now')
+    choose 'Yes, submit it now'
+    and_i_click_continue
+  end
+
+  def then_i_can_see_my_application_has_been_successfully_submitted
+    expect(page).to have_content 'Application submitted'
+  end
+end


### PR DESCRIPTION
## Context

We have agreed that it is beneficial to block certain user groups from submitting an application.

Specifically when a course won’t sponsor visas, and the candidate does not have the right to work or study in the UK.

## Changes proposed in this pull request

We add the following warning:

<img width="798" alt="Screenshot 2023-10-11 at 15 19 36" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/27509/7e0cec04-2d78-46bf-bc14-3cc0998a9113">


## Guidance to review

Scenarios for applying to a course:

### Scenario 1: Candidate is British or Irish

All courses available on submission

### Scenario 2: Candidate has the right to work and study

All courses available on submission

### Scenario 3: Candidate still didn't fill their nationality

The warning doesn't show

### Scenario 4: Foreign candidate with no right to work or study applies for a fee course with no student visa sponsorship

We show the warning

### Scenario 4: Foreign candidate with no right to work or study applies for a salary course with no skilled worker visa sponsorship

We show the warning

### Scenario 4: Foreign candidate with no right to work or study applies for a fee course with student visa sponsorship

The warning doesn't show

### Scenario 5: Foreign candidate with no right to work or study applies for a salary course with skilled worker visa sponsorship

The warning doesn't show

## Considerations

The current logic is verifying if the course is:

Funding type is Salary and can sponsor skilled worker visa
Funding type is not Salary and can sponsor student visa

So all other funding types are not include and we might block the submissions for these (apprenticeship for example, or salary with student visa sponsorship)

## Link to Trello card

https://trello.com/c/V7hMR2Jv/655-implement-flight-check-blocking-pattern-for-visa-sponsorship
