### PR TITLE
Potential fix for flakey specs

### DIFF
--- a/spec/support/test_helpers/dfe_sign_in_helpers.rb
+++ b/spec/support/test_helpers/dfe_sign_in_helpers.rb
@@ -14,9 +14,7 @@ module DfESignInHelpers
 
   def provider_signs_in_using_dfe_sign_in
     visit provider_interface_path
-    within '.govuk-main-wrapper' do
-      click_link 'Sign in'
-    end
+    find("a[href='#{provider_interface_sign_in_path}']", match: :first).click
     click_button 'Sign in using DfE Sign-in'
   end
 

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_signs_up_for_an_adviser_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_signs_up_for_an_adviser_spec.rb
@@ -75,7 +75,7 @@ RSpec.feature 'Candidate signs up for an adviser', :js, continuous_applications:
   end
 
   def when_i_click_on_the_adviser_cta
-    click_link t('application_form.adviser_sign_up.call_to_action.available.button_text')
+    find("a[href='#{new_candidate_interface_adviser_sign_up_path}']", match: :first).click
   end
 
   def then_i_should_be_on_the_adviser_sign_up_page


### PR DESCRIPTION
- Unable to find css ".govuk-main-wrapper"
- Unable to find link "Get an adviser"

Using `.find` should wait for page load.