### PR TITLE
Add StatusTotals to the MonthlyStatistics page

### DIFF
--- a/app/components/publications/status_totals_component.html.erb
+++ b/app/components/publications/status_totals_component.html.erb
@@ -5,12 +5,12 @@
     <div class="itt-status-totals__row">
       <div class="govuk-!-display-inline-block govuk-!-margin-right-9">
         <h3 class="govuk-heading-s itt-status-totals__count-header"><%= heading_one %></h3>
-        <h3 class="govuk-heading-s"><%= status_total_one %></h3>
+        <span class="govuk-heading-s"><%= status_total_one %></span>
       </div>
 
       <div class="govuk-!-display-inline-block">
         <h3 class="govuk-heading-s itt-status-totals__count-header"><%= heading_two %></h3>
-        <h3 class="govuk-heading-s"><%= status_total_two %></h3>
+        <span class="govuk-heading-s"><%= status_total_two %></span>
       </div>
     </div>
   </div>

--- a/app/components/publications/status_totals_component.html.erb
+++ b/app/components/publications/status_totals_component.html.erb
@@ -6,12 +6,12 @@
   <div>
     <div class="govuk-!-display-inline-block govuk-!-margin-right-9">
       <h3 class="govuk-heading-s itt-status-totals__count-header"><%= heading_one %></h3>
-      <span class="govuk-heading-s"><%= status_total_one %></span>
+      <span class="govuk-heading-s"><%= status_total_one.to_fs(:delimited) %></span>
     </div>
 
     <div class="govuk-!-display-inline-block">
       <h3 class="govuk-heading-s itt-status-totals__count-header"><%= heading_two %></h3>
-      <span class="govuk-heading-s"><%= status_total_two %></span>
+      <span class="govuk-heading-s"><%= status_total_two.to_fs(:delimited) %></span>
     </div>
   </div>
 </div>

--- a/app/components/publications/status_totals_component.html.erb
+++ b/app/components/publications/status_totals_component.html.erb
@@ -1,17 +1,17 @@
-<div class="itt-status-totals govuk-grid-column-one-half">
-  <div class="app-grid-column--grey">
+<div class="itt-status-totals itt-status-totals--grey">
+  <div>
     <h2 class="govuk-heading-m"><%= title %></h2>
     <p class="govuk-body-s"><%= summary %></p>
-    <div class="itt-status-totals__row">
-      <div class="govuk-!-display-inline-block govuk-!-margin-right-9">
-        <h3 class="govuk-heading-s itt-status-totals__count-header"><%= heading_one %></h3>
-        <span class="govuk-heading-s"><%= status_total_one.to_fs(:delimiter) %></span>
-      </div>
+  </div>
+  <div>
+    <div class="govuk-!-display-inline-block govuk-!-margin-right-9">
+      <h3 class="govuk-heading-s itt-status-totals__count-header"><%= heading_one %></h3>
+      <span class="govuk-heading-s"><%= status_total_one %></span>
+    </div>
 
-      <div class="govuk-!-display-inline-block">
-        <h3 class="govuk-heading-s itt-status-totals__count-header"><%= heading_two %></h3>
-        <span class="govuk-heading-s"><%= status_total_two.to_fs(:delimiter) %></span>
-      </div>
+    <div class="govuk-!-display-inline-block">
+      <h3 class="govuk-heading-s itt-status-totals__count-header"><%= heading_two %></h3>
+      <span class="govuk-heading-s"><%= status_total_two %></span>
     </div>
   </div>
 </div>

--- a/app/components/publications/status_totals_component.html.erb
+++ b/app/components/publications/status_totals_component.html.erb
@@ -5,12 +5,12 @@
     <div class="itt-status-totals__row">
       <div class="govuk-!-display-inline-block govuk-!-margin-right-9">
         <h3 class="govuk-heading-s itt-status-totals__count-header"><%= heading_one %></h3>
-        <span class="govuk-heading-s"><%= status_total_one %></span>
+        <span class="govuk-heading-s"><%= status_total_one.to_fs(:delimiter) %></span>
       </div>
 
       <div class="govuk-!-display-inline-block">
         <h3 class="govuk-heading-s itt-status-totals__count-header"><%= heading_two %></h3>
-        <span class="govuk-heading-s"><%= status_total_two %></span>
+        <span class="govuk-heading-s"><%= status_total_two.to_fs(:delimiter) %></span>
       </div>
     </div>
   </div>

