### PR TITLE
Block editing nationality once a candidate has submitted

### DIFF
--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -82,6 +82,10 @@ module CandidateInterface
       redirect_to candidate_interface_application_complete_path if current_application.submitted?
     end
 
+    def redirect_to_details_if_submitted
+      redirect_to candidate_interface_continuous_applications_details_path if current_application.submitted?
+    end
+
     def redirect_to_post_offer_dashboard_if_accepted_deferred_or_recruited
       redirect_to candidate_interface_application_offer_dashboard_path if any_offers_accepted_or_deferred_or_recruited?
     end

--- a/app/controllers/candidate_interface/personal_details/immigration_right_to_work_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/immigration_right_to_work_controller.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   module PersonalDetails
     class ImmigrationRightToWorkController < CandidateInterfaceController
-      before_action :redirect_to_dashboard_if_submitted
+      before_action :redirect_to_details_if_submitted
 
       def new
         @form = ImmigrationRightToWorkForm.build_from_application(current_application)

--- a/app/controllers/candidate_interface/personal_details/immigration_status_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/immigration_status_controller.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   module PersonalDetails
     class ImmigrationStatusController < CandidateInterfaceController
-      before_action :redirect_to_dashboard_if_submitted
+      before_action :redirect_to_details_if_submitted
 
       def new
         @form = ImmigrationStatusForm.build_from_application(current_application)

--- a/app/controllers/candidate_interface/personal_details/nationalities_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/nationalities_controller.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   module PersonalDetails
     class NationalitiesController < CandidateInterfaceController
-      before_action :redirect_to_dashboard_if_submitted
+      before_action :redirect_to_details_if_submitted
 
       def new
         @nationalities_form = NationalitiesForm.new

--- a/app/presenters/candidate_interface/personal_details_review_presenter.rb
+++ b/app/presenters/candidate_interface/personal_details_review_presenter.rb
@@ -65,7 +65,7 @@ module CandidateInterface
       {
         key: I18n.t('application_form.personal_details.nationality.label'),
         value: formatted_nationalities,
-        action: (if @editable
+        action: (if @editable && !@application_form.submitted_applications?
                    {
                      href: candidate_interface_edit_nationalities_path(return_to_params),
                      visually_hidden_text: I18n.t('application_form.personal_details.nationality.change_action'),
@@ -86,7 +86,7 @@ module CandidateInterface
         {
           key: I18n.t('application_form.personal_details.immigration_right_to_work.label'),
           value: formatted_immigration_right_to_work,
-          action: (if @editable && !@application_form.right_to_work_or_study.nil?
+          action: (if @editable && !@application_form.right_to_work_or_study.nil? && !@application_form.submitted_applications?
                      {
                        href: candidate_interface_edit_immigration_right_to_work_path(return_to_params),
                        visually_hidden_text: I18n.t('application_form.personal_details.immigration_right_to_work.change_action'),
@@ -104,7 +104,7 @@ module CandidateInterface
         rows << {
           key: I18n.t('application_form.personal_details.immigration_status.label'),
           value: formatted_immigration_status,
-          action: (if @editable
+          action: (if @editable && !@application_form.submitted_applications?
                      {
                        href: candidate_interface_edit_immigration_status_path(return_to_params),
                        visually_hidden_text: I18n.t('application_form.personal_details.immigration_status.change_action'),

--- a/spec/system/candidate_interface/continuous_applications/entering_details/candidate_can_edit_some_sections_after_first_submission_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/entering_details/candidate_can_edit_some_sections_after_first_submission_spec.rb
@@ -77,11 +77,7 @@ RSpec.feature 'A candidate can edit some sections after first submission', :cont
 
     expect(current_candidate.current_application.reload.full_name).to eq('Robert Frank')
 
-    click_link 'Change nationality'
-    check 'Irish'
-    when_i_save_and_continue
-
-    expect(current_candidate.current_application.reload.nationalities).to include('Irish')
+    expect(page).not_to have_link('Change nationality')
   end
 
   def when_i_save_and_continue

--- a/spec/system/candidate_interface/continuous_applications/entering_details/candidate_can_not_edit_some_personal_details_after_first_submission_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/entering_details/candidate_can_not_edit_some_personal_details_after_first_submission_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.feature 'A candidate can not edit some personal details after first submission', :continuous_applications do
+  include SignInHelper
+  include CandidateHelper
+
+  before do
+    FeatureFlag.activate(:one_personal_statement)
+    create_and_sign_in_candidate
+  end
+
+  scenario 'candidate can not edit personal details after submission' do
+    given_i_already_have_one_completed_application
+    and_i_visit_the_personal_details_page
+
+    then_i_can_edit_the_nationality
+    and_i_can_edit_the_right_to_work
+    and_i_can_edit_the_immigration_status
+
+    when_i_submit_my_application
+    and_i_visit_the_personal_details_page
+
+    then_i_cant_edit_the_nationality
+    and_i_cant_edit_the_right_to_work
+    and_i_cant_edit_the_immigration_status
+
+    when_i_try_to_visit_the_nationality_page
+    then_i_should_be_redirected_to_your_details_page
+
+    when_i_try_to_visit_the_right_to_work_page
+    then_i_should_be_redirected_to_your_details_page
+
+    when_i_try_to_visit_the_immigration_status_page
+    then_i_should_be_redirected_to_your_details_page
+  end
+
+  def given_i_already_have_one_completed_application
+    create(
+      :application_form,
+      :completed,
+      first_nationality: 'Albanian',
+      right_to_work_or_study: 'yes',
+      candidate: current_candidate,
+    )
+  end
+
+  def when_i_submit_my_application
+    create(:application_choice, :awaiting_provider_decision, application_form: ApplicationForm.first)
+  end
+end
+
+def and_i_visit_the_personal_details_page
+  visit candidate_interface_personal_details_show_path
+end
+
+def then_i_can_edit_the_nationality
+  expect(page).to have_content('Change nationality')
+end
+
+def and_i_can_edit_the_right_to_work
+  expect(page).to have_content('Change if you have the right to work or study in the UK')
+end
+
+def and_i_can_edit_the_immigration_status
+  expect(page).to have_content('Change immigration status')
+end
+
+def then_i_cant_edit_the_nationality
+  expect(page).not_to have_content('Change nationality')
+end
+
+def and_i_cant_edit_the_right_to_work
+  expect(page).not_to have_content('Change if you have the right to work or study in the UK')
+end
+
+def and_i_cant_edit_the_immigration_status
+  expect(page).not_to have_content('Change immigration status')
+end
+
+def when_i_try_to_visit_the_nationality_page
+  visit candidate_interface_nationalities_path
+end
+
+def when_i_try_to_visit_the_right_to_work_page
+  visit candidate_interface_immigration_right_to_work_path
+end
+
+def when_i_try_to_visit_the_immigration_status_page
+  visit candidate_interface_immigration_status_path
+end
+
+def then_i_should_be_redirected_to_your_details_page
+  expect(page).to have_current_path candidate_interface_continuous_applications_details_path
+end


### PR DESCRIPTION
Hide the actions for nationality, right to work and immigration status rows if the candidate has submitted their application. And prevent access to the pages via the URL.

![](https://github.trello.services/images/mini-trello-icon.png) [Block editing nationality once a candidate has submitted](https://trello.com/c/BARWqaru/749-block-editing-nationality-once-a-candidate-has-submitted)

<img width="1005" alt="Screenshot 2023-10-13 at 10 22 54" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/5bd8de3b-2506-424c-90ca-8fbf7b38065b">
