### PR TITLE
ITT Monthly Statistics template, controller and routes

### DIFF
--- a/app/controllers/publications/v2/monthly_statistics_controller.rb
+++ b/app/controllers/publications/v2/monthly_statistics_controller.rb
@@ -1,0 +1,39 @@
+module Publications
+  module V2
+    class MonthlyStatisticsController < ApplicationController
+      def show
+        @presenter = MonthlyStatisticsPresenter.new(current_report)
+        @csv_export_types_and_sizes = calculate_download_sizes(@presenter)
+      end
+
+      # TODO: Downloads
+      def download
+        # export_type = params[:export_type]
+        # export_filename = "#{export_type}-#{params[:month]}.csv"
+        # raw_data = current_report.statistics[export_type]
+        # header_row = raw_data['rows'].first.keys
+        # data = SafeCSV.generate(raw_data['rows'].map(&:values), header_row)
+        # send_data data, filename: export_filename, disposition: :attachment
+      end
+
+      def calculate_download_sizes(_report)
+        []
+        # cache 'data_sizes' do
+        #   report.statistics.map do |k, raw_data|
+        #     next unless raw_data.is_a?(Hash)
+        #
+        #     header_row = raw_data['rows'].first.keys
+        #     data = SafeCSV.generate(raw_data['rows'].map(&:values), header_row)
+        #     [k, data.size]
+        #   end.compact
+        # end
+      end
+
+    private
+
+      def current_report
+        DfE::Bigquery::StubbedReport.new
+      end
+    end
+  end
+end

--- a/app/lib/dfe/bigquery/stubbed_report.rb
+++ b/app/lib/dfe/bigquery/stubbed_report.rb
@@ -36,6 +36,10 @@ module DfE
               title: I18n.t('publications.itt_monthly_report_generator.route_into_teaching.title'),
               data: route_into_teaching_data,
             },
+            candidate_primary_subject: {
+              title: I18n.t('publications.itt_monthly_report_generator.primary_subject.title'),
+              data: primary_subject_data,
+            },
           },
         }
       end
@@ -307,6 +311,83 @@ module DfE
             { title: 'School Direct (fee-paying)', this_cycle: rand(1000), last_cycle: rand(2000) },
             { title: 'School Direct (salaried)', this_cycle: rand(1000), last_cycle: rand(2000) },
             { title: 'School-centred initial teacher training (SCITT)', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+        }
