### PR TITLE
Add the missing full stop

### DIFF
--- a/app/views/candidate_interface/safeguarding/_form.html.erb
+++ b/app/views/candidate_interface/safeguarding/_form.html.erb
@@ -15,7 +15,7 @@
 
 <p class="govuk-body">
   Not all convictions or police cautions on a criminal record will stop you from training to be a teacher.
-  <%= govuk_link_to 'Learn more about when you need to tell someone about your criminal record', t('govuk.safeguarding') %>
+  <%= govuk_link_to 'Learn more about when you need to tell someone about your criminal record', t('govuk.safeguarding') %>.
 </p>
 
 <p class="govuk-body">


### PR DESCRIPTION
## Context

Missing full stop on the safeguarding section.

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="655" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/7fa2282a-fa75-4294-9659-f6ca623b6695">|<img width="670" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/1f738064-b0c2-49c8-8e12-b4d2ce3e162a">|