### PR TITLE
Update monthly statistics link

### DIFF
--- a/app/views/publications/monthly_statistics/v2/show.html.erb
+++ b/app/views/publications/monthly_statistics/v2/show.html.erb
@@ -281,7 +281,7 @@
     <p class="govuk-body">The Apply for teacher training (Apply) service is the only service for postgraduate Initial Teacher Training (ITT) applications in England to Higher Education Institution (HEI), School Centred Initial Teacher Training (SCITT)-based, School Direct, School Direct (salaried) and Teaching Apprenticeship courses.</p>
 
     <p class="govuk-body">
-      <%= govuk_link_to "View statistical releases from previous months during ITT#{@presenter.current_year}", publications_monthly_report_itt_url %>.
+    <%= govuk_link_to "View statistical releases from previous months during ITT#{@presenter.current_year}", 'https://www.gov.uk/government/publications/monthly-statistics-on-initial-teacher-training-recruitment-2023-to-2024' %>.
     </p>
 
     <p class="govuk-body">


### PR DESCRIPTION
## Context

The link is wrong. The correct one to use is:
https://www.gov.uk/government/publications/monthly-statistics-on-initial-teacher-training-recruitment-2023-to-2024

Unfortunately there's not a lot of consistency with the naming of this URL, so it's hardcoded for now.

## Changes proposed in this pull request

URL updated in the footnotes

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/0mbymkJX/980-fix-broken-link-in-monthly-stats-page

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
