### PR TITLE
Allow providers to interview inactive apps

### DIFF
--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -4,7 +4,7 @@ class ApplicationStateChange
   STATES_NOT_VISIBLE_TO_PROVIDER = %i[unsubmitted cancelled application_not_sent].freeze
   STATES_VISIBLE_TO_PROVIDER = %i[awaiting_provider_decision interviewing offer pending_conditions recruited rejected declined withdrawn conditions_not_met offer_withdrawn offer_deferred inactive].freeze
 
-  INTERVIEWABLE_STATES = %i[awaiting_provider_decision interviewing].freeze
+  INTERVIEWABLE_STATES = %i[awaiting_provider_decision interviewing inactive].freeze
   ACCEPTED_STATES = %i[pending_conditions conditions_not_met recruited offer_deferred].freeze
   OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer offer_withdrawn]).freeze
   POST_OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer_withdrawn]).freeze

--- a/spec/services/interview_workflow_constraints_spec.rb
+++ b/spec/services/interview_workflow_constraints_spec.rb
@@ -13,6 +13,18 @@ RSpec.describe InterviewWorkflowConstraints do
     I18n.t("activemodel.errors.models.interview_workflow_constraints.attributes.#{error}")
   end
 
+  context 'application in interviewable state' do
+    let(:application_choice) { create(:application_choice, :inactive, course_option:) }
+
+    context 'new interview' do
+      let(:interview) { build(:interview, application_choice:, skip_application_choice_status_update: true) }
+
+      it 'does not raises InterviewWorkflowError' do
+        expect { workflow_constraints.create! }.not_to raise_error(InterviewWorkflowConstraints::WorkflowError)
+      end
+    end
+  end
+
   context 'application_choice past interviewing stage' do
     let(:application_choice) { create(:application_choice, :offered, course_option:) }
 


### PR DESCRIPTION
## Context

inactive is an interviewable state – longer term we will sort application state change but let's get this working as providers are encountering 500s