### PR TITLE
Update Dockerfile to use latest version of openssl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,8 @@ ENV WKHTMLTOPDF_GEM=wkhtmltopdf-binary-edge-alpine \
     REDIS_CACHE_URL=redis://127.0.0.1:6379
 
 RUN apk -U upgrade && \
-    apk add --update --no-cache tzdata libpq libxml2 libxslt graphviz ttf-dejavu ttf-droid ttf-freefont ttf-liberation libx11 && \
+    apk add --update --no-cache tzdata libpq libxml2 libxslt graphviz \
+    ttf-dejavu ttf-droid ttf-freefont ttf-liberation libx11 openssl && \
     echo "Europe/London" > /etc/timezone && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime
 


### PR DESCRIPTION
This is a security update to address CVE-2023-5678
https://security.snyk.io/vuln/SNYK-ALPINE316-OPENSSL-6069876