### PR TITLE
Monthly statistics csv

### DIFF
--- a/app/controllers/publications/v2/monthly_statistics_controller.rb
+++ b/app/controllers/publications/v2/monthly_statistics_controller.rb
@@ -3,33 +3,29 @@ module Publications
     class MonthlyStatisticsController < ApplicationController
       def show
         @presenter = MonthlyStatisticsPresenter.new(current_report)
-        @csv_export_types_and_sizes = calculate_download_sizes(@presenter)
       end
 
-      # TODO: Downloads
       def download
-        # export_type = params[:export_type]
-        # export_filename = "#{export_type}-#{params[:month]}.csv"
-        # raw_data = current_report.statistics[export_type]
-        # header_row = raw_data['rows'].first.keys
-        # data = SafeCSV.generate(raw_data['rows'].map(&:values), header_row)
-        # send_data data, filename: export_filename, disposition: :attachment
-      end
+        return not_found unless csv_exists?
 
-      def calculate_download_sizes(_report)
-        []
-        # cache 'data_sizes' do
-        #   report.statistics.map do |k, raw_data|
-        #     next unless raw_data.is_a?(Hash)
-        #
-        #     header_row = raw_data['rows'].first.keys
-        #     data = SafeCSV.generate(raw_data['rows'].map(&:values), header_row)
-        #     [k, data.size]
-        #   end.compact
-        # end
+        export_filename = "#{export_type}-#{params[:month]}.csv"
+
+        send_data current_report_csv['data'], filename: export_filename, disposition: :attachment
       end
 
     private
+
+      def csv_exists?
+        current_report_csv.present?
+      end
+
+      def export_type
+        params[:export_type]
+      end
+
+      def current_report_csv
+        current_report.statistics['formats']['csv'][export_type]
+      end
 
       # TODO: This will be split into many actions in this controller
       def current_report

--- a/app/controllers/publications/v2/monthly_statistics_controller.rb
+++ b/app/controllers/publications/v2/monthly_statistics_controller.rb
@@ -8,7 +8,7 @@ module Publications
       def download
         return not_found unless csv_exists?
 
-        export_filename = "#{export_type}-#{params[:month]}.csv"
+        export_filename = "#{export_type}-#{month}.csv"
 
         send_data current_report_csv['data'], filename: export_filename, disposition: :attachment
       end
@@ -21,6 +21,10 @@ module Publications
 
       def export_type
         params[:export_type]
+      end
+
+      def month
+        params[:month]
       end
 
       def current_report_csv

--- a/app/lib/dfe/bigquery/application_metrics.rb
+++ b/app/lib/dfe/bigquery/application_metrics.rb
@@ -22,7 +22,8 @@ module DfE
                     :last_date_in_week,
                     :cycle_week,
                     :nonsubject_filter,
-                    :subject_filter
+                    :subject_filter,
+                    :subject_filter_category
 
       def initialize(attributes)
         attributes.each do |key, value|
@@ -68,6 +69,14 @@ module DfE
 
       def self.provider_region(cycle_week:)
         query(provider_region_query(cycle_week:))
+      end
+
+      def self.provider_region_and_subject(cycle_week:)
+        query(provider_region_and_subject_query(cycle_week:))
+      end
+
+      def self.candidate_area_and_subject(cycle_week:)
+        query(candidate_area_and_subject_query(cycle_week:))
       end
 
       def self.candidate_headline_statistics_query(cycle_week:)
@@ -159,6 +168,26 @@ module DfE
           subject_filter_category: 'Total excluding Further Education',
           nonsubject_filter_category: 'Provider region',
         )
+        .to_sql
+      end
+
+      def self.provider_region_and_subject_query(cycle_week:)
+        where(
+          recruitment_cycle_year:,
+          cycle_week:,
+          nonsubject_filter_category: 'Provider region',
+        )
+        .where('subject_filter_category IN ("Primary subject", "Secondary subject excluding Further Education")')
+        .to_sql
+      end
+
+      def self.candidate_area_and_subject_query(cycle_week:)
+        where(
+          recruitment_cycle_year:,
+          cycle_week:,
+          nonsubject_filter_category: 'Candidate region',
+        )
+        .where('subject_filter_category IN ("Primary subject", "Secondary subject excluding Further Education")')
         .to_sql
       end
 

--- a/app/lib/dfe/bigquery/test_helper.rb
+++ b/app/lib/dfe/bigquery/test_helper.rb
@@ -1,18 +1,15 @@
 module DfE
   module Bigquery
     module TestHelper
-      def stub_bigquery_application_metrics_request
-        stub_bigquery_client
-        allow(bigquery_client).to receive(:query).and_return(application_metrics_results)
-      end
-
-      def stub_bigquery_client
-        @bigquery_client = nil
+      def stub_bigquery_application_metrics_request(stub_results = [])
+        bigquery_client = instance_double(Google::Cloud::Bigquery::Project)
         allow(DfE::Bigquery).to receive(:client).and_return(bigquery_client)
-      end
 
-      def bigquery_client
-        @bigquery_client ||= instance_double(Google::Cloud::Bigquery::Project)
+        if stub_results.present?
+          allow(bigquery_client).to receive(:query).and_return(stub_results)
+        else
+          allow(bigquery_client).to receive(:query).and_return(application_metrics_results)
+        end
       end
 
       def application_metrics_results(options = {})

--- a/app/lib/dfe/bigquery/test_helper.rb
+++ b/app/lib/dfe/bigquery/test_helper.rb
@@ -7,7 +7,7 @@ module DfE
       end
 
       def stub_bigquery_client
-        DfE::Bigquery.instance_variable_set(:@client, nil)
+        @bigquery_client = nil
         allow(DfE::Bigquery).to receive(:client).and_return(bigquery_client)
       end
 

--- a/app/lib/dfe/bigquery/test_helper.rb
+++ b/app/lib/dfe/bigquery/test_helper.rb
@@ -7,6 +7,7 @@ module DfE
       end
 
       def stub_bigquery_client
+        DfE::Bigquery.instance_variable_set(:@client, nil)
         allow(DfE::Bigquery).to receive(:client).and_return(bigquery_client)
       end
 

--- a/app/models/publications/itt_monthly_report_generator.rb
+++ b/app/models/publications/itt_monthly_report_generator.rb
@@ -1,5 +1,19 @@
 module Publications
   class ITTMonthlyReportGenerator
+    include MonthlyStatistics::ReportSections
+    include MonthlyStatistics::DescribeQueries
+    SECTIONS = %i[
+      candidate_headline_statistics
+      candidate_age_group
+      candidate_sex
+      candidate_area
+      candidate_phase
+      candidate_route_into_teaching
+      candidate_primary_subject
+      candidate_secondary_subject
+      candidate_provider_region
+    ].freeze
+
     attr_accessor :generation_date,
                   :publication_date,
                   :month,
@@ -7,17 +21,6 @@ module Publications
                   :report_expected_time,
                   :cycle_week,
                   :model
-
-    delegate :candidate_headline_statistics_query,
-             :age_group_query,
-             :sex_query,
-             :area_query,
-             :phase_query,
-             :route_into_teaching_query,
-             :primary_subject_query,
-             :secondary_subject_query,
-             :provider_region_query,
-             to: ::DfE::Bigquery::ApplicationMetrics
 
     def initialize(generation_date: Time.zone.now, publication_date: nil, model: MonthlyStatistics::MonthlyStatisticsReport)
       @generation_date = generation_date.to_time
@@ -34,69 +37,30 @@ module Publications
     end
 
     def to_h
