### PR TITLE
Fix Sidekiq retry errors on Review Apps

### DIFF
--- a/app/workers/detect_invariants_daily_check.rb
+++ b/app/workers/detect_invariants_daily_check.rb
@@ -15,7 +15,7 @@ class DetectInvariantsDailyCheck
   def detect_if_the_monthly_statistics_has_not_run
     latest_monthly_report = Publications::MonthlyStatistics::MonthlyStatisticsReport.last
 
-    return if latest_monthly_report.generation_date >= MonthlyStatisticsTimetable.current_generation_date
+    return if latest_monthly_report.nil? || latest_monthly_report.generation_date >= MonthlyStatisticsTimetable.current_generation_date
 
     latest_month = MonthlyStatisticsTimetable.last_publication_date.strftime('%B')
 

--- a/app/workers/slack_notification_worker.rb
+++ b/app/workers/slack_notification_worker.rb
@@ -4,6 +4,8 @@ class SlackNotificationWorker
   include Sidekiq::Worker
 
   def perform(text, url = nil, channel = nil)
+    return if HostingEnvironment.review?
+
     @webhook_url = ENV['STATE_CHANGE_SLACK_URL']
 
     if @webhook_url.present?


### PR DESCRIPTION
The `SlackNotificationWorker` and `DetectInvariantsDailyCheck` workers
keep retrying on Review Apps with the following error:

```SlackNotificationWorker::SlackMessageError: Slack error: invalid_token`
```NoMethodError: undefined method `generation_date' for nil:NilClass```

<img width="1121" alt="Screenshot 2023-11-17 at 11 59 28" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/9621360c-f24c-4a27-bf09-71ad176ade59">
