### PR TITLE
Remove `inactive` from the activity log on the timeline

### DIFF
--- a/app/components/provider_interface/application_timeline_component.rb
+++ b/app/components/provider_interface/application_timeline_component.rb
@@ -29,7 +29,13 @@ module ProviderInterface
   private
 
     def map_activity_log_events_for(attr)
-      filtered = @activity_log_events.select { |event| event.application_status_at_event != 'interviewing' && event.changes.key?(attr) }
+      filtered = @activity_log_events
+        .select do |event|
+          event.application_status_at_event != 'interviewing' &&
+            event.changes.key?(attr) &&
+            !event.changes['status']&.include?('inactive')
+        end
+
       filtered.map { |event| yield event }
     end
 

--- a/spec/components/provider_interface/application_timeline_component_spec.rb
+++ b/spec/components/provider_interface/application_timeline_component_spec.rb
@@ -74,6 +74,18 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
     end
   end
 
+  context 'when an application has a status change to inactive' do
+    it 'renders the component excluding the inactive event' do
+      inactive_audit = build_stubbed(
+        :application_choice_audit,
+        audited_changes: { 'status' => %w[offer inactive] },
+      )
+      application_choice = application_choice_with_audits([inactive_audit])
+
+      expect { render_inline(described_class.new(application_choice: application_choice)) }.not_to raise_error
+    end
+  end
+
   context 'for an application with a note' do
     let(:application_choice) { create(:application_choice) }
 


### PR DESCRIPTION
## Context

There is currently no mapping for `inactive` in `TITLES`. This is causing `title_for(status)` to return `nil`. 

We don't want to show this status so we are removing it from the activity log.

https://dfe-teacher-services.sentry.io/issues/4605401101/?alert_rule_id=4434951&alert_type=issue&environment=production&notification_uuid=0ecaacf0-4462-44a6-b103-ace5d3956a1b&project=1765973&referrer=slack

