### PR TITLE
Highlight candidate application edits on manage

### DIFF
--- a/app/components/provider_interface/application_card_component.html.erb
+++ b/app/components/provider_interface/application_card_component.html.erb
@@ -21,6 +21,11 @@
           <span data-qa="provider"><%= course_provider_name %></span>
           <%= "(#{accredited_provider.name})" if accredited_provider.present? %>
         </dd>
+        <% if application_choice.updated_recently_since_submitted? %>
+        <dd class="govuk-hint govuk-body-s govuk-!-font-size-16">
+          <span><%= @application_choice.application_form.full_name %> updated on <%= @application_choice.application_form.updated_at.to_fs(:govuk_date) %> at <%= @application_choice.application_form.updated_at.to_fs(:govuk_time) %></span>
+        </dd>
+        <% end %>
       </dl>
     </div>
 

--- a/app/components/provider_interface/application_card_component.html.erb
+++ b/app/components/provider_interface/application_card_component.html.erb
@@ -1,4 +1,4 @@
-<section class="app-application-card">
+<section id="<%= dom_id(application_choice) %>" class="app-application-card">
   <header class="app-application-card__header">
     <h3 class="govuk-heading-s">
       <%= govuk_link_to candidate_name, provider_interface_application_choice_path(application_choice), no_visited_state: true %>

--- a/app/components/provider_interface/application_timeline_component.rb
+++ b/app/components/provider_interface/application_timeline_component.rb
@@ -34,7 +34,17 @@ module ProviderInterface
     end
 
     def timeline_events
-      (status_change_events + note_events + feedback_events + change_offer_events + change_course_events + interview_events).sort_by(&:date).reverse
+      [status_change_events,
+       note_events,
+       feedback_events,
+       change_offer_events,
+       interview_preference_events,
+       personal_information_events,
+       disability_disclosure_events,
+       equality_diversity_events,
+       contact_information_events,
+       change_course_events,
+       interview_events].flatten.sort_by(&:date).reverse
     end
 
     def status_change_events
@@ -107,6 +117,83 @@ module ProviderInterface
           actor_for(event),
           event.created_at,
           *interview_link_params(event.audit.auditable),
+        )
+      end
+    end
+
+    def interview_preference_events
+      interviews, @activity_log_events = @activity_log_events.partition { |e| e.audit.audited_changes['interview_preferences'] }
+      interviews.map do |event|
+        Event.new(
+          'Interview preference updated',
+          actor_for(event),
+          event.created_at,
+          'View Application',
+          provider_interface_application_choice_path(application_choice, anchor: 'interview-preferences-section'),
+        )
+      end
+    end
+
+    def personal_information_events
+      information, @activity_log_events = @activity_log_events.partition { |e| e.audit.audited_changes.keys.intersection(%w[first_name last_name date_of_birth]).present? }
+      information.map do |event|
+        Event.new(
+          'Personal information updated',
+          actor_for(event),
+          event.created_at,
+          'View Application',
+          provider_interface_application_choice_path(application_choice, anchor: 'personal-information-section'),
+        )
+      end
+    end
+
+    def contact_information_events
+      attributes = %w[last_name
+                      phone_number
+                      address_line1
+                      address_line2
+                      address_line3
+                      address_line4
+                      country
+                      postcode]
+      information, @activity_log_events = @activity_log_events.partition { |e| e.audit.audited_changes.keys.intersection(attributes).present? }
+      information.map do |event|
+        Event.new(
+          'Contact information updated',
+          actor_for(event),
+          event.created_at,
+          'View Application',
+          provider_interface_application_choice_path(application_choice, anchor: 'contact-information-section'),
+        )
+      end
+    end
+
+    def disability_disclosure_events
+      disability_disclosure, @activity_log_events = @activity_log_events.partition do |e|
+        e.audit.audited_changes.key?('disability_disclosure')
+      end
+      disability_disclosure.map do |event|
+        Event.new(
+          'Disability disclosure updated',
+          actor_for(event),
+          event.created_at,
+          'View Application',
+          provider_interface_application_choice_path(application_choice, anchor: 'disability-disclosure-section'),
+        )
+      end
+    end
+
+    def equality_diversity_events
+      equality_diversity, @activity_log_events = @activity_log_events.partition do |e|
+        e.audit.audited_changes.key?('disability_disclosure')
+      end
+      equality_diversity.map do |event|
+        Event.new(
+          'Equality and Diversity updated',
+          actor_for(event),
+          event.created_at,
+          'View Application',
+          provider_interface_application_choice_path(application_choice, anchor: 'equality-diversity-section'),
         )
       end
     end

