### PR TITLE
Add all remaining sections to ITT monthly report

### DIFF
--- a/app/lib/dfe/bigquery/application_metrics.rb
+++ b/app/lib/dfe/bigquery/application_metrics.rb
@@ -1,6 +1,7 @@
 module DfE
   module Bigquery
     class ApplicationMetrics
+      extend ::DfE::Bigquery::Relation
       attr_accessor :number_of_candidates_submitted_to_date,
                     :number_of_candidates_submitted_to_same_date_previous_cycle,
                     :number_of_candidates_with_offers_to_date,
@@ -31,10 +32,6 @@ module DfE
 
       def self.table_name
         :'dataform.application_metrics'
-      end
-
-      def self.where(conditions)
-        ::DfE::Bigquery::Table.new(name: table_name).where(conditions)
       end
 
       def self.candidate_headline_statistics(cycle_week:)

--- a/app/lib/dfe/bigquery/application_metrics.rb
+++ b/app/lib/dfe/bigquery/application_metrics.rb
@@ -19,7 +19,8 @@ module DfE
                     :number_of_candidates_who_did_not_meet_any_offer_conditions_this_cycle_to_same_date_previous_cycle,
                     :first_date_in_week,
                     :last_date_in_week,
-                    :cycle_week
+                    :cycle_week,
+                    :nonsubject_filter
 
       def initialize(attributes)
         attributes.each do |key, value|
@@ -40,6 +41,22 @@ module DfE
         ).first
 
         new(result)
+      end
+
+      def self.age_group(cycle_week:)
+        results = ::DfE::Bigquery.client.query(
+          <<~SQL,
+            SELECT *
+            FROM dataform.application_metrics
+            WHERE recruitment_cycle_year = #{RecruitmentCycle.current_year}
+            AND cycle_week = #{cycle_week}
+            AND subject_filter_category = "Total excluding Further Education"
+            AND nonsubject_filter_category = "Age group"
+            ORDER BY nonsubject_filter ASC
+          SQL
+        )
+
+        results.map { |result| new(result) }
       end
     end
   end

--- a/app/lib/dfe/bigquery/application_metrics.rb
+++ b/app/lib/dfe/bigquery/application_metrics.rb
@@ -109,10 +109,6 @@ module DfE
       def self.recruitment_cycle_year
         RecruitmentCycle.current_year
       end
-
-      def self.query(sql_query)
-        ::DfE::Bigquery.client.query(sql_query).map { |result| new(result) }
-      end
     end
   end
 end

--- a/app/lib/dfe/bigquery/condition.rb
+++ b/app/lib/dfe/bigquery/condition.rb
@@ -1,0 +1,17 @@
+module DfE
+  module Bigquery
+    class Condition
+      include ActiveModel::Model
+      attr_writer :value
+      attr_accessor :column
+
+      def value
+        if @value.is_a? Numeric
+          @value
+        else
+          "\"#{@value}\""
+        end
+      end
+    end
+  end
+end

--- a/app/lib/dfe/bigquery/condition.rb
+++ b/app/lib/dfe/bigquery/condition.rb
@@ -12,6 +12,12 @@ module DfE
           "\"#{@value}\""
         end
       end
+
+      def to_sql
+        return "#{column} = #{value}\n" if @value.present?
+
+        "#{column}\n"
+      end
     end
   end
 end

--- a/app/lib/dfe/bigquery/relation.rb
+++ b/app/lib/dfe/bigquery/relation.rb
@@ -1,0 +1,15 @@
+module DfE
+  module Bigquery
+    module Relation
+      def table
+        ::DfE::Bigquery::Table.new(name: table_name)
+      end
+
+      delegate :where, :order, to: :table
+
+      def self.table_name
+        raise NotImplementedError
+      end
+    end
+  end
+end

--- a/app/lib/dfe/bigquery/relation.rb
+++ b/app/lib/dfe/bigquery/relation.rb
@@ -7,7 +7,11 @@ module DfE
 
       delegate :where, :order, to: :table
 
-      def self.table_name
+      def query(sql_query)
+        ::DfE::Bigquery.client.query(sql_query).map { |result| new(result) }
+      end
+
+      def table_name
         raise NotImplementedError
       end
     end

--- a/app/lib/dfe/bigquery/table.rb
+++ b/app/lib/dfe/bigquery/table.rb
@@ -9,7 +9,7 @@ module DfE
       end
 
       def where(conditions)
-        @conditions << conditions.map { |column, value| Condition.new(column:, value:) }
+        @conditions << Array(conditions).map { |column, value| Condition.new(column:, value:) }
         @conditions.flatten!
 
         self
@@ -28,7 +28,7 @@ module DfE
           @conditions.each_with_index do |condition, index|
             base_sql << (index.zero? ? 'WHERE ' : 'AND ')
 
-            base_sql << "#{condition.column} = #{condition.value}\n"
+            base_sql << condition.to_sql
           end
         end
 

