### PR TITLE
Fix an issue with the sort order of inactive applications

### DIFF
--- a/app/services/provider_interface/sort_application_choices.rb
+++ b/app/services/provider_interface/sort_application_choices.rb
@@ -80,12 +80,7 @@ module ProviderInterface
 
     def self.awaiting_provider_decision_non_urgent
       <<~AWAITING_PROVIDER_DECISION.squish
-        (
-          (status = 'awaiting_provider_decision' OR status = 'inactive')
-            AND (
-              DATE(reject_by_default_at) >= DATE('#{pg_now}'::TIMESTAMPTZ)
-            )
-        )
+        (status = 'awaiting_provider_decision' OR status = 'inactive')
       AWAITING_PROVIDER_DECISION
     end
 

--- a/spec/services/provider_interface/sort_application_choices_spec.rb
+++ b/spec/services/provider_interface/sort_application_choices_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe ProviderInterface::SortApplicationChoices, time: Time.zone.local(
       end
 
       it '.inactive' do
-        create(:application_choice, :inactive, reject_by_default_at: 6.business_days.from_now)
+        create(:application_choice, :inactive, reject_by_default_at: 6.business_days.ago)
         expect(application_choice.task_view_group).to eq(4)
       end
     end


### PR DESCRIPTION
Inactive applications were appearing under the `No action needed` header instead of the `Received – make a decision` header. This was because it was ignoring the inactive choices with a `reject_by_default_at` date in the past.

![](https://github.trello.services/images/mini-trello-icon.png) [Manage: Group inactive applications under the correct section](https://trello.com/c/JBf3GZ5M/763-manage-group-inactive-applications-under-the-correct-section)

### Before:
<img width="669" alt="Screenshot 2023-10-26 at 16 19 08" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/a5c974a4-b2a3-4964-a4bd-c722c2c9f940">

### After:
<img width="687" alt="Screenshot 2023-10-26 at 16 38 12" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/caa95d9c-2b62-40cd-88ff-08db8d013366">
