### PR TITLE
Update application state change categories

### DIFF
--- a/app/components/candidate_interface/application_dashboard_course_choices_component.rb
+++ b/app/components/candidate_interface/application_dashboard_course_choices_component.rb
@@ -99,7 +99,7 @@ module CandidateInterface
         .includes(:course, :site, :provider, :current_course, :current_course_option, :interviews)
         .includes(offer: :conditions)
         .order(id: :asc)
-        .select { |ac| ac.status.to_sym.in?(ApplicationStateChange::ACCEPTED_STATES) }
+        .select { |ac| ac.status.to_sym.in?(ApplicationStateChange.accepted) }
     end
 
     def all_application_choices
@@ -111,7 +111,7 @@ module CandidateInterface
     end
 
     def application_choice_with_accepted_state_present?
-      @application_form.application_choices.any? { |ac| ApplicationStateChange::ACCEPTED_STATES.include?(ac.status.to_sym) }
+      @application_form.application_choices.any? { |ac| ApplicationStateChange.accepted.include?(ac.status.to_sym) }
     end
 
     def withdraw_row(application_choice)

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -259,7 +259,7 @@ module CandidateInterface
     def application_choices_with_accepted_states
       application_choices_with_includes.order(id: :asc)
         .order(id: :asc)
-        .select { |ac| ac.status.to_sym.in?(ApplicationStateChange::ACCEPTED_STATES) }
+        .select { |ac| ac.status.to_sym.in?(ApplicationStateChange.accepted) }
     end
 
     def all_application_choices
@@ -267,7 +267,7 @@ module CandidateInterface
     end
 
     def application_choice_with_accepted_state_present?
-      @application_form.application_choices.any? { |ac| ApplicationStateChange::ACCEPTED_STATES.include?(ac.status.to_sym) }
+      @application_form.application_choices.any? { |ac| ApplicationStateChange.accepted.include?(ac.status.to_sym) }
     end
 
     def candidate_has_pending_or_missing_gcses?(application_choice)

--- a/app/components/candidate_interface/previous_applications_component.rb
+++ b/app/components/candidate_interface/previous_applications_component.rb
@@ -41,11 +41,11 @@ module CandidateInterface
 
     def application_choices_without_accepted_states
       current_application_choices
-        .reject { |ac| ApplicationStateChange::ACCEPTED_STATES.include?(ac.status.to_sym) }
+        .reject { |ac| ApplicationStateChange.accepted.include?(ac.status.to_sym) }
     end
 
     def application_choice_has_accepted_state_present?
-      current_application_choices.any? { |ac| ApplicationStateChange::ACCEPTED_STATES.include?(ac.status.to_sym) }
+      current_application_choices.any? { |ac| ApplicationStateChange.accepted.include?(ac.status.to_sym) }
     end
 
     def current_application_choices

--- a/app/components/provider_interface/application_choice_header_component.rb
+++ b/app/components/provider_interface/application_choice_header_component.rb
@@ -118,7 +118,7 @@ module ProviderInterface
     end
 
     def offer_present?
-      ApplicationStateChange::OFFERED_STATES.include?(application_choice.status.to_sym)
+      ApplicationStateChange.offered.include?(application_choice.status.to_sym)
     end
   end
 end

--- a/app/components/provider_interface/diversity_information_component.rb
+++ b/app/components/provider_interface/diversity_information_component.rb
@@ -48,7 +48,7 @@ module ProviderInterface
     end
 
     def application_in_correct_state?
-      ApplicationStateChange::POST_OFFERED_STATES.include?(application_choice.status.to_sym)
+      ApplicationStateChange.post_offered.include?(application_choice.status.to_sym)
     end
 
     def current_user_has_permission_to_view_diversity_information?

--- a/app/components/shared/state_explanation_component.html.erb
+++ b/app/components/shared/state_explanation_component.html.erb
@@ -8,7 +8,7 @@
       <dl class="govuk-list app-list--definition">
         <dt>Application status</dt>
         <dd><code><%= govuk_link_to state_name.inspect, api_docs_reference_path(anchor: 'applicationattributes-object') %></code></dd>
-        <% if ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER.include?(state_name.to_sym) %>
+        <% if ApplicationStateChange.visible_to_provider.include?(state_name.to_sym) %>
           <dt>Appears to candidate as</dd>
           <% component = CandidateInterface::ApplicationStatusTagComponent.new(application_choice: Struct.new(:status).new(state_name)) %>
           <dd><%= govuk_tag(text: t("candidate_application_states.#{state_name}"), colour: component.colour) %></dd>

--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -232,7 +232,7 @@ module SupportInterface
     def any_successful_application_choices?(application_choice)
       choice_statuses = application_choice.application_form.application_choices.map(&:status)
 
-      choice_statuses.any? { |choice_status| ApplicationStateChange::ACCEPTED_STATES.include? choice_status.to_sym }
+      choice_statuses.any? { |choice_status| ApplicationStateChange.accepted.include? choice_status.to_sym }
     end
   end
 end

--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -159,7 +159,7 @@ module SupportInterface
     end
 
     def visible_over_vendor_api?
-      ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER.include?(application_choice.status.to_sym)
+      ApplicationStateChange.visible_to_provider.include?(application_choice.status.to_sym)
     end
 
     def visible_over_register_api?

--- a/app/controllers/provider_interface/interviews_controller.rb
+++ b/app/controllers/provider_interface/interviews_controller.rb
@@ -11,7 +11,7 @@ module ProviderInterface
     before_action :redirect_to_index_if_cancel_store_cleared, only: %i[destroy]
 
     def index
-      application_at_interviewable_stage = ApplicationStateChange::INTERVIEWABLE_STATES.include?(
+      application_at_interviewable_stage = ApplicationStateChange.interviewable.include?(
         @application_choice.status.to_sym,
       )
       @interviews_can_be_created_and_edited = application_at_interviewable_stage && @provider_user_can_set_up_interviews

--- a/app/controllers/provider_interface/offers_controller.rb
+++ b/app/controllers/provider_interface/offers_controller.rb
@@ -94,7 +94,7 @@ module ProviderInterface
     end
 
     def confirm_application_is_in_offered_state
-      return if ApplicationStateChange::OFFERED_STATES.include?(@application_choice.status.to_sym)
+      return if ApplicationStateChange.offered.include?(@application_choice.status.to_sym)
 
       redirect_to(provider_interface_application_choice_path(@application_choice))
     end

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -165,7 +165,7 @@ module ProviderInterface
         course_option: @application_choice.current_course_option,
       )
       @course_associated_with_user_providers = provider_authorisation.course_associated_with_user_providers?(course: @application_choice.current_course)
-      @offer_present = ApplicationStateChange::OFFERED_STATES.include?(@application_choice.status.to_sym)
+      @offer_present = ApplicationStateChange.offered.include?(@application_choice.status.to_sym)
     end
 
     def provider_authorisation

--- a/app/forms/provider_interface/application_data_export_form.rb
+++ b/app/forms/provider_interface/application_data_export_form.rb
@@ -30,7 +30,7 @@ module ProviderInterface
     def selected_statuses
       statuses.push('inactive') if statuses.include?('awaiting_provider_decision')
 
-      custom_status_selected? ? statuses : ApplicationStateChange.states_visible_to_provider
+      custom_status_selected? ? statuses : ApplicationStateChange.visible_to_provider
     end
 
     def actor_has_more_than_one_provider?

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -251,7 +251,7 @@ private
 
   def references_without_an_accepted_offer?
     @application_form.reload
-    @application_form.application_choices.flat_map(&:status).none? { |status| ApplicationStateChange::ACCEPTED_STATES.include?(status.to_sym) }
+    @application_form.application_choices.flat_map(&:status).none? { |status| ApplicationStateChange.accepted.include?(status.to_sym) }
   end
 
   def set_reference_state

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -63,7 +63,7 @@ class ApplicationChoice < ApplicationRecord
 
   scope :reappliable, -> { where(status: ApplicationStateChange.reapply_states) }
   scope :not_reappliable, -> { where(status: ApplicationStateChange.non_reapply_states) }
-  scope :decision_pending, -> { where(status: ApplicationStateChange::DECISION_PENDING_STATUSES) }
+  scope :decision_pending, -> { where(status: ApplicationStateChange.decision_pending) }
   scope :decision_pending_and_inactive, -> { where(status: ApplicationStateChange::DECISION_PENDING_AND_INACTIVE_STATUSES) }
   scope :accepted, -> { where(status: ApplicationStateChange::ACCEPTED_STATES) }
   scope :inactive_past_day, -> { inactive.where(inactive_at: 1.day.ago..Time.zone.now) }

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -65,7 +65,7 @@ class ApplicationChoice < ApplicationRecord
   scope :not_reappliable, -> { where(status: ApplicationStateChange.non_reapply_states) }
   scope :decision_pending, -> { where(status: ApplicationStateChange.decision_pending) }
   scope :decision_pending_and_inactive, -> { where(status: ApplicationStateChange.decision_pending_and_inactive }
-  scope :accepted, -> { where(status: ApplicationStateChange::ACCEPTED_STATES) }
+  scope :accepted, -> { where(status: ApplicationStateChange.accepted) }
   scope :inactive_past_day, -> { inactive.where(inactive_at: 1.day.ago..Time.zone.now) }
 
   def submitted?
@@ -93,7 +93,7 @@ class ApplicationChoice < ApplicationRecord
   end
 
   def accepted_choice?
-    ApplicationStateChange::ACCEPTED_STATES.include? status.to_sym
+    ApplicationStateChange.accepted.include? status.to_sym
   end
 
   def different_offer?

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -61,7 +61,7 @@ class ApplicationChoice < ApplicationRecord
     vendor_api_rejection_reasons: 'vendor_api_rejection_reasons', # Rejection reasons via the Vendor API.
   }, _prefix: :rejection_reasons_type
 
