### PR TITLE
Remove other build dates for now

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -195,7 +195,7 @@ jobs:
             integration_candidate,
           ]
         feature-flags: [on, off]
-        offset-date: [real_world, 7.days.from_now, '2023-10-04 09:00:00', '2023-10-11 09:00:00']
+        offset-date: [real_world]
         include:
           - tests: unit_shared
             include-pattern: spec/.*_spec.rb


### PR DESCRIPTION
## Context

The builds are taking 40 minutes. Removing the three groups are they are more useful towards the end of the cycle.