### PR TITLE
Withdraw inactive applications upon offer acceptance

### DIFF
--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -62,6 +62,7 @@ class ApplicationChoice < ApplicationRecord
   }, _prefix: :rejection_reasons_type
 
   scope :decision_pending, -> { where(status: ApplicationStateChange::DECISION_PENDING_STATUSES) }
+  scope :decision_pending_and_inactive, -> { where(status: ApplicationStateChange::DECISION_PENDING_AND_INACTIVE_STATUSES) }
   scope :accepted, -> { where(status: ApplicationStateChange::ACCEPTED_STATES) }
 
   delegate :continuous_applications?, to: :application_form

--- a/app/services/accept_offer.rb
+++ b/app/services/accept_offer.rb
@@ -54,7 +54,7 @@ protected
   def application_choices_awaiting_provider_decision
     application_choice
       .self_and_siblings
-      .decision_pending
+      .decision_pending_and_inactive
   end
 
   def references_completed

--- a/spec/services/accept_offer_spec.rb
+++ b/spec/services/accept_offer_spec.rb
@@ -105,11 +105,13 @@ RSpec.describe AcceptOffer do
       application_form = application_choice.application_form
       other_choice_awaiting_decision = create(:application_choice, :awaiting_provider_decision, application_form:)
       other_choice_interviewing = create(:application_choice, :interviewing, application_form:)
+      other_choice_inactive = create(:application_choice, :inactive, application_form:)
 
       described_class.new(application_choice:).save!
 
       expect(other_choice_awaiting_decision.reload.status).to eq('withdrawn')
       expect(other_choice_interviewing.reload.status).to eq('withdrawn')
+      expect(other_choice_inactive.reload.status).to eq('withdrawn')
     end
   end
 


### PR DESCRIPTION
Use a scope to include inactive applications with decision pending. Otherwise we could end up with a candidate who has accepted an offer, but could still receive another.

![](https://github.trello.services/images/mini-trello-icon.png) [Apply: Withdraw inactive applications upon offer acceptance](https://trello.com/c/1TiW3Dii/794-apply-withdraw-inactive-applications-upon-offer-acceptance)