### PR TITLE
Fix Sentry URL and remove Logit from `Useful links for this application`

### DIFF
--- a/app/components/support_interface/application_navigation_component.rb
+++ b/app/components/support_interface/application_navigation_component.rb
@@ -9,7 +9,6 @@ module SupportInterface
     def links
       [
         email_log_link,
-        logit_link,
         sentry_link,
       ]
     end
@@ -24,34 +23,12 @@ module SupportInterface
     end
 
     def sentry_link
-      link = "https://sentry.io/organizations/dfe-bat/issues/?project=1765973&query=user.id%3A%22candidate_#{@application_form.candidate_id}%22"
+      link = "https://dfe-teacher-services.sentry.io/issues/?project=1765973&query=user.id%3A%22candidate_#{@application_form.candidate_id}%22&statsPeriod=90d"
 
       {
         title: 'Sentry errors for this candidate',
         href: link,
       }
-    end
-
-    def logit_link
-      link = "https://kibana.logit.io/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15d,to:now))&_a=(columns:!(_source),filters:!(),index:'8ac115c0-aac1-11e8-88ea-0383c11b333c',interval:auto,query:(language:kuery,query:'application:%22#{current_logit_application_name}%22%20AND%20payload.candidate_id:#{@application_form.candidate_id}'),sort:!('@timestamp',desc))"
-
-      {
-        title: 'Logit logs for this candidate',
-        href: link,
-      }
-    end
-
-    def current_logit_application_name
-      if HostingEnvironment.environment_name == 'production' && HostingEnvironment.sandbox_mode?
-        'apply-sandbox'
-      elsif HostingEnvironment.production?
-        'apply-prod'
-      else
-        {
-          'staging' => 'apply-staging',
-          'qa' => 'apply-qa',
-        }[HostingEnvironment.environment_name]
-      end
     end
   end
 end

--- a/docs/developer-onboarding.md
+++ b/docs/developer-onboarding.md
@@ -4,14 +4,12 @@
 
 This document describes the on-boardng steps for new Developers when they join the team.
 
-## You can request access to the following by asking in the #digital-tools-support slack channel:
+## You can request access to the following by asking in the #digital-tools-support slack channel
 
 - [DfE-Digital](https://github.com/DFE-Digital) GitHub group access. Once you're added to the BAT (Becoming a Teacher) team you will have access to all repos. Ours are [Find](https://github.com/DFE-Digital/find-teacher-training) and [Apply](https://github.com/DFE-Digital/apply-for-teacher-training)
-- [Logit access](https://dashboard.logit.io/a/eeeb8311-79d8-49ab-9410-9b6d76b26f72) (Stack: Becoming a teacher - PaaS)
 - [Sentry access](https://sentry.io/auth/login/dfe-teacher-services/)
 
 ## DevOps steps
-
 
 ### Getting familiar with AKS
 
@@ -37,23 +35,19 @@ Note: You can also navigate to the Add Support User page by logging into support
 Have a read through [Teacher Services technical documentation](https://teacher-services-tech-docs.london.cloudapps.digital/#teacher-services-technical-documentation) and [DfE Technical Guidance](https://technical-guidance.education.gov.uk/).
 
 # Developer Slack Channels
+
 These are a small number of recommended Slack channels for new developers to join
 
 - Join `#apply-dev-notifications` for GitHub notifications from the [Find postgraduate teacher training](https://github.com/DFE-Digital/apply-for-teacher-training) and [Apply for teacher training](https://github.com/DFE-Digital/find-teacher-training) codebases
 
-
 - `#civil_servant_devs` is a channel for civil servant developers. Join if you would like to be part of ongoing developer discussion, meet ups and technical talks.
 This is a private channel, so ask a permanent developer within Teacher Services to invite you.
 
-
 - `#developers` is a generic channel for anything technical related. It's for developers across DfE, not just in Teaching Workforce Directorate.
-
 
 - `#twd_developers` is a channel for discussion between developers within the Teaching Workforce Directorate. Also join if you want to take part in developer meet ups
 on Wednesdays at 15:00, every fortnight
 
-
 - `#twd_apply_tech` is a channel for all technical discussion relating to the [Find postgraduate teacher training](https://github.com/DFE-Digital/apply-for-teacher-training) and [Apply for teacher training](https://github.com/DFE-Digital/find-teacher-training) codebases
-
 
 - For all Teacher services infrastructure related topics, join `#teacher-services-infra`

--- a/spec/components/support_interface/application_navigation_component_spec.rb
+++ b/spec/components/support_interface/application_navigation_component_spec.rb
@@ -10,50 +10,5 @@ RSpec.describe SupportInterface::ApplicationNavigationComponent do
 
     expect(page).to have_link('Emails about this application', href: /email-log.+#{form.id}/)
     expect(page).to have_link('Sentry errors for this candidate', href: /sentry.io.+#{candidate_id}/)
-    expect(page).to have_link('Logit logs for this candidate', href: /logit.io.+#{candidate_id}/)
-  end
-
-  describe 'logit link' do
-    it 'is correct in the sandbox' do
-      ClimateControl.modify(HOSTING_ENVIRONMENT_NAME: 'production', SANDBOX: 'true') do
-        render_inline(described_class.new(form))
-        expect(page).to have_link('Logit logs for this candidate', href: /logit.io.+apply-sandbox/)
-      end
-    end
-
-    it 'is correct in production' do
-      ClimateControl.modify(HOSTING_ENVIRONMENT_NAME: 'production') do
-        render_inline(described_class.new(form))
-        expect(page).to have_link('Logit logs for this candidate', href: /logit.io.+apply-prod/)
-      end
-    end
-
-    it 'is correct in qa' do
-      ClimateControl.modify(HOSTING_ENVIRONMENT_NAME: 'qa') do
-        render_inline(described_class.new(form))
-        expect(page).to have_link('Logit logs for this candidate', href: /logit.io.+apply-qa/)
-      end
-    end
-
-    it 'is correct in staging' do
-      ClimateControl.modify(HOSTING_ENVIRONMENT_NAME: 'staging') do
-        render_inline(described_class.new(form))
-        expect(page).to have_link('Logit logs for this candidate', href: /logit.io.+apply-staging/)
-      end
-    end
-
-    it 'leaves empty quote marks in review' do
-      ClimateControl.modify(HOSTING_ENVIRONMENT_NAME: 'review') do
-        render_inline(described_class.new(form))
-        expect(page).to have_link('Logit logs for this candidate', href: /logit.io.+application:%22%22/)
-      end
-    end
-
-    it 'leaves empty quote marks in development' do
-      ClimateControl.modify(HOSTING_ENVIRONMENT_NAME: 'development') do
-        render_inline(described_class.new(form))
-        expect(page).to have_link('Logit logs for this candidate', href: /logit.io.+application:%22%22/)
-      end
-    end
   end
 end


### PR DESCRIPTION
The Sentry URL was pointing to the wrong domain, and we're not using [Logit anymore](https://ukgovernmentdfe.slack.com/archives/C05D5S8C6PJ/p1699613633021219). I set the Sentry date range to the last 90 days, the default is 14 days. 

<img width="337" alt="Screenshot 2023-11-10 at 16 13 19" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/14361f9d-62d4-4239-b80f-83c18ad57923">
