### PR TITLE
Fix incorrect `Add a qualification` button rendering

### DIFF
--- a/app/components/candidate_interface/other_qualifications_review_component.html.erb
+++ b/app/components/candidate_interface/other_qualifications_review_component.html.erb
@@ -36,14 +36,16 @@
   <% elsif @submitting_application && application_form.other_qualifications_completed %>
     <%= render(SummaryCardComponent.new(rows: no_qualification_row, editable: @editable)) %>
   <% else %>
-    <%= govuk_inset_text(classes: 'govuk-!-width-two-thirds govuk-!-margin-top-0') do %>
-      <p class="govuk-body">Adding A levels and other qualifications makes your application stronger. They demonstrate subject knowledge not covered in your degree or work experience.</p>
-      <p class="govuk-body">Training providers usually ask you for them later in the process.</p>
+    <% if @editable %>
+      <%= govuk_inset_text(classes: 'govuk-!-width-two-thirds govuk-!-margin-top-0') do %>
+        <p class="govuk-body">Adding A levels and other qualifications makes your application stronger. They demonstrate subject knowledge not covered in your degree or work experience.</p>
+        <p class="govuk-body">Training providers usually ask you for them later in the process.</p>
 
-      <%= govuk_button_link_to t('application_form.other_qualification.first.button'),
-        candidate_interface_other_qualification_type_path,
-        secondary: true,
-        class: 'govuk-!-margin-bottom-0' %>
+        <%= govuk_button_link_to t('application_form.other_qualification.first.button'),
+          candidate_interface_other_qualification_type_path,
+          secondary: true,
+          class: 'govuk-!-margin-bottom-0' %>
+      <% end %>
     <% end %>
 
     <%= render(SummaryCardComponent.new(rows: no_qualification_row, editable: @editable)) %>

--- a/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
+++ b/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
@@ -229,5 +229,26 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
         Rails.application.routes.url_helpers.candidate_interface_other_qualification_type_path,
       )
     end
+
+    describe '`Add a qualification` button' do
+      let(:application_form) { create(:application_form) }
+      let(:result) { render_inline(described_class.new(application_form:, submitting_application: false, editable:)) }
+
+      context 'when the form is editable' do
+        let(:editable) { true }
+
+        it 'shows the `Add a qualification` button' do
+          expect(result.text).to include('Add a qualification')
+        end
+      end
+
+      context 'when the form is not editable' do
+        let(:editable) { false }
+
+        it 'shows the `Add a qualification` button' do
+          expect(result.text).not_to include('Add a qualification')
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Button was being displayed on submitted forms with the `I do not want to add any A levels and other qualifications` option selected.

![](https://github.trello.services/images/mini-trello-icon.png) [Bug: If you say you have don't want to add A levels, and submit an app, you have an add qualification button that redirects to the your details page](https://trello.com/c/4WhUUX15/839-bug-if-you-say-you-have-dont-want-to-add-a-levels-and-submit-an-app-you-have-an-add-qualification-button-that-redirects-to-the-y)

### Before:
<img width="864" alt="Screenshot 2023-10-27 at 14 32 06" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/93371e96-cac9-4af8-b021-ac3b8f880725">

### After:
<img width="836" alt="Screenshot 2023-10-27 at 14 31 53" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/cbca0529-8f2a-4474-ae90-4cc9f8ce6640">
