### PR TITLE
Hide status in the whole report with less than 3

### DIFF
--- a/app/models/publications/itt_monthly_report_generator.rb
+++ b/app/models/publications/itt_monthly_report_generator.rb
@@ -52,16 +52,19 @@ module Publications
       }
 
       SECTIONS.each do |section_identifier|
+        data = send(section_identifier)
+
         report[:data][section_identifier] = {
           title: I18n.t("publications.itt_monthly_report_generator.#{section_identifier}.title"),
           subtitle: I18n.t("publications.itt_monthly_report_generator.#{section_identifier}.subtitle"),
-          data: send(section_identifier),
+          data:,
         }
 
         report[:formats][:csv][section_identifier] = MonthlyStatistics::CSVSection.new(
           section_identifier:,
           records: bigquery_records[section_identifier],
           title_section: bigquery_title_section[section_identifier],
+          grouped_data: data,
         ).call
       end
 

--- a/app/models/publications/itt_monthly_report_generator.rb
+++ b/app/models/publications/itt_monthly_report_generator.rb
@@ -52,19 +52,17 @@ module Publications
       }
 
       SECTIONS.each do |section_identifier|
-        data = send(section_identifier)
-
         report[:data][section_identifier] = {
           title: I18n.t("publications.itt_monthly_report_generator.#{section_identifier}.title"),
           subtitle: I18n.t("publications.itt_monthly_report_generator.#{section_identifier}.subtitle"),
-          data:,
+          data: send(section_identifier),
         }
 
         report[:formats][:csv][section_identifier] = MonthlyStatistics::CSVSection.new(
           section_identifier:,
           records: bigquery_records[section_identifier],
           title_section: bigquery_title_section[section_identifier],
-          grouped_data: data,
+          headline_statistics: report[:data][:candidate_headline_statistics][:data],
         ).call
       end
 

--- a/app/models/publications/monthly_statistics/csv_section.rb
+++ b/app/models/publications/monthly_statistics/csv_section.rb
@@ -1,13 +1,13 @@
 module Publications
   module MonthlyStatistics
     class CSVSection
-      attr_reader :section_identifier, :records, :title_section, :grouped_data
+      attr_reader :section_identifier, :records, :title_section, :headline_statistics
 
-      def initialize(section_identifier:, records:, title_section:, grouped_data:)
+      def initialize(section_identifier:, records:, title_section:, headline_statistics:)
         @section_identifier = section_identifier
         @records = Array(records)
         @title_section = title_section
-        @grouped_data = grouped_data
+        @headline_statistics = headline_statistics
       end
 
       def call
@@ -55,11 +55,7 @@ module Publications
       end
 
       def status_attributes_headers
-        statuses = grouped_data.keys.reject do |status|
-          StatisticsDataProcessor.new(status_data: grouped_data[status]).violates_gdpr?
-        end
-
-        statuses.map do |status|
+        headline_statistics.keys.map do |status|
           status_title = I18n.t("publications.itt_monthly_report_generator.status.#{status}.title")
 
           ["#{status_title} this cycle", "#{status_title} last cycle"]
@@ -81,7 +77,7 @@ module Publications
       end
 
       def status_attributes(record)
