### PR TITLE
Maths GCSE in support interface

### DIFF
--- a/app/forms/support_interface/math_gcse_form.rb
+++ b/app/forms/support_interface/math_gcse_form.rb
@@ -170,7 +170,6 @@ module SupportInterface
     def reset_other_uk_qualification_type
       @other_uk_qualification_type = nil unless other_uk_qualification?
     end
-    end
 
     def reset_non_uk_qualification_type
       if !non_uk_qualification?

--- a/app/forms/support_interface/math_gcse_form.rb
+++ b/app/forms/support_interface/math_gcse_form.rb
@@ -168,9 +168,8 @@ module SupportInterface
     end
 
     def reset_other_uk_qualification_type
-      if !other_uk_qualification?
-        @other_uk_qualification_type = nil
-      end
+      @other_uk_qualification_type = nil unless other_uk_qualification?
+    end
     end
 
     def reset_non_uk_qualification_type

--- a/app/forms/support_interface/math_gcse_form.rb
+++ b/app/forms/support_interface/math_gcse_form.rb
@@ -1,25 +1,201 @@
 module SupportInterface
   class MathGcseForm
+    GCSE = 'gcse'.freeze
+    OTHER_UK_QUALIFICATION_TYPE = 'other_uk'.freeze
+    NON_UK_QUALIFICATION_TYPE = 'non_uk'.freeze
+    MISSING_QUALIFICATION_TYPE = 'missing'.freeze
     include ActiveModel::Model
-    attr_accessor :application_form, :grade, :other_grade, :qualification_type, :qualification
+    attr_accessor :qualification,
+                  :application_form,
+                  :qualification_type,
+                  :subject,
+                  :other_uk_qualification_type,
+                  :non_uk_qualification_type,
+                  :enic_reference,
+                  :comparable_uk_qualification,
+                  :not_completed_explanation,
+                  :missing_explanation,
+                  :institution_country,
+                  :grade,
+                  :award_year,
+                  :audit_comment
+
+    attr_writer :currently_completing_qualification
+
+    validates :audit_comment, presence: true
+    validates_with ZendeskUrlValidator
+
+    validates :grade, presence: true, unless: :missing_qualification?
+    validates :award_year, presence: true, year: { future: true }, unless: :missing_qualification?
+    validates :award_year, o_level_award_year: true, unless: ->(c) { c.errors.attribute_names.include?(:award_year) }
+
+    validates :other_uk_qualification_type, presence: true, if: :other_uk_qualification?
+    validates :non_uk_qualification_type, presence: true, if: :non_uk_qualification?
+    validates :non_uk_qualification_type, :subject, :qualification_type, length: { maximum: ApplicationQualification::MAX_QUALIFICATION_TYPE_LENGTH }
+    validates :other_uk_qualification_type, length: { maximum: 100 }
+
+    validates :institution_country, presence: true, inclusion: { in: COUNTRIES_AND_TERRITORIES }, if: :non_uk_qualification?
+
+    validates :not_completed_explanation, presence: true, if: ->(record) { record.missing_qualification? && record.currently_completing_qualification? }
+    validates :not_completed_explanation, word_count: { maximum: 200 }
+    validate :validates_currently_completing_qualification, if: :missing_qualification?
 
     def self.build_from_qualification(qualification)