--- a/app/components/publications/status_totals_component.rb
+++ b/app/components/publications/status_totals_component.rb
@@ -1,6 +1,15 @@
 module Publications
   class StatusTotalsComponent < ViewComponent::Base
     include ActiveModel::Model
-    attr_accessor :title, :summary, :heading_one, :status_total_one, :heading_two, :status_total_two
+    attr_accessor :title, :summary, :heading_one, :heading_two
+    attr_writer :status_total_one, :status_total_two
+
+    def status_total_one
+      @status_total_one.to_i
+    end
+
+    def status_total_two
+      @status_total_two.to_i
+    end
   end
 end

--- a/app/frontend/styles/_grid.scss
+++ b/app/frontend/styles/_grid.scss
@@ -5,7 +5,7 @@
 }
 
 .app-grid-column--grey {
-  background-color: #ebf2f6;
+  background-color: $app-grey;
   padding: govuk-spacing(6) govuk-spacing(6) govuk-spacing(2) govuk-spacing(6);
   margin-bottom: govuk-spacing(6);
 }

--- a/app/frontend/styles/application-publications.scss
+++ b/app/frontend/styles/application-publications.scss
@@ -1,5 +1,8 @@
 @import "application";
 @import "publications/metadata";
 @import "publications/sortable_table";
+
+// Specific to ITT Monthly Report
 @import "publications/itt_data_table";
-@import "publications/itt_status_totals"
+@import "publications/itt_grid";
+@import "publications/itt_status_totals";

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -6,7 +6,11 @@
   @return url("~assets/images/" + $filename);
 }
 
+// app colours that don't appear in govuk-frontend
+// but are used throughout DfE
+// e.g. https://github.com/search?q=org%3ADFE-Digital+EBF2F6&type=code
 $app-grey: #ebf2f6;
+
 $govuk-font-url-function: frontend-font-url;
 $govuk-image-url-function: frontend-image-url;
 

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -6,6 +6,7 @@
   @return url("~assets/images/" + $filename);
 }
 
+$app-grey: #ebf2f6;
 $govuk-font-url-function: frontend-font-url;
 $govuk-image-url-function: frontend-image-url;
 

--- a/app/frontend/styles/publications/_itt_grid.scss
+++ b/app/frontend/styles/publications/_itt_grid.scss
@@ -1,0 +1,15 @@
+.govuk-grid-row:has(.itt-grid) {
+  margin-right: 0;
+}
+
+.itt-grid {
+  display: grid;
+  grid-template-columns: repeat(1, 1fr);
+  gap: govuk-spacing(3) govuk-spacing(4);
+}
+
+@include govuk-media-query($from: tablet) {
+  .itt-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}

--- a/app/frontend/styles/publications/_itt_status_totals.scss
+++ b/app/frontend/styles/publications/_itt_status_totals.scss
@@ -1,9 +1,14 @@
 .itt-status-totals {
-  &__row {
-    display: flex;
-  }
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: govuk-spacing(4) govuk-spacing(4) govuk-spacing(2) govuk-spacing(4);
 
   &__count-header {
     color: govuk-colour("blue");
+  }
+
+  &--grey {
+    background-color: $app-grey;
   }
 }

