### PR TITLE
Add all remaining sections to itt report

### DIFF
--- a/app/lib/dfe/bigquery/application_metrics.rb
+++ b/app/lib/dfe/bigquery/application_metrics.rb
@@ -54,6 +54,22 @@ module DfE
         query(phase_query(cycle_week:))
       end
 
+      def self.route_into_teaching(cycle_week:)
+        query(route_into_teaching_query(cycle_week:))
+      end
+
+      def self.primary_subject(cycle_week:)
+        query(primary_subject_query(cycle_week:))
+      end
+
+      def self.secondary_subject(cycle_week:)
+        query(secondary_subject_query(cycle_week:))
+      end
+
+      def self.provider_region(cycle_week:)
+        query(provider_region_query(cycle_week:))
+      end
+
       def self.candidate_headline_statistics_query(cycle_week:)
         where(
           recruitment_cycle_year:,
@@ -102,6 +118,46 @@ module DfE
           cycle_week:,
           subject_filter_category: 'Total excluding Further Education',
           nonsubject_filter_category: 'Sex',
+        )
+        .to_sql
+      end
+
+      def self.route_into_teaching_query(cycle_week:)
+        where(
+          recruitment_cycle_year:,
+          cycle_week:,
+          subject_filter_category: 'Total excluding Further Education',
+          nonsubject_filter_category: 'Route into teaching',
+        )
+        .to_sql
+      end
+
+      def self.primary_subject_query(cycle_week:)
+        where(
+          recruitment_cycle_year:,
+          cycle_week:,
+          subject_filter_category: 'Primary subject',
+          nonsubject_filter_category: 'Total',
+        )
+        .to_sql
+      end
+
+      def self.secondary_subject_query(cycle_week:)
+        where(
+          recruitment_cycle_year:,
+          cycle_week:,
+          subject_filter_category: 'Secondary subject excluding Further Education',
+          nonsubject_filter_category: 'Total',
+        )
+        .to_sql
+      end
+
+      def self.provider_region_query(cycle_week:)
+        where(
+          recruitment_cycle_year:,
+          cycle_week:,
+          subject_filter_category: 'Total excluding Further Education',
+          nonsubject_filter_category: 'Provider region',
         )
         .to_sql
       end

--- a/app/models/publications/itt_monthly_report_generator.rb
+++ b/app/models/publications/itt_monthly_report_generator.rb
@@ -2,7 +2,16 @@ module Publications
   class ITTMonthlyReportGenerator
     attr_accessor :generation_date, :publication_date, :first_cycle_week, :report_expected_time, :cycle_week
 
-    delegate :candidate_headline_statistics_query, :age_group_query, :sex_query, :area_query, :phase_query, to: ::DfE::Bigquery::ApplicationMetrics
+    delegate :candidate_headline_statistics_query,
+             :age_group_query,
+             :sex_query,
+             :area_query,
+             :phase_query,
+             :route_into_teaching_query,
+             :primary_subject_query,
+             :secondary_subject_query,
+             :provider_region_query,
+             to: ::DfE::Bigquery::ApplicationMetrics
 
     def initialize(generation_date: Time.zone.now, publication_date: nil)
       @generation_date = generation_date
@@ -35,6 +44,22 @@ module Publications
           title: I18n.t('publications.itt_monthly_report_generator.phase.title'),
           data: candidate_phase,
         },
+        candidate_route_into_teaching: {
+          title: I18n.t('publications.itt_monthly_report_generator.route_into_teaching.title'),
+          data: candidate_route_into_teaching,
+        },
+        candidate_primary_subject: {
+          title: I18n.t('publications.itt_monthly_report_generator.primary_subject.title'),
+          data: candidate_primary_subject,
+        },
+        candidate_secondary_subject: {
+          title: I18n.t('publications.itt_monthly_report_generator.secondary_subject.title'),
+          data: candidate_secondary_subject,
+        },
+        candidate_provider_region: {
+          title: I18n.t('publications.itt_monthly_report_generator.provider_region.title'),
+          data: candidate_provider_region,
+        },
       }
     end
 
