### PR TITLE
Add recruited pending SKE content to candidate offer page

### DIFF
--- a/app/components/candidate_interface/ske_conditions_component.html.erb
+++ b/app/components/candidate_interface/ske_conditions_component.html.erb
@@ -16,32 +16,42 @@
   <% end %>
 </ol>
 
-<% if ske_conditions.many? %>
+<% if recruited? && !ske_conditions.all?(&:met?) %>
   <p class="govuk-body">
-    You should start these courses by <%= start_by.to_fs(:month_and_year) %> to give yourself enough
-    time to finish them before your teacher training starts in <%= training_starts.to_fs(:month_and_year) %>.
+    Remember to complete your subject knowledge enhancement course to meet the conditions of this offer.
   </p>
 
   <p class="govuk-body">
-    The courses will be free and you’ll receive £175 per week.
-  </p>
-
-  <p class="govuk-body">
-    <%= govuk_link_to 'Choose a provider to do your courses with', 'https://www.gov.uk/government/publications/subject-knowledge-enhancement-course-directory/subject-knowledge-enhancement-ske-course-directory', target: :blank %>.
+    You should try to finish your SKE course before your teacher training starts.
   </p>
 <% else %>
-  <p class="govuk-body">
-    You should start this course by <%= start_by.to_fs(:month_and_year) %> to give yourself enough
-    time to finish it before your teacher training starts in <%= training_starts.to_fs(:month_and_year) %>.
-  </p>
+  <% if ske_conditions.many? %>
+    <p class="govuk-body">
+      You should start these courses by <%= start_by.to_fs(:month_and_year) %> to give yourself enough
+      time to finish them before your teacher training starts in <%= training_starts.to_fs(:month_and_year) %>.
+    </p>
 
-  <p class="govuk-body">
-    The course will be free and you’ll receive £175 per week.
-  </p>
+    <p class="govuk-body">
+      The courses will be free and you’ll receive £175 per week.
+    </p>
 
-  <p class="govuk-body">
-    <%= govuk_link_to 'Choose a provider to do your course with', 'https://www.gov.uk/government/publications/subject-knowledge-enhancement-course-directory/subject-knowledge-enhancement-ske-course-directory', target: :blank %>.
-  </p>
+    <p class="govuk-body">
+      <%= govuk_link_to 'Choose a provider to do your courses with', 'https://www.gov.uk/government/publications/subject-knowledge-enhancement-course-directory/subject-knowledge-enhancement-ske-course-directory', target: :blank %>.
+    </p>
+  <% else %>
+    <p class="govuk-body">
+      You should start this course by <%= start_by.to_fs(:month_and_year) %> to give yourself enough
+      time to finish it before your teacher training starts in <%= training_starts.to_fs(:month_and_year) %>.
+    </p>
+
+    <p class="govuk-body">
+      The course will be free and you’ll receive £175 per week.
+    </p>
+
+    <p class="govuk-body">
+      <%= govuk_link_to 'Choose a provider to do your course with', 'https://www.gov.uk/government/publications/subject-knowledge-enhancement-course-directory/subject-knowledge-enhancement-ske-course-directory', target: :blank %>.
+    </p>
+  <% end %>
 <% end %>
 
 <p class="govuk-body">

--- a/app/components/candidate_interface/ske_conditions_component.rb
+++ b/app/components/candidate_interface/ske_conditions_component.rb
@@ -20,10 +20,16 @@ module CandidateInterface
       course.provider.name
     end
 
+    delegate :recruited?, to: :application_choice
+
   private
 
     def course
       @course ||= @ske_conditions.first.offer.course_option.course
+    end
+
+    def application_choice
+      @application_choice ||= @ske_conditions.first.application_choice
     end
 
     def total_length

--- a/app/controllers/provider_interface/offer/recruit_with_pending_conditions_controller.rb
+++ b/app/controllers/provider_interface/offer/recruit_with_pending_conditions_controller.rb
@@ -18,7 +18,7 @@ module ProviderInterface
           )
 
         if @recruit_with_pending_conditions_form.save
-          flash[:success] = 'Applicant recruited with conditions pending'
+          flash[:success] = 'Applicant recruited with conditions pending' if @recruit_with_pending_conditions_form.confirmed?
           redirect_to(
             provider_interface_application_choice_offer_path(application_choice_id: @application_choice.id),
           )

--- a/app/forms/provider_interface/recruit_with_pending_conditions_form.rb
+++ b/app/forms/provider_interface/recruit_with_pending_conditions_form.rb
@@ -8,12 +8,10 @@ module ProviderInterface
     validates :confirmation, inclusion: { in: %w[yes no] }
 
     def save
