### PR TITLE
Redirect withdraw pages for withdrawn applications

### DIFF
--- a/app/controllers/provider_interface/decline_or_withdraw_controller.rb
+++ b/app/controllers/provider_interface/decline_or_withdraw_controller.rb
@@ -3,6 +3,7 @@ module ProviderInterface
     before_action :render_404_unless_feature_flag_active
     before_action :set_application_choice
     before_action :requires_make_decisions_permission
+    before_action :redirect_to_application_choice_if_not_withdrawable_or_declinable
 
     def edit
       @interview_cancellation_presenter = InterviewCancellationExplanationPresenter.new(@application_choice)
@@ -25,6 +26,16 @@ module ProviderInterface
 
     def render_404_unless_feature_flag_active
       render_404 unless FeatureFlag.active?(:withdraw_at_candidates_request)
+    end
+
+    def redirect_to_application_choice_if_not_withdrawable_or_declinable
+      return if withdrawable_or_declinable?
+
+      redirect_to provider_interface_application_choice_path(@application_choice)
+    end
+
+    def withdrawable_or_declinable?
+      @application_choice.offer? || ApplicationStateChange.new(@application_choice).can_withdraw?
     end
   end
 end

--- a/spec/system/provider_interface/withdraw_an_application_at_candidates_request_spec.rb
+++ b/spec/system/provider_interface/withdraw_an_application_at_candidates_request_spec.rb
@@ -20,6 +20,9 @@ RSpec.describe "withdrawing an application at the candidate's request", type: :f
     and_i_can_no_longer_see_the_withdraw_at_candidates_request_link
     and_the_candidate_receives_an_email_about_the_withdrawal
     and_the_interview_has_been_cancelled
+
+    when_i_visit_the_decline_or_withdraw_page
+    then_i_get_redirected_to_the_application_choice
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -67,6 +70,7 @@ RSpec.describe "withdrawing an application at the candidate's request", type: :f
     expect(page).to have_current_path(provider_interface_application_choice_path(@application_choice))
     expect(page).to have_content('Application withdrawn')
   end
+  alias_method :then_i_get_redirected_to_the_application_choice, :then_i_see_a_message_confirming_that_the_application_has_been_withdrawn
 
   def and_i_can_no_longer_see_the_withdraw_at_candidates_request_link
     expect(page).not_to have_link 'Withdraw at candidate’s request'
@@ -84,5 +88,9 @@ RSpec.describe "withdrawing an application at the candidate's request", type: :f
 
   def and_the_interview_has_been_cancelled
     expect(@interview.reload.cancelled_at).not_to be_nil
+  end
+
+  def when_i_visit_the_decline_or_withdraw_page
+    visit provider_interface_decline_or_withdraw_edit_path(@application_choice)
   end
 end


### PR DESCRIPTION
This was causing an issue where the provider could access the `decline-or-withdraw` pages for a withdrawn application, and then get an error when trying to withdraw it.

Fixes: https://dfe-teacher-services.sentry.io/issues/4280428777/

![](https://github.trello.services/images/mini-trello-icon.png) [[BUG] Provider can access the withdraw/decline page after the application has been withdrawn.](https://trello.com/c/6DbIZwqk/899-bug-provider-can-access-the-withdraw-decline-page-after-the-application-has-been-withdrawn)