--- a/app/components/provider_interface/contact_information_component.html.erb
+++ b/app/components/provider_interface/contact_information_component.html.erb
@@ -1,4 +1,4 @@
-<section class="app-section govuk-!-width-two-thirds" data-qa="contact-information">
+<section id="contact-information-section" class="app-section govuk-!-width-two-thirds" data-qa="contact-information">
   <h2 class="govuk-heading-m govuk-!-font-size-27" id="contact-information">Contact information</h2>
   <%= render SummaryListComponent.new(rows: rows) %>
 </section>

--- a/app/components/provider_interface/diversity_information_component.html.erb
+++ b/app/components/provider_interface/diversity_information_component.html.erb
@@ -1,4 +1,4 @@
-<section class="app-section govuk-!-width-two-thirds">
+<section id="diversity-section" class="app-section govuk-!-width-two-thirds">
   <h2 class="govuk-heading-m govuk-!-font-size-27" id="diversity-information">Sex, disability and ethnicity</h2>
 
   <%= render SummaryListComponent.new(rows: rows) %>

--- a/app/components/provider_interface/personal_information_component.html.erb
+++ b/app/components/provider_interface/personal_information_component.html.erb
@@ -1,4 +1,4 @@
-<section class="app-section govuk-!-width-two-thirds" data-qa="personal-information">
+<section id="personal-information-section" class="app-section govuk-!-width-two-thirds" data-qa="personal-information">
   <h2 class="govuk-heading-m govuk-!-font-size-27" id="personal-information">Personal information</h2>
   <%= render SummaryListComponent.new(rows: rows) %>
 </section>

--- a/app/components/provider_interface/training_with_disability_component.html.erb
+++ b/app/components/provider_interface/training_with_disability_component.html.erb
@@ -1,4 +1,4 @@
-<section class="app-section govuk-!-width-two-thirds" id="disability-access-and-other-needs">
+<section id="disability-disclosure-section" class="app-section govuk-!-width-two-thirds">
   <h2 class="govuk-heading-m govuk-!-font-size-27">Disability support</h2>
 
   <%= render SummaryListComponent.new(rows: rows) %>

--- a/app/components/shared/interview_preferences_component.html.erb
+++ b/app/components/shared/interview_preferences_component.html.erb
@@ -1,4 +1,4 @@
-<section class="app-section govuk-!-width-two-thirds">
+<section id="interview-preferences-section" class="app-section govuk-!-width-two-thirds">
   <h2 class="govuk-heading-m govuk-!-font-size-27" id="interview"><%= t('page_titles.interview_preferences.heading') %></h2>
 
   <%= render SummaryListComponent.new(rows: rows) %>

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -55,6 +55,8 @@ module ProviderInterface
       @available_training_providers = available_training_providers
       @available_courses = available_courses
       @available_course_options = available_course_options
+
+      @show_updated_recently_banner = @application_choice.updated_recently_since_submitted?
     end
 
     def timeline; end

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -32,8 +32,6 @@ class ApplicationChoice < ApplicationRecord
   audited associated_with: :application_form
   dateable :sent_to_provider, :offered
 
