### PR TITLE
Fix english edit after submission

### DIFF
--- a/app/controllers/candidate_interface/gcse/english/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/english/grade_controller.rb
@@ -76,7 +76,7 @@ module CandidateInterface
     end
 
     def view_path(update_path: false)
-      if gcse_qualification? && application_not_submitted_yet?
+      if gcse_qualification?
         if update_path
           'candidate_interface/gcse/english/grade/multiple_gcse_edit'
         else
@@ -91,10 +91,6 @@ module CandidateInterface
 
     def gcse_qualification?
       gcse_english_qualification.qualification_type == 'gcse'
-    end
-
-    def application_not_submitted_yet?
-      @current_application.submitted_at.nil?
     end
 
     def gcse_english_qualification

--- a/spec/system/temporarily_editable_sections_spec.rb
+++ b/spec/system/temporarily_editable_sections_spec.rb
@@ -142,6 +142,21 @@ RSpec.feature 'Unlocking non editable sections temporarily via support', :contin
     expect(page).to have_content('BB')
     expect(page).to have_content('1988')
     expect(page).to have_content('Change qualification for UK O level (from before 1989), english')
+
+    click_link 'Change qualification for UK O level (from before 1989), english'
+    choose 'GCSE'
+    and_i_click_save_and_continue
+
+    expect(page).to have_content('English (Single award)')
+    check 'English (Single award)'
+    fill_in 'candidate_interface_english_gcse_grade_form[grade_english_single]', with: 'C'
+    and_i_click_save_and_continue
+    fill_in 'Year', with: '2022'
+    and_i_click_save_and_continue
+
+    expect(page).to have_content('Change qualification for GCSE, english')
+    expect(page).to have_content('GradeC (English Single award)')
+    expect(page).to have_content("Year awarded\n2022")
   end
 
   def when_the_editable_time_is_expired


### PR DESCRIPTION
## Context

There is a bug when editting the english GCSE after granted an extension. 

Ways to reproduce the bug:

1. Have GCSE in the application
2. Make editable English GCSE or equivalent
3. Switch to UK O level
4. Switch back to GCSE

Then we show single graded but we should show multiple grades for english GCSE.

## Guidance to review

1. Does it work?
2. Does it work changing all the types?

## Link to Trello card

https://trello.com/c/KKoYw49Y/888-fix-english-gcse-edit-after-submission-change-type

