### PR TITLE
Allow recruit with pending conditions when accredited body is a SCITT

### DIFF
--- a/app/services/can_recruit_with_pending_conditions.rb
+++ b/app/services/can_recruit_with_pending_conditions.rb
@@ -2,14 +2,14 @@ class CanRecruitWithPendingConditions < HasPendingSkeConditionsOnly
   def call
     application_choice.pending_conditions? &&
       pending_ske_conditions_only? &&
-      provider_is_scitt? &&
+      provider_or_accredited_provider_is_scitt? &&
       course_is_within_time_limit?
   end
 
 private
 
-  def provider_is_scitt?
-    application_choice.provider&.scitt?
+  def provider_or_accredited_provider_is_scitt?
+    application_choice.provider&.scitt? || application_choice.accredited_provider&.scitt?
   end
 
   def course_is_within_time_limit?


### PR DESCRIPTION
Following on from https://github.com/DFE-Digital/apply-for-teacher-training/pull/8650, this allows recruitment with pending conditions when the accredited body is a SCITT and the training provider is a lead school.

## Context

We have opened up recruit with pending conditions to SCITT providers, but this excludes lead schools, even where the accredited body is a SCITT, thereby creating confusion.

## Changes proposed in this pull request

Allow recruitment with pending conditions when the accredited body is a SCITT and the training provider is a lead school.

## Guidance to review

1. Does it make sense?
2. Do the tests pass?

## Link to Trello card

https://trello.com/c/i0Z1M9a5/6339-allow-recruit-with-pending-conditions-where-accredited-body-is-a-scitt-and-the-training-partner-is-a-lead-school

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