-  scope :reappliable, -> { where(status: ApplicationStateChange.reapply_states) }
+  scope :reappliable, -> { where(status: ApplicationStateChange.reapply) }
   scope :not_reappliable, -> { where(status: ApplicationStateChange.non_reapply_states) }
   scope :decision_pending, -> { where(status: ApplicationStateChange.decision_pending) }
   scope :decision_pending_and_inactive, -> { where(status: ApplicationStateChange.decision_pending_and_inactive }

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -88,6 +88,10 @@ class ApplicationChoice < ApplicationRecord
     ApplicationStateChange.unsuccessful.include? status.to_sym
   end
 
+  def in_progress?
+    ApplicationStateChange.in_progress.include? status.to_sym
+  end
+
   def application_unsuccessful_without_inactive?
     (ApplicationStateChange::UNSUCCESSFUL_STATES - %i[inactive]).include? status.to_sym
   end

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -64,7 +64,7 @@ class ApplicationChoice < ApplicationRecord
   scope :reappliable, -> { where(status: ApplicationStateChange.reapply_states) }
   scope :not_reappliable, -> { where(status: ApplicationStateChange.non_reapply_states) }
   scope :decision_pending, -> { where(status: ApplicationStateChange.decision_pending) }
-  scope :decision_pending_and_inactive, -> { where(status: ApplicationStateChange::DECISION_PENDING_AND_INACTIVE_STATUSES) }
+  scope :decision_pending_and_inactive, -> { where(status: ApplicationStateChange.decision_pending_and_inactive }
   scope :accepted, -> { where(status: ApplicationStateChange::ACCEPTED_STATES) }
   scope :inactive_past_day, -> { inactive.where(inactive_at: 1.day.ago..Time.zone.now) }
 
@@ -73,7 +73,7 @@ class ApplicationChoice < ApplicationRecord
   end
 
   def decision_pending?
-    ApplicationStateChange::DECISION_PENDING_AND_INACTIVE_STATUSES.include? status.to_sym
+    ApplicationStateChange.decision_pending_and_inactive.include? status.to_sym
   end
 
   def pre_offer?

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -85,7 +85,7 @@ class ApplicationChoice < ApplicationRecord
   end
 
   def application_unsuccessful?
-    ApplicationStateChange::UNSUCCESSFUL_STATES.include? status.to_sym
+    ApplicationStateChange.unsuccessful.include? status.to_sym
   end
 
   def application_unsuccessful_without_inactive?

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -77,7 +77,7 @@ class ApplicationChoice < ApplicationRecord
   end
 
   def pre_offer?
-    ApplicationStateChange::OFFERED_STATES.exclude? status.to_sym
+    ApplicationStateChange.offered.exclude? status.to_sym
   end
 
   def application_in_progress?

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -64,7 +64,7 @@ class ApplicationChoice < ApplicationRecord
   scope :reappliable, -> { where(status: ApplicationStateChange.reapply) }
   scope :not_reappliable, -> { where(status: ApplicationStateChange.non_reapply_states) }
   scope :decision_pending, -> { where(status: ApplicationStateChange.decision_pending) }
-  scope :decision_pending_and_inactive, -> { where(status: ApplicationStateChange.decision_pending_and_inactive }
+  scope :decision_pending_and_inactive, -> { where(status: ApplicationStateChange.decision_pending_and_inactive) }
   scope :accepted, -> { where(status: ApplicationStateChange.accepted) }
   scope :inactive_past_day, -> { inactive.where(inactive_at: 1.day.ago..Time.zone.now) }
 

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -339,7 +339,7 @@ class ApplicationForm < ApplicationRecord
 
   def successful?
     application_choices.present? &&
-      application_choices.map(&:status).map(&:to_sym).any? { |status| ApplicationStateChange::SUCCESSFUL_STATES.include?(status) }
+      application_choices.map(&:status).map(&:to_sym).any? { |status| ApplicationStateChange.successful.include?(status) }
   end
 
   def any_offer_accepted?
@@ -354,7 +354,7 @@ class ApplicationForm < ApplicationRecord
 
   def provider_decision_made?
     application_choices.present? &&
-      application_choices.map(&:status).map(&:to_sym).all? { |status| (ApplicationStateChange::SUCCESSFUL_STATES + ApplicationStateChange.unsuccessful).include?(status) }
+      application_choices.map(&:status).map(&:to_sym).all? { |status| (ApplicationStateChange.successful + ApplicationStateChange.unsuccessful).include?(status) }
   end
 
   def incomplete_degree_information?

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -349,12 +349,12 @@ class ApplicationForm < ApplicationRecord
 
   def ended_without_success?
     application_choices.present? &&
-      application_choices.map(&:status).map(&:to_sym).all? { |status| ApplicationStateChange::UNSUCCESSFUL_STATES.include?(status) }
+      application_choices.map(&:status).map(&:to_sym).all? { |status| ApplicationStateChange.unsuccessful.include?(status) }
   end
 
   def provider_decision_made?
     application_choices.present? &&
-      application_choices.map(&:status).map(&:to_sym).all? { |status| (ApplicationStateChange::SUCCESSFUL_STATES + ApplicationStateChange::UNSUCCESSFUL_STATES).include?(status) }
+      application_choices.map(&:status).map(&:to_sym).all? { |status| (ApplicationStateChange::SUCCESSFUL_STATES + ApplicationStateChange.unsuccessful).include?(status) }
   end
 
   def incomplete_degree_information?

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -344,7 +344,7 @@ class ApplicationForm < ApplicationRecord
 
   def any_offer_accepted?
     application_choices.present? &&
-      application_choices.map(&:status).map(&:to_sym).any? { |status| (ApplicationStateChange::ACCEPTED_STATES - [:conditions_not_met]).include?(status) }
+      application_choices.map(&:status).map(&:to_sym).any? { |status| (ApplicationStateChange.accepted - [:conditions_not_met]).include?(status) }
   end
 
   def ended_without_success?

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -222,7 +222,7 @@ private
   def application_choices
     choices = ApplicationChoice
       .joins(application_form: :candidate)
-      .where(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
+      .where(status: ApplicationStateChange.visible_to_provider)
       .where('candidates.hide_in_reporting' => false)
 
     if year

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -71,7 +71,7 @@ class PerformanceStatistics
 
   def form_ended_without_success_sql
     sql = 'ARRAY_AGG(DISTINCT ch.status)'
-    ApplicationStateChange::UNSUCCESSFUL_STATES.each do |state|
+    ApplicationStateChange.unsuccessful.each do |state|
       sql = "ARRAY_REMOVE(#{sql}, '#{state}')"
     end
 

--- a/app/presenters/concerns/hesa_itt_data_api_data.rb
+++ b/app/presenters/concerns/hesa_itt_data_api_data.rb
@@ -3,7 +3,7 @@ module HesaIttDataAPIData
   HESA_DISABILITY_OTHER = '96'.freeze
 
   def hesa_itt_data
-    return nil unless ApplicationStateChange::ACCEPTED_STATES.include?(application_choice.status.to_sym)
+    return nil unless ApplicationStateChange.accepted.include?(application_choice.status.to_sym)
 
     unless (data = application_form&.equality_and_diversity).nil?
       hesa_codes(data).merge(additional_hesa_itt_data(data))

--- a/app/presenters/vendor_api/application_presenter.rb
+++ b/app/presenters/vendor_api/application_presenter.rb
@@ -140,7 +140,7 @@ module VendorAPI
     end
 
     def application_accepted?
-      ApplicationStateChange::ACCEPTED_STATES.include?(application_choice.status.to_sym)
+      ApplicationStateChange.accepted.include?(application_choice.status.to_sym)
     end
 
     def application_unsuccessful?

--- a/app/presenters/vendor_api/application_presenter.rb
+++ b/app/presenters/vendor_api/application_presenter.rb
@@ -144,7 +144,7 @@ module VendorAPI
     end
 
     def application_unsuccessful?
-      ApplicationStateChange::UNSUCCESSFUL_STATES.include?(application_choice.status.to_sym)
+      ApplicationStateChange.unsuccessful.include?(application_choice.status.to_sym)
     end
   end
 end

--- a/app/presenters/vendor_api/application_presenter/equality_and_diversity.rb
+++ b/app/presenters/vendor_api/application_presenter/equality_and_diversity.rb
@@ -8,7 +8,7 @@ module VendorAPI::ApplicationPresenter::EqualityAndDiversity
   end
 
   def equality_and_diversity
-    return nil unless ApplicationStateChange::ACCEPTED_STATES.include?(application_choice.status.to_sym) && application_choice.application_form.recruitment_cycle_year == RecruitmentCycle.current_year
+    return nil unless ApplicationStateChange.accepted.include?(application_choice.status.to_sym) && application_choice.application_form.recruitment_cycle_year == RecruitmentCycle.current_year
 
     equality_and_diversity_data = application_form&.equality_and_diversity
 

--- a/app/queries/get_activity_log_events.rb
+++ b/app/queries/get_activity_log_events.rb
@@ -81,7 +81,7 @@ class GetActivityLogEvents
       "jsonb_exists(audited_changes, '#{change}')"
     end.join(' OR ')
 
-    filtered_statuses = ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER - IGNORE_STATUS
+    filtered_statuses = ApplicationStateChange.visible_to_provider - IGNORE_STATUS
     status_transitions_to_include = filtered_statuses.map { |status| "'#{status}'" }.join(', ')
 
     application_choice_audits_filter += " OR audited_changes::json#>>'{status, 1}' IN (#{status_transitions_to_include})"

--- a/app/queries/get_application_choices_for_providers.rb
+++ b/app/queries/get_application_choices_for_providers.rb
@@ -23,7 +23,7 @@ class GetApplicationChoicesForProviders
     raise MissingProvider if providers.blank? || providers.any?(&:blank?)
 
     provider_ids = providers.map(&:id)
-    statuses = exclude_deferrals ? ApplicationStateChange.states_visible_to_provider_without_deferred : ApplicationStateChange.states_visible_to_provider
+    statuses = exclude_deferrals ? ApplicationStateChange.states_visible_to_provider_without_deferred : ApplicationStateChange.visible_to_provider
 
     ApplicationChoice
       .where(provider_ids_check(provider_ids))

--- a/app/refinements/inverse_hash.rb
+++ b/app/refinements/inverse_hash.rb
@@ -1,11 +1,26 @@
 module InverseHash
   refine Hash do
+    Hash::UninversableHashError = Class.new(StandardError)
+
     def inverse
       each_with_object({}) do |(key, value), object|
-        value.each do |val|
-          object[val] ||= []
-          object[val] << key unless object[val].include?(key)
-          object[val].sort!
+        if value.is_a?(Array)
+          value.each do |val|
+            if object[val].is_a?(Array)
+              object[val] << key
+            elsif object[val].nil?
+              object[val] = [key]
+            else
+              mid = object[val]
+              object[val] = []
+              object[val] << mid << key
+            end
+            object[val].sort!
+          end
+        elsif value.is_a?(Hash)
+          raise Hash::UninversableHashError, 'Cannot inverse a nested hash'
+        else
+          object[value] = key
         end
       end
     end

--- a/app/refinements/inverse_hash.rb
+++ b/app/refinements/inverse_hash.rb
@@ -1,7 +1,5 @@
 module InverseHash
   refine Hash do
-    Hash::UninversableHashError = Class.new(StandardError)
-
     def inverse
       each_with_object({}) do |(key, value), object|
         if value.is_a?(Array)
@@ -18,7 +16,7 @@ module InverseHash
             object[val].sort!
           end
         elsif value.is_a?(Hash)
-          raise Hash::UninversableHashError, 'Cannot inverse a nested hash'
+          raise StandardError, 'UninversableHashError: Cannot inverse a nested hash'
         else
           object[value] = key
         end

--- a/app/refinements/inverse_hash.rb
+++ b/app/refinements/inverse_hash.rb
@@ -1,0 +1,13 @@
+module InverseHash
+  refine Hash do
+    def inverse
+      each_with_object({}) do |(key, value), object|
+        value.each do |val|
+          object[val] ||= []
+          object[val] << key unless object[val].include?(key)
+          object[val].sort!
+        end
+      end
+    end
+  end
+end

--- a/app/services/application_form_state_inferrer.rb
+++ b/app/services/application_form_state_inferrer.rb
@@ -28,7 +28,7 @@ class ApplicationFormStateInferrer
       :pending_conditions
     elsif any_state_is?('offer_deferred')
       :offer_deferred
-    elsif (states.uniq.map(&:to_sym) - ApplicationStateChange::UNSUCCESSFUL_STATES).empty?
+    elsif (states.uniq.map(&:to_sym) - ApplicationStateChange.unsuccessful).empty?
       :ended_without_success
     elsif any_state_is?('unsubmitted')
       :unsubmitted_in_progress

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -1,3 +1,30 @@
+# Manage and arrange the states and Workflow for teh ApplicationChoice#status state machine property
+#
+# Big Question: Do the states categories need to have meaning relative to one another?
+#
+# 1. What is decision pending, where is it used and why does it not include inactive
+#  a) app/mailers/candidate_mailer#changed_offer
+#     We send an email to candidates when an offer they received has changed. We list the other decision pending in the email and ask if they want to accept the offer or hear back about their decision pending offers. We do not list the inactive ones in this email.
+#  b)
+#
+#
+#  With inactive
+#  1) When accepting an offer we withdraw all decision pending, including inactive
+#
+#
+#
+#
+# Categories:
+#   The full list of possible states of an ApplicationChoice can be arranged into higher categories which communicate the meaning of the states, allow performing operation on records.
+#   1. Unsubmitted - The form has been created and perhaps completed by the candidate but it has not been submitted
+#   2. Submitted
+#     a. In Progress - The application is submitted but it is in the pipeline for consideration.
+#       i) Awaiting Provider Decision
+#      ii) Interviewing
+#     iii) Offer Conditions Not Met
+#
+#     b. Post Offer -
+#
 class ApplicationStateChange
   include Workflow
   using InverseHash

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -206,8 +206,6 @@ class ApplicationStateChange
   # Application Progression States
   # Unsubmitted -> Decision Pending -> Offered -> Success/Unsuccess
 
-  POST_OFFERED_STATES = (accepted + %i[declined offer_withdrawn]).freeze
-
   UNSUCCESSFUL_STATES = %i[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn application_not_sent inactive].freeze
   SUCCESSFUL_STATES = %i[pending_conditions offer offer_deferred recruited].freeze
 

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -208,7 +208,6 @@ class ApplicationStateChange
 
 
   # Utility states
-  STATES_NOT_VISIBLE_TO_PROVIDER = %i[unsubmitted cancelled application_not_sent].freeze
   STATES_VISIBLE_TO_PROVIDER = %i[awaiting_provider_decision interviewing offer pending_conditions recruited rejected declined withdrawn conditions_not_met offer_withdrawn offer_deferred inactive].freeze
 
   REAPPLY_STATUSES = %i[rejected cancelled withdrawn declined offer_withdrawn].freeze

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -200,6 +200,29 @@ class ApplicationStateChange
     end
   end
 
+  # Application Progression States
+  # Unsubmitted -> Decision Pending -> Offered -> Success/Unsuccess
+  DECISION_PENDING_AND_INACTIVE_STATUSES = %i[awaiting_provider_decision interviewing inactive].freeze
+  INTERVIEWABLE_STATES = %i[awaiting_provider_decision interviewing].freeze
+
+  ACCEPTED_STATES = %i[pending_conditions conditions_not_met recruited offer_deferred].freeze
+  OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer offer_withdrawn]).freeze
+
+  POST_OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer_withdrawn]).freeze
+
+  UNSUCCESSFUL_STATES = %i[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn application_not_sent inactive].freeze
+  SUCCESSFUL_STATES = %i[pending_conditions offer offer_deferred recruited].freeze
+
+  TERMINAL_STATES = UNSUCCESSFUL_STATES + %i[recruited].freeze
+
+  # Utility states
+  STATES_NOT_VISIBLE_TO_PROVIDER = %i[unsubmitted cancelled application_not_sent].freeze
+  STATES_VISIBLE_TO_PROVIDER = %i[awaiting_provider_decision interviewing offer pending_conditions recruited rejected declined withdrawn conditions_not_met offer_withdrawn offer_deferred inactive].freeze
+
+  REAPPLY_STATUSES = %i[rejected cancelled withdrawn declined offer_withdrawn].freeze
+  # Used to determine if a candidate can add another application to their form
+  IN_PROGRESS_STATES = decision_pending + ACCEPTED_STATES + %i[offer].freeze
+
 private
 
   def update_candidate_api_updated_at_if_application_forms_state_has_changed(previous_application_form_status, current_application_form_status)

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -190,6 +190,10 @@ class ApplicationStateChange
     states_by_category[:decision_pending]
   end
 
