### PR TITLE
Update link to get school experience service

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,7 +39,7 @@ en:
     url_international_candidates: https://getintoteaching.education.gov.uk/non-uk-teachers
     url_support_if_you_are_disabled: https://getintoteaching.education.gov.uk/funding-and-support/if-youre-disabled
     url_online_chat: https://getintoteaching.education.gov.uk/help-and-support
-    url_get_school_experience: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/get-school-experience
+    url_get_school_experience: https://https://getintoteaching.education.gov.uk/is-teaching-right-for-me/get-school-experience
     url_ways_to_train: https://getintoteaching.education.gov.uk/train-to-be-a-teacher
     url_choose_your_referees: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/how-to-apply-for-teacher-training#choose-your-references
     url_if_you_dont_have_a_degree: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/if-you-dont-have-a-degree

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,7 +39,7 @@ en:
     url_international_candidates: https://getintoteaching.education.gov.uk/non-uk-teachers
     url_support_if_you_are_disabled: https://getintoteaching.education.gov.uk/funding-and-support/if-youre-disabled
     url_online_chat: https://getintoteaching.education.gov.uk/help-and-support
-    url_get_school_experience: https://https://getintoteaching.education.gov.uk/is-teaching-right-for-me/get-school-experience
+    url_get_school_experience: https://getintoteaching.education.gov.uk/is-teaching-right-for-me/get-school-experience
     url_ways_to_train: https://getintoteaching.education.gov.uk/train-to-be-a-teacher
     url_choose_your_referees: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/how-to-apply-for-teacher-training#choose-your-references
     url_if_you_dont_have_a_degree: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/if-you-dont-have-a-degree


### PR DESCRIPTION
## Context

GIT have changed their URL for their school experience page.

## Changes proposed in this pull request


Page | Old address | New address
-- | -- | --
Get school experience | getintoteaching.education.gov.uk/train-to-be-a-teacher/get-school-experience | https://getintoteaching.education.gov.uk/is-teaching-right-for-me/get-school-experience


## Guidance to review

Does this work?

## Link to Trello card

N/A

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
