### PR TITLE
Add Publications::DataTableComponent

### DIFF
--- a/app/components/publications/data_table_component.html.erb
+++ b/app/components/publications/data_table_component.html.erb
@@ -1,0 +1,37 @@
+<h3 class="govuk-heading-m"><%= caption %></h3>
+<div class="govuk-tabs itt-report-tabs" data-module="govuk-tabs">
+  <ul class="govuk-tabs__list" role="tablist">
+    <% tab_names.each do |tab_name| %>
+      <li class="govuk-tabs__list-item" role="presentation">
+        <a class="govuk-tabs__tab" href="#<%= dom_id(title, tab_name) %>" id="tab-<%= dom_id(title, tab_name) %>" role="tab" aria-controls="<%= tab_name %>" aria-selected="false" tabindex="-1">
+          <%= tab_name.to_s.humanize %>
+        </a>
+      </li>
+    <% end %>
+  </ul>
+
+  <% data.each.with_index do |(tab_name, rows), index| %>
+    <div class="govuk-tabs__panel <%= 'govuk-tabs__panel--hidden' if index.positive? %>" id="<%= dom_id(title, tab_name) %>" role="tabpanel" aria-labelledby="tab-<%= dom_id(title, tab_name) %>">
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header"><%= title %></th>
+            <% rows.first.except(:title).keys.each do |header| %>
+            <th scope="col" class="govuk-table__header"><%= header.to_s.humanize %></th>
+            <% end %>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <% rows.each do |row| %>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__header"><%= row.values.first %></th>
+              <% row.values.from(1).each do |td| %>
+                <td class="govuk-table__cell"><%= td %></td>
+              <% end %>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
+</div>

--- a/app/components/publications/data_table_component.html.erb
+++ b/app/components/publications/data_table_component.html.erb
@@ -3,7 +3,8 @@
   <ul class="govuk-tabs__list" role="tablist">
     <% tab_names.each do |tab_name| %>
       <li class="govuk-tabs__list-item" role="presentation">
-        <a class="govuk-tabs__tab" href="#<%= dom_id(title, tab_name) %>" id="tab-<%= dom_id(title, tab_name) %>" role="tab" aria-controls="<%= tab_name %>" aria-selected="false" tabindex="-1">
+        <%# for explanation of title attribute see app/frontend/styles/publications/_itt_data_table.scss %>
+        <a class="govuk-tabs__tab" title="<%= tab_name.to_s.humanize %>" href="#<%= dom_id(title, tab_name) %>" id="tab-<%= dom_id(title, tab_name) %>" role="tab" aria-controls="<%= tab_name %>" aria-selected="false" tabindex="-1">
           <%= tab_name.to_s.humanize %>
         </a>
       </li>

--- a/app/components/publications/data_table_component.rb
+++ b/app/components/publications/data_table_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Publications
+  class DataTableComponent < ViewComponent::Base
+    attr_reader :caption, :title, :data
+
+    def initialize(caption:, title:, data:)
+      @caption = caption
+      @title = title
+      @data = data
+    end
+
+    def tab_names
+      data.keys
+    end
+
+    def dom_id(title, tab_name)
+      "#{title}-#{tab_name}".downcase.dasherize
+    end
+  end
+end

--- a/app/frontend/styles/application-publications.scss
+++ b/app/frontend/styles/application-publications.scss
@@ -1,3 +1,4 @@
 @import "application";
 @import "publications/metadata";
 @import "publications/sortable_table";
+@import "publications/itt_data_table";

--- a/app/frontend/styles/publications/_itt_data_table.scss
+++ b/app/frontend/styles/publications/_itt_data_table.scss
@@ -22,6 +22,18 @@
     padding: govuk-spacing(2);
     border: govuk-spacing(0);
     background-color: transparent;