-  UPDATED_RECENTLY_DAYS = 40
-
   # Note that prior to October 2020, we used to have awaiting_references and
   # application_complete statuses. These will still show up in older audit logs.
   enum status: {
@@ -268,10 +266,7 @@ class ApplicationChoice < ApplicationRecord
   end
 
   def updated_recently_since_submitted?
-    return false if sent_to_provider_at.blank?
-
-    since = [UPDATED_RECENTLY_DAYS.days.ago, sent_to_provider_at].max
-    RecentlyUpdatedApplicationChoice.new.call(application_choice: self, since: since).exists?
+    RecentlyUpdatedApplicationChoice.new(application_choice: self).call
   end
 
 private

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -32,6 +32,8 @@ class ApplicationChoice < ApplicationRecord
   audited associated_with: :application_form
   dateable :sent_to_provider, :offered
 
+  UPDATED_RECENTLY_DAYS = 40
+
   # Note that prior to October 2020, we used to have awaiting_references and
   # application_complete statuses. These will still show up in older audit logs.
   enum status: {
@@ -263,6 +265,13 @@ class ApplicationChoice < ApplicationRecord
         supplementary_statuses << :ske_pending_conditions
       end
     end
+  end
+
+  def updated_recently_since_submitted?
+    return false if sent_to_provider_at.blank?
+
+    since = [UPDATED_RECENTLY_DAYS.days.ago, sent_to_provider_at].max
+    RecentlyUpdatedApplicationChoice.new.call(application_choice: self, since: since).exists?
   end
 
 private

--- a/app/queries/recently_updated_application_choice.rb
+++ b/app/queries/recently_updated_application_choice.rb
@@ -1,18 +1,32 @@
 # Find audits for updates to editable sections on the application form
 class RecentlyUpdatedApplicationChoice
-  def call(application_choice:, since: application_choice.created_at)
-    Audited::Audit
-      .where('audits.created_at >= :since AND audits.action = \'update\'', since: since)
-      .where(auditable_type: 'ApplicationForm', auditable_id: application_choice.application_form_id)
-      .where(application_form_audits_filter_sql)
-      .order('audits.created_at DESC')
+  UPDATED_RECENTLY_DAYS = 40
+
+  def initialize(application_choice:)
+    @application_choice = application_choice
   end
 
+  def call
+    return false if @application_choice.sent_to_provider_at.blank?
+
+    since = [UPDATED_RECENTLY_DAYS.days.ago, @application_choice.sent_to_provider_at].max
+
+    Audited::Audit
+      .where('audits.created_at >= ? AND audits.action = \'update\'', since)
+      .where(auditable_type: 'ApplicationForm', auditable_id: @application_choice.application_form_id)
+      .where(application_form_audits_filter_sql)
+      .exists?
+  end
+
+private
+
   def application_form_audits_filter_sql
-    attributes.map do |change|
-      "jsonb_exists(audited_changes, '#{change}')"
+    attributes.map do |attribute|
+      "jsonb_exists(audited_changes, '#{attribute}')"
     end.join(' OR ')
   end
+
+  attr_reader :application_choice
 
   def attributes
     [

--- a/app/queries/recently_updated_application_choice.rb
+++ b/app/queries/recently_updated_application_choice.rb
@@ -1,0 +1,43 @@
+# Find audits for updates to editable sections on the application form
+class RecentlyUpdatedApplicationChoice
+  def call(application_choice:, since: application_choice.created_at)
+    Audited::Audit
+      .where('audits.created_at >= :since AND audits.action = \'update\'', since: since)
+      .where(auditable_type: 'ApplicationForm', auditable_id: application_choice.application_form_id)
+      .where(application_form_audits_filter_sql)
+      .order('audits.created_at DESC')
+  end
+
+  def application_form_audits_filter_sql
+    attributes.map do |change|
+      "jsonb_exists(audited_changes, '#{change}')"
+    end.join(' OR ')
+  end
+
+  def attributes
+    [
+      # Personal Information
+      'date_of_birth',
+      'first_name',
+      'last_name',
+
+      # Contact Information
+      'phone_number',
+      'address_line1',
+      'address_line2',
+      'address_line3',
+      'address_line4',
+      'country',
+      'postcode',
+
+      # Interview Preferences
+      'interview_preferences',
+
+      # Disability
+      'disability_disclosure',
+
+      # Equality and diversity
+      'equality_and_diversity',
+    ]
+  end
+end

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -1,5 +1,12 @@
 <% content_for :browser_title, "#{@application_choice.application_form.full_name} – #{@application_choice.course.name_and_code}" %>
 
+<% if @show_updated_recently_banner %>
+  <%= govuk_notification_banner(title_text: t('notification_banner.important')) do |notification_banner| %>
+    <% notification_banner.with_heading(text: "#{@application_choice.application_form.full_name} updated their application on #{@application_choice.application_form.updated_at.to_fs(:govuk_date)} at #{@application_choice.application_form.updated_at.to_fs(:govuk_time)}") %>
+    <p class="govuk-body"><%= govuk_link_to 'View the timeline for their updates', provider_interface_application_choice_timeline_path(@application_choice.id) %></p>
+  <% end %>
+<% end %>
+
 <%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(
   application_choice: @application_choice,
   provider_can_respond: @provider_user_can_make_decisions,

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -18,6 +18,8 @@
 
 <h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Application</h2>
 
+<p class="govuk-body govuk-!-display-none-print govuk-!-width-two-thirds"><%= @application_choice.application_form.full_name %> will be able to edit some sections of their application. You’ll get a notification if they add any new information.</p>
+
 <p class="govuk-body govuk-!-display-none-print">
   <% if FeatureFlag.active?(:withdraw_at_candidates_request) && application_withdrawable? %>
     <%= govuk_link_to(

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,6 +3,29 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
+      "fingerprint": "094c4d4bd37df3a900e58709379ace20718201acf89d88108a2950dca8f861bc",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/queries/get_activity_log_events.rb",
+      "line": 71,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "Audited::Audit.includes(:user => ([:provider_user, :support_user]), :auditable => ([:application_form, :course_option, :course, :site, :provider, :accredited_provider, :current_course_option])).joins(\"INNER JOIN (#{application_choices.to_sql}) ac\\n  ON (\\n    auditable_type = 'ApplicationChoice'\\n    AND auditable_id = ac.id\\n    AND action = 'update'\\n    AND ( #{application_choice_audits_filter_sql} )\\n  ) OR (\\n    associated_type = 'ApplicationChoice'\\n    AND associated_id = ac.id\\n    AND NOT auditable_type = 'OfferCondition'\\n  ) OR (\\n    auditable_type = 'ApplicationForm'\\n    AND auditable_id = ac.application_form_id\\n    AND action = 'update'\\n    AND ( #{application_form_audits_filter_sql} )\\n  )\\n\".squish)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "GetActivityLogEvents",
+        "method": "s(:self).call"
+      },
+      "user_input": "application_choice_audits_filter_sql",
+      "confidence": "Weak",
+      "cwe_id": [
+        89
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
       "fingerprint": "16284076c64f5cf82c4de57b76a655983bef3201432a3206f302d6cb49fb2466",
       "check_name": "SQL",
       "message": "Possible SQL injection",
@@ -231,29 +254,6 @@
       "note": ""
     },
     {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "8d47ca53c31589141f357f2ee543042879b2512c30b261840f89cec9f6da0518",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/queries/get_activity_log_events.rb",
-      "line": 44,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "Audited::Audit.includes(:user => ([:provider_user, :support_user]), :auditable => ([:application_form, :course_option, :course, :site, :provider, :accredited_provider, :current_course_option])).joins(\"INNER JOIN (#{application_choices.to_sql}) ac\\n  ON (\\n    auditable_type = 'ApplicationChoice'\\n    AND auditable_id = ac.id\\n    AND action = 'update'\\n    AND ( #{application_choice_audits_filter_sql} )\\n  ) OR (\\n    associated_type = 'ApplicationChoice'\\n    AND associated_id = ac.id\\n    AND NOT auditable_type = 'OfferCondition'\\n  )\\n\".squish)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "GetActivityLogEvents",
-        "method": "s(:self).call"
-      },
-      "user_input": "application_choice_audits_filter_sql",
-      "confidence": "Weak",
-      "cwe_id": [
-        89
-      ],
-      "note": ""
-    },
-    {
       "warning_type": "Unscoped Find",
       "warning_code": 82,
       "fingerprint": "9e900042a97ec79a46b47b5c58b9adfa1391693e495a89dbf455607b3b2603d8",
@@ -415,6 +415,6 @@
       "note": ""
     }
   ],
-  "updated": "2023-02-23 15:37:29 +0000",
-  "brakeman_version": "5.4.1"
+  "updated": "2023-10-18 13:21:48 +0100",
+  "brakeman_version": "6.0.1"
 }

--- a/spec/factories/audit.rb
+++ b/spec/factories/audit.rb
@@ -117,4 +117,23 @@ FactoryBot.define do
       audit.audited_changes = evaluator.changes
     end
   end
+
+  factory :application_form_audit, class: 'Audited::Audit' do
+    action { 'update' }
+    user { create(:provider_user) }
+    version { 1 }
+    request_uuid { SecureRandom.uuid }
+    created_at { Time.zone.now }
+
+    transient do
+      application_choice { build_stubbed(:application_choice) }
+      changes { {} }
+    end
+
+    after(:build) do |audit, evaluator|
+      audit.auditable_type = 'ApplicationForm'
+      audit.auditable_id = evaluator.application_choice.application_form.id
+      audit.audited_changes = evaluator.changes
+    end
+  end
 end

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -548,51 +548,24 @@ RSpec.describe ApplicationChoice do
   end
 
   describe '#updated_recently_since_submitted?' do
-    let(:choice) do
-      create(:application_choice, {
-        created_at: 7.months.ago,
-        sent_to_provider_at:,
-        updated_at: edited_at + 1.second,
-      })
-    end
-    let(:sent_to_provider_at) { 6.months.ago }
-
     before do
-      create(:application_form_audit, {
-        created_at: edited_at,
-        application_choice: choice,
-        changes: { 'date_of_birth' => %w[01-01-2000 02-01-2000] },
-      })
+      allow(RecentlyUpdatedApplicationChoice).to receive(:new).and_return(
+        instance_double(RecentlyUpdatedApplicationChoice, call: service_response),
+      )
     end
 
-    context 'update_at is before than UPDATED_RECENTLY_DAYS days ago' do
-      let(:edited_at) { described_class::UPDATED_RECENTLY_DAYS.days.ago + 1 }
+    let(:choice) { build_stubbed(:application_choice) }
+
+    context 'when the service returns true' do
+      let(:service_response) { true }
 
       it 'is not recently updated' do
         expect(choice).to be_updated_recently_since_submitted
       end
     end
 
-    context 'update_at is after than UPDATED_RECENTLY_DAYS days ago' do
-      let(:edited_at) { described_class::UPDATED_RECENTLY_DAYS.days.ago - 1 }
-
-      it 'is recently updated' do
-        expect(choice).not_to be_updated_recently_since_submitted
-      end
-    end
-
-    context 'false unless sent_to_provider_at' do
-      let(:edited_at) { described_class::UPDATED_RECENTLY_DAYS.days.ago + 1 }
-      let(:sent_to_provider_at) { nil }
-
-      it 'is not recently updated' do
-        expect(choice).not_to be_updated_recently_since_submitted
-      end
-    end
-
-    context 'when update is before sent_to_provider_at' do
-      let(:edited_at) { described_class::UPDATED_RECENTLY_DAYS.days.ago - 2 }
-      let(:sent_to_provider_at) { described_class::UPDATED_RECENTLY_DAYS.days.ago - 1 }
+    context 'when the service returns false' do
+      let(:service_response) { false }
 
       it 'is not recently updated' do
         expect(choice).not_to be_updated_recently_since_submitted

--- a/spec/queries/get_activity_log_events_spec.rb
+++ b/spec/queries/get_activity_log_events_spec.rb
@@ -97,16 +97,33 @@ RSpec.describe GetActivityLogEvents, :with_audited do
         changes: { 'reject_by_default_at' => [nil, 40.days.from_now.iso8601] },
       )
 
