### PR TITLE
Add monthly_statistics_redirected FeatureFlag

### DIFF
--- a/app/constraints/publications/monthly_statistics_constraint.rb
+++ b/app/constraints/publications/monthly_statistics_constraint.rb
@@ -1,0 +1,7 @@
+module Publications
+  class MonthlyStatisticsConstraint
+    def matches?(_request)
+      FeatureFlag.inactive?(:monthly_statistics_redirected)
+    end
+  end
+end

--- a/app/controllers/publications/monthly_statistics_controller.rb
+++ b/app/controllers/publications/monthly_statistics_controller.rb
@@ -3,7 +3,9 @@ module Publications
     rescue_from ActiveRecord::RecordNotFound, with: :render_404
 
     def show
-      redirect_to publications_monthly_statistics_temporarily_unavailable_path if params[:year].to_i == RecruitmentCycle.current_year
+      if FeatureFlag.active?(:monthly_statistics_redirected) && params[:year].to_i == RecruitmentCycle.current_year
+        redirect_to publications_monthly_statistics_temporarily_unavailable_path
+      end
 
       @presenter = Publications::MonthlyStatisticsPresenter.new(current_report)
       @csv_export_types_and_sizes = calculate_download_sizes(current_report)

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -39,6 +39,7 @@ class FeatureFlag
     [:continuous_applications, 'The new continuous applications flow', 'James Glenn'],
     [:course_has_vacancies, 'Using the new publish status to set a course as open or closed', 'Tomas & James'],
     [:recruit_with_pending_conditions, 'Providers will be able to recruit candidates that have a SKE condition pending provided there are no other pending conditions', 'Steve Hook'],
+    [:monthly_statistics_redirected, 'Redirect requests for Publications Monthly Statistics to temporarily unavailable', 'Iain McNulty'],
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day

--- a/config/routes/publications.rb
+++ b/config/routes/publications.rb
@@ -1,9 +1,11 @@
 namespace :publications, path: '/publications' do
   get '/monthly-statistics/temporarily-unavailable', to: 'monthly_statistics#temporarily_unavailable', as: :monthly_statistics_temporarily_unavailable
   get '/monthly-statistics/ITT(:year)' => 'monthly_statistics#show', as: :monthly_report_itt
-  get '/monthly-statistics(/:month)' => redirect('/publications/monthly-statistics/temporarily-unavailable'), as: :monthly_report
-  get '/monthly-statistics/:month/:export_type' => redirect('/publications/monthly-statistics/temporarily-unavailable'), as: :monthly_report_download
-  # get '/monthly-statistics(/:month)' => 'monthly_statistics#show', as: :monthly_report
-  # get '/monthly-statistics/:month/:export_type' => 'monthly_statistics#download', as: :monthly_report_download
+  constraints(Publications::MonthlyStatisticsConstraint.new) do
+    get '/monthly-statistics(/:month)' => 'monthly_statistics#show', as: :monthly_report
+    get '/monthly-statistics/:month/:export_type' => 'monthly_statistics#download', as: :monthly_report_download
+  end
+  get '/monthly-statistics(/:month)' => redirect('/publications/monthly-statistics/temporarily-unavailable'), as: :monthly_report_unavailable
+  get '/monthly-statistics/:month/:export_type' => redirect('/publications/monthly-statistics/temporarily-unavailable'), as: :monthly_report_download_unavailable
   get '/mid-cycle-report' => 'mid_cycle_report#show', as: :mid_cycle_report
 end

--- a/spec/requests/publications/monthly_statistics_spec.rb
+++ b/spec/requests/publications/monthly_statistics_spec.rb
@@ -33,158 +33,265 @@ RSpec.describe 'Monthly Statistics', time: Time.zone.local(2022, 11, 29) do
       report.save
     end
 
-    it 'renders the report for 2022-11' do
-      get '/publications/monthly-statistics/'
-      # expect(response).to have_http_status(:ok)
-      # expect(response.body).to include('to 22 November 2022')
-      expect(response).to redirect_to(temporarily_unavailable)
-      get temporarily_unavailable
-      expect(response.body).to include('The first publication of ITT statistics for the new cycle will be on Monday 27 November 2023.')
-      expect(response.body).to include('https://www.gov.uk/government/publications/monthly-statistics-on-initial-teacher-training-itt-recruitment')
-      expect(response.body).to include('becomingateacher@digital.education.gov.uk')
+    context 'with monthly statistics redirect disabled' do
+      before do
+        FeatureFlag.deactivate(:monthly_statistics_redirected)
+      end
 