-        grouped_data.each_key.map do |status|
+        headline_statistics.each_key.map do |status|
           [
             column_value_for(record:, status:, cycle: :this_cycle),
             column_value_for(record:, status:, cycle: :last_cycle),

--- a/app/models/publications/monthly_statistics/csv_section.rb
+++ b/app/models/publications/monthly_statistics/csv_section.rb
@@ -1,12 +1,13 @@
 module Publications
   module MonthlyStatistics
     class CSVSection
-      attr_reader :section_identifier, :records, :title_section
+      attr_reader :section_identifier, :records, :title_section, :grouped_data
 
-      def initialize(section_identifier:, records:, title_section:)
+      def initialize(section_identifier:, records:, title_section:, grouped_data:)
         @section_identifier = section_identifier
         @records = Array(records)
         @title_section = title_section
+        @grouped_data = grouped_data
       end
 
       def call
@@ -54,7 +55,11 @@ module Publications
       end
 
       def status_attributes_headers
-        I18n.t('publications.itt_monthly_report_generator.status').each_key.map do |status|
+        statuses = grouped_data.keys.reject do |status|
+          StatisticsDataProcessor.new(status_data: grouped_data[status]).violates_gdpr?
+        end
+
+        statuses.map do |status|
           status_title = I18n.t("publications.itt_monthly_report_generator.status.#{status}.title")
 
           ["#{status_title} this cycle", "#{status_title} last cycle"]
@@ -76,7 +81,7 @@ module Publications
       end
 
       def status_attributes(record)
-        I18n.t('publications.itt_monthly_report_generator.status').each_key.map do |status|
+        grouped_data.each_key.map do |status|
           [
             column_value_for(record:, status:, cycle: :this_cycle),
             column_value_for(record:, status:, cycle: :last_cycle),

--- a/app/models/publications/monthly_statistics/report_sections.rb
+++ b/app/models/publications/monthly_statistics/report_sections.rb
@@ -41,14 +41,16 @@ module Publications
       def candidate_headline_statistics(data = {})
         application_metrics = bigquery_records[:candidate_headline_statistics]
 
-        data.tap do |_d|
-          I18n.t('publications.itt_monthly_report_generator.status').each_key do |status|
-            data[status] = {
-              title: I18n.t("publications.itt_monthly_report_generator.status.#{status}.title"),
-              this_cycle: column_value_for(application_metrics:, status:, cycle: :this_cycle),
-              last_cycle: column_value_for(application_metrics:, status:, cycle: :last_cycle),
-            }
-          end
+        I18n.t('publications.itt_monthly_report_generator.status').each_key do |status|
+          data[status] = {
+            title: I18n.t("publications.itt_monthly_report_generator.status.#{status}.title"),
+            this_cycle: column_value_for(application_metrics:, status:, cycle: :this_cycle),
+            last_cycle: column_value_for(application_metrics:, status:, cycle: :last_cycle),
+          }
+        end
+
+        data.reject do |_, status_data|
+          ::Publications::MonthlyStatistics::StatisticsDataProcessor.new(status_data:).violates_gdpr?
         end
       end
 
@@ -127,20 +129,22 @@ module Publications
     private
 
       def group_data_for_report(results:, title_column:, data: {}, extra_columns: {})
-        data.tap do |_d|
-          I18n.t('publications.itt_monthly_report_generator.status').each_key do |status|
-            data[status] = results.map do |application_metrics|
-              {
-                title: application_metrics.send(title_column),
-                this_cycle: column_value_for(application_metrics:, status:, cycle: :this_cycle),
-                last_cycle: column_value_for(application_metrics:, status:, cycle: :last_cycle),
-              }.tap do |row|
-                extra_columns.each do |field, column|
-                  row[field] = application_metrics.send(column[:attribute])
-                end
+        I18n.t('publications.itt_monthly_report_generator.status').each_key do |status|
+          data[status] = results.map do |application_metrics|
+            {
+              title: application_metrics.send(title_column),
+              this_cycle: column_value_for(application_metrics:, status:, cycle: :this_cycle),
+              last_cycle: column_value_for(application_metrics:, status:, cycle: :last_cycle),
+            }.tap do |row|
+              extra_columns.each do |field, column|
+                row[field] = application_metrics.send(column[:attribute])
               end
             end
           end
+        end
+
+        data.reject do |_, status_data|
+          ::Publications::MonthlyStatistics::StatisticsDataProcessor.new(status_data:).violates_gdpr?
         end
       end
 

--- a/app/models/publications/monthly_statistics/report_sections.rb
+++ b/app/models/publications/monthly_statistics/report_sections.rb
@@ -129,7 +129,7 @@ module Publications
     private
 
       def group_data_for_report(results:, title_column:, data: {}, extra_columns: {})
-        I18n.t('publications.itt_monthly_report_generator.status').each_key do |status|
+        candidate_headline_statistics.each_key do |status|
           data[status] = results.map do |application_metrics|
             {
               title: application_metrics.send(title_column),
@@ -143,9 +143,7 @@ module Publications
           end
         end
 
-        data.reject do |_, status_data|
-          ::Publications::MonthlyStatistics::StatisticsDataProcessor.new(status_data:).violates_gdpr?
-        end
+        data
       end
 
       def column_value_for(application_metrics:, status:, cycle:)

--- a/app/models/publications/monthly_statistics/statistics_data_processor.rb
+++ b/app/models/publications/monthly_statistics/statistics_data_processor.rb
@@ -1,7 +1,7 @@
 module Publications
   module MonthlyStatistics
     class StatisticsDataProcessor
-      LOWER_STATS_THAT_VIOLATES_GDPR = 3
+      MINIMUM_GDPR_COMPLIANT_TOTAL = 3
       attr_reader :status_data
 
       def initialize(status_data:)
@@ -9,8 +9,8 @@ module Publications
       end
 
       def violates_gdpr?
-        totals[:this_cycle] < LOWER_STATS_THAT_VIOLATES_GDPR ||
-          totals[:last_cycle] < LOWER_STATS_THAT_VIOLATES_GDPR
+        totals[:this_cycle] < MINIMUM_GDPR_COMPLIANT_TOTAL ||
+          totals[:last_cycle] < MINIMUM_GDPR_COMPLIANT_TOTAL
       end
 
     private

--- a/app/models/publications/monthly_statistics/statistics_data_processor.rb
+++ b/app/models/publications/monthly_statistics/statistics_data_processor.rb
@@ -1,0 +1,32 @@
+module Publications
+  module MonthlyStatistics
+    class StatisticsDataProcessor
+      LOWER_STATS_THAT_VIOLATES_GDPR = 3
+      attr_reader :status_data
+
+      def initialize(status_data:)
+        @status_data = status_data
+      end
+
+      def violates_gdpr?
+        totals[:this_cycle] < LOWER_STATS_THAT_VIOLATES_GDPR ||
+          totals[:last_cycle] < LOWER_STATS_THAT_VIOLATES_GDPR
+      end
+
+    private
+
+      def totals
+        return @status_data if headline_statistics?
+
+        {
+          this_cycle: @status_data.sum { |data| data[:this_cycle] },
+          last_cycle: @status_data.sum { |data| data[:last_cycle] },
+        }
+      end
+
+      def headline_statistics?
+        @status_data.is_a?(Hash)
+      end
+    end
+  end
+end

--- a/app/models/publications/monthly_statistics/statistics_data_processor.rb
+++ b/app/models/publications/monthly_statistics/statistics_data_processor.rb
@@ -9,23 +9,8 @@ module Publications
       end
 
       def violates_gdpr?
-        totals[:this_cycle] < MINIMUM_GDPR_COMPLIANT_TOTAL ||
-          totals[:last_cycle] < MINIMUM_GDPR_COMPLIANT_TOTAL
-      end
-
-    private
-
-      def totals
-        return @status_data if headline_statistics?
-
-        {
-          this_cycle: @status_data.sum { |data| data[:this_cycle] },
-          last_cycle: @status_data.sum { |data| data[:last_cycle] },
-        }
-      end
-
-      def headline_statistics?
-        @status_data.is_a?(Hash)
+        @status_data[:this_cycle] < MINIMUM_GDPR_COMPLIANT_TOTAL ||
+          @status_data[:last_cycle] < MINIMUM_GDPR_COMPLIANT_TOTAL
       end
     end
   end

--- a/app/presenters/publications/v2/monthly_statistics_presenter.rb
+++ b/app/presenters/publications/v2/monthly_statistics_presenter.rb
@@ -11,41 +11,39 @@ module Publications
       end
 
       def headline_stats
-        statistics.dig(:data, :candidate_headline_statistics)[:data]
-          .deep_merge(I18n.t('publications.itt_monthly_report_generator.status'))
-          .values
+        statistics_data_for(:candidate_headline_statistics, status_merge: true)
       end
 
       def by_age
-        statistics.dig(:data, :candidate_age_group)
+        statistics_data_for(:candidate_age_group)
       end
 
       def by_sex
-        statistics.dig(:data, :candidate_sex)
+        statistics_data_for(:candidate_sex)
       end
 
       def by_area
-        statistics.dig(:data, :candidate_area)
+        statistics_data_for(:candidate_area)
       end
 
       def by_phase
-        statistics.dig(:data, :candidate_phase)
+        statistics_data_for(:candidate_phase)
       end
 
       def by_route
-        statistics.dig(:data, :candidate_route_into_teaching)
+        statistics_data_for(:candidate_route_into_teaching)
       end
 
       def by_primary_subject
-        statistics.dig(:data, :candidate_primary_subject)
+        statistics_data_for(:candidate_primary_subject)
       end
 
       def by_secondary_subject
-        statistics.dig(:data, :candidate_secondary_subject)
+        statistics_data_for(:candidate_secondary_subject)
       end
 
       def by_provider_region
-        statistics.dig(:data, :candidate_provider_region)
+        statistics_data_for(:candidate_provider_region)
       end
 
       def current_reporting_period
@@ -80,10 +78,6 @@ module Publications
         MonthlyStatisticsTimetable.next_publication_date
       end
 
-      def deferred_applications_count
-        statistics.dig(:data, :candidate_headline_statistics, :deferred_applications_count) || 0
-      end
-
       def previous_year
         current_year - 1
       end
@@ -94,6 +88,22 @@ module Publications
 
       def csvs
         statistics.dig(:formats, :csv)
+      end
+
+    private
+
+      def statistics_data_for(section_name, status_merge: false)
+        section = statistics.dig(:data, section_name)
+
+        return section if status_merge.blank?
+
+        section[:data].each_key do |status|
+          section[:data][status].merge!(
+            I18n.t("publications.itt_monthly_report_generator.status.#{status}"),
+          )
+        end
+
+        section[:data].values
       end
     end
   end

--- a/spec/models/publications/itt_monthly_report_generator_spec.rb
+++ b/spec/models/publications/itt_monthly_report_generator_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
       number_of_candidates_submitted_to_date: 8586,
       number_of_candidates_submitted_to_same_date_previous_cycle: 5160,
       number_of_candidates_who_did_not_meet_any_offer_conditions_this_cycle_to_date: 0,
-      number_of_candidates_who_did_not_meet_any_offer_conditions_this_cycle_to_same_date_previous_cycle: 0,
+      number_of_candidates_who_did_not_meet_any_offer_conditions_this_cycle_to_same_date_previous_cycle: 1,
       number_of_candidates_who_had_all_applications_rejected_this_cycle_to_date: 246,
       number_of_candidates_who_had_all_applications_rejected_this_cycle_to_same_date_previous_cycle: 131,
-      number_of_candidates_with_all_accepted_offers_withdrawn_this_cycle_to_date: 1,
-      number_of_candidates_with_all_accepted_offers_withdrawn_this_cycle_to_same_date_previous_cycle: 0,
+      number_of_candidates_with_all_accepted_offers_withdrawn_this_cycle_to_date: 7,
+      number_of_candidates_with_all_accepted_offers_withdrawn_this_cycle_to_same_date_previous_cycle: 6,
       number_of_candidates_with_deferred_offers_from_this_cycle_to_date: 0,
       number_of_candidates_with_deferred_offers_from_this_cycle_to_same_date_previous_cycle: 0,
       number_of_candidates_with_offers_to_date: 598,
@@ -263,6 +263,11 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
             this_cycle: 285,
             last_cycle: 213,
           },
+          withdrawn: {
+            title: 'Withdrawn',
+            this_cycle: 7,
+            last_cycle: 6,
+          },
         },
       })
     end
