### PR TITLE
Amend link in monthly stats unavailable page to reflect 2023 to 2024

### DIFF
--- a/app/views/publications/monthly_statistics/temporarily_unavailable.html.erb
+++ b/app/views/publications/monthly_statistics/temporarily_unavailable.html.erb
@@ -13,7 +13,7 @@
     </p>
 
     <p class="govuk-body">
-      You can view <%= govuk_link_to 'monthly statistics on initial teacher training', 'https://www.gov.uk/government/publications/monthly-statistics-on-initial-teacher-training-itt-recruitment' %>
+      You can view <%= govuk_link_to 'monthly statistics on initial teacher training', 'https://www.gov.uk/government/publications/monthly-statistics-on-initial-teacher-training-recruitment-2023-to-2024' %>
       from the last cycle (from October 2022 until September 2023).
     </p>
 

--- a/spec/requests/publications/monthly_statistics_spec.rb
+++ b/spec/requests/publications/monthly_statistics_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe 'Monthly Statistics', time: Time.zone.local(2022, 11, 29) do
         expect(response).to redirect_to(temporarily_unavailable)
         get temporarily_unavailable
         expect(response.body).to include('The first publication of ITT statistics for the new cycle will be on Monday 27 November 2023.')
-        expect(response.body).to include('https://www.gov.uk/government/publications/monthly-statistics-on-initial-teacher-training-itt-recruitment')
+        expect(response.body).to include('https://www.gov.uk/government/publications/monthly-statistics-on-initial-teacher-training-recruitment-2023-to-2024')
         expect(response.body).to include('becomingateacher@digital.education.gov.uk')
 
         get '/publications/monthly-statistics/2022-10'


### PR DESCRIPTION
## Context

The link we had pointed to 2022 data, not 2023.

## Changes proposed in this pull request

Link is updated to correct one.

## Guidance to review

Do the tests pass?

## Link to Trello card

N/A

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
