### PR TITLE
Warning delete if deleting an app in production

### DIFF
--- a/app/views/support_interface/application_forms/delete_application/confirm_delete.html.erb
+++ b/app/views/support_interface/application_forms/delete_application/confirm_delete.html.erb
@@ -12,8 +12,8 @@
 
       <h1 class="govuk-heading-l">Are you sure you want to delete all the personal information for <%= @form.email_address %>?</h1>
 
-      <p class="govuk-body">This operation cannot be undone.</p>
-      <p class="govuk-body">You can only delete unsubmitted applications.</p>
+      <p class="govuk-body govuk-!-font-weight-bold">This operation cannot be undone.</p>
+      <p class="govuk-body">You can only delete the accounts of candidates with unsubmitted applications.</p>
 
       <%= f.govuk_text_field(
         :audit_comment_ticket,
@@ -29,7 +29,10 @@
         <%= f.govuk_check_box :accept_guidance, true, multiple: false, label: { text: 'I have read the guidance' }, link_errors: true %>
       <% end %>
 
-      <%= f.govuk_submit %>
+      <% if HostingEnvironment.production? %>
+        <%= govuk_warning_text(text: 'You are about to delete an account in the PRODUCTION environment.') %>
+      <% end %>
+      <%= f.govuk_submit('Delete candidate account', warning: true) %>
     <% end %>
   </div>
 </div>

--- a/spec/system/support_interface/delete_application_spec.rb
+++ b/spec/system/support_interface/delete_application_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'Delete a candidate application (by anonymising all of their data)
     when_i_click_delete_application
     then_i_see_a_confirmation_page_prompting_for_an_audit_comment
 
-    when_i_click_continue
+    when_i_delete_the_account
     then_i_see_a_validation_error
 
     when_i_add_an_audit_comment_and_click_continue
@@ -72,8 +72,8 @@ RSpec.feature 'Delete a candidate application (by anonymising all of their data)
     expect(page).to have_content('This operation cannot be undone.')
   end
 
-  def when_i_click_continue
-    click_button 'Continue'
+  def when_i_delete_the_account
+    click_button 'Delete candidate account'
   end
 
   def then_i_see_a_validation_error
@@ -87,7 +87,7 @@ RSpec.feature 'Delete a candidate application (by anonymising all of their data)
   def when_i_add_an_audit_comment_and_click_continue
     fill_in 'Zendesk ticket URL', with: 'https://becomingateacher.zendesk.com/agent/tickets/123'
     check 'I have read the guidance'
-    click_button 'Continue'
+    click_button 'Delete candidate account'
   end
 
   def then_i_see_the_application_page


### PR DESCRIPTION
## Context

Add an additional warning on the `confirm delete` view if the user is in the production environment and update the button styling to use a warning button.

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="766" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/5c4bbb71-a9ca-4730-8344-dfe1ae61b58d">|<img width="779" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/642ba1f9-b90b-45c3-a198-6e360166954d">|
