### PR TITLE
Update gems and restrict factory_bot_rails to 6.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ gem 'activerecord-cte'
 gem 'sentry-rails'
 gem 'sentry-sidekiq'
 
-gem 'factory_bot_rails'
+gem 'factory_bot_rails', '~> 6.2.0'
 gem 'satisfactory', '~> 0.3'
 
 # Leave 2.22.0 otherwise it could fail generating applications in sandbox

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,7 @@ GEM
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     aes_key_wrap (1.1.0)
-    anyway_config (2.5.0)
+    anyway_config (2.5.4)
       ruby-next-core (>= 0.14.0)
     ar-sequence (0.2.1)
       activerecord
@@ -138,7 +138,7 @@ GEM
     audited (5.4.2)
       activerecord (>= 5.0, < 7.2)
       request_store (~> 1.2)
-    bcrypt (3.1.19)
+    bcrypt (3.1.20)
     better_html (2.0.2)
       actionview (>= 6.0)
       activesupport (>= 6.0)
@@ -191,7 +191,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    date (3.3.3)
+    date (3.3.4)
     db-query-matchers (0.11.0)
       activesupport (>= 4.0, < 7.1)
       rspec (>= 3.0)
@@ -222,7 +222,7 @@ GEM
       rubocop
       smart_properties
     erubi (1.12.0)
-    excon (0.92.4)
+    excon (0.104.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -262,7 +262,7 @@ GEM
     faraday_middleware-circuit_breaker (0.5.0)
       faraday (>= 0.9, < 2.0)
       stoplight (>= 2.1, < 4.0)
-    ffi (1.15.5)
+    ffi (1.16.3)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
@@ -270,9 +270,9 @@ GEM
     geocoder (1.8.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    google-apis-bigquery_v2 (0.59.0)
+    google-apis-bigquery_v2 (0.61.0)
       google-apis-core (>= 0.11.0, < 2.a)
-    google-apis-core (0.11.1)
+    google-apis-core (0.11.2)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.16.2, < 2.a)
       httpclient (>= 2.8.1, < 3.a)
@@ -311,7 +311,7 @@ GEM
     govuk_markdown (2.0.1)
       activesupport
       redcarpet
-    guard (2.18.0)
+    guard (2.18.1)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
       lumberjack (>= 1.0.12, < 2.0)
@@ -384,7 +384,7 @@ GEM
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    lumberjack (1.2.8)
+    lumberjack (1.2.10)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
@@ -400,27 +400,27 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
-    mime-types (3.4.1)
+    mime-types (3.5.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2022.0105)
+    mime-types-data (3.2023.1003)
     mini_mime (1.1.5)
     mini_portile2 (2.8.5)
     minitest (5.20.0)
     multi_json (1.15.0)
     multipart-post (2.3.0)
     nenv (0.3.0)
-    net-imap (0.4.2)
+    net-imap (0.4.5)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.2.1)
+    net-protocol (0.2.2)
       timeout
     net-smtp (0.4.0)
       net-protocol
     netrc (0.11.0)
-    nio4r (2.5.9)
-    nokogiri (1.15.4)
+    nio4r (2.6.1)
+    nokogiri (1.15.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     notiffany (0.1.3)
@@ -478,7 +478,7 @@ GEM
       pry (>= 0.13, < 0.15)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
-    public_suffix (5.0.3)
+    public_suffix (5.0.4)
     puma (6.4.0)
       nio4r (~> 2.0)
     racc (1.7.3)
@@ -495,7 +495,7 @@ GEM
       rack (>= 2.1.0)
     rack-protection (3.0.5)
       rack
-    rack-proxy (0.7.6)
+    rack-proxy (0.7.7)
       rack
     rack-test (2.1.0)
       rack (>= 1.3)
@@ -577,10 +577,10 @@ GEM
     rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.5)
+    rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-rails (6.0.3)
+    rspec-rails (6.0.4)
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       railties (>= 6.1)
@@ -674,7 +674,7 @@ GEM
     sniffer (0.5.0)
       anyway_config (>= 1.0)
       dry-initializer (~> 3)
-    sprockets (4.2.0)
+    sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
     sprockets-rails (3.4.2)
@@ -698,7 +698,7 @@ GEM
     thor (1.3.0)
     timecop (0.9.8)
     timeliness (0.4.5)
-    timeout (0.4.0)
+    timeout (0.4.1)
     trailblazer-option (0.1.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -745,7 +745,7 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    wkhtmltopdf-binary (0.12.6.5)
+    wkhtmltopdf-binary (0.12.6.6)
     workflow (3.0.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
@@ -805,7 +805,7 @@ DEPENDENCIES
   discard
   dotenv-rails
   erb_lint
-  factory_bot_rails
+  factory_bot_rails (~> 6.2.0)
   faker (= 2.22.0)
   geocoder
   get_into_teaching_api_client_faraday!


### PR DESCRIPTION
The latest version of factory_bot_rails crashes the app on initialization.
I'll remove the restriction once the issue is fixed.
https://github.com/thoughtbot/factory_bot_rails/issues/433

I also updated to the latest version some gems that don't seem to be picked up by dependabot.