### PR TITLE
The immigration_route field is not used anymore, so we can remove it.

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -105,11 +105,6 @@ class ApplicationForm < ApplicationRecord
     decide_later: 'decide_later',
   }, _prefix: true
 
-  enum immigration_route: {
-    visa_sponsored_by_provider: 'visa_sponsored_by_provider',
-    other_route: 'other_route',
-  }
-
   enum immigration_status: {
     eu_settled: 'eu_settled',
     eu_pre_settled: 'eu_pre_settled',

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -38,7 +38,6 @@
     - address_type
     - latitude
     - longitude
-    - immigration_route
     - feedback_form_complete
   :authentication_tokens:
     - id


### PR DESCRIPTION
It got migrated out of the database in 2022. Please let me know if this is not correct.