### PR TITLE
Ensure consistent timestamps in diversity report export

### DIFF
--- a/app/services/provider_interface/diversity_report_export.rb
+++ b/app/services/provider_interface/diversity_report_export.rb
@@ -14,12 +14,12 @@ module ProviderInterface
 
     def call
       export_folder = "tmp/#{Time.zone.today}-xr-export"
+      timestamp = Time.zone.now.strftime('%Y%m%d_%H%M%S')
 
       FileUtils.mkdir_p(export_folder)
 
       %w[sex disability ethnicity age].each do |type|
         export_data = send("#{type}_export")
-        timestamp = Time.zone.now.strftime('%Y%m%d_%H%M%S')
         csv_filename = "#{type}_#{timestamp}.csv"
         File.write("#{export_folder}/#{csv_filename}", export_data)
       end
@@ -27,7 +27,6 @@ module ProviderInterface
       zip_filename = "#{export_folder}.zip"
       Zip::OutputStream.open(zip_filename) do |zos|
         %w[sex disability ethnicity age].each do |type|
-          timestamp = Time.zone.now.strftime('%Y%m%d_%H%M%S')
           csv_filename = "#{type}_#{timestamp}.csv"
           zos.put_next_entry(csv_filename)
           zos.write(File.read("#{export_folder}/#{csv_filename}"))

--- a/spec/services/provider_interface/diversity_report_export_spec.rb
+++ b/spec/services/provider_interface/diversity_report_export_spec.rb
@@ -17,16 +17,18 @@ RSpec.describe ProviderInterface::DiversityReportExport do
     end
 
     it 'creates and returns a zip file containing CSV files' do
-      zip_file = export.call
-      expect(zip_file).to be_a(String)
-      expect(File.exist?(zip_file)).to be(true)
+      Timecop.scale(100) do
+        zip_file = export.call
+        expect(zip_file).to be_a(String)
+        expect(File.exist?(zip_file)).to be(true)
 
-      %w[sex disability ethnicity age].each do |type|
-        csv_filename = "#{type}_*.csv"
-        expect(zip_file).to have_csv_files(csv_filename)
+        %w[sex disability ethnicity age].each do |type|
+          csv_filename = "#{type}_*.csv"
+          expect(zip_file).to have_csv_files(csv_filename)
 
-        csv_data = export.send("#{type}_export")
-        expect(zip_file).to have_csv_file_content(csv_filename, csv_data)
+          csv_data = export.send("#{type}_export")
+          expect(zip_file).to have_csv_file_content(csv_filename, csv_data)
+        end
       end
     end
   end


### PR DESCRIPTION
## Context

This is “possibly” the cause of a bug where the timestamps could be different, leading to mismatched filenames when creating and reading.

https://dfe-teacher-services.sentry.io/issues/4285141489/?alert_rule_id=853774&alert_type=issue&notification_uuid=95e37bbc-a730-48c3-84b2-55c0360549f8&project=1765973&referrer=slack

## Changes proposed in this pull request

Ensures consistent timestamp usage throughout the export operation, possibly resolving related file mismatch issues.