-      if qualification.qualification_type == 'non_uk'
-        new(
-          qualification:,
-          application_form: qualification.application_form,
-          grade: qualification.set_grade,
-          other_grade: qualification.set_other_grade,
-          qualification_type: qualification.qualification_type,
+      new(
+        qualification:,
+        application_form: qualification.application_form,
+        qualification_type: qualification.qualification_type,
+        subject: qualification.subject,
+        grade: qualification.grade,
+        award_year: qualification.award_year,
+        other_uk_qualification_type: qualification.other_uk_qualification_type,
+        non_uk_qualification_type: qualification.non_uk_qualification_type,
+        enic_reference: qualification.enic_reference,
+        comparable_uk_qualification: qualification.comparable_uk_qualification,
+        currently_completing_qualification: qualification.currently_completing_qualification,
+        not_completed_explanation: qualification.not_completed_explanation,
+        missing_explanation: qualification.missing_explanation,
+        institution_country: qualification.institution_country,
+      )
+    end
+
+    def assign_values(params)
+      @qualification_type = qualification.qualification_type = params[:qualification_type]
+      @grade = params[:grade]
+      @award_year = params[:award_year]
+      @other_uk_qualification_type = params[:other_uk_qualification_type]
+      @non_uk_qualification_type = params[:non_uk_qualification_type]
+      @enic_reference = params[:enic_reference]
+      @comparable_uk_qualification = params[:comparable_uk_qualification]
+      @currently_completing_qualification = params[:currently_completing_qualification]
+      @not_completed_explanation = params[:not_completed_explanation]
+      @missing_explanation = params[:missing_explanation]
+      @institution_country = params[:institution_country]
+      @audit_comment = params[:audit_comment]
+
+      reset_other_uk_qualification_type
+      reset_non_uk_qualification_type
+      reset_currently_completing_qualification
+    end
+
+    def save
+      return false unless valid?
+
+      update_gcse.tap do
+        reset_missing_and_not_completed_explanations!(qualification)
+      end
+    end
+
+    def update_gcse
+      if gcse?
+        qualification.update(
+          award_year:,
+          qualification_type:,
+          grade:,
+          other_uk_qualification_type: nil,
+          non_uk_qualification_type: nil,
+          enic_reference: nil,
+          comparable_uk_qualification: nil,
+          currently_completing_qualification: nil,
+          not_completed_explanation: nil,
+          missing_explanation: nil,
+        )
+      elsif missing_qualification?
+        qualification.update!(
+          qualification_type:,
+          currently_completing_qualification:,
+          not_completed_explanation:,
+          missing_explanation:,
+          grade: nil,
+          constituent_grades: nil,
+          award_year: nil,
+          institution_name: nil,
+          institution_country: nil,
+          other_uk_qualification_type: nil,
+          non_uk_qualification_type: nil,
+          enic_reference: nil,
+          comparable_uk_qualification: nil,
         )
       else
-        new(
-          qualification:,
-          application_form: qualification.application_form,
-          grade: qualification.grade,
-          qualification_type: qualification.qualification_type,
+        qualification.update(
+          grade:,
+          award_year:,
+          qualification_type:,
+          other_uk_qualification_type:,
+          non_uk_qualification_type:,
+          enic_reference:,
+          comparable_uk_qualification:,
+          institution_country:,
+          constituent_grades: nil,
+          currently_completing_qualification: nil,
+          not_completed_explanation: nil,
+          missing_explanation: nil,
         )
       end
+    end
+
+    def gcse?
+      qualification_type == GCSE
+    end
+
+    def missing_qualification?
+      qualification_type == MISSING_QUALIFICATION_TYPE
+    end
+
+    def currently_completing_qualification?
+      currently_completing_qualification.present?
+    end
+
+    def currently_completing_qualification
+      ActiveModel::Type::Boolean.new.cast(@currently_completing_qualification)
+    end
+
+    def non_uk_qualification?
+      qualification_type == NON_UK_QUALIFICATION_TYPE
+    end
+
+    def other_uk_qualification?
+      qualification_type == OTHER_UK_QUALIFICATION_TYPE
+    end
+
+    def validates_currently_completing_qualification
+      unless currently_completing_qualification.in? [true, false]
+        errors.add(
+          :currently_completing_qualification,
+          message: 'Choose an option if candidate is currently studying for a GCSE',
+        )
+      end
+    end
+
+    def reset_other_uk_qualification_type
+      if !other_uk_qualification?
+        @other_uk_qualification_type = nil
+      end
+    end
+
+    def reset_non_uk_qualification_type
+      if !non_uk_qualification?
+        @non_uk_qualification_type = nil
+        @enic_reference = nil
+        @comparable_uk_qualification = nil
+        @institution_country = nil
+      end
+    end
+
+    def reset_currently_completing_qualification
+      return unless missing_qualification?
+
+      if currently_completing_qualification?
+        @missing_explanation = nil
+      else
+        @not_completed_explanation = nil
+      end
+    end
+
+    def reset_missing_and_not_completed_explanations!(qualification)
+      return true unless qualification.pass_gcse?
+
+      qualification.update(missing_explanation: nil, not_completed_explanation: nil)
     end
   end
 end

--- a/app/views/support_interface/application_forms/gcses/edit.html.erb
+++ b/app/views/support_interface/application_forms/gcses/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, title_with_error_prefix('Edit GCSE grade', @gcse_form.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix('Edit GCSE', @gcse_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(@gcse_form.application_form)) %>
 
 <div class="govuk-grid-row">

--- a/app/views/support_interface/math_gcse_forms/_math_gcse_form.html.erb
+++ b/app/views/support_interface/math_gcse_forms/_math_gcse_form.html.erb
@@ -1,0 +1,48 @@
+<%= f.govuk_error_summary %>
+
+<h1 class="govuk-heading-l">Edit GCSE</h1>
+
+<%= f.govuk_radio_buttons_fieldset :qualification_type,
+  legend: { text: t('gcse_edit_type.page_titles.maths'), size: 'l' } do %>
+    <%= f.govuk_radio_button :qualification_type, :gcse, label: { text: t('application_form.gcse.qualification_types.gcse') } %>
+    <%= f.govuk_radio_button :qualification_type, :gce_o_level, label: { text: t('application_form.gcse.qualification_types.gce_o_level') } %>
+    <%= f.govuk_radio_button :qualification_type, :scottish_national_5, label: { text: t('application_form.gcse.qualification_types.scottish_national_5') } %>
+    <%= f.govuk_radio_button :qualification_type, :other_uk, label: { text: t('application_form.gcse.qualification_types.other_uk') } do %>
+      <% f.govuk_text_field :other_uk_qualification_type, label: { text: t('application_form.gcse.other_uk.label'), size: 's' } %>
+    <% end %>
+
+    <%= f.govuk_radio_divider %>
+
+    <%= f.govuk_radio_button :qualification_type, :non_uk, label: { text: t('application_form.gcse.qualification_types.non_uk') } do %>
+      <%= f.govuk_text_field :non_uk_qualification_type, label: { text: t('application_form.gcse.non_uk.label'), size: 's' }, hint: { text: t('application_form.gcse.non_uk.hint_text') } %>
+      <%= f.govuk_collection_select :institution_country, select_country_options, :id, :name, label: { text: t('gcse_edit_institution_country.page_title', subject: f.object.subject.capitalize) } %>
+      <%= f.govuk_text_field :enic_reference, label: { text: "#{t('service_name.enic.short_name')} reference number", size: 's' }, hint: { text: 'For example ‘4000228363’' }, width: 20, spellcheck: false %>
+      <%= f.govuk_radio_buttons_fieldset :comparable_uk_qualification, legend: { text: t('application_form.gcse.comparable_uk_qualification.label'), size: 's' }, hint: { text: t('application_form.gcse.comparable_uk_qualification.hint_text') } do %>
+        <%= f.govuk_radio_button :comparable_uk_qualification, t('application_form.gcse.comparable_uk_qualification.values.gcse'), label: { text: t('application_form.gcse.comparable_uk_qualification.values.gcse') }, link_errors: true %>
+        <%= f.govuk_radio_button :comparable_uk_qualification, t('application_form.gcse.comparable_uk_qualification.values.gcse_aslevel'), label: { text: t('application_form.gcse.comparable_uk_qualification.values.gcse_aslevel') } %>
+        <%= f.govuk_radio_button :comparable_uk_qualification, t('application_form.gcse.comparable_uk_qualification.values.aslevel_alevel'), label: { text: t('application_form.gcse.comparable_uk_qualification.values.aslevel_alevel') } %>
+        <%= f.govuk_radio_button :comparable_uk_qualification, t('application_form.gcse.comparable_uk_qualification.values.alevel'), label: { text: t('application_form.gcse.comparable_uk_qualification.values.alevel') } %>
+      <% end %>
+    <% end %>
+
+    <%= f.govuk_radio_divider %>
+
+    <%= f.govuk_radio_button :qualification_type, :missing, label: { text: t('application_form.gcse.qualification_types.missing', subject: capitalize_english(f.object.subject)) } do %>
+      <%= f.govuk_radio_buttons_fieldset :not_yet_completed, legend: { text: "Are you currently studying for a GCSE in #{capitalize_english(f.object.subject)}, or equivalent?" } do %>
+        <%= f.govuk_radio_button :currently_completing_qualification, true, label: { text: 'Yes' }, link_errors: true do %>
+              <%= f.govuk_text_area :not_completed_explanation, label: { text: 'Details of the qualification you’re studying for', size: 's' }, rows: 12, max_words: 200, threshold: 90 do %>
+              <% end %>
+        <% end %>
+        <%= f.govuk_radio_button :currently_completing_qualification, false, label: { text: 'No' } do %>
+          <%= f.govuk_text_area :missing_explanation, label: { text: "If you have other evidence of having #{capitalize_english(f.object.subject)} skills at the required standard, give details (optional)", size: 'm' }, rows: 12, max_words: 200, threshold: 90 %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+<%= f.govuk_text_field :grade, label: { text: t('application_form.gcse.grade.label'), size: 'm' }, hint: { text: t('gcse_edit_grade.hint.other.non_gcse') }, width: 4 %>
+<%= f.govuk_text_field :award_year, label: { text: 'Award year', size: 'm' }, width: 4 %>
+
+<%= f.govuk_text_field :audit_comment, label: { text: t('support_interface.audit_comment_ticket.label'), size: 'm' }, hint: { text: t('support_interface.audit_comment_ticket.hint') } %>
+
+<%= f.govuk_submit 'Update details' %>

--- a/app/views/support_interface/math_gcse_forms/_math_gcse_form.html.erb
+++ b/app/views/support_interface/math_gcse_forms/_math_gcse_form.html.erb
@@ -15,7 +15,7 @@
 
     <%= f.govuk_radio_button :qualification_type, :non_uk, label: { text: t('application_form.gcse.qualification_types.non_uk') } do %>
       <%= f.govuk_text_field :non_uk_qualification_type, label: { text: t('application_form.gcse.non_uk.label'), size: 's' }, hint: { text: t('application_form.gcse.non_uk.hint_text') } %>
-      <%= f.govuk_collection_select :institution_country, select_country_options, :id, :name, label: { text: t('gcse_edit_institution_country.page_title', subject: f.object.subject.capitalize) } %>
+      <%= f.govuk_collection_select :institution_country, select_country_options, :id, :name, label: { text: t('gcse_edit_institution_country.page_title', subject: f.object.subject.capitalize), size: 's' } %>
       <%= f.govuk_text_field :enic_reference, label: { text: "#{t('service_name.enic.short_name')} reference number", size: 's' }, hint: { text: 'For example ‘4000228363’' }, width: 20, spellcheck: false %>
       <%= f.govuk_radio_buttons_fieldset :comparable_uk_qualification, legend: { text: t('application_form.gcse.comparable_uk_qualification.label'), size: 's' }, hint: { text: t('application_form.gcse.comparable_uk_qualification.hint_text') } do %>
         <%= f.govuk_radio_button :comparable_uk_qualification, t('application_form.gcse.comparable_uk_qualification.values.gcse'), label: { text: t('application_form.gcse.comparable_uk_qualification.values.gcse') }, link_errors: true %>

--- a/config/locales/support_interface/gcse.yml
+++ b/config/locales/support_interface/gcse.yml
@@ -36,6 +36,27 @@ en:
               in_future: Enter a year before %{date}
             other_grade:
               blank: Enter your grade
+        support_interface/math_gcse_form:
+          attributes:
+            grade:
+              blank: Enter your grade
+              invalid: Enter a real grade
+            award_year:
+              blank: Enter the year you gained your qualification
+              gce_o_level_in_future: Enter a year before %{date} - GSCEs replaced O levels in 1988
+            other_uk_qualification_type:
+              blank: Enter qualification name
+              too_long: Type of degree must be %{count} characters or fewer
+            not_completed_explanation:
+              blank: Enter details of the qualification you’re studying for
+              too_many_words: Qualification details must be %{maximum} words or less
+            audit_comment:
+              blank: You must provide an audit comment
+            non_uk_qualification_type:
+              blank: Enter qualification name
+            institution_country:
+              blank: Enter the country or territory you studied in
+              inclusion: Select the country or territory you studied in from the list
         support_interface/english_gcse_form:
           attributes:
             grade:

--- a/spec/system/support_interface/change_maths_gcse_spec.rb
+++ b/spec/system/support_interface/change_maths_gcse_spec.rb
@@ -1,0 +1,360 @@
+require 'rails_helper'
+
+RSpec.feature 'Change maths GCSE' do
+  include DfESignInHelpers
+
+  scenario 'Change the maths GCSE on an application form', :with_audited do
+    given_i_am_a_support_user
+    and_there_is_an_application_choice_awaiting_provider_decision
+
+    when_i_visit_the_application_page
+    and_i_click_to_change_my_maths_gcse
+
+    and_i_choose_no_qualification
+    and_i_click_update
+    then_i_see_a_validation_error_about_no_qualification
+
+    and_i_added_that_candidate_is_currently_studying_for_the_gcse
+    and_i_click_update
+    then_i_see_a_validation_error_to_enter_details
+
+    when_i_added_the_details_of_the_qualification
+    and_i_add_the_zendesk_ticket_url
+    and_i_click_update
+    then_it_should_save_missing_qualification_into_the_application_form
+
+    and_i_click_to_change_my_maths_gcse
+    and_i_add_the_candidate_is_not_studying_for_gcse
+    and_i_add_the_zendesk_ticket_url
+    and_i_click_update
+    then_it_should_save_missing_qualification_with_missing_explanation_into_the_application_form
+
+    and_i_click_to_change_my_maths_gcse
+    when_i_choose_uk_o_level
+    and_i_click_update
+    then_i_see_a_validation_error_about_uk_o_level
+
+    when_i_add_an_award_year_greater_than_1988
+    and_i_click_update
+    then_i_see_a_validation_error_about_uk_o_level_award_year
+
+    when_i_add_all_details_for_uk_o_level
+    and_i_click_update
+    then_it_should_save_uk_o_level_into_the_application_form
+
+    and_i_click_to_change_my_maths_gcse
+    and_i_choose_scottish_national_gcse
+    and_i_click_update
+    then_i_see_a_validation_error_about_scottish_national_gcse
+
+    when_i_add_all_details_for_scottish_national_gcse
+    and_i_click_update
+    then_it_should_save_scottish_national_gcse_into_the_application_form
+
+    and_i_click_to_change_my_maths_gcse
+    and_i_choose_non_uk_gcse
+    and_i_click_update
+    then_i_see_a_validation_error_about_non_uk_gcse
+
+    and_i_add_all_details_for_non_uk_gcse
+    and_i_click_update
+    then_it_should_save_non_uk_gcse_into_the_application_form
+
+    and_i_click_to_change_my_maths_gcse
+    and_i_choose_another_uk_qualification
+    and_i_click_update
+    then_i_see_a_validation_error_about_another_uk_qualification
+
+    and_i_add_all_details_for_another_uk_qualification
+    and_i_click_update
+    then_it_should_save_another_uk_qualification_into_the_application_form
+
+    and_i_click_to_change_my_maths_gcse
+    and_i_choose_gcse
+    and_i_click_update
+    then_i_see_a_validation_error_about_gcse
+
+    and_i_add_the_zendesk_ticket_url
+    and_i_click_update
+
+    then_it_should_save_gcses_into_the_application_form
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_is_an_application_choice_awaiting_provider_decision
+    @application_form = create(
+      :application_form,
+      submitted_at: Time.zone.now,
+    )
+    @maths_gcse = create(:gcse_qualification, subject: 'maths', application_form: @application_form)
+
+    @application_choice = create(
+      :application_choice,
+      :awaiting_provider_decision,
+      application_form: @application_form,
+    )
+  end
+
+  def when_i_visit_the_application_page
+    visit support_interface_application_form_path(@application_choice.application_form_id)
+  end
+
+  def then_i_see_a_change_maths_link
+    expect(page).to have_link('Change')
+  end
+
+  def and_i_click_to_change_my_maths_gcse
+    within('.app-edit-qualification') do
+      click_link 'Change'
+    end
+  end
+  alias_method :when_i_click_to_change_my_maths_gcse, :and_i_click_to_change_my_maths_gcse
+
+  def when_i_click_update
+    click_button 'Update details'
+  end
+  alias_method :and_i_click_update, :when_i_click_update
+
+  def when_i_choose_uk_o_level
+    choose 'UK O level (from before 1989)'
+  end
+
+  def and_i_choose_no_qualification
+    choose 'I do not have a qualification in maths yet'
+  end
+
+  def then_i_see_a_validation_error_about_no_qualification
+    expect(page).to have_content('Choose an option if candidate is currently studying for a GCSE')
+  end
+
+  def and_i_added_that_candidate_is_currently_studying_for_the_gcse
+    choose 'Yes'
+  end
+
+  def then_i_see_a_validation_error_about_uk_o_level
+    expect(page).to have_content('You must provide an audit comment')
+    expect(page).to have_content('Enter your grade')
+  end
+
+  def then_i_see_a_validation_error_about_scottish_national_gcse
+    expect(page).to have_content('You must provide an audit comment')
+    expect(page).to have_content('Enter your grade')
+    expect(page).to have_content('Enter the year you gained your qualification')
+  end
+
+  def when_i_add_an_award_year_greater_than_1988
+    fill_in 'Award year', with: '1989'
+  end
+
+  def then_i_see_a_validation_error_about_uk_o_level_award_year
+    expect(page).to have_content('Enter a year before 1989 - GSCEs replaced O levels in 1988')
+  end
+
+  def then_i_see_a_validation_error_to_enter_details
+    expect(page).to have_content('Enter details of the qualification you’re studying for')
+  end
+
+  def and_i_choose_scottish_national_gcse
+    choose 'Scottish National 5'
+    fill_in 'support_interface_gcse_form[grade]', with: ''
+    fill_in 'Award year', with: ''
+  end
+
+  def when_i_add_all_details_for_scottish_national_gcse
+    fill_in 'support_interface_gcse_form[grade]', with: 'CD'
+    fill_in 'Award year', with: '2021'
+    and_i_add_the_zendesk_ticket_url
+  end
+
+  def when_i_add_all_details_for_uk_o_level
+    fill_in 'Grade', with: 'A'
+    fill_in 'Award year', with: '1988'
+    and_i_add_the_zendesk_ticket_url
+  end
+
+  def and_i_add_the_zendesk_ticket_url
+    fill_in 'Zendesk ticket URL', with: 'https://becomingateacher.zendesk.com/agent/tickets/12345'
+  end
+
+  def when_i_added_the_details_of_the_qualification
+    fill_in 'Details of the qualification you’re studying for', with: 'I am studying'
+  end
+
+  def and_i_add_the_candidate_is_not_studying_for_gcse
+    choose 'No'
+    fill_in 'If you have other evidence of having maths skills at the required standard, give details (optional)', with: 'Many reasons listed'
+  end
+
+  def and_i_choose_non_uk_gcse
+    choose 'Qualification from outside the UK'
+  end
+
+  def and_i_choose_another_uk_qualification
+    choose 'Another UK qualification'
+  end
+
+  def and_i_choose_gcse
+    choose 'GCSE'
+  end
+
+  def then_i_see_a_validation_error_about_non_uk_gcse
+    expect(page).to have_content('You must provide an audit comment')
+    expect(page).to have_content('Enter qualification name')
+  end
+  alias_method :then_i_see_a_validation_error_about_another_uk_qualification, :then_i_see_a_validation_error_about_non_uk_gcse
+
+  def when_i_add_the_grades
+    fill_in 'support_interface_gcse_form[grade_maths_single]', with: '4'
+    fill_in 'support_interface_gcse_form[grade_maths_double]', with: '1-1'
+    fill_in 'support_interface_gcse_form[grade_maths_language]', with: 'A'
+    fill_in 'support_interface_gcse_form[grade_maths_literature]', with: 'B'
+    fill_in 'support_interface_gcse_form[grade_maths_studies_single]', with: 'C'
+    fill_in 'support_interface_gcse_form[grade_maths_studies_double]', with: 'A*A'
+    fill_in 'support_interface_gcse_form[other_maths_gcse_name]', with: 'Awesome name'
+    fill_in 'support_interface_gcse_form[grade_other_maths_gcse]', with: '3'
+    and_i_add_the_zendesk_ticket_url
+  end
+
+  def then_i_see_a_validation_error_about_gcse_grades
+    expect(page).to have_content('Enter your English (Single award) grade')
+    expect(page).to have_content('Enter your English (Double award) grade')
+  end
+
+  def then_i_see_a_validation_error_about_gcse
+    expect(page).to have_content('You must provide an audit comment')
+  end
+
+  def and_i_add_all_details_for_non_uk_gcse
+    fill_in 'support_interface_gcse_form[non_uk_qualification_type]', with: 'Higher Secondary School Certificate'
+    select 'Brazil', from: 'support_interface_gcse_form[institution_country]'
+    fill_in 'UK ENIC reference number', with: '4000228363'
+    choose 'GCE Advanced (A) level'
+    and_i_add_the_zendesk_ticket_url
+  end
+
+  def and_i_add_all_details_for_another_uk_qualification
+    fill_in 'support_interface_gcse_form[other_uk_qualification_type]', with: 'Other UK qualification'
+    fill_in 'support_interface_gcse_form[grade]', with: 'D'
+    fill_in 'Award year', with: '2022'
+    and_i_add_the_zendesk_ticket_url
+  end
+
+  def then_it_should_save_missing_qualification_into_the_application_form
+    expect(page).to have_content('GCSE updated')
+
+    expect(page).to have_current_path(support_interface_application_form_path(@application_form))
+
+    @maths_gcse.reload
+    expect(@maths_gcse.attributes.symbolize_keys).to include(
+      qualification_type: 'missing',
+      not_completed_explanation: 'I am studying',
+      currently_completing_qualification: true,
+      missing_explanation: nil,
+      grade: nil,
+      constituent_grades: nil,
+      award_year: nil,
+      institution_name: nil,
+      institution_country: nil,
+      other_uk_qualification_type: nil,
+      non_uk_qualification_type: nil,
+      enic_reference: nil,
+      comparable_uk_qualification: nil,
+    )
+  end
+
+  def then_it_should_save_missing_qualification_with_missing_explanation_into_the_application_form
+    expect(page).to have_content('GCSE updated')
+
+    @maths_gcse.reload
+
+    expect(@maths_gcse.attributes.symbolize_keys).to include(
+      qualification_type: 'missing',
+      currently_completing_qualification: false,
+      missing_explanation: 'Many reasons listed',
+      not_completed_explanation: nil,
+      grade: nil,
+      constituent_grades: nil,
+      award_year: nil,
+      institution_name: nil,
+      institution_country: nil,
+      other_uk_qualification_type: nil,
+      non_uk_qualification_type: nil,
+      enic_reference: nil,
+      comparable_uk_qualification: nil,
+    )
+  end
+
+  def then_it_should_save_uk_o_level_into_the_application_form
+    expect(page).to have_content('GCSE updated')
+
+    @maths_gcse.reload
+    expect(@maths_gcse.attributes.symbolize_keys).to include(
+      qualification_type: 'gce_o_level',
+      award_year: '1988',
+      grade: 'A',
+      not_completed_explanation: nil,
+      currently_completing_qualification: nil,
+      missing_explanation: nil,
+    )
+  end
+
+  def then_it_should_save_scottish_national_gcse_into_the_application_form
+    expect(page).to have_content('GCSE updated')
+
+    @maths_gcse.reload
+    expect(@maths_gcse.attributes.symbolize_keys).to include(
+      qualification_type: 'scottish_national_5',
+      award_year: '2021',
+      grade: 'CD',
+      not_completed_explanation: nil,
+      currently_completing_qualification: nil,
+      missing_explanation: nil,
+    )
+  end
+
+  def then_it_should_save_non_uk_gcse_into_the_application_form
+    expect(page).to have_content('GCSE updated')
+
+    @maths_gcse.reload
+    expect(@maths_gcse.attributes.symbolize_keys).to include(
+      qualification_type: 'non_uk',
+      non_uk_qualification_type: 'Higher Secondary School Certificate',
+      comparable_uk_qualification: 'GCE Advanced (A) level',
+      enic_reference: '4000228363',
+      institution_country: 'BR',
+    )
+  end
+
+  def then_it_should_save_another_uk_qualification_into_the_application_form
+    expect(page).to have_content('GCSE updated')
+
+    @maths_gcse.reload
+    expect(@maths_gcse.attributes.symbolize_keys).to include(
+      qualification_type: 'other_uk',
+      grade: 'D',
+      other_uk_qualification_type: 'Other UK qualification',
+      non_uk_qualification_type: nil,
+      comparable_uk_qualification: nil,
+      enic_reference: nil,
+      institution_country: nil,
+    )
+  end
+
+  def then_it_should_save_gcses_into_the_application_form
+    expect(page).to have_content('GCSE updated')
+
+    @maths_gcse.reload
+    expect(@maths_gcse.attributes.symbolize_keys).to include(
+      qualification_type: 'gcse',
+      grade: 'D',
+      other_uk_qualification_type: nil,
+      non_uk_qualification_type: nil,
+      comparable_uk_qualification: nil,
+      enic_reference: nil,
+      institution_country: nil,
+    )
+  end
+end


### PR DESCRIPTION
## Context

This enables Maths GCSE edit into support UI.

## Changes proposed in this pull request

![screencapture-localhost-3000-support-applications-719-gcses-2085-edit-2023-11-01-15_34_37](https://github.com/DFE-Digital/apply-for-teacher-training/assets/27509/de2d6eb3-6bb0-4345-a62f-fd199513e090)


## Guidance to review

1. Does it work?

## Link to Trello card

https://trello.com/c/rnhWVd0w/837-support-edit-gcses-functionality
