### PR TITLE
Implement the first section of the new monthly statistics

### DIFF
--- a/app/lib/dfe/bigquery/application_metrics.rb
+++ b/app/lib/dfe/bigquery/application_metrics.rb
@@ -1,0 +1,46 @@
+module DfE
+  module Bigquery
+    class ApplicationMetrics
+      attr_accessor :number_of_candidates_submitted_to_date,
+                    :number_of_candidates_submitted_to_same_date_previous_cycle,
+                    :number_of_candidates_with_offers_to_date,
+                    :number_of_candidates_with_offers_to_same_date_previous_cycle,
+                    :number_of_candidates_accepted_to_date,
+                    :number_of_candidates_accepted_to_same_date_previous_cycle,
+                    :number_of_candidates_who_had_all_applications_rejected_this_cycle_to_date,
+                    :number_of_candidates_who_had_all_applications_rejected_this_cycle_to_same_date_previous_cycle,
+                    :number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_date,
+                    :number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_same_date_previous_cycle,
+                    :number_of_candidates_with_deferred_offers_from_this_cycle_to_date,
+                    :number_of_candidates_with_deferred_offers_from_this_cycle_to_same_date_previous_cycle,
+                    :number_of_candidates_with_all_accepted_offers_withdrawn_this_cycle_to_date,
+                    :number_of_candidates_with_all_accepted_offers_withdrawn_this_cycle_to_same_date_previous_cycle,
+                    :number_of_candidates_who_did_not_meet_any_offer_conditions_this_cycle_to_date,
+                    :number_of_candidates_who_did_not_meet_any_offer_conditions_this_cycle_to_same_date_previous_cycle,
+                    :first_date_in_week,
+                    :last_date_in_week,
+                    :cycle_week
+
+      def initialize(attributes)
+        attributes.each do |key, value|
+          send("#{key}=", value) if respond_to?("#{key}=")
+        end
+      end
+
+      def self.candidate_headline_statistics(cycle_week:)
+        result = ::DfE::Bigquery.client.query(
+          <<~SQL,
+            SELECT *
+            FROM dataform.application_metrics
+            WHERE recruitment_cycle_year = #{RecruitmentCycle.current_year}
+            AND cycle_week = #{cycle_week}
+            AND subject_filter_category = "Total excluding Further Education"
+            AND nonsubject_filter_category = "Total"
+          SQL
+        ).first
+
+        new(result)
+      end
+    end
+  end
+end