@@ -312,13 +317,6 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
               title: '21',
               this_cycle: 200,
               last_cycle: 100,
-            },
-          ],
-          conditions_not_met: [
-            {
-              title: '21',
-              this_cycle: 30,
-              last_cycle: 15,
             },
           ],
         },
@@ -371,13 +369,6 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
                 title: 'Male',
                 this_cycle: 200,
                 last_cycle: 100,
-              },
-            ],
-            conditions_not_met: [
-              {
-                title: 'Male',
-                this_cycle: 30,
-                last_cycle: 15,
               },
             ],
           },
@@ -433,13 +424,6 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
                 last_cycle: 100,
               },
             ],
-            conditions_not_met: [
-              {
-                title: 'Gondor',
-                this_cycle: 30,
-                last_cycle: 15,
-              },
-            ],
           },
         },
       )
@@ -491,13 +475,6 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
                 title: 'Primary',
                 this_cycle: 200,
                 last_cycle: 100,
-              },
-            ],
-            conditions_not_met: [
-              {
-                title: 'Primary',
-                this_cycle: 30,
-                last_cycle: 15,
               },
             ],
           },
@@ -553,13 +530,6 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
                 last_cycle: 100,
               },
             ],
-            conditions_not_met: [
-              {
-                title: 'Higher education',
-                this_cycle: 30,
-                last_cycle: 15,
-              },
-            ],
           },
         },
       )
