### PR TITLE
Remove DBD from running in clock

### DIFF
--- a/config/clock.rb
+++ b/config/clock.rb
@@ -20,7 +20,6 @@ class Clock
   every(1.hour, 'ProcessStaleApplications', at: '**:10') do
     ProcessStaleApplicationsWorker.perform_async
   end
-  every(1.hour, 'DeclineOffersByDefault', at: '**:15') { DeclineOffersByDefaultWorker.perform_async }
   every(1.hour, 'ChaseReferences', at: '**:20') { ChaseReferences.perform_async }
   every(1.hour, 'UpdateOutOfDateProviderIdsOnApplicationChoices', at: '**:20') { UpdateOutOfDateProviderIdsOnApplicationChoices.perform_async }
   every(1.hour, 'UpdateDuplicateMatchesWorker', at: '**:25') { UpdateDuplicateMatchesWorker.perform_async('notify_slack_at' => 13) }

--- a/spec/support_specs/clockwork_spec.rb
+++ b/spec/support_specs/clockwork_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe Clockwork, :clockwork do
   end
 
   [
-    { worker: DeclineOffersByDefaultWorker, task: 'DeclineOffersByDefault' },
     { worker: SendChaseEmailToCandidatesWorker, task: 'SendChaseEmailToCandidates' },
   ].each do |worker|
     describe 'worker schedule' do


### PR DESCRIPTION
## Context

The DBD should not run for continuous applications and we have 22 records with DBD (because an unexpected place is setting the DBD) so let's remove the call from worker to minimise problem.
