### PR TITLE
Prevent candidates from reapplying to the same course multiple times

### DIFF
--- a/app/controllers/candidate_interface/continuous_applications/course_choices/reached_reapplication_limit_controller.rb
+++ b/app/controllers/candidate_interface/continuous_applications/course_choices/reached_reapplication_limit_controller.rb
@@ -1,0 +1,33 @@
+module CandidateInterface
+  module ContinuousApplications
+    module CourseChoices
+      class ReachedReapplicationLimitController < BaseController
+        before_action :set_course
+        before_action :set_backlink, only: [:new] # rubocop:disable Rails/LexicallyScopedActionFilter
+        skip_before_action :redirect_to_your_applications_if_maximum_amount_of_choices_have_been_used
+
+      private
+
+        def step_params
+          params[current_step] = {
+            provider_id: params.delete(:provider_id),
+            course_id: params.delete(:course_id),
+          }
+          params
+        end
+
+        def current_step
+          :reached_reapplication_limit
+        end
+
+        def set_course
+          @course = Course.find(params[:course_id])
+        end
+
+        def set_backlink
+          @backlink = candidate_interface_continuous_applications_choices_path if request.referer.blank?
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/candidate_interface/continuous_applications/course_choices/reached_reapplication_limit_controller.rb
+++ b/app/controllers/candidate_interface/continuous_applications/course_choices/reached_reapplication_limit_controller.rb
@@ -3,7 +3,6 @@ module CandidateInterface
     module CourseChoices
       class ReachedReapplicationLimitController < BaseController
         before_action :set_course
-        before_action :set_backlink, only: [:new] # rubocop:disable Rails/LexicallyScopedActionFilter
         skip_before_action :redirect_to_your_applications_if_maximum_amount_of_choices_have_been_used
 
       private
@@ -22,10 +21,6 @@ module CandidateInterface
 
         def set_course
           @course = Course.find(params[:course_id])
-        end
-
-        def set_backlink
-          @backlink = candidate_interface_continuous_applications_choices_path if request.referer.blank?
         end
       end
     end

--- a/app/forms/candidate_interface/continuous_applications/course_selection_wizard.rb
+++ b/app/forms/candidate_interface/continuous_applications/course_selection_wizard.rb
@@ -11,6 +11,7 @@ module CandidateInterface
           { provider_selection: ProviderSelectionStep },
           { which_course_are_you_applying_to: WhichCourseAreYouApplyingToStep },
           { duplicate_course_selection: DuplicateCourseSelectionStep },
+          { reached_reapplication_limit: ReachedReapplicationLimitStep },
           { full_course_selection: FullCourseSelectionStep },
           { course_study_mode: CourseStudyModeStep },
           { course_site: CourseSiteStep },

--- a/app/forms/candidate_interface/continuous_applications/reached_reapplication_limit_step.rb
+++ b/app/forms/candidate_interface/continuous_applications/reached_reapplication_limit_step.rb
@@ -1,0 +1,23 @@
+module CandidateInterface
+  module ContinuousApplications
+    class ReachedReapplicationLimitStep < DfE::WizardStep
+      include Concerns::CourseSelectionStepHelper
+      attr_accessor :provider_id, :course_id
+      validates :provider_id, :course_id, presence: true
+
+      def self.permitted_params
+        %i[provider_id course_id]
+      end
+
+      def previous_step
+        :which_course_are_you_applying_to
+      end
+
+      def next_step; end
+
+      def previous_step_path_arguments
+        { provider_id: provider_id }
+      end
+    end
+  end
+end

--- a/app/validators/candidate_interface/continuous_applications/course_selection_validator.rb
+++ b/app/validators/candidate_interface/continuous_applications/course_selection_validator.rb
@@ -12,6 +12,7 @@ module CandidateInterface
 
         if reached_reapplication_limit?(scope, record)
           record.errors.add :base, :reached_reapplication_limit, message: 'You cannot apply to this training provider and course again'
+          return
         end
 
         if exists_duplicate_application?(scope, record)

