### PR TITLE
Add parameter to pass explicit unique key to DataTableComoponent

### DIFF
--- a/app/components/publications/data_table_component.html.erb
+++ b/app/components/publications/data_table_component.html.erb
@@ -4,7 +4,7 @@
     <% tab_names.each do |tab_name| %>
       <li class="govuk-tabs__list-item" role="presentation">
         <%# for explanation of title attribute see app/frontend/styles/publications/_itt_data_table.scss %>
-        <a class="govuk-tabs__tab" title="<%= tab_name.to_s.humanize %>" href="#<%= dom_id(title, tab_name) %>" id="tab-<%= dom_id(title, tab_name) %>" role="tab" aria-controls="<%= tab_name %>" aria-selected="false" tabindex="-1">
+        <a class="govuk-tabs__tab" title="<%= tab_name.to_s.humanize %>" href="#<%= dom_id(tab_name) %>" id="tab-<%= dom_id(tab_name) %>" role="tab" aria-controls="<%= tab_name %>" aria-selected="false" tabindex="-1">
           <%= tab_name.to_s.humanize %>
         </a>
       </li>
@@ -12,7 +12,7 @@
   </ul>
 
   <% data.each.with_index do |(tab_name, rows), index| %>
-    <div class="govuk-tabs__panel <%= 'govuk-tabs__panel--hidden' if index.positive? %>" id="<%= dom_id(title, tab_name) %>" role="tabpanel" aria-labelledby="tab-<%= dom_id(title, tab_name) %>">
+    <div class="govuk-tabs__panel <%= 'govuk-tabs__panel--hidden' if index.positive? %>" id="<%= dom_id(tab_name) %>" role="tabpanel" aria-labelledby="tab-<%= dom_id(tab_name) %>">
       <table class="govuk-table">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">

--- a/app/components/publications/data_table_component.rb
+++ b/app/components/publications/data_table_component.rb
@@ -4,18 +4,23 @@ module Publications
   class DataTableComponent < ViewComponent::Base
     attr_reader :caption, :title, :data
 
-    def initialize(caption:, title:, data:)
+    def initialize(caption:, title:, data:, key: title)
       @caption = caption
       @title = title
       @data = data
+      @key = key
     end
 
     def tab_names
       data.keys
     end
 
-    def dom_id(title, tab_name)
-      "#{title}-#{tab_name}".downcase.dasherize
+    def dom_id(tab_name)
+      "#{key.parameterize}-#{tab_name}".downcase.dasherize
     end
+
+  private
+
+    attr_reader :key
   end
 end

--- a/spec/components/publications/data_table_component_spec.rb
+++ b/spec/components/publications/data_table_component_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Publications::DataTableComponent do
   let(:component) { described_class.new(caption:, title:, data:) }
   let(:caption) { 'Table with data' }
   let(:title) { 'Age' }
+  let(:key) { 'unique' }
   let(:data) do
     {
       submitted: [
@@ -36,5 +37,17 @@ RSpec.describe Publications::DataTableComponent do
     actual = data[:submitted].first[:this_cycle].to_s
 
     expect(submitted_this_cycle_value).to eq(actual)
+  end
+
+  it 'defaults the key to the title' do
+    expect(component.dom_id('one')).to eq("#{component.title.downcase}-one")
+  end
+
+  context 'when an explicit key is passed to the constructor' do
+    let(:component) { described_class.new(caption:, title:, data:, key:) }
+
+    it 'accepts a unique key' do
+      expect(component.dom_id('one')).to eq("#{key}-one")
+    end
   end
 end

--- a/spec/components/publications/data_table_component_spec.rb
+++ b/spec/components/publications/data_table_component_spec.rb
@@ -50,4 +50,12 @@ RSpec.describe Publications::DataTableComponent do
       expect(component.dom_id('one')).to eq("#{key}-one")
     end
   end
+
+  context 'when title has spaces' do
+    let(:title) { 'Two Words' }
+
+    it 'the dom_id is a valid identifier' do
+      expect(component.dom_id('one')).to eq('two-words-one')
+    end
+  end
 end


### PR DESCRIPTION
## Context

  The `key` value is used to generate a unique dom id for the tab links.
  Until now, the dom id would use the `title` value of the table but this
  does not work if two components exist on the same page with the same
  title value.


## Screenshots
The value used as the column heading is Subject for both tables. We need to pass in a unique key so the two tables can have page wide unique dom ids.

|Primary subject|Secondary subject|
|---|---|
|![Screenshot from 2023-11-14 09-17-49](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/3d30734a-a037-4033-992f-a61ed04896b4)|![Screenshot from 2023-11-14 09-18-01](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/577f5254-9fbb-49f6-b95e-58c7d34f9e67)|

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->