### PR TITLE
Add delimiter to data table component

### DIFF
--- a/app/components/publications/data_table_component.html.erb
+++ b/app/components/publications/data_table_component.html.erb
@@ -27,7 +27,7 @@
             <tr class="govuk-table__row">
               <th scope="row" class="govuk-table__header"><%= row.values.first %></th>
               <% row.values.from(1).each do |td| %>
-                <td class="govuk-table__cell"><%= td %></td>
+                <td class="govuk-table__cell"><%= number_with_delimiter(td) %></td>
               <% end %>
             </tr>
           <% end %>


### PR DESCRIPTION
## Context

We need to format the table numbers with a delimiter

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="454" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/01786f08-bf9e-448d-a74d-44db615577a0">|<img width="455" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/f829e0c2-5d99-4b08-b657-392ec1f4d078">|

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/UsxmoYFJ/959-monthly-statistics-add-delimiter-to-publicationsdatatablecomponent

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
