### PR TITLE
Add email notifications for applying to another/multiple courses after 30 days of inactivity

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -567,7 +567,7 @@ class CandidateMailer < ApplicationMailer
     @application_form = application_form
     application_choices = application_form.application_choices.inactive_past_day
 
-    return unless application_choices.any?
+    return unless application_choices.size > 1
 
     @applications = application_choices.map do |application_choice|
       {

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -558,7 +558,7 @@ class CandidateMailer < ApplicationMailer
 
     email_for_candidate(
       @application_form,
-      subject: I18n.t!('candidate_mailer.apply_to_another_course_after_30_working_days.subject'),
+      subject: I18n.t!('candidate_mailer.apply_to_course_after_inactivity.subject'),
       layout: false,
     )
   end
@@ -581,7 +581,7 @@ class CandidateMailer < ApplicationMailer
 
     email_for_candidate(
       @application_form,
-      subject: I18n.t!('candidate_mailer.apply_to_multiple_courses_after_30_working_days.subject'),
+      subject: I18n.t!('candidate_mailer.apply_to_course_after_inactivity.subject'),
       layout: false,
     )
   end

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -567,7 +567,7 @@ class CandidateMailer < ApplicationMailer
     @application_form = application_form
     application_choices = application_form.application_choices.inactive_past_day
 
-    return unless application_choices.size > 1
+    return unless application_choices.many?
 
     @applications = application_choices.map do |application_choice|
       {

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -546,6 +546,29 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def apply_to_another_course_after_30_working_days(application_choice:)
+    @application_form = application_choice.application_form
+    @application_choice = application_choice
+
+    email_for_candidate(
+      @application_choice.application_form,
+      subject: I18n.t!('candidate_mailer.apply_to_another_course_after_30_working_days.subject'),
+      layout: false,
+    )
+  end
+
+  def apply_to_multiple_courses_after_30_working_days(application_choices_ids:)
+    @application_choices = ApplicationChoice.where(id: application_choices_ids)
+    @application_form = @application_choices.first.application_form
+    @choices_remaining = ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES - @application_choices.count
+    @submitted_at = @application_choices.first.sent_to_provider_at.to_date.to_fs(:govuk_date)
+    email_for_candidate(
+      @application_form,
+      subject: I18n.t!('candidate_mailer.apply_to_multiple_courses_after_30_working_days.subject'),
+      layout: false,
+    )
+  end
+
 private
 
   def new_offer(application_choice, template_name)

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -66,6 +66,7 @@ class ApplicationChoice < ApplicationRecord
   scope :decision_pending, -> { where(status: ApplicationStateChange::DECISION_PENDING_STATUSES) }
   scope :decision_pending_and_inactive, -> { where(status: ApplicationStateChange::DECISION_PENDING_AND_INACTIVE_STATUSES) }
   scope :accepted, -> { where(status: ApplicationStateChange::ACCEPTED_STATES) }
+  scope :inactive_past_day, -> { inactive.where(inactive_at: 1.day.ago..Time.zone.now) }
 
   delegate :continuous_applications?, to: :application_form
 

--- a/app/models/chaser_sent.rb
+++ b/app/models/chaser_sent.rb
@@ -22,5 +22,7 @@ class ChaserSent < ApplicationRecord
     find_service_is_now_open: 'find_service_is_now_open',
     apply_service_open_organisation_notification: 'apply_service_open_organisation_notification',
     find_service_open_organisation_notification: 'find_service_open_organisation_notification',
+    apply_to_another_course_after_30_working_days: 'apply_to_another_course_after_30_working_days',
+    apply_to_multiple_courses_after_30_working_days: 'apply_to_multiple_courses_after_30_working_days',
   }
 end

--- a/app/queries/get_inactive_applications_from_past_day.rb
+++ b/app/queries/get_inactive_applications_from_past_day.rb
@@ -4,7 +4,7 @@ class GetInactiveApplicationsFromPastDay
       .select('application_forms.id')
       .group('application_forms.id')
       .having(single ? 'COUNT(application_choices) = 1' : 'COUNT(application_choices) > 1')
-      .where(application_choices: { status: 'inactive' })
+      .where(application_choices: { status: :inactive })
       .where('application_choices.inactive_at > ? AND application_choices.inactive_at <= ?', 1.day.ago, Time.zone.now)
   end
 end

--- a/app/queries/get_inactive_applications_from_past_day.rb
+++ b/app/queries/get_inactive_applications_from_past_day.rb
@@ -1,0 +1,10 @@
+class GetInactiveApplicationsFromPastDay
+  def self.call(single: true)
+    ApplicationForm.current_cycle.joins(:application_choices)
+      .select('application_forms.id')
+      .group('application_forms.id')
+      .having(single ? 'COUNT(application_choices) = 1' : 'COUNT(application_choices) > 1')
+      .where(application_choices: { status: 'inactive' })
+      .where('application_choices.inactive_at > ? AND application_choices.inactive_at <= ?', 1.day.ago, Time.zone.now)
+  end
+end

--- a/app/services/batch_delivery.rb
+++ b/app/services/batch_delivery.rb
@@ -9,7 +9,7 @@ class BatchDelivery
 
   def each(&block)
     next_batch_time = Time.zone.now
-    relation_count = relation.count
+    relation_count = relation.length # use length instead of count to account for GROUP_BY queries
     interval_between_batches ||= begin
       number_of_batches = (relation_count.to_f / batch_size).ceil
       number_of_batches < 2 ? stagger_over : stagger_over / (number_of_batches - 1).to_f

--- a/app/services/send_apply_to_another_course_when_inactive_email_to_candidate.rb
+++ b/app/services/send_apply_to_another_course_when_inactive_email_to_candidate.rb
@@ -1,0 +1,18 @@
+class SendApplyToAnotherCourseWhenInactiveEmailToCandidate
+  def self.call(application_choice:)
+    application_form = application_choice.application_form
+    return if already_sent_to?(application_form)
+
+    CandidateMailer.apply_to_another_course_after_30_working_days(
+      application_choice:,
+    ).deliver_later
+
+    ChaserSent.create!(chased: application_form, chaser_type: :apply_to_another_course_after_30_working_days)
+  end
+
+  def self.already_sent_to?(application_form)
+    application_form.chasers_sent.where(
+      chaser_type: :apply_to_another_course_after_30_working_days,
+    ).where('created_at > ?', 1.day.ago).present?
+  end
+end

--- a/app/services/send_apply_to_another_course_when_inactive_email_to_candidate.rb
+++ b/app/services/send_apply_to_another_course_when_inactive_email_to_candidate.rb
@@ -1,11 +1,8 @@
 class SendApplyToAnotherCourseWhenInactiveEmailToCandidate
-  def self.call(application_choice:)
-    application_form = application_choice.application_form
+  def self.call(application_form)
     return if already_sent_to?(application_form)
 
-    CandidateMailer.apply_to_another_course_after_30_working_days(
-      application_choice:,
-    ).deliver_later
+    CandidateMailer.apply_to_another_course_after_30_working_days(application_form).deliver_later
 
     ChaserSent.create!(chased: application_form, chaser_type: :apply_to_another_course_after_30_working_days)
   end

--- a/app/services/send_apply_to_multiple_courses_when_inactive_email_to_candidate.rb
+++ b/app/services/send_apply_to_multiple_courses_when_inactive_email_to_candidate.rb
@@ -1,11 +1,8 @@
 class SendApplyToMultipleCoursesWhenInactiveEmailToCandidate
-  def self.call(application_form_id:, application_choices_ids:)
-    application_form = ApplicationForm.find(application_form_id)
+  def self.call(application_form)
     return if already_sent_to?(application_form)
 
-    CandidateMailer.apply_to_multiple_courses_after_30_working_days(
-      application_choices_ids:,
-    ).deliver_later
+    CandidateMailer.apply_to_multiple_courses_after_30_working_days(application_form).deliver_later
 
     ChaserSent.create!(chased: application_form, chaser_type: :apply_to_multiple_courses_after_30_working_days)
   end

--- a/app/services/send_apply_to_multiple_courses_when_inactive_email_to_candidate.rb
+++ b/app/services/send_apply_to_multiple_courses_when_inactive_email_to_candidate.rb
@@ -1,0 +1,18 @@
+class SendApplyToMultipleCoursesWhenInactiveEmailToCandidate
+  def self.call(application_form_id:, application_choices_ids:)
+    application_form = ApplicationForm.find(application_form_id)
+    return if already_sent_to?(application_form)
+
+    CandidateMailer.apply_to_multiple_courses_after_30_working_days(
+      application_choices_ids:,
+    ).deliver_later
+
+    ChaserSent.create!(chased: application_form, chaser_type: :apply_to_multiple_courses_after_30_working_days)
+  end
+
+  def self.already_sent_to?(application_form)
+    application_form.chasers_sent.where(
+      chaser_type: :apply_to_multiple_courses_after_30_working_days,
+    ).where('created_at > ?', 1.day.ago).present?
+  end
+end

--- a/app/views/candidate_mailer/apply_to_another_course_after_30_working_days.text.erb
+++ b/app/views/candidate_mailer/apply_to_another_course_after_30_working_days.text.erb
@@ -1,9 +1,9 @@
 Hello <%= @application_form.first_name %>
 
-To give yourself the best chance of success, you can apply to another training provider while you wait for a response to your application for <%= @application_choice.course.name %> at <%= @application_choice.course.provider.name %>.
+To give yourself the best chance of success, you can apply to another training provider while you wait for a response to your application for <%= @course_name_and_code %> at <%= @provider_name %>.
 
 Candidates who apply for 4 or more courses are more likely to receive an offer.
 
 [Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>) to apply for another course.
 
-You can also contact <%= @application_choice.course.provider.name %> to check on your application.
+You can also contact <%= @provider_name %> to check on your application.

--- a/app/views/candidate_mailer/apply_to_another_course_after_30_working_days.text.erb
+++ b/app/views/candidate_mailer/apply_to_another_course_after_30_working_days.text.erb
@@ -1,0 +1,9 @@
+Hello <%= @application_form.first_name %>
+
+To give yourself the best chance of success, you can apply to another training provider while you wait for a response to your application for <%= @application_choice.course.name %> at <%= @application_choice.course.provider.name %>.
+
+Candidates who apply for 4 or more courses are more likely to receive an offer.
+
+[Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>) to apply for another course.
+
+You can also contact <%= @application_choice.course.provider.name %> to check on your application.

--- a/app/views/candidate_mailer/apply_to_multiple_courses_after_30_working_days.text.erb
+++ b/app/views/candidate_mailer/apply_to_multiple_courses_after_30_working_days.text.erb
@@ -6,7 +6,7 @@ You submitted the following applications on <%= @submitted_at %>:
   * <%= application[:course_name_and_code] %> at <%= application[:provider_name] %>
 <% end %>
 
-While you wait for a response on these applications, you can apply to <%= @choices_remaining %> more courses at different training providers.
+While you wait for a response on these applications, you can apply to <%= @choices_remaining %> more <%= 'course'.pluralize(@choices_remaining) %> at different training providers.
 
 Candidates who apply for 4 or more courses are more likely to receive an offer.
 

--- a/app/views/candidate_mailer/apply_to_multiple_courses_after_30_working_days.text.erb
+++ b/app/views/candidate_mailer/apply_to_multiple_courses_after_30_working_days.text.erb
@@ -1,0 +1,13 @@
+Hello <%= @application_form.first_name %>
+
+You submitted the following applications on <%= @submitted_at %>:
+
+<% @application_choices.each do |application_choice| %>
+  * <%= application_choice.course.name %> at <%= application_choice.course.provider.name %>
+<% end %>
+
+While you wait for a response on these applications, you can apply to <%= @choices_remaining %> more courses at different training providers.
+
+Candidates who apply for 4 or more courses are more likely to receive an offer.
+
+[Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>) to apply for another course.

--- a/app/views/candidate_mailer/apply_to_multiple_courses_after_30_working_days.text.erb
+++ b/app/views/candidate_mailer/apply_to_multiple_courses_after_30_working_days.text.erb
@@ -2,8 +2,8 @@ Hello <%= @application_form.first_name %>
 
 You submitted the following applications on <%= @submitted_at %>:
 
-<% @application_choices.each do |application_choice| %>
-  * <%= application_choice.course.name %> at <%= application_choice.course.provider.name %>
+<% @applications.each do |application| %>
+  * <%= application[:course_name_and_code] %> at <%= application[:provider_name] %>
 <% end %>
 
 While you wait for a response on these applications, you can apply to <%= @choices_remaining %> more courses at different training providers.

--- a/app/workers/send_apply_to_another_course_when_inactive_email_to_candidates_batch_worker.rb
+++ b/app/workers/send_apply_to_another_course_when_inactive_email_to_candidates_batch_worker.rb
@@ -1,0 +1,12 @@
+class SendApplyToAnotherCourseWhenInactiveEmailToCandidatesBatchWorker
+  include Sidekiq::Worker
+
+  def perform(application_ids)
+    ApplicationForm.where(id: application_ids).each do |application_form|
+      application_choice = application_form.application_choices.inactive
+                          .find_by(inactive_at: 1.day.ago..Time.zone.now)
+
+      SendApplyToAnotherCourseWhenInactiveEmailToCandidate.call(application_choice:)
+    end
+  end
+end

--- a/app/workers/send_apply_to_another_course_when_inactive_email_to_candidates_batch_worker.rb
+++ b/app/workers/send_apply_to_another_course_when_inactive_email_to_candidates_batch_worker.rb
@@ -3,10 +3,7 @@ class SendApplyToAnotherCourseWhenInactiveEmailToCandidatesBatchWorker
 
   def perform(application_ids)
     ApplicationForm.where(id: application_ids).each do |application_form|
-      application_choice = application_form.application_choices.inactive
-                          .find_by(inactive_at: 1.day.ago..Time.zone.now)
-
-      SendApplyToAnotherCourseWhenInactiveEmailToCandidate.call(application_choice:)
+      SendApplyToAnotherCourseWhenInactiveEmailToCandidate.call(application_form)
     end
   end
 end

--- a/app/workers/send_apply_to_another_course_when_inactive_email_to_candidates_worker.rb
+++ b/app/workers/send_apply_to_another_course_when_inactive_email_to_candidates_worker.rb
@@ -1,10 +1,11 @@
 class SendApplyToAnotherCourseWhenInactiveEmailToCandidatesWorker
   include Sidekiq::Worker
 
-  BATCH_SIZE = 120
+  STAGGER_OVER = 3.hours
+  BATCH_SIZE = 150
 
   def perform
-    BatchDelivery.new(relation: GetInactiveApplicationsFromPastDay.call, batch_size: BATCH_SIZE).each do |batch_time, records|
+    BatchDelivery.new(relation: GetInactiveApplicationsFromPastDay.call, stagger_over: STAGGER_OVER, batch_size: BATCH_SIZE).each do |batch_time, records|
       SendApplyToAnotherCourseWhenInactiveEmailToCandidatesBatchWorker.perform_at(
         batch_time,
         records.pluck(:id),

--- a/app/workers/send_apply_to_another_course_when_inactive_email_to_candidates_worker.rb
+++ b/app/workers/send_apply_to_another_course_when_inactive_email_to_candidates_worker.rb
@@ -1,0 +1,12 @@
+class SendApplyToAnotherCourseWhenInactiveEmailToCandidatesWorker
+  include Sidekiq::Worker
+
+  def perform
+    BatchDelivery.new(relation: GetInactiveApplicationsFromPastDay.call).each do |batch_time, records|
+      SendApplyToAnotherCourseWhenInactiveEmailToCandidatesBatchWorker.perform_at(
+        batch_time,
+        records.pluck(:id),
+      )
+    end
+  end
+end

--- a/app/workers/send_apply_to_another_course_when_inactive_email_to_candidates_worker.rb
+++ b/app/workers/send_apply_to_another_course_when_inactive_email_to_candidates_worker.rb
@@ -1,8 +1,10 @@
 class SendApplyToAnotherCourseWhenInactiveEmailToCandidatesWorker
   include Sidekiq::Worker
 
+  BATCH_SIZE = 120
+
   def perform
-    BatchDelivery.new(relation: GetInactiveApplicationsFromPastDay.call).each do |batch_time, records|
+    BatchDelivery.new(relation: GetInactiveApplicationsFromPastDay.call, batch_size: BATCH_SIZE).each do |batch_time, records|
       SendApplyToAnotherCourseWhenInactiveEmailToCandidatesBatchWorker.perform_at(
         batch_time,
         records.pluck(:id),

--- a/app/workers/send_apply_to_multiple_courses_when_inactive_email_to_candidates_batch_worker.rb
+++ b/app/workers/send_apply_to_multiple_courses_when_inactive_email_to_candidates_batch_worker.rb
@@ -1,0 +1,11 @@
+class SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesBatchWorker
+  include Sidekiq::Worker
+
+  def perform(application_ids)
+    ApplicationForm.where(id: application_ids).each do |application_form|
+      application_choices_ids = application_form.application_choices.inactive
+                          .where(inactive_at: 1.day.ago..Time.zone.now).pluck(:id)
+      SendApplyToMultipleCoursesWhenInactiveEmailToCandidate.call(application_form_id: application_form.id, application_choices_ids:)
+    end
+  end
+end

--- a/app/workers/send_apply_to_multiple_courses_when_inactive_email_to_candidates_batch_worker.rb
+++ b/app/workers/send_apply_to_multiple_courses_when_inactive_email_to_candidates_batch_worker.rb
@@ -3,9 +3,7 @@ class SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesBatchWorker
 
   def perform(application_ids)
     ApplicationForm.where(id: application_ids).each do |application_form|
-      application_choices_ids = application_form.application_choices.inactive
-                          .where(inactive_at: 1.day.ago..Time.zone.now).pluck(:id)
-      SendApplyToMultipleCoursesWhenInactiveEmailToCandidate.call(application_form_id: application_form.id, application_choices_ids:)
+      SendApplyToMultipleCoursesWhenInactiveEmailToCandidate.call(application_form)
     end
   end
 end

--- a/app/workers/send_apply_to_multiple_courses_when_inactive_email_to_candidates_worker.rb
+++ b/app/workers/send_apply_to_multiple_courses_when_inactive_email_to_candidates_worker.rb
@@ -1,8 +1,11 @@
 class SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesWorker
   include Sidekiq::Worker
 
+  STAGGER_OVER = 3.hours
+  BATCH_SIZE = 150
+
   def perform
-    BatchDelivery.new(relation: GetInactiveApplicationsFromPastDay.call(single: false)).each do |batch_time, records|
+    BatchDelivery.new(relation: GetInactiveApplicationsFromPastDay.call(single: false), stagger_over: STAGGER_OVER, batch_size: BATCH_SIZE).each do |batch_time, records|
       SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesBatchWorker.perform_at(
         batch_time,
         records.pluck(:id),

--- a/app/workers/send_apply_to_multiple_courses_when_inactive_email_to_candidates_worker.rb
+++ b/app/workers/send_apply_to_multiple_courses_when_inactive_email_to_candidates_worker.rb
@@ -1,0 +1,12 @@
+class SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesWorker
+  include Sidekiq::Worker
+
+  def perform
+    BatchDelivery.new(relation: GetInactiveApplicationsFromPastDay.call(single: false)).each do |batch_time, records|
+      SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesBatchWorker.perform_at(
+        batch_time,
+        records.pluck(:id),
+      )
+    end
+  end
+end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -44,6 +44,8 @@ class Clock
 
   every(1.day, 'TriggerFullSyncIfFindClosed', at: '00:05') { TeacherTrainingPublicAPI::TriggerFullSyncIfFindClosed.call }
   every(1.day, 'NudgeCandidatesWorker', at: '10:00') { NudgeCandidatesWorker.perform_async }
+  every(1.day, 'SendApplyToAnotherCourseWhenInactiveEmailToCandidatesWorker', at: '10:00') { SendApplyToAnotherCourseWhenInactiveEmailToCandidatesWorker.perform_async }
+  every(1.day, 'SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesWorker', at: '10:00') { SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesWorker.perform_async }
 
   # every(1.day, 'CancelUnsubmittedApplicationsWorker', at: '11:00') { CancelUnsubmittedApplicationsWorker.perform_async }
 

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -124,7 +124,5 @@ en:
       subject: Get help choosing a teacher training course
     nudge_unsubmitted_with_incomplete_personal_statement:
       subject: Get help with your personal statement
-    apply_to_another_course_after_30_working_days:
-      subject: Apply to another course while you wait
-    apply_to_multiple_courses_after_30_working_days:
-      subject: Apply to more courses while you wait
+    apply_to_course_after_inactivity:
+      subject: Increase your chances of receiving an offer for teacher training

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -124,3 +124,7 @@ en:
       subject: Get help choosing a teacher training course
     nudge_unsubmitted_with_incomplete_personal_statement:
       subject: Get help with your personal statement
+    apply_to_another_course_after_30_working_days:
+      subject: Apply to another course while you wait
+    apply_to_multiple_courses_after_30_working_days:
+      subject: Apply to more courses while you wait

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -873,4 +873,45 @@ RSpec.describe CandidateMailer do
       expect(email.body).to include('utm_content=apply_1')
     end
   end
+
+  describe '.apply_to_another_course_after_30_working_days' do
+    let(:application_form) { build_stubbed(:application_form, :minimum_info, first_name: 'Fred') }
+    let(:application_choice) {
+      build_stubbed(
+        :application_choice,
+        :inactive,
+        application_form:,
+        course_option: course_option,
+      )
+    }
+    let(:email) { mailer.apply_to_another_course_after_30_working_days(application_choice:) }
+
+    it_behaves_like(
+      'a mail with subject and content',
+      'Apply to another course while you wait',
+      'greeting' => 'Hello Fred',
+      'content' => 'To give yourself the best chance of success, you can apply to another training provider',
+    )
+  end
+
+  describe '.apply_to_multiple_courses_after_30_working_days' do
+    let(:application_form) { build_stubbed(:application_form, :minimum_info, first_name: 'Fred') }
+    let(:application_choices) {
+      build_stubbed_list(
+        :application_choice,
+        2,
+        :inactive,
+        application_form:,
+        course_option: course_option,
+      )
+    }
+    let(:email) { mailer.apply_to_multiple_courses_after_30_working_days(application_choices:) }
+
+    it_behaves_like(
+      'a mail with subject and content',
+      'Apply to more courses while you wait',
+      'greeting' => 'Hello Fred',
+      'content' => 'While you wait for a response on these applications',
+    )
+  end
 end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -875,16 +875,21 @@ RSpec.describe CandidateMailer do
   end
 
   describe '.apply_to_another_course_after_30_working_days' do
-    let(:application_form) { build_stubbed(:application_form, :minimum_info, first_name: 'Fred') }
-    let(:application_choice) {
-      build_stubbed(
-        :application_choice,
-        :inactive,
-        application_form:,
-        course_option: course_option,
+    let(:application_form) do
+      create(
+        :application_form,
+        :minimum_info,
+        first_name: 'Fred',
+        application_choices: [
+          create(
+            :application_choice,
+            :inactive,
+          ),
+        ],
       )
-    }
-    let(:email) { mailer.apply_to_another_course_after_30_working_days(application_choice:) }
+    end
+
+    let(:email) { mailer.apply_to_another_course_after_30_working_days(application_form) }
 
     it_behaves_like(
       'a mail with subject and content',
@@ -895,17 +900,20 @@ RSpec.describe CandidateMailer do
   end
 
   describe '.apply_to_multiple_courses_after_30_working_days' do
-    let(:application_form) { build_stubbed(:application_form, :minimum_info, first_name: 'Fred') }
-    let(:application_choices) {
-      build_stubbed_list(
-        :application_choice,
-        2,
-        :inactive,
-        application_form:,
-        course_option: course_option,
+    let(:application_form) do
+      create(
+        :application_form,
+        :minimum_info,
+        first_name: 'Fred',
+        application_choices: create_list(
+          :application_choice,
+          2,
+          :inactive,
+        ),
       )
-    }
-    let(:email) { mailer.apply_to_multiple_courses_after_30_working_days(application_choices:) }
+    end
+
+    let(:email) { mailer.apply_to_multiple_courses_after_30_working_days(application_form) }
 
     it_behaves_like(
       'a mail with subject and content',

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -893,7 +893,7 @@ RSpec.describe CandidateMailer do
 
     it_behaves_like(
       'a mail with subject and content',
-      'Apply to another course while you wait',
+      'Increase your chances of receiving an offer for teacher training',
       'greeting' => 'Hello Fred',
       'content' => 'To give yourself the best chance of success, you can apply to another training provider',
     )
@@ -917,7 +917,7 @@ RSpec.describe CandidateMailer do
 
     it_behaves_like(
       'a mail with subject and content',
-      'Apply to more courses while you wait',
+      'Increase your chances of receiving an offer for teacher training',
       'greeting' => 'Hello Fred',
       'content' => 'While you wait for a response on these applications',
     )

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -972,36 +972,34 @@ class CandidateMailerPreview < ActionMailer::Preview
   end
 
   def apply_to_another_course_after_30_working_days
-    application_choice = FactoryBot.build_stubbed(
-      :application_choice,
-      :inactive,
-      application_form:,
-      course:,
-      inactive_at: 1.hour.ago,
+    application_form = FactoryBot.create(
+      :application_form,
+      :minimum_info,
+      first_name: 'Fred',
+      application_choices: [
+        FactoryBot.create(
+          :application_choice,
+          :inactive,
+        ),
+      ],
     )
 
-    CandidateMailer.apply_to_another_course_after_30_working_days(application_choice:)
+    CandidateMailer.apply_to_another_course_after_30_working_days(application_form)
   end
 
   def apply_to_multiple_courses_after_30_working_days
-    application_choices = [
-      FactoryBot.build_stubbed(
+    application_form = FactoryBot.create(
+      :application_form,
+      :minimum_info,
+      first_name: 'Fred',
+      application_choices: FactoryBot.create_list(
         :application_choice,
+        2,
         :inactive,
-        application_form:,
-        course:,
-        inactive_at: 1.hour.ago,
       ),
-      FactoryBot.build_stubbed(
-        :application_choice,
-        :inactive,
-        application_form:,
-        course:,
-        inactive_at: 1.hour.ago,
-      ),
-    ]
+    )
 
-    CandidateMailer.apply_to_multiple_courses_after_30_working_days(application_choices:)
+    CandidateMailer.apply_to_multiple_courses_after_30_working_days(application_form)
   end
 
 private

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -971,6 +971,39 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.nudge_unsubmitted_with_incomplete_references(application_form)
   end
 
+  def apply_to_another_course_after_30_working_days
+    application_choice = FactoryBot.build_stubbed(
+      :application_choice,
+      :inactive,
+      application_form:,
+      course:,
+      inactive_at: 1.hour.ago,
+    )
+
+    CandidateMailer.apply_to_another_course_after_30_working_days(application_choice:)
+  end
+
+  def apply_to_multiple_courses_after_30_working_days
+    application_choices = [
+      FactoryBot.build_stubbed(
+        :application_choice,
+        :inactive,
+        application_form:,
+        course:,
+        inactive_at: 1.hour.ago,
+      ),
+      FactoryBot.build_stubbed(
+        :application_choice,
+        :inactive,
+        application_form:,
+        course:,
+        inactive_at: 1.hour.ago,
+      ),
+    ]
+
+    CandidateMailer.apply_to_multiple_courses_after_30_working_days(application_choices:)
+  end
+
 private
 
   def candidate

--- a/spec/queries/get_inactive_applications_from_past_day_spec.rb
+++ b/spec/queries/get_inactive_applications_from_past_day_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe GetInactiveApplicationsFromPastDay do
+  before do
+    create_list(:application_choice, 3)
+  end
+
+  describe '#call' do
+    it 'returns an empty set if no inactive applications are found' do
+      expect(described_class.call).to be_empty
+    end
+
+    context 'when there are inactive applications' do
+      let(:application_form) { create(:application_form) }
+      let!(:application_choice) { create(:application_choice, :inactive) }
+      let!(:application_choices) { create_list(:application_choice, 2, :inactive, application_form:) }
+
+      context 'when single is true' do
+        it 'returns applications that have one inactive choice' do
+          expect(described_class.call(single: true).pluck(:id)).to eq([application_choice.application_form_id])
+        end
+      end
+
+      context 'when single is false' do
+        it 'returns applications that have multiple inactive choices' do
+          expect(described_class.call(single: false).pluck(:id)).to eq([application_choices.first.application_form_id])
+        end
+      end
+    end
+  end
+end

--- a/spec/services/batch_delivery_spec.rb
+++ b/spec/services/batch_delivery_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe BatchDelivery do
     before do
       @candidates = double
 
-      allow(@candidates).to receive(:count).and_return(300)
+      allow(@candidates).to receive(:length).and_return(300)
       allow(@candidates).to receive(:find_in_batches).and_yield(
         (1..120).map { |id| Candidate.new(id:) },
       ).and_yield(

--- a/spec/services/send_apply_to_another_course_when_inactive_email_to_candidate_spec.rb
+++ b/spec/services/send_apply_to_another_course_when_inactive_email_to_candidate_spec.rb
@@ -2,24 +2,28 @@ require 'rails_helper'
 
 RSpec.describe SendApplyToAnotherCourseWhenInactiveEmailToCandidate do
   describe '#call' do
-    let(:application_form) { create(:completed_application_form) }
-    let(:application_choice) { create(:application_choice, :inactive, application_form:) }
+    let(:application_form) do
+      create(
+        :completed_application_form,
+        application_choices: [create(:application_choice, :inactive)],
+      )
+    end
 
     before do
       mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
       allow(CandidateMailer).to receive(:apply_to_another_course_after_30_working_days).and_return(mail)
 
-      described_class.call(application_choice:)
+      described_class.call(application_form)
     end
 
     it 'sends apply to another course email' do
-      expect(CandidateMailer).to have_received(:apply_to_another_course_after_30_working_days).with(application_choice: application_choice)
+      expect(CandidateMailer).to have_received(:apply_to_another_course_after_30_working_days).with(application_form)
       expect(application_form.chasers_sent.apply_to_another_course_after_30_working_days.count).to eq(1)
     end
 
     it 'does not send the email again' do
-      described_class.call(application_choice:)
-      expect(CandidateMailer).to have_received(:apply_to_another_course_after_30_working_days).with(application_choice: application_choice).once
+      described_class.call(application_form)
+      expect(CandidateMailer).to have_received(:apply_to_another_course_after_30_working_days).with(application_form).once
       expect(application_form.chasers_sent.apply_to_another_course_after_30_working_days.count).to eq(1)
     end
   end

--- a/spec/services/send_apply_to_another_course_when_inactive_email_to_candidate_spec.rb
+++ b/spec/services/send_apply_to_another_course_when_inactive_email_to_candidate_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe SendApplyToAnotherCourseWhenInactiveEmailToCandidate do
+  describe '#call' do
+    let(:application_form) { create(:completed_application_form) }
+    let(:application_choice) { create(:application_choice, :inactive, application_form:) }
+
+    before do
+      mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+      allow(CandidateMailer).to receive(:apply_to_another_course_after_30_working_days).and_return(mail)
+
+      described_class.call(application_choice:)
+    end
+
+    it 'sends apply to another course email' do
+      expect(CandidateMailer).to have_received(:apply_to_another_course_after_30_working_days).with(application_choice: application_choice)
+      expect(application_form.chasers_sent.apply_to_another_course_after_30_working_days.count).to eq(1)
+    end
+
+    it 'does not send the email again' do
+      described_class.call(application_choice:)
+      expect(CandidateMailer).to have_received(:apply_to_another_course_after_30_working_days).with(application_choice: application_choice).once
+      expect(application_form.chasers_sent.apply_to_another_course_after_30_working_days.count).to eq(1)
+    end
+  end
+end

--- a/spec/services/send_apply_to_multiple_courses_when_inactive_email_to_candidate_spec.rb
+++ b/spec/services/send_apply_to_multiple_courses_when_inactive_email_to_candidate_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe SendApplyToMultipleCoursesWhenInactiveEmailToCandidate do
+  describe '#call' do
+    let(:application_form) { create(:completed_application_form) }
+    let(:application_choices) { create_list(:application_choice, 2, :inactive, application_form:) }
+
+    before do
+      mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+      allow(CandidateMailer).to receive(:apply_to_multiple_courses_after_30_working_days).and_return(mail)
+
+      described_class.call(application_choices:)
+    end
+
+    it 'sends apply to multiple courses email' do
+      expect(CandidateMailer).to have_received(:apply_to_multiple_courses_after_30_working_days).with(application_choices: application_choices)
+      expect(application_form.chasers_sent.apply_to_multiple_courses_after_30_working_days.count).to eq(1)
+    end
+
+    it 'does not send the email again' do
+      described_class.call(application_choices:)
+      expect(CandidateMailer).to have_received(:apply_to_multiple_courses_after_30_working_days).with(application_choices: application_choices).once
+      expect(application_form.chasers_sent.apply_to_multiple_courses_after_30_working_days.count).to eq(1)
+    end
+  end
+end

--- a/spec/services/send_apply_to_multiple_courses_when_inactive_email_to_candidate_spec.rb
+++ b/spec/services/send_apply_to_multiple_courses_when_inactive_email_to_candidate_spec.rb
@@ -2,24 +2,35 @@ require 'rails_helper'
 
 RSpec.describe SendApplyToMultipleCoursesWhenInactiveEmailToCandidate do
   describe '#call' do
-    let(:application_form) { create(:completed_application_form) }
-    let(:application_choices) { create_list(:application_choice, 2, :inactive, application_form:) }
+    let(:application_form) do
+      create(
+        :completed_application_form,
+        application_choices: create_list(:application_choice, 2, :inactive),
+      )
+    end
 
     before do
       mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
       allow(CandidateMailer).to receive(:apply_to_multiple_courses_after_30_working_days).and_return(mail)
 
-      described_class.call(application_choices:)
+      described_class.call(application_form)
     end
 
     it 'sends apply to multiple courses email' do
-      expect(CandidateMailer).to have_received(:apply_to_multiple_courses_after_30_working_days).with(application_choices: application_choices)
+      expect(CandidateMailer).to have_received(
+        :apply_to_multiple_courses_after_30_working_days,
+      ).with(application_form)
+
       expect(application_form.chasers_sent.apply_to_multiple_courses_after_30_working_days.count).to eq(1)
     end
 
     it 'does not send the email again' do
-      described_class.call(application_choices:)
-      expect(CandidateMailer).to have_received(:apply_to_multiple_courses_after_30_working_days).with(application_choices: application_choices).once
+      described_class.call(application_form)
+
+      expect(CandidateMailer).to have_received(
+        :apply_to_multiple_courses_after_30_working_days,
+      ).with(application_form).once
+
       expect(application_form.chasers_sent.apply_to_multiple_courses_after_30_working_days.count).to eq(1)
     end
   end

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -62,6 +62,8 @@ RSpec.feature 'Docs' do
       provider_mailer-reference_received
       candidate_mailer-application_rejected
       candidate_mailer-application_choice_submitted
+      candidate_mailer-apply_to_another_course_after_30_working_days
+      candidate_mailer-apply_to_multiple_courses_after_30_working_days
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"

--- a/spec/workers/send_apply_to_another_course_when_inactive_email_to_candidates_batch_worker_spec.rb
+++ b/spec/workers/send_apply_to_another_course_when_inactive_email_to_candidates_batch_worker_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe SendApplyToAnotherCourseWhenInactiveEmailToCandidatesBatchWorker, :sidekiq do
+  describe '#perform' do
+    let(:application_forms) { create_list(:completed_application_form, 2) }
+
+    subject(:perform) { described_class.new.perform(application_forms.pluck(:id)) }
+
+    before do
+      create(:application_choice, :inactive, application_form: application_forms.first)
+      create(:application_choice, :inactive, application_form: application_forms.second)
+      perform
+    end
+
+    it 'sends apply to another course email' do
+      expect(email_template_sent?).to be_truthy
+      expect(application_forms.first.chasers_sent.apply_to_another_course_after_30_working_days.count).to eq(1)
+      expect(application_forms.second.chasers_sent.apply_to_another_course_after_30_working_days.count).to eq(1)
+    end
+
+    it 'does not send the email again' do
+      expect {
+        perform
+      }.to not_change(ActionMailer::Base.deliveries, :count)
+     .and not_change(application_forms.first.chasers_sent.apply_to_another_course_after_30_working_days, :count)
+     .and not_change(application_forms.second.chasers_sent.apply_to_another_course_after_30_working_days, :count)
+    end
+  end
+
+  def email_template_sent?
+    template = 'apply_to_another_course_after_30_working_days'
+    ActionMailer::Base.deliveries.find { |e| e.header['rails_mail_template'].value == template }
+  end
+end

--- a/spec/workers/send_apply_to_multiple_courses_when_inactive_email_to_candidates_batch_worker_spec.rb
+++ b/spec/workers/send_apply_to_multiple_courses_when_inactive_email_to_candidates_batch_worker_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesBatchWorker, :sidekiq do
+  describe '#perform' do
+    let(:application_forms) { create_list(:completed_application_form, 2) }
+
+    subject(:perform) { described_class.new.perform(application_forms.pluck(:id)) }
+
+    before do
+      create(:application_choice, :inactive, application_form: application_forms.first)
+      create(:application_choice, :inactive, application_form: application_forms.second)
+      perform
+    end
+
+    it 'sends apply to another course email' do
+      expect(email_template_sent?).to be_truthy
+      expect(application_forms.first.chasers_sent.apply_to_multiple_courses_after_30_working_days.count).to eq(1)
+      expect(application_forms.second.chasers_sent.apply_to_multiple_courses_after_30_working_days.count).to eq(1)
+    end
+
+    it 'does not send the email again' do
+      expect {
+        perform
+      }.to not_change(ActionMailer::Base.deliveries, :count)
+     .and not_change(application_forms.first.chasers_sent.apply_to_multiple_courses_after_30_working_days, :count)
+     .and not_change(application_forms.second.chasers_sent.apply_to_multiple_courses_after_30_working_days, :count)
+    end
+  end
+
+  def email_template_sent?
+    template = 'apply_to_multiple_courses_after_30_working_days'
+    ActionMailer::Base.deliveries.find { |e| e.header['rails_mail_template'].value == template }
+  end
+end

--- a/spec/workers/send_apply_to_multiple_courses_when_inactive_email_to_candidates_worker_spec.rb
+++ b/spec/workers/send_apply_to_multiple_courses_when_inactive_email_to_candidates_worker_spec.rb
@@ -1,23 +1,40 @@
 require 'rails_helper'
 
-RSpec.describe SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesBatchWorker, :sidekiq do
+RSpec.describe SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesWorker, :sidekiq do
   describe '#perform' do
     let(:application_forms) { create_list(:completed_application_form, 2) }
 
-    subject(:perform) { described_class.new.perform(application_forms.pluck(:id)) }
+    subject(:perform) { described_class.new.perform }
 
     before do
+      stub_const('SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesWorker::BATCH_SIZE', 3) # to make sure it loops through all the applications
+
       create(:application_choice, :inactive, application_form: application_forms.first)
       create(:application_choice, :inactive, application_form: application_forms.first)
       create(:application_choice, :inactive, application_form: application_forms.second)
+
+      create_list(
+        :application_choice,
+        2,
+        :inactive,
+        application_form: create(:completed_application_form),
+      )
+
+      create_list(
+        :application_choice,
+        2,
+        :inactive,
+        application_form: create(:completed_application_form),
+      )
+
       perform
     end
 
     it 'sends apply to another course email' do
       expect(email_template_sent?).to be_truthy
       expect(application_forms.first.chasers_sent.apply_to_multiple_courses_after_30_working_days.count).to eq(1)
-      expect(application_forms.second.chasers_sent.apply_to_multiple_courses_after_30_working_days.count).to eq(1)
-      expect(ActionMailer::Base.deliveries.count).to eq(1)
+      expect(application_forms.second.chasers_sent.apply_to_multiple_courses_after_30_working_days.count).to eq(0)
+      expect(ActionMailer::Base.deliveries.count).to eq(3)
     end
 
     it 'does not send the email again' do


### PR DESCRIPTION
After 30 working days (when we consider the application to be 'inactive'), candidates can apply to another course if they have not received an answer from one or more of their previous submissions.

![](https://github.trello.services/images/mini-trello-icon.png) [Implement a new 'inactive' email for candidates](https://trello.com/c/2TPYdovB/464-implement-a-new-inactive-email-for-candidates)

Two new email were added:

- Email 1: we will send this content if the candidate only has 1 application that has reached an inactive state on a specific date.
<img width="617" alt="Screenshot 2023-11-14 at 20 02 21" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/bb1a5152-ecb0-4c11-9ccf-a9a5525e44fd">

- Email 2: we will send this email if the candidates has multiple (2 or more) applications that have reached an inactive state on a specific date.
<img width="589" alt="Screenshot 2023-11-14 at 20 02 09" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/f2559ec7-5880-479d-a5b4-487c0cfeca1d">
