### PR TITLE
Remove memoized provider_cache_key instance variable

### DIFF
--- a/app/forms/candidate_interface/continuous_applications/provider_selection_step.rb
+++ b/app/forms/candidate_interface/continuous_applications/provider_selection_step.rb
@@ -9,7 +9,7 @@ module CandidateInterface
       end
 
       def provider_cache_key
-        @provider_cache_key ||= "provider-list-#{Provider.maximum(:updated_at)}"
+        "provider-list-#{Provider.maximum(:updated_at)}"
       end
 
       def available_providers


### PR DESCRIPTION
Some providers don't show in the list although they should. I'm not sure why this is happening, we might have to remove caching altogether.