@@ -45,6 +70,10 @@ module Publications
         sex_query: sex_query(cycle_week:),
         area_query: area_query(cycle_week:),
         phase_query: phase_query(cycle_week:),
+        route_into_teaching_query: route_into_teaching_query(cycle_week:),
+        primary_subject_query: primary_subject_query(cycle_week:),
+        secondary_subject_query: secondary_subject_query(cycle_week:),
+        provider_region_query: provider_region_query(cycle_week:),
       }.each do |key, value|
         # rubocop:disable Rails/Output
         puts "========= #{key.to_s.humanize} =========="
@@ -106,6 +135,34 @@ module Publications
       group_data(
         results: ::DfE::Bigquery::ApplicationMetrics.phase(cycle_week:),
         title_column: :subject_filter,
+      )
+    end
+
+    def candidate_route_into_teaching
+      group_data(
+        results: ::DfE::Bigquery::ApplicationMetrics.route_into_teaching(cycle_week:),
+        title_column: :nonsubject_filter,
+      )
+    end
+
+    def candidate_primary_subject
+      group_data(
+        results: ::DfE::Bigquery::ApplicationMetrics.primary_subject(cycle_week:),
+        title_column: :subject_filter,
+      )
+    end
+
+    def candidate_secondary_subject
+      group_data(
+        results: ::DfE::Bigquery::ApplicationMetrics.secondary_subject(cycle_week:),
+        title_column: :subject_filter,
+      )
+    end
+
+    def candidate_provider_region
+      group_data(
+        results: ::DfE::Bigquery::ApplicationMetrics.provider_region(cycle_week:),
+        title_column: :nonsubject_filter,
       )
     end
 

--- a/config/locales/publications/itt_monthly_report_generator.yml
+++ b/config/locales/publications/itt_monthly_report_generator.yml
@@ -17,6 +17,18 @@ en:
       phase:
         title: Course phase
         subtitle: Course Phase
+      route_into_teaching:
+        title: Route into teaching
+        subtitle: Course type
+      primary_subject:
+        title: Primary specialist subject
+        subtitle: Subject
+      secondary_subject:
+        title: Secondary subject
+        subtitle: Subject
+      provider_region:
+        title: Training provider region
+        subtitle: Region
       status:
         submitted:
           title: Submitted

--- a/spec/lib/dfe/bigquery/application_metrics_spec.rb
+++ b/spec/lib/dfe/bigquery/application_metrics_spec.rb
@@ -232,4 +232,184 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
       expect(application_metrics.last.subject_filter).to eq('Secondary')
     end
   end