-      {
+      report = {
         meta:,
-        data: {
-          candidate_headline_statistics: {
-            title: I18n.t('publications.itt_monthly_report_generator.candidate_headline_statistics.title'),
-            data: candidate_headline_statistics,
-          },
-          candidate_age_group: {
-            title: I18n.t('publications.itt_monthly_report_generator.age_group.title'),
-            data: candidate_age_group,
-          },
-          candidate_sex: {
-            title: I18n.t('publications.itt_monthly_report_generator.sex.title'),
-            data: candidate_sex,
-          },
-          candidate_area: {
-            title: I18n.t('publications.itt_monthly_report_generator.area.title'),
-            data: candidate_area,
-          },
-          candidate_phase: {
-            title: I18n.t('publications.itt_monthly_report_generator.phase.title'),
-            data: candidate_phase,
-          },
-          candidate_route_into_teaching: {
-            title: I18n.t('publications.itt_monthly_report_generator.route_into_teaching.title'),
-            data: candidate_route_into_teaching,
-          },
-          candidate_primary_subject: {
-            title: I18n.t('publications.itt_monthly_report_generator.primary_subject.title'),
-            data: candidate_primary_subject,
-          },
-          candidate_secondary_subject: {
-            title: I18n.t('publications.itt_monthly_report_generator.secondary_subject.title'),
-            data: candidate_secondary_subject,
-          },
-          candidate_provider_region: {
-            title: I18n.t('publications.itt_monthly_report_generator.provider_region.title'),
-            data: candidate_provider_region,
-          },
-        },
+        data: {},
+        formats: { csv: {} },
       }
+
+      SECTIONS.each do |section_identifier|
+        data = send(section_identifier)
+
+        report[:data][section_identifier] = {
+          title: I18n.t("publications.itt_monthly_report_generator.#{section_identifier}.title"),
+          subtitle: I18n.t("publications.itt_monthly_report_generator.#{section_identifier}.subtitle"),
+          data:,
+        }
+
+        report[:formats][:csv][section_identifier] = MonthlyStatistics::CSVSection.new(
+          section_identifier:,
+          section: report[:data][section_identifier],
+        ).call
+      end
+
+      report
     end
     alias statistics to_h
-
-    def describe
-      {
-        candidate_headline_statistics_query: candidate_headline_statistics_query(cycle_week:),
-        age_group_query: age_group_query(cycle_week:),
-        sex_query: sex_query(cycle_week:),
-        area_query: area_query(cycle_week:),
-        phase_query: phase_query(cycle_week:),
-        route_into_teaching_query: route_into_teaching_query(cycle_week:),
-        primary_subject_query: primary_subject_query(cycle_week:),
-        secondary_subject_query: secondary_subject_query(cycle_week:),
-        provider_region_query: provider_region_query(cycle_week:),
-      }.each do |key, value|
-        # rubocop:disable Rails/Output
-        puts "========= #{key.to_s.humanize} =========="
-        puts value
-        puts '=' * 40
-        # rubocop:enable Rails/Output
-      end; nil
-    end
 
     def meta
       {
@@ -109,98 +73,6 @@ module Publications
 
     def period
       "From #{first_cycle_week.to_fs(:govuk_date)} to #{report_expected_time.to_fs(:govuk_date)}"
-    end
-
-    def candidate_headline_statistics(data = {})
-      application_metrics = DfE::Bigquery::ApplicationMetrics.candidate_headline_statistics(cycle_week:)
-
-      data.tap do |_d|
-        I18n.t('publications.itt_monthly_report_generator.status').each_key do |status|
-          data[status] = {
-            title: I18n.t("publications.itt_monthly_report_generator.status.#{status}.title"),
-            this_cycle: column_value_for(application_metrics:, status:, cycle: :this_cycle),
-            last_cycle: column_value_for(application_metrics:, status:, cycle: :last_cycle),
-          }
-        end
-      end
-    end
-
-    def candidate_age_group
-      group_data(
-        results: ::DfE::Bigquery::ApplicationMetrics.age_group(cycle_week:),
-        title_column: :nonsubject_filter,
-      )
-    end
-
-    def candidate_sex
-      group_data(
-        results: ::DfE::Bigquery::ApplicationMetrics.sex(cycle_week:),
-        title_column: :nonsubject_filter,
-      )
-    end
-
-    def candidate_area
-      group_data(
-        results: ::DfE::Bigquery::ApplicationMetrics.area(cycle_week:),
-        title_column: :nonsubject_filter,
-      )
-    end
-
-    def candidate_phase
-      group_data(
-        results: ::DfE::Bigquery::ApplicationMetrics.phase(cycle_week:),
-        title_column: :subject_filter,
-      )
-    end
-
-    def candidate_route_into_teaching
-      group_data(
-        results: ::DfE::Bigquery::ApplicationMetrics.route_into_teaching(cycle_week:),
-        title_column: :nonsubject_filter,
-      )
-    end
-
-    def candidate_primary_subject
-      group_data(
-        results: ::DfE::Bigquery::ApplicationMetrics.primary_subject(cycle_week:),
-        title_column: :subject_filter,
-      )
-    end
-
-    def candidate_secondary_subject
-      group_data(
-        results: ::DfE::Bigquery::ApplicationMetrics.secondary_subject(cycle_week:),
-        title_column: :subject_filter,
-      )
-    end
-
-    def candidate_provider_region
-      group_data(
-        results: ::DfE::Bigquery::ApplicationMetrics.provider_region(cycle_week:),
-        title_column: :nonsubject_filter,
-      )
-    end
-
-  private
-
-    def group_data(results:, title_column:, data: {})
-      data.tap do |_d|
-        I18n.t('publications.itt_monthly_report_generator.status').each_key do |status|
-          data[status] = results.map do |application_metrics|
-            {
-              title: application_metrics.send(title_column),
-              this_cycle: column_value_for(application_metrics:, status:, cycle: :this_cycle),
-              last_cycle: column_value_for(application_metrics:, status:, cycle: :last_cycle),
-            }
-          end
-        end
-      end
-    end
-
-    def column_value_for(application_metrics:, status:, cycle:)
-      application_metrics.send(
-        I18n.t("publications.itt_monthly_report_generator.status.#{status}.application_metrics_column.#{cycle}"),
-      )
     end
   end
 end

--- a/app/models/publications/itt_monthly_report_generator.rb
+++ b/app/models/publications/itt_monthly_report_generator.rb
@@ -12,6 +12,8 @@ module Publications
       candidate_primary_subject
       candidate_secondary_subject
       candidate_provider_region
+      candidate_provider_region_and_subject
+      candidate_area_and_subject
     ].freeze
 
     attr_accessor :generation_date,
@@ -38,7 +40,13 @@ module Publications
 
     def to_h
       report = {
-        meta:,
+        meta: {
+          generation_date:,
+          publication_date:,
+          period:,
+          cycle_week:,
+          month:,
+        },
         data: {},
         formats: { csv: {} },
       }
@@ -61,15 +69,6 @@ module Publications
       report
     end
     alias statistics to_h
-
-    def meta
-      {
-        generation_date:,
-        publication_date:,
-        period:,
-        cycle_week:,
-      }
-    end
 
     def period
       "From #{first_cycle_week.to_fs(:govuk_date)} to #{report_expected_time.to_fs(:govuk_date)}"

--- a/app/models/publications/itt_monthly_report_generator.rb
+++ b/app/models/publications/itt_monthly_report_generator.rb
@@ -52,17 +52,16 @@ module Publications
       }
 
       SECTIONS.each do |section_identifier|
-        data = send(section_identifier)
-
         report[:data][section_identifier] = {
           title: I18n.t("publications.itt_monthly_report_generator.#{section_identifier}.title"),
           subtitle: I18n.t("publications.itt_monthly_report_generator.#{section_identifier}.subtitle"),
-          data:,
+          data: send(section_identifier),
         }
 
         report[:formats][:csv][section_identifier] = MonthlyStatistics::CSVSection.new(
           section_identifier:,
-          section: report[:data][section_identifier],
+          records: bigquery_records[section_identifier],
+          title_section: bigquery_title_section[section_identifier],
         ).call
       end
 

--- a/app/models/publications/monthly_statistics/csv_section.rb
+++ b/app/models/publications/monthly_statistics/csv_section.rb
@@ -18,20 +18,23 @@ module Publications
       end
 
       def headings
-        I18n.t('publications.itt_monthly_report_generator.status').each_key.map do |status|
+        status_headings = I18n.t('publications.itt_monthly_report_generator.status').each_key.map do |status|
           status_title = I18n.t("publications.itt_monthly_report_generator.status.#{status}.title")
           ["#{status_title} this cycle", "#{status_title} last cycle"]
-        end.flatten.unshift(section[:subtitle])
+        end
+
+        [section[:subtitle], extra_headings, status_headings].flatten.compact
       end
 
       def rows
         grouped_row.map do |key, value|
           [
-            key,
+            title_for(key),
+            extra_attributes(value),
             I18n.t('publications.itt_monthly_report_generator.status').each_key.map do |status|
-              [value[status][:this_cycle], value[status][:last_cycle]]
+              [value[status][:this_cycle], value[status][:last_cycle]].compact
             end,
-          ].flatten
+          ].compact.flatten
         end
       end
 
@@ -50,10 +53,14 @@ module Publications
       def grouped_row(grouped_data = {})
         section_data.each.map do |status, records|
           records.each.map do |record|
-            title = record[:title]
+            grouped_key = if sections_with_extra_columns?
+                            "#{record[:title]},#{record[:subject]}"
+                          else
+                            record[:title]
+                          end
 
-            grouped_data[title] ||= { status => record }
-            grouped_data[title][status] = record
+            grouped_data[grouped_key] ||= { status => record }
+            grouped_data[grouped_key][status] = record
           end
         end
 
@@ -68,6 +75,30 @@ module Publications
 
       def candidate_headline_unique_row
         section_data.each_value.map { |value| [value[:this_cycle], value[:last_cycle]] }.flatten
+      end
+
+      def extra_headings
+        I18n.t("publications.itt_monthly_report_generator.#{section_identifier}.subject") if sections_with_extra_columns?
+      end
+
+      def extra_attributes(statuses)
+        if sections_with_extra_columns?
+          statuses.each_value.map { |status| status[:subject] }.uniq
+        end
+      end
+
+      def sections_with_extra_columns?
+        section_identifier.in?(sections_with_extra_columns)
+      end
+
+      def sections_with_extra_columns
+        %i[candidate_provider_region_and_subject candidate_area_and_subject]
+      end
+
+      def title_for(key)
+        return key unless sections_with_extra_columns?
+
+        key.split(',').first
       end
     end
   end