@@ -611,13 +581,6 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
                 title: 'Primary with English',
                 this_cycle: 200,
                 last_cycle: 100,
-              },
-            ],
-            conditions_not_met: [
-              {
-                title: 'Primary with English',
-                this_cycle: 30,
-                last_cycle: 15,
               },
             ],
           },
@@ -673,13 +636,6 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
                 last_cycle: 100,
               },
             ],
-            conditions_not_met: [
-              {
-                title: 'Drama',
-                this_cycle: 30,
-                last_cycle: 15,
-              },
-            ],
           },
         },
       )
@@ -731,13 +687,6 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
                 title: 'Hogsmeade',
                 this_cycle: 200,
                 last_cycle: 100,
-              },
-            ],
-            conditions_not_met: [
-              {
-                title: 'Hogsmeade',
-                this_cycle: 30,
-                last_cycle: 15,
               },
             ],
           },
@@ -870,26 +819,6 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
               subject: 'Music',
             },
           ],
-          conditions_not_met: [
-            {
-              title: 'Fangorn Forest',
-              this_cycle: 30,
-              last_cycle: 15,
-              subject: 'Geography',
-            },
-            {
-              title: 'Fangorn Forest',
-              this_cycle: 30,
-              last_cycle: 15,
-              subject: 'History',
-            },
-            {
-              title: 'Fangorn Forest',
-              this_cycle: 30,
-              last_cycle: 15,
-              subject: 'Music',
-            },
-          ],
         },
       )
     end
@@ -1019,83 +948,63 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
               subject: 'Mathematics',
             },
           ],
