### PR TITLE
Monthly statistics – redirect away from 2024

### DIFF
--- a/app/controllers/publications/monthly_statistics_controller.rb
+++ b/app/controllers/publications/monthly_statistics_controller.rb
@@ -3,6 +3,8 @@ module Publications
     rescue_from ActiveRecord::RecordNotFound, with: :render_404
 
     def show
+      redirect_to publications_monthly_statistics_temporarily_unavailable_path if params[:year].to_i == RecruitmentCycle.current_year
+
       @presenter = Publications::MonthlyStatisticsPresenter.new(current_report)
       @csv_export_types_and_sizes = calculate_download_sizes(current_report)
     end
@@ -25,6 +27,8 @@ module Publications
         [k, data.size]
       end.compact
     end
+
+    def temporarily_unavailable; end
 
   private
 

--- a/app/views/publications/monthly_statistics/temporarily_unavailable.html.erb
+++ b/app/views/publications/monthly_statistics/temporarily_unavailable.html.erb
@@ -1,0 +1,24 @@
+<%= content_for :title, 'Monthly Statistics - ITT2024' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Monthly statistics</h1>
+
+    <p class="govuk-body">
+      The 2022 to 2023 teacher training recruitment cycle has now finished. The 2023 to 2024 recruitment cycle started on Tuesday 10 October 2023 when Apply for teacher training opened for applications.
+    </p>
+
+    <p class="govuk-body">
+      The first publication of ITT statistics for the new cycle will be on Monday 27 November 2023.
+    </p>
+
+    <p class="govuk-body">
+      You can view <%= govuk_link_to 'monthly statistics on initial teacher training', 'https://www.gov.uk/government/publications/monthly-statistics-on-initial-teacher-training-itt-recruitment' %>
+      from the last cycle (from October 2022 until September 2023).
+    </p>
+
+    <p class="govuk-body">
+      If you have any feedback or queries about the ITT statistics reports, please get in touch at <%= govuk_mail_to 'becomingateacher@digital.education.gov.uk' %>
+    </p>
+  </div>
+</div>

--- a/config/routes/publications.rb
+++ b/config/routes/publications.rb
@@ -1,6 +1,9 @@
 namespace :publications, path: '/publications' do
+  get '/monthly-statistics/temporarily-unavailable', to: 'monthly_statistics#temporarily_unavailable', as: :monthly_statistics_temporarily_unavailable
   get '/monthly-statistics/ITT(:year)' => 'monthly_statistics#show', as: :monthly_report_itt
-  get '/monthly-statistics(/:month)' => 'monthly_statistics#show', as: :monthly_report
-  get '/monthly-statistics/:month/:export_type' => 'monthly_statistics#download', as: :monthly_report_download
+  get '/monthly-statistics(/:month)' => redirect('/publications/monthly-statistics/temporarily-unavailable'), as: :monthly_report
+  get '/monthly-statistics/:month/:export_type' => redirect('/publications/monthly-statistics/temporarily-unavailable'), as: :monthly_report_download
+  # get '/monthly-statistics(/:month)' => 'monthly_statistics#show', as: :monthly_report
+  # get '/monthly-statistics/:month/:export_type' => 'monthly_statistics#download', as: :monthly_report_download
   get '/mid-cycle-report' => 'mid_cycle_report#show', as: :mid_cycle_report
 end

--- a/spec/requests/publications/monthly_statistics_spec.rb
+++ b/spec/requests/publications/monthly_statistics_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe 'Monthly Statistics', time: Time.zone.local(2022, 11, 29) do
   include StatisticsTestHelper
 
+  let(:temporarily_unavailable) { '/publications/monthly-statistics/temporarily-unavailable' }
+
   before do
     generate_statistics_test_data
 
@@ -33,29 +35,39 @@ RSpec.describe 'Monthly Statistics', time: Time.zone.local(2022, 11, 29) do
 
     it 'renders the report for 2022-11' do
       get '/publications/monthly-statistics/'
-      expect(response).to have_http_status(:ok)
-      expect(response.body).to include('to 22 November 2022')
+      # expect(response).to have_http_status(:ok)
+      # expect(response.body).to include('to 22 November 2022')
+      expect(response).to redirect_to(temporarily_unavailable)
+      get temporarily_unavailable
+      expect(response.body).to include('The first publication of ITT statistics for the new cycle will be on Monday 27 November 2023.')
+      expect(response.body).to include('https://www.gov.uk/government/publications/monthly-statistics-on-initial-teacher-training-itt-recruitment')
+      expect(response.body).to include('becomingateacher@digital.education.gov.uk')
 
       get '/publications/monthly-statistics/2022-10'
-      expect(response).to have_http_status(:ok)
-      expect(response.body).to include('to 18 October 2022')
+      # expect(response).to have_http_status(:ok)
+      # expect(response.body).to include('to 18 October 2022')
+      expect(response).to redirect_to(temporarily_unavailable)
 
       get '/publications/monthly-statistics/2022-11'
