### PR TITLE
Update candidate terms and conditions with 5 working day rule

### DIFF
--- a/app/views/content/terms_candidate.html.erb
+++ b/app/views/content/terms_candidate.html.erb
@@ -63,7 +63,7 @@
 
     <h3 class="govuk-heading-s">Making changes to your application</h3>
 
-    <p class="govuk-body">When you submit your first application, you will have 5 working days to email becomingateacher@digital.eduction.gov.uk to ask to make changes to:</p>
+    <p class="govuk-body">If you realise you have made a mistake after submitting your first application, you can email becomingateacher@digital.education.gov.uk to ask to make changes to some sections of your application. Our team will give you 5 working days to change:</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>your English, maths or science GCSE or equivalent qualifications</li>
@@ -75,7 +75,7 @@
       <li>safeguarding information</li>
     </ul>
 
-    <p class="govuk-body">Some sections are always editable after you have submitted your first application. You will not need to email us to make change to the following sections:</p>
+    <p class="govuk-body">Some sections are always editable after you have submitted your first application. You will not need to email us to make changes to the following sections:</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>Personal information</li>

--- a/app/views/content/terms_candidate.html.erb
+++ b/app/views/content/terms_candidate.html.erb
@@ -63,9 +63,19 @@
 
     <h3 class="govuk-heading-s">Making changes to your application</h3>
 
-    <p class="govuk-body">When you submit your first application, you will have 5 working days to make any changes to all the sections in the tab called ‘Your details’.</p>
+    <p class="govuk-body">When you submit your first application, you will have 5 working days to email becomingateacher@digital.eduction.gov.uk to ask to make changes to:</p>
 
-    <p class="govuk-body">After 5 working days from submitting your first application, you will only be able to make changes to:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>your English, maths or science GCSE or equivalent qualifications</li>
+      <li>your A levels and other qualifications</li>
+      <li>your degree</li>
+      <li>your work history</li>
+      <li>unpaid experience</li>
+      <li>your references</li>
+      <li>safeguarding information</li>
+    </ul>
+
+    <p class="govuk-body">Some sections are always editable after you have submitted your first application. You will not need to email us to make change to the following sections:</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>Personal information</li>
@@ -75,6 +85,8 @@
       <li>Interview availability</li>
       <li>Equality and diversity questions</li>
     </ul>
+
+    <p class="govuk-body">If you make changes to your application after submitting it, you should tell the training provider you applied to.</p>
 
     <h3 class="govuk-heading-s">Withdrawing your application</h3>
 

--- a/app/views/content/terms_candidate.html.erb
+++ b/app/views/content/terms_candidate.html.erb
@@ -63,7 +63,7 @@
 
     <h3 class="govuk-heading-s">Making changes to your application</h3>
 
-    <p class="govuk-body">When you submit your first application, you will have 5 working days to make any changes to all the sections in the tab called 'Your details'.</p>
+    <p class="govuk-body">When you submit your first application, you will have 5 working days to make any changes to all the sections in the tab called ‘Your details’.</p>
 
     <p class="govuk-body">After 5 working days from submitting your first application, you will only be able to make changes to:</p>
 

--- a/app/views/content/terms_candidate.html.erb
+++ b/app/views/content/terms_candidate.html.erb
@@ -63,8 +63,8 @@
 
     <h3 class="govuk-heading-s">Making changes to your application</h3>
 
-    <p class="govuk-body">After submitting your first application, you can email becomingateacher@digital.education.gov.uk to ask to make changes to some sections if you have made a mistake.</p>
-    <p class="govuk-body">Our team will give you 5 working days to change:</p>
+    <p class="govuk-body">After submitting your first application, you can email becomingateacher@digital.education.gov.uk within 5 working days to ask to make changes to some sections if you have made a mistake.</p>
+    <p class="govuk-body">You can ask for these sections to be changed:</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>your English, maths or science GCSE or equivalent qualifications</li>

--- a/app/views/content/terms_candidate.html.erb
+++ b/app/views/content/terms_candidate.html.erb
@@ -63,9 +63,9 @@
 
     <h3 class="govuk-heading-s">Making changes to your application</h3>
 
-    <p class="govuk-body">Once you submit an application, it is sent to the teacher training provider you applied to.</p>
+    <p class="govuk-body">When you submit your first application, you will have 5 working days to make any changes to all the sections in the tab called 'Your details'.</p>
 
-    <p class="govuk-body">You will be able to make changes to these details after you submit an application:</p>
+    <p class="govuk-body">After 5 working days from submitting your first application, you will only be able to make changes to:</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>Personal information</li>
@@ -74,14 +74,6 @@
       <li>Asking for support if you're disabled</li>
       <li>Interview availability</li>
       <li>Equality and diversity questions</li>
-    </ul>
-
-    <p class="govuk-body">You can contact us at becomingateacher@digital.education.gov.uk if you need to update information about:</p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>Qualifications</li>
-      <li>Work experience</li>
-      <li>Safeguarding</li>
     </ul>
 
     <h3 class="govuk-heading-s">Withdrawing your application</h3>

--- a/app/views/content/terms_candidate.html.erb
+++ b/app/views/content/terms_candidate.html.erb
@@ -63,8 +63,7 @@
 
     <h3 class="govuk-heading-s">Making changes to your application</h3>
 
-    <p class="govuk-body">If you make a mistake after submitting your first application, you can email becomingateacher@digital.education.gov.uk to ask to make changes to some sections of your application.</p>
-    
+    <p class="govuk-body">After submitting your first application, you can email becomingateacher@digital.education.gov.uk to ask to make changes to some sections if you have made a mistake.</p>
     <p class="govuk-body">Our team will give you 5 working days to change:</p>
 
     <ul class="govuk-list govuk-list--bullet">

--- a/app/views/content/terms_candidate.html.erb
+++ b/app/views/content/terms_candidate.html.erb
@@ -63,7 +63,9 @@
 
     <h3 class="govuk-heading-s">Making changes to your application</h3>
 
-    <p class="govuk-body">If you realise you have made a mistake after submitting your first application, you can email becomingateacher@digital.education.gov.uk to ask to make changes to some sections of your application. Our team will give you 5 working days to change:</p>
+    <p class="govuk-body">If you make a mistake after submitting your first application, you can email becomingateacher@digital.education.gov.uk to ask to make changes to some sections of your application.</p>
+    
+    <p class="govuk-body">Our team will give you 5 working days to change:</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>your English, maths or science GCSE or equivalent qualifications</li>


### PR DESCRIPTION
## Context

We have seen a huge amount of support tickets from candidates asking to update their applications once they haven submitted. while we investigate this issue properly, we've developed some interim fixes to help with the support burden. One of these is to allow candidates to edit their application within 5 working days of submitting their first application.

We need to update our Terms and Conditions to mention this.

## Changes proposed in this pull request

Edited the section in our candidate T&Cs under the header "Making changes to your application"

## Link to Trello card

[<!-- http://trello.com/123-example-card -->](https://trello.com/c/CCPhwAUW/870-ca-introduce-5-day-editable-window)

https://trello.com/c/2x99UFoH/871-update-candidate-terms-and-conditions-to-mention-5-working-day-rule-for-updating-applications

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