-      get '/publications/monthly-statistics/2022-10'
-      # expect(response).to have_http_status(:ok)
-      # expect(response.body).to include('to 18 October 2022')
-      expect(response).to redirect_to(temporarily_unavailable)
+      it 'renders the report for 2022-11' do
+        get '/publications/monthly-statistics/'
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('to 22 November 2022')
 
-      get '/publications/monthly-statistics/2022-11'
-      # expect(response).to have_http_status(:ok)
-      # expect(response.body).to include('to 22 November 2022')
-      expect(response).to redirect_to(temporarily_unavailable)
+        get '/publications/monthly-statistics/2022-10'
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('to 18 October 2022')
 
-      get '/publications/monthly-statistics/2022-12'
-      # expect(response).to have_http_status(:not_found)
+        get '/publications/monthly-statistics/2022-11'
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('to 22 November 2022')
+
+        get '/publications/monthly-statistics/2022-12'
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'returns application by status csv for 2022-10' do
+        get '/publications/monthly-statistics/2022-10/applications_by_status.csv'
+        expect(response).to have_http_status(:ok)
+      end
+
+      it '404s for a badly formatted date' do
+        get '/publications/monthly-statistics/12-23'
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'with monthly statistics redirect enabled' do
+      before do
+        FeatureFlag.activate(:monthly_statistics_redirected)
+      end
+
+      it 'renders the report for 2022-11' do
+        get '/publications/monthly-statistics/'
+        expect(response).to redirect_to(temporarily_unavailable)
+        get temporarily_unavailable
+        expect(response.body).to include('The first publication of ITT statistics for the new cycle will be on Monday 27 November 2023.')
+        expect(response.body).to include('https://www.gov.uk/government/publications/monthly-statistics-on-initial-teacher-training-itt-recruitment')
+        expect(response.body).to include('becomingateacher@digital.education.gov.uk')
+
+        get '/publications/monthly-statistics/2022-10'
+        expect(response).to redirect_to(temporarily_unavailable)
+
+        get '/publications/monthly-statistics/2022-11'
+        expect(response).to redirect_to(temporarily_unavailable)
+
+        get '/publications/monthly-statistics/2022-12'
+        expect(response).to redirect_to(temporarily_unavailable)
+      end
+
+      it 'returns application by status csv for 2022-10' do
+        get '/publications/monthly-statistics/2022-10/applications_by_status.csv'
+        expect(response).to redirect_to(temporarily_unavailable)
+      end
+
+      it '404s for a badly formatted date' do
+        get '/publications/monthly-statistics/12-23'
+        expect(response).to redirect_to(temporarily_unavailable)
+      end
+    end
+  end
+
+  context 'with monthly statistics redirect enabled' do
+    before do
+      FeatureFlag.activate(:monthly_statistics_redirected)
+    end
+
+    it 'returns the latest application for old cycles' do
+      get '/publications/monthly-statistics/ITT2022'
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('to 19 September 2022')
+    end
+
+    it 'returns the latest application for new cycle' do
+      get '/publications/monthly-statistics/ITT2023'
       expect(response).to redirect_to(temporarily_unavailable)
     end
 
-    it 'returns application by status csv for 2022-10' do
-      get '/publications/monthly-statistics/2022-10/applications_by_status.csv'
-      # expect(response).to have_http_status(:ok)
+    it 'returns a 404 when an old date is in the URL' do
+      get '/publications/monthly-statistics/ITT2002'
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to include 'Page not found'
+      expect(response.header['Content-Type']).not_to include 'text/csv'
+    end
+
+    it 'returns a 404 when an invalid date is in the URL params' do
+      get '/publications/monthly-statistics/foo-2022-11'
       expect(response).to redirect_to(temporarily_unavailable)
     end
 
