### PR TITLE
Validate every step of course selection journey

### DIFF
--- a/app/controllers/candidate_interface/continuous_applications/course_choices/concerns/duplicate_course_redirect.rb
+++ b/app/controllers/candidate_interface/continuous_applications/course_choices/concerns/duplicate_course_redirect.rb
@@ -1,0 +1,24 @@
+module CandidateInterface
+  module ContinuousApplications
+    module CourseChoices
+      module Concerns
+        module DuplicateCourseRedirect
+          extend ActiveSupport::Concern
+
+          included do
+            before_action :redirect_duplicate, only: %w[new] # rubocop:disable Rails/LexicallyScopedActionFilter
+          end
+
+        private
+
+          def redirect_duplicate
+            course = Course.find(params[:course_id])
+            return unless current_application.contains_course?(course)
+
+            redirect_to candidate_interface_continuous_applications_duplicate_course_selection_path(course.provider_id, course.id)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/candidate_interface/continuous_applications/course_choices/course_site_controller.rb
+++ b/app/controllers/candidate_interface/continuous_applications/course_choices/course_site_controller.rb
@@ -2,18 +2,12 @@ module CandidateInterface
   module ContinuousApplications
     module CourseChoices
       class CourseSiteController < BaseController
-        before_action :redirect_duplicate, only: %w[new] # rubocop:disable Rails/LexicallyScopedActionFilter
+        include Concerns::DuplicateCourseRedirect
 
       private
 
         def current_step
           :course_site
-        end
-
-        def redirect_duplicate
-          return unless current_application.contains_course?(Course.find(params[:course_id]))
-
-          redirect_to candidate_interface_continuous_applications_duplicate_course_selection_path(params[:provider_id], params[:course_id])
         end
       end
     end

--- a/app/controllers/candidate_interface/continuous_applications/course_choices/course_site_controller.rb
+++ b/app/controllers/candidate_interface/continuous_applications/course_choices/course_site_controller.rb
@@ -2,10 +2,18 @@ module CandidateInterface
   module ContinuousApplications
     module CourseChoices
       class CourseSiteController < BaseController
+        before_action :redirect_duplicate, only: %w[new] # rubocop:disable Rails/LexicallyScopedActionFilter
+
       private
 
         def current_step
           :course_site
+        end
+
+        def redirect_duplicate
+          return unless current_application.contains_course?(Course.find(params[:course_id]))
+
+          redirect_to candidate_interface_continuous_applications_duplicate_course_selection_path(params[:provider_id], params[:course_id])
         end
       end
     end

--- a/app/controllers/candidate_interface/continuous_applications/course_choices/course_study_mode_controller.rb
+++ b/app/controllers/candidate_interface/continuous_applications/course_choices/course_study_mode_controller.rb
@@ -2,6 +2,8 @@ module CandidateInterface
   module ContinuousApplications
     module CourseChoices
       class CourseStudyModeController < BaseController
+        before_action :redirect_duplicate, only: %w[new] # rubocop:disable Rails/LexicallyScopedActionFilter
+
       private
 
         def step_params
@@ -20,6 +22,12 @@ module CandidateInterface
 
         def current_step
           :course_study_mode
+        end
+
+        def redirect_duplicate
+          return unless current_application.contains_course?(Course.find(params[:course_id]))
+
+          redirect_to candidate_interface_continuous_applications_duplicate_course_selection_path(params[:provider_id], params[:course_id])
         end
       end
     end

--- a/app/controllers/candidate_interface/continuous_applications/course_choices/course_study_mode_controller.rb
+++ b/app/controllers/candidate_interface/continuous_applications/course_choices/course_study_mode_controller.rb
@@ -2,7 +2,7 @@ module CandidateInterface
   module ContinuousApplications
     module CourseChoices
       class CourseStudyModeController < BaseController
-        before_action :redirect_duplicate, only: %w[new] # rubocop:disable Rails/LexicallyScopedActionFilter
+        include Concerns::DuplicateCourseRedirect
 
       private
 