+
+  describe '.route_into_teaching' do
+    subject(:application_metrics) do
+      described_class.route_into_teaching(cycle_week: 7)
+    end
+
+    let(:results) do
+      [
+        {
+          nonsubject_filter: 'Postgraduate teaching apprenticeship',
+          cycle_week: 7,
+        },
+        {
+          nonsubject_filter: 'School Direct (salaried)',
+          cycle_week: 7,
+        },
+      ]
+    end
+
+    before do
+      allow(client).to receive(:query)
+        .with(
+          <<~SQL,
+            SELECT *
+            FROM dataform.application_metrics
+            WHERE recruitment_cycle_year = 2024
+            AND cycle_week = 7
+            AND subject_filter_category = "Total excluding Further Education"
+            AND nonsubject_filter_category = "Route into teaching"
+          SQL
+        )
+        .and_return(results)
+    end
+
+    it 'instantiate an application metrics' do
+      expect(application_metrics).to be_instance_of(Array)
+      expect(application_metrics.size).to be 2
+    end
+
+    it 'assigns the attributes for the application metrics' do
+      expect(application_metrics.first.cycle_week).to be 7
+      expect(application_metrics.first.nonsubject_filter).to eq('Postgraduate teaching apprenticeship')
+      expect(application_metrics.last.nonsubject_filter).to eq('School Direct (salaried)')
+    end
+  end
+
+  describe '.primary_subject' do
+    subject(:application_metrics) do
+      described_class.primary_subject(cycle_week: 7)
+    end
+
+    let(:results) do
+      [
+        {
+          subject_filter: 'Primary with English',
+          cycle_week: 7,
+        },
+        {
+          subject_filter: 'Primary with Science',
+          cycle_week: 7,
+        },
+      ]
+    end
+
+    before do
+      allow(client).to receive(:query)
+        .with(
+          <<~SQL,
+            SELECT *
+            FROM dataform.application_metrics
+            WHERE recruitment_cycle_year = 2024
+            AND cycle_week = 7
+            AND subject_filter_category = "Primary subject"
+            AND nonsubject_filter_category = "Total"
+          SQL
+        )
+        .and_return(results)
+    end
+
+    it 'instantiate an application metrics' do
+      expect(application_metrics).to be_instance_of(Array)
+      expect(application_metrics.size).to be 2
+    end
+
+    it 'assigns the attributes for the application metrics' do
+      expect(application_metrics.first.cycle_week).to be 7
+      expect(application_metrics.first.subject_filter).to eq('Primary with English')
+      expect(application_metrics.last.subject_filter).to eq('Primary with Science')
+    end
+  end
+
+  describe '.secondary_subject' do
+    subject(:application_metrics) do
+      described_class.secondary_subject(cycle_week: 7)
+    end
+
+    let(:results) do
+      [
+        {
+          subject_filter: 'Magic tricks',
+          cycle_week: 7,
+        },
+        {
+          subject_filter: 'Illusion tricks',
+          cycle_week: 7,
+        },
+      ]
+    end
+
+    before do
+      allow(client).to receive(:query)
+        .with(
+          <<~SQL,
+            SELECT *
+            FROM dataform.application_metrics
+            WHERE recruitment_cycle_year = 2024
+            AND cycle_week = 7
+            AND subject_filter_category = "Secondary subject excluding Further Education"
+            AND nonsubject_filter_category = "Total"
+          SQL
+        )
+        .and_return(results)
+    end
+
+    it 'instantiate an application metrics' do
+      expect(application_metrics).to be_instance_of(Array)
+      expect(application_metrics.size).to be 2
+    end
+
+    it 'assigns the attributes for the application metrics' do
+      expect(application_metrics.first.cycle_week).to be 7
+      expect(application_metrics.first.subject_filter).to eq('Magic tricks')
+      expect(application_metrics.last.subject_filter).to eq('Illusion tricks')
+    end
+  end
+
+  describe '.provider_region' do
+    subject(:application_metrics) do
+      described_class.provider_region(cycle_week: 7)
+    end
+
+    let(:results) do
+      [
+        {
+          nonsubject_filter: 'Gondor',
+          cycle_week: 7,
+        },
+        {
+          nonsubject_filter: 'Mordor',
+          cycle_week: 7,
+        },
+      ]
+    end
+
+    before do
+      allow(client).to receive(:query)
+        .with(
+          <<~SQL,
+            SELECT *
+            FROM dataform.application_metrics
+            WHERE recruitment_cycle_year = 2024
+            AND cycle_week = 7
+            AND subject_filter_category = "Total excluding Further Education"
+            AND nonsubject_filter_category = "Provider region"
+          SQL
+        )
+        .and_return(results)
+    end
+
+    it 'instantiate an application metrics' do
+      expect(application_metrics).to be_instance_of(Array)
+      expect(application_metrics.size).to be 2
+    end
+
+    it 'assigns the attributes for the application metrics' do
+      expect(application_metrics.first.cycle_week).to be 7
+      expect(application_metrics.first.nonsubject_filter).to eq('Gondor')
+      expect(application_metrics.last.nonsubject_filter).to eq('Mordor')
+    end
+  end
 end