--- a/app/models/publications/monthly_statistics/csv_section.rb
+++ b/app/models/publications/monthly_statistics/csv_section.rb
@@ -1,0 +1,74 @@
+module Publications
+  module MonthlyStatistics
+    class CSVSection
+      attr_reader :section, :section_identifier, :section_data
+
+      def initialize(section_identifier:, section:)
+        @section = section
+        @section_identifier = section_identifier
+        @section_data = section[:data]
+      end
+
+      def call
+        if section_identifier == :candidate_headline_statistics
+          generate(headings: candidate_headline_statistics_headings, rows: [candidate_headline_unique_row])
+        else
+          generate(headings:, rows:)
+        end
+      end
+
+      def headings
+        I18n.t('publications.itt_monthly_report_generator.status').each_key.map do |status|
+          status_title = I18n.t("publications.itt_monthly_report_generator.status.#{status}.title")
+          ["#{status_title} this cycle", "#{status_title} last cycle"]
+        end.flatten.unshift(section[:subtitle])
+      end
+
+      def rows
+        grouped_row.map do |key, value|
+          [
+            key,
+            I18n.t('publications.itt_monthly_report_generator.status').each_key.map do |status|
+              [value[status][:this_cycle], value[status][:last_cycle]]
+            end,
+          ].flatten
+        end
+      end
+
+    private
+
+      def generate(headings:, rows:)
+        data = SafeCSV.generate(rows, headings)
+        size = data.size
+
+        {
+          size:,
+          data:,
+        }
+      end
+
+      def grouped_row(grouped_data = {})
+        section_data.each.map do |status, records|
+          records.each.map do |record|
+            title = record[:title]
+
+            grouped_data[title] ||= { status => record }
+            grouped_data[title][status] = record
+          end
+        end
+
+        grouped_data
+      end
+
+      def candidate_headline_statistics_headings
+        section_data.each_value.map do |value|
+          ["#{value[:title]} this cycle", "#{value[:title]} last cycle"]
+        end.flatten
+      end
+
+      def candidate_headline_unique_row
+        section_data.each_value.map { |value| [value[:this_cycle], value[:last_cycle]] }.flatten
+      end
+    end
+  end
+end

--- a/app/models/publications/monthly_statistics/describe_queries.rb
+++ b/app/models/publications/monthly_statistics/describe_queries.rb
@@ -1,0 +1,36 @@
+module Publications
+  module MonthlyStatistics
+    module DescribeQueries
+      delegate :candidate_headline_statistics_query,
+               :age_group_query,
+               :sex_query,
+               :area_query,
+               :phase_query,
+               :route_into_teaching_query,
+               :primary_subject_query,
+               :secondary_subject_query,
+               :provider_region_query,
+               to: ::DfE::Bigquery::ApplicationMetrics
+
+      def describe
+        {
+          candidate_headline_statistics_query: candidate_headline_statistics_query(cycle_week:),
+          age_group_query: age_group_query(cycle_week:),
+          sex_query: sex_query(cycle_week:),
+          area_query: area_query(cycle_week:),
+          phase_query: phase_query(cycle_week:),
+          route_into_teaching_query: route_into_teaching_query(cycle_week:),
+          primary_subject_query: primary_subject_query(cycle_week:),
+          secondary_subject_query: secondary_subject_query(cycle_week:),
+          provider_region_query: provider_region_query(cycle_week:),
+        }.each do |key, value|
+          # rubocop:disable Rails/Output
+          puts "========= #{key.to_s.humanize} =========="
+          puts value
+          puts '=' * 40
+          # rubocop:enable Rails/Output
+        end; nil
+      end
+    end
+  end
+end

--- a/app/models/publications/monthly_statistics/describe_queries.rb
+++ b/app/models/publications/monthly_statistics/describe_queries.rb
@@ -28,11 +28,9 @@ module Publications
           provider_region_and_subject_query: provider_region_and_subject_query(cycle_week:),
           candidate_area_and_subject_query: candidate_area_and_subject_query(cycle_week:),
         }.each do |key, value|
-          # rubocop:disable Rails/Output
-          puts "========= #{key.to_s.humanize} =========="
-          puts value
-          puts '=' * 40
-          # rubocop:enable Rails/Output
+          Rails.logger.info { "========= #{key.to_s.humanize} ==========" }
+          Rails.logger.info value
+          Rails.logger.info '=' * 40
         end; nil
       end
     end

--- a/app/models/publications/monthly_statistics/describe_queries.rb
+++ b/app/models/publications/monthly_statistics/describe_queries.rb
@@ -10,6 +10,8 @@ module Publications
                :primary_subject_query,
                :secondary_subject_query,
                :provider_region_query,
+               :provider_region_and_subject_query,
+               :candidate_area_and_subject_query,
                to: ::DfE::Bigquery::ApplicationMetrics
 
       def describe
@@ -23,6 +25,8 @@ module Publications
           primary_subject_query: primary_subject_query(cycle_week:),
           secondary_subject_query: secondary_subject_query(cycle_week:),
           provider_region_query: provider_region_query(cycle_week:),
+          provider_region_and_subject_query: provider_region_and_subject_query(cycle_week:),
+          candidate_area_and_subject_query: candidate_area_and_subject_query(cycle_week:),
         }.each do |key, value|
           # rubocop:disable Rails/Output
           puts "========= #{key.to_s.humanize} =========="

--- a/app/models/publications/monthly_statistics/report_sections.rb
+++ b/app/models/publications/monthly_statistics/report_sections.rb
@@ -1,0 +1,97 @@
+module Publications
+  module MonthlyStatistics
+    module ReportSections
+      def candidate_headline_statistics(data = {})
+        application_metrics = DfE::Bigquery::ApplicationMetrics.candidate_headline_statistics(cycle_week:)
+
+        data.tap do |_d|
+          I18n.t('publications.itt_monthly_report_generator.status').each_key do |status|
+            data[status] = {
+              title: I18n.t("publications.itt_monthly_report_generator.status.#{status}.title"),
+              this_cycle: column_value_for(application_metrics:, status:, cycle: :this_cycle),
+              last_cycle: column_value_for(application_metrics:, status:, cycle: :last_cycle),
+            }
+          end
+        end
+      end
+
+      def candidate_age_group
+        group_data(
+          results: ::DfE::Bigquery::ApplicationMetrics.age_group(cycle_week:),
+          title_column: :nonsubject_filter,
+        )
+      end
+
+      def candidate_sex
+        group_data(
+          results: ::DfE::Bigquery::ApplicationMetrics.sex(cycle_week:),
+          title_column: :nonsubject_filter,
+        )
+      end
+
+      def candidate_area
+        group_data(
+          results: ::DfE::Bigquery::ApplicationMetrics.area(cycle_week:),
+          title_column: :nonsubject_filter,
+        )
+      end
+
+      def candidate_phase
+        group_data(
+          results: ::DfE::Bigquery::ApplicationMetrics.phase(cycle_week:),
+          title_column: :subject_filter,
+        )
+      end
+
+      def candidate_route_into_teaching
+        group_data(
+          results: ::DfE::Bigquery::ApplicationMetrics.route_into_teaching(cycle_week:),
+          title_column: :nonsubject_filter,
+        )
+      end
+
+      def candidate_primary_subject
+        group_data(
+          results: ::DfE::Bigquery::ApplicationMetrics.primary_subject(cycle_week:),
+          title_column: :subject_filter,
+        )
+      end
+
+      def candidate_secondary_subject
+        group_data(
+          results: ::DfE::Bigquery::ApplicationMetrics.secondary_subject(cycle_week:),
+          title_column: :subject_filter,
+        )
+      end
+
+      def candidate_provider_region
+        group_data(
+          results: ::DfE::Bigquery::ApplicationMetrics.provider_region(cycle_week:),
+          title_column: :nonsubject_filter,
+        )
+      end
+
+    private
+
+      def group_data(results:, title_column:, data: {})
+        data.tap do |_d|
+          I18n.t('publications.itt_monthly_report_generator.status').each_key do |status|
+            data[status] = results.map do |application_metrics|
+              {
+                title: application_metrics.send(title_column),
+                this_cycle: column_value_for(application_metrics:, status:, cycle: :this_cycle),
+                last_cycle: column_value_for(application_metrics:, status:, cycle: :last_cycle),
+              }
+            end
+          end
+        end
+      end
+
+      def column_value_for(application_metrics:, status:, cycle:)
+        application_metrics.send(
+          I18n.t("publications.itt_monthly_report_generator.status.#{status}.application_metrics_column.#{cycle}"),
+        )
+      end
+    end
+  end
+end

--- a/app/models/publications/monthly_statistics/report_sections.rb
+++ b/app/models/publications/monthly_statistics/report_sections.rb
@@ -71,9 +71,25 @@ module Publications
         )
       end
 
+      def candidate_provider_region_and_subject
+        group_data(
+          results: ::DfE::Bigquery::ApplicationMetrics.provider_region_and_subject(cycle_week:),
+          title_column: :nonsubject_filter,
+          extra_columns: { subject: { attribute: :subject_filter } },
+        )
+      end
+
+      def candidate_area_and_subject
+        group_data(
+          results: ::DfE::Bigquery::ApplicationMetrics.candidate_area_and_subject(cycle_week:),
+          title_column: :nonsubject_filter,
+          extra_columns: { subject: { attribute: :subject_filter } },
+        )
+      end
+
     private
 
