### PR TITLE
Redirect when trying to delete an item that has already been deleted

### DIFF
--- a/app/controllers/candidate_interface/degrees/destroy_controller.rb
+++ b/app/controllers/candidate_interface/degrees/destroy_controller.rb
@@ -2,12 +2,10 @@ module CandidateInterface
   module Degrees
     class DestroyController < BaseController
       before_action :render_application_feedback_component, except: %i[confirm_destroy destroy]
+      before_action :redirect_to_review_page, unless: -> { current_degree }
 
       def confirm_destroy
         @degree = current_degree
-        if @degree.nil?
-          redirect_to candidate_interface_application_form_path
-        end
       end
 
       def destroy
@@ -26,6 +24,10 @@ module CandidateInterface
       def degree_store
         key = "degree_wizard_store_#{current_user.id}_#{current_application.id}"
         WizardStateStores::RedisStore.new(key:)
+      end
+
+      def redirect_to_review_page
+        redirect_to candidate_interface_degree_review_path
       end
     end
   end

--- a/app/controllers/candidate_interface/other_qualifications/base_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/base_controller.rb
@@ -4,7 +4,7 @@ module CandidateInterface
     before_action :render_application_feedback_component
 
     def current_qualification
-      @current_qualification ||= current_application.application_qualifications.other.find(params[:id])
+      @current_qualification ||= current_application.application_qualifications.other.find_by(id: params[:id])
     end
 
   private

--- a/app/controllers/candidate_interface/other_qualifications/destroy_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/destroy_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   class OtherQualifications::DestroyController < OtherQualifications::BaseController
     before_action :render_application_feedback_component, except: %i[confirm_destroy destroy]
+    before_action :redirect_to_review_page, unless: -> { current_qualification }
 
     def confirm_destroy
       @qualification = OtherQualificationDetailsForm.build_from_qualification(current_qualification)
@@ -15,6 +16,12 @@ module CandidateInterface
 
         redirect_to candidate_interface_review_other_qualifications_path
       end
+    end
+
+  private
+
+    def redirect_to_review_page
+      redirect_to candidate_interface_review_other_qualifications_path
     end
   end
 end

--- a/app/controllers/candidate_interface/references/review_controller.rb
+++ b/app/controllers/candidate_interface/references/review_controller.rb
@@ -3,6 +3,7 @@ module CandidateInterface
     class ReviewController < BaseController
       before_action :set_references, only: %i[show complete]
       before_action :set_destroy_backlink, only: %i[confirm_destroy_reference]
+      before_action :redirect_to_review_page, unless: -> { @reference }, only: %i[confirm_destroy_reference destroy]
 
       def show
         @section_complete_form = ReferenceSectionCompleteForm.new(
@@ -24,13 +25,9 @@ module CandidateInterface
         end
       end
 
-      def confirm_destroy_reference
-        redirect_to_review_page if @reference.blank?
-      end
+      def confirm_destroy_reference; end
 
       def destroy
-        return redirect_to_review_page if @reference.blank?
-
         DeleteReference.new.call(reference: @reference)
 
         VerifyAndMarkReferencesIncomplete.new(current_application).call

--- a/app/controllers/candidate_interface/volunteering/destroy_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/destroy_controller.rb
@@ -1,15 +1,14 @@
 module CandidateInterface
   class Volunteering::DestroyController < Volunteering::BaseController
+    before_action :set_current_experience
+    before_action :redirect_to_review_page, unless: -> { @current_experience }
+
     def confirm_destroy
-      current_experience = current_application.application_volunteering_experiences.find(current_volunteering_role_id)
-      @volunteering_role = VolunteeringRoleForm.build_from_experience(current_experience)
+      @volunteering_role = VolunteeringRoleForm.build_from_experience(@current_experience)
     end
 
     def destroy
-      current_application
-        .application_volunteering_experiences
-        .find(current_volunteering_role_id)
-        .destroy!
+      @current_experience.destroy!
 
       if current_application.application_volunteering_experiences.blank?
         current_application.update!(volunteering_completed: nil)
@@ -17,6 +16,18 @@ module CandidateInterface
       else
         redirect_to candidate_interface_review_volunteering_path
       end
+    end
+
+  private
+
+    def set_current_experience
+      @current_experience = current_application
+        .application_volunteering_experiences
+        .find_by(id: current_volunteering_role_id)
+    end
+
+    def redirect_to_review_page
+      redirect_to candidate_interface_review_volunteering_path
     end
   end
 end

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_delete_and_replace_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_delete_and_replace_degrees_spec.rb
@@ -13,10 +13,9 @@ RSpec.feature 'Deleting and replacing a degree', continuous_applications: false 
     and_i_confirm_that_i_want_to_delete_my_degree
     then_i_see_the_undergraduate_degree_form
     and_when_i_click_back_on_the_browser
-    then_i_am_redirected_to_application_review_page_as_degree_no_longer_exists
+    then_i_am_redirected_to_degrees_review_page_as_degree_no_longer_exists
 
-    when_i_click_on_degree
-    and_i_click_add_degree
+    when_i_click_add_degree
     and_i_add_my_degree_back_in
     and_i_mark_the_section_as_incomplete
     and_i_click_on_continue
@@ -64,7 +63,7 @@ RSpec.feature 'Deleting and replacing a degree', continuous_applications: false 
     expect(page).to have_content 'Add a degree'
   end
 
-  def and_i_click_add_degree
+  def when_i_click_add_degree
     click_link 'Add a degree'
   end
 
@@ -250,7 +249,7 @@ RSpec.feature 'Deleting and replacing a degree', continuous_applications: false 
     visit candidate_interface_confirm_degree_destroy_path(@degree_id)
   end
 
-  def then_i_am_redirected_to_application_review_page_as_degree_no_longer_exists
-    expect(page).to have_current_path(candidate_interface_application_form_path)
+  def then_i_am_redirected_to_degrees_review_page_as_degree_no_longer_exists
+    expect(page).to have_current_path(candidate_interface_degree_review_path)
   end
 end


### PR DESCRIPTION
Prevent candidate from accessing the confirm and delete pages for qualifications, degrees and experiences that have already been deleted. This can happen by double clicking on the delete button or by accesign the URL directly.

Fixes https://dfe-teacher-services.sentry.io/issues/4410427119/

Thought about adding a system spec for it, but not sure it's worth it.

![](https://github.trello.services/images/mini-trello-icon.png) [Error when trying to delete a degree that doesn't exist anymore.](https://trello.com/c/UJybRCgf/814-error-when-trying-to-delete-a-degree-that-doesnt-exist-anymore)