+  def self.decision_pending_and_inactive
+    states_by_category[:decision_pending_and_inactive]
+  end
+
   def self.interviewable
     states_by_category[:interviewable]
   end

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -206,10 +206,7 @@ class ApplicationStateChange
   # Application Progression States
   # Unsubmitted -> Decision Pending -> Offered -> Success/Unsuccess
 
-  UNSUCCESSFUL_STATES = %i[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn application_not_sent inactive].freeze
-  SUCCESSFUL_STATES = %i[pending_conditions offer offer_deferred recruited].freeze
-
-  TERMINAL_STATES = UNSUCCESSFUL_STATES + %i[recruited].freeze
+  TERMINAL_STATES = unsuccessful + %i[recruited].freeze
 
   # Utility states
   STATES_NOT_VISIBLE_TO_PROVIDER = %i[unsubmitted cancelled application_not_sent].freeze

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -202,7 +202,6 @@ class ApplicationStateChange
 
   # Application Progression States
   # Unsubmitted -> Decision Pending -> Offered -> Success/Unsuccess
-  INTERVIEWABLE_STATES = %i[awaiting_provider_decision interviewing].freeze
 
   ACCEPTED_STATES = %i[pending_conditions conditions_not_met recruited offer_deferred].freeze
   OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer offer_withdrawn]).freeze

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -64,7 +64,7 @@ class ApplicationStateChange
     interviewable:                 %i[awaiting_provider_decision interviewing],
     offered:                       %i[conditions_not_met declined offer offer_deferred offer_withdrawn pending_conditions recruited],
 
-    post_offered:                  %i[conditions_not_met declined declined offer offer_deferred offer_withdrawn offer_withdrawn pending_conditions recruited],
+    post_offered:                  %i[conditions_not_met declined declined offer_deferred offer_withdrawn offer_withdrawn pending_conditions recruited],
     accepted:                      %i[conditions_not_met offer_deferred pending_conditions recruited],
     exclusive_offer:               %i[offer_deferred pending_conditions recruited],
     unsuccessful:                  %i[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn application_not_sent inactive],

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -206,8 +206,6 @@ class ApplicationStateChange
   # Application Progression States
   # Unsubmitted -> Decision Pending -> Offered -> Success/Unsuccess
 
-  OFFERED_STATES = (accepted + %i[declined offer offer_withdrawn]).freeze
-
   POST_OFFERED_STATES = (accepted + %i[declined offer_withdrawn]).freeze
 
   UNSUCCESSFUL_STATES = %i[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn application_not_sent inactive].freeze

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -25,9 +25,10 @@
 #
 #     b. Post Offer -
 #
+require_relative Rails.root.join('app', 'refinements', 'inverse_hash')
 class ApplicationStateChange
   include Workflow
-  using InverseHash
+  using ::InverseHash
 
   # Application Progression States
   # Unsubmitted -> Decision Pending -> Offered -> Success/Unsuccess
@@ -72,6 +73,7 @@ class ApplicationStateChange
     terminal:                      %i[application_not_sent cancelled conditions_not_met declined inactive offer_withdrawn recruited rejected withdrawn],
 
     in_progress:                   %i[awaiting_provider_decision interviewing conditions_not_met offer_deferred pending_conditions recruited offer],
+    active:                        %i[unsubmitted awaiting_provider_decision interviewing conditions_not_met offer_deferred pending_conditions recruited offer],
     reapply:                       %i[cancelled declined offer_withdrawn rejected withdrawn],
     not_visible_to_provider:       %i[unsubmitted cancelled application_not_sent],
     visible_to_provider:           %i[awaiting_provider_decision conditions_not_met declined inactive interviewing offer offer_deferred offer_withdrawn pending_conditions recruited rejected withdrawn],
@@ -222,8 +224,13 @@ class ApplicationStateChange
     states_by_category[:terminal]
   end
 
+  # These are the states that contribute towards the limit of application choices a candidate may have concurrently
   def self.in_progress
     states_by_category[:in_progress]
+  end
+
+  def self.active
+    states_by_category[:active]
   end
 
   def self.reapply

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -157,6 +157,12 @@ class ApplicationStateChange
     STATES_BY_CATEGORY
   end
 
+  states_by_category.each do |k, v|
+    define_singleton_method(k) do
+      v
+    end
+  end
+
   def persist_workflow_state(new_state)
     previous_application_form_status = ApplicationFormStateInferrer.new(application_choice.application_form).state
     application_choice.update!(status: new_state)
@@ -167,10 +173,6 @@ class ApplicationStateChange
   # State Categories
   def self.valid_states
     workflow_spec.states.keys
-  end
-
-  def self.reapply_states
-    REAPPLY_STATUSES
   end
 
   def self.non_reapply_states
@@ -193,22 +195,12 @@ class ApplicationStateChange
     ApplicationChoice.where(status: state_name).count
   end
 
-  states_by_category.each do |k, v|
-    define_singleton_method(k) do
-      v
-    end
-  end
-
   # Application Progression States
   # Unsubmitted -> Decision Pending -> Offered -> Success/Unsuccess
-
 
   # Utility states
   # Used to determine if a candidate can add another application to their form
   IN_PROGRESS_STATES = decision_pending + accepted + %i[offer].freeze
-
-  REAPPLY_STATUSES = %i[rejected cancelled withdrawn declined offer_withdrawn].freeze
-
 
 private
 

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -202,7 +202,6 @@ class ApplicationStateChange
 
   # Application Progression States
   # Unsubmitted -> Decision Pending -> Offered -> Success/Unsuccess
-  DECISION_PENDING_AND_INACTIVE_STATUSES = %i[awaiting_provider_decision interviewing inactive].freeze
   INTERVIEWABLE_STATES = %i[awaiting_provider_decision interviewing].freeze
 
   ACCEPTED_STATES = %i[pending_conditions conditions_not_met recruited offer_deferred].freeze

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -206,7 +206,6 @@ class ApplicationStateChange
   # Application Progression States
   # Unsubmitted -> Decision Pending -> Offered -> Success/Unsuccess
 
-  TERMINAL_STATES = unsuccessful + %i[recruited].freeze
 
   # Utility states
   STATES_NOT_VISIBLE_TO_PROVIDER = %i[unsubmitted cancelled application_not_sent].freeze

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -184,10 +184,54 @@ class ApplicationStateChange
     STATES_BY_CATEGORY
   end
 
-  states_by_category.each do |k, v|
-    define_singleton_method(k) do
-      v
-    end
+  ## States by Category methods
+
+  def self.decision_pending
+    states_by_category[:decision_pending]
+  end
+
+  def self.interviewable
+    states_by_category[:interviewable]
+  end
+
+  def self.offered
+    states_by_category[:offered]
+  end
+
+  def self.post_offered
+    states_by_category[:post_offered]
+  end
+
+  def self.accepted
+    states_by_category[:accepted]
+  end
+
+  def self.successful
+    states_by_category[:successful]
+  end
+
+  def self.unsuccessful
+    states_by_category[:unsuccessful]
+  end
+
+  def self.terminal
+    states_by_category[:terminal]
+  end
+
+  def self.in_progress
+    states_by_category[:in_progress]
+  end
+
+  def self.reapply
+    states_by_category[:reapply]
+  end
+
+  def self.not_visible_to_provider
+    states_by_category[:not_visible_to_provider]
+  end
+
+  def self.visible_to_provider
+    states_by_category[:visible_to_provider]
   end
 
   def persist_workflow_state(new_state)

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -222,13 +222,6 @@ class ApplicationStateChange
     ApplicationChoice.where(status: state_name).count
   end
 
