### PR TITLE
Prevent provider pages from crashing on inactive applications

### DIFF
--- a/app/components/provider_interface/status_box_component.rb
+++ b/app/components/provider_interface/status_box_component.rb
@@ -10,14 +10,14 @@ module ProviderInterface
     end
 
     def application_status
-      application_choice.status
+      application_choice.inactive? ? 'awaiting_provider_decision' : application_choice.status
     end
 
     def status_box_component_to_render
       "ProviderInterface::StatusBoxComponents::#{application_status.camelize}Component".constantize
     end
 
-    # Should never happpen, but who knows
+    # Should never happen, but who knows
     class ComponentMismatchError < StandardError; end
   end
 end

--- a/spec/components/provider_interface/status_box_component_spec.rb
+++ b/spec/components/provider_interface/status_box_component_spec.rb
@@ -1,21 +1,29 @@
 require 'rails_helper'
 
 RSpec.describe ProviderInterface::StatusBoxComponent do
-  it 'chooses sub-component according to application_choice status' do
-    application_choice = instance_double(ApplicationChoice)
-    allow(application_choice).to receive(:status).and_return('dummy')
+  let(:application_choice) { build(:application_choice) }
 
-    expect { render_inline(described_class.new(application_choice:)) }.to \
-      raise_error(
-        NameError,
-        /uninitialized constant ProviderInterface::StatusBoxComponents::DummyComponent/,
-      )
+  context 'with an invalid status' do
+    before do
+      allow(application_choice).to receive(:status).and_return('dummy')
+    end
+
+    it 'chooses sub-component according to application_choice status' do
+      expect { render_inline(described_class.new(application_choice:)) }.to \
+        raise_error(
+          NameError,
+          /uninitialized constant ProviderInterface::StatusBoxComponents::DummyComponent/,
+        )
+    end
   end
 
-  it 'does not render for certain application choice statuses' do
-    application_choice = instance_double(ApplicationChoice)
-    allow(application_choice).to receive(:status).and_return('withdrawn')
+  context 'with a withdrawn status' do
+    before do
+      application_choice.inactive!
+    end
 
-    expect(render_inline(described_class.new(application_choice:)).to_html).to eq ''
+    it 'does not render for certain application choice statuses' do
+      expect(render_inline(described_class.new(application_choice:)).to_html).to eq ''
+    end
   end
 end


### PR DESCRIPTION
Previously, if a provider tried to open an inactive application, the page would crash with a 500 error. This commit fixes that by setting the status to `awaiting_provider_decision` if the application is inactive.

This is to avoid creating `StatusBoxComponents::InactiveComponent`.

![](https://github.trello.services/images/mini-trello-icon.png) [Clicking on an inactive application as a provider results in a 500 error](https://trello.com/c/RyDwZsct/765-clicking-on-an-inactive-application-as-a-provider-results-in-a-500-error)