-    it '404s for a badly formatted date' do
-      get '/publications/monthly-statistics/12-23'
-      # expect(response).to have_http_status(:not_found)
+    it 'returns application by status csv' do
+      get '/publications/monthly-statistics/2022-11/applications_by_status.csv'
+      expect(response).to redirect_to(temporarily_unavailable)
+    end
+
+    it 'returns candidates by status csv' do
+      get '/publications/monthly-statistics/2022-11/candidates_by_status'
+      expect(response).to redirect_to(temporarily_unavailable)
+    end
+
+    it 'returns candidates by age group csv' do
+      get '/publications/monthly-statistics/2022-11/by_age_group'
+      expect(response).to redirect_to(temporarily_unavailable)
+    end
+
+    it 'returns applications by course age group csv' do
+      get '/publications/monthly-statistics/2022-11/by_course_age_group'
+      expect(response).to redirect_to(temporarily_unavailable)
+    end
+
+    it 'returns candidates by area csv' do
+      get '/publications/monthly-statistics/2022-11/by_area'
+      expect(response).to redirect_to(temporarily_unavailable)
+    end
+
+    it 'returns candidates by sex csv' do
+      get '/publications/monthly-statistics/2022-11/by_sex'
+      expect(response).to redirect_to(temporarily_unavailable)
+    end
+
+    it 'returns applications by course type csv' do
+      get '/publications/monthly-statistics/2022-11/by_course_type'
+      expect(response).to redirect_to(temporarily_unavailable)
+    end
+
+    it 'returns applications by primary specialist subject csv' do
+      get '/publications/monthly-statistics/2022-11/by_primary_specialist_subject'
+      expect(response).to redirect_to(temporarily_unavailable)
+    end
+
+    it 'returns applications by secondary subject csv' do
+      get '/publications/monthly-statistics/2022-11/by_secondary_subject'
+      expect(response).to redirect_to(temporarily_unavailable)
+    end
+
+    it 'returns applications by provider area csv' do
+      get '/publications/monthly-statistics/2022-11/by_provider_area'
+      expect(response).to redirect_to(temporarily_unavailable)
+    end
+
+    it 'returns a 404 when an invalid date is in the URL' do
+      get '/publications/monthly-statistics/foo-2022-11/by_provider_area'
       expect(response).to redirect_to(temporarily_unavailable)
     end
   end
 
-  it 'returns the latest application for old cycles' do
-    get '/publications/monthly-statistics/ITT2022'
-    expect(response).to have_http_status(:ok)
-    expect(response.body).to include('to 19 September 2022')
-  end
+  context 'with monthly statistics redirect disabled' do
+    before do
+      FeatureFlag.deactivate(:monthly_statistics_redirected)
+    end
 
-  it 'returns the latest application for new cycle' do
-    get '/publications/monthly-statistics/ITT2023'
-    # expect(response).to have_http_status(:ok)
-    # expect(response.body).to include('to 22 November 2022')
-    expect(response).to redirect_to(temporarily_unavailable)
-  end
+    it 'returns the latest application for old cycles' do
+      get '/publications/monthly-statistics/ITT2022'
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('to 19 September 2022')
+    end
 
-  it 'returns a 404 when an old date is in the URL' do
-    get '/publications/monthly-statistics/ITT2002'
-    expect(response).to have_http_status(:not_found)
-    expect(response.body).to include 'Page not found'
-    expect(response.header['Content-Type']).not_to include 'text/csv'
-  end
+    it 'returns the latest application for new cycle' do
+      get '/publications/monthly-statistics/ITT2023'
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('to 22 November 2022')
+    end
 
-  it 'returns a 404 when an invalid date is in the URL params' do
-    get '/publications/monthly-statistics/foo-2022-11'
-    # expect(response).to have_http_status(:not_found)
-    # expect(response.body).to include 'Page not found'
-    # expect(response.header['Content-Type']).not_to include 'text/csv'
-    expect(response).to redirect_to(temporarily_unavailable)
-  end
+    it 'returns a 404 when an old date is in the URL' do
+      get '/publications/monthly-statistics/ITT2002'
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to include 'Page not found'
+      expect(response.header['Content-Type']).not_to include 'text/csv'
+    end
 
-  it 'returns application by status csv' do
-    get '/publications/monthly-statistics/2022-11/applications_by_status.csv'
-    # expect(response).to have_http_status(:ok)
-    # expect(response.body).to start_with 'Status,First application,Apply again,Total'
-    # expect(response.header['Content-Type']).to include 'text/csv'
-    expect(response).to redirect_to(temporarily_unavailable)
-  end
+    it 'returns a 404 when an invalid date is in the URL params' do
+      get '/publications/monthly-statistics/foo-2022-11'
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to include 'Page not found'
+      expect(response.header['Content-Type']).not_to include 'text/csv'
+    end
 
-  it 'returns candidates by status csv' do
-    get '/publications/monthly-statistics/2022-11/candidates_by_status'
-    # expect(response).to have_http_status(:ok)
-    # expect(response.body).to start_with 'Status,First application,Apply again,Total'
-    # expect(response.header['Content-Type']).to include 'text/csv'
-    expect(response).to redirect_to(temporarily_unavailable)
-  end
+    it 'returns application by status csv' do
+      get '/publications/monthly-statistics/2022-11/applications_by_status.csv'
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to start_with 'Status,First application,Apply again,Total'
+      expect(response.header['Content-Type']).to include 'text/csv'
+    end
 
