### PR TITLE
Remove change link on unexplained breaks

### DIFF
--- a/app/components/shared/work_history_and_unpaid_experience_item_component.html.erb
+++ b/app/components/shared/work_history_and_unpaid_experience_item_component.html.erb
@@ -6,7 +6,7 @@
     <h3 class="govuk-heading-s govuk-!-margin-bottom-0">
       <%= title %>
 
-      <% if @editable %>
+      <% if @editable && edit_path %>
         <%= govuk_link_to edit_path, class: 'govuk-body' do %>
           Change <span class="govuk-visually-hidden">role details</span>
         <% end %>


### PR DESCRIPTION
A blank `Change` link was showing on unexplained breaks.

![](https://github.trello.services/images/mini-trello-icon.png) [Apply: delete Change link for breaks in work history on Support Console](https://trello.com/c/UrQPGgkB/896-apply-delete-change-link-for-breaks-in-work-history-on-support-console)

<img width="542" alt="Screenshot 2023-11-15 at 21 11 05" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/9074330a-2258-469e-992e-a9a41c0841cf">
