### PR TITLE
Add manual data migration to set the decline by default apps to offer

### DIFF
--- a/app/services/data_migrations/remove_dbd_from_current_cycle.rb
+++ b/app/services/data_migrations/remove_dbd_from_current_cycle.rb
@@ -18,7 +18,10 @@ module DataMigrations
       ApplicationChoice.where(
         declined_by_default: true,
         current_recruitment_cycle_year: 2024,
-      )
+      ).reject do |application_choice|
+        application_choice.application_form.application_choices.offer.any? { |ac| ac.course_option == application_choice.course_option } ||
+          application_choice.application_form.any_offer_accepted?
+      end
     end
   end
 end

--- a/app/services/data_migrations/remove_dbd_from_current_cycle.rb
+++ b/app/services/data_migrations/remove_dbd_from_current_cycle.rb
@@ -1,0 +1,24 @@
+module DataMigrations
+  class RemoveDbdFromCurrentCycle
+    TIMESTAMP = 20231122153455
+    MANUAL_RUN = true
+
+    def change
+      records.each do |application_choice|
+        application_choice.update_columns(
+          declined_by_default: false,
+          decline_by_default_days: nil,
+          declined_at: nil,
+          status: 'offer',
+        )
+      end
+    end
+
+    def records
+      ApplicationChoice.where(
+        declined_by_default: true,
+        current_recruitment_cycle_year: 2024,
+      )
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveDbdFromCurrentCycle',
   'DataMigrations::RemoveRecruitWithPendingConditionsFeatureFlag',
   'DataMigrations::BackfillFeedbackFormComplete',
   'DataMigrations::RemoveMidCycleReportFeatureFlag',

--- a/spec/services/data_migrations/remove_dbd_from_current_cycle_spec.rb
+++ b/spec/services/data_migrations/remove_dbd_from_current_cycle_spec.rb
@@ -34,6 +34,59 @@ RSpec.describe DataMigrations::RemoveDbdFromCurrentCycle do
         expect(application_choice.declined_at).to be_nil
       end
     end
+
+    context 'when the candidate re-applied for the same course' do
+      let(:course_option) { create(:course_option) }
+      let(:application_form) do
+        create(
+          :application_form,
+          :minimum_info,
+          application_choices: [
+            create(
+              :application_choice,
+              :offer,
+              current_recruitment_cycle_year: 2024,
+              course_option:,
+            ),
+            create(
+              :application_choice,
+              :declined_by_default,
+              current_recruitment_cycle_year: 2024,
+              course_option:,
+            ),
+          ],
+        )
+      end
+
+      it 'does not update records' do
+        expect { described_class.new.change }.not_to(change { application_form.application_choices.declined.count })
+      end
+    end
+
+    context 'when the candidate accepted another application' do
+      let(:application_form) do
+        create(
+          :application_form,
+          :minimum_info,
+          application_choices: [
+            create(
+              :application_choice,
+              :accepted,
+              current_recruitment_cycle_year: 2024,
+            ),
+            create(
+              :application_choice,
+              :declined_by_default,
+              current_recruitment_cycle_year: 2024,
+            ),
+          ],
+        )
+      end
+
+      it 'does not update records' do
+        expect { described_class.new.change }.not_to(change { application_form.application_choices.declined.count })
+      end
+    end
   end
 
   context 'when application is declined but not by default' do

--- a/spec/services/data_migrations/remove_dbd_from_current_cycle_spec.rb
+++ b/spec/services/data_migrations/remove_dbd_from_current_cycle_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveDbdFromCurrentCycle do
+  context 'when application is declined by default' do
+    context 'when 2023 recruitment cycle' do
+      let!(:application_choice) do
+        create(
+          :application_choice,
+          :declined_by_default,
+          current_recruitment_cycle_year: 2023,
+        )
+      end
+
+      it 'does not update records' do
+        expect { described_class.new.change }.not_to change { application_choice }
+      end
+    end
+
+    context 'when 2024 recruitment cycle' do
+      let!(:application_choice) do
+        create(
+          :application_choice,
+          :declined_by_default,
+          current_recruitment_cycle_year: 2024,
+        )
+      end
+
+      it 'updates records and set to offer made' do
+        described_class.new.change
+        application_choice.reload
+        expect(application_choice.status).to eq('offer')
+        expect(application_choice.declined_by_default).to be(false)
+        expect(application_choice.decline_by_default_days).to be_nil
+        expect(application_choice.declined_at).to be_nil
+      end
+    end
+  end
+
+  context 'when application is declined but not by default' do
+    let!(:application_choice) do
+      create(
+        :application_choice,
+        :declined,
+        declined_by_default: false,
+        current_recruitment_cycle_year: 2024,
+      )
+    end
+
+    it 'does not update records' do
+      expect { described_class.new.change }.not_to change { application_choice }
+    end
+  end
+end

--- a/spec/services/data_migrations/remove_dbd_from_current_cycle_spec.rb
+++ b/spec/services/data_migrations/remove_dbd_from_current_cycle_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe DataMigrations::RemoveDbdFromCurrentCycle do
       end
 
       it 'does not update records' do
-        expect { described_class.new.change }.not_to change { application_choice }
+        expect { described_class.new.change }.not_to(change { application_choice })
       end
     end
 
@@ -47,7 +47,7 @@ RSpec.describe DataMigrations::RemoveDbdFromCurrentCycle do
     end
 
     it 'does not update records' do
-      expect { described_class.new.change }.not_to change { application_choice }
+      expect { described_class.new.change }.not_to(change { application_choice })
     end
   end
 end


### PR DESCRIPTION
## Context

22 application choices (15 candidates) have been declined by default. Decline by Default is functionality that shouldn’t exist/happen any more.

So we need to return to offer made.

## Trello

https://trello.com/c/oaqDYTs8/983-application-choices-being-declined-by-default