--- a/app/lib/dfe/bigquery/stubbed_report.rb
+++ b/app/lib/dfe/bigquery/stubbed_report.rb
@@ -14,7 +14,7 @@ module DfE
           data: {
             candidate_headline_statistics: {
               title: 'Statistics',
-              data: { deferred_applications_count: 100 },
+              data: candidate_headline_statistics,
             },
             candidate_sex: {
               title: I18n.t('publications.itt_monthly_report_generator.sex.title'),
@@ -57,6 +57,41 @@ module DfE
       end
 
     private
+
+      def candidate_headline_statistics
+        {
+          submitted: {
+            title: 'Submitted',
+            this_cycle: rand(10000),
+            last_cycle: rand(10000),
+          },
+          with_offers: {
+            title: 'With Offers',
+            this_cycle: rand(10000),
+            last_cycle: rand(10000),
+          },
+          accepted: {
+            title: 'Accepted',
+            this_cycle: rand(10000),
+            last_cycle: rand(10000),
+          },
+          rejected: {
+            title: 'Rejected',
+            this_cycle: rand(10000),
+            last_cycle: rand(10000),
+          },
+          reconfirmed: {
+            title: 'Reconfirmed',
+            this_cycle: rand(10000),
+            last_cycle: rand(10000),
+          },
+          deferred: {
+            title: 'Deferred',
+            this_cycle: rand(10000),
+            last_cycle: rand(10000),
+          },
+        }
+      end
 
       def sex_data
         {

--- a/app/lib/dfe/bigquery/stubbed_report.rb
+++ b/app/lib/dfe/bigquery/stubbed_report.rb
@@ -90,6 +90,16 @@ module DfE
             this_cycle: rand(10000),
             last_cycle: rand(10000),
           },
+          withdrawn: {
+            title: 'Deferred',
+            this_cycle: rand(10000),
+            last_cycle: rand(10000),
+          },
+          conditions_not_met: {
+            title: 'Deferred',
+            this_cycle: rand(10000),
+            last_cycle: rand(10000),
+          },
         }
       end
 

--- a/app/presenters/publications/v2/monthly_statistics_presenter.rb
+++ b/app/presenters/publications/v2/monthly_statistics_presenter.rb
@@ -11,6 +11,10 @@ module Publications
         Time.zone.parse(@report.dig(:meta, :publication_date))
       end
 
+      def headline_stats
+        report.dig(:data, :candidate_headline_statistics)
+      end
+
       def by_age
         report.dig(:data, :candidate_age_group)
       end

--- a/app/presenters/publications/v2/monthly_statistics_presenter.rb
+++ b/app/presenters/publications/v2/monthly_statistics_presenter.rb
@@ -12,7 +12,9 @@ module Publications
       end
 
       def headline_stats
-        report.dig(:data, :candidate_headline_statistics)
+        report.dig(:data, :candidate_headline_statistics)[:data]
+          .deep_merge(I18n.t('publications.itt_monthly_report_generator.status'))
+          .values
       end
 
       def by_age

--- a/app/presenters/publications/v2/monthly_statistics_presenter.rb
+++ b/app/presenters/publications/v2/monthly_statistics_presenter.rb
@@ -1,60 +1,61 @@
 module Publications
   module V2
     class MonthlyStatisticsPresenter
-      attr_accessor :report
+      attr_accessor :report, :statistics
 
       def initialize(report)
-        @report = report.statistics.deep_symbolize_keys
+        @report = report
+        @statistics = report.statistics.deep_symbolize_keys
       end
 
       def publication_date
-        Time.zone.parse(@report.dig(:meta, :publication_date))
+        @report.publication_date
       end
 
       def headline_stats
-        report.dig(:data, :candidate_headline_statistics)[:data]
+        statistics.dig(:data, :candidate_headline_statistics)[:data]
           .deep_merge(I18n.t('publications.itt_monthly_report_generator.status'))
           .values
       end
 
       def by_age
-        report.dig(:data, :candidate_age_group)
+        statistics.dig(:data, :candidate_age_group)
       end
 
       def by_sex
-        report.dig(:data, :candidate_sex)
+        statistics.dig(:data, :candidate_sex)
       end
 
       def by_area
-        report.dig(:data, :candidate_area)
+        statistics.dig(:data, :candidate_area)
       end
 
       def by_phase
-        report.dig(:data, :candidate_phase)
+        statistics.dig(:data, :candidate_phase)
       end
 
       def by_route
-        report.dig(:data, :candidate_route_into_teaching)
+        statistics.dig(:data, :candidate_route_into_teaching)
       end
 
       def by_primary_subject
-        report.dig(:data, :candidate_primary_subject)
+        statistics.dig(:data, :candidate_primary_subject)
       end
 
       def by_secondary_subject
-        report.dig(:data, :candidate_secondary_subject)
+        statistics.dig(:data, :candidate_secondary_subject)
       end
 
       def by_provider_region
-        report.dig(:data, :candidate_provider_region)
+        statistics.dig(:data, :candidate_provider_region)
       end
 
       def current_reporting_period
-        report.dig(:meta, :period)
+        statistics.dig(:meta, :period)
       end
 
       def current_year
-        CycleTimetable.current_year(@report.dig(:meta, :generation_date).to_time)
+        CycleTimetable.current_year(statistics.dig(:meta, :generation_date).to_time)
       end
 
       # The Academic year for a given recruitment cycle is effectively the next
@@ -82,7 +83,7 @@ module Publications
       end
 
       def deferred_applications_count
-        report.dig(:data, :candidate_headline_statistics, :deferred_applications_count) || 0
+        statistics.dig(:data, :candidate_headline_statistics, :deferred_applications_count) || 0
       end
 
       def previous_year

--- a/app/views/publications/v2/monthly_statistics/show.html.erb
+++ b/app/views/publications/v2/monthly_statistics/show.html.erb
@@ -146,10 +146,8 @@
 
   <div class="govuk-grid-column-full">
     <div class="itt-grid">
-    <% @presenter.headline_stats[:data].deep_merge(I18n.t('publications.itt_monthly_report_generator.status')).each_slice(2) do |row| %>
-      <% row.to_h.each do |_k, status| %>
-        <%= render Publications::StatusTotalsComponent.new(title: status[:title], summary: status[:summary], heading_one: 'This cycle', heading_two: 'Last cycle', status_total_one: status[:last_cycle], status_total_two: status[:this_cycle]) %>
-      <% end %>
+    <% @presenter.headline_stats[:data].deep_merge(I18n.t('publications.itt_monthly_report_generator.status')).each do |_k, status| %>
+      <%= render Publications::StatusTotalsComponent.new(title: status[:title], summary: status[:summary], heading_one: 'This cycle', heading_two: 'Last cycle', status_total_one: status[:last_cycle], status_total_two: status[:this_cycle]) %>
     <% end %>
     </div>
   </div>

--- a/app/views/publications/v2/monthly_statistics/show.html.erb
+++ b/app/views/publications/v2/monthly_statistics/show.html.erb
@@ -146,7 +146,7 @@
 
   <div class="govuk-grid-column-full">
     <div class="itt-grid">
-    <% @presenter.headline_stats[:data].deep_merge(I18n.t('publications.itt_monthly_report_generator.status')).each do |_k, status| %>
+    <% @presenter.headline_stats.each do |status| %>
       <%= render Publications::StatusTotalsComponent.new(title: status[:title], summary: status[:summary], heading_one: 'This cycle', heading_two: 'Last cycle', status_total_one: status[:last_cycle], status_total_two: status[:this_cycle]) %>
     <% end %>
     </div>

--- a/app/views/publications/v2/monthly_statistics/show.html.erb
+++ b/app/views/publications/v2/monthly_statistics/show.html.erb
@@ -8,6 +8,7 @@
     </h1>
   </div>
 </div>
+
 <div class="govuk-grid-row">
   <div class="metadata-wrapper">
     <div class="govuk-grid-column-two-thirds metadata-column">
@@ -128,6 +129,9 @@
     <p class="govuk-body">These statistics collect data from <%= CycleTimetable.apply_opens.to_fs(:govuk_date) %> up to and including the day before they were published.</p>
     <p class="govuk-body">There will be monthly updates throughout the recruitment cycle.</p>
   </div>
+</div>
+
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l" id="headline-statistics">2. Candidate headline statistics</h2>
 
@@ -139,42 +143,14 @@
 
     <p class="govuk-body">Every recruitment cycle starts on the second Tuesday of October and not on the same date each calendar year. The figures for ‘last recruitment cycle’ and the current cycle in the table are calculated by counting the same number of days from when applications opened. This means days in last cycle will not be the same calendar date as days in this cycle. For example, day one of last cycle was on <%= CycleTimetable.apply_2_deadline(CycleTimetable.previous_year).to_fs(:govuk_date) %>, but day one of the current cycle was <%= CycleTimetable.apply_opens.to_fs(:govuk_date) %>.</p>
   </div>
-</div>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-half">
-    <div class="app-grid-column--grey">
-      <h2 class="govuk-heading-m">Accepted</h2>
-      <p class="govuk-body-s">Candidates who have been accepted on to a course this cycle, or who deferred an application in a previous cycle and have had that place reconfirmed by the training provider for this cycle. Applications which have been withdrawn or deferred to the next cycle are excluded.</p>
-      <div class="" style="display: flex;">
-
-        <div class="govuk-!-display-inline-block" style="margin-right: 40px;">
-          <h3 class="govuk-heading-s" style="color: #1d70b8;"> This cycle</h3>
-          <h3 class="govuk-heading-s">45,617</h3>  </div>
-
-        <div class="govuk-!-display-inline-block">
-          <h3 class="govuk-heading-s" style="color: #1d70b8;"> Last cycle</h3>
-          <h3 class="govuk-heading-s">38,580</h3>  </div>
-      </div>
-    </div>
-  </div>
-
-  <div class="govuk-grid-column-one-half">
-    <div class="app-grid-column--grey">
-
-      <h2 class="govuk-heading-m">All applications rejected</h2>
-      <p class="govuk-body-s">Candidates whose applications this cycle have all been rejected. Applications which were withdrawn are excluded. Candidates with one or more application this cycle that has not been rejected are included.</p>
-      <br>
-      <div class="" style="display: flex;">
-
-        <div class="govuk-!-display-inline-block" style="margin-right: 40px;">
-          <h3 class="govuk-heading-s" style="color: #1d70b8;"> This cycle</h3>
-          <h3 class="govuk-heading-s">45,617</h3>  </div>
-
-        <div class="govuk-!-display-inline-block">
-          <h3 class="govuk-heading-s" style="color: #1d70b8;"> Last cycle</h3>
-          <h3 class="govuk-heading-s">38,580</h3>  </div>
-      </div>
+  <div class="govuk-grid-column-full">
+    <div class="itt-grid">
+    <% @presenter.headline_stats[:data].deep_merge(I18n.t('publications.itt_monthly_report_generator.status')).each_slice(2) do |row| %>
+      <% row.to_h.each do |_k, status| %>
+        <%= render Publications::StatusTotalsComponent.new(title: status[:title], summary: status[:summary], heading_one: 'This cycle', heading_two: 'Last cycle', status_total_one: status[:last_cycle], status_total_two: status[:this_cycle]) %>
+      <% end %>
+    <% end %>
     </div>
   </div>
 </div>

--- a/config/locales/publications/itt_monthly_report_generator.yml
+++ b/config/locales/publications/itt_monthly_report_generator.yml
@@ -32,41 +32,49 @@ en:
       status:
         submitted:
           title: Submitted
+          summary: Candidates who have submitted one or more applications this cycle. Candidates for whom all applications have been withdrawn or deferred are included.
           application_metrics_column:
             this_cycle: number_of_candidates_submitted_to_date
             last_cycle: number_of_candidates_submitted_to_same_date_previous_cycle
         with_offers:
           title: With offers
+          summary: Candidates who have received one or more offers this cycle. Applications which were then withdrawn or deferred are included. Candidates for whom all applications have been withdrawn or deferred are included.
           application_metrics_column:
             this_cycle: number_of_candidates_with_offers_to_date
             last_cycle: number_of_candidates_with_offers_to_same_date_previous_cycle
         accepted:
           title: Accepted
+          summary: Candidates whose application has been accepted on to a course this cycle or who deferred an application in a previous cycle and have had that place reconfirmed by the training provider for this cycle, excluding applications which have been withdrawn or deferred to the next cycle.
           application_metrics_column:
             this_cycle: number_of_candidates_accepted_to_date
             last_cycle: number_of_candidates_accepted_to_same_date_previous_cycle
         rejected:
           title: All applications rejected
+          summary: Candidates whose applications this cycle have all been rejected, excluding applications which were withdrawn. Candidates with one or more application this cycle that has not been rejected are excluded.
           application_metrics_column:
             this_cycle: number_of_candidates_who_had_all_applications_rejected_this_cycle_to_date
             last_cycle: number_of_candidates_who_had_all_applications_rejected_this_cycle_to_same_date_previous_cycle
         reconfirmed:
           title: Reconfirmed from previous cycle
+          summary: Candidates who were offered a place in the previous cycle whose offer has been reconfirmed by the training provider for the current cycle, excluding applications which have been withdrawn or deferred to the next cycle.
           application_metrics_column:
             this_cycle: number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_date
             last_cycle: number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_same_date_previous_cycle
         deferred:
           title: Deferred
+          summary: Candidates who have received an offer this cycle but have deferred it to the next cycle, excluding offers for withdrawn applications. Candidates who deferred again to the next cycle after that are included in the cycle they first deferred in.
           application_metrics_column:
             this_cycle: number_of_candidates_with_deferred_offers_from_this_cycle_to_date
             last_cycle: number_of_candidates_with_deferred_offers_from_this_cycle_to_same_date_previous_cycle
         withdrawn:
           title: Withdrawn
+          summary: Candidates who have received one or more offers this cycle but whose applications have been withdrawn, including applications which were deferred to the next cycle.
           application_metrics_column:
             this_cycle: number_of_candidates_with_all_accepted_offers_withdrawn_this_cycle_to_date
             last_cycle: number_of_candidates_with_all_accepted_offers_withdrawn_this_cycle_to_same_date_previous_cycle
         conditions_not_met:
           title: Offer conditions not met
+          summary: Candidates who have received one or more offers this cycle but who have not met the conditions of any of their offers, excluding offers for withdrawn applications.
           application_metrics_column:
             this_cycle: number_of_candidates_who_did_not_meet_any_offer_conditions_this_cycle_to_date
             last_cycle: number_of_candidates_who_did_not_meet_any_offer_conditions_this_cycle_to_same_date_previous_cycle

--- a/spec/components/publications/status_totals_component_spec.rb
+++ b/spec/components/publications/status_totals_component_spec.rb
@@ -33,15 +33,15 @@ RSpec.describe Publications::StatusTotalsComponent, type: :component do
     expect(@rendered.text).to include(heading_one)
   end
 
-  it 'renders the first number' do
-    expect(@rendered.text).to include(data['this_cycle'])
+  it 'renders the first number formatted' do
+    expect(@rendered.text).to include('11,239')
   end
 
   it 'renders the second number heading' do
     expect(@rendered.text).to include(heading_two)
   end
 
-  it 'renders the second number' do
-    expect(@rendered.text).to include(data['last_cycle'])
+  it 'renders the second number formatted' do
+    expect(@rendered.text).to include('7,091')
   end
 end

--- a/spec/presenters/publications/v2/monthly_statistics_presenter_spec.rb
+++ b/spec/presenters/publications/v2/monthly_statistics_presenter_spec.rb
@@ -2,16 +2,17 @@ require 'rails_helper'
 
 RSpec.describe Publications::V2::MonthlyStatisticsPresenter do
   let(:report) do
-    DfE::Bigquery::StubbedReport.new
+    create(:monthly_statistics_report,
+           :v2,
+           generation_date: 1.week.ago.beginning_of_day,
+           publication_date: Time.zone.now.beginning_of_day)
   end
 
   subject(:presenter) { described_class.new(report) }
 
   describe '#publication_date' do
     it 'returns correct date' do
-      travel_temporarily_to(1.day.ago) do
-        expect(presenter.publication_date).to eq(1.day.ago)
-      end
+      expect(presenter.publication_date).to eq(report.publication_date)
     end
   end
 

--- a/spec/presenters/publications/v2/monthly_statistics_presenter_spec.rb
+++ b/spec/presenters/publications/v2/monthly_statistics_presenter_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Publications::V2::MonthlyStatisticsPresenter do
-  let(:statistics) { {} }
   let(:report) do
     DfE::Bigquery::StubbedReport.new
   end

--- a/spec/presenters/publications/v2/monthly_statistics_presenter_spec.rb
+++ b/spec/presenters/publications/v2/monthly_statistics_presenter_spec.rb
@@ -1,0 +1,173 @@
+require 'rails_helper'
+
+RSpec.describe Publications::V2::MonthlyStatisticsPresenter do
+  let(:statistics) { {} }
+  let(:report) do
+    DfE::Bigquery::StubbedReport.new
+  end
+
+  subject(:presenter) { described_class.new(report) }
+
+  describe '#publication_date' do
+    it 'returns correct date' do
+      travel_temporarily_to(1.day.ago) do
+        expect(presenter.publication_date).to eq(1.day.ago)
+      end
+    end
+  end
+
+  describe 'cycle year names', time: Date.new(2023, 11, 12) do
+    describe '#current_cycle_name' do
+      it 'returns string' do
+        expect(presenter.current_cycle_name).to eq('2023 to 2024')
+      end
+    end
+
+    describe '#academic_year_name' do
+      it 'returns string' do
+        expect(presenter.academic_year_name).to eq('2024 to 2025')
+      end
+    end
+
+    describe '#current_cycle_verbose_name' do
+      it 'returns string' do
+        expect(presenter.current_cycle_verbose_name).to eq('October 2023 to September 2024')
+      end
+    end
+  end
+
+  describe '#current_year' do
+    it 'returns correct year' do
+      expect(presenter.current_year).to eq(2024)
+    end
+  end
+
+  describe '#current_reporting_period' do
+    it 'returns correct year' do
+      expect(presenter.current_reporting_period).to eq('From 2 October 2023 to 12 November 2023')
+    end
+  end
+
+  describe '#headline_stats' do
+    it 'returns headline_stats', :aggregate_failures do
+      scope = 'publications.itt_monthly_report_generator.status'
+      expected = [{
+        title: 'Submitted',
+        summary: I18n.t('.submitted.summary', scope:),
+        this_cycle: Numeric,
+        last_cycle: Numeric,
+      }, {
+        title: 'With offers',
+        summary: I18n.t('.with_offers.summary', scope:),
+        this_cycle: Numeric,
+        last_cycle: Numeric,
+      }, {
+        title: 'Accepted',
+        summary: I18n.t('.accepted.summary', scope:),
+        this_cycle: Numeric,
+        last_cycle: Numeric,
+      }, {
+        title: 'All applications rejected',
+        summary: I18n.t('.rejected.summary', scope:),
+        this_cycle: Numeric,
+        last_cycle: Numeric,
+      }, {
+        title: 'Reconfirmed from previous cycle',
+        summary: I18n.t('.reconfirmed.summary', scope:),
+        this_cycle: Numeric,
+        last_cycle: Numeric,
+      }, {
+        title: 'Deferred',
+        summary: I18n.t('.deferred.summary', scope:),
+        this_cycle: Numeric,
+        last_cycle: Numeric,
+      }, {
+        title: 'Withdrawn',
+        summary: I18n.t('.withdrawn.summary', scope:),
+        this_cycle: Numeric,
+        last_cycle: Numeric,
+      }, {
+        title: 'Offer conditions not met',
+        summary: I18n.t('.conditions_not_met.summary', scope:),
+        this_cycle: Numeric,
+        last_cycle: Numeric,
+      }]
+
+      presenter.headline_stats.each_with_index do |stat, index|
+        expect(stat).to include(expected[index])
+      end
+    end
+  end
+
+  describe '#by_age' do
+    it 'returns by_age' do
+      expect(presenter.by_age).to include({
+        title: I18n.t('publications.itt_monthly_report_generator.age_group.title'),
+        data: Hash,
+      })
+    end
+  end
+
+  describe '#by_sex' do
+    it 'returns by_sex' do
+      expect(presenter.by_sex).to include({
+        title: I18n.t('publications.itt_monthly_report_generator.sex.title'),
+        data: Hash,
+      })
+    end
+  end
+
+  describe '#by_area' do
+    it 'returns by_area' do
+      expect(presenter.by_area).to include({
+        title: I18n.t('publications.itt_monthly_report_generator.area.title'),
+        data: Hash,
+      })
+    end
+  end
+
+  describe '#by_phase' do
+    it 'returns by_phase' do
+      expect(presenter.by_phase).to include({
+        title: I18n.t('publications.itt_monthly_report_generator.phase.title'),
+        data: Hash,
+      })
+    end
+  end
+
+  describe '#by_route' do
+    it 'returns by_route' do
+      expect(presenter.by_route).to include({
+        title: I18n.t('publications.itt_monthly_report_generator.route_into_teaching.title'),
+        data: Hash,
+      })
+    end
+  end
+
+  describe '#by_primary_subject' do
+    it 'returns by_primary_subject' do
+      expect(presenter.by_primary_subject).to include({
+        title: I18n.t('publications.itt_monthly_report_generator.primary_subject.title'),
+        data: Hash,
+      })
+    end
+  end
+
+  describe '#by_secondary_subject' do
+    it 'returns by_secondary_subject' do
+      expect(presenter.by_secondary_subject).to include({
+        title: I18n.t('publications.itt_monthly_report_generator.secondary_subject.title'),
+        data: Hash,
+      })
+    end
+  end
+
+  describe '#by_provider_region' do
+    it 'returns by_provider_region' do
+      expect(presenter.by_provider_region).to include({
+        title: I18n.t('publications.itt_monthly_report_generator.provider_region.title'),
+        data: Hash,
+      })
+    end
+  end
+end


### PR DESCRIPTION
## Context

Integrate the Publications::StatusTotalsComponent into the new MonthlyStatistics Report page

## Changes proposed in this pull request

This PR introduces `display: grid` to the project for the first time. We are specifically using it to make each grid cell consistent in height regardless of the cells content.

The styles are scoped to the status totals component as much as possible.

The layout classes and markup have been rearranged to be more semantic.

## Guidance to review

## Video

[status-totals.webm](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/01dd9914-8e8b-4b71-941f-eec875b2e7a1)


## Link to Trello card

[Trello Ticket](https://trello.com/c/OWU4Jgms/953-monthly-statistics-implement-status-totals-in-the-itt-report)