-      included = create(
-        :application_choice_audit,
-        application_choice: choice,
-        changes: { 'status' => %w[awaiting_provider_decision offer] },
-      )
+      included = [
+        create(
+          :application_choice_audit,
+          application_choice: choice,
+          changes: { 'status' => %w[awaiting_provider_decision offer] },
+        ),
+        create(
+          :application_form_audit,
+          application_choice: choice,
+          changes: { 'date_of_birth' => %w[01-01-2000 02-02-2002] },
+        ),
+        create(
+          :application_form_audit,
+          application_choice: choice,
+          changes: { 'disability_disclosure' => %w[Hello Hi] },
+        ),
+        create(
+          :application_form_audit,
+          application_choice: choice,
+          changes: { 'interview_preferences' => %w[This That] },
+        ),
+      ]
 
       result = service_call
 
       expect(result).not_to include(excluded)
-      expect(result).to include(included)
+      expect(result).to match_array(included)
     end
 
     it 'includes events with a reject_by_default_feedback_sent_at change' do

--- a/spec/queries/recently_updated_application_choice_spec.rb
+++ b/spec/queries/recently_updated_application_choice_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe RecentlyUpdatedApplicationChoice, :with_audited do
+  subject(:service) { described_class.new(application_choice:).call }
+
+  describe '#call' do
+    let(:application_choice) do
+      create(:application_choice, {
+        created_at: 7.months.ago,
+        sent_to_provider_at:,
+        updated_at: edited_at + 1.second,
+      })
+    end
+    let(:sent_to_provider_at) { 6.months.ago }
+
+    before do
+      create(:application_form_audit, {
+        created_at: edited_at,
+        application_choice: application_choice,
+        changes: { 'date_of_birth' => %w[01-01-2000 02-01-2000] },
+      })
+    end
+
+    context 'update_at is before than UPDATED_RECENTLY_DAYS days ago' do
+      let(:edited_at) { described_class::UPDATED_RECENTLY_DAYS.days.ago + 1 }
+
+      it 'is not recently updated' do
+        expect(service).to be(true)
+      end
+    end
+
+    context 'update_at is after than UPDATED_RECENTLY_DAYS days ago' do
+      let(:edited_at) { described_class::UPDATED_RECENTLY_DAYS.days.ago - 1 }
+
+      it 'is recently updated' do
+        expect(service).to be(false)
+      end
+    end
+
+    context 'false unless sent_to_provider_at' do
+      let(:edited_at) { described_class::UPDATED_RECENTLY_DAYS.days.ago + 1 }
+      let(:sent_to_provider_at) { nil }
+
+      it 'is not recently updated' do
+        expect(service).to be(false)
+      end
+    end
+
+    context 'when update is before sent_to_provider_at' do
+      let(:edited_at) { described_class::UPDATED_RECENTLY_DAYS.days.ago - 2 }
+      let(:sent_to_provider_at) { described_class::UPDATED_RECENTLY_DAYS.days.ago - 1 }
+
+      it 'is not recently updated' do
+        expect(service).to be(false)
+      end
+    end
+  end
+end

