### PR TITLE
Rectify table sort orders in Monthly Stats

### DIFF
--- a/app/lib/dfe/bigquery/application_metrics.rb
+++ b/app/lib/dfe/bigquery/application_metrics.rb
@@ -85,7 +85,8 @@ module DfE
           cycle_week:,
           subject_filter_category: 'Total excluding Further Education',
           nonsubject_filter_category: 'Total',
-        ).to_sql
+        )
+        .to_sql
       end
 
       def self.age_group_query(cycle_week:)
@@ -118,6 +119,7 @@ module DfE
           subject_filter_category: 'Total excluding Further Education',
           nonsubject_filter_category: 'Candidate region',
         )
+        .order(nonsubject_filter: :asc)
         .to_sql
       end
 
@@ -128,6 +130,7 @@ module DfE
           subject_filter_category: 'Total excluding Further Education',
           nonsubject_filter_category: 'Sex',
         )
+        .order(nonsubject_filter: :asc)
         .to_sql
       end
 
@@ -158,6 +161,7 @@ module DfE
           subject_filter_category: 'Secondary subject excluding Further Education',
           nonsubject_filter_category: 'Total',
         )
+        .order(subject_filter: :asc)
         .to_sql
       end
 
@@ -168,6 +172,7 @@ module DfE
           subject_filter_category: 'Total excluding Further Education',
           nonsubject_filter_category: 'Provider region',
         )
+        .order(nonsubject_filter: :asc)
         .to_sql
       end
 

--- a/app/lib/dfe/bigquery/table.rb
+++ b/app/lib/dfe/bigquery/table.rb
@@ -33,10 +33,25 @@ module DfE
         end
 
         if @order_clause.present?
-          base_sql << "ORDER BY #{@order_clause.keys.first} #{@order_clause.values.first.to_s.upcase}\n"
+          order_clause_key = @order_clause.keys.first
+          base_sql << "#{default_order_clause(order_clause_key)}, #{order_clause_key} #{@order_clause.values.first.to_s.upcase}\n"
         end
 
         base_sql
+      end
+
+    private
+
+      def default_order_clause(order_clause_key)
+        <<~SQL
+          ORDER BY (
+            CASE WHEN #{order_clause_key}='Prefer not to say' THEN 4
+                 WHEN #{order_clause_key}='Unknown' THEN 3
+                 WHEN #{order_clause_key}='Other' OR #{order_clause_key}='Others' THEN 2
+                 ELSE 1
+            END
+          )
+        SQL
       end
     end
   end

--- a/spec/lib/dfe/bigquery/application_metrics_spec.rb
+++ b/spec/lib/dfe/bigquery/application_metrics_spec.rb
@@ -72,7 +72,14 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
             AND cycle_week = 7
             AND subject_filter_category = "Total excluding Further Education"
             AND nonsubject_filter_category = "Age group"
-            ORDER BY nonsubject_filter ASC
+            ORDER BY (
+              CASE WHEN nonsubject_filter='Prefer not to say' THEN 4
+                   WHEN nonsubject_filter='Unknown' THEN 3
+                   WHEN nonsubject_filter='Other' OR nonsubject_filter='Others' THEN 2
+                   ELSE 1
+              END
+            )
+            , nonsubject_filter ASC
           SQL
         )
         .and_return(results)
@@ -125,6 +132,14 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
             AND cycle_week = 7
             AND subject_filter_category = "Total excluding Further Education"
             AND nonsubject_filter_category = "Sex"
+            ORDER BY (
+              CASE WHEN nonsubject_filter='Prefer not to say' THEN 4
+                   WHEN nonsubject_filter='Unknown' THEN 3
+                   WHEN nonsubject_filter='Other' OR nonsubject_filter='Others' THEN 2
+                   ELSE 1
+              END
+            )
+            , nonsubject_filter ASC
           SQL
         )
         .and_return(results)
@@ -168,6 +183,14 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
             AND cycle_week = 7
             AND subject_filter_category = "Total excluding Further Education"
             AND nonsubject_filter_category = "Candidate region"