--- a/app/views/candidate_interface/continuous_applications/course_choices/reached_reapplication_limit/new.html.erb
+++ b/app/views/candidate_interface/continuous_applications/course_choices/reached_reapplication_limit/new.html.erb
@@ -1,14 +1,15 @@
-<% content_for :title, title_with_error_prefix('Duplicate course chosen', false) %>
+<% content_for :title, title_with_error_prefix('Invalid course chosen', false) %>
 <% content_for(:before_content, govuk_back_link_to(@backlink || @wizard.previous_step_path)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      <%= t('page_titles.duplicate_application_selection', course_name: @course.name_and_code, provider_name: @course.provider.name) %>
+      <%= t('page_titles.reached_reapplication_limit', course_name: @course.name_and_code, provider_name: @course.provider.name) %>
     </h1>
+    <p class="govuk-body">You have applied to <%= @course.provider.name %> and <%= @course.name_and_code %> twice and have been unsuccessful.</p>
 
     <% if @course.provider.courses.current_cycle.open_on_apply.open_for_applications.exposed_in_find.count > 1 %>
-      <p class="govuk-body">You can:</p>
+      <p class="govuk-body">Instead, you must:</p>
       <ul class="govuk-list govuk-list--bullet">
 
         <li>apply to a <%= govuk_link_to 'different course', candidate_interface_continuous_applications_which_course_are_you_applying_to_path(provider_id: @course.provider.id) %> offered by <%= @course.provider.name %></li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,6 +77,7 @@ en:
     application_review: Your application to %{provider_name}
     application_review_and_submit: Review your application to %{provider_name}
     duplicate_application_selection: You already have an application for %{course_name} at %{provider_name}
+    reached_reapplication_limit: You cannot apply to this training provider and course again
     efl:
       ielts: Your IELTS result
       other: Your English language assessment result

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -362,6 +362,7 @@ namespace :candidate_interface, path: '/candidate' do
       get '/:application_choice_id/review' => 'continuous_applications/course_choices/review#show', as: :continuous_applications_course_review
       get '/:application_choice_id/review-and-submit' => 'continuous_applications/course_choices/review_and_submit#show', as: :continuous_applications_course_review_and_submit
 
+      get '/provider/:provider_id/courses/:course_id/reached-reapplication-limit' => 'continuous_applications/course_choices/reached_reapplication_limit#new', as: :continuous_applications_reached_reapplication_limit
       get '/provider/:provider_id/courses/:course_id/duplicate' => 'continuous_applications/course_choices/duplicate_course_selection#new', as: :continuous_applications_duplicate_course_selection
       get '/provider/:provider_id/courses/:course_id/full' => 'continuous_applications/course_choices/full_course_selection#new', as: :continuous_applications_full_course_selection
 

--- a/spec/forms/candidate_interface/continuous_applications/which_course_are_you_applying_to_step_spec.rb
+++ b/spec/forms/candidate_interface/continuous_applications/which_course_are_you_applying_to_step_spec.rb
@@ -46,19 +46,67 @@ RSpec.describe CandidateInterface::ContinuousApplications::WhichCourseAreYouAppl
       let(:course_id) { course.id }
 
       context 'when choice exists on the application form' do
-        let(:application_choice) { create(:application_choice, :inactive, course_option:, application_form: current_application) }
+        before do
+          create(:application_choice, :inactive, course_option:, application_form: current_application)
+        end
 
         it 'validates false' do
           expect(wizard.current_step.valid?(:course_choice)).to be false
         end
+
+        it 'returns the correct error message' do
+          wizard.current_step.errors.added?(:base, :duplicate_application_selection)
+        end
       end
 
       context 'when course does not exist on application form' do
-        let(:application_choice) { nil }
-
         it 'validates true' do
           expect(wizard.current_step.valid?(:course_choice)).to be true
         end
+      end
+    end
+  end
+
+  context 'validates reapplication of course_choice', :continuous_applications do
+    let(:provider_id) { provider.id }
+    let(:course_id) { course.id }
+
+    context 'with one rejected choice on the application form' do
+      before do
+        create(:application_choice, :rejected, course_option:, application_form: current_application)
+      end
+
+      it 'validates true' do
+        expect(wizard.current_step.valid?(:course_choice)).to be true
+      end
+    end
+
+    context 'with two rejected choices on the application form' do
+      before do
+        create_list(:application_choice, 2, :rejected,
+                    course_option:,
+                    application_form: current_application)
+      end
+
+      it 'validates false' do
+        expect(wizard.current_step.valid?(:course_choice)).to be false
+      end
+
+      it 'returns the correct error message' do
+        wizard.current_step.errors.added?(:base, :reached_reapplication_limit)
+      end
+    end
+
+    context 'with two rejected choices from previous cycle on the application form' do
+      before do
+        create_list(:application_choice, 2, :rejected,
+                    course_option:,
+                    application_form: current_application,
+                    current_recruitment_cycle_year: RecruitmentCycle.previous_year)
+      end
+
+      it 'validates true' do
+        expect(wizard.current_step.valid?(:course_choice)).to be true
       end
     end
   end

--- a/spec/forms/candidate_interface/continuous_applications/which_course_are_you_applying_to_step_spec.rb
+++ b/spec/forms/candidate_interface/continuous_applications/which_course_are_you_applying_to_step_spec.rb
@@ -50,12 +50,10 @@ RSpec.describe CandidateInterface::ContinuousApplications::WhichCourseAreYouAppl
           create(:application_choice, :inactive, course_option:, application_form: current_application)
         end
 
-        it 'validates false' do
+        it 'validates false and returns the correct error message' do
           expect(wizard.current_step.valid?(:course_choice)).to be false
-        end
-
-        it 'returns the correct error message' do
-          wizard.current_step.errors.added?(:base, :duplicate_application_selection)
+          expect(wizard.current_step.errors.added?(:base, :duplicate_application_selection)).to be true
+          expect(wizard.current_step.errors.added?(:base, :reached_reapplication_limit)).to be false
         end
       end
 
@@ -88,12 +86,10 @@ RSpec.describe CandidateInterface::ContinuousApplications::WhichCourseAreYouAppl
                     application_form: current_application)
       end
 