-      def group_data(results:, title_column:, data: {})
+      def group_data(results:, title_column:, data: {}, extra_columns: {})
         data.tap do |_d|
           I18n.t('publications.itt_monthly_report_generator.status').each_key do |status|
             data[status] = results.map do |application_metrics|
@@ -81,7 +97,11 @@ module Publications
                 title: application_metrics.send(title_column),
                 this_cycle: column_value_for(application_metrics:, status:, cycle: :this_cycle),
                 last_cycle: column_value_for(application_metrics:, status:, cycle: :last_cycle),
-              }
+              }.tap do |row|
+                extra_columns.each do |field, column|
+                  row[field] = application_metrics.send(column[:attribute])
+                end
+              end
             end
           end
         end

--- a/app/models/publications/monthly_statistics/report_sections.rb
+++ b/app/models/publications/monthly_statistics/report_sections.rb
@@ -1,8 +1,45 @@
 module Publications
   module MonthlyStatistics
     module ReportSections
+      def bigquery_records
+        @bigquery_records ||= {
+          candidate_headline_statistics: DfE::Bigquery::ApplicationMetrics.candidate_headline_statistics(cycle_week:),
+          candidate_age_group: ::DfE::Bigquery::ApplicationMetrics.age_group(cycle_week:),
+          candidate_sex: ::DfE::Bigquery::ApplicationMetrics.sex(cycle_week:),
+          candidate_area: ::DfE::Bigquery::ApplicationMetrics.area(cycle_week:),
+          candidate_phase: ::DfE::Bigquery::ApplicationMetrics.phase(cycle_week:),
+          candidate_route_into_teaching: ::DfE::Bigquery::ApplicationMetrics.route_into_teaching(cycle_week:),
+          candidate_primary_subject: ::DfE::Bigquery::ApplicationMetrics.primary_subject(cycle_week:),
+          candidate_secondary_subject: ::DfE::Bigquery::ApplicationMetrics.secondary_subject(cycle_week:),
+          candidate_provider_region: ::DfE::Bigquery::ApplicationMetrics.provider_region(cycle_week:),
+          candidate_provider_region_and_subject: ::DfE::Bigquery::ApplicationMetrics.provider_region_and_subject(cycle_week:),
+          candidate_area_and_subject: ::DfE::Bigquery::ApplicationMetrics.candidate_area_and_subject(cycle_week:),
+        }
+      end
+
+      def bigquery_title_section
+        @bigquery_title_section ||= {
+          candidate_age_group: :nonsubject_filter,
+          candidate_sex: :nonsubject_filter,
+          candidate_area: :nonsubject_filter,
+          candidate_phase: :subject_filter,
+          candidate_route_into_teaching: :nonsubject_filter,
+          candidate_primary_subject: :subject_filter,
+          candidate_secondary_subject: :subject_filter,
+          candidate_provider_region: :nonsubject_filter,
+          candidate_provider_region_and_subject: {
+            title_column: :nonsubject_filter,
+            extra_columns: { subject: { attribute: :subject_filter } },
+          },
+          candidate_area_and_subject: {
+            title_column: :nonsubject_filter,
+            extra_columns: { subject: { attribute: :subject_filter } },
+          },
+        }
+      end
+
       def candidate_headline_statistics(data = {})
-        application_metrics = DfE::Bigquery::ApplicationMetrics.candidate_headline_statistics(cycle_week:)
+        application_metrics = bigquery_records[:candidate_headline_statistics]
 
         data.tap do |_d|
           I18n.t('publications.itt_monthly_report_generator.status').each_key do |status|
@@ -16,80 +53,80 @@ module Publications
       end
 
       def candidate_age_group