@@ -22,12 +22,6 @@ module CandidateInterface
 
         def current_step
           :course_study_mode
-        end
-
-        def redirect_duplicate
-          return unless current_application.contains_course?(Course.find(params[:course_id]))
-
-          redirect_to candidate_interface_continuous_applications_duplicate_course_selection_path(params[:provider_id], params[:course_id])
         end
       end
     end

--- a/app/controllers/candidate_interface/continuous_applications/course_choices/duplicate_course_selection_controller.rb
+++ b/app/controllers/candidate_interface/continuous_applications/course_choices/duplicate_course_selection_controller.rb
@@ -3,6 +3,7 @@ module CandidateInterface
     module CourseChoices
       class DuplicateCourseSelectionController < BaseController
         before_action :set_course
+        before_action :set_backlink, only: [:new] # rubocop:disable Rails/LexicallyScopedActionFilter
         skip_before_action :redirect_to_your_applications_if_maximum_amount_of_choices_have_been_used
 
       private
@@ -21,6 +22,10 @@ module CandidateInterface
 
         def set_course
           @course = Course.find(params[:course_id])
+        end
+
+        def set_backlink
+          @backlink = candidate_interface_continuous_applications_details_path if request.referer.blank?
         end
       end
     end

--- a/app/controllers/candidate_interface/continuous_applications/course_choices/duplicate_course_selection_controller.rb
+++ b/app/controllers/candidate_interface/continuous_applications/course_choices/duplicate_course_selection_controller.rb
@@ -25,7 +25,7 @@ module CandidateInterface
         end
 
         def set_backlink
-          @backlink = candidate_interface_continuous_applications_details_path if request.referer.blank?
+          @backlink = candidate_interface_continuous_applications_choices_path if request.referer.blank?
         end
       end
     end

--- a/app/controllers/candidate_interface/continuous_applications/course_choices/find_course_selection_controller.rb
+++ b/app/controllers/candidate_interface/continuous_applications/course_choices/find_course_selection_controller.rb
@@ -2,10 +2,19 @@ module CandidateInterface
   module ContinuousApplications
     module CourseChoices
       class FindCourseSelectionController < BaseController
+        before_action :redirect_duplicate, only: %w[new] # rubocop:disable Rails/LexicallyScopedActionFilter
+
       private
 
         def current_step
           :find_course_selection
+        end
+
+        def redirect_duplicate
+          course = Course.find(params[:course_id])
+          return unless current_application.contains_course?(course)
+
+          redirect_to candidate_interface_continuous_applications_duplicate_course_selection_path(course.provider_id, course.id)
         end
       end
     end

--- a/app/controllers/candidate_interface/continuous_applications/course_choices/find_course_selection_controller.rb
+++ b/app/controllers/candidate_interface/continuous_applications/course_choices/find_course_selection_controller.rb
@@ -2,19 +2,12 @@ module CandidateInterface
   module ContinuousApplications
     module CourseChoices
       class FindCourseSelectionController < BaseController
-        before_action :redirect_duplicate, only: %w[new] # rubocop:disable Rails/LexicallyScopedActionFilter
+        include Concerns::DuplicateCourseRedirect
 
       private
 
         def current_step
           :find_course_selection
-        end
-
-        def redirect_duplicate
-          course = Course.find(params[:course_id])
-          return unless current_application.contains_course?(course)
-
-          redirect_to candidate_interface_continuous_applications_duplicate_course_selection_path(course.provider_id, course.id)
         end
       end
     end

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -62,6 +62,7 @@ class ApplicationChoice < ApplicationRecord
   }, _prefix: :rejection_reasons_type
 
   scope :reappliable, -> { where(status: ApplicationStateChange.reapply_states) }
