### PR TITLE
Add draft feature flag for monthly statistics

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -22,6 +22,7 @@ class FeatureFlag
     [:enable_chat_support, 'Enable Zendesk chat support', 'Apply team'],
     [:lock_external_report_to_january_2022, 'Lock the current external report to January 2022', 'Apply team'],
     [:unlock_application_for_editing, 'Allow the candidate to make edits to their application form post submission', 'Find and Apply team'],
+    [:monthly_statistics_preview, 'Preview unpublished monthly statistics reports', 'Tomas'],
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = [
@@ -40,7 +41,6 @@ class FeatureFlag
     [:continuous_applications, 'The new continuous applications flow', 'James Glenn'],
     [:course_has_vacancies, 'Using the new publish status to set a course as open or closed', 'Tomas & James'],
     [:monthly_statistics_redirected, 'Redirect requests for Publications Monthly Statistics to temporarily unavailable', 'Iain McNulty'],
-    [:monthly_statistics_draft, 'Allow to see monthly statistics reports before being published', 'Tomas']
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -40,6 +40,7 @@ class FeatureFlag
     [:continuous_applications, 'The new continuous applications flow', 'James Glenn'],
     [:course_has_vacancies, 'Using the new publish status to set a course as open or closed', 'Tomas & James'],
     [:monthly_statistics_redirected, 'Redirect requests for Publications Monthly Statistics to temporarily unavailable', 'Iain McNulty'],
+    [:monthly_statistics_draft, 'Allow to see monthly statistics reports before being published', 'Tomas']
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day


### PR DESCRIPTION
## Context

We need to see the November and December reports before being published, so I am creating a feature flag for checking the draft monthly statistics reports.

## Link to Trello card

https://trello.com/c/xfHhFuVU/894-monthly-statistics-reactivate-the-monthly-statistics-page