--- a/app/models/publications/itt_monthly_report_generator.rb
+++ b/app/models/publications/itt_monthly_report_generator.rb
@@ -1,0 +1,81 @@
+module Publications
+  class ITTMonthlyReportGenerator
+    attr_reader :generation_date, :first_cycle_week, :report_expected_time, :cycle_week
+
+    def initialize(generation_date: Time.zone.now)
+      @generation_date = generation_date
+      @first_cycle_week = CycleTimetable.find_opens.beginning_of_week
+      @report_expected_time = @generation_date.beginning_of_week(:sunday)
+      @cycle_week = (@report_expected_time - first_cycle_week).seconds.in_weeks.round
+    end
+
+    def to_h
+      {
+        meta:,
+        candidate_headline_statistics: {
+          title: I18n.t('publications.itt_monthly_report_generator.candidate_headline_statistics.title'),
+          data: candidate_headline_statistics,
+        },
+      }
+    end
+
+    def meta
+      {
+        generation_date:,
+        period:,
+        cycle_week:,
+      }
+    end
+
+    def period
+      "From #{first_cycle_week.to_fs(:govuk_date)} to #{report_expected_time.to_fs(:govuk_date)}"
+    end
+
+    def candidate_headline_statistics
+      application_metrics = DfE::Bigquery::ApplicationMetrics.candidate_headline_statistics(cycle_week:)
+
+      {
+        submitted: {
+          title: I18n.t('publications.itt_monthly_report_generator.candidate_headline_statistics.submitted.title'),
+          this_cycle: application_metrics.number_of_candidates_submitted_to_date,
+          last_cycle: application_metrics.number_of_candidates_submitted_to_same_date_previous_cycle,
+        },
+        with_offers: {
+          title: I18n.t('publications.itt_monthly_report_generator.candidate_headline_statistics.with_offers.title'),
+          this_cycle: application_metrics.number_of_candidates_with_offers_to_date,
+          last_cycle: application_metrics.number_of_candidates_with_offers_to_same_date_previous_cycle,
+        },
+        accepted: {
+          title: I18n.t('publications.itt_monthly_report_generator.candidate_headline_statistics.accepted.title'),
+          this_cycle: application_metrics.number_of_candidates_accepted_to_date,
+          last_cycle: application_metrics.number_of_candidates_accepted_to_same_date_previous_cycle,
+        },
+        rejected: {
+          title: I18n.t('publications.itt_monthly_report_generator.candidate_headline_statistics.rejected.title'),
+          this_cycle: application_metrics.number_of_candidates_who_had_all_applications_rejected_this_cycle_to_date,
+          last_cycle: application_metrics.number_of_candidates_who_had_all_applications_rejected_this_cycle_to_same_date_previous_cycle,
+        },
+        reconfirmed: {
+          title: I18n.t('publications.itt_monthly_report_generator.candidate_headline_statistics.reconfirmed.title'),
+          this_cycle: application_metrics.number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_date,
+          last_cycle: application_metrics.number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_same_date_previous_cycle,
+        },
+        deferred: {
+          title: I18n.t('publications.itt_monthly_report_generator.candidate_headline_statistics.deferred.title'),
+          this_cycle: application_metrics.number_of_candidates_with_deferred_offers_from_this_cycle_to_date,
+          last_cycle: application_metrics.number_of_candidates_with_deferred_offers_from_this_cycle_to_same_date_previous_cycle,
+        },
+        withdrawn: {
+          title: I18n.t('publications.itt_monthly_report_generator.candidate_headline_statistics.withdrawn.title'),
+          this_cycle: application_metrics.number_of_candidates_with_all_accepted_offers_withdrawn_this_cycle_to_date,
+          last_cycle: application_metrics.number_of_candidates_with_all_accepted_offers_withdrawn_this_cycle_to_same_date_previous_cycle,
+        },
+        conditions_not_met: {
+          title: I18n.t('publications.itt_monthly_report_generator.candidate_headline_statistics.conditions_not_met.title'),
+          this_cycle: application_metrics.number_of_candidates_who_did_not_meet_any_offer_conditions_this_cycle_to_date,
+          last_cycle: application_metrics.number_of_candidates_who_did_not_meet_any_offer_conditions_this_cycle_to_same_date_previous_cycle,
+        },
+      }
+    end
+  end
+end

--- a/config/initializers/zeitwerk.rb
+++ b/config/initializers/zeitwerk.rb
@@ -2,6 +2,8 @@ Rails.autoloaders.each do |autoloader|
   autoloader.inflector.inflect(
     # should be VendorAPIUser, maintained for backwards compat with the audit log
     'vendor_api_user' => 'VendorApiUser',
+    'itt_monthly_report' => 'ITTMonthlyReport',
+    'itt_monthly_report_generator' => 'ITTMonthlyReportGenerator',
   )
   autoloader.collapse('app/components/shared')
   autoloader.collapse('app/components/utility')

--- a/config/locales/publications/itt_monthly_report_generator.yml
+++ b/config/locales/publications/itt_monthly_report_generator.yml
@@ -1,0 +1,23 @@
+en:
+  publications:
+    itt_monthly_report_generator:
+      candidate_headline_statistics:
+        title: Candidate Headline statistics
+        this_cycle: This cycle
+        last_cycle: Last cycle
+        submitted:
+          title: Submitted
+        with_offers:
+          title: With offers
+        accepted:
+          title: Accepted
+        rejected:
+          title: All applications rejected
+        reconfirmed:
+          title: Reconfirmed from previous cycle
+        deferred:
+          title: Deferred
+        withdrawn:
+          title: Withdrawn
+        conditions_not_met:
+          title: Offer conditions not met

