### PR TITLE
Allow SKE conditions to be marked as met after recruited

### DIFF
--- a/app/components/provider_interface/offer_summary_component.html.erb
+++ b/app/components/provider_interface/offer_summary_component.html.erb
@@ -20,7 +20,7 @@
   <% end %>
 
   <% if editable && !show_recruit_pending_button %>
-    <% if @application_choice.pending_conditions? %>
+    <% if conditions_to_update? %>
       <div class='govuk-body'>
         <%= govuk_link_to 'Update status of conditions', update_conditions_path %>
       </div>
@@ -37,7 +37,7 @@
 
   <% if editable && show_recruit_pending_button %>
     <div class='govuk-body'>
-      <% if @application_choice.pending_conditions? %>
+      <% if conditions_to_update? %>
         <%= govuk_button_to(
           'Update status of conditions',
           update_conditions_path,

--- a/app/components/provider_interface/offer_summary_component.rb
+++ b/app/components/provider_interface/offer_summary_component.rb
@@ -89,6 +89,10 @@ module ProviderInterface
       CanRecruitWithPendingConditions.new(application_choice:).call
     end
 
+    def conditions_to_update?
+      @application_choice.pending_conditions? || RecruitedWithPendingConditions.new(application_choice:).call
+    end
+
   private
 
     def accredited_body_details(course_option)

--- a/app/controllers/provider_interface/condition_statuses_controller.rb
+++ b/app/controllers/provider_interface/condition_statuses_controller.rb
@@ -30,7 +30,7 @@ module ProviderInterface
   private
 
     def redirect_unless_application_pending_conditions
-      return if @application_choice.pending_conditions?
+      return if @application_choice.pending_conditions? || RecruitedWithPendingConditions.new(application_choice: @application_choice).call
 
       flash[:warning] = I18n.t('activerecord.errors.models.application_choice.attributes.status.invalid_transition')
       redirect_to provider_interface_application_choice_path(@application_choice)

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -95,6 +95,7 @@ class ApplicationStateChange
     state :recruited do
       event :withdraw, transitions_to: :withdrawn
       event :defer_offer, transitions_to: :offer_deferred
+      event :confirm_conditions_met, transitions_to: :recruited
     end
 
     # This state is no longer used. Before the "uncoupled references" feature,

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -499,6 +499,13 @@ en:
         - candidate_mailer-new_offer_multiple_offers
         - candidate_mailer-new_offer_decisions_pending
 
+    recruited-confirm_conditions_met:
+      name: Provider confirms conditions are met
+      by: provider
+      description: The provider confirms that the candidate has met the conditions set out in the offer.
+      emails:
+        - candidate_mailer-conditions_met
+
     offer_withdrawn-make_offer:
       name: Provider makes offer
       by: provider

--- a/spec/services/provider_interface/save_condition_statuses_spec.rb
+++ b/spec/services/provider_interface/save_condition_statuses_spec.rb
@@ -54,8 +54,16 @@ RSpec.describe ProviderInterface::SaveConditionStatuses do
         end
 
         # rubocop:disable RSpec/NestedGroups
-        context 'when the application is not in the pending_conditions state' do
+        context 'when the application is in the recruited state' do
           let(:application_choice) { create(:application_choice, :recruited, offer:) }
+
+          it 'leaves the application in the recruited state' do
+            expect { service.save! }.not_to change(application_choice, :status)
+          end
+        end
+
+        context 'when the application is not in the pending_conditions or recruited state' do
+          let(:application_choice) { create(:application_choice, :offer, offer:) }
 
           it 'raises a Workflow::NoTransitionAllowed error' do
             expect { service.save! }.to raise_error(Workflow::NoTransitionAllowed)

--- a/spec/system/provider_interface/provider_can_recruit_with_pending_ske_condition_spec.rb
+++ b/spec/system/provider_interface/provider_can_recruit_with_pending_ske_condition_spec.rb
@@ -47,6 +47,16 @@ RSpec.feature 'Confirm conditions met' do
 
     when_i_log_in_as_the_candidate
     then_i_see_the_offer_page_with_a_message_about_pending_ske_conditions
+
+    when_i_sign_back_in_as_the_provider_and_open_application_choice
+    and_i_navigate_to_the_offer_tab
+    and_i_click_on_confirm_conditions
+    then_i_should_see_a_summary_of_the_conditions
+
+    when_i_change_the_status_of_the_ske_condition_to_met
+    and_confirm_all_conditions_met_on_the_next_page
+    and_i_navigate_to_the_offer_tab
+    then_i_see_application_is_recruited_with_all_conditions_met
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -109,6 +119,7 @@ RSpec.feature 'Confirm conditions met' do
   def when_i_click_on_confirm_conditions
     click_button 'Update status of conditions'
   end
+  alias_method :and_i_click_on_confirm_conditions, :when_i_click_on_confirm_conditions
 
   def when_i_click_recruit_with_pending_conditions
     click_button 'Recruit candidate with pending conditions'
@@ -127,6 +138,14 @@ RSpec.feature 'Confirm conditions met' do
       within_fieldset(condition.text) do
         choose 'Met'
       end
+    end
+
+    click_button t('continue')
+  end
+
+  def when_i_change_the_status_of_the_ske_condition_to_met
+    within_fieldset(@conditions.last.text) do
+      choose 'Met'
     end
 
     click_button t('continue')
@@ -200,5 +219,19 @@ RSpec.feature 'Confirm conditions met' do
   def then_i_see_the_offer_page_with_a_message_about_pending_ske_conditions
     visit '/'
     expect(page).to have_content('Remember to complete your subject knowledge enhancement course to meet the conditions of this offer.')
+  end
+
+  def when_i_sign_back_in_as_the_provider_and_open_application_choice
+    provider_signs_in_using_dfe_sign_in
+    visit provider_interface_application_choice_path(@application_choice)
+  end
+
+  def and_confirm_all_conditions_met_on_the_next_page
+    click_button 'Mark conditions as met and tell candidate'
+  end
+
+  def then_i_see_application_is_recruited_with_all_conditions_met
+    expect(page).to have_content('Recruited')
+    expect(page).not_to have_content('SKE conditions pending')
   end
 end


### PR DESCRIPTION
## Context

Previously the button to update condition statuses disappeared after a
candidate was recruited. Now that it's possible to have SKE conditions
still pending after recruitment we need to give providers the option to
update conditions post recruitment.

## Changes proposed in this pull request

This PR alters the test for displaying the _Update status of conditions_ link or button so that it appears if status is `recruited` and there are still pending conditions as well as if the status is `pending_conditions`.

Before:

![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/450843/8db0c41d-45cb-4dad-b120-1baf4c562aca)

After:

![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/450843/b505b265-3980-45ff-9673-14cd7e2f0c5f)

## Guidance to review

Is there anywhere else that this might be needed?

## Link to Trello card

Original card was:

https://trello.com/c/0V9VGfjL/6161-recruit-with-pending-conditions-button-on-manage

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
