### PR TITLE
ProviderInterface shows sent_to_provider_at as submitted_at

### DIFF
--- a/app/components/provider_interface/application_summary_component.rb
+++ b/app/components/provider_interface/application_summary_component.rb
@@ -3,7 +3,6 @@ module ProviderInterface
     include ViewHelper
 
     delegate :support_reference,
-             :submitted_at,
              to: :application_form
 
     def initialize(application_choice:)
@@ -49,6 +48,10 @@ module ProviderInterface
         key: 'Application number',
         value: application_choice.id,
       }
+    end
+
+    def submitted_at
+      application_choice.sent_to_provider_at
     end
 
     def recruitment_cycle_year_name

--- a/spec/components/provider_interface/application_summary_component_spec.rb
+++ b/spec/components/provider_interface/application_summary_component_spec.rb
@@ -3,10 +3,16 @@ require 'rails_helper'
 RSpec.describe ProviderInterface::ApplicationSummaryComponent do
   describe '#rows' do
     let(:application_choice) { create(:application_choice, :with_completed_application_form) }
-    let(:expected) { { key: 'Application number', value: application_choice.id } }
+    let(:expected) do
+      [
+        { key: 'Application number', value: application_choice.id },
+        { key: 'Submitted', value: application_choice.sent_to_provider_at.to_fs(:govuk_date_and_time) },
+        { key: 'Recruitment cycle', value: RecruitmentCycle.cycle_string(application_choice.application_form.recruitment_cycle_year) },
+      ]
+    end
 
     subject { described_class.new(application_choice:).rows }
 
-    it { is_expected.to include(expected) }
+    it { is_expected.to match_array(expected) }
   end
 end


### PR DESCRIPTION
## Context

Provider interface needs to show the time an the application choice was submitted, rather than the time the candidates first application choice was submitted.

## Changes proposed in this pull request

Show the time an the application choice was submitted, rather than the time the candidates first application choice was submitted.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

[Trello Ticket](https://trello.com/c/2ASdD63q/879-render-senttoproviderat-value-instead-of-submittedat-value-in-manage-view)