-        group_data(
-          results: ::DfE::Bigquery::ApplicationMetrics.age_group(cycle_week:),
-          title_column: :nonsubject_filter,
+        group_data_for_report(
+          results: bigquery_records[:candidate_age_group],
+          title_column: bigquery_title_section[:candidate_age_group],
         )
       end
 
       def candidate_sex
-        group_data(
-          results: ::DfE::Bigquery::ApplicationMetrics.sex(cycle_week:),
-          title_column: :nonsubject_filter,
+        group_data_for_report(
+          results: bigquery_records[:candidate_sex],
+          title_column: bigquery_title_section[:candidate_sex],
         )
       end
 
       def candidate_area
-        group_data(
-          results: ::DfE::Bigquery::ApplicationMetrics.area(cycle_week:),
-          title_column: :nonsubject_filter,
+        group_data_for_report(
+          results: bigquery_records[:candidate_area],
+          title_column: bigquery_title_section[:candidate_area],
         )
       end
 
       def candidate_phase
-        group_data(
-          results: ::DfE::Bigquery::ApplicationMetrics.phase(cycle_week:),
-          title_column: :subject_filter,
+        group_data_for_report(
+          results: bigquery_records[:candidate_phase],
+          title_column: bigquery_title_section[:candidate_phase],
         )
       end
 
       def candidate_route_into_teaching
-        group_data(
-          results: ::DfE::Bigquery::ApplicationMetrics.route_into_teaching(cycle_week:),
-          title_column: :nonsubject_filter,
+        group_data_for_report(
+          results: bigquery_records[:candidate_route_into_teaching],
+          title_column: bigquery_title_section[:candidate_route_into_teaching],
         )
       end
 
       def candidate_primary_subject
-        group_data(
-          results: ::DfE::Bigquery::ApplicationMetrics.primary_subject(cycle_week:),
-          title_column: :subject_filter,
+        group_data_for_report(
+          results: bigquery_records[:candidate_primary_subject],
+          title_column: bigquery_title_section[:candidate_primary_subject],
         )
       end
 
       def candidate_secondary_subject
-        group_data(
-          results: ::DfE::Bigquery::ApplicationMetrics.secondary_subject(cycle_week:),
-          title_column: :subject_filter,
+        group_data_for_report(
+          results: bigquery_records[:candidate_secondary_subject],
+          title_column: bigquery_title_section[:candidate_secondary_subject],
         )
       end
 
       def candidate_provider_region
-        group_data(
-          results: ::DfE::Bigquery::ApplicationMetrics.provider_region(cycle_week:),
-          title_column: :nonsubject_filter,
+        group_data_for_report(
+          results: bigquery_records[:candidate_provider_region],
+          title_column: bigquery_title_section[:candidate_provider_region],
         )
       end
 
       def candidate_provider_region_and_subject
-        group_data(
-          results: ::DfE::Bigquery::ApplicationMetrics.provider_region_and_subject(cycle_week:),
-          title_column: :nonsubject_filter,
-          extra_columns: { subject: { attribute: :subject_filter } },
+        group_data_for_report(
+          results: bigquery_records[:candidate_provider_region_and_subject],
+          title_column: bigquery_title_section[:candidate_provider_region_and_subject][:title_column],
+          extra_columns: bigquery_title_section[:candidate_provider_region_and_subject][:extra_columns],
         )
       end
 
       def candidate_area_and_subject
-        group_data(
-          results: ::DfE::Bigquery::ApplicationMetrics.candidate_area_and_subject(cycle_week:),
-          title_column: :nonsubject_filter,
-          extra_columns: { subject: { attribute: :subject_filter } },
+        group_data_for_report(
+          results: bigquery_records[:candidate_area_and_subject],
+          title_column: bigquery_title_section[:candidate_area_and_subject][:title_column],
+          extra_columns: bigquery_title_section[:candidate_area_and_subject][:extra_columns],
         )
       end
 
     private
 
-      def group_data(results:, title_column:, data: {}, extra_columns: {})
+      def group_data_for_report(results:, title_column:, data: {}, extra_columns: {})
         data.tap do |_d|
           I18n.t('publications.itt_monthly_report_generator.status').each_key do |status|
             data[status] = results.map do |application_metrics|

--- a/app/models/publications/monthly_statistics/stubbed_report.rb
+++ b/app/models/publications/monthly_statistics/stubbed_report.rb
@@ -1,5 +1,5 @@
-module DfE
-  module Bigquery
+module Publications
+  module MonthlyStatistics
     class StubbedReport
       attr_reader :data
 
@@ -14,39 +14,56 @@ module DfE
           data: {
             candidate_headline_statistics: {
               title: 'Statistics',
+              subtitle: 'Headline Statistics',
               data: candidate_headline_statistics,
             },
             candidate_sex: {
-              title: I18n.t('publications.itt_monthly_report_generator.sex.title'),
+              title: I18n.t('publications.itt_monthly_report_generator.candidate_sex.title'),
+              subtitle: I18n.t('publications.itt_monthly_report_generator.candidate_sex.subtitle'),
               data: sex_data,
             },
             candidate_age_group: {
-              title: I18n.t('publications.itt_monthly_report_generator.age_group.title'),
+              title: I18n.t('publications.itt_monthly_report_generator.candidate_age_group.title'),
+              subtitle: I18n.t('publications.itt_monthly_report_generator.candidate_age_group.subtitle'),
               data: age_data,
             },
             candidate_area: {
-              title: I18n.t('publications.itt_monthly_report_generator.area.title'),
+              title: I18n.t('publications.itt_monthly_report_generator.candidate_area.title'),
+              subtitle: I18n.t('publications.itt_monthly_report_generator.candidate_area.subtitle'),
               data: area_data,
             },
             candidate_phase: {
-              title: I18n.t('publications.itt_monthly_report_generator.phase.title'),
+              title: I18n.t('publications.itt_monthly_report_generator.candidate_phase.title'),
+              subtitle: I18n.t('publications.itt_monthly_report_generator.candidate_phase.subtitle'),
               data: phase_data,
             },
             candidate_route_into_teaching: {
-              title: I18n.t('publications.itt_monthly_report_generator.route_into_teaching.title'),
+              title: I18n.t('publications.itt_monthly_report_generator.candidate_route_into_teaching.title'),
+              subtitle: I18n.t('publications.itt_monthly_report_generator.candidate_route_into_teaching.subtitle'),
               data: route_into_teaching_data,
             },
             candidate_primary_subject: {
-              title: I18n.t('publications.itt_monthly_report_generator.primary_subject.title'),
+              title: I18n.t('publications.itt_monthly_report_generator.candidate_primary_subject.title'),
+              subtitle: I18n.t('publications.itt_monthly_report_generator.candidate_primary_subject.subtitle'),
               data: primary_subject_data,
             },
             candidate_secondary_subject: {
-              title: I18n.t('publications.itt_monthly_report_generator.secondary_subject.title'),
+              title: I18n.t('publications.itt_monthly_report_generator.candidate_secondary_subject.title'),
+              subtitle: I18n.t('publications.itt_monthly_report_generator.candidate_primary_subject.subtitle'),
               data: secondary_subject_data,
             },
             candidate_provider_region: {
-              title: I18n.t('publications.itt_monthly_report_generator.provider_region.title'),
+              title: I18n.t('publications.itt_monthly_report_generator.candidate_provider_region.title'),
+              subtitle: I18n.t('publications.itt_monthly_report_generator.candidate_provider_region.subtitle'),
               data: provider_region_data,
+            },
+          },
+          formats: {
+            csv: {
+              candidate_age_group: {
+                size: 510,
+                data: "Age Group,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Deferred this cycle,Deferred last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\n21,400,200,598,567,20,10,100,50,285,213,0,0,200,100,30,15\n",
+              },
             },
           },
         }

--- a/app/presenters/publications/v2/monthly_statistics_presenter.rb
+++ b/app/presenters/publications/v2/monthly_statistics_presenter.rb
@@ -1,12 +1,13 @@
 module Publications
   module V2
     class MonthlyStatisticsPresenter
-      attr_reader :month
+      attr_reader :month, :statistics
       attr_accessor :report
 
       def initialize(report)
         @month = report.month
-        @report = report.statistics.deep_symbolize_keys
+        @report = report
+        @statistics = report.statistics.deep_symbolize_keys
       end
 
       def publication_date
@@ -96,7 +97,7 @@ module Publications
       end
 
       def csvs
-        report.dig(:formats, :csv)
+        statistics.dig(:formats, :csv)
       end
     end
   end

--- a/app/presenters/publications/v2/monthly_statistics_presenter.rb
+++ b/app/presenters/publications/v2/monthly_statistics_presenter.rb
@@ -1,11 +1,12 @@
 module Publications
   module V2
     class MonthlyStatisticsPresenter
-      attr_accessor :report, :statistics
+      attr_reader :month
+      attr_accessor :report
 
       def initialize(report)
-        @report = report
-        @statistics = report.statistics.deep_symbolize_keys
+        @month = report.month
+        @report = report.statistics.deep_symbolize_keys
       end
 
       def publication_date
@@ -92,6 +93,10 @@ module Publications
 
       def next_year
         current_year + 1
+      end
+
+      def csvs
+        report.dig(:formats, :csv)
       end
     end
   end

--- a/app/views/publications/v2/monthly_statistics/show.html.erb
+++ b/app/views/publications/v2/monthly_statistics/show.html.erb
@@ -162,7 +162,7 @@
     <p class="govuk-body">Ages are calculated at the end of the recruitment cycle, just before courses start for the next academic year. Courses usually start in September, but sometimes in January. This data therefore reflects the likely age of a candidate at the point of starting a course, rather than their age when they apply.</p>
   </div>
 </div>
-<%= render Publications::DataTableComponent.new(caption: "Table 3.1: #{@presenter.by_age[:title]}", title: t('publications.itt_monthly_report_generator.age_group.subtitle'), data: @presenter.by_age[:data]) %>
+<%= render Publications::DataTableComponent.new(caption: "Table 3.1: #{@presenter.by_age[:title]}", title: @presenter.by_age[:subtitle], data: @presenter.by_age[:data]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -172,7 +172,7 @@
   </div>
 </div>
 
-<%= render Publications::DataTableComponent.new(caption: "Table 4.1: #{@presenter.by_sex[:title]}", title: t('publications.itt_monthly_report_generator.sex.subtitle'), data: @presenter.by_sex[:data]) %>
+<%= render Publications::DataTableComponent.new(caption: "Table 4.1: #{@presenter.by_sex[:title]}", title: @presenter.by_sex[:subtitle], data: @presenter.by_sex[:data]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -184,7 +184,7 @@
   </div>
 </div>
 
-<%= render Publications::DataTableComponent.new(caption: "Table 5.1: #{@presenter.by_area[:title]}", title: t('publications.itt_monthly_report_generator.area.subtitle'), data: @presenter.by_area[:data]) %>
+<%= render Publications::DataTableComponent.new(caption: "Table 5.1: #{@presenter.by_area[:title]}", title: @presenter.by_area[:subtitle], data: @presenter.by_area[:data]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -195,7 +195,7 @@
   </div>
 </div>
 
-<%= render Publications::DataTableComponent.new(caption: "Table 6.1: #{@presenter.by_phase[:title]}", title: t('publications.itt_monthly_report_generator.phase.subtitle'), data: @presenter.by_phase[:data]) %>
+<%= render Publications::DataTableComponent.new(caption: "Table 6.1: #{@presenter.by_phase[:title]}", title: @presenter.by_phase[:subtitle], data: @presenter.by_phase[:data]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -213,7 +213,7 @@
   </div>
 </div>
 
-<%= render Publications::DataTableComponent.new(caption: "Table 7.1: #{@presenter.by_route[:title]}", title: t('publications.itt_monthly_report_generator.route_into_teaching.subtitle'), data: @presenter.by_route[:data]) %>
+<%= render Publications::DataTableComponent.new(caption: "Table 7.1: #{@presenter.by_route[:title]}", title: @presenter.by_route[:title], data: @presenter.by_route[:data]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -225,7 +225,7 @@
   </div>
 </div>
 
-<%= render Publications::DataTableComponent.new(caption: "Table 8.1: #{@presenter.by_primary_subject[:title]}", title: t('publications.itt_monthly_report_generator.primary_subject.subtitle'), data: @presenter.by_primary_subject[:data], key: 'primary-subject') %>
+<%= render Publications::DataTableComponent.new(caption: "Table 8.1: #{@presenter.by_primary_subject[:title]}", title: @presenter.by_primary_subject[:subtitle], data: @presenter.by_primary_subject[:data], key: 'primary-subject') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -236,7 +236,7 @@
   </div>
 </div>
 
-<%= render Publications::DataTableComponent.new(caption: "Table 9.1: #{@presenter.by_secondary_subject[:title]}", title: t('publications.itt_monthly_report_generator.secondary_subject.subtitle'), data: @presenter.by_secondary_subject[:data], key: 'secondary-subject') %>
+<%= render Publications::DataTableComponent.new(caption: "Table 9.1: #{@presenter.by_secondary_subject[:title]}", title: @presenter.by_secondary_subject[:subtitle], data: @presenter.by_secondary_subject[:data], key: 'secondary-subject') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -249,7 +249,7 @@
   </div>
 </div>
 
-<%= render Publications::DataTableComponent.new(caption: "Table 10.1: #{@presenter.by_provider_region[:title]}", title: t('publications.itt_monthly_report_generator.provider_region.subtitle'), data: @presenter.by_provider_region[:data]) %>
+<%= render Publications::DataTableComponent.new(caption: "Table 10.1: #{@presenter.by_provider_region[:title]}", title: @presenter.by_provider_region[:subtitle], data: @presenter.by_provider_region[:data]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -257,9 +257,9 @@
 
     <p class="govuk-body">You can download all of the data on this page in CSV (comma separated values) format, which can be opened in a spreadsheet and used in other analysis tools.</p>
 
-    <% @csv_export_types_and_sizes.each do |export_type, size| %>
+    <% @presenter.csvs.each do |section_identifier, csv|  %>
       <p class="govuk-body">
-      <%= govuk_link_to t("#{export_type}.label") + " #{size.to_fs(:human_size)}", publications_monthly_report_download_path(export_type: export_type, month: @presenter.month, format: :csv) %>
+      <%= govuk_link_to t("publications.itt_monthly_report_generator.#{section_identifier}.title") + " (CSV) #{csv[:size].to_fs(:human_size)}", publications_monthly_report_download_v2_path(export_type: section_identifier, month: @presenter.month, format: :csv) %>
        </p>
     <% end %>
   </div>

--- a/app/views/publications/v2/monthly_statistics/show.html.erb
+++ b/app/views/publications/v2/monthly_statistics/show.html.erb
@@ -147,7 +147,7 @@
   <div class="govuk-grid-column-full">
     <div class="itt-grid">
     <% @presenter.headline_stats.each do |status| %>
-      <%= render Publications::StatusTotalsComponent.new(title: status[:title], summary: status[:summary], heading_one: 'This cycle', heading_two: 'Last cycle', status_total_one: status[:last_cycle], status_total_two: status[:this_cycle]) %>
+      <%= render Publications::StatusTotalsComponent.new(title: status[:title], summary: status[:summary], heading_one: 'This cycle', heading_two: 'Last cycle', status_total_one: status[:this_cycle], status_total_two: status[:last_cycle]) %>
     <% end %>
     </div>
   </div>

--- a/app/views/publications/v2/monthly_statistics/show.html.erb
+++ b/app/views/publications/v2/monthly_statistics/show.html.erb
@@ -257,7 +257,7 @@
 
     <p class="govuk-body">You can download all of the data on this page in CSV (comma separated values) format, which can be opened in a spreadsheet and used in other analysis tools.</p>
 
-    <% @presenter.csvs.each do |section_identifier, csv|  %>
+    <% @presenter.csvs.each do |section_identifier, csv| %>
       <p class="govuk-body">
       <%= govuk_link_to t("publications.itt_monthly_report_generator.#{section_identifier}.title") + " (CSV) #{csv[:size].to_fs(:human_size)}", publications_monthly_report_download_v2_path(export_type: section_identifier, month: @presenter.month, format: :csv) %>
        </p>

--- a/config/locales/publications/itt_monthly_report_generator.yml
+++ b/config/locales/publications/itt_monthly_report_generator.yml
@@ -5,28 +5,29 @@ en:
       last_cycle: Last cycle
       candidate_headline_statistics:
         title: Candidate Headline statistics
-      age_group:
+        subtitle: Headline Statistics
+      candidate_age_group:
         title: Candidate statistics by age group
         subtitle: Age Group
-      sex:
+      candidate_sex:
         title: Candidate statistics by sex
         subtitle: Sex
-      area:
+      candidate_area:
         title: Candidate statistics by UK region or country, or other area
         subtitle: Area
-      phase:
+      candidate_phase:
         title: Candidate statistics by course phase
         subtitle: Course Phase
-      route_into_teaching:
+      candidate_route_into_teaching:
         title: Candidate statistics by route into teaching
         subtitle: Course type
-      primary_subject:
+      candidate_primary_subject:
         title: Candidate statistics by primary specialist subject
         subtitle: Subject
-      secondary_subject:
+      candidate_secondary_subject:
         title: Candidate statistics by secondary subject
         subtitle: Subject
-      provider_region:
+      candidate_provider_region:
         title: Candidate statistics by training provider region of England
         subtitle: Region
       status:

--- a/config/locales/publications/itt_monthly_report_generator.yml
+++ b/config/locales/publications/itt_monthly_report_generator.yml
@@ -30,6 +30,14 @@ en:
       candidate_provider_region:
         title: Candidate statistics by training provider region of England
         subtitle: Region
+      candidate_provider_region_and_subject:
+        title: Candidate statistics by provider region of England and subject
+        subtitle: Region
+        subject: Subject
+      candidate_area_and_subject:
+        title: Candidate statistics by UK region or country, or other area, and subject
+        subtitle: Area
+        subject: Subject
       status:
         submitted:
           title: Submitted

--- a/config/routes/publications.rb
+++ b/config/routes/publications.rb
@@ -17,6 +17,7 @@ namespace :publications, path: '/publications' do
     get '/monthly-statistics/:month/:export_type' => redirect('/publications/monthly-statistics/temporarily-unavailable'), as: :monthly_report_download_unavailable
   end
 
+  get '/monthly-statistics/v2/:month/:export_type' => 'v2/monthly_statistics#download', as: :monthly_report_download_v2
   get '/monthly-statistics(/:month)' => 'monthly_statistics#show', as: :monthly_report
   get '/monthly-statistics/:month/:export_type' => 'monthly_statistics#download', as: :monthly_report_download
   get '/mid-cycle-report' => 'mid_cycle_report#show', as: :mid_cycle_report

--- a/spec/factories/monthly_statistics_reports.rb
+++ b/spec/factories/monthly_statistics_reports.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     end
 
     trait :v2 do
-      statistics { DfE::Bigquery::StubbedReport.new.to_h }
+      statistics { Publications::MonthlyStatistics::StubbedReport.new.to_h }
     end
   end
 end

--- a/spec/models/publications/itt_monthly_report_generator_spec.rb
+++ b/spec/models/publications/itt_monthly_report_generator_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
       expect(model.generation_date).to eq(generation_date)
       expect(model.publication_date).to eq(publication_date)
       expect(model.month).to eq('2024-01')
-      expect(model.statistics.keys).to eq(%w[meta data])
+      expect(model.statistics.keys).to eq(%w[meta data formats])
       expect(model.statistics['data'].keys).to eq(%w[
         candidate_headline_statistics
         candidate_age_group
@@ -197,6 +197,7 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
     it 'returns candidate headline statistics' do
       expect(report[:data][:candidate_headline_statistics]).to eq({
         title: 'Candidate Headline statistics',
+        subtitle: 'Headline Statistics',
         data: {
           submitted: {
             title: 'Submitted',
@@ -245,6 +246,7 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
     it 'returns age group' do
       expect(report[:data][:candidate_age_group]).to eq({
         title: 'Candidate statistics by age group',
+        subtitle: 'Age Group',
         data: {
           submitted: [
             {
@@ -310,6 +312,7 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
       expect(report[:data][:candidate_sex]).to eq(
         {
           title: 'Candidate statistics by sex',
+          subtitle: 'Sex',
           data: {
             submitted: [
               {
@@ -376,6 +379,7 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
       expect(report[:data][:candidate_area]).to eq(
         {
           title: 'Candidate statistics by UK region or country, or other area',
+          subtitle: 'Area',
           data: {
             submitted: [
               {
@@ -442,6 +446,7 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
       expect(report[:data][:candidate_phase]).to eq(
         {
           title: 'Candidate statistics by course phase',
+          subtitle: 'Course Phase',
           data: {
             submitted: [
               {
@@ -508,6 +513,7 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
       expect(report[:data][:candidate_route_into_teaching]).to eq(
         {
           title: 'Candidate statistics by route into teaching',
+          subtitle: 'Course type',
           data: {
             submitted: [
               {
@@ -574,6 +580,7 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
       expect(report[:data][:candidate_primary_subject]).to eq(
         {
           title: 'Candidate statistics by primary specialist subject',
+          subtitle: 'Subject',
           data: {
             submitted: [
               {
@@ -640,6 +647,7 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
       expect(report[:data][:candidate_secondary_subject]).to eq(
         {
           title: 'Candidate statistics by secondary subject',
+          subtitle: 'Subject',
           data: {
             submitted: [
               {
@@ -706,6 +714,7 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
       expect(report[:data][:candidate_provider_region]).to eq(
         {
           title: 'Candidate statistics by training provider region of England',
+          subtitle: 'Region',
           data: {
             submitted: [
               {
@@ -765,6 +774,48 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
             ],
           },
         },
+      )
+    end
+
+    it 'returns candidate headline statistics into CSV' do
+      expect(report[:formats][:csv][:candidate_headline_statistics]).to eq(
+        size: 496,
+        data: "Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Deferred this cycle,Deferred last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\n8586,5160,598,567,538,478,246,131,285,213,0,0,1,0,0,0\n",
+      )
+    end
+
+    it 'returns candidate age group into CSV' do
+      expect(report[:formats][:csv][:candidate_age_group]).to eq(
+        size: 510,
+        data: "Age Group,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Deferred this cycle,Deferred last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\n21,400,200,598,567,20,10,100,50,285,213,0,0,200,100,30,15\n",
+      )
+    end
+
+    it 'returns candidate sex into CSV' do
+      expect(report[:formats][:csv][:candidate_sex]).to eq(
+        size: 506,
+        data: "Sex,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Deferred this cycle,Deferred last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\nMale,400,200,598,567,20,10,100,50,285,213,0,0,200,100,30,15\n",
+      )
+    end
+
+    it 'returns candidate area into CSV' do
+      expect(report[:formats][:csv][:candidate_area]).to eq(
+        size: 509,
+        data: "Area,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Deferred this cycle,Deferred last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\nGondor,400,200,598,567,20,10,100,50,285,213,0,0,200,100,30,15\n",
+      )
+    end
+
+    it 'returns candidate phase into CSV' do
+      expect(report[:formats][:csv][:candidate_phase]).to eq(
+        size: 518,
+        data: "Course Phase,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Deferred this cycle,Deferred last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\nPrimary,400,200,598,567,20,10,100,50,285,213,0,0,200,100,30,15\n",
+      )
+    end
+
+    it 'returns candidate route into teaching into CSV' do
+      expect(report[:formats][:csv][:candidate_route_into_teaching]).to eq(
+        size: 526,
+        data: "Course type,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Deferred this cycle,Deferred last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\nHigher education,400,200,598,567,20,10,100,50,285,213,0,0,200,100,30,15\n",
       )
     end
   end

--- a/spec/models/publications/itt_monthly_report_generator_spec.rb
+++ b/spec/models/publications/itt_monthly_report_generator_spec.rb
@@ -33,6 +33,42 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
   let(:primary_subject) { age_group.dup.merge(subject_filter: 'Primary with English') }
   let(:secondary_subject) { age_group.dup.merge(subject_filter: 'Drama') }
   let(:provider_region) { age_group.dup.merge(nonsubject_filter: 'Hogsmeade') }
+  let(:first_provider_region_and_subject) do
+    age_group.dup.merge(
+      nonsubject_filter: 'Fangorn Forest',
+      subject_filter: 'Geography',
+    )
+  end
+  let(:second_provider_region_and_subject) do
+    age_group.dup.merge(
+      nonsubject_filter: 'Fangorn Forest',
+      subject_filter: 'History',
+    )
+  end
+  let(:third_provider_region_and_subject) do
+    age_group.dup.merge(
+      nonsubject_filter: 'Fangorn Forest',
+      subject_filter: 'Music',
+    )
+  end
+  let(:first_candidate_area_and_subject) do
+    age_group.dup.merge(
+      nonsubject_filter: 'Isengard',
+      subject_filter: 'Drama',
+    )
+  end
+  let(:second_candidate_area_and_subject) do
+    age_group.dup.merge(
+      nonsubject_filter: 'Isengard',
+      subject_filter: 'Primary with Mathematics',
+    )
+  end
+  let(:third_candidate_area_and_subject) do
+    age_group.dup.merge(
+      nonsubject_filter: 'Isengard',
+      subject_filter: 'Mathematics',
+    )
+  end
 
   describe '#generation_date' do
     context 'when passing in initialize' do
@@ -171,6 +207,8 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
         candidate_primary_subject
         candidate_secondary_subject
         candidate_provider_region
+        candidate_provider_region_and_subject
+        candidate_area_and_subject
       ])
     end
   end
@@ -191,6 +229,7 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
         publication_date:,
         period: 'From 2 October 2023 to 19 November 2023',
         cycle_week: 7,
+        month: '2023-11',
       })
     end
 
@@ -777,6 +816,344 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
       )
     end
 
+    it 'returns provider region with subject' do
+      expect(report[:data][:candidate_provider_region_and_subject]).to eq(
+        title: 'Candidate statistics by provider region of England and subject',
+        subtitle: 'Region',
+        data: {
+          submitted: [
+            {
+              title: 'Fangorn Forest',
+              this_cycle: 400,
+              last_cycle: 200,
+              subject: 'Geography',
+            },
+            {
+              title: 'Fangorn Forest',
+              this_cycle: 400,
+              last_cycle: 200,
+              subject: 'History',
+            },
+            {
+              title: 'Fangorn Forest',
+              this_cycle: 400,
+              last_cycle: 200,
+              subject: 'Music',
+            },
+          ],
+          with_offers: [
+            {
+              title: 'Fangorn Forest',
+              this_cycle: 598,
+              last_cycle: 567,
+              subject: 'Geography',
+            },
+            {
+              title: 'Fangorn Forest',
+              this_cycle: 598,
+              last_cycle: 567,
+              subject: 'History',
+            },
+            {
+              title: 'Fangorn Forest',
+              this_cycle: 598,
+              last_cycle: 567,
+              subject: 'Music',
+            },
+          ],
+          accepted: [
+            {
+              title: 'Fangorn Forest',
+              this_cycle: 20,
+              last_cycle: 10,
+              subject: 'Geography',
+            },
+            {
+              title: 'Fangorn Forest',
+              this_cycle: 20,
+              last_cycle: 10,
+              subject: 'History',
+            },
+            {
+              title: 'Fangorn Forest',
+              this_cycle: 20,
+              last_cycle: 10,
+              subject: 'Music',
+            },
+          ],
+          rejected: [
+            {
+              title: 'Fangorn Forest',
+              this_cycle: 100,
+              last_cycle: 50,
+              subject: 'Geography',
+            },
+            {
+              title: 'Fangorn Forest',
+              this_cycle: 100,
+              last_cycle: 50,
+              subject: 'History',
+            },
+            {
+              title: 'Fangorn Forest',
+              this_cycle: 100,
+              last_cycle: 50,
+              subject: 'Music',
+            },
+          ],
+          reconfirmed: [
+            {
+              title: 'Fangorn Forest',
+              this_cycle: 285,
+              last_cycle: 213,
+              subject: 'Geography',
+            },
+            {
+              title: 'Fangorn Forest',
+              this_cycle: 285,
+              last_cycle: 213,
+              subject: 'History',
+            },
+            {
+              title: 'Fangorn Forest',
+              this_cycle: 285,
+              last_cycle: 213,
+              subject: 'Music',
+            },
+          ],
+          deferred: [
+            {
+              title: 'Fangorn Forest',
+              this_cycle: 0,
+              last_cycle: 0,
+              subject: 'Geography',
+            },
+            {
+              title: 'Fangorn Forest',
+              this_cycle: 0,
+              last_cycle: 0,
+              subject: 'History',
+            },
+            {
+              title: 'Fangorn Forest',
+              this_cycle: 0,
+              last_cycle: 0,
+              subject: 'Music',
+            },
+          ],
+          withdrawn: [
+            {
+              title: 'Fangorn Forest',
+              this_cycle: 200,
+              last_cycle: 100,
+              subject: 'Geography',
+            },
+            {
+              title: 'Fangorn Forest',
+              this_cycle: 200,
+              last_cycle: 100,
+              subject: 'History',
+            },
+            {
+              title: 'Fangorn Forest',
+              this_cycle: 200,
+              last_cycle: 100,
+              subject: 'Music',
+            },
+          ],
+          conditions_not_met: [
+            {
+              title: 'Fangorn Forest',
+              this_cycle: 30,
+              last_cycle: 15,
+              subject: 'Geography',
+            },
+            {
+              title: 'Fangorn Forest',
+              this_cycle: 30,
+              last_cycle: 15,
+              subject: 'History',
+            },
+            {
+              title: 'Fangorn Forest',
+              this_cycle: 30,
+              last_cycle: 15,
+              subject: 'Music',
+            },
+          ],
+        },
+      )
+    end
+
+    it 'returns candidate area with subject' do
+      expect(report[:data][:candidate_area_and_subject]).to eq(
+        title: 'Candidate statistics by UK region or country, or other area, and subject',
+        subtitle: 'Area',
+        data: {
+          submitted: [
+            {
+              title: 'Isengard',
+              this_cycle: 400,
+              last_cycle: 200,
+              subject: 'Drama',
+            },
+            {
+              title: 'Isengard',
+              this_cycle: 400,
+              last_cycle: 200,
+              subject: 'Primary with Mathematics',
+            },
+            {
+              title: 'Isengard',
+              this_cycle: 400,
+              last_cycle: 200,
+              subject: 'Mathematics',
+            },
+          ],
+          with_offers: [
+            {
+              title: 'Isengard',
+              this_cycle: 598,
+              last_cycle: 567,
+              subject: 'Drama',
+            },
+            {
+              title: 'Isengard',
+              this_cycle: 598,
+              last_cycle: 567,
+              subject: 'Primary with Mathematics',
+            },
+            {
+              title: 'Isengard',
+              this_cycle: 598,
+              last_cycle: 567,
+              subject: 'Mathematics',
+            },
+          ],
+          accepted: [
+            {
+              title: 'Isengard',
+              this_cycle: 20,
+              last_cycle: 10,
+              subject: 'Drama',
+            },
+            {
+              title: 'Isengard',
+              this_cycle: 20,
+              last_cycle: 10,
+              subject: 'Primary with Mathematics',
+            },
+            {
+              title: 'Isengard',
+              this_cycle: 20,
+              last_cycle: 10,
+              subject: 'Mathematics',
+            },
+          ],
+          rejected: [
+            {
+              title: 'Isengard',
+              this_cycle: 100,
+              last_cycle: 50,
+              subject: 'Drama',
+            },
+            {
+              title: 'Isengard',
+              this_cycle: 100,
+              last_cycle: 50,
+              subject: 'Primary with Mathematics',
+            },
+            {
+              title: 'Isengard',
+              this_cycle: 100,
+              last_cycle: 50,
+              subject: 'Mathematics',
+            },
+          ],
+          reconfirmed: [
+            {
+              title: 'Isengard',
+              this_cycle: 285,
+              last_cycle: 213,
+              subject: 'Drama',
+            },
+            {
+              title: 'Isengard',
+              this_cycle: 285,
+              last_cycle: 213,
+              subject: 'Primary with Mathematics',
+            },
+            {
+              title: 'Isengard',
+              this_cycle: 285,
+              last_cycle: 213,
+              subject: 'Mathematics',
+            },
+          ],
+          deferred: [
+            {
+              title: 'Isengard',
+              this_cycle: 0,
+              last_cycle: 0,
+              subject: 'Drama',
+            },
+            {
+              title: 'Isengard',
+              this_cycle: 0,
+              last_cycle: 0,
+              subject: 'Primary with Mathematics',
+            },
+            {
+              title: 'Isengard',
+              this_cycle: 0,
+              last_cycle: 0,
+              subject: 'Mathematics',
+            },
+          ],
+          withdrawn: [
+            {
+              title: 'Isengard',
+              this_cycle: 200,
+              last_cycle: 100,
+              subject: 'Drama',
+            },
+            {
+              title: 'Isengard',
+              this_cycle: 200,
+              last_cycle: 100,
+              subject: 'Primary with Mathematics',
+            },
+            {
+              title: 'Isengard',
+              this_cycle: 200,
+              last_cycle: 100,
+              subject: 'Mathematics',
+            },
+          ],
+          conditions_not_met: [
+            {
+              title: 'Isengard',
+              this_cycle: 30,
+              last_cycle: 15,
+              subject: 'Drama',
+            },
+            {
+              title: 'Isengard',
+              this_cycle: 30,
+              last_cycle: 15,
+              subject: 'Primary with Mathematics',
+            },
+            {
+              title: 'Isengard',
+              this_cycle: 30,
+              last_cycle: 15,
+              subject: 'Mathematics',
+            },
+          ],
+        },
+      )
+    end
+
     it 'returns candidate headline statistics into CSV' do
       expect(report[:formats][:csv][:candidate_headline_statistics]).to eq(
         size: 496,
@@ -818,6 +1195,20 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
         data: "Course type,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Deferred this cycle,Deferred last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\nHigher education,400,200,598,567,20,10,100,50,285,213,0,0,200,100,30,15\n",
       )
     end
+
+    it 'returns provider area and subject into CSV' do
+      expect(report[:formats][:csv][:candidate_provider_region_and_subject]).to eq(
+        size: 691,
+        data: "Region,Subject,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Deferred this cycle,Deferred last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\nFangorn Forest,Geography,400,200,598,567,20,10,100,50,285,213,0,0,200,100,30,15\nFangorn Forest,History,400,200,598,567,20,10,100,50,285,213,0,0,200,100,30,15\nFangorn Forest,Music,400,200,598,567,20,10,100,50,285,213,0,0,200,100,30,15\n",
+      )
+    end
+
+    it 'returns candidate area and subject into CSV' do
+      expect(report[:formats][:csv][:candidate_area_and_subject]).to eq(
+        size: 690,
+        data: "Area,Subject,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Deferred this cycle,Deferred last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\nIsengard,Drama,400,200,598,567,20,10,100,50,285,213,0,0,200,100,30,15\nIsengard,Primary with Mathematics,400,200,598,567,20,10,100,50,285,213,0,0,200,100,30,15\nIsengard,Mathematics,400,200,598,567,20,10,100,50,285,213,0,0,200,100,30,15\n",
+      )
+    end
   end
 
   def stub_application_metrics(cycle_week:)
@@ -856,5 +1247,25 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
     allow(DfE::Bigquery::ApplicationMetrics).to receive(:provider_region)
       .with(cycle_week:)
       .and_return([DfE::Bigquery::ApplicationMetrics.new(provider_region)])
+
+    allow(DfE::Bigquery::ApplicationMetrics).to receive(:provider_region_and_subject)
+      .with(cycle_week:)
+      .and_return(
+        [
+          DfE::Bigquery::ApplicationMetrics.new(first_provider_region_and_subject),
+          DfE::Bigquery::ApplicationMetrics.new(second_provider_region_and_subject),
+          DfE::Bigquery::ApplicationMetrics.new(third_provider_region_and_subject),
+        ],
+      )
+
+    allow(DfE::Bigquery::ApplicationMetrics).to receive(:candidate_area_and_subject)
+      .with(cycle_week:)
+      .and_return(
+        [
+          DfE::Bigquery::ApplicationMetrics.new(first_candidate_area_and_subject),
+          DfE::Bigquery::ApplicationMetrics.new(second_candidate_area_and_subject),
+          DfE::Bigquery::ApplicationMetrics.new(third_candidate_area_and_subject),
+        ],
+      )
   end
 end

--- a/spec/presenters/publications/v2/monthly_statistics_presenter_spec.rb
+++ b/spec/presenters/publications/v2/monthly_statistics_presenter_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Publications::V2::MonthlyStatisticsPresenter do
   describe '#by_age' do
     it 'returns by_age' do
       expect(presenter.by_age).to include({
-        title: I18n.t('publications.itt_monthly_report_generator.age_group.title'),
+        title: I18n.t('publications.itt_monthly_report_generator.candidate_age_group.title'),
         data: Hash,
       })
     end
@@ -111,7 +111,7 @@ RSpec.describe Publications::V2::MonthlyStatisticsPresenter do
   describe '#by_sex' do
     it 'returns by_sex' do
       expect(presenter.by_sex).to include({
-        title: I18n.t('publications.itt_monthly_report_generator.sex.title'),
+        title: I18n.t('publications.itt_monthly_report_generator.candidate_sex.title'),
         data: Hash,
       })
     end
@@ -120,7 +120,7 @@ RSpec.describe Publications::V2::MonthlyStatisticsPresenter do
   describe '#by_area' do
     it 'returns by_area' do
       expect(presenter.by_area).to include({
-        title: I18n.t('publications.itt_monthly_report_generator.area.title'),
+        title: I18n.t('publications.itt_monthly_report_generator.candidate_area.title'),
         data: Hash,
       })
     end
@@ -129,7 +129,7 @@ RSpec.describe Publications::V2::MonthlyStatisticsPresenter do
   describe '#by_phase' do
     it 'returns by_phase' do
       expect(presenter.by_phase).to include({
-        title: I18n.t('publications.itt_monthly_report_generator.phase.title'),
+        title: I18n.t('publications.itt_monthly_report_generator.candidate_phase.title'),
         data: Hash,
       })
     end
@@ -138,7 +138,7 @@ RSpec.describe Publications::V2::MonthlyStatisticsPresenter do
   describe '#by_route' do
     it 'returns by_route' do
       expect(presenter.by_route).to include({
-        title: I18n.t('publications.itt_monthly_report_generator.route_into_teaching.title'),
+        title: I18n.t('publications.itt_monthly_report_generator.candidate_route_into_teaching.title'),
         data: Hash,
       })
     end
@@ -147,7 +147,7 @@ RSpec.describe Publications::V2::MonthlyStatisticsPresenter do
   describe '#by_primary_subject' do
     it 'returns by_primary_subject' do
       expect(presenter.by_primary_subject).to include({
-        title: I18n.t('publications.itt_monthly_report_generator.primary_subject.title'),
+        title: I18n.t('publications.itt_monthly_report_generator.candidate_primary_subject.title'),
         data: Hash,
       })
     end
@@ -156,7 +156,7 @@ RSpec.describe Publications::V2::MonthlyStatisticsPresenter do
   describe '#by_secondary_subject' do
     it 'returns by_secondary_subject' do
       expect(presenter.by_secondary_subject).to include({
-        title: I18n.t('publications.itt_monthly_report_generator.secondary_subject.title'),
+        title: I18n.t('publications.itt_monthly_report_generator.candidate_secondary_subject.title'),
         data: Hash,
       })
     end
@@ -165,7 +165,7 @@ RSpec.describe Publications::V2::MonthlyStatisticsPresenter do
   describe '#by_provider_region' do
     it 'returns by_provider_region' do
       expect(presenter.by_provider_region).to include({
-        title: I18n.t('publications.itt_monthly_report_generator.provider_region.title'),
+        title: I18n.t('publications.itt_monthly_report_generator.candidate_provider_region.title'),
         data: Hash,
       })
     end

--- a/spec/workers/generate_monthly_statistics_spec.rb
+++ b/spec/workers/generate_monthly_statistics_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe GenerateMonthlyStatistics, :sidekiq do
       expect(report.month).to eq('2023-11')
       expect(report.generation_date).to eq(Date.new(2023, 11, 20))
       expect(report.publication_date).to eq(Date.new(2023, 11, 27))
-      expect(report.statistics.keys).to eq(%w[meta data])
+      expect(report.statistics.keys).to eq(%w[meta data formats])
       expect(report.statistics['data'].keys).to eq(%w[
         candidate_headline_statistics
         candidate_age_group

--- a/spec/workers/generate_monthly_statistics_spec.rb
+++ b/spec/workers/generate_monthly_statistics_spec.rb
@@ -50,6 +50,8 @@ RSpec.describe GenerateMonthlyStatistics, :sidekiq do
         candidate_primary_subject
         candidate_secondary_subject
         candidate_provider_region
+        candidate_provider_region_and_subject
+        candidate_area_and_subject
       ])
     end
   end


### PR DESCRIPTION
## Context

This PR adds the download section into the ITT Monthly report

## About the implementation

Because we will have only 12 records into the DB per year, I decided to store the CSVs into the report statistics so I can access during download and also didn't need to calculate the download size.

I made a SQL query for one record:

```
select pg_column_size(statistics)
from monthly_statistics_reports
where id = 13 # id of my report
```

And the results was `7,475` bytes - which I think it is satisfactory for the monthly statistics. 

## Changes proposed in this pull request

See lookup report on trello https://trello.com/c/zKFVpK1H/925-monthly-statistics-generate-csvs

## Guidance to review

See the report for the first cycle week (October)
https://apply-review-8789.test.teacherservices.cloud/publications/monthly-statistics/ITT2024

1. Does it work downloading all sections into CSV?
2. Does it work downloading the extra two sections into CSV?
3. Are you ok to store the CSVs into the DB?

## Link to Trello card

https://trello.com/c/zKFVpK1H/925-monthly-statistics-generate-csvs

