### PR TITLE
Use the correct date for the deferred course email

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -398,6 +398,7 @@ class CandidateMailer < ApplicationMailer
     @provider_name = @course_option.provider.name
     @course_name = @course_option.course.name_and_code
     @conditions = @application_choice.offer.all_conditions_text
+    @next_year_start_date = @course_option.course.start_date.advance(years: 1).to_fs(:month_and_year)
 
     email_for_candidate(
       @application_choice.application_form,

--- a/app/views/candidate_mailer/reinstated_offer.text.erb
+++ b/app/views/candidate_mailer/reinstated_offer.text.erb
@@ -2,7 +2,7 @@ Dear <%= @application_form.first_name %>
 
 <%= @provider_name %> has confirmed your deferred offer to study <%= @course_option.course.name_and_code %>.
 
-The course starts in <%= @course_option.course.start_date.to_fs(:month_and_year) %>.
+The course starts in <%= @next_year_start_date %>.
 
 <% if @application_choice.offer.conditions.all?(&:met?) %>
   They’ll let you know if they need further information before you start training.

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -312,7 +312,7 @@ RSpec.describe CandidateMailer do
         'heading' => 'Dear Bob',
         'provider name' => 'Falconholt Technical College has confirmed your deferred offer to study',
         'name and code for course' => 'Forensic Science (E0FO)',
-        'start date of new course' => 'June 2020',
+        'start date of new course' => 'June 2021',
         'course starts text' => 'The course starts',
       )
 
@@ -333,7 +333,7 @@ RSpec.describe CandidateMailer do
         'heading' => 'Dear Bob',
         'provider name' => 'Falconholt Technical College has confirmed your deferred offer to study',
         'name and code for course' => 'Forensic Science (E0FO)',
-        'start date of new course' => 'June 2020',
+        'start date of new course' => 'June 2021',
         'conditions section' => 'You still need to meet the following condition',
         'conditions of offer' => 'GCSE Maths grade 4 (C) or above, or equivalent',
         'course starts text' => 'The course starts',
@@ -352,7 +352,7 @@ RSpec.describe CandidateMailer do
         'heading' => 'Dear Bob',
         'provider name' => 'Falconholt Technical College has confirmed your deferred offer to study',
         'name and code for course' => 'Forensic Science (E0FO)',
-        'start date of new course' => 'June 2020',
+        'start date of new course' => 'June 2021',
         'course starts text' => 'The course starts',
       )
 

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -485,6 +485,10 @@ RSpec.describe CandidateMailer do
       'pending condition text' => 'You still need to meet the following condition',
       'pending condition' => 'Be cool',
     )
+
+    it 'displays the correct deferred start date' do
+      expect(email.body).to include(course_option.course.start_date.advance(years: 1).to_fs(:month_and_year))
+    end
   end
 
   describe '.unconditional_offer_accepted' do


### PR DESCRIPTION
## Context

It has been flagged that we are not using the correct date in this email. It should be + 1 year since the start date has been deferred.

Ask for additional context.