### PR TITLE
Remove notice to contact support on uneditable sections

### DIFF
--- a/app/components/candidate_interface/complete_section_component.html.erb
+++ b/app/components/candidate_interface/complete_section_component.html.erb
@@ -13,8 +13,4 @@
 
     <%= form.govuk_submit t('continue') %>
   <% end %>
-<% else %>
-  <div class="govuk-inset-text">
-    Contact <%= bat_contact_mail_to %> if you need to update this section.
-  </div>
 <% end %>

--- a/spec/system/candidate_interface/continuous_applications/entering_details/candidate_can_not_edit_some_sections_after_first_submission_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/entering_details/candidate_can_not_edit_some_sections_after_first_submission_spec.rb
@@ -69,8 +69,6 @@ RSpec.feature 'A candidate can not edit some sections after first submission', :
     expect(page).not_to have_content('Change')
     expect(page).not_to have_content('Any changes you make will be included in applications you’ve already submitted.')
     expect(page.all('button').map(&:text)).not_to include('Continue')
-
-    expect(page).to have_content('Contact becomingateacher@digital.education.gov.uk if you need to update this section.')
   end
 
   def and_i_can_not_edit_the_section


### PR DESCRIPTION
## Context

Too many support requests to edit unediteable sections. Removing the notice to contact support via email will help reduce the burden.


|Before|After|
|----|---|
|![Screenshot from 2023-10-26 14-24-53](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/e8e40b70-2231-4195-ba1a-d94517d31e2d)|![Screenshot from 2023-10-26 14-25-04](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/7df92414-c764-4192-979e-7a1f8cfe7340)|
## Changes proposed in this pull request

Remove html inset encouraging candidates to contact support.
## Link to Trello card

[Trello Ticket](https://trello.com/c/rcoJUgcY/873-remove-inset-text-about-telling-candidates-to-contact-support-to-edit-sections-of-the-application)