-      if valid? && confirmed?
-        ConfirmOfferWithPendingSkeConditions.new(actor:, application_choice:).save
-      end
-    end
+      ConfirmOfferWithPendingSkeConditions.new(actor:, application_choice:).save if valid? && confirmed?
 
-  private
+      valid?
+    end
 
     def confirmed?
       confirmation.to_s == 'yes'

--- a/app/views/candidate_mailer/conditions_met.text.erb
+++ b/app/views/candidate_mailer/conditions_met.text.erb
@@ -7,7 +7,7 @@ Dear <%= @application_form.first_name %>
   You can sign into your account if you need to check the progress of your reference requests.
 
   <% if RecruitedWithPendingConditions.new(application_choice: @application_choice).call %>
-    Remember to complete your subject knowledge enhancement (SKE) course to meet the conditions of this offer.
+  Remember to complete your subject knowledge enhancement (SKE) course to meet the conditions of this offer.
   <% end %>
 
   [Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>).

--- a/spec/system/provider_interface/provider_can_recruit_with_pending_ske_condition_spec.rb
+++ b/spec/system/provider_interface/provider_can_recruit_with_pending_ske_condition_spec.rb
@@ -36,7 +36,12 @@ RSpec.feature 'Confirm conditions met' do
     then_i_see_a_validation_error
     and_the_candidate_is_still_pending_conditions
 
-    when_i_select_yes_and_click_continue
+    when_i_select_no_and_click_continue
+    then_i_see_the_offer_page_without_a_flash_message
+    and_the_candidate_is_still_pending_conditions
+
+    when_i_click_recruit_with_pending_conditions
+    and_i_select_yes_and_click_continue
     then_i_see_the_offer_page_with_a_flash_message
     and_the_application_is_now_recruited
 
@@ -163,9 +168,19 @@ RSpec.feature 'Confirm conditions met' do
     )
   end
 
-  def when_i_select_yes_and_click_continue
+  def when_i_select_no_and_click_continue
+    choose('No')
+    when_i_click_continue
+  end
+
+  def and_i_select_yes_and_click_continue
     choose('Yes')
     when_i_click_continue
+  end
+
+  def then_i_see_the_offer_page_without_a_flash_message
+    expect(page).to have_current_path(provider_interface_application_choice_offer_path(application_choice_id: @application_choice.id))
+    expect(page).not_to have_content('Applicant recruited with conditions pending')
   end
 
   def then_i_see_the_offer_page_with_a_flash_message

--- a/spec/system/provider_interface/provider_can_recruit_with_pending_ske_condition_spec.rb
+++ b/spec/system/provider_interface/provider_can_recruit_with_pending_ske_condition_spec.rb
@@ -39,6 +39,9 @@ RSpec.feature 'Confirm conditions met' do
     when_i_select_yes_and_click_continue
     then_i_see_the_offer_page_with_a_flash_message
     and_the_application_is_now_recruited
+
+    when_i_log_in_as_the_candidate
+    then_i_see_the_offer_page_with_a_message_about_pending_ske_conditions
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -172,5 +175,15 @@ RSpec.feature 'Confirm conditions met' do
 
   def and_the_application_is_now_recruited
     expect(@application_choice.reload.recruited?).to be_truthy
+  end
+
+  def when_i_log_in_as_the_candidate
+    logout
+    login_as(@application_choice.candidate)
+  end
+
+  def then_i_see_the_offer_page_with_a_message_about_pending_ske_conditions
+    visit '/'
+    expect(page).to have_content('Remember to complete your subject knowledge enhancement course to meet the conditions of this offer.')
   end
 end


### PR DESCRIPTION
## Context

It would be beneficial to SCITT providers if we allowed them to move a candidate who was only pending SKE conditions to ‘Recruited’ as this would automatically import their record into Register saving them from having to manually create it. This is particularly useful for providers (and DfE) who are busy getting their ITT data ready for the ITT census deadline in October.

## Changes proposed in this pull request

This PR adds new content to the candidate's offer page if they have been recruited with a pending SKE condition.

![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/450843/c7d003e6-24c2-4b04-b493-751c4079d31f)

Also adds some missing logic behind the _No_ radio button on the _Recruit with pending conditions_ form.

## Guidance to review

- Is this the correct content?
- Does it appear in the right place?

## Link to Trello card

https://trello.com/c/obPov8hN/6184-once-a-candidate-is-recruited-with-pending-conditions-should-that-be-reflected-in-some-way-on-the-offer-dashboard-in-apply

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