--- a/spec/lib/dfe/bigquery/application_metrics_spec.rb
+++ b/spec/lib/dfe/bigquery/application_metrics_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe DfE::Bigquery::ApplicationMetrics do
+  describe '.candidate_headline_statistics' do
+    subject(:application_metrics) do
+      described_class.candidate_headline_statistics(cycle_week: 11)
+    end
+
+    let(:client) { instance_double(Google::Cloud::Bigquery::Project) }
+    let(:results) do
+      [
+        {
+          number_of_candidates_submitted_to_date: 100,
+          cycle_week: 11,
+        },
+      ]
+    end
+
+    before do
+      allow(DfE::Bigquery).to receive(:client).and_return(client)
+      allow(client).to receive(:query).and_return(results)
+    end
+
+    it 'instantiate an application metrics' do
+      expect(application_metrics).to be_instance_of(described_class)
+    end
+
+    it 'assigns the attributes for the application metrics' do
+      expect(application_metrics.number_of_candidates_submitted_to_date).to be 100
+      expect(application_metrics.cycle_week).to be 11
+    end
+  end
+end

--- a/spec/models/publications/itt_monthly_report_generator_spec.rb
+++ b/spec/models/publications/itt_monthly_report_generator_spec.rb
@@ -1,0 +1,163 @@
+require 'rails_helper'
+
+RSpec.describe Publications::ITTMonthlyReportGenerator do
+  describe '#generation_date' do
+    context 'when passing in initialize' do
+      it 'returns custom generation date' do
+        generation_date = 1.week.ago
+        expect(described_class.new(generation_date:).generation_date).to eq(generation_date)
+      end
+    end
+
+    context 'when not passing in initialize' do
+      it 'returns current date' do
+        generation_date = Time.zone.now
+
+        travel_temporarily_to(generation_date, freeze: true) do
+          expect(described_class.new.generation_date).to eq(generation_date)
+        end
+      end
+    end
+  end
+
+  describe '#first_cycle_week' do
+    context 'when we are on 2023 recruitment cycle' do
+      it 'returns first monday week of beginning of the cycle' do
+        travel_temporarily_to(Time.zone.local(2023, 9, 1)) do
+          expect(described_class.new.first_cycle_week).to eq(Time.zone.local(2022, 10, 3))
+        end
+      end
+    end
+
+    context 'when we are on 2024 recruitment cycle' do
+      it 'returns first monday week of beginning of the cycle' do
+        travel_temporarily_to(Time.zone.local(2023, 11, 15)) do
+          expect(described_class.new.first_cycle_week).to eq(Time.zone.local(2023, 10, 2))
+        end
+      end
+    end
+  end
+
+  describe '#report_expected_time' do
+    it 'returns the last Sunday of the expected generation time' do
+      generation_date = Time.zone.local(2023, 11, 8)
+      expect(described_class.new(generation_date:).report_expected_time).to eq(Time.zone.local(2023, 11, 5))
+    end
+  end
+
+  describe '#cycle_week' do
+    context 'when first cycle week' do
+      it 'returns one' do
+        generation_date = Time.zone.local(2023, 10, 9)
+        expect(described_class.new(generation_date:).cycle_week).to be 1
+      end
+    end
+
+    context 'when mid cycle' do
+      it 'returns the number of weeks' do
+        generation_date = Time.zone.local(2023, 11, 20)
+        expect(described_class.new(generation_date:).cycle_week).to be 7
+      end
+    end
+
+    context 'when last cycle week' do
+      it 'returns 52' do
+        generation_date = Time.zone.local(2024, 9, 30)
+        expect(described_class.new(generation_date:).cycle_week).to be 52
+      end
+    end
+  end
+
+  describe '#to_h' do
+    subject(:report) do
+      described_class.new(generation_date:).to_h
+    end
+
+    let(:generation_date) { Time.zone.local(2023, 11, 22) }
+    let(:candidate_headline_statistics) do
+      {
+        cycle_week: 7,
+        first_date_in_week: Date.new(2023, 11, 13),
+        last_date_in_week: Date.new(2023, 11, 19),
+        number_of_candidates_accepted_to_date: 538,
+        number_of_candidates_accepted_to_same_date_previous_cycle: 478,
+        number_of_candidates_submitted_to_date: 8586,
+        number_of_candidates_submitted_to_same_date_previous_cycle: 5160,
+        number_of_candidates_who_did_not_meet_any_offer_conditions_this_cycle_to_date: 0,
+        number_of_candidates_who_did_not_meet_any_offer_conditions_this_cycle_to_same_date_previous_cycle: 0,
+        number_of_candidates_who_had_all_applications_rejected_this_cycle_to_date: 246,
+        number_of_candidates_who_had_all_applications_rejected_this_cycle_to_same_date_previous_cycle: 131,
+        number_of_candidates_with_all_accepted_offers_withdrawn_this_cycle_to_date: 1,
+        number_of_candidates_with_all_accepted_offers_withdrawn_this_cycle_to_same_date_previous_cycle: 0,
+        number_of_candidates_with_deferred_offers_from_this_cycle_to_date: 0,
+        number_of_candidates_with_deferred_offers_from_this_cycle_to_same_date_previous_cycle: 0,
+        number_of_candidates_with_offers_to_date: 598,
+        number_of_candidates_with_offers_to_same_date_previous_cycle: 567,
+        number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_date: 285,
+        number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_same_date_previous_cycle: 213,
+      }
+    end
+
+    before do
+      allow(DfE::Bigquery::ApplicationMetrics).to receive(:candidate_headline_statistics)
+        .with(cycle_week: 7)
+        .and_return(DfE::Bigquery::ApplicationMetrics.new(candidate_headline_statistics))
+    end
+
+    it 'returns meta information' do
+      expect(report[:meta]).to eq({
+        generation_date:,
+        period: 'From 2 October 2023 to 19 November 2023',
+        cycle_week: 7,
+      })
+    end
+
+    it 'returns candidate headline statistics' do
+      expect(report[:candidate_headline_statistics]).to eq({
+        title: 'Candidate Headline statistics',
+        data: {
+          submitted: {
+            title: 'Submitted',
+            this_cycle: 8586,
+            last_cycle: 5160,
+          },
+          with_offers: {
+            title: 'With offers',
+            this_cycle: 598,
+            last_cycle: 567,
+          },
+          accepted: {
+            title: 'Accepted',
+            this_cycle: 538,
+            last_cycle: 478,
+          },
+          rejected: {
+            title: 'All applications rejected',
+            this_cycle: 246,
+            last_cycle: 131,
+          },
+          reconfirmed: {
+            title: 'Reconfirmed from previous cycle',
+            this_cycle: 285,
+            last_cycle: 213,
+          },
+          deferred: {
+            title: 'Deferred',
+            this_cycle: 0,
+            last_cycle: 0,
+          },
+          withdrawn: {
+            title: 'Withdrawn',
+            this_cycle: 1,
+            last_cycle: 0,
+          },
+          conditions_not_met: {
+            title: 'Offer conditions not met',
+            this_cycle: 0,
+            last_cycle: 0,
+          },
+        },
+      })
+    end
+  end
+end


### PR DESCRIPTION
## Context

First we are just generating the report as to_h which can also be easily convert to json or csv.

The reason is that:

1. We can call for now `to_h` in the controller
2. Later we can save into database as JSON column

## Integration

If the below doesn't work due to credentials you need to add the following env vars to you `.env` file (but don't commit!):

1. `ENV['BIG_QUERY_PROJECT_ID']`
2. `ENV['DFE_BIGQUERY_API_JSON_KEY']`

## Guidance to review

1. Does it work when calling:

```ruby
Publications::ITTMonthlyReportGenerator.new.to_h
```

Or for a specific time:

```ruby
 Publications::ITTMonthlyReportGenerator.new(generation_date: some_date).to_h
```

## Link to Trello card

https://trello.com/c/GvYUP1xR/916-monthly-statistics-candidate-headline-stats-section