--- a/spec/lib/dfe/bigquery/application_metrics_spec.rb
+++ b/spec/lib/dfe/bigquery/application_metrics_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
         .and_return(results)
     end
 
-    it 'instantiate an application metrics' do
-      expect(application_metrics).to be_instance_of(described_class)
+    it 'returns the first result' do
+      expect(application_metrics.as_json).to eq(results.first.as_json)
     end
 
     it 'assigns the attributes for the application metrics' do
@@ -78,9 +78,8 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
         .and_return(results)
     end
 
-    it 'instantiate an application metrics' do
-      expect(application_metrics).to be_instance_of(Array)
-      expect(application_metrics.size).to be 1
+    it 'returns the correct results' do
+      expect(application_metrics.as_json).to eq(results.as_json)
     end
 
     it 'assigns the attributes for the application metrics' do
@@ -131,9 +130,8 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
         .and_return(results)
     end
 
-    it 'instantiate an application metrics' do
-      expect(application_metrics).to be_instance_of(Array)
-      expect(application_metrics.size).to be 4
+    it 'returns the correct results' do
+      expect(application_metrics.as_json).to eq(results.as_json)
     end
 
     it 'assigns the attributes for the application metrics' do
@@ -175,9 +173,8 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
         .and_return(results)
     end
 
-    it 'instantiate an application metrics' do
-      expect(application_metrics).to be_instance_of(Array)
-      expect(application_metrics.size).to be 2
+    it 'returns the correct results' do
+      expect(application_metrics.as_json).to eq(results.as_json)
     end
 
     it 'assigns the attributes for the application metrics' do
@@ -221,9 +218,8 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
         .and_return(results)
     end
 
-    it 'instantiate an application metrics' do
-      expect(application_metrics).to be_instance_of(Array)
-      expect(application_metrics.size).to be 2
+    it 'returns the correct results' do
+      expect(application_metrics.as_json).to eq(results.as_json)
     end
 
     it 'assigns the attributes for the application metrics' do
@@ -266,9 +262,8 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
         .and_return(results)
     end
 
-    it 'instantiate an application metrics' do
-      expect(application_metrics).to be_instance_of(Array)
-      expect(application_metrics.size).to be 2
+    it 'returns the correct results' do
+      expect(application_metrics.as_json).to eq(results.as_json)
     end
 
     it 'assigns the attributes for the application metrics' do
@@ -311,9 +306,8 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
         .and_return(results)
     end
 
-    it 'instantiate an application metrics' do
-      expect(application_metrics).to be_instance_of(Array)
-      expect(application_metrics.size).to be 2
+    it 'returns the correct results' do
+      expect(application_metrics.as_json).to eq(results.as_json)
     end
 
     it 'assigns the attributes for the application metrics' do
@@ -356,9 +350,8 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
         .and_return(results)
     end
 
-    it 'instantiate an application metrics' do
-      expect(application_metrics).to be_instance_of(Array)
-      expect(application_metrics.size).to be 2
+    it 'returns the correct results' do
+      expect(application_metrics.as_json).to eq(results.as_json)
     end
 
     it 'assigns the attributes for the application metrics' do
@@ -401,9 +394,8 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
         .and_return(results)
     end
 
-    it 'instantiate an application metrics' do
-      expect(application_metrics).to be_instance_of(Array)
-      expect(application_metrics.size).to be 2
+    it 'returns the correct results' do
+      expect(application_metrics.as_json).to eq(results.as_json)
     end
 
     it 'assigns the attributes for the application metrics' do

--- a/spec/models/publications/itt_monthly_report_generator_spec.rb
+++ b/spec/models/publications/itt_monthly_report_generator_spec.rb
@@ -144,6 +144,10 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
     let(:sex) { age_group.dup.merge(nonsubject_filter: 'Male') }
     let(:area) { age_group.dup.merge(nonsubject_filter: 'Gondor') }
     let(:phase) { age_group.dup.merge(subject_filter: 'Primary') }