-  # Application Progression States
-  # Unsubmitted -> Decision Pending -> Offered -> Success/Unsuccess
-
-  # Utility states
-  # Used to determine if a candidate can add another application to their form
-  IN_PROGRESS_STATES = decision_pending + accepted + %i[offer].freeze
-
 private
 
   def update_candidate_api_updated_at_if_application_forms_state_has_changed(previous_application_form_status, current_application_form_status)

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -174,19 +174,15 @@ class ApplicationStateChange
   end
 
   def self.non_reapply_states
-    valid_states - REAPPLY_STATUSES
-  end
-
-  def self.states_visible_to_provider
-    STATES_VISIBLE_TO_PROVIDER
+    valid_states - reapply
   end
 
   def self.states_visible_to_provider_without_deferred
-    states_visible_to_provider - [:offer_deferred]
+    visible_to_provider - [:offer_deferred]
   end
 
   def self.states_visible_to_provider_without_inactive
-    states_visible_to_provider - [:inactive]
+    visible_to_provider - [:inactive]
   end
 
   def self.i18n_namespace
@@ -208,11 +204,11 @@ class ApplicationStateChange
 
 
   # Utility states
-  STATES_VISIBLE_TO_PROVIDER = %i[awaiting_provider_decision interviewing offer pending_conditions recruited rejected declined withdrawn conditions_not_met offer_withdrawn offer_deferred inactive].freeze
-
-  REAPPLY_STATUSES = %i[rejected cancelled withdrawn declined offer_withdrawn].freeze
   # Used to determine if a candidate can add another application to their form
   IN_PROGRESS_STATES = decision_pending + accepted + %i[offer].freeze
+
+  REAPPLY_STATUSES = %i[rejected cancelled withdrawn declined offer_withdrawn].freeze
+
 
 private
 

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -2,38 +2,49 @@ class ApplicationStateChange
   include Workflow
   using InverseHash
 
+  # Application Progression States
+  # Unsubmitted -> Decision Pending -> Offered -> Success/Unsuccess
+  DECISION_PENDING_STATUSES = %i[awaiting_provider_decision interviewing].freeze
+  DECISION_PENDING_AND_INACTIVE_STATUSES = %i[awaiting_provider_decision interviewing inactive].freeze
+  INTERVIEWABLE_STATES = %i[awaiting_provider_decision interviewing inactive].freeze
+
+  ACCEPTED_STATES = %i[pending_conditions conditions_not_met recruited offer_deferred].freeze
+  OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer offer_withdrawn]).freeze
+
+  POST_OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer_withdrawn]).freeze
+
+  UNSUCCESSFUL_STATES = %i[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn application_not_sent inactive].freeze
+  SUCCESSFUL_STATES = %i[pending_conditions offer offer_deferred recruited].freeze
+
+  TERMINAL_STATES = UNSUCCESSFUL_STATES + %i[recruited].freeze
+
+  # Utility states
   STATES_NOT_VISIBLE_TO_PROVIDER = %i[unsubmitted cancelled application_not_sent].freeze
   STATES_VISIBLE_TO_PROVIDER = %i[awaiting_provider_decision interviewing offer pending_conditions recruited rejected declined withdrawn conditions_not_met offer_withdrawn offer_deferred inactive].freeze
 
-  INTERVIEWABLE_STATES = %i[awaiting_provider_decision interviewing inactive].freeze
-  ACCEPTED_STATES = %i[pending_conditions conditions_not_met recruited offer_deferred].freeze
-  OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer offer_withdrawn]).freeze
-  POST_OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer_withdrawn]).freeze
-  UNSUCCESSFUL_STATES = %i[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn application_not_sent inactive].freeze
-  SUCCESSFUL_STATES = %i[pending_conditions offer offer_deferred recruited].freeze
-  DECISION_PENDING_STATUSES = %i[awaiting_provider_decision interviewing].freeze
-  DECISION_PENDING_AND_INACTIVE_STATUSES = %i[awaiting_provider_decision interviewing inactive].freeze
-
   REAPPLY_STATUSES = %i[rejected cancelled withdrawn declined offer_withdrawn].freeze
-
-  TERMINAL_STATES = UNSUCCESSFUL_STATES + %i[recruited].freeze
+  # Used to determine if a candidate can add another application to their form
   IN_PROGRESS_STATES = DECISION_PENDING_STATUSES + ACCEPTED_STATES + %i[offer].freeze
 
   # rubocop:disable Layout/HashAlignment
   STATES_BY_CATEGORY = {
-    not_visible_to_provider:       %i[unsubmitted cancelled application_not_sent],
-    visible_to_provider:           %i[awaiting_provider_decision conditions_not_met declined inactive interviewing offer offer_deferred offer_withdrawn pending_conditions recruited rejected withdrawn],
-    interviewable:                 %i[awaiting_provider_decision interviewing],
-    accepted:                      %i[conditions_not_met offer_deferred pending_conditions recruited],
-    offered:                       %i[conditions_not_met declined offer offer_deferred offer_withdrawn pending_conditions recruited],
-    post_offered:                  %i[conditions_not_met declined declined offer offer_deferred offer_withdrawn offer_withdrawn pending_conditions recruited],
-    unsuccessful:                  %i[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn application_not_sent inactive],
-    successful:                    %i[offer offer_deferred pending_conditions recruited],
+    # Why is recruiteed in "in_progress"
     decision_pending:              %i[awaiting_provider_decision interviewing],
     decision_pending_and_inactive: %i[awaiting_provider_decision inactive interviewing],
-    reapply:                       %i[cancelled declined offer_withdrawn rejected withdrawn],
+
+    interviewable:                 %i[awaiting_provider_decision interviewing],
+    offered:                       %i[conditions_not_met declined offer offer_deferred offer_withdrawn pending_conditions recruited],
+
+    post_offered:                  %i[conditions_not_met declined declined offer offer_deferred offer_withdrawn offer_withdrawn pending_conditions recruited],
+    accepted:                      %i[conditions_not_met offer_deferred pending_conditions recruited],
+    unsuccessful:                  %i[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn application_not_sent inactive],
+    successful:                    %i[offer offer_deferred pending_conditions recruited],
     terminal:                      %i[application_not_sent cancelled conditions_not_met declined inactive offer_withdrawn recruited rejected withdrawn],
+
     in_progress:                   %i[awaiting_provider_decision interviewing conditions_not_met offer_deferred pending_conditions recruited offer],
+    reapply:                       %i[cancelled declined offer_withdrawn rejected withdrawn],
+    not_visible_to_provider:       %i[unsubmitted cancelled application_not_sent],
+    visible_to_provider:           %i[awaiting_provider_decision conditions_not_met declined inactive interviewing offer offer_deferred offer_withdrawn pending_conditions recruited rejected withdrawn],
   }.freeze
   # rubocop:enable Layout/HashAlignment
 

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -11,6 +11,8 @@ class ApplicationStateChange
   ACCEPTED_STATES = %i[pending_conditions conditions_not_met recruited offer_deferred].freeze
   OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer offer_withdrawn]).freeze
 
+  EXCLUSIVE_OFFER_STATES = %i[pending_conditions recruited offer_deferred].freeze
+
   POST_OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer_withdrawn]).freeze
 
   UNSUCCESSFUL_STATES = %i[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn application_not_sent inactive].freeze
@@ -37,6 +39,7 @@ class ApplicationStateChange
 
     post_offered:                  %i[conditions_not_met declined declined offer offer_deferred offer_withdrawn offer_withdrawn pending_conditions recruited],
     accepted:                      %i[conditions_not_met offer_deferred pending_conditions recruited],
+    exclusive_offer:               %i[offer_deferred pending_conditions recruited],
     unsuccessful:                  %i[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn application_not_sent inactive],
     successful:                    %i[offer offer_deferred pending_conditions recruited],
     terminal:                      %i[application_not_sent cancelled conditions_not_met declined inactive offer_withdrawn recruited rejected withdrawn],
@@ -203,10 +206,9 @@ class ApplicationStateChange
   # Application Progression States
   # Unsubmitted -> Decision Pending -> Offered -> Success/Unsuccess
 
-  ACCEPTED_STATES = %i[pending_conditions conditions_not_met recruited offer_deferred].freeze
-  OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer offer_withdrawn]).freeze
+  OFFERED_STATES = (accepted + %i[declined offer offer_withdrawn]).freeze
 
-  POST_OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer_withdrawn]).freeze
+  POST_OFFERED_STATES = (accepted + %i[declined offer_withdrawn]).freeze
 
   UNSUCCESSFUL_STATES = %i[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn application_not_sent inactive].freeze
   SUCCESSFUL_STATES = %i[pending_conditions offer offer_deferred recruited].freeze
@@ -219,7 +221,7 @@ class ApplicationStateChange
 
   REAPPLY_STATUSES = %i[rejected cancelled withdrawn declined offer_withdrawn].freeze
   # Used to determine if a candidate can add another application to their form
-  IN_PROGRESS_STATES = decision_pending + ACCEPTED_STATES + %i[offer].freeze
+  IN_PROGRESS_STATES = decision_pending + accepted + %i[offer].freeze
 
 private
 

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -61,7 +61,7 @@ class ApplicationStateChange
     decision_pending:              %i[awaiting_provider_decision interviewing],
     decision_pending_and_inactive: %i[awaiting_provider_decision inactive interviewing],
 
-    interviewable:                 %i[awaiting_provider_decision interviewing],
+    interviewable:                 %i[awaiting_provider_decision interviewing inactive],
     offered:                       %i[conditions_not_met declined offer offer_deferred offer_withdrawn pending_conditions recruited],
 
     post_offered:                  %i[conditions_not_met declined declined offer_deferred offer_withdrawn offer_withdrawn pending_conditions recruited],

--- a/app/services/get_referees_to_chase.rb
+++ b/app/services/get_referees_to_chase.rb
@@ -1,6 +1,6 @@
 class GetRefereesToChase
   attr_accessor :chase_referee_by, :rejected_chased_ids
-  APPLICATION_STATUSES = ApplicationStateChange::SUCCESSFUL_STATES - [:offer]
+  APPLICATION_STATUSES = ApplicationStateChange.successful - [:offer]
 
   def initialize(chase_referee_by:, rejected_chased_ids:)
     @chase_referee_by = chase_referee_by

--- a/app/services/interview_validations.rb
+++ b/app/services/interview_validations.rb
@@ -1,7 +1,7 @@
 class InterviewValidations
   include ActiveModel::Model
 
-  APPLICATION_STATES_ALLOWING_CHANGES = ApplicationStateChange::INTERVIEWABLE_STATES.map(&:to_s).freeze
+  APPLICATION_STATES_ALLOWING_CHANGES = ApplicationStateChange.interviewable.map(&:to_s).freeze
 
   attr_reader :interview, :today
 

--- a/app/services/interview_workflow_constraints.rb
+++ b/app/services/interview_workflow_constraints.rb
@@ -1,5 +1,5 @@
 class InterviewWorkflowConstraints
-  STATES_ALLOWING_INTERVIEW_CHANGES = ApplicationStateChange::INTERVIEWABLE_STATES.map(&:to_s).freeze
+  STATES_ALLOWING_INTERVIEW_CHANGES = ApplicationStateChange.interviewable.map(&:to_s).freeze
 
   attr_reader :interview, :today
   delegate :application_choice, to: :interview

