### PR TITLE
Do not render RBD copy for users without permissions

### DIFF
--- a/app/components/provider_interface/application_header_components/awaiting_decision_cannot_respond_component.html.erb
+++ b/app/components/provider_interface/application_header_components/awaiting_decision_cannot_respond_component.html.erb
@@ -1,8 +1,3 @@
 <p class="govuk-body">
-  <% if time_is_today_or_tomorrow?(application_choice.reject_by_default_at) -%>
-    This application will be automatically rejected at <%= time_today_or_tomorrow(application_choice.reject_by_default_at) %>.
-  <% else -%>
-    <%= "There are #{days_until(application_choice.reject_by_default_at.to_date)} to respond." %>
-    This application will be automatically rejected on <%= application_choice.reject_by_default_at.to_fs(:govuk_date) %>.
-  <% end -%>
+  This application was received <%= days_since(application_choice.days_since_sent_to_provider) %>. You should try and respond to the candidate within 30 days.
 </p>

--- a/spec/components/provider_interface/application_choice_header_component_spec.rb
+++ b/spec/components/provider_interface/application_choice_header_component_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe ProviderInterface::ApplicationChoiceHeaderComponent do
       let(:status) { 'interviewing' }
 
       it 'presents content without a heading or button' do
-        expect(result.css('.govuk-inset-text').text).to include('There are 10 days to respond.')
+        expect(result.css('.govuk-inset-text').text).to include('This application was received today. You should try and respond to the candidate within 30 days')
       end
     end
 
@@ -108,18 +108,6 @@ RSpec.describe ProviderInterface::ApplicationChoiceHeaderComponent do
           expect(result.css('.govuk-inset-text > h2').text).to include('Waiting for candidate’s response')
           expect(result.css('.govuk-inset-text > p').text).to include('You made this offer 3 days ago. Most candidates respond to offers within 15 working days. The candidate will receive reminders to respond.')
         end
-      end
-    end
-
-    context 'when the application is awaiting provider decision, reject by default is tomorrow and user cannot make decisions' do
-      let(:provider_can_respond) { false }
-      let(:provider_can_set_up_interviews) { false }
-      let(:reject_by_default_at) { 1.day.from_now }
-
-      it 'formats the reject by default time in a sentence' do
-        expect(result.css('.govuk-inset-text').text).to include(
-          "This application will be automatically rejected at #{reject_by_default_at.to_fs(:govuk_time)} tomorrow",
-        )
       end
     end
 

--- a/spec/components/provider_interface/application_header_components/awaiting_decision_cannot_respond_component_spec.rb
+++ b/spec/components/provider_interface/application_header_components/awaiting_decision_cannot_respond_component_spec.rb
@@ -3,19 +3,14 @@ require 'rails_helper'
 RSpec.describe ProviderInterface::ApplicationHeaderComponents::AwaitingDecisionCannotRespondComponent do
   describe 'rendered component' do
     it 'renders days left to respond' do
-      application_choice = build_stubbed(:application_choice, :awaiting_provider_decision, reject_by_default_at: 3.days.from_now)
-      result = render_inline(described_class.new(application_choice:, provider_can_respond: true))
+      application_choice = build_stubbed(:application_choice, :awaiting_provider_decision)
+      result = render_inline(described_class.new(application_choice:, provider_can_respond: false))
 
-      expect(result.css('.govuk-body').text).to match(/There are \d+ days to respond/)
-      expect(result.css('.govuk-body').text).to match(/This application will be automatically rejected on/)
-    end
-
-    it 'omits days left to respond if the application is about to be rejected' do
-      application_choice = build_stubbed(:application_choice, :awaiting_provider_decision, reject_by_default_at: 1.day.from_now)
-      result = render_inline(described_class.new(application_choice:, provider_can_respond: true))
-
-      expect(result.css('.govuk-body').text).not_to match(/There are \d+ days to respond/)
-      expect(result.css('.govuk-body').text).to match(/This application will be automatically rejected at/)
+      expect(result.css('h2').text.strip).not_to eq('Make a decision')
+      expect(result.css('.govuk-body').text.strip).to eq(
+        'This application was received today. You should try and respond to the candidate within 30 days.',
+      )
+      expect(result.css('.govuk-button').text.strip).not_to eq('Make decision')
     end
   end
 end


### PR DESCRIPTION
## Context

If the provider user doesn't have permission to respond to an application then we present them with RBD related copy. We need to remove this.

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="713" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/2622e4c6-58b6-4faa-afae-8be6cdaf22dc">|<img width="675" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/96dd917a-de2b-4f13-aa9f-03d0a51ef030">|

## Guidance to review

Sign in as a provider user who doesn't have the ability to make decisions on main and you'll see this copy whilst viewing a received application.

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