+
+    // This is a hack to prevent the text from changing the size of the element when it becomes bold.
+    // Make the ::before element take up the same amount of space the element would if it were bold.
+    a::before {
+      display: block;
+      content: attr(title);
+      font-weight: bold;
+      height: 0;
+      overflow: hidden;
+      visibility: hidden;
+    }
+    // end hack
   }
 
   .govuk-tabs__list-item--selected {

--- a/app/frontend/styles/publications/_itt_data_table.scss
+++ b/app/frontend/styles/publications/_itt_data_table.scss
@@ -1,0 +1,46 @@
+.itt-report-tabs.govuk-tabs {
+  padding: govuk-spacing(2);
+  background-color: govuk-colour("light-grey");
+
+  .govuk-tabs__list {
+    border-bottom: govuk-spacing(0);
+  }
+
+  .govuk-tabs__panel {
+    border: govuk-spacing(0);
+  }
+
+  .govuk-tabs__tab {
+    padding-bottom: 2px;
+    color: $govuk-link-colour;
+    cursor: pointer;
+    text-decoration: underline;
+  }
+
+  .govuk-tabs__list-item {
+    margin-right: 0;
+    padding: govuk-spacing(2);
+    border: govuk-spacing(0);
+    background-color: transparent;
+  }
+
+  .govuk-tabs__list-item--selected {
+    margin-top: govuk-spacing(0);
+    font-weight: $govuk-font-weight-bold;
+
+    a {
+      text-decoration: none;
+    }
+  }
+
+  .govuk-table {
+    font-size: 1rem;
+  }
+
+  .govuk-table__body {
+    th[scope="row"] {
+      font-weight: $govuk-font-weight-regular;
+    }
+  }
+
+}

--- a/spec/components/previews/publications/data_table_component/default.html.erb
+++ b/spec/components/previews/publications/data_table_component/default.html.erb
@@ -1,0 +1,7 @@
+<%= stylesheet_pack_tag 'application-publications' %>
+<div>
+  <%= render Publications::DataTableComponent.new(caption: 'Applications by Age', title: local_assigns[:age_title], data: local_assigns[:age_data]) %>
+</div>
+<div>
+  <%= render Publications::DataTableComponent.new(caption: 'Applications by Phase', title: local_assigns[:phase_title], data: local_assigns[:phase_data]) %>
+</div>

--- a/spec/components/previews/publications/data_table_component_preview.rb
+++ b/spec/components/previews/publications/data_table_component_preview.rb
@@ -1,0 +1,41 @@
+module Publications
+  class DataTableComponentPreview < ViewComponent::Preview
+    def default
+      render_with_template(template: 'publications/data_table_component/default', locals: { age_title:, age_data:, phase_title:, phase_data: })
+    end
+
+  private
+
+    def age_title = 'Age'
+
+    def age_data
+      {
+        submitted: [
+          { title: '18 - 21', this_cycle: rand(100), last_cycle: rand(100) },
+          { title: '22 - 30', this_cycle: rand(100), last_cycle: rand(100) },
+          { title: '30 - 45', this_cycle: rand(100), last_cycle: rand(100) },
+        ],
+        with_offers: [
+          { title: '18 - 21', this_cycle: rand(100), last_cycle: rand(100) },
+          { title: '22 - 30', this_cycle: rand(100), last_cycle: rand(100) },
+          { title: '30 - 45', this_cycle: rand(100), last_cycle: rand(100) },
+        ],
+      }
+    end
+
+    def phase_title = 'Phase'
+
+    def phase_data
+      {
+        submitted: [
+          { title: 'Primary', this_cycle: rand(100), last_cycle: rand(100) },
+          { title: 'Secondary', this_cycle: rand(100), last_cycle: rand(100) },
+        ],
+        with_offers: [
+          { title: 'Primary', this_cycle: rand(100), last_cycle: rand(100) },
+          { title: 'Secondary', this_cycle: rand(100), last_cycle: rand(100) },
+        ],
+      }
+    end
+  end
+end

--- a/spec/components/publications/data_table_component_spec.rb
+++ b/spec/components/publications/data_table_component_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe Publications::DataTableComponent do
+  let(:component) { described_class.new(caption:, title:, data:) }
+  let(:caption) { 'Table with data' }
+  let(:title) { 'Age' }
+  let(:data) do
+    {
+      submitted: [
+        { title: '18 - 21', this_cycle: 22, last_cycle: 44 },
+      ],
+      with_offers: [
+        { title: '18 - 21', this_cycle: 55, last_cycle: 88 },
+      ],
+    }
+  end
+
+  it 'renders the table caption' do
+    result = render_inline(component)
+    expect(result).to have_css('.govuk-heading-m', text: caption)
+  end
+
+  it 'renders the "submitted" table' do
+    result = render_inline(component)
+    expect(result).to have_css('#age-submitted')
+  end
+
+  it 'does not render the "with-offers" table' do
+    result = render_inline(component)
+    expect(result).not_to have_css('#age-with_offers')
+  end
+
+  it 'shows the right data in the right cell' do
+    result = render_inline(component)
+    submitted_this_cycle_value = result.css('#age-submitted tbody td:first-of-type').text
+    actual = data[:submitted].first[:this_cycle].to_s
+
+    expect(submitted_this_cycle_value).to eq(actual)
+  end
+end


### PR DESCRIPTION
## Context

The 2023-2024 recruitment cycle has changed how candidates make applications and how many they make. This change has cause us to redesign the ITT monthly statistics report.

A significant change is how the tabular data is displayed.

In order to display the data as was designed, we've had to introduce a new component.

## Changes proposed in this pull request

Create a new tabular ViewComponent - `Publications::DataTableComponent`

Accepts a caption and a data object (`Hash` for now).
The schema of the data object has changed from the old schema to better match how the data is displayed.

The new component provides for showing multiple tables, which are navigated through links in the component. The Component uses the `govuk-frontend` `tabs.mjs` javascript package to show/hide the active/inactive tables.

Had to add a CSS hack to prevent the tab from changing size when it becomes bold.

### Screenshots

|Table 1| Table 2|
|---|---|
|![Screenshot from 2023-11-07 16-59-25](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/0ebe733a-8da8-421e-b45b-6f2f499bc9c4)|![Screenshot from 2023-11-07 16-59-40](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/e6dcd1ef-9682-49e4-b1b7-1a378111c332)|

## Guidance to review

[Review app component Preview](https://apply-review-8755.test.teacherservices.cloud/rails/view_components/publications/data_table_component/default)
## Link to Trello card

[Trello Ticket](https://trello.com/c/gMQbvdkU/922-monthly-statistics-fe-cohort-data-table-component)
