### PR TITLE
CSS issue with DataTableComponent

### DIFF
--- a/app/frontend/styles/publications/_itt_data_table.scss
+++ b/app/frontend/styles/publications/_itt_data_table.scss
@@ -2,30 +2,32 @@
   padding: govuk-spacing(2);
   background-color: govuk-colour("light-grey");
 
-  .govuk-tabs__list {
-    border-bottom: govuk-spacing(0);
-  }
+  .govuk-tabs {
+    &__list {
+      border-bottom: govuk-spacing(0);
+    }
 
-  .govuk-tabs__panel {
-    border: govuk-spacing(0);
-  }
+    &__panel {
+      border: govuk-spacing(0);
+    }
 
-  .govuk-tabs__tab {
-    padding-bottom: 2px;
-    color: $govuk-link-colour;
-    cursor: pointer;
-    text-decoration: underline;
-  }
+    &__tab {
+      padding-bottom: 2px;
+      color: $govuk-link-colour;
+      cursor: pointer;
+      text-decoration: underline;
+    }
 
-  .govuk-tabs__list-item {
-    margin-right: 0;
-    padding: govuk-spacing(2);
-    border: govuk-spacing(0);
-    background-color: transparent;
+    &__list-item {
+      margin-right: 0;
+      padding: govuk-spacing(2);
+      border: govuk-spacing(0);
+      background-color: transparent;
+    }
 
     // This is a hack to prevent the text from changing the size of the element when it becomes bold.
     // Make the ::before element take up the same amount of space the element would if it were bold.
-    a::before {
+    &__list-item a::before {
       display: block;
       content: attr(title);
       font-weight: bold;
@@ -34,13 +36,13 @@
       visibility: hidden;
     }
     // end hack
-  }
 
-  .govuk-tabs__list-item--selected {
-    margin-top: govuk-spacing(0);
-    font-weight: $govuk-font-weight-bold;
+    &__list-item--selected {
+      margin-top: govuk-spacing(0);
+      font-weight: $govuk-font-weight-bold;
+    }
 
-    a {
+    &__list-item--selected a {
       text-decoration: none;
     }
   }
@@ -54,5 +56,4 @@
       font-weight: $govuk-font-weight-regular;
     }
   }
-
 }

--- a/app/frontend/styles/publications/_itt_data_table.scss
+++ b/app/frontend/styles/publications/_itt_data_table.scss
@@ -4,6 +4,9 @@
 
   .govuk-tabs {
     &__list {
+      display: flex;
+      flex-wrap: wrap;
+
       border-bottom: govuk-spacing(0);
     }
 


### PR DESCRIPTION
## Context

The CSS in the Publications::DataTableComponent has a bug.

If the last element in the list before the list wraps is selected, the next element shifts off the left margin to be inline with the previous element.

## Screenshot

|Before|After|
|---|---|
|![Screenshot from 2023-11-14 11-43-29](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/edfc7af4-58ae-44c1-af2a-43a66a22a6d1)|![Screenshot from 2023-11-14 11-49-01](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/6b5c5185-661b-4526-b400-da79fc5c8ac9)|

## Changes proposed in this pull request

Apply flex wrap to the list.

## Guidance to review

Visit the review app and click the `Reconfirmed from previous cycle` tab on any of the DataTableComponents.
[Review App](https://apply-review-8778.test.teacherservices.cloud/publications/monthly-statistics/ITT2024)

## Link to Trello card

[Trello Ticket](https://trello.com/c/zAOJDdvQ/951-monthly-statistics-css-issue-with-datatablecomponent)
