### PR TITLE
Remove feature flag for recruiting with pending conditions

### DIFF
--- a/app/services/data_migrations/remove_recruit_with_pending_conditions_feature_flag.rb
+++ b/app/services/data_migrations/remove_recruit_with_pending_conditions_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class RemoveRecruitWithPendingConditionsFeatureFlag
+    TIMESTAMP = 20231115095550
+    MANUAL_RUN = false
+
+    def change
+      Feature.where(name: 'recruit_with_pending_conditions').delete_all
+    end
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -38,7 +38,6 @@ class FeatureFlag
     [:structured_reference_condition, 'Structured reference condition that can be added as a condition to an offer', 'Tomas Destefi'],
     [:continuous_applications, 'The new continuous applications flow', 'James Glenn'],
     [:course_has_vacancies, 'Using the new publish status to set a course as open or closed', 'Tomas & James'],
-    [:recruit_with_pending_conditions, 'Providers will be able to recruit candidates that have a SKE condition pending provided there are no other pending conditions', 'Steve Hook'],
     [:monthly_statistics_redirected, 'Redirect requests for Publications Monthly Statistics to temporarily unavailable', 'Iain McNulty'],
   ].freeze
 

--- a/app/services/has_pending_ske_conditions_only.rb
+++ b/app/services/has_pending_ske_conditions_only.rb
@@ -6,17 +6,12 @@ class HasPendingSkeConditionsOnly
   end
 
   def pending_ske_conditions_only?
-    feature_flag_enabled? &&
-      application_has_offer? &&
+    application_has_offer? &&
       offer_has_pending_ske_conditions? &&
       all_non_ske_conditions_met?
   end
 
 private
-
-  def feature_flag_enabled?
-    FeatureFlag.active?(:recruit_with_pending_conditions)
-  end
 
   def application_has_offer?
     application_choice.offer.present?

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveRecruitWithPendingConditionsFeatureFlag',
   'DataMigrations::BackfillFeedbackFormComplete',
   'DataMigrations::RemoveMidCycleReportFeatureFlag',
   'DataMigrations::BackfillEqualityAndDiversityCompletedAttributes',

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -436,7 +436,6 @@ RSpec.describe CandidateMailer do
     end
 
     before do
-      FeatureFlag.activate(:recruit_with_pending_conditions)
       application_choices.first.provider.provider_type = :scitt
       application_choices.first.course.start_date = 2.months.from_now
     end

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -812,7 +812,6 @@ class CandidateMailerPreview < ActionMailer::Preview
   end
 
   def conditions_met_with_pending_ske_conditions
-    FeatureFlag.activate(:recruit_with_pending_conditions)
     application_choice = application_choice_pending_conditions.tap do |choice|
       choice.offer.conditions.first.status = :met
       choice.offer.ske_conditions = [FactoryBot.build_stubbed(:ske_condition, status: :pending)]

--- a/spec/services/can_recruit_with_pending_conditions_spec.rb
+++ b/spec/services/can_recruit_with_pending_conditions_spec.rb
@@ -5,85 +5,66 @@ RSpec.describe CanRecruitWithPendingConditions do
 
   subject(:service) { described_class.new(application_choice: offer.application_choice) }
 
-  context 'when feature flag is off' do
+  context 'when there is a pending SKE condition and other met conditions' do
     let(:offer) { create(:offer, :with_ske_conditions) }
+    let(:provider_type) { :scitt }
 
     before do
-      FeatureFlag.deactivate(:recruit_with_pending_conditions)
       offer.conditions.reject { |condition| condition.is_a?(SkeCondition) }.each do |condition|
         condition.update!(status: :met)
       end
+      offer.application_choice.provider.update(provider_type: provider_type)
+      offer.application_choice.course.update(start_date: 2.months.from_now)
     end
 
-    it 'returns false' do
-      expect(service.call).to be(false)
+    context 'when the provider is a SCITT and the course start date is within 3 months' do
+      it 'returns true' do
+        expect(service.call).to be(true)
+      end
     end
-  end
 
-  context 'when feature flag is on' do
-    before { FeatureFlag.activate(:recruit_with_pending_conditions) }
-
-    context 'when there is a pending SKE condition and other met conditions' do
-      let(:offer) { create(:offer, :with_ske_conditions) }
-      let(:provider_type) { :scitt }
+    context 'when the provider is a lead school and accredited body is a SCITT' do
+      let(:accredited_provider) { create(:provider, :scitt) }
 
       before do
-        offer.conditions.reject { |condition| condition.is_a?(SkeCondition) }.each do |condition|
-          condition.update!(status: :met)
-        end
-        offer.application_choice.provider.update(provider_type: provider_type)
-        offer.application_choice.course.update(start_date: 2.months.from_now)
+        offer.application_choice.course.update(accredited_provider: accredited_provider)
       end
 
-      context 'when the provider is a SCITT and the course start date is within 3 months' do
-        it 'returns true' do
-          expect(service.call).to be(true)
-        end
+      it 'returns true' do
+        expect(service.call).to be(true)
+      end
+    end
+
+    context 'when the application choice is already `recruited`' do
+      before do
+        offer.application_choice.recruited!
       end
 