-      expect(response).to have_http_status(:ok)
-      expect(response.body).to include('to 22 November 2022')
+      # expect(response).to have_http_status(:ok)
+      # expect(response.body).to include('to 22 November 2022')
+      expect(response).to redirect_to(temporarily_unavailable)
 
       get '/publications/monthly-statistics/2022-12'
-      expect(response).to have_http_status(:not_found)
+      # expect(response).to have_http_status(:not_found)
+      expect(response).to redirect_to(temporarily_unavailable)
     end
 
     it 'returns application by status csv for 2022-10' do
       get '/publications/monthly-statistics/2022-10/applications_by_status.csv'
-      expect(response).to have_http_status(:ok)
+      # expect(response).to have_http_status(:ok)
+      expect(response).to redirect_to(temporarily_unavailable)
     end
 
     it '404s for a badly formatted date' do
       get '/publications/monthly-statistics/12-23'
-      expect(response).to have_http_status(:not_found)
+      # expect(response).to have_http_status(:not_found)
+      expect(response).to redirect_to(temporarily_unavailable)
     end
   end
 
@@ -67,8 +79,9 @@ RSpec.describe 'Monthly Statistics', time: Time.zone.local(2022, 11, 29) do
 
   it 'returns the latest application for new cycle' do
     get '/publications/monthly-statistics/ITT2023'
-    expect(response).to have_http_status(:ok)
-    expect(response.body).to include('to 22 November 2022')
+    # expect(response).to have_http_status(:ok)
+    # expect(response.body).to include('to 22 November 2022')
+    expect(response).to redirect_to(temporarily_unavailable)
   end
 
   it 'returns a 404 when an old date is in the URL' do
@@ -80,86 +93,98 @@ RSpec.describe 'Monthly Statistics', time: Time.zone.local(2022, 11, 29) do
 
   it 'returns a 404 when an invalid date is in the URL params' do
     get '/publications/monthly-statistics/foo-2022-11'
-    expect(response).to have_http_status(:not_found)
-    expect(response.body).to include 'Page not found'
-    expect(response.header['Content-Type']).not_to include 'text/csv'
+    # expect(response).to have_http_status(:not_found)
+    # expect(response.body).to include 'Page not found'
+    # expect(response.header['Content-Type']).not_to include 'text/csv'
+    expect(response).to redirect_to(temporarily_unavailable)
   end
 
   it 'returns application by status csv' do
     get '/publications/monthly-statistics/2022-11/applications_by_status.csv'
-    expect(response).to have_http_status(:ok)
-    expect(response.body).to start_with 'Status,First application,Apply again,Total'
-    expect(response.header['Content-Type']).to include 'text/csv'
+    # expect(response).to have_http_status(:ok)
+    # expect(response.body).to start_with 'Status,First application,Apply again,Total'
+    # expect(response.header['Content-Type']).to include 'text/csv'
+    expect(response).to redirect_to(temporarily_unavailable)
   end
 
   it 'returns candidates by status csv' do
     get '/publications/monthly-statistics/2022-11/candidates_by_status'
-    expect(response).to have_http_status(:ok)
-    expect(response.body).to start_with 'Status,First application,Apply again,Total'
-    expect(response.header['Content-Type']).to include 'text/csv'
+    # expect(response).to have_http_status(:ok)
+    # expect(response.body).to start_with 'Status,First application,Apply again,Total'
+    # expect(response.header['Content-Type']).to include 'text/csv'
+    expect(response).to redirect_to(temporarily_unavailable)
   end
 
   it 'returns candidates by age group csv' do
     get '/publications/monthly-statistics/2022-11/by_age_group'
-    expect(response).to have_http_status(:ok)
-    expect(response.body).to start_with 'Age group,Recruited,Conditions pending'
-    expect(response.header['Content-Type']).to include 'text/csv'
+    # expect(response).to have_http_status(:ok)
+    # expect(response.body).to start_with 'Age group,Recruited,Conditions pending'
+    # expect(response.header['Content-Type']).to include 'text/csv'
+    expect(response).to redirect_to(temporarily_unavailable)
   end
 
   it 'returns applications by course age group csv' do
     get '/publications/monthly-statistics/2022-11/by_course_age_group'
-    expect(response).to have_http_status(:ok)
-    expect(response.body).to start_with 'Course phase,Recruited,Conditions pending'
-    expect(response.header['Content-Type']).to include 'text/csv'
+    # expect(response).to have_http_status(:ok)
+    # expect(response.body).to start_with 'Course phase,Recruited,Conditions pending'
+    # expect(response.header['Content-Type']).to include 'text/csv'
+    expect(response).to redirect_to(temporarily_unavailable)
   end
 
   it 'returns candidates by area csv' do
     get '/publications/monthly-statistics/2022-11/by_area'
-    expect(response).to have_http_status(:ok)
-    expect(response.body).to start_with 'Area,Recruited,Conditions pending'
-    expect(response.header['Content-Type']).to include 'text/csv'
+    # expect(response).to have_http_status(:ok)
+    # expect(response.body).to start_with 'Area,Recruited,Conditions pending'
+    # expect(response.header['Content-Type']).to include 'text/csv'
+    expect(response).to redirect_to(temporarily_unavailable)
   end
 
   it 'returns candidates by sex csv' do
     get '/publications/monthly-statistics/2022-11/by_sex'