-      it 'validates false' do
+      it 'validates false and returns the correct error message' do
         expect(wizard.current_step.valid?(:course_choice)).to be false
-      end
-
-      it 'returns the correct error message' do
-        wizard.current_step.errors.added?(:base, :reached_reapplication_limit)
+        expect(wizard.current_step.errors.added?(:base, :reached_reapplication_limit)).to be true
+        expect(wizard.current_step.errors.added?(:base, :duplicate_application_selection)).to be false
       end
     end
 

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_reaching_reapplication_limit_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_reaching_reapplication_limit_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'Selecting a course', :continuous_applications do
     and_i_choose_a_provider
     then_i_should_see_a_course_and_its_description
 
-    and_i_choose_a_course_rejected_twice
+    when_i_choose_a_course_rejected_twice
     then_i_should_be_on_the_reached_reapplication_limit_page
     when_i_click_back
     then_i_should_be_on_the_course_choice_page
@@ -60,7 +60,7 @@ RSpec.feature 'Selecting a course', :continuous_applications do
     expect(page).to have_content(@course.description)
   end
 
-  def and_i_choose_a_course_rejected_twice
+  def when_i_choose_a_course_rejected_twice
     choose 'Primary (2XT2)'
     click_button t('continue')
   end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_reaching_reapplication_limit_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_reaching_reapplication_limit_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.feature 'Selecting a course', :continuous_applications do
+  include CandidateHelper
+
+  it 'Candidate selects a course they have already been rejected from twice' do
+    given_i_am_signed_in
+    and_there_are_course_options
+    and_i_have_two_rejected_application_to_a_course
+
+    when_i_visit_the_site
+    and_i_click_on_course_choices
+    and_i_choose_that_i_know_where_i_want_to_apply
+    and_i_choose_a_provider
+    then_i_should_see_a_course_and_its_description
+
+    and_i_choose_a_course_rejected_twice
+    then_i_should_be_on_the_reached_reapplication_limit_page
+    when_i_click_back
+    then_i_should_be_on_the_course_choice_page
+  end
+
+  def given_i_am_signed_in
+    @candidate = create(:candidate)
+    create_and_sign_in_candidate(candidate: @candidate)
+  end
+
+  def and_there_are_course_options
+    @provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
+    @course = create(:course, :open_on_apply, name: 'Primary', code: '2XT2', provider: @provider)
+    create(:course_option, course: @course)
+  end
+
+  def and_i_have_two_rejected_application_to_a_course
+    create(:application_choice, :rejected, course_option: @course.course_options.first, application_form: @candidate.current_application)
+    create(:application_choice, :rejected, course_option: @course.course_options.first, application_form: @candidate.current_application)
+  end
+
+  def when_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def and_i_click_on_course_choices
+    click_link 'Your application'
+    click_link 'Add application'
+  end
+
+  def and_i_choose_that_i_know_where_i_want_to_apply
+    choose 'Yes, I know where I want to apply'
+    click_button t('continue')
+  end
+
+  def and_i_choose_a_provider
+    select 'Gorse SCITT (1N1)'
+    click_button t('continue')
+  end
+
+  def then_i_should_see_a_course_and_its_description
+    expect(page).to have_content(@course.name_and_code)
+    expect(page).to have_content(@course.description)
+  end
+
+  def and_i_choose_a_course_rejected_twice
+    choose 'Primary (2XT2)'
+    click_button t('continue')
+  end
+
+  def then_i_should_be_on_the_reached_reapplication_limit_page
+    expect(page).to have_content('You cannot apply to this training provider and course again')
+    expect(page).to have_content('You have applied to Gorse SCITT and Primary (2XT2) twice and have been unsuccessful.')
+  end
+
+  def when_i_click_back
+    click_link 'Back'
+  end
+
+  def then_i_should_be_on_the_course_choice_page
+    expect(page.current_url).to end_with(candidate_interface_continuous_applications_which_course_are_you_applying_to_path(provider_id: @provider.id))
+  end
+end


### PR DESCRIPTION
Candidate should only be able to reapply once to exactly the same course. This approach is very similar to @inulty-dfe's PR https://github.com/DFE-Digital/apply-for-teacher-training/pull/8566. A new step was added to the wizard for the reapplication limit page and the validation was updated to reflect this change.

When the candidate selects a corse from which he got rejected twice they will get redirected to this page:
<img width="668" alt="Screenshot 2023-11-02 at 10 32 21" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/29511cd9-c6c0-4500-9252-3d26aa429089">

![](https://github.trello.services/images/mini-trello-icon.png) [Prevent a candidate from applying to the same provider and same course three or more times](https://trello.com/c/1sJ6v177/821-prevent-a-candidate-from-applying-to-the-same-provider-and-same-course-three-or-more-times)
