### PR TITLE
Update the Slack summary stats post to reflect continuous applications

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -38,6 +38,8 @@ class ApplicationForm < ApplicationRecord
         .where(mail_template:),
     )
   }
+  scope :international, -> { where.not(first_nationality: %w[British Irish]) }
+  scope :domestic, -> { where(first_nationality: %w[British Irish]) }
 
   REQUIRED_REFERENCE_SELECTIONS = 2
   REQUIRED_REFERENCES = 2

--- a/spec/services/stats_summary_spec.rb
+++ b/spec/services/stats_summary_spec.rb
@@ -3,20 +3,22 @@ require 'rails_helper'
 RSpec.describe StatsSummary do
   it 'generates correct stats' do
     create(:candidate)
-    create(:application_form)
-    create(:application_form, :submitted)
-    create(:application_choice, :recruited)
-    create(:application_choice, :offered)
-    create(:application_choice, :rejected)
-    create(:application_choice, :accepted)
-    create(:application_choice, :accepted)
-    create(:application_choice, :rejected_by_default)
+    create(:application_choice, :recruited, application_form: create(:application_form, :minimum_info))
+    create(:application_choice, :offered, application_form: create(:application_form, first_nationality: 'Vatican citizen'))
+    create(:application_choice, :rejected, application_form: create(:application_form, :minimum_info))
+    create(:application_choice, :rejected, application_form: create(:application_form, :minimum_info))
+    create(:application_choice, :accepted, application_form: create(:application_form, first_nationality: 'Vatican citizen'))
+    create(:application_choice, :accepted, application_form: create(:application_form, :minimum_info))
+    create(:application_choice, :rejected_by_default, application_form: create(:application_form, first_nationality: 'Vatican citizen'))
+    create(:application_choice, :inactive, application_form: create(:application_form, :minimum_info))
+    create(:application_choice, :inactive, application_form: create(:application_form, first_nationality: 'Vatican citizen'))
 
     travel_temporarily_to(CycleTimetable.this_day_last_cycle) do
-      last_cycle_form = create(:application_form, :submitted)
-      create(:application_choice, :recruited, application_form: last_cycle_form)
-      create(:application_choice, :offered, application_form: last_cycle_form)
-      create(:application_choice, :rejected, application_form: last_cycle_form)
+      last_cycle_international_form = create(:application_form, :submitted, first_nationality: 'Vatican citizen')
+      last_cycle_domestic_form = create(:application_form, :submitted)
+      create(:application_choice, :recruited, application_form: last_cycle_domestic_form)
+      create(:application_choice, :offered, application_form: last_cycle_international_form)
+      create(:application_choice, :rejected, application_form: last_cycle_domestic_form)
       create(:application_choice, :rejected)
       create(:application_choice, :offered)
     end
@@ -25,13 +27,19 @@ RSpec.describe StatsSummary do
 
     output = described_class.new.as_slack_message
 
-    expect(output).to match('9 candidate signups \\| 3 last cycle')
-    expect(output).to match('8 applications begun \\| 3 last cycle')
-    expect(output).to match('7 applications submitted \\| 3 last cycle')
-    expect(output).to match('3 offers accepted \\| 1 last cycle')
+    expect(output).to match('10 candidate signups \\| 4 last cycle')
+    expect(output).to match('5 applications submitted \\| 4 last cycle')
+    expect(output).to match('2 offers accepted \\| 1 last cycle')
     expect(output).to match('1 candidate recruited \\| 1 last cycle')
-    expect(output).to match('4 offers made \\| 3 last cycle')
-    expect(output).to match('2 rejections issued')
-    expect(output).to match('of which 1 was RBD \\| 2 last cycle')
+    expect(output).to match('2 offers made \\| 2 last cycle')
+    expect(output).to match('2 rejections issued \\| 2 last cycle')
+    expect(output).to match('1 application turned to inactive')
+
+    expect(output).to match('4 applications submitted \\| 1 last cycle')
+    expect(output).to match('1 offer accepted \\| 0 last cycle')
+    expect(output).to match('0 candidates recruited \\| 0 last cycle')
+    expect(output).to match('2 offers made \\| 1 last cycle')
+    expect(output).to match('1 rejection issued \\| 0 last cycle')
+    expect(output).to match('1 application turned to inactive')
   end
 end


### PR DESCRIPTION
## Context

With the changes to the application process, certain statistics no longer have the same significance as they did in previous recruitment cycles. We're also missing the new inactive status.

## Changes proposed in this pull request

<img width="323" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/c7f41acf-7188-47ae-9de3-1aabe9b4990e">


## Guidance to review

I've defined domestic as the first nationality being British/Irish, rather than just any of the 5 nationalities containing these values – this has been discussed before, but I'm unable to find evidence of the chat! This does contradict `international_applicant?` so we should confirm this for risk of this scope being used beyond just the stats post.