-      context 'when the provider is a lead school and accredited body is a SCITT' do
-        let(:accredited_provider) { create(:provider, :scitt) }
+      it 'returns false if the status is already `recruited`' do
+        expect(service.call).to be(false)
+      end
+    end
 
-        before do
-          offer.application_choice.course.update(accredited_provider: accredited_provider)
-        end
+    context 'when the provider is NOT a SCITT and the course start date is within 3 months' do
+      let(:hei_provider) { create(:provider, :university) }
 
-        it 'returns true' do
-          expect(service.call).to be(true)
-        end
+      before do
+        offer.application_choice.provider.update(provider_type: :university)
+        offer.application_choice.course.update(accredited_provider: hei_provider)
       end
 
-      context 'when the application choice is already `recruited`' do
-        before do
-          offer.application_choice.recruited!
-        end
+      it 'returns false' do
+        expect(service.call).to be(false)
+      end
+    end
 
-        it 'returns false if the status is already `recruited`' do
-          expect(service.call).to be(false)
-        end
+    context 'when the provider is a SCITT and the course start date is NOT within 3 months' do
+      before do
+        offer.application_choice.course.update(start_date: 4.months.from_now)
       end
 
-      context 'when the provider is NOT a SCITT and the course start date is within 3 months' do
-        let(:hei_provider) { create(:provider, :university) }
-
-        before do
-          offer.application_choice.provider.update(provider_type: :university)
-          offer.application_choice.course.update(accredited_provider: hei_provider)
-        end
-
-        it 'returns false' do
-          expect(service.call).to be(false)
-        end
-      end
-
-      context 'when the provider is a SCITT and the course start date is NOT within 3 months' do
-        before do
-          offer.application_choice.course.update(start_date: 4.months.from_now)
-        end
-
-        it 'returns false' do
-          expect(service.call).to be(false)
-        end
+      it 'returns false' do
+        expect(service.call).to be(false)
       end
     end
   end

--- a/spec/services/data_migrations/remove_recruit_with_pending_conditions_feature_flag_spec.rb
+++ b/spec/services/data_migrations/remove_recruit_with_pending_conditions_feature_flag_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveRecruitWithPendingConditionsFeatureFlag do
+  context 'when the feature flag exists' do
+    before do
+      create(:feature, name: 'recruit_with_pending_conditions')
+    end
+
+    it 'removes the relevant feature flags' do
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: 'recruit_with_pending_conditions')).to be_empty
+    end
+  end
+
+  context 'when the feature flag has already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end

--- a/spec/services/recruited_with_pending_conditions_spec.rb
+++ b/spec/services/recruited_with_pending_conditions_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RecruitedWithPendingConditions do
 
   subject(:service) { described_class.new(application_choice: offer.application_choice) }
 
-  context 'when feature flag is off' do
+  context 'when there is a pending SKE condition and other met conditions' do
     let(:offer) { create(:offer, :with_ske_conditions) }
 
     before do
@@ -14,31 +14,13 @@ RSpec.describe RecruitedWithPendingConditions do
       end
     end
 
-    it 'returns false' do
+    it 'returns false if the status is `pending_conditions`' do
       expect(service.call).to be(false)
     end
-  end
 
-  context 'when feature flag is on' do
-    before { FeatureFlag.activate(:recruit_with_pending_conditions) }
-
-    context 'when there is a pending SKE condition and other met conditions' do
-      let(:offer) { create(:offer, :with_ske_conditions) }
-
-      before do
-        offer.conditions.reject { |condition| condition.is_a?(SkeCondition) }.each do |condition|
-          condition.update!(status: :met)
-        end
-      end
-
-      it 'returns false if the status is `pending_conditions`' do
-        expect(service.call).to be(false)
-      end
-
-      it 'returns true if the status is `recruited`' do
-        offer.application_choice.recruited!
-        expect(service.call).to be(true)
-      end
+    it 'returns true if the status is `recruited`' do
+      offer.application_choice.recruited!
+      expect(service.call).to be(true)
     end
   end
 end

--- a/spec/system/provider_interface/provider_can_recruit_with_pending_ske_condition_spec.rb
+++ b/spec/system/provider_interface/provider_can_recruit_with_pending_ske_condition_spec.rb
@@ -9,7 +9,6 @@ RSpec.feature 'Confirm conditions met' do
 
   scenario 'Provider user confirms offer conditions have been met by the candidate' do
     given_i_am_a_provider_user_with_dfe_sign_in
-    and_the_feature_flag_is_enabled
     and_i_am_an_authorised_provider_user
     and_i_can_access_the_provider_interface
 
@@ -73,10 +72,6 @@ RSpec.feature 'Confirm conditions met' do
     provider_signs_in_using_dfe_sign_in
     visit provider_interface_applications_path
     expect(page).to have_current_path provider_interface_applications_path
-  end
-
-  def and_the_feature_flag_is_enabled
-    FeatureFlag.activate(:recruit_with_pending_conditions)
   end
 
   def when_i_navigate_to_an_offer_accepted_by_the_candidate


### PR DESCRIPTION
The functionality is live and the feature flag is no longer needed.

## Link to Trello card

https://trello.com/c/7dsBjVrl/6369-clean-up-feature-flag-for-recruit-with-pending-conditions-on-apply

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
