### PR TITLE
Attempt to fix dependabot builds with long branch names

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,6 @@ updates:
       - DevOps
       - dependencies
       - github_actions
+    pull-request-branch-name:
+      separator: "-"
+      max-length: 100


### PR DESCRIPTION
We currently have an issue with dependabot builds failing due to long branch names. This is an attempt to fix that. I have no idea if this works because they [this is not documented](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#pull-request-branch-nameseparator). I only noticed the option by looking through [dependebot's source code.](https://github.com/dependabot/dependabot-core/blob/main/common/lib/dependabot/pull_request_creator.rb#L91)


e.g. [Bump sentry-sidekiq, dfe-analytics, dfe-autocomplete, dfe-reference-data, get_into_teaching_api_client_faraday, rspec-retry and sentry-rails](https://github.com/DFE-Digital/apply-for-teacher-training/actions/runs/6503291408/job/17663550382?pr=8663)