+  scope :not_reappliable, -> { where(status: ApplicationStateChange.non_reapply_states) }
   scope :decision_pending, -> { where(status: ApplicationStateChange::DECISION_PENDING_STATUSES) }
   scope :accepted, -> { where(status: ApplicationStateChange::ACCEPTED_STATES) }
 

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -61,6 +61,7 @@ class ApplicationChoice < ApplicationRecord
     vendor_api_rejection_reasons: 'vendor_api_rejection_reasons', # Rejection reasons via the Vendor API.
   }, _prefix: :rejection_reasons_type
 
+  scope :reappliable, -> { where(status: ApplicationStateChange.reapply_states) }
   scope :decision_pending, -> { where(status: ApplicationStateChange::DECISION_PENDING_STATUSES) }
   scope :accepted, -> { where(status: ApplicationStateChange::ACCEPTED_STATES) }
 

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -428,10 +428,11 @@ class ApplicationForm < ApplicationRecord
   end
 
   def contains_course?(course)
-    potential_course_option_ids = CourseOption.where(course_id: course.id).map(&:id)
-    current_course_option_ids = application_choices.where({ status: ApplicationStateChange::NON_REAPPLY_STATUSES }).pluck(:course_option_id)
-
-    potential_course_option_ids.intersect?(current_course_option_ids)
+    application_choices
+      .joins(:course_option)
+      .where(course_options: { course_id: course.id })
+      .where.not(status: ApplicationChoice.reappliable.select('status'))
+      .exists?
   end
 
   # The `english_main_language` and `english_language_details` database fields

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -430,9 +430,8 @@ class ApplicationForm < ApplicationRecord
   def contains_course?(course)
     application_choices
       .joins(:course_option)
-      .where(course_options: { course_id: course.id })
-      .where.not(status: ApplicationChoice.reappliable.select('status'))
-      .exists?
+      .not_reappliable
+      .exists?(course_options: { course_id: course.id })
   end
 
   # The `english_main_language` and `english_language_details` database fields

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -126,6 +126,10 @@ class ApplicationStateChange
     REAPPLY_STATUSES
   end
 
+  def self.non_reapply_states
+    NON_REAPPLY_STATUSES
+  end
+
   def self.valid_states
     workflow_spec.states.keys
   end

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -122,6 +122,10 @@ class ApplicationStateChange
     update_candidate_api_updated_at_if_application_forms_state_has_changed(previous_application_form_status, current_application_form_status)
   end
 
+  def self.reapply_states
+    REAPPLY_STATUSES
+  end
+
   def self.valid_states
     workflow_spec.states.keys
   end

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -13,7 +13,6 @@ class ApplicationStateChange
   DECISION_PENDING_STATUSES = %i[awaiting_provider_decision interviewing].freeze
   DECISION_PENDING_AND_INACTIVE_STATUSES = %i[awaiting_provider_decision interviewing inactive].freeze
 
-  NON_REAPPLY_STATUSES = %i[awaiting_provider_decision interviewing pending_conditions conditions_not_met recruited offer offer_deferred inactive unsubmitted].freeze
   REAPPLY_STATUSES = %i[rejected cancelled withdrawn declined offer_withdrawn].freeze
 
   TERMINAL_STATES = UNSUCCESSFUL_STATES + %i[recruited].freeze
@@ -122,16 +121,17 @@ class ApplicationStateChange
     update_candidate_api_updated_at_if_application_forms_state_has_changed(previous_application_form_status, current_application_form_status)
   end
 
+  # State Categories
+  def self.valid_states
+    workflow_spec.states.keys
+  end
+
   def self.reapply_states
     REAPPLY_STATUSES
   end
 
   def self.non_reapply_states
-    NON_REAPPLY_STATUSES
-  end
-
-  def self.valid_states
-    workflow_spec.states.keys
+    valid_states - REAPPLY_STATUSES
   end
 
   def self.states_visible_to_provider

