### PR TITLE
All interview activity log events rendered correctly

### DIFF
--- a/app/components/provider_interface/activity_log/interview.rb
+++ b/app/components/provider_interface/activity_log/interview.rb
@@ -11,7 +11,7 @@ module ProviderInterface
         return I18n.t('provider_interface.activity_log.interview.create', candidate:, user:) if event.audit.action == 'create'
         return I18n.t('provider_interface.activity_log.interview.cancelled_at', candidate:, user:) if event.audit.audited_changes.key?('cancelled_at')
 
-        I18n.t('provider_interface.activity_log.interview.edited', candidate:, user:)
+        I18n.t('provider_interface.activity_log.interview.updated', candidate:, user:)
       end
 
       def user

--- a/spec/components/provider_interface/activity_log_event_component_spec.rb
+++ b/spec/components/provider_interface/activity_log_event_component_spec.rb
@@ -43,16 +43,47 @@ RSpec.describe ProviderInterface::ActivityLogEventComponent do
   end
 
   describe '#event_description for an interview audit' do
-    it 'presents interview details' do
-      audit = build_stubbed(
-        :interview_audit,
-        audited_changes: {},
-        auditable: build_stubbed(:interview),
-        associated: build_stubbed(:application_choice),
-      )
+    context 'interview cancelled_at is changed' do
+      it 'presents interview details' do
+        audit = build_stubbed(
+          :interview_audit,
+          audited_changes: { 'cancelled_at' => [nil, Time.zone.now] },
+          action: 'updated',
+          auditable: build_stubbed(:interview),
+          associated: build_stubbed(:application_choice),
+        )
+        expected = "#{audit.user.full_name} cancelled interview with #{audit.associated.application_form.full_name}"
+        expect(component_for(audit).event_description).to eq(expected)
+      end
+    end
 
-      expected = "#{audit.user.full_name} set up an interview with #{audit.associated.application_form.full_name}"
-      expect(component_for(audit).event_description).to eq(expected)
+    context 'interview is updated' do
+      it 'presents interview details' do
+        audit = build_stubbed(
+          :interview_audit,
+          audited_changes: {},
+          action: 'updated',
+          auditable: build_stubbed(:interview),
+          associated: build_stubbed(:application_choice),
+        )
+
+        expected = "#{audit.user.full_name} updated interview with #{audit.associated.application_form.full_name}"
+        expect(component_for(audit).event_description).to eq(expected)
+      end
+    end
+
+    context 'interview is created' do
+      it 'presents interview details' do
+        audit = build_stubbed(
+          :interview_audit,
+          audited_changes: {},
+          auditable: build_stubbed(:interview),
+          associated: build_stubbed(:application_choice),
+        )
+
+        expected = "#{audit.user.full_name} set up an interview with #{audit.associated.application_form.full_name}"
+        expect(component_for(audit).event_description).to eq(expected)
+      end
     end
   end
 


### PR DESCRIPTION
## Context

Translation could not be found for Interview updated on ActivityLog

## Changes proposed in this pull request

use correct translation path and add specs for rendering each interview translation variation.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