--- a/spec/system/provider_interface/see_updated_applications_post_submission_spec.rb
+++ b/spec/system/provider_interface/see_updated_applications_post_submission_spec.rb
@@ -1,0 +1,105 @@
+require 'rails_helper'
+
+RSpec.feature 'See updated applications post-submission' do
+  include CourseOptionHelpers
+  include DfESignInHelpers
+
+  scenario 'Notifications and indicators are visible', :with_audited do
+    given_i_am_a_provider_user_authenticated_with_dfe_sign_in
+    and_my_apply_account_has_been_created
+    and_my_organisation_has_two_submitted_applications
+
+    when_1_day_passes
+    then_the_updated_long_ago_application_has_the_address_updated
+
+    when_1_month_passes
+    then_the_updated_recently_application_has_the_address_updated
+
+    when_1_month_passes
+
+    and_i_sign_in_to_the_provider_interface
+    then_i_should_see_the_applications_from_my_organisation
+
+    # Visit the recently updated application
+    when_i_click_on_the_recently_updated_application
+    then_i_should_be_on_the_application_view_page
+    and_i_should_see_the_updated_recently_notification
+
+    # Visit the application updated long ago
+    when_i_click_on_applications_in_the_navigation_bar
+    and_i_visit_the_updated_long_ago_application
+    then_i_should_not_see_the_updated_recently_notification
+  end
+
+  def and_my_apply_account_has_been_created
+    provider_user_exists_in_apply_database(provider_code: 'ABC')
+  end
+
+  def given_i_am_a_provider_user_authenticated_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+    provider_signs_in_using_dfe_sign_in
+  end
+
+  def then_the_updated_recently_application_has_the_address_updated
+    @updated_recently.application_form.update(address_line1: '123 Fake Street')
+  end
+
+  def then_the_updated_long_ago_application_has_the_address_updated
+    @updated_long_ago.application_form.update(address_line1: '123 Fake Street')
+  end
+
+  def when_1_day_passes
+    TestSuiteTimeMachine.travel_permanently_to(1.day.from_now)
+  end
+
+  def when_1_month_passes
+    TestSuiteTimeMachine.travel_permanently_to(1.month.from_now)
+  end
+
+  def and_my_organisation_has_two_submitted_applications
+    course_option = course_option_for_provider_code(provider_code: 'ABC')
+
+    @updated_recently = create(:application_choice,
+                               :awaiting_provider_decision,
+                               course_option:)
+    @updated_long_ago = create(:application_choice,
+                               :awaiting_provider_decision,
+                               :with_completed_application_form,
+                               course_option:)
+  end
+
+  def then_i_should_see_the_applications_from_my_organisation
+    expect(page).to have_title 'Applications (2)'
+    expect(page).to have_content 'Applications (2)'
+    expect(page).to have_content @updated_long_ago.application_form.full_name
+    expect(page).to have_content @updated_recently.application_form.full_name
+  end
+
+  def when_i_click_on_the_recently_updated_application
+    click_link @updated_recently.application_form.full_name
+  end
+
+  def then_i_should_be_on_the_application_view_page
+    expect(page).to have_content @updated_recently.id
+
+    expect(page).to have_content @updated_recently.application_form.full_name
+  end
+
+  def and_i_should_see_the_updated_recently_notification
+    expect(page).to have_content 'View the timeline for their updates'
+  end
+
+  def then_i_should_not_see_the_updated_recently_notification
+    expect(page).not_to have_content 'View the timeline for their updates'
+  end
+
+  def and_i_visit_the_updated_long_ago_application
+    click_link @updated_long_ago.application_form.full_name
+  end
+
+  def when_i_click_on_applications_in_the_navigation_bar
+    within '.app-primary-navigation' do
+      click_link 'Applications'
+    end
+  end
+end