-  it 'returns candidates by age group csv' do
-    get '/publications/monthly-statistics/2022-11/by_age_group'
-    # expect(response).to have_http_status(:ok)
-    # expect(response.body).to start_with 'Age group,Recruited,Conditions pending'
-    # expect(response.header['Content-Type']).to include 'text/csv'
-    expect(response).to redirect_to(temporarily_unavailable)
-  end
+    it 'returns candidates by status csv' do
+      get '/publications/monthly-statistics/2022-11/candidates_by_status'
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to start_with 'Status,First application,Apply again,Total'
+      expect(response.header['Content-Type']).to include 'text/csv'
+    end
 
-  it 'returns applications by course age group csv' do
-    get '/publications/monthly-statistics/2022-11/by_course_age_group'
-    # expect(response).to have_http_status(:ok)
-    # expect(response.body).to start_with 'Course phase,Recruited,Conditions pending'
-    # expect(response.header['Content-Type']).to include 'text/csv'
-    expect(response).to redirect_to(temporarily_unavailable)
-  end
+    it 'returns candidates by age group csv' do
+      get '/publications/monthly-statistics/2022-11/by_age_group'
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to start_with 'Age group,Recruited,Conditions pending'
+      expect(response.header['Content-Type']).to include 'text/csv'
+    end
 
-  it 'returns candidates by area csv' do
-    get '/publications/monthly-statistics/2022-11/by_area'
-    # expect(response).to have_http_status(:ok)
-    # expect(response.body).to start_with 'Area,Recruited,Conditions pending'
-    # expect(response.header['Content-Type']).to include 'text/csv'
-    expect(response).to redirect_to(temporarily_unavailable)
-  end
+    it 'returns applications by course age group csv' do
+      get '/publications/monthly-statistics/2022-11/by_course_age_group'
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to start_with 'Course phase,Recruited,Conditions pending'
+      expect(response.header['Content-Type']).to include 'text/csv'
+    end
 
-  it 'returns candidates by sex csv' do
-    get '/publications/monthly-statistics/2022-11/by_sex'
-    # expect(response).to have_http_status(:ok)
-    # expect(response.body).to start_with 'Sex,Recruited,Conditions pending'
-    # expect(response.header['Content-Type']).to include 'text/csv'
-    expect(response).to redirect_to(temporarily_unavailable)
-  end
+    it 'returns candidates by area csv' do
+      get '/publications/monthly-statistics/2022-11/by_area'
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to start_with 'Area,Recruited,Conditions pending'
+      expect(response.header['Content-Type']).to include 'text/csv'
+    end
 
-  it 'returns applications by course type csv' do
-    get '/publications/monthly-statistics/2022-11/by_course_type'
-    # expect(response).to have_http_status(:ok)
-    # expect(response.body).to start_with 'Course type,Recruited,Conditions pending'
-    # expect(response.header['Content-Type']).to include 'text/csv'
-    expect(response).to redirect_to(temporarily_unavailable)
-  end
+    it 'returns candidates by sex csv' do
+      get '/publications/monthly-statistics/2022-11/by_sex'
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to start_with 'Sex,Recruited,Conditions pending'
+      expect(response.header['Content-Type']).to include 'text/csv'
+    end
 
-  it 'returns applications by primary specialist subject csv' do
-    get '/publications/monthly-statistics/2022-11/by_primary_specialist_subject'
-    # expect(response).to have_http_status(:ok)
-    # expect(response.body).to start_with 'Subject,Recruited,Conditions pending'
-    # expect(response.header['Content-Type']).to include 'text/csv'
-    expect(response).to redirect_to(temporarily_unavailable)
-  end
+    it 'returns applications by course type csv' do
+      get '/publications/monthly-statistics/2022-11/by_course_type'
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to start_with 'Course type,Recruited,Conditions pending'
+      expect(response.header['Content-Type']).to include 'text/csv'
+    end
 
-  it 'returns applications by secondary subject csv' do
-    get '/publications/monthly-statistics/2022-11/by_secondary_subject'
-    # expect(response).to have_http_status(:ok)
-    # expect(response.body).to start_with 'Subject,Recruited,Conditions pending'
-    # expect(response.header['Content-Type']).to include 'text/csv'
-    expect(response).to redirect_to(temporarily_unavailable)
-  end
+    it 'returns applications by primary specialist subject csv' do
+      get '/publications/monthly-statistics/2022-11/by_primary_specialist_subject'
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to start_with 'Subject,Recruited,Conditions pending'
+      expect(response.header['Content-Type']).to include 'text/csv'
+    end
 