-          conditions_not_met: [
-            {
-              title: 'Isengard',
-              this_cycle: 30,
-              last_cycle: 15,
-              subject: 'Drama',
-            },
-            {
-              title: 'Isengard',
-              this_cycle: 30,
-              last_cycle: 15,
-              subject: 'Primary with Mathematics',
-            },
-            {
-              title: 'Isengard',
-              this_cycle: 30,
-              last_cycle: 15,
-              subject: 'Mathematics',
-            },
-          ],
         },
       )
     end
 
     it 'returns candidate headline statistics into CSV (ignoring status less than 3 records)' do
       expect(report[:formats][:csv][:candidate_headline_statistics]).to eq(
-        size: 330,
-        data: "Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle\n8586,5160,598,567,538,478,246,131,285,213\n",
+        size: 376,
+        data: "Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Withdrawn this cycle,Withdrawn last cycle\n8586,5160,598,567,538,478,246,131,285,213,7,6\n",
       )
     end
 
     it 'returns candidate age group into CSV' do
       expect(report[:formats][:csv][:candidate_age_group]).to eq(
-        size: 466,
-        data: "Age Group,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\n21,400,200,598,567,20,10,100,50,285,213,200,100,30,15\n",
+        size: 388,
+        data: "Age Group,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Withdrawn this cycle,Withdrawn last cycle\n21,400,200,598,567,20,10,100,50,285,213,200,100\n",
       )
     end
 
     it 'returns candidate sex into CSV' do
       expect(report[:formats][:csv][:candidate_sex]).to eq(
-        size: 462,
-        data: "Sex,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\nMale,400,200,598,567,20,10,100,50,285,213,200,100,30,15\n",
+        size: 384,
+        data: "Sex,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Withdrawn this cycle,Withdrawn last cycle\nMale,400,200,598,567,20,10,100,50,285,213,200,100\n",
       )
     end
 
     it 'returns candidate area into CSV' do
       expect(report[:formats][:csv][:candidate_area]).to eq(
-        size: 465,
-        data: "Area,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\nGondor,400,200,598,567,20,10,100,50,285,213,200,100,30,15\n",
+        size: 387,
+        data: "Area,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Withdrawn this cycle,Withdrawn last cycle\nGondor,400,200,598,567,20,10,100,50,285,213,200,100\n",
       )
     end
 
     it 'returns candidate phase into CSV' do
       expect(report[:formats][:csv][:candidate_phase]).to eq(
-        size: 474,
-        data: "Course Phase,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\nPrimary,400,200,598,567,20,10,100,50,285,213,200,100,30,15\n",
+        size: 396,
+        data: "Course Phase,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Withdrawn this cycle,Withdrawn last cycle\nPrimary,400,200,598,567,20,10,100,50,285,213,200,100\n",
       )
     end
 
     it 'returns candidate route into teaching into CSV' do
       expect(report[:formats][:csv][:candidate_route_into_teaching]).to eq(
-        size: 482,
-        data: "Course type,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\nHigher education,400,200,598,567,20,10,100,50,285,213,200,100,30,15\n",
+        size: 404,
+        data: "Course type,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Withdrawn this cycle,Withdrawn last cycle\nHigher education,400,200,598,567,20,10,100,50,285,213,200,100\n",
       )
     end
 
     it 'returns provider area and subject into CSV' do
       expect(report[:formats][:csv][:candidate_provider_region_and_subject]).to eq(
-        size: 639,
-        data: "Region,Subject,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\nFangorn Forest,Geography,400,200,598,567,20,10,100,50,285,213,200,100,30,15\nFangorn Forest,History,400,200,598,567,20,10,100,50,285,213,200,100,30,15\nFangorn Forest,Music,400,200,598,567,20,10,100,50,285,213,200,100,30,15\n",
+        size: 549,
+        data: "Region,Subject,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Withdrawn this cycle,Withdrawn last cycle\nFangorn Forest,Geography,400,200,598,567,20,10,100,50,285,213,200,100\nFangorn Forest,History,400,200,598,567,20,10,100,50,285,213,200,100\nFangorn Forest,Music,400,200,598,567,20,10,100,50,285,213,200,100\n",
       )
     end
 
     it 'returns candidate area and subject into CSV' do
       expect(report[:formats][:csv][:candidate_area_and_subject]).to eq(
-        size: 638,
-        data: "Area,Subject,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\nIsengard,Drama,400,200,598,567,20,10,100,50,285,213,200,100,30,15\nIsengard,Primary with Mathematics,400,200,598,567,20,10,100,50,285,213,200,100,30,15\nIsengard,Mathematics,400,200,598,567,20,10,100,50,285,213,200,100,30,15\n",
+        size: 548,
+        data: "Area,Subject,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Withdrawn this cycle,Withdrawn last cycle\nIsengard,Drama,400,200,598,567,20,10,100,50,285,213,200,100\nIsengard,Primary with Mathematics,400,200,598,567,20,10,100,50,285,213,200,100\nIsengard,Mathematics,400,200,598,567,20,10,100,50,285,213,200,100\n",
       )
     end
   end

--- a/spec/models/publications/itt_monthly_report_generator_spec.rb
+++ b/spec/models/publications/itt_monthly_report_generator_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
       })
     end
 
-    it 'returns candidate headline statistics' do
+    it 'returns candidate headline statistics (ignoring status less than 3 records)' do
       expect(report[:data][:candidate_headline_statistics]).to eq({
         title: 'Candidate Headline statistics',
         subtitle: 'Headline Statistics',
@@ -262,21 +262,6 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
             title: 'Reconfirmed from previous cycle',
             this_cycle: 285,
             last_cycle: 213,
-          },
-          deferred: {
-            title: 'Deferred',
-            this_cycle: 0,
-            last_cycle: 0,
-          },
-          withdrawn: {
-            title: 'Withdrawn',
-            this_cycle: 1,
-            last_cycle: 0,
-          },
-          conditions_not_met: {
-            title: 'Offer conditions not met',
-            this_cycle: 0,
-            last_cycle: 0,
           },
         },
       })