--- a/spec/system/provider_interface/see_updated_applications_post_submission_spec.rb
+++ b/spec/system/provider_interface/see_updated_applications_post_submission_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature 'See updated applications post-submission' do
+  include ActionView::RecordIdentifier
   include CourseOptionHelpers
   include DfESignInHelpers
 
@@ -10,7 +11,7 @@ RSpec.feature 'See updated applications post-submission' do
     and_my_organisation_has_two_submitted_applications
 
     when_1_day_passes
-    then_the_updated_long_ago_application_has_the_address_updated
+    then_the_distantly_updated_application_has_the_address_updated
 
     when_1_month_passes
     then_the_updated_recently_application_has_the_address_updated
@@ -20,6 +21,10 @@ RSpec.feature 'See updated applications post-submission' do
     and_i_sign_in_to_the_provider_interface
     then_i_should_see_the_applications_from_my_organisation
 
+    when_i_am_on_the_application_choice_index_page
+    then_the_recently_updated_candidate_card_has_an_updated_notice
+    then_the_distantly_updated_candidate_card_has_no_updated_notice
+
     # Visit the recently updated application
     when_i_click_on_the_recently_updated_application
     then_i_should_be_on_the_application_view_page
@@ -27,8 +32,24 @@ RSpec.feature 'See updated applications post-submission' do
 
     # Visit the application updated long ago
     when_i_click_on_applications_in_the_navigation_bar