+    let(:route_into_teaching) { age_group.dup.merge(nonsubject_filter: 'Higher education') }
+    let(:primary_subject) { age_group.dup.merge(subject_filter: 'Primary with English') }
+    let(:secondary_subject) { age_group.dup.merge(subject_filter: 'Drama') }
+    let(:provider_region) { age_group.dup.merge(nonsubject_filter: 'Hogsmeade') }
 
     before do
       allow(DfE::Bigquery::ApplicationMetrics).to receive(:candidate_headline_statistics)
@@ -165,6 +169,22 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
       allow(DfE::Bigquery::ApplicationMetrics).to receive(:phase)
         .with(cycle_week: 7)
         .and_return([DfE::Bigquery::ApplicationMetrics.new(phase)])
+
+      allow(DfE::Bigquery::ApplicationMetrics).to receive(:route_into_teaching)
+        .with(cycle_week: 7)
+        .and_return([DfE::Bigquery::ApplicationMetrics.new(route_into_teaching)])
+
+      allow(DfE::Bigquery::ApplicationMetrics).to receive(:primary_subject)
+        .with(cycle_week: 7)
+        .and_return([DfE::Bigquery::ApplicationMetrics.new(primary_subject)])
+
+      allow(DfE::Bigquery::ApplicationMetrics).to receive(:secondary_subject)
+        .with(cycle_week: 7)
+        .and_return([DfE::Bigquery::ApplicationMetrics.new(secondary_subject)])
+
+      allow(DfE::Bigquery::ApplicationMetrics).to receive(:provider_region)
+        .with(cycle_week: 7)
+        .and_return([DfE::Bigquery::ApplicationMetrics.new(provider_region)])
     end
 
     it 'returns meta information' do