+            ORDER BY (
+              CASE WHEN nonsubject_filter='Prefer not to say' THEN 4
+                   WHEN nonsubject_filter='Unknown' THEN 3
+                   WHEN nonsubject_filter='Other' OR nonsubject_filter='Others' THEN 2
+                   ELSE 1
+              END
+            )
+            , nonsubject_filter ASC
           SQL
         )
         .and_return(results)
@@ -212,7 +235,14 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
             AND subject_filter_category = "Level"
             AND nonsubject_filter_category = "Total"
             AND subject_filter != "Further Education"
-            ORDER BY subject_filter ASC
+            ORDER BY (
+              CASE WHEN subject_filter='Prefer not to say' THEN 4
+                   WHEN subject_filter='Unknown' THEN 3
+                   WHEN subject_filter='Other' OR subject_filter='Others' THEN 2
+                   ELSE 1
+              END
+            )
+            , subject_filter ASC
           SQL
         )
         .and_return(results)
@@ -345,6 +375,14 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
             AND cycle_week = 7
             AND subject_filter_category = "Secondary subject excluding Further Education"
             AND nonsubject_filter_category = "Total"
+            ORDER BY (
+              CASE WHEN subject_filter='Prefer not to say' THEN 4
+                   WHEN subject_filter='Unknown' THEN 3
+                   WHEN subject_filter='Other' OR subject_filter='Others' THEN 2
+                   ELSE 1
+              END
+            )
+            , subject_filter ASC
           SQL
         )
         .and_return(results)
@@ -389,6 +427,14 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
             AND cycle_week = 7
             AND subject_filter_category = "Total excluding Further Education"
             AND nonsubject_filter_category = "Provider region"
+            ORDER BY (
+              CASE WHEN nonsubject_filter='Prefer not to say' THEN 4
+                   WHEN nonsubject_filter='Unknown' THEN 3
+                   WHEN nonsubject_filter='Other' OR nonsubject_filter='Others' THEN 2
+                   ELSE 1
+              END
+            )
+            , nonsubject_filter ASC
           SQL
         )
         .and_return(results)

--- a/spec/lib/dfe/bigquery/table_spec.rb
+++ b/spec/lib/dfe/bigquery/table_spec.rb
@@ -39,14 +39,18 @@ RSpec.describe DfE::Bigquery::Table do
 
     context 'when order' do
       it 'returns order' do
-        expect(table.order(magic_name: :asc).to_sql).to eq(
-          <<~SQL,
+        expect(table.order(magic_name: :asc).to_sql.squish).to eq(
+          <<~SQL.squish,
             SELECT *
             FROM datapoint.magic_tricks
-            ORDER BY magic_name ASC
+            #{default_order_clause}, magic_name ASC
           SQL
         )
       end
     end
+  end
+
+  def default_order_clause
+    table.send(:default_order_clause, 'magic_name')
   end
 end


### PR DESCRIPTION
Sort all table values in this order:
- custom value
- anything containing "other"
- anything containing "unknown"
- anything containing "Prefer not to say".

![](https://github.trello.services/images/mini-trello-icon.png) [Rectify table sort orders in Monthly Stats](https://trello.com/c/sljloZDr/985-rectify-table-sort-orders-in-monthly-stats)

## Before examples:
<img width="252" alt="Screenshot 2023-11-23 at 13 48 15" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/655e4e10-e366-41e6-9341-e1f048a3757b">
<img width="162" alt="Screenshot 2023-11-23 at 13 48 20" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/74e1a51a-4f76-4598-a06c-dc5af1cf3344">
<img width="360" alt="Screenshot 2023-11-23 at 13 48 51" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/1cb231a6-0800-4770-91e8-d0e9e991eeba">

## After examples
<img width="222" alt="Screenshot 2023-11-23 at 16 44 49" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/6594fd9b-350e-4a9d-84d9-682513f61f9f">
<img width="311" alt="Screenshot 2023-11-23 at 16 44 54" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/3087556c-5ce8-4981-8251-dea6f51ee1c7">
<img width="380" alt="Screenshot 2023-11-23 at 16 45 06" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/c88608ad-2b35-450e-84b3-0abe159ddee2">
<img width="395" alt="Screenshot 2023-11-23 at 16 45 10" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/07d1768c-5dbc-4059-a5c8-53860baa047a">
