### PR TITLE
Candidate can edit their applications up to 5 days after 1st submission

### DIFF
--- a/app/services/candidate_interface/section_policy.rb
+++ b/app/services/candidate_interface/section_policy.rb
@@ -26,7 +26,15 @@ module CandidateInterface
     end
 
     def can_edit?
-      any_offer_accepted? || all_applications_unsubmitted? || editable_section?
+      five_days_after_first_submission? ||
+        any_offer_accepted? ||
+        all_applications_unsubmitted? ||
+        editable_section?
+    end
+
+    def five_days_after_first_submission?
+      @current_application.submitted_at.present? &&
+        5.business_days.after(@current_application.submitted_at).end_of_day >= Time.zone.now
     end
 
     def personal_statement?

--- a/spec/services/candidate_interface/section_policy_spec.rb
+++ b/spec/services/candidate_interface/section_policy_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe CandidateInterface::SectionPolicy do
         end
       end
 
-      context 'when accessing an non editable section' do
+      context 'when accessing a future non editable section' do
         let(:controller_path) { 'some-non-editable/controller' }
 
         it 'returns true' do

--- a/spec/services/candidate_interface/section_policy_spec.rb
+++ b/spec/services/candidate_interface/section_policy_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe CandidateInterface::SectionPolicy do
       end
     end
 
-    context 'when candidate already submitted at least once' do
-      let(:application_form) { create(:application_form) }
+    context 'when candidate already submitted more than 5 working days ago' do
+      let(:current_application) { create(:application_form, submitted_at: 6.business_day.ago) }
 
       before do
         create(:application_choice, :awaiting_provider_decision, application_form: current_application)
@@ -45,8 +45,32 @@ RSpec.describe CandidateInterface::SectionPolicy do
       context 'when accessing an non editable section' do
         let(:controller_path) { 'some-non-editable/controller' }
 
-        it 'returns false' do
+        it 'returns true' do
           expect(section_policy.can_edit?).to be false
+        end
+      end
+    end
+
+    context 'when candidate submitted in the 5 working days window' do
+      let(:current_application) { create(:application_form, submitted_at: 1.day.ago) }
+
+      before do
+        create(:application_choice, :awaiting_provider_decision, application_form: current_application)
+      end
+
+      context 'when accessing an editable section' do
+        let(:controller_path) { 'candidate_interface/personal_details/review' }
+
+        it 'returns true' do
+          expect(section_policy.can_edit?).to be true
+        end
+      end
+
+      context 'when accessing an non editable section' do
+        let(:controller_path) { 'some-non-editable/controller' }
+
+        it 'returns true' do
+          expect(section_policy.can_edit?).to be true
         end
       end
     end

--- a/spec/services/candidate_interface/section_policy_spec.rb
+++ b/spec/services/candidate_interface/section_policy_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe CandidateInterface::SectionPolicy do
       context 'when accessing an non editable section' do
         let(:controller_path) { 'some-non-editable/controller' }
 
-        it 'returns true' do
+        it 'returns false' do
           expect(section_policy.can_edit?).to be false
         end
       end


### PR DESCRIPTION
## Context

Using the submitted_at date on an ApplicationForm we will allow edits to an application form by the candidate as long as it’s within a 5 day working window from the date of their first submission.

## Guidance to review

1. Does it work?
2. When editing after submission, is it possible to leave empty data on any section?

## Link to Trello card

https://trello.com/c/CCPhwAUW/870-ca-introduce-5-day-editable-window