@@ -477,6 +497,270 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
             conditions_not_met: [
               {
                 title: 'Primary',
+                this_cycle: 30,
+                last_cycle: 15,
+              },
+            ],
+          },
+        },
+      )
+    end
+
+    it 'returns route into teaching data' do
+      expect(report[:candidate_route_into_teaching]).to eq(
+        {
+          title: 'Route into teaching',
+          data: {
+            submitted: [
+              {
+                title: 'Higher education',
+                this_cycle: 400,
+                last_cycle: 200,
+              },
+            ],
+            with_offers: [
+              {
+                title: 'Higher education',
+                this_cycle: 598,
+                last_cycle: 567,
+              },
+            ],
+            accepted: [
+              {
+                title: 'Higher education',
+                this_cycle: 20,
+                last_cycle: 10,
+              },
+            ],
+            rejected: [
+              {
+                title: 'Higher education',
+                this_cycle: 100,
+                last_cycle: 50,
+              },
+            ],
+            reconfirmed: [
+              {
+                title: 'Higher education',
+                this_cycle: 285,
+                last_cycle: 213,
+              },
+            ],
+            deferred: [
+              {
+                title: 'Higher education',
+                this_cycle: 0,
+                last_cycle: 0,
+              },
+            ],
+            withdrawn: [
+              {
+                title: 'Higher education',
+                this_cycle: 200,
+                last_cycle: 100,
+              },
+            ],
+            conditions_not_met: [
+              {
+                title: 'Higher education',
+                this_cycle: 30,
+                last_cycle: 15,
+              },
+            ],
+          },
+        },
+      )
+    end
+
+    it 'returns primary subject data' do
+      expect(report[:candidate_primary_subject]).to eq(
+        {
+          title: 'Primary specialist subject',
+          data: {
+            submitted: [
+              {
+                title: 'Primary with English',
+                this_cycle: 400,
+                last_cycle: 200,
+              },
+            ],
+            with_offers: [
+              {
+                title: 'Primary with English',
+                this_cycle: 598,
+                last_cycle: 567,
+              },
+            ],
+            accepted: [
+              {
+                title: 'Primary with English',
+                this_cycle: 20,
+                last_cycle: 10,
+              },
+            ],
+            rejected: [
+              {
+                title: 'Primary with English',
+                this_cycle: 100,
+                last_cycle: 50,
+              },
+            ],
+            reconfirmed: [
+              {
+                title: 'Primary with English',
+                this_cycle: 285,
+                last_cycle: 213,
+              },
+            ],
+            deferred: [
+              {
+                title: 'Primary with English',
+                this_cycle: 0,
+                last_cycle: 0,
+              },
+            ],
+            withdrawn: [
+              {
+                title: 'Primary with English',
+                this_cycle: 200,
+                last_cycle: 100,
+              },
+            ],
+            conditions_not_met: [
+              {
+                title: 'Primary with English',
+                this_cycle: 30,
+                last_cycle: 15,
+              },
+            ],
+          },
+        },
+      )
+    end
+
+    it 'returns secondary subject data' do
+      expect(report[:candidate_secondary_subject]).to eq(
+        {
+          title: 'Secondary subject',
+          data: {
+            submitted: [
+              {
+                title: 'Drama',
+                this_cycle: 400,
+                last_cycle: 200,
+              },
+            ],
+            with_offers: [
+              {
+                title: 'Drama',
+                this_cycle: 598,
+                last_cycle: 567,
+              },
+            ],
+            accepted: [
+              {
+                title: 'Drama',
+                this_cycle: 20,
+                last_cycle: 10,
+              },
+            ],
+            rejected: [
+              {
+                title: 'Drama',
+                this_cycle: 100,
+                last_cycle: 50,
+              },
+            ],
+            reconfirmed: [
+              {
+                title: 'Drama',
+                this_cycle: 285,
+                last_cycle: 213,
+              },
+            ],
+            deferred: [
+              {
+                title: 'Drama',
+                this_cycle: 0,
+                last_cycle: 0,
+              },
+            ],
+            withdrawn: [
+              {
+                title: 'Drama',
+                this_cycle: 200,
+                last_cycle: 100,
+              },
+            ],
+            conditions_not_met: [
+              {
+                title: 'Drama',
+                this_cycle: 30,
+                last_cycle: 15,
+              },
+            ],
+          },
+        },
+      )
+    end
+
+    it 'returns provider region data' do
+      expect(report[:candidate_provider_region]).to eq(
+        {
+          title: 'Training provider region',
+          data: {
+            submitted: [
+              {
+                title: 'Hogsmeade',
+                this_cycle: 400,
+                last_cycle: 200,
+              },
+            ],
+            with_offers: [
+              {
+                title: 'Hogsmeade',
+                this_cycle: 598,
+                last_cycle: 567,
+              },
+            ],
+            accepted: [
+              {
+                title: 'Hogsmeade',
+                this_cycle: 20,
+                last_cycle: 10,
+              },
+            ],
+            rejected: [
+              {
+                title: 'Hogsmeade',
+                this_cycle: 100,
+                last_cycle: 50,
+              },
+            ],
+            reconfirmed: [
+              {
+                title: 'Hogsmeade',
+                this_cycle: 285,
+                last_cycle: 213,
+              },
+            ],
+            deferred: [
+              {
+                title: 'Hogsmeade',
+                this_cycle: 0,
+                last_cycle: 0,
+              },
+            ],
+            withdrawn: [
+              {
+                title: 'Hogsmeade',
+                this_cycle: 200,
+                last_cycle: 100,
+              },
+            ],
+            conditions_not_met: [
+              {
+                title: 'Hogsmeade',
                 this_cycle: 30,
                 last_cycle: 15,
               },


### PR DESCRIPTION
## Context

There are 4 more sections to the report:

1. Route into teaching
2. Primary subject
3. Secondary subject
4. Provider region

To generate the report take a look on https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/docs/bigquery_and_reports.md

## Guidance to review

1. Does it work when generation the Hash/JSON in the report?

## Link to Trello card

https://trello.com/c/I2mz1epN/933-monthly-statistics-final-sections