-    and_i_visit_the_updated_long_ago_application
+    and_i_visit_the_distantly_updated_application
     then_i_should_not_see_the_updated_recently_notification
+  end
+
+  def then_the_recently_updated_candidate_card_has_an_updated_notice
+    within("##{dom_id(@recently_updated)}") do
+      expect(page).to have_content('updated on ')
+    end
+  end
+
+  def when_i_am_on_the_application_choice_index_page
+    expect(page).to have_current_path('/provider/applications')
+  end
+
+  def then_the_distantly_updated_candidate_card_has_no_updated_notice
+    within("##{dom_id(@distantly_updated)}") do
+      expect(page).not_to have_content('updated on ')
+    end
   end
 
   def and_my_apply_account_has_been_created
@@ -41,11 +62,11 @@ RSpec.feature 'See updated applications post-submission' do
   end
 
   def then_the_updated_recently_application_has_the_address_updated
-    @updated_recently.application_form.update(address_line1: '123 Fake Street')
+    @recently_updated.application_form.update(address_line1: '123 Fake Street')
   end
 
-  def then_the_updated_long_ago_application_has_the_address_updated
-    @updated_long_ago.application_form.update(address_line1: '123 Fake Street')
+  def then_the_distantly_updated_application_has_the_address_updated
+    @distantly_updated.application_form.update(address_line1: '123 Fake Street')
   end
 
   def when_1_day_passes