--- a/app/validators/candidate_interface/continuous_applications/course_selection_validator.rb
+++ b/app/validators/candidate_interface/continuous_applications/course_selection_validator.rb
@@ -9,7 +9,7 @@ module CandidateInterface
         scope = record.wizard.current_application.application_choices.joins(:course_option)
         scope = omit_current_application_choice(scope, record) if editing?(record)
         exists = scope
-                  .where({ status: ApplicationStateChange::NON_REAPPLY_STATUSES })
+          .where({ status: ApplicationStateChange.non_reapply_states })
                   .exists?(course_option: { course_id: record.course.id })
 
         if exists

--- a/app/validators/reapply_validator.rb
+++ b/app/validators/reapply_validator.rb
@@ -25,7 +25,7 @@ class ReapplyValidator < ActiveModel::Validator
   end
 
   def restrict_to_reapply_statuses(scope)
-    scope.where({ status: ApplicationStateChange::NON_REAPPLY_STATUSES })
+    scope.where({ status: ApplicationStateChange.non_reapply_states })
   end
 
   def record_has_reapply_status?(record)

--- a/app/views/candidate_interface/continuous_applications/course_choices/duplicate_course_selection/new.html.erb
+++ b/app/views/candidate_interface/continuous_applications/course_choices/duplicate_course_selection/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix('Duplicate course chosen', false) %>
-<% content_for(:before_content, govuk_back_link_to(@wizard.previous_step_path)) %>
+<% content_for(:before_content, govuk_back_link_to(@backlink || @wizard.previous_step_path)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -24,19 +24,19 @@ RSpec.describe ApplicationChoice do
   end
 
   describe '.not_reappliable' do
-    it 'returns nothing when there are no records with status in NON_REAPPLY_STATUSES' do
-      (ApplicationStateChange.valid_states - ApplicationStateChange::NON_REAPPLY_STATUSES).each do |status|
+    it 'returns nothing when there are no records with status in non_reapply_states' do
+      (ApplicationStateChange.valid_states - ApplicationStateChange.non_reapply_states).each do |status|
         create(:application_choice, status:)
       end
 
       expect(described_class.not_reappliable).to be_empty
     end
 
-    it 'scopes to NON_REAPPLY_STATUSES choices' do
-      (ApplicationStateChange.valid_states - ApplicationStateChange::NON_REAPPLY_STATUSES).each do |state|
+    it 'scopes to non_reapply_states choices' do
+      (ApplicationStateChange.valid_states - ApplicationStateChange.non_reapply_states).each do |state|
         create(:application_choice, status: state)
       end
-      not_reappliable = ApplicationStateChange::NON_REAPPLY_STATUSES.map do |state|
+      not_reappliable = ApplicationStateChange.non_reapply_states.map do |state|
         create(:application_choice, status: state)
       end
 
@@ -45,8 +45,8 @@ RSpec.describe ApplicationChoice do
   end
 
   describe '.reappliable' do
-    it 'returns nothing when there are no records with status in NON_REAPPLY_STATUSES' do
-      ApplicationStateChange::NON_REAPPLY_STATUSES.each do |status|
+    it 'returns nothing when there are no records with status in non_reapply_states' do
+      ApplicationStateChange.non_reapply_states.each do |status|
         create(:application_choice, status:)
       end
 
@@ -242,7 +242,7 @@ RSpec.describe ApplicationChoice do
     let(:course_option) { create(:course_option) }
 
     context 'when the application is not in a reappliable state' do
-      ApplicationStateChange::NON_REAPPLY_STATUSES.each do |status|
+      ApplicationStateChange.non_reapply_states.each do |status|
         it "validates uniqueness of course option to form when status is '#{status}'" do
           create(:application_choice, application_form:, course_option:, status: status)
 

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -23,6 +23,27 @@ RSpec.describe ApplicationChoice do
     end
   end
 
+  describe '.not_reappliable' do
+    it 'returns nothing when there are no records with status in NON_REAPPLY_STATUSES' do
+      (ApplicationStateChange.valid_states - ApplicationStateChange::NON_REAPPLY_STATUSES).each do |status|
+        create(:application_choice, status:)
+      end
+
+      expect(described_class.not_reappliable).to be_empty
+    end
+
+    it 'scopes to NON_REAPPLY_STATUSES choices' do
+      (ApplicationStateChange.valid_states - ApplicationStateChange::NON_REAPPLY_STATUSES).each do |state|
+        create(:application_choice, status: state)
+      end
+      not_reappliable = ApplicationStateChange::NON_REAPPLY_STATUSES.map do |state|
+        create(:application_choice, status: state)
+      end
+
+      expect(described_class.not_reappliable.pluck(:status)).to match_array(not_reappliable.map(&:status))
+    end
+  end
+
   describe '.reappliable' do
     it 'returns nothing when there are no records with status in NON_REAPPLY_STATUSES' do
       ApplicationStateChange::NON_REAPPLY_STATUSES.each do |status|

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -1004,19 +1004,25 @@ RSpec.describe ApplicationForm do
 
   describe '#contains_course?' do
     let(:application_form) { create(:application_form) }
-    let(:course) { create(:course, :with_a_course_option) }
+    let(:course) { create(:course) }
+    let(:course_option_applied) { build(:course_option, course:) }
+    let(:course_option_not_applied) { build(:course_option, course:) }
 
-    context 'when the course exists but the candidate cannot reapply for it' do
-      it 'returns true' do
-        create(:application_choice, :awaiting_provider_decision, course:, application_form:)
-        expect(application_form.contains_course?(course)).to be true
+    context 'when the candidate cannot reapply for it' do
+      (ApplicationStateChange.valid_states - ApplicationStateChange.reapply_states).each do |status|
+        it "returns true when status is #{status}" do
+          create(:application_choice, status.to_sym, course_option: course_option_applied, application_form:)
+          expect(application_form.contains_course?(course)).to be true
+        end
       end
     end
 
-    context 'when the course exists but the candidate can reapply for it' do
-      it 'returns false' do
-        create(:application_choice, :rejected, course:, application_form:)
-        expect(application_form.contains_course?(course)).to be false
+    context 'when the candidate can reapply for it' do
+      ApplicationStateChange.reapply_states.each do |status|
+        it "returns false when the states is #{status}" do
+          create(:application_choice, status.to_sym, course:, application_form:)
+          expect(application_form.contains_course?(course)).to be false
+        end
       end
     end
   end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_visiting_selection_flow_for_selected_course_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_visiting_selection_flow_for_selected_course_spec.rb
@@ -17,6 +17,9 @@ RSpec.feature 'Selecting a course', :continuous_applications do
 
     when_i_click_the_back_link
     then_i_am_on_the_which_course_step
+
+    when_i_come_from_find_and_arrive_on_confirm_selection_page
+    then_i_am_redirected_to_the_duplicate_course_selection_step
   end
 
   def given_i_am_signed_in
@@ -60,5 +63,9 @@ RSpec.feature 'Selecting a course', :continuous_applications do
 
   def then_i_am_on_the_which_course_step
     expect(page).to have_current_path(candidate_interface_continuous_applications_which_course_are_you_applying_to_path(@course_one.provider.id))
+  end
+
+  def when_i_come_from_find_and_arrive_on_confirm_selection_page
+    visit candidate_interface_continuous_applications_course_confirm_selection_path(course_id: @course_one.id)
   end
 end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_visiting_selection_flow_for_selected_course_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_visiting_selection_flow_for_selected_course_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature 'Selecting a course', :continuous_applications do
     then_i_am_redirected_to_the_duplicate_course_selection_step
 
     when_i_click_the_back_link
-    then_i_am_on_details_page
+    then_i_am_on_my_applications_page
 
     when_i_come_from_find_and_arrive_on_confirm_selection_page
     then_i_am_redirected_to_the_duplicate_course_selection_step
@@ -60,8 +60,8 @@ RSpec.feature 'Selecting a course', :continuous_applications do
     click_link 'Back'
   end
 
-  def then_i_am_on_details_page
-    expect(page).to have_current_path(candidate_interface_continuous_applications_details_path)
+  def then_i_am_on_my_applications_page
+    expect(page).to have_current_path(candidate_interface_continuous_applications_choices_path)
   end
 
   def when_i_come_from_find_and_arrive_on_confirm_selection_page

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_visiting_selection_flow_for_selected_course_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_visiting_selection_flow_for_selected_course_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.feature 'Selecting a course', :continuous_applications do
+  include CandidateHelper
+
+  it 'Candidate selects a course they have already applied to when editing' do
+    given_i_am_signed_in
+    and_is_one_course_option_with_both_study_modes_and_two_sites
+    and_i_have_an_unsubmitted_applicaiton_to_the_course
+
+    when_i_visit_the_site
+    and_i_visit_the_study_mode_selection_for_my_existing_course_selection
+    then_i_am_redirected_to_the_duplicate_course_selection_step
+
+    when_i_visit_the_sites_selection_for_my_existing_course_selection
+    then_i_am_redirected_to_the_duplicate_course_selection_step
+
+    when_i_click_the_back_link
+    then_i_am_on_the_which_course_step
+  end
+
+  def given_i_am_signed_in
+    @candidate = create(:candidate)
+    create_and_sign_in_candidate(candidate: @candidate)
+  end
+
+  def and_is_one_course_option_with_both_study_modes_and_two_sites
+    provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
+
+    site = create(:site, provider:)
+    create(:site, provider:)
+    @course_one = create(:course, :open_on_apply, :with_both_study_modes, name: 'Primary', code: '2XT2', provider:)
+    create(:course_option, site:, course: @course_one, study_mode: :full_time)
+    create(:course_option, site:, course: @course_one, study_mode: :part_time)
+  end
+
+  def and_i_have_an_unsubmitted_applicaiton_to_the_course
+    @application_one = create(:application_choice, :unsubmitted, course_option: @course_one.course_options.first, application_form: @candidate.current_application)
+  end
+
+  def when_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def and_i_visit_the_study_mode_selection_for_my_existing_course_selection
+    visit candidate_interface_continuous_applications_course_study_mode_path(provider_id: @course_one.provider_id, course_id: @course_one.id)
+  end
+
+  def when_i_visit_the_sites_selection_for_my_existing_course_selection
+    visit candidate_interface_continuous_applications_course_site_path(provider_id: @course_one.provider_id, course_id: @course_one.id, study_mode: :full_time)
+  end
+
+  def then_i_am_redirected_to_the_duplicate_course_selection_step
+    expect(page).to have_current_path(candidate_interface_continuous_applications_duplicate_course_selection_path(@course_one.provider.id, @course_one.id))
+  end
+
+  def when_i_click_the_back_link
+    click_link 'Back'
+  end
+
+  def then_i_am_on_the_which_course_step
+    expect(page).to have_current_path(candidate_interface_continuous_applications_which_course_are_you_applying_to_path(@course_one.provider.id))
+  end
+end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_visiting_selection_flow_for_selected_course_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_visiting_selection_flow_for_selected_course_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature 'Selecting a course', :continuous_applications do
     then_i_am_redirected_to_the_duplicate_course_selection_step
 
     when_i_click_the_back_link
-    then_i_am_on_the_which_course_step
+    then_i_am_on_details_page
 
     when_i_come_from_find_and_arrive_on_confirm_selection_page
     then_i_am_redirected_to_the_duplicate_course_selection_step
@@ -61,8 +61,8 @@ RSpec.feature 'Selecting a course', :continuous_applications do
     click_link 'Back'
   end
 
-  def then_i_am_on_the_which_course_step
-    expect(page).to have_current_path(candidate_interface_continuous_applications_which_course_are_you_applying_to_path(@course_one.provider.id))
+  def then_i_am_on_details_page
+    expect(page).to have_current_path(candidate_interface_continuous_applications_details_path)
   end
 
   def when_i_come_from_find_and_arrive_on_confirm_selection_page

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_visiting_selection_flow_for_selected_course_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_visiting_selection_flow_for_selected_course_spec.rb
@@ -5,8 +5,8 @@ RSpec.feature 'Selecting a course', :continuous_applications do
 
   it 'Candidate is redirected when visiting later steps on a duplicate course selection' do
     given_i_am_signed_in
-    and_is_one_course_option_with_both_study_modes_and_two_sites
-    and_i_have_an_unsubmitted_applicaiton_to_the_course
+    and_there_is_one_course_option_with_both_study_modes_and_two_sites
+    and_i_have_an_unsubmitted_application_to_the_course
 
     when_i_visit_the_site
     and_i_visit_the_study_mode_selection_for_my_existing_course_selection
@@ -27,17 +27,16 @@ RSpec.feature 'Selecting a course', :continuous_applications do
     create_and_sign_in_candidate(candidate: @candidate)
   end
 
-  def and_is_one_course_option_with_both_study_modes_and_two_sites
+  def and_there_is_one_course_option_with_both_study_modes_and_two_sites
     provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
 
     site = create(:site, provider:)
-    create(:site, provider:)
     @course_one = create(:course, :open_on_apply, :with_both_study_modes, name: 'Primary', code: '2XT2', provider:)
     create(:course_option, site:, course: @course_one, study_mode: :full_time)
     create(:course_option, site:, course: @course_one, study_mode: :part_time)
   end
 
-  def and_i_have_an_unsubmitted_applicaiton_to_the_course
+  def and_i_have_an_unsubmitted_application_to_the_course
     @application_one = create(:application_choice, :unsubmitted, course_option: @course_one.course_options.first, application_form: @candidate.current_application)
   end
 

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_visiting_selection_flow_for_selected_course_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_visiting_selection_flow_for_selected_course_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Selecting a course', :continuous_applications do
   include CandidateHelper
 
-  it 'Candidate selects a course they have already applied to when editing' do
+  it 'Candidate is redirected when visiting later steps on a duplicate course selection' do
     given_i_am_signed_in
     and_is_one_course_option_with_both_study_modes_and_two_sites
     and_i_have_an_unsubmitted_applicaiton_to_the_course


### PR DESCRIPTION
## Context

A candidate goes through steps to build up a course selection.
First they pick a course, then full time / part time, then one of many sites to study at.

If the candidate has already an open application for the course, they should be prevented from continuing along the course selection journey.

The candidate cannot naturally access the later steps if they have an open application, but if they have bookmarked the path of the later steps, they can access the step, try to submit the form and they trigger an exception.

This happens on the study site selection step and the study mode selection step.
It can also occur when the candidate chooses a course on Find and arrives to the `FindCourseSelection` step.

This PR redirects the candidate to the details page on the study mode and site steps.

## Changes proposed in this pull request

Add `reapplyable` scope to `ApplicationChoice`.
Add `DuplicateCourseRedirect` concern that will check if the candidate can access the current step in the `CourseSelectionWizard` and redirect them to the DuplicateCourseSelection step.
Backlink on the DuplicateCourseStep targets `/candidate/application/details` if there is no referer.
## Guidance to review


### Review App
**Sign in as this candidate**
https://apply-review-8723.test.teacherservices.cloud/support/applications/41

**Choose Study Mode**
https://apply-review-8723.test.teacherservices.cloud/candidate/application/continuous-applications/provider/3/courses/70

**Choose Study Site**
https://apply-review-8723.test.teacherservices.cloud/candidate/application/continuous-applications/provider/3/courses/70/part_time

**Confirm selection from find**
https://apply-review-8723.test.teacherservices.cloud/candidate/application/continuous-applications/confirm-selection/70

## Link to Trello card

[Trello Ticket](https://trello.com/c/Yi203XWw/792-ca-validate-every-step-of-course-selection-journey)