-    expect(response).to have_http_status(:ok)
-    expect(response.body).to start_with 'Sex,Recruited,Conditions pending'
-    expect(response.header['Content-Type']).to include 'text/csv'
+    # expect(response).to have_http_status(:ok)
+    # expect(response.body).to start_with 'Sex,Recruited,Conditions pending'
+    # expect(response.header['Content-Type']).to include 'text/csv'
+    expect(response).to redirect_to(temporarily_unavailable)
   end
 
   it 'returns applications by course type csv' do
     get '/publications/monthly-statistics/2022-11/by_course_type'
-    expect(response).to have_http_status(:ok)
-    expect(response.body).to start_with 'Course type,Recruited,Conditions pending'
-    expect(response.header['Content-Type']).to include 'text/csv'
+    # expect(response).to have_http_status(:ok)
+    # expect(response.body).to start_with 'Course type,Recruited,Conditions pending'
+    # expect(response.header['Content-Type']).to include 'text/csv'
+    expect(response).to redirect_to(temporarily_unavailable)
   end
 
   it 'returns applications by primary specialist subject csv' do
     get '/publications/monthly-statistics/2022-11/by_primary_specialist_subject'
-    expect(response).to have_http_status(:ok)
-    expect(response.body).to start_with 'Subject,Recruited,Conditions pending'
-    expect(response.header['Content-Type']).to include 'text/csv'
+    # expect(response).to have_http_status(:ok)
+    # expect(response.body).to start_with 'Subject,Recruited,Conditions pending'
+    # expect(response.header['Content-Type']).to include 'text/csv'
+    expect(response).to redirect_to(temporarily_unavailable)
   end
 
   it 'returns applications by secondary subject csv' do
     get '/publications/monthly-statistics/2022-11/by_secondary_subject'
-    expect(response).to have_http_status(:ok)
-    expect(response.body).to start_with 'Subject,Recruited,Conditions pending'
-    expect(response.header['Content-Type']).to include 'text/csv'
+    # expect(response).to have_http_status(:ok)
+    # expect(response.body).to start_with 'Subject,Recruited,Conditions pending'
+    # expect(response.header['Content-Type']).to include 'text/csv'
+    expect(response).to redirect_to(temporarily_unavailable)
   end
 
   it 'returns applications by provider area csv' do
     get '/publications/monthly-statistics/2022-11/by_provider_area'
-    expect(response).to have_http_status(:ok)
-    expect(response.body).to start_with 'Area,Recruited,Conditions pending'
-    expect(response.header['Content-Type']).to include 'text/csv'
+    # expect(response).to have_http_status(:ok)
+    # expect(response.body).to start_with 'Area,Recruited,Conditions pending'
+    # expect(response.header['Content-Type']).to include 'text/csv'
+    expect(response).to redirect_to(temporarily_unavailable)
   end
 
   it 'returns a 404 when an invalid date is in the URL' do
     get '/publications/monthly-statistics/foo-2022-11/by_provider_area'
-    expect(response).to have_http_status(:not_found)
-    expect(response.body).to include 'Page not found'
-    expect(response.header['Content-Type']).not_to include 'text/csv'
+    # expect(response).to have_http_status(:not_found)
+    # expect(response.body).to include 'Page not found'
+    # expect(response.header['Content-Type']).not_to include 'text/csv'
+    expect(response).to redirect_to(temporarily_unavailable)
   end
 
   def new_report(options)

--- a/spec/system/monthly_statistics/monthly_statistics_page_spec.rb
+++ b/spec/system/monthly_statistics/monthly_statistics_page_spec.rb
@@ -12,9 +12,10 @@ RSpec.feature 'Monthly statistics page', mid_cycle: false do
 
   scenario 'User can download a CSV from the monthly statistics page' do
     given_i_visit_the_monthly_statistics_page
-    and_i_see_the_monthly_statistics
-    when_i_click_a_link
-    then_a_csv_downloads
+    then_i_should_be_redirected_to_the_temporarily_unavailable_page
+    # and_i_see_the_monthly_statistics
+    # when_i_click_a_link
+    # then_a_csv_downloads
   end
 
   def create_monthly_stats_report
@@ -23,6 +24,10 @@ RSpec.feature 'Monthly statistics page', mid_cycle: false do
 
   def given_i_visit_the_monthly_statistics_page
     visit '/publications/monthly-statistics'
+  end
+
+  def then_i_should_be_redirected_to_the_temporarily_unavailable_page
+    expect(page).to have_current_path('/publications/monthly-statistics/temporarily-unavailable')
   end
 
   def and_i_see_the_monthly_statistics


### PR DESCRIPTION
## Context

We end and start the cycle in October, so we don't want to render a report for it.

## Changes proposed in this pull request

Redirect away from the monthly statistics until we're ready to publish it in November.
<img width="743" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/927ccda1-56d3-45ea-985a-d05b5a4a97a2">


## Guidance to review

It's quick and perhaps not the cleanest, but we can revert it. We're rebuilding the monthly statistics for 2024 onwards anyway...

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
