### PR TITLE
Update content once a candidate has reached the maximum application limit

### DIFF
--- a/app/views/candidate_interface/continuous_applications_choices/index.html.erb
+++ b/app/views/candidate_interface/continuous_applications_choices/index.html.erb
@@ -32,7 +32,12 @@
       <% else %>
         <% unless @application_form_presenter.can_add_more_choices? %>
           <p class="govuk-body">You cannot add any more applications.</p>
-          <p class="govuk-body">If one of your applications is unsuccessful, or you withdraw or remove it, you will be able to add another application.</p>
+          <p class="govuk-body">You can add more applications if:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>one of your submitted applications becomes unsuccessful</li>
+            <li>you withdraw or remove an application</li>
+          </ul>
+          <p class="govuk-body">Once you have a total of <%= ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS %> unsuccessful or withdrawn applications, you will not be able to apply for any more courses until <%= CycleTimetable.apply_reopens.to_fs(:month_and_year) %>.</p>
           <p class="govuk-body">
             <%= govuk_link_to 'Read how the application process works', candidate_interface_guidance_path %>.
           </p>

--- a/spec/system/candidate_interface/continuous_applications/submitting/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/submitting/candidate_submitting_application_spec.rb
@@ -164,7 +164,9 @@ RSpec.feature 'Candidate submits the application', :continuous_applications do
   def then_i_can_no_longer_add_more_course_choices
     visit current_path
     expect(page).to have_content 'You cannot add any more applications.'
-    expect(page).to have_content 'If one of your applications is unsuccessful, or you withdraw or remove it, you will be able to add another application.'
+    expect(page).to have_content 'You can add more applications if'
+    expect(page).to have_content 'one of your submitted applications becomes unsuccessful'
+    expect(page).to have_content 'you withdraw or remove an application'
   end
   alias_method :then_i_still_cannot_add_course_choices, :then_i_can_no_longer_add_more_course_choices
 


### PR DESCRIPTION
## Context

We've placed a ‘limit’ on the number of applications a candidate can submit and then withdraw. We should make this clear in the service.

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="807" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/89e3d067-d608-40d2-828b-72684695f92b">|<img width="818" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/c683d813-62ae-4d3a-98c4-582892498cc8">|

## Guidance to review

Hit the limit, then you'll see it

## Link to Trello card

https://trello.com/c/Iz3bbY7a/759-change-content-where-a-candidate-has-submitted-4-applications-already

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