--- a/app/services/offer_validations.rb
+++ b/app/services/offer_validations.rb
@@ -101,7 +101,7 @@ private
   def can_not_receive_other_offers?
     (application_choice.self_and_siblings - [application_choice])
       .map(&:status).map(&:to_sym)
-      .intersect?(ApplicationStateChange::ACCEPTED_STATES - [:conditions_not_met])
+      .intersect?(ApplicationStateChange.exclusive_offer)
   end
 
   def candidate_in_apply_2?

--- a/app/services/provider_interface/diversity_data_by_provider.rb
+++ b/app/services/provider_interface/diversity_data_by_provider.rb
@@ -184,7 +184,7 @@ module ProviderInterface
     def status_bucket_for(application_form)
       if application_form.statuses.include?('recruited')
         :recruited
-      elsif application_form.statuses.any? { |status| ApplicationStateChange::OFFERED_STATES.include?(status.to_sym) }
+      elsif application_form.statuses.any? { |status| ApplicationStateChange.offered.include?(status.to_sym) }
         :offer
       else
         :applied

--- a/app/services/provider_interface/hesa_data_export.rb
+++ b/app/services/provider_interface/hesa_data_export.rb
@@ -47,7 +47,7 @@ module ProviderInterface
 
     def export_data
       GetApplicationChoicesForProviders.call(providers: actor.providers, recruitment_cycle_year:)
-        .where('candidates.hide_in_reporting' => false, 'status' => ApplicationStateChange::ACCEPTED_STATES)
+        .where('candidates.hide_in_reporting' => false, 'status' => ApplicationStateChange.accepted)
         .joins(application_form: :candidate)
     end
 

--- a/app/services/reject_by_default_feedback.rb
+++ b/app/services/reject_by_default_feedback.rb
@@ -1,0 +1,60 @@
+class RejectByDefaultFeedback
+  include ImpersonationAuditHelper
+
+  attr_reader :application_choice, :rejection_reason, :structured_rejection_reasons
+
+  def initialize(actor:, application_choice:, rejection_reason: nil, structured_rejection_reasons: nil)
+    @actor = actor
+    @application_choice = application_choice
+    @rejection_reason = rejection_reason
+    @structured_rejection_reasons = structured_rejection_reasons
+  end
+
+  def save
+    audit(@actor) do
+      ActiveRecord::Base.transaction do
+        application_choice.rejection_reason = rejection_reason
+        application_choice.structured_rejection_reasons = structured_rejection_reasons
+        application_choice.rejection_reasons_type = structured_rejection_reasons.blank? ? :rejection_reason : structured_rejection_reasons.class.name.underscore
+        application_choice.reject_by_default_feedback_sent_at = Time.zone.now
+        application_choice.save!
+      end
+
+      show_apply_again_guidance = unsuccessful_application_choices? && not_applied_again?
+
+      unless application_choice.continuous_applications?
+        CandidateMailer.feedback_received_for_application_rejected_by_default(application_choice, show_apply_again_guidance).deliver_later
+      end
+
+      notify_slack
+    end
+  end
+
+  def notify_slack
+    provider_name = application_choice.current_course.provider.name
+    candidate_name = application_form.first_name
+    message = ":telephone_receiver: #{provider_name} has sent feedback for #{candidate_name}’s RBD application"
+    url = Rails.application.routes.url_helpers.support_interface_application_form_url(application_form)
+
+    SlackNotificationWorker.perform_async(message, url)
+  end
+
+private
+
+  def not_applied_again?
+    application_form.subsequent_application_form.nil?
+  end
+
+  def unsuccessful_application_choices?
+    application_form
+      .application_choices
+      .map(&:status)
+      .all? { |status| ApplicationStateChange.unsuccessful.include?(status.to_sym) }
+  end
+
+  def application_form
+    @application_form ||= application_choice.application_form
+  end
+
+  delegate :candidate, to: :application_form
+end

--- a/app/services/revert_rejected_by_default.rb
+++ b/app/services/revert_rejected_by_default.rb
@@ -1,0 +1,46 @@
+class RevertRejectedByDefault
+  attr_reader :ids, :new_rbd_date
+
+  def initialize(ids:, new_rbd_date:)
+    @ids = ids
+    @new_rbd_date = new_rbd_date
+  end
+
+  def call
+    Audited.audit_class.as_user('RevertRejectedByDefault worker') do
+      ApplicationChoice
+        .where(application_form_id: ids)
+        .where(rejected_by_default: true)
+        .find_each do |application_choice|
+          statuses_for_form = application_choice.self_and_siblings.pluck(:status)
+
+          # do not continue if the application has an accepted offer
+          next if statuses_for_form.any? do |s|
+            ApplicationStateChange.accepted.include?(s.to_sym)
+          end
+
+          application_choice.update!(
+            reject_by_default_at: new_rbd_date,
+            status: :awaiting_provider_decision,
+            rejected_by_default: false,
+            rejected_at: nil,
+            rejection_reason: nil,
+            structured_rejection_reasons: nil,
+          )
+
+          application_choice.self_and_siblings.where(status: :offer).update(
+            decline_by_default_at: nil,
+            decline_by_default_days: nil,
+          )
+        end
+
+      ApplicationForm
+        .where(id: ids)
+        .find_each do |form|
+          form.chasers_sent
+            .where(chaser_type: :candidate_decision_request)
+            .destroy_all
+        end
+    end
+  end
+end

--- a/app/services/submit_reference.rb
+++ b/app/services/submit_reference.rb
@@ -44,7 +44,7 @@ private
   end
 
   def accepted_application
-    @application_choices ||= reference.application_form.application_choices.where(status: ApplicationStateChange::SUCCESSFUL_STATES).first
+    @application_choices ||= reference.application_form.application_choices.where(status: ApplicationStateChange.successful).first
   end
 
   # Only progress the applications if the reference that is being submitted is

--- a/app/services/support_interface/application_monitor.rb
+++ b/app/services/support_interface/application_monitor.rb
@@ -28,7 +28,7 @@ module SupportInterface
       ApplicationForm
         .includes(%i[candidate application_choices])
         .joins(application_choices: [:course_option])
-        .where.not(application_choices: { status: ApplicationStateChange::TERMINAL_STATES })
+        .where.not(application_choices: { status: ApplicationStateChange.terminal })
         .order('application_forms.id desc')
         .distinct
     end

--- a/app/services/support_interface/candidate_journey_tracker.rb
+++ b/app/services/support_interface/candidate_journey_tracker.rb
@@ -125,7 +125,7 @@ module SupportInterface
     def ended_without_success
       earliest_update_audit_for(
         @application_choice,
-        status: ApplicationStateChange::UNSUCCESSFUL_STATES.map(&:to_s),
+        status: ApplicationStateChange.unsuccessful.map(&:to_s),
       )
     end
 

--- a/app/services/support_interface/change_application_choice_course_option.rb
+++ b/app/services/support_interface/change_application_choice_course_option.rb
@@ -2,7 +2,7 @@ module SupportInterface
   class ApplicationStateError < StandardError; end
 
   class ChangeApplicationChoiceCourseOption
-    VALID_STATES = ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER
+    VALID_STATES = ApplicationStateChange.visible_to_provider
 
     attr_reader :application_choice, :provider_id, :course_code, :study_mode, :site_code, :audit_comment
     attr_accessor :confirm_course_change

--- a/app/services/support_interface/tad_provider_stats_export.rb
+++ b/app/services/support_interface/tad_provider_stats_export.rb
@@ -39,7 +39,7 @@ module SupportInterface
     end
 
     def count_offers(choice_statuses)
-      choice_statuses.count { |status| ApplicationStateChange::OFFERED_STATES.include?(status.to_sym) }
+      choice_statuses.count { |status| ApplicationStateChange.offered.include?(status.to_sym) }
     end
 
     def count_acceptances(choice_statuses)

--- a/app/services/support_interface/tad_provider_stats_export.rb
+++ b/app/services/support_interface/tad_provider_stats_export.rb
@@ -43,7 +43,7 @@ module SupportInterface
     end
 
     def count_acceptances(choice_statuses)
-      choice_statuses.count { |status| ApplicationStateChange::ACCEPTED_STATES.include?(status.to_sym) }
+      choice_statuses.count { |status| ApplicationStateChange.accepted.include?(status.to_sym) }
     end
   end
 end

--- a/app/validators/reapply_validator.rb
+++ b/app/validators/reapply_validator.rb
@@ -29,7 +29,7 @@ class ReapplyValidator < ActiveModel::Validator
   end
 
   def record_has_reapply_status?(record)
-    ApplicationStateChange::REAPPLY_STATUSES.include?(record.status.to_s.to_sym)
+    ApplicationStateChange.reapply.include?(record.status.to_s.to_sym)
   end
 
   def blank_attributes?(record)

--- a/app/views/api_docs/vendor_api_docs/reference/_v1_1_changes.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/_v1_1_changes.html.erb
@@ -47,7 +47,7 @@
 
 <p class="govuk-body">Applications in the following states will transition to the <code>withdrawn</code> state:</p>
 <ul class="govuk-list govuk-list--bullet">
-  <% (ApplicationStateChange::SUCCESSFUL_STATES + ApplicationStateChange.decision_pending).each do |state| %>
+  <% (ApplicationStateChange.successful + ApplicationStateChange.decision_pending).each do |state| %>
     <li><code><%= state %></code></li>
   <% end %>
 </ul>

--- a/app/views/api_docs/vendor_api_docs/reference/_v1_1_changes.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/_v1_1_changes.html.erb
@@ -47,7 +47,7 @@
 
 <p class="govuk-body">Applications in the following states will transition to the <code>withdrawn</code> state:</p>
 <ul class="govuk-list govuk-list--bullet">
-  <% (ApplicationStateChange::SUCCESSFUL_STATES + ApplicationStateChange::DECISION_PENDING_STATUSES).each do |state| %>
+  <% (ApplicationStateChange::SUCCESSFUL_STATES + ApplicationStateChange.decision_pending).each do |state| %>
     <li><code><%= state %></code></li>
   <% end %>
 </ul>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -57,7 +57,7 @@
   </div>
 <% end %>
 
