### PR TITLE
Group inactive applications under the correct section

### DIFF
--- a/app/components/provider_interface/application_status_tag_component.rb
+++ b/app/components/provider_interface/application_status_tag_component.rb
@@ -15,9 +15,9 @@ module ProviderInterface
       case status
       when 'unsubmitted', 'cancelled', 'application_not_sent'
         # will never be visible to the provider
-      when 'awaiting_provider_decision'
+      when 'awaiting_provider_decision', 'inactive'
         'purple'
-      when 'interviewing', 'offer_deferred', 'inactive'
+      when 'interviewing', 'offer_deferred'
         'yellow'
       when 'offer'
         'turquoise'

--- a/app/services/provider_interface/sort_application_choices.rb
+++ b/app/services/provider_interface/sort_application_choices.rb
@@ -81,7 +81,7 @@ module ProviderInterface
     def self.awaiting_provider_decision_non_urgent
       <<~AWAITING_PROVIDER_DECISION.squish
         (
-          status = 'awaiting_provider_decision'
+          (status = 'awaiting_provider_decision' OR status = 'inactive')
             AND (
               DATE(reject_by_default_at) >= DATE('#{pg_now}'::TIMESTAMPTZ)
             )

--- a/spec/services/provider_interface/sort_application_choices_spec.rb
+++ b/spec/services/provider_interface/sort_application_choices_spec.rb
@@ -69,9 +69,16 @@ RSpec.describe ProviderInterface::SortApplicationChoices, time: Time.zone.local(
       expect(application_choice.task_view_group).to eq(3)
     end
 
-    it '#awaiting_provider_decision_non_urgent' do
-      create(:application_choice, :awaiting_provider_decision, reject_by_default_at: 6.business_days.from_now)
-      expect(application_choice.task_view_group).to eq(4)
+    describe '#awaiting_provider_decision_non_urgent' do
+      it '.awaiting_provider_decision' do
+        create(:application_choice, :awaiting_provider_decision, reject_by_default_at: 6.business_days.from_now)
+        expect(application_choice.task_view_group).to eq(4)
+      end
+
+      it '.inactive' do
+        create(:application_choice, :inactive, reject_by_default_at: 6.business_days.from_now)
+        expect(application_choice.task_view_group).to eq(4)
+      end
     end
 
     it '#interviewing_non_urgent' do


### PR DESCRIPTION
Move the inactive applications to the correct section in the provider interface and update the colour of the tag.

![](https://github.trello.services/images/mini-trello-icon.png) [Manage: Group inactive applications under the correct section](https://trello.com/c/JBf3GZ5M/763-manage-group-inactive-applications-under-the-correct-section)

### Before:
<img width="662" alt="Screenshot 2023-10-25 at 21 02 08" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/c36bf41a-39cd-46b6-9ae2-dfa11d0c6461">

### After:
<img width="675" alt="Screenshot 2023-10-25 at 21 01 24" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/34eb1432-221d-425d-88b7-6e13087763e9">