+      end
+
+      def primary_subject_data
+        {
+          submitted: [
+            { title: 'Primary', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with English', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Geography and History', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Mathematics', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Modern Languages', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Physical Education', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Science', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          with_offers: [
+            { title: 'Primary', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with English', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Geography and History', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Mathematics', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Modern Languages', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Physical Education', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Science', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          accepted: [
+            { title: 'Primary', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with English', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Geography and History', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Mathematics', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Modern Languages', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Physical Education', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Science', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          all_applications_rejected: [
+            { title: 'Primary', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with English', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Geography and History', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Mathematics', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Modern Languages', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Physical Education', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Science', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          reconfirmed_from_previous_cycle: [
+            { title: 'Primary', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with English', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Geography and History', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Mathematics', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Modern Languages', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Physical Education', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Science', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          deferred: [
+            { title: 'Primary', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with English', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Geography and History', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Mathematics', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Modern Languages', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Physical Education', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Science', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          withdrawn: [
+            { title: 'Primary', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with English', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Geography and History', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Mathematics', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Modern Languages', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Physical Education', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Science', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          conditions_not_met: [
+            { title: 'Primary', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with English', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Geography and History', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Mathematics', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Modern Languages', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Physical Education', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Primary with Science', this_cycle: rand(1000), last_cycle: rand(2000) },
           ],
         }
       end

--- a/app/lib/dfe/bigquery/stubbed_report.rb
+++ b/app/lib/dfe/bigquery/stubbed_report.rb
@@ -44,6 +44,10 @@ module DfE
               title: I18n.t('publications.itt_monthly_report_generator.secondary_subject.title'),
               data: secondary_subject_data,
             },
+            candidate_provider_region: {
+              title: I18n.t('publications.itt_monthly_report_generator.provider_region.title'),
+              data: provider_region_data,
+            },
           },
         }
       end
@@ -469,6 +473,83 @@ module DfE
             { title: 'Classics', this_cycle: rand(1000), last_cycle: rand(2000) },
             { title: 'Computing', this_cycle: rand(1000), last_cycle: rand(2000) },
             { title: 'Design & Technology', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+        }
+      end
+
+      def provider_region_data
+        {
+          submitted: [
+            { title: 'East of England', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'East Midlands', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'London', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'North East', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'North West', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'South East', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'South West', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          with_offers: [
+            { title: 'East of England', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'East Midlands', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'London', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'North East', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'North West', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'South East', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'South West', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          accepted: [
+            { title: 'East of England', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'East Midlands', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'London', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'North East', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'North West', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'South East', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'South West', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          all_applications_rejected: [
+            { title: 'East of England', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'East Midlands', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'London', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'North East', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'North West', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'South East', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'South West', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          reconfirmed_from_previous_cycle: [
+            { title: 'East of England', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'East Midlands', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'London', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'North East', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'North West', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'South East', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'South West', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          deferred: [
+            { title: 'East of England', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'East Midlands', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'London', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'North East', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'North West', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'South East', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'South West', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          withdrawn: [
+            { title: 'East of England', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'East Midlands', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'London', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'North East', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'North West', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'South East', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'South West', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          conditions_not_met: [
+            { title: 'East of England', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'East Midlands', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'London', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'North East', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'North West', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'South East', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'South West', this_cycle: rand(1000), last_cycle: rand(2000) },
           ],
         }
       end

--- a/app/lib/dfe/bigquery/stubbed_report.rb
+++ b/app/lib/dfe/bigquery/stubbed_report.rb
@@ -1,0 +1,250 @@
+module DfE
+  module Bigquery
+    class StubbedReport
+      attr_reader :data
+
+      def initialize
+        @data = {
+          meta: {
+            publication_date: 1.day.ago,
+            generation_date: 8.days.ago,
+            period: 'From 2 October 2023 to 12 November 2023',
+            cycle_week: 2,
+          },
+          data: {
+            candidate_headline_statistics: {
+              title: 'Statistics',
+              data: { deferred_applications_count: 100 },
+            },
+            candidate_sex: {
+              title: I18n.t('publications.itt_monthly_report_generator.sex.title'),
+              data: sex_data,
+            },
+            candidate_age_group: {
+              title: I18n.t('publications.itt_monthly_report_generator.age_group.title'),
+              data: age_data,
+            },
+            candidate_area: {
+              title: I18n.t('publications.itt_monthly_report_generator.area.title'),
+              data: area_data,
+            },
+            candidate_phase: {
+              title: I18n.t('publications.itt_monthly_report_generator.phase.title'),
+              data: phase_data,
+            },
+          },
+        }
+      end
+
+      def to_h
+        @data
+      end
+
+    private
+
+      def sex_data
+        {
+          submitted: [
+            { title: 'Female', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Male', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Other', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Prefer not to say', this_cycle: rand(50), last_cycle: rand(100) },
+          ],
+          with_offers: [
+            { title: 'Female', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Male', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Other', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Prefer not to say', this_cycle: rand(50), last_cycle: rand(100) },
+          ],
+          accepted: [
+            { title: 'Female', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Male', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Other', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Prefer not to say', this_cycle: rand(50), last_cycle: rand(100) },
+          ],
+          all_applications_rejected: [
+            { title: 'Female', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Male', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Other', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Prefer not to say', this_cycle: rand(50), last_cycle: rand(100) },
+          ],
+          reconfirmed_from_previous_cycle: [
+            { title: 'Female', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Male', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Other', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Prefer not to say', this_cycle: rand(50), last_cycle: rand(100) },
+          ],
+          deferred: [
+            { title: 'Female', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Male', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Other', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Prefer not to say', this_cycle: rand(50), last_cycle: rand(100) },
+          ],
+          withdrawn: [
+            { title: 'Female', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Male', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Other', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Prefer not to say', this_cycle: rand(50), last_cycle: rand(100) },
+          ],
+          conditions_not_met: [
+            { title: 'Female', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Male', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Other', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Prefer not to say', this_cycle: rand(50), last_cycle: rand(100) },
+          ],
+        }
+      end
+
+      def age_data
+        {
+          submitted: [
+            { title: '18 - 21', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: '21-35', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: '36-50', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: '51-65', this_cycle: rand(50), last_cycle: rand(100) },
+          ],
+          with_offers: [
+            { title: '18 - 21', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: '21-35', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: '36-50', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: '51-65', this_cycle: rand(50), last_cycle: rand(100) },
+          ],
+          accepted: [
+            { title: '18 - 21', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: '21-35', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: '36-50', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: '51-65', this_cycle: rand(50), last_cycle: rand(100) },
+          ],
+          all_applications_rejected: [
+            { title: '18 - 21', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: '21-35', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: '36-50', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: '51-65', this_cycle: rand(50), last_cycle: rand(100) },
+          ],
+          reconfirmed_from_previous_cycle: [
+            { title: '18 - 21', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: '21-35', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: '36-50', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: '51-65', this_cycle: rand(50), last_cycle: rand(100) },
+          ],
+          deferred: [
+            { title: '18 - 21', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: '21-35', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: '36-50', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: '51-65', this_cycle: rand(50), last_cycle: rand(100) },
+          ],
+          withdrawn: [
+            { title: '18 - 21', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: '21-35', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: '36-50', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: '51-65', this_cycle: rand(50), last_cycle: rand(100) },
+          ],
+          conditions_not_met: [
+            { title: '18 - 21', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: '21-35', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: '36-50', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: '51-65', this_cycle: rand(50), last_cycle: rand(100) },
+          ],
+        }
+      end
+
+      def area_data
+        {
+          submitted: [
+            { title: 'London', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'West', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'North', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'East', this_cycle: rand(50), last_cycle: rand(100) },
+            { title: 'South', this_cycle: rand(50), last_cycle: rand(100) },
+          ],
+          with_offers: [
+            { title: 'London', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'West', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'North', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'East', this_cycle: rand(50), last_cycle: rand(100) },
+            { title: 'South', this_cycle: rand(50), last_cycle: rand(100) },
+          ],
+          accepted: [
+            { title: 'London', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'West', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'North', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'East', this_cycle: rand(50), last_cycle: rand(100) },
+            { title: 'South', this_cycle: rand(50), last_cycle: rand(100) },
+          ],
+          all_applications_rejected: [
+            { title: 'London', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'West', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'North', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'East', this_cycle: rand(50), last_cycle: rand(100) },
+            { title: 'South', this_cycle: rand(50), last_cycle: rand(100) },
+          ],
+          reconfirmed_from_previous_cycle: [
+            { title: 'London', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'West', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'North', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'East', this_cycle: rand(50), last_cycle: rand(100) },
+            { title: 'South', this_cycle: rand(50), last_cycle: rand(100) },
+          ],
+          deferred: [
+            { title: 'London', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'West', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'North', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'East', this_cycle: rand(50), last_cycle: rand(100) },
+            { title: 'South', this_cycle: rand(50), last_cycle: rand(100) },
+          ],
+          withdrawn: [
+            { title: 'London', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'West', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'North', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'East', this_cycle: rand(50), last_cycle: rand(100) },
+            { title: 'South', this_cycle: rand(50), last_cycle: rand(100) },
+          ],
+          conditions_not_met: [
+            { title: 'London', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'West', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'North', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'East', this_cycle: rand(50), last_cycle: rand(100) },
+            { title: 'South', this_cycle: rand(50), last_cycle: rand(100) },
+          ],
+        }
+      end
+
+      def phase_data
+        {
+          submitted: [
+            { title: 'Primary', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Secondar', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          with_offers: [
+            { title: 'Primary', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Secondar', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          accepted: [
+            { title: 'Primary', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Secondar', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          all_applications_rejected: [
+            { title: 'Primary', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Secondar', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          reconfirmed_from_previous_cycle: [
+            { title: 'Primary', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Secondar', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          deferred: [
+            { title: 'Primary', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Secondar', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          withdrawn: [
+            { title: 'Primary', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Secondar', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          conditions_not_met: [
+            { title: 'Primary', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Secondar', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+        }
+      end
+    end
+  end
+end

--- a/app/lib/dfe/bigquery/stubbed_report.rb
+++ b/app/lib/dfe/bigquery/stubbed_report.rb
@@ -395,6 +395,83 @@ module DfE
           ],
         }
       end
+
+      def secondary_subject_data
+        {
+          submitted: [
+            { title: 'Art & Design', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Biology', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Business Studies', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Chemistry', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Classics', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Computing', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Design & Technology', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          with_offers: [
+            { title: 'Art & Design', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Biology', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Business Studies', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Chemistry', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Classics', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Computing', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Design & Technology', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          accepted: [
+            { title: 'Art & Design', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Biology', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Business Studies', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Chemistry', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Classics', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Computing', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Design & Technology', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          all_applications_rejected: [
+            { title: 'Art & Design', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Biology', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Business Studies', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Chemistry', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Classics', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Computing', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Design & Technology', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          reconfirmed_from_previous_cycle: [
+            { title: 'Art & Design', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Biology', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Business Studies', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Chemistry', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Classics', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Computing', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Design & Technology', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          deferred: [
+            { title: 'Art & Design', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Biology', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Business Studies', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Chemistry', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Classics', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Computing', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Design & Technology', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          withdrawn: [
+            { title: 'Art & Design', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Biology', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Business Studies', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Chemistry', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Classics', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Computing', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Design & Technology', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          conditions_not_met: [
+            { title: 'Art & Design', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Biology', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Business Studies', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Chemistry', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Classics', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Computing', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Design & Technology', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+        }
+      end
     end
   end
 end

--- a/app/lib/dfe/bigquery/stubbed_report.rb
+++ b/app/lib/dfe/bigquery/stubbed_report.rb
@@ -40,6 +40,10 @@ module DfE
               title: I18n.t('publications.itt_monthly_report_generator.primary_subject.title'),
               data: primary_subject_data,
             },
+            candidate_secondary_subject: {
+              title: I18n.t('publications.itt_monthly_report_generator.secondary_subject.title'),
+              data: secondary_subject_data,
+            },
           },
         }
       end

--- a/app/lib/dfe/bigquery/stubbed_report.rb
+++ b/app/lib/dfe/bigquery/stubbed_report.rb
@@ -32,6 +32,10 @@ module DfE
               title: I18n.t('publications.itt_monthly_report_generator.phase.title'),
               data: phase_data,
             },
+            candidate_route_into_teaching: {
+              title: I18n.t('publications.itt_monthly_report_generator.route_into_teaching.title'),
+              data: route_into_teaching_data,
+            },
           },
         }
       end
@@ -242,6 +246,67 @@ module DfE
           conditions_not_met: [
             { title: 'Primary', this_cycle: rand(1000), last_cycle: rand(2000) },
             { title: 'Secondar', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+        }
+      end
+
+      def route_into_teaching_data
+        {
+          submitted: [
+            { title: 'Higher education', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Postgraduate teaching apprenticeship', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'School Direct (fee-paying)', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'School Direct (salaried)', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'School-centred initial teacher training (SCITT)', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          with_offers: [
+            { title: 'Higher education', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Postgraduate teaching apprenticeship', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'School Direct (fee-paying)', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'School Direct (salaried)', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'School-centred initial teacher training (SCITT)', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          accepted: [
+            { title: 'Higher education', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Postgraduate teaching apprenticeship', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'School Direct (fee-paying)', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'School Direct (salaried)', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'School-centred initial teacher training (SCITT)', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          all_applications_rejected: [
+            { title: 'Higher education', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Postgraduate teaching apprenticeship', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'School Direct (fee-paying)', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'School Direct (salaried)', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'School-centred initial teacher training (SCITT)', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          reconfirmed_from_previous_cycle: [
+            { title: 'Higher education', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Postgraduate teaching apprenticeship', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'School Direct (fee-paying)', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'School Direct (salaried)', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'School-centred initial teacher training (SCITT)', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          deferred: [
+            { title: 'Higher education', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Postgraduate teaching apprenticeship', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'School Direct (fee-paying)', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'School Direct (salaried)', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'School-centred initial teacher training (SCITT)', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          withdrawn: [
+            { title: 'Higher education', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Postgraduate teaching apprenticeship', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'School Direct (fee-paying)', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'School Direct (salaried)', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'School-centred initial teacher training (SCITT)', this_cycle: rand(1000), last_cycle: rand(2000) },
+          ],
+          conditions_not_met: [
+            { title: 'Higher education', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'Postgraduate teaching apprenticeship', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'School Direct (fee-paying)', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'School Direct (salaried)', this_cycle: rand(1000), last_cycle: rand(2000) },
+            { title: 'School-centred initial teacher training (SCITT)', this_cycle: rand(1000), last_cycle: rand(2000) },
           ],
         }
       end

--- a/app/presenters/publications/v2/monthly_statistics_presenter.rb
+++ b/app/presenters/publications/v2/monthly_statistics_presenter.rb
@@ -31,6 +31,10 @@ module Publications
         report.dig(:data, :candidate_route_into_teaching)
       end
 
+      def by_primary_subject
+        report.dig(:data, :candidate_primary_subject)
+      end
+
       def current_reporting_period
         report.dig(:meta, :period)
       end

--- a/app/presenters/publications/v2/monthly_statistics_presenter.rb
+++ b/app/presenters/publications/v2/monthly_statistics_presenter.rb
@@ -1,0 +1,71 @@
+module Publications
+  module V2
+    class MonthlyStatisticsPresenter
+      attr_accessor :report
+
+      def initialize(report)
+        @report = report.to_h
+      end
+
+      def publication_date
+        @report.dig(:meta, :publication_date)
+      end
+
+      def by_age
+        report.dig(:data, :candidate_age_group)
+      end
+
+      def by_sex
+        report.dig(:data, :candidate_sex)
+      end
+
+      def by_phase
+        report.dig(:data, :candidate_phase)
+      end
+
+      def by_area
+        report.dig(:data, :candidate_area)
+      end
+
+      def current_reporting_period
+        report.dig(:meta, :period)
+      end
+
+      def next_cycle_name
+        RecruitmentCycle.cycle_name(next_year)
+      end
+
+      def current_cycle_name
+        RecruitmentCycle.cycle_name
+      end
+
+      def current_cycle_verbose_name
+        RecruitmentCycle.verbose_cycle_name(current_year)
+      end
+
+      def current_cycle?
+        current_year == CycleTimetable.current_year
+      end
+
+      def next_publication_date
+        MonthlyStatisticsTimetable.next_publication_date
+      end
+
+      def deferred_applications_count
+        report.dig(:data, :candidate_headline_statistics, :deferred_applications_count) || 0
+      end
+
+      def previous_year
+        current_year - 1
+      end
+
+      def next_year
+        current_year + 1
+      end
+
+      def current_year
+        CycleTimetable.current_year(@report.dig(:meta, :generation_date).to_time)
+      end
+    end
+  end
+end

--- a/app/presenters/publications/v2/monthly_statistics_presenter.rb
+++ b/app/presenters/publications/v2/monthly_statistics_presenter.rb
@@ -35,6 +35,10 @@ module Publications
         report.dig(:data, :candidate_primary_subject)
       end
 
+      def by_secondary_subject
+        report.dig(:data, :candidate_secondary_subject)
+      end
+
       def current_reporting_period
         report.dig(:meta, :period)
       end

--- a/app/presenters/publications/v2/monthly_statistics_presenter.rb
+++ b/app/presenters/publications/v2/monthly_statistics_presenter.rb
@@ -39,6 +39,10 @@ module Publications
         report.dig(:data, :candidate_secondary_subject)
       end
 
+      def by_provider_region
+        report.dig(:data, :candidate_provider_region)
+      end
+
       def current_reporting_period
         report.dig(:meta, :period)
       end

--- a/app/presenters/publications/v2/monthly_statistics_presenter.rb
+++ b/app/presenters/publications/v2/monthly_statistics_presenter.rb
@@ -31,7 +31,15 @@ module Publications
         report.dig(:meta, :period)
       end
 
-      def next_cycle_name
+      def current_year
+        CycleTimetable.current_year(@report.dig(:meta, :generation_date).to_time)
+      end
+
+      # The Academic year for a given recruitment cycle is effectively the next
+      # recruitment cycle. If the report is for 2023-2024 recruitment cycle,
+      # the academic year or the year the candidates are applying for is the
+      # 2024-2025
+      def academic_year_name
         RecruitmentCycle.cycle_name(next_year)
       end
 
@@ -61,10 +69,6 @@ module Publications
 
       def next_year
         current_year + 1
-      end
-
-      def current_year
-        CycleTimetable.current_year(@report.dig(:meta, :generation_date).to_time)
       end
     end
   end

--- a/app/presenters/publications/v2/monthly_statistics_presenter.rb
+++ b/app/presenters/publications/v2/monthly_statistics_presenter.rb
@@ -19,12 +19,16 @@ module Publications
         report.dig(:data, :candidate_sex)
       end
 
+      def by_area
+        report.dig(:data, :candidate_area)
+      end
+
       def by_phase
         report.dig(:data, :candidate_phase)
       end
 
-      def by_area
-        report.dig(:data, :candidate_area)
+      def by_route
+        report.dig(:data, :candidate_route_into_teaching)
       end
 
       def current_reporting_period

--- a/app/views/publications/v2/monthly_statistics/show.html.erb
+++ b/app/views/publications/v2/monthly_statistics/show.html.erb
@@ -110,18 +110,21 @@
     <h2 class="govuk-heading-l" id="introduction">1. Introduction</h2>
 
     <p class="govuk-body">These statistics cover applications for courses in England starting in the <%= @presenter.academic_year_name %> academic year. To allow for comparison statistics covering the <%= @presenter.current_cycle_name %> academic year are also included.</p>
-    <p class="govuk-body">New definitions and methodology have been introduced for the <%= @presenter.academic_year_name %> academic year because candidates can now submit applications individually, instead of submitting 4 course choices at the same time. Improvements have also been made for clarity. Published statistics using the old methodology are also available. These use different definitions and methodology, so they cannot be compared with the statistics below.</p>
+
+    <p class="govuk-body">New definitions and methodology have been introduced for the <%= @presenter.academic_year_name %> academic year because candidates can now submit applications to courses individually up to a maximum limit of 4 open applications at any one time. Previously candidates submitted an application form containing up to 4 applications at the same time, all of which had to be processed before the candidate could submit another application form that cycle.</p>
+
+    <p class="govuk-body">Improvements have also been made for clarity. Published statistics using the old methodology are also available. These use different definitions and methodology, so they cannot be compared with the statistics below.</p>
 
     <% if @presenter.current_cycle? %>
-      <p class="govuk-body"><%= govuk_link_to "View statistics for the #{@presenter.current_cycle_name} academic year", publications_monthly_report_itt_path(@presenter.previous_year) %> for course applications in England using the old methodology.</p>
+      <p class="govuk-body"><%= govuk_link_to "View statistics for the #{@presenter.current_cycle_name} academic year for course applications in England using the old methodology.", publications_monthly_report_itt_path(@presenter.previous_year) %></p>
     <% else %>
-      <p class="govuk-body"><%= govuk_link_to "View statistics for the #{@presenter.next_year} to #{@presenter.next_year + 1} academic year", publications_monthly_report_itt_path(@presenter.next_year) %> for course applications in England using the old methodology.</p>
+      <p class="govuk-body"><%= govuk_link_to "View statistics for the #{@presenter.next_year} to #{@presenter.next_year + 1} academic year for course applications in England using the old methodology.", publications_monthly_report_itt_path(@presenter.next_year) %></p>
     <% end %>
 
     <p class="govuk-body">Statistics are also not comparable to previous figures published by UCAS, which used a different methodology and included candidates applying to providers in Wales.</p>
-    <p class="govuk-body">Applications for courses starting in the <%= @presenter.academic_year_name %> academic year are submitted in the <%= @presenter.current_cycle_verbose_name %> recruitment cycle (ITT<%= @presenter.previous_year %>) or deferred from the previous cycle for a <%= @presenter.academic_year_name %> course start date.</p>
+    <p class="govuk-body">Applications for courses starting in the <%= @presenter.academic_year_name %> academic year are submitted in the <%= @presenter.current_cycle_verbose_name %> recruitment cycle (ITT<%= @presenter.current_year %>) or deferred from the previous cycle for a <%= @presenter.academic_year_name %> course start date.</p>
 
-    <p class="govuk-body">Teacher training applications made directly to providers or Teach First are not included. Undergraduate teacher training is also not included. Applications to train to teach in Further Education are also not included.</p>
+    <p class="govuk-body">Teacher training applications made directly to providers are not included. Undergraduate teacher training is also not included. Applications to train to teach in Further Education are also not included.</p>
     <p class="govuk-body">These statistics collect data from <%= CycleTimetable.apply_opens.to_fs(:govuk_date) %> up to and including the day before they were published.</p>
     <p class="govuk-body">There will be monthly updates throughout the recruitment cycle.</p>
   </div>
@@ -132,7 +135,7 @@
 
     <p class="govuk-body">Candidates can apply for different courses. On later dates they may then apply for further courses. Any of their applications may change status throughout their lifecycle. This means that over time, some statistics may go up or down.</p>
 
-    <p class="govuk-body">For example, if a candidate’s initial 4 applications were rejected, they can submit a fifth application. Before this date, they would have been included in the count of candidates with rejected applications. After this date, they would not be included in this count. If that fifth application were also rejected, they would then be included in the count of rejected applications again.</p>
+    <p class="govuk-body">For example, if a candidate’s initial 4 applications had been rejected, they may have submitted a fifth application. Before this date, they would have been included in the count of candidates with rejected applications. After this date, they would not be included in this count. If that fifth application were also rejected, they would then be included in the count of rejected applications again. </p>
 
     <p class="govuk-body">Every recruitment cycle starts on the second Tuesday of October and not on the same date each calendar year. The figures for ‘last recruitment cycle’ and the current cycle in the table are calculated by counting the same number of days from when applications opened. This means days in last cycle will not be the same calendar date as days in this cycle. For example, day one of last cycle was on <%= CycleTimetable.apply_2_deadline(CycleTimetable.previous_year).to_fs(:govuk_date) %>, but day one of the current cycle was <%= CycleTimetable.apply_opens.to_fs(:govuk_date) %>.</p>
   </div>
@@ -281,7 +284,7 @@
     <p class="govuk-body">You can download all of the data on this page in CSV (comma separated values) format, which can be opened in a spreadsheet and used in other analysis tools.</p>
 
     <% @csv_export_types_and_sizes.each do |export_type, size| %>
-      <p class='govuk-body'>
+      <p class="govuk-body">
       <%= govuk_link_to t("#{export_type}.label") + " #{size.to_fs(:human_size)}", publications_monthly_report_download_path(export_type: export_type, month: @presenter.month, format: :csv) %>
        </p>
     <% end %>

--- a/app/views/publications/v2/monthly_statistics/show.html.erb
+++ b/app/views/publications/v2/monthly_statistics/show.html.erb
@@ -66,6 +66,18 @@
         </a>
       </li>
       <li>
+        <a href="#applications-by-route" class="govuk-link app-toc__link">
+          <span class="app-toc__number">7.</span>
+          <span class="app-toc__content">Route into teaching</span>
+        </a>
+      </li>
+      <li>
+        <a href="#downloads" class="govuk-link app-toc__link">
+          <span class="app-toc__number">7.</span>
+          <span class="app-toc__content">Route into teaching</span>
+        </a>
+      </li>
+      <li>
         <a href="#downloads" class="govuk-link app-toc__link">
           <span class="app-toc__number">7.</span>
           <span class="app-toc__content">Download the data</span>
@@ -195,6 +207,24 @@
 </div>
 
 <%= render Publications::DataTableComponent.new(caption: "Table 6.1: #{@presenter.by_phase[:title]}", title: t('publications.itt_monthly_report_generator.phase.subtitle'), data: @presenter.by_phase[:data]) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l govuk-!-padding-top-4" id="applications-by-route">7. Route into teaching</h2>
+
+    <p class="govuk-body">This table counts candidates by the route into teaching that they applied to. </p>
+    <p class="govuk-body">Apply for teacher training (Apply) allows candidates to apply for most routes into teaching, but it does not include applications:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>made directly to training providers</li>
+      <li>to Teach First</li>
+      <li>for undergraduate teacher training</li>
+    </ul>
+    <p class="govuk-body">Candidates may make different applications to more than one route into teaching. These candidates are counted under all routes that apply. This means that the total of these rows does not equal the total in the ‘Candidate headline statistics’ section.</p>
+  </div>
+</div>
+
+<%= render Publications::DataTableComponent.new(caption: "Table 7.1: #{@presenter.by_route[:title]}", title: t('publications.itt_monthly_report_generator.route_into_teaching.subtitle'), data: @presenter.by_route[:data]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/publications/v2/monthly_statistics/show.html.erb
+++ b/app/views/publications/v2/monthly_statistics/show.html.erb
@@ -95,7 +95,7 @@
     <% end %>
 
     <p class="govuk-body">Statistics are also not comparable to previous figures published by UCAS, which used a different methodology and included candidates applying to providers in Wales.</p>
-    <p class="govuk-body">Applications for courses starting in the <%= @presenter.academic_year_name %> academic year are submitted in the <%= @presenter.current_cycle_verbose_name %> recruitment cycle (ITT2024) or deferred from the previous cycle for a <%= @presenter.academic_year_name %> course start date.</p>
+    <p class="govuk-body">Applications for courses starting in the <%= @presenter.academic_year_name %> academic year are submitted in the <%= @presenter.current_cycle_verbose_name %> recruitment cycle (ITT<%= @presenter.previous_year %>) or deferred from the previous cycle for a <%= @presenter.academic_year_name %> course start date.</p>
 
     <p class="govuk-body">Teacher training applications made directly to providers or Teach First are not included. Undergraduate teacher training is also not included. Applications to train to teach in Further Education are also not included.</p>
     <p class="govuk-body">These statistics collect data from <%= CycleTimetable.apply_opens.to_fs(:govuk_date) %> up to and including the day before they were published.</p>
@@ -235,7 +235,7 @@
     </p>
 
     <p class="govuk-body">
-      Statistical releases from previous months during ITT2022 can be found here:
+      Statistical releases from previous months during ITT<%= @presenter.previous_year - 1 %> can be found here:
       <%= govuk_link_to 'https://www.gov.uk/government/publications/monthly-statistics-on-initial-teacher-training-itt-recruitment', 'https://www.gov.uk/government/publications/monthly-statistics-on-initial-teacher-training-itt-recruitment' %>.
     </p>
 

--- a/app/views/publications/v2/monthly_statistics/show.html.erb
+++ b/app/views/publications/v2/monthly_statistics/show.html.erb
@@ -85,8 +85,8 @@
       </li>
       <li>
         <a href="#by-provider-region" class="govuk-link app-toc__link">
-          <span class="app-toc__number">10. Provider region</span>
-          <span class="app-toc__content"></span>
+          <span class="app-toc__number">10.</span>
+          <span class="app-toc__content">Provider region</span>
         </a>
       </li>
       <li>

--- a/app/views/publications/v2/monthly_statistics/show.html.erb
+++ b/app/views/publications/v2/monthly_statistics/show.html.erb
@@ -111,7 +111,7 @@
 
     <p class="govuk-body">These statistics cover applications for courses in England starting in the <%= @presenter.academic_year_name %> academic year. To allow for comparison statistics covering the <%= @presenter.current_cycle_name %> academic year are also included.</p>
 
-    <p class="govuk-body">New definitions and methodology have been introduced for the <%= @presenter.academic_year_name %> academic year because candidates can now submit applications to courses individually up to a maximum limit of 4 open applications at any one time. Previously candidates submitted an application form containing up to 4 applications at the same time, all of which had to be processed before the candidate could submit another application form that cycle.</p>
+    <p class="govuk-body">New definitions and methodology have been introduced for the <%= @presenter.academic_year_name %> academic year because candidates can now submit applications to courses individually up to a maximum limit of 4 open applications at any one time. Previously candidates submitted an application form containing up to <%= ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES %> applications at the same time, all of which had to be processed before the candidate could submit another application form that cycle.</p>
 
     <p class="govuk-body">Improvements have also been made for clarity. Published statistics using the old methodology are also available. These use different definitions and methodology, so they cannot be compared with the statistics below.</p>
 
@@ -135,7 +135,7 @@
 
     <p class="govuk-body">Candidates can apply for different courses. On later dates they may then apply for further courses. Any of their applications may change status throughout their lifecycle. This means that over time, some statistics may go up or down.</p>
 
-    <p class="govuk-body">For example, if a candidate’s initial 4 applications had been rejected, they may have submitted a fifth application. Before this date, they would have been included in the count of candidates with rejected applications. After this date, they would not be included in this count. If that fifth application were also rejected, they would then be included in the count of rejected applications again. </p>
+    <p class="govuk-body">For example, if a candidate’s initial <%= ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES %> applications had been rejected, they may have submitted a fifth application. Before this date, they would have been included in the count of candidates with rejected applications. After this date, they would not be included in this count. If that fifth application were also rejected, they would then be included in the count of rejected applications again. </p>
 
     <p class="govuk-body">Every recruitment cycle starts on the second Tuesday of October and not on the same date each calendar year. The figures for ‘last recruitment cycle’ and the current cycle in the table are calculated by counting the same number of days from when applications opened. This means days in last cycle will not be the same calendar date as days in this cycle. For example, day one of last cycle was on <%= CycleTimetable.apply_2_deadline(CycleTimetable.previous_year).to_fs(:govuk_date) %>, but day one of the current cycle was <%= CycleTimetable.apply_opens.to_fs(:govuk_date) %>.</p>
   </div>

--- a/app/views/publications/v2/monthly_statistics/show.html.erb
+++ b/app/views/publications/v2/monthly_statistics/show.html.erb
@@ -78,6 +78,12 @@
         </a>
       </li>
       <li>
+        <a href="#by-secondary-specialist-subject" class="govuk-link app-toc__link">
+          <span class="app-toc__number">9.</span>
+          <span class="app-toc__content">Secondary subject</span>
+        </a>
+      </li>
+      <li>
         <a href="#downloads" class="govuk-link app-toc__link">
           <span class="app-toc__number">7.</span>
           <span class="app-toc__content">Download the data</span>
@@ -237,6 +243,17 @@
 </div>
 
 <%= render Publications::DataTableComponent.new(caption: "Table 8.1: #{@presenter.by_primary_subject[:title]}", title: t('publications.itt_monthly_report_generator.primary_subject.subtitle'), data: @presenter.by_primary_subject[:data]) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l govuk-!-padding-top-4" id="by-primary-specialist-subject">9. Secondary subject</h2>
+
+    <p class="govuk-body">Candidates choose a subject for secondary teacher training. This table counts candidates who applied to secondary courses by subject.</p>
+    <p class="govuk-body">Candidates may make different applications to courses with different subjects. These candidates are counted under all subjects that apply. This means that the total of these rows does not equal the total in the ‘Candidate headline statistics’ section.</p>
+  </div>
+</div>
+
+<%= render Publications::DataTableComponent.new(caption: "Table 9.1: #{@presenter.by_secondary_subject[:title]}", title: t('publications.itt_monthly_report_generator.secondary_subject.subtitle'), data: @presenter.by_secondary_subject[:data]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/publications/v2/monthly_statistics/show.html.erb
+++ b/app/views/publications/v2/monthly_statistics/show.html.erb
@@ -292,33 +292,14 @@
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l govuk-!-padding-top-4" id="footnotes">12. Footnotes</h2>
 
-    <p class="govuk-body">The Apply for teacher training service is the sole service for postgraduate Initial Teacher Training (ITT) applications in England to Higher Education Institution (HEI), School Centred Initial Teacher Training (SCITT)-based, School Direct, School Direct (salaried) and Teaching Apprenticeship courses.</p>
+    <p class="govuk-body">The Apply for teacher training (Apply) service is the only service for postgraduate Initial Teacher Training (ITT) applications in England to Higher Education Institution (HEI), School Centred Initial Teacher Training (SCITT)-based, School Direct, School Direct (salaried) and Teaching Apprenticeship courses.</p>
 
     <p class="govuk-body">
-      Deferred candidates are counted in a separate column in the tables.
-    </p>
-
-    <% if @presenter.deferred_applications_count.zero? %>
-      <p class="govuk-body">
-        They’re counted in the statistics report for the academic year in which they start their training after their offer is re-confirmed, as well as the year in which they apply.
-      </p>
-
-      <p class="govuk-body">
-        This means that anyone who applied this year but deferring until next year will be counted in next year’s report, as well as this one.
-      </p>
-    <% end %>
-
-    <p class="govuk-body">
-      Deferred candidates are counted in the academic year in which they start their course after training providers have re-confirmed their deferred offer. Providers need to do this before candidates intend to start their training.
+    <%= govuk_link_to "View statistical releases from previous months during ITT#{@presenter.current_year}", publications_monthly_report_itt_url %>.
     </p>
 
     <p class="govuk-body">
-      Statistical releases from previous months during ITT<%= @presenter.previous_year - 1 %> can be found here:
-      <%= govuk_link_to publications_monthly_report_itt_url, publications_monthly_report_itt_url %>.
-    </p>
-
-    <p class="govuk-body">
-      If you have any feedback on the monthly ITT statistical reports, please
+      If you have any feedback on the monthly ITT statistical reports,
       get in touch at <%= bat_contact_mail_to %>.
     </p>
   </div>

--- a/app/views/publications/v2/monthly_statistics/show.html.erb
+++ b/app/views/publications/v2/monthly_statistics/show.html.erb
@@ -1,0 +1,247 @@
+<%= content_for :title, t('page_titles.monthly_statistics', academic_year_name: @presenter.next_cycle_name) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l">Statistics</span>
+    <h1 class="govuk-heading-l">
+      Initial teacher training applications for courses starting in the <%= @presenter.next_cycle_name %> academic year
+    </h1>
+  </div>
+</div>
+<div class="govuk-grid-row">
+  <div class="metadata-wrapper">
+    <div class="govuk-grid-column-two-thirds metadata-column">
+      <dl class="gem-c-metadata">
+        <dt class="gem-c-metadata__term">Published</dt>
+        <dd class="gem-c-metadata__definition"><%= @presenter.publication_date.to_fs(:govuk_date) %></dd>
+
+        <% if @presenter.current_cycle? %>
+          <dt class="gem-c-metadata__term">Next update</dt>
+          <dd class="gem-c-metadata__definition"><%= @presenter.next_publication_date.to_fs(:govuk_date) %></dd>
+        <% end %>
+      </dl>
+    </div>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1 govuk-!-margin-top-5">Contents</h2>
+
+    <ol class="govuk-list govuk-!-margin-bottom-8 app-toc">
+      <li>
+        <a href="#introduction" class="govuk-link app-toc__link">
+          <span class="app-toc__number">1.</span>
+          <span class="app-toc__content">Introduction</span>
+        </a>
+      </li>
+      <li>
+        <a href="#headline-statistics" class="govuk-link app-toc__link">
+          <span class="app-toc__number">2.</span>
+          <span class="app-toc__content">Candidate headline statistics</span>
+        </a>
+      </li>
+      <li>
+       <a href="#by-age-group" class="govuk-link app-toc__link">
+         <span class="app-toc__number">3.</span>
+         <span class="app-toc__content">Candidate age group</span>
+       </a>
+     </li>
+      <li>
+        <a href="#applications-by-sex" class="govuk-link app-toc__link">
+          <span class="app-toc__number">4.</span>
+          <span class="app-toc__content">Candidate sex</span>
+        </a>
+      </li>
+      <li>
+        <a href="#applications-by-area" class="govuk-link app-toc__link">
+          <span class="app-toc__number">5.</span>
+          <span class="app-toc__content">Candidate area</span>
+        </a>
+      </li>
+      <li>
+        <a href="#applications-by-course-phase" class="govuk-link app-toc__link">
+          <span class="app-toc__number">6.</span>
+          <span class="app-toc__content">Course phase</span>
+        </a>
+      </li>
+      <li>
+        <a href="#downloads" class="govuk-link app-toc__link">
+          <span class="app-toc__number">7.</span>
+          <span class="app-toc__content">Download the data</span>
+        </a>
+      </li>
+      <li>
+        <a href="#footnotes" class="govuk-link app-toc__link">
+          <span class="app-toc__number">8.</span>
+          <span class="app-toc__content">Footnotes</span>
+        </a>
+      </li>
+    </ol>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l" id="introduction">1. Introduction</h2>
+
+    <p class="govuk-body">These statistics cover applications for courses in England starting in the <%= @presenter.next_cycle_name %> academic year. To allow for comparison statistics covering the <%= @presenter.current_cycle_name %> academic year are also included.</p>
+    <p class="govuk-body">New definitions and methodology have been introduced for the <%= @presenter.next_cycle_name %> academic year because candidates can now submit applications individually, instead of submitting 4 course choices at the same time. Improvements have also been made for clarity. Published statistics using the old methodology are also available. These use different definitions and methodology, so they cannot be compared with the statistics below.</p>
+
+    <% if @presenter.current_cycle? %>
+      <p class="govuk-body"><%= govuk_link_to "View statistics for the #{@presenter.current_cycle_name} academic year", publications_monthly_report_itt_path(@presenter.previous_year) %> for course applications in England using the old methodology.</p>
+    <% else %>
+      <p class="govuk-body"><%= govuk_link_to "View statistics for the #{@presenter.next_year} to #{@presenter.next_year + 1} academic year", publications_monthly_report_itt_path(@presenter.next_year) %> for course applications in England using the old methodology.</p>
+    <% end %>
+
+    <p class="govuk-body">Statistics are also not comparable to previous figures published by UCAS, which used a different methodology and included candidates applying to providers in Wales.</p>
+    <p class="govuk-body">Applications for courses starting in the <%= @presenter.next_cycle_name %> academic year are submitted in the <%= @presenter.current_cycle_verbose_name %> recruitment cycle (ITT2024) or deferred from the previous cycle for a <%= @presenter.next_cycle_name %> course start date.</p>
+
+    <p class="govuk-body">Teacher training applications made directly to providers or Teach First are not included. Undergraduate teacher training is also not included. Applications to train to teach in Further Education are also not included.</p>
+    <p class="govuk-body">These statistics collect data from <%= CycleTimetable.apply_opens.to_fs(:govuk_date) %> up to and including the day before they were published.</p>
+    <p class="govuk-body">There will be monthly updates throughout the recruitment cycle.</p>
+  </div>
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l" id="headline-statistics">2. Candidate headline statistics</h2>
+
+    <p class="govuk-body">All figures in this table are counts of candidates. A candidate is a person who has submitted at least one application to an initial teacher training (ITT) course in England.</p>
+
+    <p class="govuk-body">Candidates can apply for different courses. On later dates they may then apply for further courses. Any of their applications may change status throughout their lifecycle. This means that over time, some statistics may go up or down.</p>
+
+    <p class="govuk-body">For example, if a candidate’s initial 4 applications were rejected, they can submit a fifth application. Before this date, they would have been included in the count of candidates with rejected applications. After this date, they would not be included in this count. If that fifth application were also rejected, they would then be included in the count of rejected applications again.</p>
+
+    <p class="govuk-body">Every recruitment cycle starts on the second Tuesday of October and not on the same date each calendar year. The figures for ‘last recruitment cycle’ and the current cycle in the table are calculated by counting the same number of days from when applications opened. This means days in last cycle will not be the same calendar date as days in this cycle. For example, day one of last cycle was on <%= CycleTimetable.apply_2_deadline(CycleTimetable.previous_year).to_fs(:govuk_date) %>, but day one of the current cycle was <%= CycleTimetable.apply_opens.to_fs(:govuk_date) %>.</p>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+    <div class="app-grid-column--grey">
+      <h2 class="govuk-heading-m">Accepted</h2>
+      <p class="govuk-body-s">Candidates who have been accepted on to a course this cycle, or who deferred an application in a previous cycle and have had that place reconfirmed by the training provider for this cycle. Applications which have been withdrawn or deferred to the next cycle are excluded.</p>
+      <div class="" style="display: flex;">
+
+        <div class="govuk-!-display-inline-block" style="margin-right: 40px;">
+          <h3 class="govuk-heading-s" style="color: #1d70b8;"> This cycle</h3>
+          <h3 class="govuk-heading-s">45,617</h3>  </div>
+
+        <div class="govuk-!-display-inline-block">
+          <h3 class="govuk-heading-s" style="color: #1d70b8;"> Last cycle</h3>
+          <h3 class="govuk-heading-s">38,580</h3>  </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="govuk-grid-column-one-half">
+    <div class="app-grid-column--grey">
+
+      <h2 class="govuk-heading-m">All applications rejected</h2>
+      <p class="govuk-body-s">Candidates whose applications this cycle have all been rejected. Applications which were withdrawn are excluded. Candidates with one or more application this cycle that has not been rejected are included.</p>
+      <br>
+      <div class="" style="display: flex;">
+
+        <div class="govuk-!-display-inline-block" style="margin-right: 40px;">
+          <h3 class="govuk-heading-s" style="color: #1d70b8;"> This cycle</h3>
+          <h3 class="govuk-heading-s">45,617</h3>  </div>
+
+        <div class="govuk-!-display-inline-block">
+          <h3 class="govuk-heading-s" style="color: #1d70b8;"> Last cycle</h3>
+          <h3 class="govuk-heading-s">38,580</h3>  </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l govuk-!-padding-top-4" id="by-age-group">3. Candidate age group</h2>
+
+    <p class="govuk-body">This table counts candidates by their age group. Candidate age is calculated from the date of birth they provide when applying.</p>
+
+    <p class="govuk-body">Ages are calculated at the end of the recruitment cycle, just before courses start for the next academic year. Courses usually start in September, but sometimes in January. This data therefore reflects the likely age of a candidate at the point of starting a course, rather than their age when they apply.</p>
+  </div>
+</div>
+<%= render Publications::DataTableComponent.new(caption: "Table 3.1: #{@presenter.by_age[:title]}", title: t('publications.itt_monthly_report_generator.age_group.subtitle'), data: @presenter.by_age[:data]) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l govuk-!-padding-top-4" id="applications-by-sex">4. Candidate sex</h2>
+
+    <p class="govuk-body">This table counts candidates by their sex. It’s optional for candidates to declare their sex when they are applying.</p>
+  </div>
+</div>
+
+<%= render Publications::DataTableComponent.new(caption: "Table 4.1: #{@presenter.by_sex[:title]}", title: t('publications.itt_monthly_report_generator.sex.subtitle'), data: @presenter.by_sex[:data]) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l govuk-!-padding-top-4" id="by-age-group">5. Candidate area</h2>
+
+    <p class="govuk-body">This table counts all candidates by their region in the UK, or country, or other area. Candidate areas are generated from the contact address they gave when applying.</p>
+
+    <p class="govuk-body">European Economic Area (EEA) relates to individuals with the European Union, European Economic Area or Swiss nationality, excluding the UK.</p>
+  </div>
+</div>
+
+<%= render Publications::DataTableComponent.new(caption: "Table 5.1: #{@presenter.by_area[:title]}", title: t('publications.itt_monthly_report_generator.area.subtitle'), data: @presenter.by_area[:data]) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l govuk-!-padding-top-4" id="applications-by-course-phase">6. Course phase</h2>
+
+    <p class="govuk-body">This table counts candidates by their course phase. ‘Course phase’ refers to whether a course trains candidates to teach in primary or secondary education. Further education applications are not included in these statistics.</p>
+    <p class="govuk-body">Candidates may make different applications to more than one course phase. These candidates are counted under all course phases that apply. This means that the total of these rows does not equal the total in the ‘Candidate headline statistics’ section.</p>
+  </div>
+</div>
+
+<%= render Publications::DataTableComponent.new(caption: "Table 6.1: #{@presenter.by_phase[:title]}", title: t('publications.itt_monthly_report_generator.phase.subtitle'), data: @presenter.by_phase[:data]) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l govuk-!-padding-top-4" id="downloads">8. Download the data</h2>
+
+    <p class="govuk-body">You can download all of the data on this page in CSV (comma separated values) format, which can be opened in a spreadsheet and used in other analysis tools.</p>
+
+    <% @csv_export_types_and_sizes.each do |export_type, size| %>
+      <p class='govuk-body'>
+      <%= govuk_link_to t("#{export_type}.label") + " #{size.to_fs(:human_size)}", publications_monthly_report_download_path(export_type: export_type, month: @presenter.month, format: :csv) %>
+       </p>
+    <% end %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l govuk-!-padding-top-4" id="footnotes">9. Footnotes</h2>
+
+    <p class="govuk-body">The Apply for teacher training service is the sole service for postgraduate Initial Teacher Training (ITT) applications in England to Higher Education Institution (HEI), School Centred Initial Teacher Training (SCITT)-based, School Direct, School Direct (salaried) and Teaching Apprenticeship courses.</p>
+
+    <p class="govuk-body">
+      Deferred candidates are counted in a separate column in the tables.
+    </p>
+
+    <% if @presenter.deferred_applications_count.zero? %>
+      <p class="govuk-body">
+        They’re counted in the statistics report for the academic year in which they start their training after their offer is re-confirmed, as well as the year in which they apply.
+      </p>
+
+      <p class="govuk-body">
+        This means that anyone who applied this year but deferring until next year will be counted in next year’s report, as well as this one.
+      </p>
+    <% end %>
+
+    <p class="govuk-body">
+      Deferred candidates are counted in the academic year in which they start their course after training providers have re-confirmed their deferred offer. Providers need to do this before candidates intend to start their training.
+    </p>
+
+    <p class="govuk-body">
+      Statistical releases from previous months during ITT2022 can be found here:
+      <%= govuk_link_to 'https://www.gov.uk/government/publications/monthly-statistics-on-initial-teacher-training-itt-recruitment', 'https://www.gov.uk/government/publications/monthly-statistics-on-initial-teacher-training-itt-recruitment' %>.
+    </p>
+
+    <p class="govuk-body">
+      If you have any feedback on the monthly ITT statistical reports, please
+      get in touch at <%= bat_contact_mail_to %>.
+    </p>
+  </div>
+</div>

--- a/app/views/publications/v2/monthly_statistics/show.html.erb
+++ b/app/views/publications/v2/monthly_statistics/show.html.erb
@@ -84,6 +84,12 @@
         </a>
       </li>
       <li>
+        <a href="#by-provider-region" class="govuk-link app-toc__link">
+          <span class="app-toc__number">10. Provider region</span>
+          <span class="app-toc__content"></span>
+        </a>
+      </li>
+      <li>
         <a href="#downloads" class="govuk-link app-toc__link">
           <span class="app-toc__number">7.</span>
           <span class="app-toc__content">Download the data</span>
@@ -254,6 +260,19 @@
 </div>
 
 <%= render Publications::DataTableComponent.new(caption: "Table 9.1: #{@presenter.by_secondary_subject[:title]}", title: t('publications.itt_monthly_report_generator.secondary_subject.subtitle'), data: @presenter.by_secondary_subject[:data], key: 'secondary-subject') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l govuk-!-padding-top-4" id="by-provider-region">10. Training provider region</h2>
+
+    <p class="govuk-body">Training provider regions are derived from their contact address. These areas may be different to where students do their training. </p>
+    <p class="govuk-body">This table counts all applications by the area of the training provider they applied to.</p>
+    <p class="govuk-body">This table shows the region of the training provider, not the accrediting provider.</p>
+    <p class="govuk-body">Candidates may make different applications to the same training provider more than once. These candidates are counted in all figures that apply. This means that the total of these rows does not equal the total in the ‘Candidate headline statistics’ section.</p>
+  </div>
+</div>
+
+<%= render Publications::DataTableComponent.new(caption: "Table 10.1: #{@presenter.by_provider_region[:title]}", title: t('publications.itt_monthly_report_generator.provider_region.subtitle'), data: @presenter.by_provider_region[:data]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/publications/v2/monthly_statistics/show.html.erb
+++ b/app/views/publications/v2/monthly_statistics/show.html.erb
@@ -91,13 +91,13 @@
       </li>
       <li>
         <a href="#downloads" class="govuk-link app-toc__link">
-          <span class="app-toc__number">7.</span>
+          <span class="app-toc__number">11.</span>
           <span class="app-toc__content">Download the data</span>
         </a>
       </li>
       <li>
         <a href="#footnotes" class="govuk-link app-toc__link">
-          <span class="app-toc__number">8.</span>
+          <span class="app-toc__number">12.</span>
           <span class="app-toc__content">Footnotes</span>
         </a>
       </li>
@@ -276,7 +276,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l govuk-!-padding-top-4" id="downloads">8. Download the data</h2>
+    <h2 class="govuk-heading-l govuk-!-padding-top-4" id="downloads">11. Download the data</h2>
 
     <p class="govuk-body">You can download all of the data on this page in CSV (comma separated values) format, which can be opened in a spreadsheet and used in other analysis tools.</p>
 
@@ -290,7 +290,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l govuk-!-padding-top-4" id="footnotes">9. Footnotes</h2>
+    <h2 class="govuk-heading-l govuk-!-padding-top-4" id="footnotes">12. Footnotes</h2>
 
     <p class="govuk-body">The Apply for teacher training service is the sole service for postgraduate Initial Teacher Training (ITT) applications in England to Higher Education Institution (HEI), School Centred Initial Teacher Training (SCITT)-based, School Direct, School Direct (salaried) and Teaching Apprenticeship courses.</p>
 

--- a/app/views/publications/v2/monthly_statistics/show.html.erb
+++ b/app/views/publications/v2/monthly_statistics/show.html.erb
@@ -72,9 +72,9 @@
         </a>
       </li>
       <li>
-        <a href="#downloads" class="govuk-link app-toc__link">
-          <span class="app-toc__number">7.</span>
-          <span class="app-toc__content">Route into teaching</span>
+        <a href="#by-primary-specialist-subject" class="govuk-link app-toc__link">
+          <span class="app-toc__number">8.</span>
+          <span class="app-toc__content">Primary specialist subject</span>
         </a>
       </li>
       <li>
@@ -225,6 +225,18 @@
 </div>
 
 <%= render Publications::DataTableComponent.new(caption: "Table 7.1: #{@presenter.by_route[:title]}", title: t('publications.itt_monthly_report_generator.route_into_teaching.subtitle'), data: @presenter.by_route[:data]) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l govuk-!-padding-top-4" id="by-primary-specialist-subject">8. Primary specialist subject</h2>
+
+    <p class="govuk-body">Some primary courses allow candidates to specialise in a particular subject. This may help candidates influence the way a particular subject is taught in their school when they start teaching. This table counts candidates who applied to primary courses by their specialist subject.</p>
+    <p class="govuk-body">Candidates may make different applications to courses with different specialist subjects. These candidates are counted under all subjects that apply. This means that the total of these rows does not equal the total in the ‘Candidate headline statistics’ section.</p>
+
+  </div>
+</div>
+
+<%= render Publications::DataTableComponent.new(caption: "Table 8.1: #{@presenter.by_primary_subject[:title]}", title: t('publications.itt_monthly_report_generator.primary_subject.subtitle'), data: @presenter.by_primary_subject[:data]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/publications/v2/monthly_statistics/show.html.erb
+++ b/app/views/publications/v2/monthly_statistics/show.html.erb
@@ -78,7 +78,7 @@
         </a>
       </li>
       <li>
-        <a href="#by-secondary-specialist-subject" class="govuk-link app-toc__link">
+        <a href="#by-secondary-subject" class="govuk-link app-toc__link">
           <span class="app-toc__number">9.</span>
           <span class="app-toc__content">Secondary subject</span>
         </a>
@@ -242,18 +242,18 @@
   </div>
 </div>
 
-<%= render Publications::DataTableComponent.new(caption: "Table 8.1: #{@presenter.by_primary_subject[:title]}", title: t('publications.itt_monthly_report_generator.primary_subject.subtitle'), data: @presenter.by_primary_subject[:data]) %>
+<%= render Publications::DataTableComponent.new(caption: "Table 8.1: #{@presenter.by_primary_subject[:title]}", title: t('publications.itt_monthly_report_generator.primary_subject.subtitle'), data: @presenter.by_primary_subject[:data], key: 'primary-subject') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l govuk-!-padding-top-4" id="by-primary-specialist-subject">9. Secondary subject</h2>
+    <h2 class="govuk-heading-l govuk-!-padding-top-4" id="by-secondary-subject">9. Secondary subject</h2>
 
     <p class="govuk-body">Candidates choose a subject for secondary teacher training. This table counts candidates who applied to secondary courses by subject.</p>
     <p class="govuk-body">Candidates may make different applications to courses with different subjects. These candidates are counted under all subjects that apply. This means that the total of these rows does not equal the total in the ‘Candidate headline statistics’ section.</p>
   </div>
 </div>
 
-<%= render Publications::DataTableComponent.new(caption: "Table 9.1: #{@presenter.by_secondary_subject[:title]}", title: t('publications.itt_monthly_report_generator.secondary_subject.subtitle'), data: @presenter.by_secondary_subject[:data]) %>
+<%= render Publications::DataTableComponent.new(caption: "Table 9.1: #{@presenter.by_secondary_subject[:title]}", title: t('publications.itt_monthly_report_generator.secondary_subject.subtitle'), data: @presenter.by_secondary_subject[:data], key: 'secondary-subject') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/publications/v2/monthly_statistics/show.html.erb
+++ b/app/views/publications/v2/monthly_statistics/show.html.erb
@@ -314,7 +314,7 @@
 
     <p class="govuk-body">
       Statistical releases from previous months during ITT<%= @presenter.previous_year - 1 %> can be found here:
-      <%= govuk_link_to 'https://www.gov.uk/government/publications/monthly-statistics-on-initial-teacher-training-itt-recruitment', 'https://www.gov.uk/government/publications/monthly-statistics-on-initial-teacher-training-itt-recruitment' %>.
+      <%= govuk_link_to publications_monthly_report_itt_url, publications_monthly_report_itt_url %>.
     </p>
 
     <p class="govuk-body">

--- a/app/views/publications/v2/monthly_statistics/show.html.erb
+++ b/app/views/publications/v2/monthly_statistics/show.html.erb
@@ -1,10 +1,10 @@
-<%= content_for :title, t('page_titles.monthly_statistics', academic_year_name: @presenter.next_cycle_name) %>
+<%= content_for :title, t('page_titles.monthly_statistics', academic_year_name: @presenter.academic_year_name) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l">Statistics</span>
     <h1 class="govuk-heading-l">
-      Initial teacher training applications for courses starting in the <%= @presenter.next_cycle_name %> academic year
+      Initial teacher training applications for courses starting in the <%= @presenter.academic_year_name %> academic year
     </h1>
   </div>
 </div>
@@ -85,8 +85,8 @@
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l" id="introduction">1. Introduction</h2>
 
-    <p class="govuk-body">These statistics cover applications for courses in England starting in the <%= @presenter.next_cycle_name %> academic year. To allow for comparison statistics covering the <%= @presenter.current_cycle_name %> academic year are also included.</p>
-    <p class="govuk-body">New definitions and methodology have been introduced for the <%= @presenter.next_cycle_name %> academic year because candidates can now submit applications individually, instead of submitting 4 course choices at the same time. Improvements have also been made for clarity. Published statistics using the old methodology are also available. These use different definitions and methodology, so they cannot be compared with the statistics below.</p>
+    <p class="govuk-body">These statistics cover applications for courses in England starting in the <%= @presenter.academic_year_name %> academic year. To allow for comparison statistics covering the <%= @presenter.current_cycle_name %> academic year are also included.</p>
+    <p class="govuk-body">New definitions and methodology have been introduced for the <%= @presenter.academic_year_name %> academic year because candidates can now submit applications individually, instead of submitting 4 course choices at the same time. Improvements have also been made for clarity. Published statistics using the old methodology are also available. These use different definitions and methodology, so they cannot be compared with the statistics below.</p>
 
     <% if @presenter.current_cycle? %>
       <p class="govuk-body"><%= govuk_link_to "View statistics for the #{@presenter.current_cycle_name} academic year", publications_monthly_report_itt_path(@presenter.previous_year) %> for course applications in England using the old methodology.</p>
@@ -95,7 +95,7 @@
     <% end %>
 
     <p class="govuk-body">Statistics are also not comparable to previous figures published by UCAS, which used a different methodology and included candidates applying to providers in Wales.</p>
-    <p class="govuk-body">Applications for courses starting in the <%= @presenter.next_cycle_name %> academic year are submitted in the <%= @presenter.current_cycle_verbose_name %> recruitment cycle (ITT2024) or deferred from the previous cycle for a <%= @presenter.next_cycle_name %> course start date.</p>
+    <p class="govuk-body">Applications for courses starting in the <%= @presenter.academic_year_name %> academic year are submitted in the <%= @presenter.current_cycle_verbose_name %> recruitment cycle (ITT2024) or deferred from the previous cycle for a <%= @presenter.academic_year_name %> course start date.</p>
 
     <p class="govuk-body">Teacher training applications made directly to providers or Teach First are not included. Undergraduate teacher training is also not included. Applications to train to teach in Further Education are also not included.</p>
     <p class="govuk-body">These statistics collect data from <%= CycleTimetable.apply_opens.to_fs(:govuk_date) %> up to and including the day before they were published.</p>

--- a/config/locales/publications/itt_monthly_report_generator.yml
+++ b/config/locales/publications/itt_monthly_report_generator.yml
@@ -15,19 +15,19 @@ en:
         title: Candidate statistics by UK region or country, or other area
         subtitle: Area
       phase:
-        title: Course phase
+        title: Candidate statistics by course phase
         subtitle: Course Phase
       route_into_teaching:
-        title: Route into teaching
+        title: Candidate statistics by route into teaching
         subtitle: Course type
       primary_subject:
-        title: Primary specialist subject
+        title: Candidate statistics by primary specialist subject
         subtitle: Subject
       secondary_subject:
-        title: Secondary subject
+        title: Candidate statistics by secondary subject
         subtitle: Subject
       provider_region:
-        title: Training provider region
+        title: Candidate statistics by training provider region of England
         subtitle: Region
       status:
         submitted:

--- a/config/routes/publications.rb
+++ b/config/routes/publications.rb
@@ -1,10 +1,22 @@
 namespace :publications, path: '/publications' do
   get '/monthly-statistics/temporarily-unavailable', to: 'monthly_statistics#temporarily_unavailable', as: :monthly_statistics_temporarily_unavailable
+  constraints(Publications::MonthlyStatisticsRedirectConstraint.new) do
+    constraints(->(req) { (2024..).include?(req.params[:year].to_i) }) do
+      get '/monthly-statistics/ITT(:year)' => redirect('/publications/monthly-statistics/temporarily-unavailable'), as: :monthly_report_itt_v2_redirect
+    end
+  end
+
+  constraints(->(req) { (2024..).include?(req.params[:year].to_i) }) do
+    get '/monthly-statistics/ITT(:year)' => 'v2/monthly_statistics#show', as: :monthly_report_itt_v2
+  end
+
   get '/monthly-statistics/ITT(:year)' => 'monthly_statistics#show', as: :monthly_report_itt
+
   constraints(Publications::MonthlyStatisticsRedirectConstraint.new) do
     get '/monthly-statistics(/:month)' => redirect('/publications/monthly-statistics/temporarily-unavailable'), as: :monthly_report_unavailable
     get '/monthly-statistics/:month/:export_type' => redirect('/publications/monthly-statistics/temporarily-unavailable'), as: :monthly_report_download_unavailable
   end
+
   get '/monthly-statistics(/:month)' => 'monthly_statistics#show', as: :monthly_report
   get '/monthly-statistics/:month/:export_type' => 'monthly_statistics#download', as: :monthly_report_download
   get '/mid-cycle-report' => 'mid_cycle_report#show', as: :mid_cycle_report

--- a/spec/models/publications/itt_monthly_report_generator_spec.rb
+++ b/spec/models/publications/itt_monthly_report_generator_spec.rb
@@ -443,7 +443,7 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
     it 'returns phase data' do
       expect(report[:candidate_phase]).to eq(
         {
-          title: 'Course phase',
+          title: 'Candidate statistics by course phase',
           data: {
             submitted: [
               {
@@ -509,7 +509,7 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
     it 'returns route into teaching data' do
       expect(report[:candidate_route_into_teaching]).to eq(
         {
-          title: 'Route into teaching',
+          title: 'Candidate statistics by route into teaching',
           data: {
             submitted: [
               {
@@ -575,7 +575,7 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
     it 'returns primary subject data' do
       expect(report[:candidate_primary_subject]).to eq(
         {
-          title: 'Primary specialist subject',
+          title: 'Candidate statistics by primary specialist subject',
           data: {
             submitted: [
               {
@@ -641,7 +641,7 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
     it 'returns secondary subject data' do
       expect(report[:candidate_secondary_subject]).to eq(
         {
-          title: 'Secondary subject',
+          title: 'Candidate statistics by secondary subject',
           data: {
             submitted: [
               {
@@ -707,7 +707,7 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
     it 'returns provider region data' do
       expect(report[:candidate_provider_region]).to eq(
         {
-          title: 'Training provider region',
+          title: 'Candidate statistics by training provider region of England',
           data: {
             submitted: [
               {

--- a/spec/requests/publications/v2/monthly_statistics_report_spec.rb
+++ b/spec/requests/publications/v2/monthly_statistics_report_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'V2 Monthly Statistics', time: Time.zone.local(2023, 11, 29) do
+  let(:temporarily_unavailable) { '/publications/monthly-statistics/temporarily-unavailable' }
+
+  # TODO: complete this when implementing month and csv
+
+  describe 'publications/monthly-statistics/ITT(:year) when year is >= 2024' do
+    context 'when monthly statistics redirect is enabled' do
+      before do
+        FeatureFlag.activate(:monthly_statistics_redirected)
+      end
+
+      it 'renders the report for 2024-11' do
+        get '/publications/monthly-statistics/ITT2024'
+        expect(response).to have_http_status(:redirect)
+        expect(response).to redirect_to(temporarily_unavailable)
+      end
+    end
+
+    context 'when monthly statistics redirect is disabled' do
+      before do
+        FeatureFlag.deactivate(:monthly_statistics_redirected)
+      end
+
+      it 'renders the report for 2024-11' do
+        get '/publications/monthly-statistics/ITT2024'
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('These statistics cover applications for courses in England starting in the 2024 to 2025 academic year')
+      end
+    end
+  end
+end

--- a/spec/system/publications/v2/monthly_statistics/visit_monthly_statistics_spec.rb
+++ b/spec/system/publications/v2/monthly_statistics/visit_monthly_statistics_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.feature 'Visit Monthly statistics V2 page', mid_cycle: false do
+  include StatisticsTestHelper
+
+  before do
+    TestSuiteTimeMachine.travel_permanently_to(2023, 12, 29)
+  end
+
+  scenario 'User can visit the monthly statistics page when it is enabled' do
+    given_the_monthly_statistics_redirect_is_disabled
+    and_i_visit_the_monthly_statistics_page
+    and_i_see_the_monthly_statistics
+  end
+
+  scenario 'User can visit the monthly statistics page when it is disabled' do
+    given_the_monthly_statistics_redirect_is_enabled
+    and_i_visit_the_monthly_statistics_page
+    then_i_should_be_redirected_to_the_temporarily_unavailable_page
+  end
+
+  def and_i_visit_the_monthly_statistics_page
+    visit '/publications/monthly-statistics/ITT2024'
+  end
+
+  def given_the_monthly_statistics_redirect_is_enabled
+    FeatureFlag.activate(:monthly_statistics_redirected)
+  end
+
+  def given_the_monthly_statistics_redirect_is_disabled
+    FeatureFlag.deactivate(:monthly_statistics_redirected)
+  end
+
+  def then_i_should_be_redirected_to_the_temporarily_unavailable_page
+    expect(page).to have_current_path('/publications/monthly-statistics/temporarily-unavailable')
+  end
+
+  def and_i_see_the_monthly_statistics
+    expect(page).to have_content "Initial teacher training applications for courses starting in the #{RecruitmentCycle.cycle_name(CycleTimetable.next_year)} academic year"
+  end
+end

--- a/spec/system/publications/v2/monthly_statistics/visit_monthly_statistics_spec.rb
+++ b/spec/system/publications/v2/monthly_statistics/visit_monthly_statistics_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'Visit Monthly statistics V2 page', mid_cycle: false do
     and_i_see_the_monthly_statistics
   end
 
-  scenario 'User can visit the monthly statistics page when it is disabled' do
+  scenario 'User is redirected on monthly statistics page when it is disabled' do
     given_the_monthly_statistics_redirect_is_enabled
     and_i_visit_the_monthly_statistics_page
     then_i_should_be_redirected_to_the_temporarily_unavailable_page


### PR DESCRIPTION
## Context

Provide template, controller and routing for updated Monthly Statistics resource for recruitment cycles 2024 and beyond.

The 2024 MonthlyStatistics will be calculated differently from previous years. To allow both formats to exist contemporaneously we've created `Publications::V2`.

V2 Presenter and Controller will load the new format of statistics.



## Changes proposed in this pull request

- Add `V2` Presenter and Controller to Publications namespace.
- Map ITT2023 to the old controller and ITT2024+ to the new V2 controller.


## Guidance to review

Should it be `V2` or `V2024`?

[Review App](https://apply-review-8764.test.teacherservices.cloud/publications/monthly-statistics/ITT2024)
[Lookerstudio prototype](https://lookerstudio.google.com/reporting/c0f04921-2e9d-4327-950b-2a0c6f952b8a/page/z2NZD)

## Link to Trello card

[Trello Ticket](https://trello.com/c/1FgSYegx/935-monthly-statistics-add-v2024-monthly-statistics-routes-controller-and-template)