-<% if @provider_user_can_make_decisions && ApplicationStateChange::DECISION_PENDING_STATUSES.include?(@application_choice.status.to_sym) %>
+<% if @provider_user_can_make_decisions && ApplicationStateChange.decision_pending.include?(@application_choice.status.to_sym) %>
   <%= render ProviderInterface::ChangeCourseDetailsComponent.new(
     application_choice: @application_choice,
     course_option: @application_choice.course_option,

--- a/app/workers/detect_invariants_daily_check.rb
+++ b/app/workers/detect_invariants_daily_check.rb
@@ -69,7 +69,7 @@ class DetectInvariantsDailyCheck
   def detect_submitted_applications_with_more_than_the_max_course_choices
     applications_with_too_many_choices = ApplicationForm
       .joins(:application_choices)
-      .where(application_choices: { status: (ApplicationStateChange::DECISION_PENDING_STATUSES + ApplicationStateChange::ACCEPTED_STATES + ApplicationStateChange::SUCCESSFUL_STATES) })
+      .where(application_choices: { status: (ApplicationStateChange.decision_pending + ApplicationStateChange::ACCEPTED_STATES + ApplicationStateChange::SUCCESSFUL_STATES) })
       .group('application_forms.id')
       .having("count(application_choices) > #{ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES}")
       .sort

--- a/app/workers/detect_invariants_daily_check.rb
+++ b/app/workers/detect_invariants_daily_check.rb
@@ -90,7 +90,7 @@ class DetectInvariantsDailyCheck
   def detect_submitted_applications_with_more_than_the_max_unsuccessful_choices
     applications_with_too_many_unsuccessful_choices = ApplicationForm
       .joins(:application_choices)
-      .where(application_choices: { status: (ApplicationStateChange::UNSUCCESSFUL_STATES - %i[inactive]) })
+      .where(application_choices: { status: (ApplicationStateChange.unsuccessful - %i[inactive]) })
       .group('application_forms.id')
       .having("count(application_choices) > #{ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS}")
       .sort

--- a/app/workers/detect_invariants_daily_check.rb
+++ b/app/workers/detect_invariants_daily_check.rb
@@ -69,7 +69,7 @@ class DetectInvariantsDailyCheck
   def detect_submitted_applications_with_more_than_the_max_course_choices
     applications_with_too_many_choices = ApplicationForm
       .joins(:application_choices)
-      .where(application_choices: { status: (ApplicationStateChange.decision_pending + ApplicationStateChange.accepted + ApplicationStateChange::SUCCESSFUL_STATES) })
+      .where(application_choices: { status: (ApplicationStateChange.decision_pending + ApplicationStateChange.accepted + ApplicationStateChange.successful) })
       .group('application_forms.id')
       .having("count(application_choices) > #{ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES}")
       .sort

--- a/app/workers/detect_invariants_daily_check.rb
+++ b/app/workers/detect_invariants_daily_check.rb
@@ -69,7 +69,7 @@ class DetectInvariantsDailyCheck
   def detect_submitted_applications_with_more_than_the_max_course_choices
     applications_with_too_many_choices = ApplicationForm
       .joins(:application_choices)
-      .where(application_choices: { status: (ApplicationStateChange.decision_pending + ApplicationStateChange::ACCEPTED_STATES + ApplicationStateChange::SUCCESSFUL_STATES) })
+      .where(application_choices: { status: (ApplicationStateChange.decision_pending + ApplicationStateChange.accepted + ApplicationStateChange::SUCCESSFUL_STATES) })
       .group('application_forms.id')
       .having("count(application_choices) > #{ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES}")
       .sort

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
   web:
     build: .
     image: apply-for-teacher-training
-    platform: linux/x86_64
     ports:
       - "3000:3000"
     depends_on:

--- a/docs/states/typical_flow.md
+++ b/docs/states/typical_flow.md
@@ -1,0 +1,47 @@
+# State Flow Chart
+
+
+```mermaid
+---
+title: Generic Flow
+---
+flowchart LR
+subgraph AllStates
+    subgraph Unsubmitted
+        unsubmitted[fa:fa-pen Unsubmitted]
+        application_not_sent[fa:fa-skull Application Not Sent]
+    end
+
+    subgraph Submitted
+        awaiting_provider_decision[fa:fa-hourglass-start Awaiting Provider Decision]
+    end
+
+    subgraph "InProgress"
+        interviewing[fa:fa-comments Interviewing]
+
+        offer[fa:fa-gift Offer]
+    end
+
+    subgraph PostOffer
+        pending_conditions[fa:fa-times-circle Pending Conditions]
+
+        inactive[fa:fa-hourglass-end Inactive]
+    end
+
+    subgraph Success
+        recruited[fa:fa-user-check Recruited]
+        offer_deferred[fa:fa-user-clock Offer Deferred]
+    end
+
+    subgraph Fail
+        conditions_not_met[fa:fa-times-circle Conditions Not Met]
+        withdrawn[fa:fa-arrow-down Withdrawn]
+        cancelled[fa:fa-backspace Cancelled]
+        rejected[fa:fa-ban Rejected]
+        declined[fa:fa-thumbs-down Declined]
+        offer_withdrawn[fa:fa-undo Offer Withdrawn]
+    end
+
+    Unsubmitted ---> Submitted ---> InProgress ---> PostOffer ---> Success
+end
+```

--- a/inactive.md
+++ b/inactive.md
@@ -16,7 +16,7 @@ So `inactive` is considered "not in progress".
 
 There is a limit on the number of open appliations a candidate can have on their application form. When an application becomes `inactive` they can add a new application beyond the limit.
 
-We use `DetectInvariantsDailyCheck#detect_submitted_applications_with_more_than_the_max_unsuccessful_choices` to check for candidates with more than the permitted number of in progress applicaitons.
+We use `DetectInvariantsDailyCheck#detect_submitted_applications_with_more_than_the_max_unsuccessful_choices` to check for candidates with more than the permitted number of in progress applications.
 
 ```ruby
   # app/workers/detect_invariants_daily_check.rb:90

--- a/inactive.md
+++ b/inactive.md
@@ -1,0 +1,70 @@
+# What is inactive?
+
+Inactive is when an application has not been actioned by the Provider for over 30 days.
+It is a mix between `awaiting_provider_decision` and `rejected_by_default` and a terminal state.
+
+## How does an application become inactive?
+When an application is submitted, we set the `reject_by_default` at
+
+## Why is it considered a Terminal state?
+terminal means "unsuccessful". This is `withdrawn`, `rejected`, `declined`, `conditions not met` etc.
+terminal also includes successfully `recruited`.
+
+`unsuccessful` is the opposite of `in_progress`.
+
+So `inactive` is considered "not in progress".
+
+There is a limit on the number of open appliations a candidate can have on their application form. When an application becomes `inactive` they can add a new application beyond the limit.
+
+We use `DetectInvariantsDailyCheck#detect_submitted_applications_with_more_than_the_max_unsuccessful_choices` to check for candidates with more than the permitted number of in progress applicaitons.
+
+```ruby
+  # app/workers/detect_invariants_daily_check.rb:90
+
+  def detect_submitted_applications_with_more_than_the_max_unsuccessful_choices
+    applications_with_too_many_unsuccessful_choices = ApplicationForm
+      .joins(:application_choices)
+      .where(application_choices: { status: (ApplicationStateChange.unsuccessful - %i[inactive]) })
+      .group('application_forms.id')
+      .having("count(application_choices) > #{ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS}")
+      .sort
+```
+
+```ruby
+  # app/models/application_form.rb:404
+
+  def in_progress_applications
+    application_choices.reject(&:application_unsuccessful?)
+  end
+```
+
+```ruby
+  # app/queries/get_application_progress_data_by_course:21
+
+  def provider_application_choices
+    ApplicationChoice.joins(:course)
+      .where(status: %i[awaiting_provider_decision interviewing offer pending_conditions recruited inactive])
+  end
+```
+
+** rename `inactive_since` scope on ApplicationForm **
+
+
+application_timeline_component doesn't reference inactive status, should it?
+
+In the CandidateInterface, the status tag for inactive is the same colour as `interviewing` and `awaiging_provider_decision`
+
+DetectInvariantsDailyCheck#detect_submitted_applications_with_more_than_the_max_unsuccessful_choices
+  This Gets all unsuccessful applications except inactive
+
+Inactive is unsuccessful when:
+Inactive is not unsuccessful when:
+ - We want to display the references tab in the provider interface on the application choice show action
+
+
+
+1. Inactive applications do not count towards the limit of choices a candidate can make on an application form.
+2. In the Provider interface and API, the status of inactive is shown as `received`
+    a. They are sorted to the top of the application choice index
+    b. They do not have a filter on the index
+3.

--- a/spec/components/candidate_interface/previous_applications_component_spec.rb
+++ b/spec/components/candidate_interface/previous_applications_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CandidateInterface::PreviousApplicationsComponent do
     context 'with a single application choice with an ACCEPTED state' do
       let(:current_application_form) { create_application_form_with_course_choices(statuses: [status], candidate:) }
 
-      ApplicationStateChange::ACCEPTED_STATES.each do |status|
+      ApplicationStateChange.accepted.each do |status|
         let(:status) { status }
 
         it "does not render the component for accepted state: '#{status}'" do

--- a/spec/components/provider_interface/application_timeline_component_spec.rb
+++ b/spec/components/provider_interface/application_timeline_component_spec.rb
@@ -291,6 +291,6 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
   end
 
   it 'has a title for all state transitions' do
-    expect(ApplicationStateChange.states_visible_to_provider - %i[inactive]).to match_array(ProviderInterface::ApplicationTimelineComponent::TITLES.keys.map(&:to_sym))
+    expect(ApplicationStateChange.visible_to_provider - %i[inactive]).to match_array(ProviderInterface::ApplicationTimelineComponent::TITLES.keys.map(&:to_sym))
   end
 end

--- a/spec/components/utility/degree_qualification_cards_component_spec.rb
+++ b/spec/components/utility/degree_qualification_cards_component_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe DegreeQualificationCardsComponent, type: :component do
       end
 
       it 'renders the institution even when the offer has not been accepted yet' do
-        (ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER - ApplicationStateChange.accepted).each do |state|
+        (ApplicationStateChange.visible_to_provider - ApplicationStateChange.accepted).each do |state|
           result = render_inline described_class.new([degree], application_choice_state: state)
           expect(result.text).to include 'The University of Oxford'
         end

--- a/spec/components/utility/degree_qualification_cards_component_spec.rb
+++ b/spec/components/utility/degree_qualification_cards_component_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe DegreeQualificationCardsComponent, type: :component do
       end
 
       it 'renders the institution even when the offer has not been accepted yet' do
-        (ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER - ApplicationStateChange::ACCEPTED_STATES).each do |state|
+        (ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER - ApplicationStateChange.accepted).each do |state|
           result = render_inline described_class.new([degree], application_choice_state: state)
           expect(result.text).to include 'The University of Oxford'
         end

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -32,7 +32,7 @@ FactoryBot.define do
 
     status do
       if application_form&.submitted?
-        ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER.sample
+        ApplicationStateChange.visible_to_provider.sample
       else
         'unsubmitted'
       end

--- a/spec/factory_specs/application_choice_factory_spec.rb
+++ b/spec/factory_specs/application_choice_factory_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe 'ApplicationChoice factory' do
         }
       end
 
-      field :status, one_of: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER.map(&:to_s)
+      field :status, one_of: ApplicationStateChange.visible_to_provider.map(&:to_s)
     end
 
     context 'if an unsubmitted form is provided' do

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe ApplicationChoice do
     end
 
     it 'scopes to awaiting_provider_decision and interviewing application choices' do
-      (ApplicationStateChange.valid_states - ApplicationStateChange::DECISION_PENDING_STATUSES).each do |state|
+      (ApplicationStateChange.valid_states - ApplicationStateChange.decision_pending).each do |state|
         create(:application_choice, status: state)
       end
       choice_awaiting_decision = create(:application_choice, :awaiting_provider_decision)

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -53,11 +53,11 @@ RSpec.describe ApplicationChoice do
       expect(described_class.reappliable).to be_empty
     end
 
-    it 'scopes to REAPPLY_STATUSES choices' do
-      (ApplicationStateChange.valid_states - ApplicationStateChange::REAPPLY_STATUSES).each do |state|
+    it 'scopes to .reapply choices' do
+      (ApplicationStateChange.valid_states - ApplicationStateChange.reapply).each do |state|
         create(:application_choice, status: state)
       end