@@ -322,13 +307,6 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
               last_cycle: 213,
             },
           ],
-          deferred: [
-            {
-              title: '21',
-              this_cycle: 0,
-              last_cycle: 0,
-            },
-          ],
           withdrawn: [
             {
               title: '21',
@@ -347,7 +325,7 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
       })
     end
 
-    it 'returns sex data' do
+    it 'returns sex data (ignoring status less than 3 records)' do
       expect(report[:data][:candidate_sex]).to eq(
         {
           title: 'Candidate statistics by sex',
@@ -388,13 +366,6 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
                 last_cycle: 213,
               },
             ],
-            deferred: [
-              {
-                title: 'Male',
-                this_cycle: 0,
-                last_cycle: 0,
-              },
-            ],
             withdrawn: [
               {
                 title: 'Male',
@@ -414,7 +385,7 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
       )
     end
 
-    it 'returns area data' do
+    it 'returns area data (ignoring status less than 3 records)' do
       expect(report[:data][:candidate_area]).to eq(
         {
           title: 'Candidate statistics by UK region or country, or other area',
@@ -455,13 +426,6 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
                 last_cycle: 213,
               },
             ],
-            deferred: [
-              {
-                title: 'Gondor',
-                this_cycle: 0,
-                last_cycle: 0,
-              },
-            ],
             withdrawn: [
               {
                 title: 'Gondor',
@@ -481,7 +445,7 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
       )
     end
 
-    it 'returns phase data' do
+    it 'returns phase data (ignoring status less than 3 records)' do
       expect(report[:data][:candidate_phase]).to eq(
         {
           title: 'Candidate statistics by course phase',
@@ -522,13 +486,6 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
                 last_cycle: 213,
               },
             ],
-            deferred: [
-              {
-                title: 'Primary',
-                this_cycle: 0,
-                last_cycle: 0,
-              },
-            ],
             withdrawn: [
               {
                 title: 'Primary',
@@ -548,7 +505,7 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
       )
     end
 
-    it 'returns route into teaching data' do
+    it 'returns route into teaching data (ignoring status less than 3 records)' do
       expect(report[:data][:candidate_route_into_teaching]).to eq(
         {
           title: 'Candidate statistics by route into teaching',
@@ -589,13 +546,6 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
                 last_cycle: 213,
               },
             ],
-            deferred: [
-              {
-                title: 'Higher education',
-                this_cycle: 0,
-                last_cycle: 0,
-              },
-            ],
             withdrawn: [
               {
                 title: 'Higher education',
@@ -615,7 +565,7 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
       )
     end
 
-    it 'returns primary subject data' do
+    it 'returns primary subject data (ignoring status less than 3 records)' do
       expect(report[:data][:candidate_primary_subject]).to eq(
         {
           title: 'Candidate statistics by primary specialist subject',
@@ -656,13 +606,6 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
                 last_cycle: 213,
               },
             ],
-            deferred: [
-              {
-                title: 'Primary with English',
-                this_cycle: 0,
-                last_cycle: 0,
-              },
-            ],
             withdrawn: [
               {
                 title: 'Primary with English',
@@ -682,7 +625,7 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
       )
     end
 
-    it 'returns secondary subject data' do
+    it 'returns secondary subject data (ignoring status less than 3 records)' do
       expect(report[:data][:candidate_secondary_subject]).to eq(
         {
           title: 'Candidate statistics by secondary subject',
@@ -723,13 +666,6 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
                 last_cycle: 213,
               },
             ],
-            deferred: [
-              {
-                title: 'Drama',
-                this_cycle: 0,
-                last_cycle: 0,
-              },
-            ],
             withdrawn: [
               {
                 title: 'Drama',
@@ -749,7 +685,7 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
       )
     end
 
-    it 'returns provider region data' do
+    it 'returns provider region data (ignoring status less than 3 records)' do
       expect(report[:data][:candidate_provider_region]).to eq(
         {
           title: 'Candidate statistics by training provider region of England',
@@ -790,13 +726,6 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
                 last_cycle: 213,
               },
             ],
-            deferred: [
-              {
-                title: 'Hogsmeade',
-                this_cycle: 0,
-                last_cycle: 0,
-              },
-            ],
             withdrawn: [
               {
                 title: 'Hogsmeade',
@@ -816,7 +745,7 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
       )
     end
 
-    it 'returns provider region with subject' do
+    it 'returns provider region with subject (ignoring status less than 3 records)' do
       expect(report[:data][:candidate_provider_region_and_subject]).to eq(
         title: 'Candidate statistics by provider region of England and subject',
         subtitle: 'Region',
@@ -921,26 +850,6 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
               subject: 'Music',
             },
           ],
-          deferred: [
-            {
-              title: 'Fangorn Forest',
-              this_cycle: 0,
-              last_cycle: 0,
-              subject: 'Geography',
-            },
-            {
-              title: 'Fangorn Forest',
-              this_cycle: 0,
-              last_cycle: 0,
-              subject: 'History',
-            },
-            {
-              title: 'Fangorn Forest',
-              this_cycle: 0,
-              last_cycle: 0,
-              subject: 'Music',
-            },
-          ],
           withdrawn: [
             {
               title: 'Fangorn Forest',
@@ -985,7 +894,7 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
       )
     end
 
-    it 'returns candidate area with subject' do
+    it 'returns candidate area with subject (ignoring status less than 3 records)' do
       expect(report[:data][:candidate_area_and_subject]).to eq(
         title: 'Candidate statistics by UK region or country, or other area, and subject',
         subtitle: 'Area',
@@ -1090,26 +999,6 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
               subject: 'Mathematics',
             },
           ],
-          deferred: [
-            {
-              title: 'Isengard',
-              this_cycle: 0,
-              last_cycle: 0,
-              subject: 'Drama',
-            },
-            {
-              title: 'Isengard',
-              this_cycle: 0,
-              last_cycle: 0,
-              subject: 'Primary with Mathematics',
-            },
-            {
-              title: 'Isengard',
-              this_cycle: 0,
-              last_cycle: 0,
-              subject: 'Mathematics',
-            },
-          ],
           withdrawn: [
             {
               title: 'Isengard',
@@ -1154,59 +1043,59 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
       )
     end
 
-    it 'returns candidate headline statistics into CSV' do
+    it 'returns candidate headline statistics into CSV (ignoring status less than 3 records)' do
       expect(report[:formats][:csv][:candidate_headline_statistics]).to eq(
-        size: 496,
-        data: "Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Deferred this cycle,Deferred last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\n8586,5160,598,567,538,478,246,131,285,213,0,0,1,0,0,0\n",
+        size: 330,
+        data: "Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle\n8586,5160,598,567,538,478,246,131,285,213\n",
       )
     end
 
     it 'returns candidate age group into CSV' do
       expect(report[:formats][:csv][:candidate_age_group]).to eq(
-        size: 510,
-        data: "Age Group,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Deferred this cycle,Deferred last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\n21,400,200,598,567,20,10,100,50,285,213,0,0,200,100,30,15\n",
+        size: 466,
+        data: "Age Group,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\n21,400,200,598,567,20,10,100,50,285,213,200,100,30,15\n",
       )
     end
 
     it 'returns candidate sex into CSV' do
       expect(report[:formats][:csv][:candidate_sex]).to eq(
-        size: 506,
-        data: "Sex,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Deferred this cycle,Deferred last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\nMale,400,200,598,567,20,10,100,50,285,213,0,0,200,100,30,15\n",
+        size: 462,
+        data: "Sex,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\nMale,400,200,598,567,20,10,100,50,285,213,200,100,30,15\n",
       )
     end
 
     it 'returns candidate area into CSV' do
       expect(report[:formats][:csv][:candidate_area]).to eq(
-        size: 509,
-        data: "Area,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Deferred this cycle,Deferred last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\nGondor,400,200,598,567,20,10,100,50,285,213,0,0,200,100,30,15\n",
+        size: 465,
+        data: "Area,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\nGondor,400,200,598,567,20,10,100,50,285,213,200,100,30,15\n",
       )
     end
 
     it 'returns candidate phase into CSV' do
       expect(report[:formats][:csv][:candidate_phase]).to eq(
-        size: 518,
-        data: "Course Phase,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Deferred this cycle,Deferred last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\nPrimary,400,200,598,567,20,10,100,50,285,213,0,0,200,100,30,15\n",
+        size: 474,
+        data: "Course Phase,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\nPrimary,400,200,598,567,20,10,100,50,285,213,200,100,30,15\n",
       )
     end
 
     it 'returns candidate route into teaching into CSV' do
       expect(report[:formats][:csv][:candidate_route_into_teaching]).to eq(
-        size: 526,
-        data: "Course type,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Deferred this cycle,Deferred last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\nHigher education,400,200,598,567,20,10,100,50,285,213,0,0,200,100,30,15\n",
+        size: 482,
+        data: "Course type,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\nHigher education,400,200,598,567,20,10,100,50,285,213,200,100,30,15\n",
       )
     end
 
     it 'returns provider area and subject into CSV' do
       expect(report[:formats][:csv][:candidate_provider_region_and_subject]).to eq(
-        size: 691,
-        data: "Region,Subject,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Deferred this cycle,Deferred last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\nFangorn Forest,Geography,400,200,598,567,20,10,100,50,285,213,0,0,200,100,30,15\nFangorn Forest,History,400,200,598,567,20,10,100,50,285,213,0,0,200,100,30,15\nFangorn Forest,Music,400,200,598,567,20,10,100,50,285,213,0,0,200,100,30,15\n",
+        size: 639,
+        data: "Region,Subject,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\nFangorn Forest,Geography,400,200,598,567,20,10,100,50,285,213,200,100,30,15\nFangorn Forest,History,400,200,598,567,20,10,100,50,285,213,200,100,30,15\nFangorn Forest,Music,400,200,598,567,20,10,100,50,285,213,200,100,30,15\n",
       )
     end
 
     it 'returns candidate area and subject into CSV' do
       expect(report[:formats][:csv][:candidate_area_and_subject]).to eq(
-        size: 690,
-        data: "Area,Subject,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Deferred this cycle,Deferred last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\nIsengard,Drama,400,200,598,567,20,10,100,50,285,213,0,0,200,100,30,15\nIsengard,Primary with Mathematics,400,200,598,567,20,10,100,50,285,213,0,0,200,100,30,15\nIsengard,Mathematics,400,200,598,567,20,10,100,50,285,213,0,0,200,100,30,15\n",
+        size: 638,
+        data: "Area,Subject,Submitted this cycle,Submitted last cycle,With offers this cycle,With offers last cycle,Accepted this cycle,Accepted last cycle,All applications rejected this cycle,All applications rejected last cycle,Reconfirmed from previous cycle this cycle,Reconfirmed from previous cycle last cycle,Withdrawn this cycle,Withdrawn last cycle,Offer conditions not met this cycle,Offer conditions not met last cycle\nIsengard,Drama,400,200,598,567,20,10,100,50,285,213,200,100,30,15\nIsengard,Primary with Mathematics,400,200,598,567,20,10,100,50,285,213,200,100,30,15\nIsengard,Mathematics,400,200,598,567,20,10,100,50,285,213,200,100,30,15\n",
       )
     end
   end

--- a/spec/models/publications/monthly_statistics/statistics_data_processor_spec.rb
+++ b/spec/models/publications/monthly_statistics/statistics_data_processor_spec.rb
@@ -17,54 +17,12 @@ RSpec.describe Publications::MonthlyStatistics::StatisticsDataProcessor do
       end
     end
 
-    context 'when violates GDPR in other sections' do
-      let(:status_data) do
-        [
-          {
-            title: 'London',
-            this_cycle: 0,
-            last_cycle: 10,
-          },
-          {
-            title: 'Other',
-            this_cycle: 1,
-            last_cycle: 10,
-          },
-        ]
-      end
-
-      it 'returns true' do
-        expect(violates_gdpr?).to be true
-      end
-    end
-
     context 'when does not violates GDPR in headline statistics' do
       let(:status_data) do
         {
           this_cycle: 4,
           last_cycle: 10,
         }
-      end
-
-      it 'returns false' do
-        expect(violates_gdpr?).to be false
-      end
-    end
-
-    context 'when does not violates GDPR in other sections' do
-      let(:status_data) do
-        [
-          {
-            title: 'London',
-            this_cycle: 3,
-            last_cycle: 10,
-          },
-          {
-            title: 'Other',
-            this_cycle: 1,
-            last_cycle: 10,
-          },
-        ]
       end
 
       it 'returns false' do

--- a/spec/models/publications/monthly_statistics/statistics_data_processor_spec.rb
+++ b/spec/models/publications/monthly_statistics/statistics_data_processor_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.describe Publications::MonthlyStatistics::StatisticsDataProcessor do
+  describe '#violates_gdpr?' do
+    subject(:violates_gdpr?) { described_class.new(status_data:).violates_gdpr? }
+
+    context 'when violates GDPR in headline statistics' do
+      let(:status_data) do
+        {
+          this_cycle: 1,
+          last_cycle: 10,
+        }
+      end
+
+      it 'returns true' do
+        expect(violates_gdpr?).to be true
+      end
+    end
+
+    context 'when violates GDPR in other sections' do
+      let(:status_data) do
+        [
+          {
+            title: 'London',
+            this_cycle: 0,
+            last_cycle: 10,
+          },
+          {
+            title: 'Other',
+            this_cycle: 1,
+            last_cycle: 10,
+          },
+        ]
+      end
+
+      it 'returns true' do
+        expect(violates_gdpr?).to be true
+      end
+    end
+
+    context 'when does not violates GDPR in headline statistics' do
+      let(:status_data) do
+        {
+          this_cycle: 4,
+          last_cycle: 10,
+        }
+      end
+
+      it 'returns false' do
+        expect(violates_gdpr?).to be false
+      end
+    end
+
+    context 'when does not violates GDPR in other sections' do
+      let(:status_data) do
+        [
+          {
+            title: 'London',
+            this_cycle: 3,
+            last_cycle: 10,
+          },
+          {
+            title: 'Other',
+            this_cycle: 1,
+            last_cycle: 10,
+          },
+        ]
+      end
+
+      it 'returns false' do
+        expect(violates_gdpr?).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

In the current month of Monthly stats (November 2023), the total figures for Deferrals and Offer conditions not met is 1 which means we fear it's a GDPR breach that the perturbations the D&I team have put in place will not work (any doubts about perturbations talk with D&I team).

## Guidance to review

1. Does Deferred and Conditions not met disappear from the report?
2. Does the CSV also hides the same statuses?
