### PR TITLE
Allow providers to make a decision on ianctive apps

### DIFF
--- a/app/components/provider_interface/application_choice_header_component.rb
+++ b/app/components/provider_interface/application_choice_header_component.rb
@@ -59,7 +59,7 @@ module ProviderInterface
     end
 
     def respond_to_application?
-      provider_can_respond && (application_choice.awaiting_provider_decision? || application_choice.interviewing?)
+      provider_can_respond && application_choice.decision_pending?
     end
 
     def deferred_offer?

--- a/spec/components/provider_interface/application_choice_header_component_spec.rb
+++ b/spec/components/provider_interface/application_choice_header_component_spec.rb
@@ -67,6 +67,17 @@ RSpec.describe ProviderInterface::ApplicationChoiceHeaderComponent do
       end
     end
 
+    context 'when the application is inactive and the provider can make decisions' do
+      let(:provider_can_respond) { true }
+      let(:status) { :inactive }
+
+      it 'renders the make decision button' do
+        expect(result.css('h2.govuk-heading-m').first.text.strip).to eq('Set up an interview or make a decision')
+        expect(result.css('.govuk-button').first.text).to eq('Set up interview')
+        expect(result.css('.govuk-button--secondary').last.text).to eq('Make decision')
+      end
+    end
+
     context 'when the application is RBD with no feedback and the user can make decisions' do
       let(:reject_by_default_at) { 1.day.ago }
       let(:status) { :rejected }


### PR DESCRIPTION
## Context

We're currently not rendering the "Make a decision" button if an application is inactive, we just need to include this state.