-      reappliable = ApplicationStateChange::REAPPLY_STATUSES.map do |state|
+      reappliable = ApplicationStateChange.reapply.map do |state|
         create(:application_choice, status: state)
       end
 
@@ -254,7 +254,7 @@ RSpec.describe ApplicationChoice do
     end
 
     context 'when the application is in a reappliable state' do
-      ApplicationStateChange::REAPPLY_STATUSES.each do |status|
+      ApplicationStateChange.reapply.each do |status|
         it "does not enforce unique application form and course option when status is '#{status}'" do
           create(:application_choice, application_form:, course_option:, status: status)
 

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe ApplicationChoice do
 
   describe '#decision_pending?' do
     it 'returns false for choices in states not requiring provider action' do
-      (ApplicationStateChange.valid_states - ApplicationStateChange::DECISION_PENDING_AND_INACTIVE_STATUSES).each do |state|
+      (ApplicationStateChange.valid_states - ApplicationStateChange.decision_pending_and_inactive).each do |state|
         application_choice = build_stubbed(:application_choice, status: state)
         expect(application_choice.decision_pending?).to be(false)
       end

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe ApplicationChoice do
     it 'returns all pending_conditions, conditions_not_met, recruited or offer_deferred statuses' do
       ApplicationStateChange.valid_states.each { |state| create(:application_choice, status: state) }
 
-      expect(described_class.accepted.map(&:status)).to match_array(ApplicationStateChange::ACCEPTED_STATES.map(&:to_s))
+      expect(described_class.accepted.map(&:status)).to match_array(ApplicationStateChange.accepted.map(&:to_s))
     end
   end
 

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -614,4 +614,12 @@ RSpec.describe ApplicationChoice do
       end
     end
   end
+
+  describe '#in_progress?' do
+    let(:application_choice) { build(:application_choice, :inactive) }
+
+    it 'returns false for inactive application choices' do
+      expect(application_choice.in_progress?).to be(false)
+    end
+  end
 end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -943,7 +943,7 @@ RSpec.describe ApplicationForm do
     let(:course_option_not_applied) { build(:course_option, course:) }
 
     context 'when the candidate cannot reapply for it' do
-      (ApplicationStateChange.valid_states - ApplicationStateChange.reapply_states).each do |status|
+      (ApplicationStateChange.valid_states - ApplicationStateChange.reapply).each do |status|
         it "returns true when status is #{status}" do
           create(:application_choice, status.to_sym, course_option: course_option_applied, application_form:)
           expect(application_form.contains_course?(course)).to be true
@@ -952,7 +952,7 @@ RSpec.describe ApplicationForm do
     end
 
     context 'when the candidate can reapply for it' do
-      ApplicationStateChange.reapply_states.each do |status|
+      ApplicationStateChange.reapply.each do |status|
         it "returns false when the states is #{status}" do
           create(:application_choice, status.to_sym, course:, application_form:)
           expect(application_form.contains_course?(course)).to be false

--- a/spec/refinements/inverse_hash_spec.rb
+++ b/spec/refinements/inverse_hash_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe InverseHash do
+  before do
+    stub_const('Klass', Class.new do
+      using InverseHash
+
+      def config(hsh)
+        hsh.inverse
+      end
+    end)
+  end
+
+  subject(:run) { Klass.new.config(arg) }
+
+  context 'when the hash is simple' do
+    let(:arg) { { a: 1, b: 2 } }
+
+    it { is_expected.to eq({ 1 => :a, 2 => :b }) }
+  end
+
+  context 'when the hash value is an array' do
+    let(:arg) { { a: 1, b: [1, 2] } }
+
+    it { is_expected.to eq({ 1 => %i[a b], 2 => [:b] }) }
+  end
+
+  context 'when the hash value is an hash' do
+    let(:arg) { { a: 1, b: { c: 2 } } }
+
+    it { expect { run }.to raise_error(Hash::UninversableHashError) }
+  end
+end

--- a/spec/refinements/inverse_hash_spec.rb
+++ b/spec/refinements/inverse_hash_spec.rb
@@ -28,6 +28,6 @@ RSpec.describe InverseHash do
   context 'when the hash value is an hash' do
     let(:arg) { { a: 1, b: { c: 2 } } }
 
-    it { expect { run }.to raise_error(Hash::UninversableHashError) }
+    it { expect { run }.to raise_error(StandardError, 'UninversableHashError: Cannot inverse a nested hash') }
   end
 end

--- a/spec/requests/vendor_api/v1.0/get_status_for_applications_spec.rb
+++ b/spec/requests/vendor_api/v1.0/get_status_for_applications_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Vendor API - GET /api/v1.0/applications' do
     ]
 
     # The API is not concerned with unsubmitted applications.
-    statuses = ApplicationStateChange.states_visible_to_provider - %w[unsubmitted]
+    statuses = ApplicationStateChange.visible_to_provider - %w[unsubmitted]
 
     statuses.each do |status|
       create(:application_choice, status, course_option: course_option_for_provider(provider: currently_authenticated_provider))

--- a/spec/services/application_state_change_spec.rb
+++ b/spec/services/application_state_change_spec.rb
@@ -24,6 +24,103 @@ RSpec.describe ApplicationStateChange do
       it 'matches the valid states and states not visible' do
         expect(described_class.states_visible_to_provider)
           .to match_array(described_class.valid_states - described_class::STATES_NOT_VISIBLE_TO_PROVIDER)
+
+  describe '.states_by_category' do
+    it 'has all states in the correct categories' do
+      expect(described_class.states_by_category).to include(
+        not_visible_to_provider: %i[unsubmitted cancelled application_not_sent],
+        visible_to_provider: %i[awaiting_provider_decision conditions_not_met declined inactive interviewing offer offer_deferred offer_withdrawn pending_conditions recruited rejected withdrawn],
+        interviewable: %i[awaiting_provider_decision interviewing],
+        accepted: %i[conditions_not_met offer_deferred pending_conditions recruited],
+        offered: %i[conditions_not_met declined offer offer_deferred offer_withdrawn pending_conditions recruited],
+        post_offered: %i[conditions_not_met declined declined offer offer_deferred offer_withdrawn offer_withdrawn pending_conditions recruited],
+        unsuccessful: %i[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn application_not_sent inactive],
+        successful: %i[offer offer_deferred pending_conditions recruited],
+        decision_pending: %i[awaiting_provider_decision interviewing],
+        decision_pending_and_inactive: %i[awaiting_provider_decision inactive interviewing],
+        reapply: %i[cancelled declined offer_withdrawn rejected withdrawn],
+        terminal: %i[application_not_sent cancelled conditions_not_met declined inactive offer_withdrawn recruited rejected withdrawn],
+        in_progress: %i[awaiting_provider_decision interviewing conditions_not_met offer_deferred pending_conditions recruited offer],
+      )
+    end
+  end
+
+  describe 'states by category' do
+    describe '.visible_to_provider' do
+      it 'matches the valid states and states not visible' do
+        expect(described_class.visible_to_provider).to eq(described_class::STATES_BY_CATEGORY[:visible_to_provider])
+      end
+    end
+
+    describe '.not_visible_to_provider' do
+      it 'matches the valid states and states not visible' do
+        expect(described_class.not_visible_to_provider).to eq(described_class::STATES_BY_CATEGORY[:not_visible_to_provider])
+      end
+    end
+
+    describe '.interviewable' do
+      it 'matches the valid states and states not visible' do
+        expect(described_class.interviewable).to eq(described_class::STATES_BY_CATEGORY[:interviewable])
+      end
+    end
+
+    describe '.accepted' do
+      it 'matches the valid states and states not visible' do
+        expect(described_class.accepted).to eq(described_class::STATES_BY_CATEGORY[:accepted])
+      end
+    end
+
+    describe '.offered' do
+      it 'matches the valid states and states not visible' do
+        expect(described_class.offered).to eq(described_class::STATES_BY_CATEGORY[:offered])
+      end
+    end
+
+    describe '.post_offered' do
+      it 'matches the valid states and states not visible' do
+        expect(described_class.post_offered).to eq(described_class::STATES_BY_CATEGORY[:post_offered])
+      end
+    end
+
+    describe '.unsuccessful' do
+      it 'matches the valid states and states not visible' do
+        expect(described_class.unsuccessful).to eq(described_class::STATES_BY_CATEGORY[:unsuccessful])
+      end
+    end
+
+    describe '.successful' do
+      it 'matches the valid states and states not visible' do
+        expect(described_class.successful).to eq(described_class::STATES_BY_CATEGORY[:successful])
+      end
+    end
+
+    describe '.decision_pending' do
+      it 'matches the valid states and states not visible' do
+        expect(described_class.decision_pending).to eq(described_class::STATES_BY_CATEGORY[:decision_pending])
+      end
+    end
+
+    describe '.decision_pending_and_inactive' do
+      it 'matches the valid states and states not visible' do
+        expect(described_class.decision_pending_and_inactive).to eq(described_class::STATES_BY_CATEGORY[:decision_pending_and_inactive])
+      end
+    end
+
+    describe '.decision_pending_and_inactive' do
+      it 'matches the valid states and states not visible' do
+        expect(described_class.decision_pending_and_inactive).to eq(described_class::STATES_BY_CATEGORY[:decision_pending_and_inactive])
+      end
+    end
+
+    describe '.terminal' do
+      it 'matches the valid states and states not visible' do
+        expect(described_class.terminal).to eq(described_class::STATES_BY_CATEGORY[:terminal])
+      end
+    end
+
+    describe '.in_progress' do
+      it 'matches the valid states and states not visible' do
+        expect(described_class.in_progress).to eq(described_class::STATES_BY_CATEGORY[:in_progress])
       end
     end
   end

--- a/spec/services/application_state_change_spec.rb
+++ b/spec/services/application_state_change_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe ApplicationStateChange do
   describe '.visible_to_provider' do
     it 'matches the valid states and states not visible' do
       expect(described_class.visible_to_provider)
-        .to match_array(described_class.valid_states - described_class::STATES_NOT_VISIBLE_TO_PROVIDER)
+        .to match_array(described_class.valid_states - described_class.not_visible_to_provider)
     end
   end
 

--- a/spec/services/application_state_change_spec.rb
+++ b/spec/services/application_state_change_spec.rb
@@ -109,12 +109,6 @@ RSpec.describe ApplicationStateChange do
       end
     end
 
-    describe '.decision_pending_and_inactive' do
-      it 'matches the valid states and states not visible' do
-        expect(described_class.decision_pending_and_inactive).to eq(described_class::STATES_BY_CATEGORY[:decision_pending_and_inactive])
-      end
-    end
-
     describe '.terminal' do
       it 'matches the valid states and states not visible' do
         expect(described_class.terminal).to eq(described_class::STATES_BY_CATEGORY[:terminal])

--- a/spec/services/application_state_change_spec.rb
+++ b/spec/services/application_state_change_spec.rb
@@ -19,11 +19,7 @@ RSpec.describe ApplicationStateChange do
           .to match_array(ApplicationChoice.statuses.keys.map(&:to_sym))
       end
     end
-
-    describe '.states_visible_to_provider' do
-      it 'matches the valid states and states not visible' do
-        expect(described_class.states_visible_to_provider)
-          .to match_array(described_class.valid_states - described_class::STATES_NOT_VISIBLE_TO_PROVIDER)
+  end
 
   describe '.states_by_category' do
     it 'has all states in the correct categories' do
