### PR TITLE
Add correct named route for adding Science GCSE qualification

### DIFF
--- a/app/validators/incomplete_primary_course_details_validator.rb
+++ b/app/validators/incomplete_primary_course_details_validator.rb
@@ -12,7 +12,7 @@ class IncompletePrimaryCourseDetailsValidator < ActiveModel::EachValidator
 private
 
   def link_to_science
-    view.govuk_link_to('Add your science GCSE grade (or equivalent)', Rails.application.routes.url_helpers.candidate_interface_new_gcse_science_grade_path)
+    view.govuk_link_to('Add your science GCSE grade (or equivalent)', Rails.application.routes.url_helpers.candidate_interface_gcse_details_new_type_path('science'))
   end
 
   def view

--- a/spec/services/candidate_interface/continuous_applications/application_choice_submission/incomplete_primary_course_form_spec.rb
+++ b/spec/services/candidate_interface/continuous_applications/application_choice_submission/incomplete_primary_course_form_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Incomplete primary course form details', time: CycleTimetableHel
   end
 
   def message
-    link_to_science = view.govuk_link_to('Add your science GCSE grade (or equivalent)', Rails.application.routes.url_helpers.candidate_interface_new_gcse_science_grade_path)
+    link_to_science = view.govuk_link_to('Add your science GCSE grade (or equivalent)', Rails.application.routes.url_helpers.candidate_interface_gcse_details_new_type_path('science'))
 
     t('activemodel.errors.models.candidate_interface/continuous_applications/application_choice_submission.attributes.application_choice.incomplete_primary_course_details', link_to_science:)
   end


### PR DESCRIPTION
## Context

Wrong named route used to link candidates to the page they should start to add their Science GCSE.

## Changes proposed in this pull request

## Screenshot
![link_to_science_fixed](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/0af2f944-cfb2-465d-b8a5-894dec9ce3e2)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
