### PR TITLE
Feature flag the editable unlock tool

### DIFF
--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -121,14 +121,16 @@ module SupportInterface
     end
 
     def editable_extension_row
-      {
-        key: 'Is this application editable',
-        value: application_form.editable_extension? ? "Yes, editable until #{application_form.editable_until.to_fs(:govuk_date_and_time)}" : 'No',
-        action: {
-          href: support_interface_editable_extension_path(application_form),
-          visually_hidden_text: 'editable until',
-        },
-      }
+      if FeatureFlag.active?(:unlock_application_for_editing)
+        {
+          key: 'Is this application editable',
+          value: application_form.editable_extension? ? "Yes, editable until #{application_form.editable_until.to_fs(:govuk_date_and_time)}" : 'No',
+          action: {
+            href: support_interface_editable_extension_path(application_form),
+            visually_hidden_text: 'editable until',
+          },
+        }
+      end
     end
 
     def formatted_status

--- a/app/forms/support_interface/editable_until_form.rb
+++ b/app/forms/support_interface/editable_until_form.rb
@@ -1,10 +1,10 @@
 module SupportInterface
   class EditableUntilForm
     include ActiveModel::Model
-    attr_accessor :application_form, :audit_comment, :audit_comment_description
+    attr_accessor :application_form, :audit_comment, :audit_comment_description, :policy_confirmation
     attr_writer :sections, :editable_until
 
-    validates :audit_comment, presence: true
+    validates :audit_comment, :policy_confirmation, presence: true
     validates_with ZendeskUrlValidator
 
     def non_editable_sections

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -21,6 +21,7 @@ class FeatureFlag
     [:send_request_data_to_bigquery, 'Send request data to Google Bigquery via background worker', 'Apply team'],
     [:enable_chat_support, 'Enable Zendesk chat support', 'Apply team'],
     [:lock_external_report_to_january_2022, 'Lock the current external report to January 2022', 'Apply team'],
+    [:unlock_application_for_editing, 'Allow the candidate to make edits to their application form post submission', 'Find and Apply team'],
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = [

--- a/app/views/support_interface/application_forms/editable_extension/edit.html.erb
+++ b/app/views/support_interface/application_forms/editable_extension/edit.html.erb
@@ -14,6 +14,10 @@
       <%= f.govuk_text_field :audit_comment, label: { text: 'Zendesk ticket', size: 'm' } %>
       <%= f.govuk_text_field :audit_comment_description, label: { text: 'Why are you making this application editable? (optional)', size: 'm' }, hint: { text: 'This will appear in the audit log alongside this change.' } %>
 
+      <%= f.govuk_check_boxes_fieldset :policy_confirmation, legend: nil do %>
+        <%= f.govuk_check_box :policy_confirmation, true, multiple: false, label: { text: 'I have spoken to and received confirmation from the Policy team to action this request.' }, link_errors: true %>
+      <% end %>
+
       <%= f.govuk_submit 'Update' %>
     </div>
   </div>

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -329,3 +329,5 @@ en:
             audit_comment:
               blank: Add a link to the Zendesk ticket
               invalid: Enter a valid Zendesk ticket URL
+            policy_confirmation:
+              blank: Select if you have received Policy confirmation

--- a/spec/components/support_interface/application_summary_component_spec.rb
+++ b/spec/components/support_interface/application_summary_component_spec.rb
@@ -23,5 +23,29 @@ RSpec.describe SupportInterface::ApplicationSummaryComponent do
       expect(result.css('.govuk-summary-list__key').text).to include('Submitted')
       expect(result.css('.govuk-summary-list__value').text).to include('Over 5 days ago')
     end
+
+    context 'when the unlock editing feature flag is active' do
+      before do
+        FeatureFlag.activate(:unlock_application_for_editing)
+      end
+
+      it 'renders the editable row' do
+        result = render_inline(described_class.new(application_form: create(:completed_application_form)))
+
+        expect(result.css('.govuk-summary-list__key').text).to include('Is this application editable')
+      end
+    end
+
+    context 'when the unlock editing feature flag is inactive' do
+      before do
+        FeatureFlag.deactivate(:unlock_application_for_editing)
+      end
+
+      it 'does not render the editable row' do
+        result = render_inline(described_class.new(application_form: create(:completed_application_form)))
+
+        expect(result.css('.govuk-summary-list__key').text).not_to include('Is this application editable')
+      end
+    end
   end
 end

--- a/spec/system/temporarily_editable_sections_spec.rb
+++ b/spec/system/temporarily_editable_sections_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature 'Unlocking non editable sections temporarily via support', :contin
   scenario 'Unlocking some sections via support', :with_audited do
     given_i_am_a_support_user
     and_there_is_a_submitted_application
+    and_the_feature_flag_is_active
 
     when_i_visit_the_application_page
     and_i_click_to_change_the_editable_sections
@@ -33,6 +34,10 @@ RSpec.feature 'Unlocking non editable sections temporarily via support', :contin
 
   def given_i_am_a_support_user
     sign_in_as_support_user
+  end
+
+  def and_the_feature_flag_is_active
+    FeatureFlag.activate(:unlock_application_for_editing)
   end
 
   def and_there_is_a_submitted_application


### PR DESCRIPTION
## Context

As part of https://github.com/DFE-Digital/apply-for-teacher-training/pull/8722  we introduced a new feature that allows support agents to grant candidates the ability to edit sections of their application form after submission.

We want to tightly control the use of this and require that policy signs it off.

## Changes proposed in this pull request

- Add a permanent feature flag
- Add a mandatory checkbox:
<img width="823" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/7b22ec54-790e-4bfd-8c17-2e5e63e251ff">


## Guidance to review

- Switch the FF on and off
- Try submitting without the checkbox ticked

## Link to Trello card

https://trello.com/c/B0H8fh3L/886-feature-flag-the-editable-unlock-tool