@@ -129,6 +125,13 @@ RSpec.describe ApplicationStateChange do
       it 'matches the valid states and states not visible' do
         expect(described_class.in_progress).to eq(described_class::STATES_BY_CATEGORY[:in_progress])
       end
+    end
+  end
+
+  describe '.visible_to_provider' do
+    it 'matches the valid states and states not visible' do
+      expect(described_class.visible_to_provider)
+        .to match_array(described_class.valid_states - described_class::STATES_NOT_VISIBLE_TO_PROVIDER)
     end
   end
 

--- a/spec/services/application_state_change_spec.rb
+++ b/spec/services/application_state_change_spec.rb
@@ -141,9 +141,9 @@ RSpec.describe ApplicationStateChange do
     end
   end
 
-  describe '::STATES_NOT_VISIBLE_TO_PROVIDER' do
+  describe '.not_visible_to_provider' do
     it 'contains the correct states to filter by' do
-      expect(described_class.valid_states).to include(*described_class::STATES_NOT_VISIBLE_TO_PROVIDER)
+      expect(described_class.valid_states).to include(*described_class.not_visible_to_provider)
     end
   end
 

--- a/spec/services/application_state_change_spec.rb
+++ b/spec/services/application_state_change_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ApplicationStateChange do
         interviewable: %i[awaiting_provider_decision interviewing],
         accepted: %i[conditions_not_met offer_deferred pending_conditions recruited],
         offered: %i[conditions_not_met declined offer offer_deferred offer_withdrawn pending_conditions recruited],
-        post_offered: %i[conditions_not_met declined declined offer offer_deferred offer_withdrawn offer_withdrawn pending_conditions recruited],
+        post_offered: %i[conditions_not_met declined declined offer_deferred offer_withdrawn offer_withdrawn pending_conditions recruited],
         unsuccessful: %i[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn application_not_sent inactive],
         successful: %i[offer offer_deferred pending_conditions recruited],
         decision_pending: %i[awaiting_provider_decision interviewing],

--- a/spec/services/application_state_change_spec.rb
+++ b/spec/services/application_state_change_spec.rb
@@ -45,6 +45,13 @@ RSpec.describe ApplicationStateChange do
     end
   end
 
+  describe '.categories_by_state' do
+    it 'accounts for all valid states' do
+      expect(described_class.categories_by_state.keys)
+        .to match_array(described_class.valid_states)
+    end
+  end
+
   describe 'states by category' do
     describe '.visible_to_provider' do
       it 'matches the valid states and states not visible' do

--- a/spec/services/application_state_change_spec.rb
+++ b/spec/services/application_state_change_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ApplicationStateChange do
       expect(described_class.states_by_category).to include(
         not_visible_to_provider: %i[unsubmitted cancelled application_not_sent],
         visible_to_provider: %i[awaiting_provider_decision conditions_not_met declined inactive interviewing offer offer_deferred offer_withdrawn pending_conditions recruited rejected withdrawn],
-        interviewable: %i[awaiting_provider_decision interviewing],
+        interviewable: %i[awaiting_provider_decision interviewing inactive],
         accepted: %i[conditions_not_met offer_deferred pending_conditions recruited],
         offered: %i[conditions_not_met declined offer offer_deferred offer_withdrawn pending_conditions recruited],
         post_offered: %i[conditions_not_met declined declined offer_deferred offer_withdrawn offer_withdrawn pending_conditions recruited],

--- a/spec/services/support_interface/tad_provider_stats_export_spec.rb
+++ b/spec/services/support_interface/tad_provider_stats_export_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe SupportInterface::TADProviderStatsExport, :bullet do
       [%i[awaiting_provider_decision], 1, 0, 0],
       [ApplicationStateChange.offered, offered_states.count, offered_states.count, accepted_states.count],
       [ApplicationStateChange.accepted, accepted_states.count, accepted_states.count, accepted_states.count],
-      [ApplicationStateChange::STATES_NOT_VISIBLE_TO_PROVIDER, 0, 0, 0],
+      [ApplicationStateChange.not_visible_to_provider, 0, 0, 0],
     ]
 
     test_data.each do |states, applications, offers, acceptances|

--- a/spec/services/support_interface/tad_provider_stats_export_spec.rb
+++ b/spec/services/support_interface/tad_provider_stats_export_spec.rb
@@ -17,16 +17,16 @@ RSpec.describe SupportInterface::TADProviderStatsExport, :bullet do
   describe 'calculating offers and acceptances' do
     states_excluded_from_tad_export = [:offer_deferred]
     accepted_states = ApplicationStateChange.accepted - states_excluded_from_tad_export
-    offered_states = ApplicationStateChange::OFFERED_STATES - states_excluded_from_tad_export
+    offered_states = ApplicationStateChange.offered - states_excluded_from_tad_export
 
     unless accepted_states.count < offered_states.count &&
            (offered_states & accepted_states) == accepted_states
-      raise 'This spec assumes that ApplicationStateChange.accepted is a subset of ApplicationStateChange::OFFERED_STATES'
+      raise 'This spec assumes that ApplicationStateChange.accepted is a subset of ApplicationStateChange.offered'
     end
 
     test_data = [
       [%i[awaiting_provider_decision], 1, 0, 0],
-      [ApplicationStateChange::OFFERED_STATES, offered_states.count, offered_states.count, accepted_states.count],
+      [ApplicationStateChange.offered, offered_states.count, offered_states.count, accepted_states.count],
       [ApplicationStateChange.accepted, accepted_states.count, accepted_states.count, accepted_states.count],
       [ApplicationStateChange::STATES_NOT_VISIBLE_TO_PROVIDER, 0, 0, 0],
     ]

--- a/spec/services/support_interface/tad_provider_stats_export_spec.rb
+++ b/spec/services/support_interface/tad_provider_stats_export_spec.rb
@@ -16,18 +16,18 @@ RSpec.describe SupportInterface::TADProviderStatsExport, :bullet do
 
   describe 'calculating offers and acceptances' do
     states_excluded_from_tad_export = [:offer_deferred]
-    accepted_states = ApplicationStateChange::ACCEPTED_STATES - states_excluded_from_tad_export
+    accepted_states = ApplicationStateChange.accepted - states_excluded_from_tad_export
     offered_states = ApplicationStateChange::OFFERED_STATES - states_excluded_from_tad_export
 
     unless accepted_states.count < offered_states.count &&
            (offered_states & accepted_states) == accepted_states
-      raise 'This spec assumes that ApplicationStateChange::ACCEPTED_STATES is a subset of ApplicationStateChange::OFFERED_STATES'
+      raise 'This spec assumes that ApplicationStateChange.accepted is a subset of ApplicationStateChange::OFFERED_STATES'
     end
 
     test_data = [
       [%i[awaiting_provider_decision], 1, 0, 0],
       [ApplicationStateChange::OFFERED_STATES, offered_states.count, offered_states.count, accepted_states.count],
-      [ApplicationStateChange::ACCEPTED_STATES, accepted_states.count, accepted_states.count, accepted_states.count],
+      [ApplicationStateChange.accepted, accepted_states.count, accepted_states.count, accepted_states.count],
       [ApplicationStateChange::STATES_NOT_VISIBLE_TO_PROVIDER, 0, 0, 0],
     ]
 

--- a/spec/system/candidate_interface/continuous_applications/submitting/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/submitting/candidate_submitting_application_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature 'Candidate submits the application' do
   scenario 'Candidate with a completed application' do
     given_i_am_signed_in
 
+    # One choice, unsubmitted
     when_i_have_completed_my_application_and_have_added_primary_as_a_course_choice
     and_i_continue_with_my_application
 
@@ -28,6 +29,7 @@ RSpec.feature 'Candidate submits the application' do
     when_i_edit_my_personal_statement
     and_i_continue_with_my_application
     and_i_choose_to_submit
+    # One submitted application
     then_i_can_see_my_application_has_been_successfully_submitted
     and_i_am_redirected_to_the_application_dashboard
     and_my_application_is_submitted
@@ -40,6 +42,7 @@ RSpec.feature 'Candidate submits the application' do
 
     when_i_go_back
 
+    # 1 submitted, 3 draft
     when_i_have_three_further_draft_choices
     then_i_can_no_longer_add_more_course_choices
 
@@ -47,6 +50,7 @@ RSpec.feature 'Candidate submits the application' do
     then_i_still_cannot_add_course_choices
 
     when_one_of_my_applications_becomes_inactive
+    page.driver.browser.refresh
     then_i_am_able_to_add_another_choice
   end
 


### PR DESCRIPTION
## Context

Attempt to clean up the ApplicationStateChange constants littered throughout the code base.

There are many states that an ApplicationChoice can have, although it can only have one at a time. These states have been grouped into higher order categories, which are hard to manage and reason about.

I've tried to change things in this PR to help make the states and their categories (groups? we should have a name for these groupings).

I've identified two logical groups in how states are categorised.

1. Workflow stage groups
2. Utility Groups

Workflow stage groups are logical groups of states based on the linear process of moving an application from `unsubmitted` to `recruited`. We can identify meaningful stages within this process. See the flowchart.

Utility groups only have meaning in specific contexts their elements may cross the stage boundaries of the workflow stage groups. Because they don't conform to the properties of the Workflow stage categories, they're are a different kind of group.

This is a refactoring. Everything should work the same after this change as before.

Open for suggestions.

## Changes proposed in this pull request

The need to define in the code a state relative to another state creates a dependency. It might make sense at the time but it make the categories inflexible.

1. Flat categories
Do not create categories (sub-categories) dependent on the members of another category. This increases the complexity of the category system and makes changes harder and more involved. More care is required when making changes to ensure we aren't adding states to sub-categories when they are added to high level categories.

This means the state must be explicity added to any categories that we decide it should be a member of.

### WIP

We have informally defined super states or categories within the application in order to define behaviours.

In progress is a category of states that allow us to make decisions on what behaviour the candidate has available to them in certain circumstances.

Example:
A candidates application choice is "in progress" if it is in a state that contributes towards the limit of applications a candidate can have open at any one time.

If a candidate has 4 "in progress" applications, they cannot add any more application choices to their account in a single recruitment cycle. This concept of "in progress" includes `unsubmitted`.

Another concept of "in progress" is whether any more applications can be submitted. There is a limit on the number of applications a candidate can have submitted at any one time. This, by definition, does not include `unsubmitted`.

Let's find a better way of identifying and naming these concepts and be more consistent about them throughout the codebase. This must start in the ApplicationStateChange though.

#### Two ways of counting "in progress"

https://github.com/DFE-Digital/apply-for-teacher-training/blob/dd2086687aadb62d5c0e9fb078d1010859f79e98/app/models/application_form.rb#L294-L296

https://github.com/DFE-Digital/apply-for-teacher-training/blob/dd2086687aadb62d5c0e9fb078d1010859f79e98/app/models/application_form.rb#L391-L393
### ApplicationStateChange file

https://github.com/DFE-Digital/apply-for-teacher-training/pull/8750/files#diff-09a6ff87129a22875fca1a9e7c0329e5b3b91a90ed46ccd4e51e5325790c4b4b

## Guidance to review

This PR is currently a proposal.

We still need to define what `inactive` is. There are areas where it should be considered in one category and areas where it should not be in that category. This is a blocker to solving this category situation.

## Link to Trello card

<!-- http://trello.com/123-example-card -->