--- a/app/lib/dfe/bigquery/table.rb
+++ b/app/lib/dfe/bigquery/table.rb
@@ -1,0 +1,43 @@
+module DfE
+  module Bigquery
+    class Table
+      attr_accessor :name, :conditions, :order_clause
+
+      def initialize(name:)
+        @name = name
+        @conditions = []
+      end
+
+      def where(conditions)
+        @conditions << conditions.map { |column, value| Condition.new(column:, value:) }
+        @conditions.flatten!
+
+        self
+      end
+
+      def order(options)
+        @order_clause = options
+
+        self
+      end
+
+      def to_sql
+        base_sql = "SELECT *\nFROM #{name}\n"
+
+        if @conditions.present?
+          @conditions.each_with_index do |condition, index|
+            base_sql << (index.zero? ? 'WHERE ' : 'AND ')
+
+            base_sql << "#{condition.column} = #{condition.value}\n"
+          end
+        end
+
+        if @order_clause.present?
+          base_sql << "ORDER BY #{@order_clause.keys.first} #{@order_clause.values.first.to_s.upcase}\n"
+        end
+
+        base_sql
+      end
+    end
+  end
+end

--- a/app/models/publications/itt_monthly_report_generator.rb
+++ b/app/models/publications/itt_monthly_report_generator.rb
@@ -2,6 +2,8 @@ module Publications
   class ITTMonthlyReportGenerator
     attr_accessor :generation_date, :publication_date, :first_cycle_week, :report_expected_time, :cycle_week
 
+    delegate :candidate_headline_statistics_query, :age_group_query, :sex_query, :area_query, :phase_query, to: ::DfE::Bigquery::ApplicationMetrics
+
     def initialize(generation_date: Time.zone.now, publication_date: nil)
       @generation_date = generation_date
       @publication_date = (publication_date.presence || 1.week.after(@generation_date))
@@ -21,7 +23,35 @@ module Publications
           title: I18n.t('publications.itt_monthly_report_generator.age_group.title'),
           data: candidate_age_group,
         },
+        candidate_sex: {
+          title: I18n.t('publications.itt_monthly_report_generator.sex.title'),
+          data: candidate_sex,
+        },
+        candidate_area: {
+          title: I18n.t('publications.itt_monthly_report_generator.area.title'),
+          data: candidate_area,
+        },
+        candidate_phase: {
+          title: I18n.t('publications.itt_monthly_report_generator.phase.title'),
+          data: candidate_phase,
+        },
       }
+    end
+
+    def explain
+      {
+        candidate_headline_statistics_query: candidate_headline_statistics_query(cycle_week:),
+        age_group_query: age_group_query(cycle_week:),
+        sex_query: sex_query(cycle_week:),
+        area_query: area_query(cycle_week:),
+        phase_query: phase_query(cycle_week:),
+      }.each do |key, value|
+        # rubocop:disable Rails/Output
+        puts "========= #{key.to_s.humanize} =========="
+        puts value
+        puts '=' * 40
+        # rubocop:enable Rails/Output
+      end; nil
     end
 
     def meta
@@ -37,40 +67,63 @@ module Publications
       "From #{first_cycle_week.to_fs(:govuk_date)} to #{report_expected_time.to_fs(:govuk_date)}"
     end
 
-    def candidate_headline_statistics
+    def candidate_headline_statistics(data = {})
       application_metrics = DfE::Bigquery::ApplicationMetrics.candidate_headline_statistics(cycle_week:)
-      data = {}
 