@@ -59,30 +80,30 @@ RSpec.feature 'See updated applications post-submission' do
   def and_my_organisation_has_two_submitted_applications
     course_option = course_option_for_provider_code(provider_code: 'ABC')
 
-    @updated_recently = create(:application_choice,
+    @recently_updated = create(:application_choice,
                                :awaiting_provider_decision,
                                course_option:)
-    @updated_long_ago = create(:application_choice,
-                               :awaiting_provider_decision,
-                               :with_completed_application_form,
-                               course_option:)
+    @distantly_updated = create(:application_choice,
+                                :awaiting_provider_decision,
+                                :with_completed_application_form,
+                                course_option:)
   end
 
   def then_i_should_see_the_applications_from_my_organisation
     expect(page).to have_title 'Applications (2)'
     expect(page).to have_content 'Applications (2)'
-    expect(page).to have_content @updated_long_ago.application_form.full_name
-    expect(page).to have_content @updated_recently.application_form.full_name
+    expect(page).to have_content @distantly_updated.application_form.full_name
+    expect(page).to have_content @recently_updated.application_form.full_name
   end
 
   def when_i_click_on_the_recently_updated_application
-    click_link @updated_recently.application_form.full_name
+    click_link @recently_updated.application_form.full_name
   end
 
   def then_i_should_be_on_the_application_view_page
-    expect(page).to have_content @updated_recently.id
+    expect(page).to have_content @recently_updated.id
 
-    expect(page).to have_content @updated_recently.application_form.full_name
+    expect(page).to have_content @recently_updated.application_form.full_name
   end
 
   def and_i_should_see_the_updated_recently_notification
@@ -93,8 +114,8 @@ RSpec.feature 'See updated applications post-submission' do
     expect(page).not_to have_content 'View the timeline for their updates'
   end
 
-  def and_i_visit_the_updated_long_ago_application
-    click_link @updated_long_ago.application_form.full_name
+  def and_i_visit_the_distantly_updated_application
+    click_link @distantly_updated.application_form.full_name
   end
 
   def when_i_click_on_applications_in_the_navigation_bar


### PR DESCRIPTION
## Context

Providers will want to be aware when a candidate has updated their submitted application.

1. Show notification banner on the candidates application page in the provider interface
2. Add notification text informing provider that applications can be edited
3. Show list of changes that have occurred on the application in the Timeline
4. Show notification line on updated cards on the applications index

The ticket outlined an implementation where the data that was changed is shown in the Timeline. I have not implemented this in this PR as it would require consideration about how and what could be shared between the history component and the timeline component.

As a stopgap, the link to "View Application" in the Timeline brings the user to the specific section of the application that has been changed.

## Screenshots

|Notification Banner|Notification text|
|---|---|
|![1  notification banner](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/a4e2e5b8-8f75-428e-804d-8cc013d6f668)|![Screenshot from 2023-10-18 14-16-16](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/812b13ba-7f98-4083-9f4b-7162c897b8a3)|


|Index card notifications|Timeline updates|
|---|---|
|![2  index notifications](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/12f2960e-26c5-484c-8948-07b2b9c56341)|![3  Timeline updates](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/2918a216-3c1f-4e6a-8254-53559c9a5447)|


## Changes proposed in this pull request



## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

[Trello Ticket](https://trello.com/c/IcuPiaZJ/33-ca-highlight-candidate-application-edits-on-manage)