-  it 'returns applications by provider area csv' do
-    get '/publications/monthly-statistics/2022-11/by_provider_area'
-    # expect(response).to have_http_status(:ok)
-    # expect(response.body).to start_with 'Area,Recruited,Conditions pending'
-    # expect(response.header['Content-Type']).to include 'text/csv'
-    expect(response).to redirect_to(temporarily_unavailable)
-  end
+    it 'returns applications by secondary subject csv' do
+      get '/publications/monthly-statistics/2022-11/by_secondary_subject'
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to start_with 'Subject,Recruited,Conditions pending'
+      expect(response.header['Content-Type']).to include 'text/csv'
+    end
 
-  it 'returns a 404 when an invalid date is in the URL' do
-    get '/publications/monthly-statistics/foo-2022-11/by_provider_area'
-    # expect(response).to have_http_status(:not_found)
-    # expect(response.body).to include 'Page not found'
-    # expect(response.header['Content-Type']).not_to include 'text/csv'
-    expect(response).to redirect_to(temporarily_unavailable)
+    it 'returns applications by provider area csv' do
+      get '/publications/monthly-statistics/2022-11/by_provider_area'
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to start_with 'Area,Recruited,Conditions pending'
+      expect(response.header['Content-Type']).to include 'text/csv'
+    end
+
+    it 'returns a 404 when an invalid date is in the URL' do
+      get '/publications/monthly-statistics/foo-2022-11/by_provider_area'
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to include 'Page not found'
+      expect(response.header['Content-Type']).not_to include 'text/csv'
+    end
   end
 
   def new_report(options)

--- a/spec/routes/monthly_statistics/publications_spec.rb
+++ b/spec/routes/monthly_statistics/publications_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe 'Routes for MonthlyStatistics', type: :routing do
+  describe 'when monthly_statistics_redirected is disabled' do
+    before { FeatureFlag.deactivate(:monthly_statistics_redirected) }
+
+    it 'routes /publications/monthly-statistics/august' do
+      expect(get('/publications/monthly-statistics')).to route_to('publications/monthly_statistics#show')
+    end
+  end
+
+  describe 'when monthly_statistics_redirected is enabled' do
+    before { FeatureFlag.activate(:monthly_statistics_redirected) }
+
+    it 'routes /publications/monthly-statistics/august' do
+      expect(get('/publications/monthly-statistics')).to route_to({ 'controller' => 'errors', 'action' => 'not_found', 'path' => 'publications/monthly-statistics' })
+    end
+  end
+end

--- a/spec/system/monthly_statistics/monthly_statistics_page_spec.rb
+++ b/spec/system/monthly_statistics/monthly_statistics_page_spec.rb
@@ -10,12 +10,28 @@ RSpec.feature 'Monthly statistics page', mid_cycle: false do
     create_monthly_stats_report
   end
 
-  scenario 'User can download a CSV from the monthly statistics page' do
-    given_i_visit_the_monthly_statistics_page
-    then_i_should_be_redirected_to_the_temporarily_unavailable_page
-    # and_i_see_the_monthly_statistics
-    # when_i_click_a_link
-    # then_a_csv_downloads
+  context 'with monthly statistics redirect enabled' do
+    before do
+      FeatureFlag.activate(:monthly_statistics_redirected)
+    end
+
+    scenario 'User can download a CSV from the monthly statistics page' do
+      given_i_visit_the_monthly_statistics_page
+      then_i_should_be_redirected_to_the_temporarily_unavailable_page
+    end
+  end
+
+  context 'with monthly statistics redirect disabled' do
+    before do
+      FeatureFlag.deactivate(:monthly_statistics_redirected)
+    end
+
+    scenario 'User can download a CSV from the monthly statistics page' do
+      given_i_visit_the_monthly_statistics_page
+      and_i_see_the_monthly_statistics
+      when_i_click_a_link
+      then_a_csv_downloads
+    end
   end
 
   def create_monthly_stats_report


### PR DESCRIPTION
## Context

We have hard coded the routing redirect for the publications monthly statistics page when requesting a specific month.
When we complete the work for the new MonthlyStatistics page, we will want to be able to reenable the routing using a FeatureFlag rather that have to make a new release.

## Changes proposed in this pull request

Add a `FeatureFlag` `:monthly_statistics_redirected` and use it in a routing constraint.

## Guidance to review

1. Toggle the FeatureFlag [here](https://apply-review-8768.test.teacherservices.cloud/support/settings/feature-flags)
2. Test that the page redirects to temporarily-unavailable [here](https://apply-review-8768.test.teacherservices.cloud/publications/monthly-statistics/august)
## Link to Trello card

[Trello Ticket](https://trello.com/c/Fw6JhKXI/934-monthly-statistics-add-featureflag-for-suspending-monthly-stats-endpoint)