-      I18n.t('publications.itt_monthly_report_generator.status').each_key do |status|
-        data[status] = {
-          title: I18n.t("publications.itt_monthly_report_generator.status.#{status}.title"),
-          this_cycle: column_value_for(application_metrics:, status:, cycle: :this_cycle),
-          last_cycle: column_value_for(application_metrics:, status:, cycle: :last_cycle),
-        }
-      end
-
-      data
-    end
-
-    def candidate_age_group
-      results = ::DfE::Bigquery::ApplicationMetrics.age_group(cycle_week:)
-
-      data = {}
-
-      I18n.t('publications.itt_monthly_report_generator.status').each_key do |status|
-        data[status] = results.map do |application_metrics|
-          {
-            title: application_metrics.nonsubject_filter,
+      data.tap do
+        I18n.t('publications.itt_monthly_report_generator.status').each_key do |status|
+          data[status] = {
+            title: I18n.t("publications.itt_monthly_report_generator.status.#{status}.title"),
             this_cycle: column_value_for(application_metrics:, status:, cycle: :this_cycle),
             last_cycle: column_value_for(application_metrics:, status:, cycle: :last_cycle),
           }
         end
       end
+    end
 
-      data
+    def candidate_age_group
+      group_data(
+        results: ::DfE::Bigquery::ApplicationMetrics.age_group(cycle_week:),
+        title_column: :nonsubject_filter,
+      )
+    end
+
+    def candidate_sex
+      group_data(
+        results: ::DfE::Bigquery::ApplicationMetrics.sex(cycle_week:),
+        title_column: :nonsubject_filter,
+      )
+    end
+
+    def candidate_area
+      group_data(
+        results: ::DfE::Bigquery::ApplicationMetrics.area(cycle_week:),
+        title_column: :nonsubject_filter,
+      )
+    end
+
+    def candidate_phase
+      group_data(
+        results: ::DfE::Bigquery::ApplicationMetrics.phase(cycle_week:),
+        title_column: :subject_filter,
+      )
     end
 
   private
+
+    def group_data(results:, title_column:, data: {})
+      data.tap do
+        I18n.t('publications.itt_monthly_report_generator.status').each_key do |status|
+          data[status] = results.map do |application_metrics|
+            {
+              title: application_metrics.send(title_column),
+              this_cycle: column_value_for(application_metrics:, status:, cycle: :this_cycle),
+              last_cycle: column_value_for(application_metrics:, status:, cycle: :last_cycle),
+            }
+          end
+        end
+      end
+    end
 
     def column_value_for(application_metrics:, status:, cycle:)
       application_metrics.send(

--- a/app/models/publications/itt_monthly_report_generator.rb
+++ b/app/models/publications/itt_monthly_report_generator.rb
@@ -38,7 +38,7 @@ module Publications
       }
     end
 
-    def explain
+    def describe
       {
         candidate_headline_statistics_query: candidate_headline_statistics_query(cycle_week:),
         age_group_query: age_group_query(cycle_week:),

--- a/app/models/publications/itt_monthly_report_generator.rb
+++ b/app/models/publications/itt_monthly_report_generator.rb
@@ -70,7 +70,7 @@ module Publications
     def candidate_headline_statistics(data = {})
       application_metrics = DfE::Bigquery::ApplicationMetrics.candidate_headline_statistics(cycle_week:)
 
-      data.tap do
+      data.tap do |_d|
         I18n.t('publications.itt_monthly_report_generator.status').each_key do |status|
           data[status] = {
             title: I18n.t("publications.itt_monthly_report_generator.status.#{status}.title"),
@@ -112,7 +112,7 @@ module Publications
   private
 
     def group_data(results:, title_column:, data: {})
-      data.tap do
+      data.tap do |_d|
         I18n.t('publications.itt_monthly_report_generator.status').each_key do |status|
           data[status] = results.map do |application_metrics|
             {

--- a/app/models/publications/itt_monthly_report_generator.rb
+++ b/app/models/publications/itt_monthly_report_generator.rb
@@ -1,9 +1,10 @@
 module Publications
   class ITTMonthlyReportGenerator
-    attr_reader :generation_date, :first_cycle_week, :report_expected_time, :cycle_week
+    attr_accessor :generation_date, :publication_date, :first_cycle_week, :report_expected_time, :cycle_week
 
-    def initialize(generation_date: Time.zone.now)
+    def initialize(generation_date: Time.zone.now, publication_date: nil)
       @generation_date = generation_date
+      @publication_date = (publication_date.presence || 1.week.after(@generation_date))
       @first_cycle_week = CycleTimetable.find_opens.beginning_of_week
       @report_expected_time = @generation_date.beginning_of_week(:sunday)
       @cycle_week = (@report_expected_time - first_cycle_week).seconds.in_weeks.round
@@ -16,12 +17,17 @@ module Publications
           title: I18n.t('publications.itt_monthly_report_generator.candidate_headline_statistics.title'),
           data: candidate_headline_statistics,
         },
+        candidate_age_group: {
+          title: I18n.t('publications.itt_monthly_report_generator.age_group.title'),
+          data: candidate_age_group,
+        },
       }
     end
 
     def meta
       {
         generation_date:,
+        publication_date:,
         period:,
         cycle_week:,
       }
@@ -33,49 +39,43 @@ module Publications
 
     def candidate_headline_statistics
       application_metrics = DfE::Bigquery::ApplicationMetrics.candidate_headline_statistics(cycle_week:)
+      data = {}
 
-      {
-        submitted: {
-          title: I18n.t('publications.itt_monthly_report_generator.candidate_headline_statistics.submitted.title'),
-          this_cycle: application_metrics.number_of_candidates_submitted_to_date,
-          last_cycle: application_metrics.number_of_candidates_submitted_to_same_date_previous_cycle,
-        },
-        with_offers: {
-          title: I18n.t('publications.itt_monthly_report_generator.candidate_headline_statistics.with_offers.title'),
-          this_cycle: application_metrics.number_of_candidates_with_offers_to_date,
-          last_cycle: application_metrics.number_of_candidates_with_offers_to_same_date_previous_cycle,
-        },
-        accepted: {
-          title: I18n.t('publications.itt_monthly_report_generator.candidate_headline_statistics.accepted.title'),
-          this_cycle: application_metrics.number_of_candidates_accepted_to_date,
-          last_cycle: application_metrics.number_of_candidates_accepted_to_same_date_previous_cycle,
-        },
-        rejected: {
-          title: I18n.t('publications.itt_monthly_report_generator.candidate_headline_statistics.rejected.title'),
-          this_cycle: application_metrics.number_of_candidates_who_had_all_applications_rejected_this_cycle_to_date,
-          last_cycle: application_metrics.number_of_candidates_who_had_all_applications_rejected_this_cycle_to_same_date_previous_cycle,
-        },
-        reconfirmed: {
-          title: I18n.t('publications.itt_monthly_report_generator.candidate_headline_statistics.reconfirmed.title'),
-          this_cycle: application_metrics.number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_date,
-          last_cycle: application_metrics.number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_same_date_previous_cycle,
-        },
-        deferred: {
-          title: I18n.t('publications.itt_monthly_report_generator.candidate_headline_statistics.deferred.title'),
-          this_cycle: application_metrics.number_of_candidates_with_deferred_offers_from_this_cycle_to_date,
-          last_cycle: application_metrics.number_of_candidates_with_deferred_offers_from_this_cycle_to_same_date_previous_cycle,
-        },
-        withdrawn: {
-          title: I18n.t('publications.itt_monthly_report_generator.candidate_headline_statistics.withdrawn.title'),
-          this_cycle: application_metrics.number_of_candidates_with_all_accepted_offers_withdrawn_this_cycle_to_date,
-          last_cycle: application_metrics.number_of_candidates_with_all_accepted_offers_withdrawn_this_cycle_to_same_date_previous_cycle,
-        },
-        conditions_not_met: {
-          title: I18n.t('publications.itt_monthly_report_generator.candidate_headline_statistics.conditions_not_met.title'),
-          this_cycle: application_metrics.number_of_candidates_who_did_not_meet_any_offer_conditions_this_cycle_to_date,
-          last_cycle: application_metrics.number_of_candidates_who_did_not_meet_any_offer_conditions_this_cycle_to_same_date_previous_cycle,
-        },
-      }
+      I18n.t('publications.itt_monthly_report_generator.status').each_key do |status|
+        data[status] = {
+          title: I18n.t("publications.itt_monthly_report_generator.status.#{status}.title"),
+          this_cycle: column_value_for(application_metrics:, status:, cycle: :this_cycle),
+          last_cycle: column_value_for(application_metrics:, status:, cycle: :last_cycle),
+        }
+      end
+
+      data
+    end
+
+    def candidate_age_group
+      results = ::DfE::Bigquery::ApplicationMetrics.age_group(cycle_week:)
+
+      data = {}
+
+      I18n.t('publications.itt_monthly_report_generator.status').each_key do |status|
+        data[status] = results.map do |application_metrics|
+          {
+            title: application_metrics.nonsubject_filter,
+            this_cycle: column_value_for(application_metrics:, status:, cycle: :this_cycle),
+            last_cycle: column_value_for(application_metrics:, status:, cycle: :last_cycle),
+          }
+        end
+      end
+
+      data
+    end
+
+  private
+
+    def column_value_for(application_metrics:, status:, cycle:)
+      application_metrics.send(
+        I18n.t("publications.itt_monthly_report_generator.status.#{status}.application_metrics_column.#{cycle}"),
+      )
     end
   end
 end

--- a/config/locales/publications/itt_monthly_report_generator.yml
+++ b/config/locales/publications/itt_monthly_report_generator.yml
@@ -8,6 +8,15 @@ en:
       age_group:
         title: Candidate statistics by age group
         subtitle: Age Group
+      sex:
+        title: Candidate statistics by sex
+        subtitle: Sex
+      area:
+        title: Candidate statistics by UK region or country, or other area
+        subtitle: Area
+      phase:
+        title: Course phase
+        subtitle: Course Phase
       status:
         submitted:
           title: Submitted

--- a/config/locales/publications/itt_monthly_report_generator.yml
+++ b/config/locales/publications/itt_monthly_report_generator.yml
@@ -1,23 +1,51 @@
 en:
   publications:
     itt_monthly_report_generator:
+      this_cycle: This cycle
+      last_cycle: Last cycle
       candidate_headline_statistics:
         title: Candidate Headline statistics
-        this_cycle: This cycle
-        last_cycle: Last cycle
+      age_group:
+        title: Candidate statistics by age group
+        subtitle: Age Group
+      status:
         submitted:
           title: Submitted
+          application_metrics_column:
+            this_cycle: number_of_candidates_submitted_to_date
+            last_cycle: number_of_candidates_submitted_to_same_date_previous_cycle
         with_offers:
           title: With offers
+          application_metrics_column:
+            this_cycle: number_of_candidates_with_offers_to_date
+            last_cycle: number_of_candidates_with_offers_to_same_date_previous_cycle
         accepted:
           title: Accepted
+          application_metrics_column:
+            this_cycle: number_of_candidates_accepted_to_date
+            last_cycle: number_of_candidates_accepted_to_same_date_previous_cycle
         rejected:
           title: All applications rejected
+          application_metrics_column:
+            this_cycle: number_of_candidates_who_had_all_applications_rejected_this_cycle_to_date
+            last_cycle: number_of_candidates_who_had_all_applications_rejected_this_cycle_to_same_date_previous_cycle
         reconfirmed:
           title: Reconfirmed from previous cycle
+          application_metrics_column:
+            this_cycle: number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_date
+            last_cycle: number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_same_date_previous_cycle
         deferred:
           title: Deferred
+          application_metrics_column:
+            this_cycle: number_of_candidates_with_deferred_offers_from_this_cycle_to_date
+            last_cycle: number_of_candidates_with_deferred_offers_from_this_cycle_to_same_date_previous_cycle
         withdrawn:
           title: Withdrawn
+          application_metrics_column:
+            this_cycle: number_of_candidates_with_all_accepted_offers_withdrawn_this_cycle_to_date
+            last_cycle: number_of_candidates_with_all_accepted_offers_withdrawn_this_cycle_to_same_date_previous_cycle
         conditions_not_met:
           title: Offer conditions not met
+          application_metrics_column:
+            this_cycle: number_of_candidates_who_did_not_meet_any_offer_conditions_this_cycle_to_date
+            last_cycle: number_of_candidates_who_did_not_meet_any_offer_conditions_this_cycle_to_same_date_previous_cycle

--- a/docs/bigquery_and_reports.md
+++ b/docs/bigquery_and_reports.md
@@ -5,13 +5,18 @@ reports.
 
 ## BigQuery credentials
 
-Ask Data insights team for access and credentials to access the BigQuery in
-Apply.
+Ask [#twd_data_insights](https://app.slack.com/client/T50RK42V7/C01H0LBCBDW) on Slack
+for access and credentials to access the BigQuery in Apply.
+
+The moment you have the credentials, locally you can add this env vars to `.env`:
+
+1. ENV['BIG_QUERY_PROJECT_ID']
+2. ENV['DFE_BIGQUERY_API_JSON_KEY']
 
 ## ITT monthly report
 
-We generate the ITT monthly report by making queries to big query and
-then generate a JSON compiling the big query responses into a single structure.
+We generate the ITT monthly report by making queries to BigQuery and
+then generate a JSON compiling the BigQuery responses into a single structure.
 
 In order to see the JSON that is generated from BigQuery:
 
@@ -19,9 +24,9 @@ In order to see the JSON that is generated from BigQuery:
   Publications::ITTMonthlyReportGenerator.new.to_h
 ```
 
-In case any day the report fails for generate (e.g BigQuery is timing out, etc)
+In case any day the report fails to generate (e.g BigQuery is timing out, etc)
 you can generate the JSON again by passing a generation and publication date.
-The code will calculate the last sunday from the generation date and consider
+The code will calculate the last Sunday from the generation date and consider
 that the cycle week that this data will consider in the report:
 
 ```ruby
@@ -31,9 +36,9 @@ that the cycle week that this data will consider in the report:
   ).to_h
 ```
 
-In order to know all the queries we make to big query for this report,
+In order to know all the queries we make to BigQuery for this report,
 you can run the command in rails console:
 
 ```ruby
-  Publications::ITTMonthlyReportGenerator.new.explain
+  Publications::ITTMonthlyReportGenerator.new.describe
 ```

--- a/docs/bigquery_and_reports.md
+++ b/docs/bigquery_and_reports.md
@@ -1,0 +1,39 @@
+## BigQuery and reports
+
+This documents explain briefly the relationship between BigQuery and our
+reports.
+
+## BigQuery credentials
+
+Ask Data insights team for access and credentials to access the BigQuery in
+Apply.
+
+## ITT monthly report
+
+We generate the ITT monthly report by making queries to big query and
+then generate a JSON compiling the big query responses into a single structure.
+
+In order to see the JSON that is generated from BigQuery:
+
+```ruby
+  Publications::ITTMonthlyReportGenerator.new.to_h
+```
+
+In case any day the report fails for generate (e.g BigQuery is timing out, etc)
+you can generate the JSON again by passing a generation and publication date.
+The code will calculate the last sunday from the generation date and consider
+that the cycle week that this data will consider in the report:
+
+```ruby
+  Publications::ITTMonthlyReportGenerator.new(
+    generation_date: 1.day.ago,
+    publication_date: 6.days.from_now,
+  ).to_h
+```
+
+In order to know all the queries we make to big query for this report,
+you can run the command in rails console:
+
+```ruby
+  Publications::ITTMonthlyReportGenerator.new.explain
+```

--- a/spec/lib/dfe/bigquery/application_metrics_spec.rb
+++ b/spec/lib/dfe/bigquery/application_metrics_spec.rb
@@ -1,24 +1,38 @@
 require 'rails_helper'
 
 RSpec.describe DfE::Bigquery::ApplicationMetrics do
+  let(:client) { instance_double(Google::Cloud::Bigquery::Project) }
+
+  before { set_time(Time.zone.local(2023, 11, 20)) }
+
   describe '.candidate_headline_statistics' do
     subject(:application_metrics) do
-      described_class.candidate_headline_statistics(cycle_week: 11)
+      described_class.candidate_headline_statistics(cycle_week: 7)
     end
 
-    let(:client) { instance_double(Google::Cloud::Bigquery::Project) }
     let(:results) do
       [
         {
           number_of_candidates_submitted_to_date: 100,
-          cycle_week: 11,
+          cycle_week: 7,
         },
       ]
     end
 
     before do
       allow(DfE::Bigquery).to receive(:client).and_return(client)
-      allow(client).to receive(:query).and_return(results)
+      allow(client).to receive(:query)
+        .with(
+          <<~SQL,
+            SELECT *
+            FROM dataform.application_metrics
+            WHERE recruitment_cycle_year = 2024
+            AND cycle_week = 7
+            AND subject_filter_category = "Total excluding Further Education"
+            AND nonsubject_filter_category = "Total"
+          SQL
+        )
+        .and_return(results)
     end
 
     it 'instantiate an application metrics' do
@@ -27,7 +41,51 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
 
     it 'assigns the attributes for the application metrics' do
       expect(application_metrics.number_of_candidates_submitted_to_date).to be 100
-      expect(application_metrics.cycle_week).to be 11
+      expect(application_metrics.cycle_week).to be 7
+    end
+  end
+
+  describe '.age_group' do
+    subject(:application_metrics) do
+      described_class.age_group(cycle_week: 7)
+    end
+
+    let(:results) do
+      [
+        {
+          number_of_candidates_submitted_to_date: 100,
+          nonsubject_filter: '25 to 29',
+          cycle_week: 7,
+        },
+      ]
+    end
+
+    before do
+      allow(DfE::Bigquery).to receive(:client).and_return(client)
+      allow(client).to receive(:query)
+        .with(
+          <<~SQL,
+            SELECT *
+            FROM dataform.application_metrics
+            WHERE recruitment_cycle_year = 2024
+            AND cycle_week = 7
+            AND subject_filter_category = "Total excluding Further Education"
+            AND nonsubject_filter_category = "Age group"
+            ORDER BY nonsubject_filter ASC
+          SQL
+        )
+        .and_return(results)
+    end
+
+    it 'instantiate an application metrics' do
+      expect(application_metrics).to be_instance_of(Array)
+      expect(application_metrics.size).to be 1
+    end
+
+    it 'assigns the attributes for the application metrics' do
+      expect(application_metrics.first.number_of_candidates_submitted_to_date).to be 100
+      expect(application_metrics.first.cycle_week).to be 7
+      expect(application_metrics.first.nonsubject_filter).to eq('25 to 29')
     end
   end
 end

--- a/spec/lib/dfe/bigquery/table_spec.rb
+++ b/spec/lib/dfe/bigquery/table_spec.rb
@@ -10,13 +10,17 @@ RSpec.describe DfE::Bigquery::Table do
           table.where(
             magic_name: 'Battle of the Barrels',
             year: 1970,
-          ).to_sql,
+          )
+         .where(
+           'magic_name != "Pulling bunny out of hat"',
+         ).to_sql,
         ).to eq(
           <<~SQL,
             SELECT *
             FROM datapoint.magic_tricks
             WHERE magic_name = "Battle of the Barrels"
             AND year = 1970
+            AND magic_name != "Pulling bunny out of hat"
           SQL
         )
       end

--- a/spec/lib/dfe/bigquery/table_spec.rb
+++ b/spec/lib/dfe/bigquery/table_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe DfE::Bigquery::Table do
+  subject(:table) { described_class.new(name: 'datapoint.magic_tricks') }
+
+  describe '#to_sql' do
+    context 'when using where' do
+      it 'returns where conditions using "AND"' do
+        expect(
+          table.where(
+            magic_name: 'Battle of the Barrels',
+            year: 1970,
+          ).to_sql,
+        ).to eq(
+          <<~SQL,
+            SELECT *
+            FROM datapoint.magic_tricks
+            WHERE magic_name = "Battle of the Barrels"
+            AND year = 1970
+          SQL
+        )
+      end
+    end
+
+    context 'when not using where' do
+      it 'returns default query' do
+        expect(table.to_sql).to eq(
+          <<~SQL,
+            SELECT *
+            FROM datapoint.magic_tricks
+          SQL
+        )
+      end
+    end
+
+    context 'when order' do
+      it 'returns order' do
+        expect(table.order(magic_name: :asc).to_sql).to eq(
+          <<~SQL,
+            SELECT *
+            FROM datapoint.magic_tricks
+            ORDER BY magic_name ASC
+          SQL
+        )
+      end
+    end
+  end
+end

--- a/spec/models/publications/itt_monthly_report_generator_spec.rb
+++ b/spec/models/publications/itt_monthly_report_generator_spec.rb
@@ -20,6 +20,25 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
     end
   end
 
+  describe '#publication_date' do
+    context 'when passing in initialize' do
+      it 'returns custom publication date' do
+        publication_date = 1.week.ago
+        expect(described_class.new(publication_date:).publication_date).to eq(publication_date)
+      end
+    end
+
+    context 'when not passing in initialize' do
+      it 'returns 1 week after generation date' do
+        generation_date = Time.zone.local(2023, 11, 20)
+
+        travel_temporarily_to(generation_date, freeze: true) do
+          expect(described_class.new.publication_date).to eq(generation_date + 1.week)
+        end
+      end
+    end
+  end
+
   describe '#first_cycle_week' do
     context 'when we are on 2023 recruitment cycle' do
       it 'returns first monday week of beginning of the cycle' do
@@ -74,6 +93,7 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
     end
 
     let(:generation_date) { Time.zone.local(2023, 11, 22) }
+    let(:publication_date) { generation_date + 1.week }
     let(:candidate_headline_statistics) do
       {
         cycle_week: 7,
@@ -97,16 +117,45 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
         number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_same_date_previous_cycle: 213,
       }
     end
+    let(:age_group) do
+      {
+        cycle_week: 7,
+        first_date_in_week: Date.new(2023, 11, 13),
+        last_date_in_week: Date.new(2023, 11, 19),
+        nonsubject_filter: '21',
+        number_of_candidates_submitted_to_date: 400,
+        number_of_candidates_submitted_to_same_date_previous_cycle: 200,
+        number_of_candidates_who_did_not_meet_any_offer_conditions_this_cycle_to_date: 30,
+        number_of_candidates_who_did_not_meet_any_offer_conditions_this_cycle_to_same_date_previous_cycle: 15,
+        number_of_candidates_who_had_all_applications_rejected_this_cycle_to_date: 100,
+        number_of_candidates_who_had_all_applications_rejected_this_cycle_to_same_date_previous_cycle: 50,
+        number_of_candidates_with_all_accepted_offers_withdrawn_this_cycle_to_date: 200,
+        number_of_candidates_with_all_accepted_offers_withdrawn_this_cycle_to_same_date_previous_cycle: 100,
+        number_of_candidates_with_deferred_offers_from_this_cycle_to_date: 0,
+        number_of_candidates_with_deferred_offers_from_this_cycle_to_same_date_previous_cycle: 0,
+        number_of_candidates_with_offers_to_date: 598,
+        number_of_candidates_with_offers_to_same_date_previous_cycle: 567,
+        number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_date: 285,
+        number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_same_date_previous_cycle: 213,
+        number_of_candidates_accepted_to_date: 20,
+        number_of_candidates_accepted_to_same_date_previous_cycle: 10,
+      }
+    end
 
     before do
       allow(DfE::Bigquery::ApplicationMetrics).to receive(:candidate_headline_statistics)
         .with(cycle_week: 7)
         .and_return(DfE::Bigquery::ApplicationMetrics.new(candidate_headline_statistics))
+
+      allow(DfE::Bigquery::ApplicationMetrics).to receive(:age_group)
+        .with(cycle_week: 7)
+        .and_return([DfE::Bigquery::ApplicationMetrics.new(age_group)])
     end
 
     it 'returns meta information' do
       expect(report[:meta]).to eq({
         generation_date:,
+        publication_date:,
         period: 'From 2 October 2023 to 19 November 2023',
         cycle_week: 7,
       })
@@ -156,6 +205,70 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
             this_cycle: 0,
             last_cycle: 0,
           },
+        },
+      })
+    end
+
+    it 'returns age group' do
+      expect(report[:candidate_age_group]).to eq({
+        title: 'Candidate statistics by age group',
+        data: {
+          submitted: [
+            {
+              title: '21',
+              this_cycle: 400,
+              last_cycle: 200,
+            },
+          ],
+          with_offers: [
+            {
+              title: '21',
+              this_cycle: 598,
+              last_cycle: 567,
+            },
+          ],
+          accepted: [
+            {
+              title: '21',
+              this_cycle: 20,
+              last_cycle: 10,
+            },
+          ],
+          rejected: [
+            {
+              title: '21',
+              this_cycle: 100,
+              last_cycle: 50,
+            },
+          ],
+          reconfirmed: [
+            {
+              title: '21',
+              this_cycle: 285,
+              last_cycle: 213,
+            },
+          ],
+          deferred: [
+            {
+              title: '21',
+              this_cycle: 0,
+              last_cycle: 0,
+            },
+          ],
+          withdrawn: [
+            {
+              title: '21',
+              this_cycle: 200,
+              last_cycle: 100,
+            },
+          ],
+          conditions_not_met: [
+            {
+              title: '21',
+              this_cycle: 30,
+              last_cycle: 15,
+            },
+          ],
         },
       })
     end

--- a/spec/models/publications/itt_monthly_report_generator_spec.rb
+++ b/spec/models/publications/itt_monthly_report_generator_spec.rb
@@ -141,6 +141,9 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
         number_of_candidates_accepted_to_same_date_previous_cycle: 10,
       }
     end
+    let(:sex) { age_group.dup.merge(nonsubject_filter: 'Male') }
+    let(:area) { age_group.dup.merge(nonsubject_filter: 'Gondor') }
+    let(:phase) { age_group.dup.merge(subject_filter: 'Primary') }
 
     before do
       allow(DfE::Bigquery::ApplicationMetrics).to receive(:candidate_headline_statistics)
@@ -150,6 +153,18 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
       allow(DfE::Bigquery::ApplicationMetrics).to receive(:age_group)
         .with(cycle_week: 7)
         .and_return([DfE::Bigquery::ApplicationMetrics.new(age_group)])
+
+      allow(DfE::Bigquery::ApplicationMetrics).to receive(:sex)
+        .with(cycle_week: 7)
+        .and_return([DfE::Bigquery::ApplicationMetrics.new(sex)])
+
+      allow(DfE::Bigquery::ApplicationMetrics).to receive(:area)
+        .with(cycle_week: 7)
+        .and_return([DfE::Bigquery::ApplicationMetrics.new(area)])
+
+      allow(DfE::Bigquery::ApplicationMetrics).to receive(:phase)
+        .with(cycle_week: 7)
+        .and_return([DfE::Bigquery::ApplicationMetrics.new(phase)])
     end
 
     it 'returns meta information' do
@@ -271,6 +286,204 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
           ],
         },
       })
+    end
+
+    it 'returns sex data' do
+      expect(report[:candidate_sex]).to eq(
+        {
+          title: 'Candidate statistics by sex',
+          data: {
+            submitted: [
+              {
+                title: 'Male',
+                this_cycle: 400,
+                last_cycle: 200,
+              },
+            ],
+            with_offers: [
+              {
+                title: 'Male',
+                this_cycle: 598,
+                last_cycle: 567,
+              },
+            ],
+            accepted: [
+              {
+                title: 'Male',
+                this_cycle: 20,
+                last_cycle: 10,
+              },
+            ],
+            rejected: [
+              {
+                title: 'Male',
+                this_cycle: 100,
+                last_cycle: 50,
+              },
+            ],
+            reconfirmed: [
+              {
+                title: 'Male',
+                this_cycle: 285,
+                last_cycle: 213,
+              },
+            ],
+            deferred: [
+              {
+                title: 'Male',
+                this_cycle: 0,
+                last_cycle: 0,
+              },
+            ],
+            withdrawn: [
+              {
+                title: 'Male',
+                this_cycle: 200,
+                last_cycle: 100,
+              },
+            ],
+            conditions_not_met: [
+              {
+                title: 'Male',
+                this_cycle: 30,
+                last_cycle: 15,
+              },
+            ],
+          },
+        },
+      )
+    end
+
+    it 'returns area data' do
+      expect(report[:candidate_area]).to eq(
+        {
+          title: 'Candidate statistics by UK region or country, or other area',
+          data: {
+            submitted: [
+              {
+                title: 'Gondor',
+                this_cycle: 400,
+                last_cycle: 200,
+              },
+            ],
+            with_offers: [
+              {
+                title: 'Gondor',
+                this_cycle: 598,
+                last_cycle: 567,
+              },
+            ],
+            accepted: [
+              {
+                title: 'Gondor',
+                this_cycle: 20,
+                last_cycle: 10,
+              },
+            ],
+            rejected: [
+              {
+                title: 'Gondor',
+                this_cycle: 100,
+                last_cycle: 50,
+              },
+            ],
+            reconfirmed: [
+              {
+                title: 'Gondor',
+                this_cycle: 285,
+                last_cycle: 213,
+              },
+            ],
+            deferred: [
+              {
+                title: 'Gondor',
+                this_cycle: 0,
+                last_cycle: 0,
+              },
+            ],
+            withdrawn: [
+              {
+                title: 'Gondor',
+                this_cycle: 200,
+                last_cycle: 100,
+              },
+            ],
+            conditions_not_met: [
+              {
+                title: 'Gondor',
+                this_cycle: 30,
+                last_cycle: 15,
+              },
+            ],
+          },
+        },
+      )
+    end
+
+    it 'returns phase data' do
+      expect(report[:candidate_phase]).to eq(
+        {
+          title: 'Course phase',
+          data: {
+            submitted: [
+              {
+                title: 'Primary',
+                this_cycle: 400,
+                last_cycle: 200,
+              },
+            ],
+            with_offers: [
+              {
+                title: 'Primary',
+                this_cycle: 598,
+                last_cycle: 567,
+              },
+            ],
+            accepted: [
+              {
+                title: 'Primary',
+                this_cycle: 20,
+                last_cycle: 10,
+              },
+            ],
+            rejected: [
+              {
+                title: 'Primary',
+                this_cycle: 100,
+                last_cycle: 50,
+              },
+            ],
+            reconfirmed: [
+              {
+                title: 'Primary',
+                this_cycle: 285,
+                last_cycle: 213,
+              },
+            ],
+            deferred: [
+              {
+                title: 'Primary',
+                this_cycle: 0,
+                last_cycle: 0,
+              },
+            ],
+            withdrawn: [
+              {
+                title: 'Primary',
+                this_cycle: 200,
+                last_cycle: 100,
+              },
+            ],
+            conditions_not_met: [
+              {
+                title: 'Primary',
+                this_cycle: 30,
+                last_cycle: 15,
+              },
+            ],
+          },
+        },
+      )
     end
   end
 end


### PR DESCRIPTION
## Context

This PR adds all remaining sections in the interface, when generating the ITTMonthlyReport.

Also refactor the headline statistics to look into the locales because we need to find the right attribute for each status.

I chosen to map into the same locale as configuration.

## Guidance to review

1. Does it work?
2. Does it produces the right data?

## Documentation to review

I added a documentation on https://github.com/DFE-Digital/apply-for-teacher-training/blob/e17a73f04aab7762f80f86a2ac4ac01df07ced7f/docs/bigquery_and_reports.md

Please feel free to add more or suggest any edits.

## Link to Trello card

https://trello.com/c/BUyDUGYX/917-monthly-statistics-candidate-age-group-section
