### PR TITLE
Sort 'Route into teaching' and 'Primary specialist subject' tables

### DIFF
--- a/app/lib/dfe/bigquery/application_metrics.rb
+++ b/app/lib/dfe/bigquery/application_metrics.rb
@@ -141,6 +141,7 @@ module DfE
           subject_filter_category: 'Total excluding Further Education',
           nonsubject_filter_category: 'Route into teaching',
         )
+        .order(nonsubject_filter: :asc)
         .to_sql
       end
 
@@ -151,6 +152,7 @@ module DfE
           subject_filter_category: 'Primary subject',
           nonsubject_filter_category: 'Total',
         )
+        .order(subject_filter: :asc)
         .to_sql
       end
 

--- a/spec/lib/dfe/bigquery/application_metrics_spec.rb
+++ b/spec/lib/dfe/bigquery/application_metrics_spec.rb
@@ -287,6 +287,14 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
             AND cycle_week = 7
             AND subject_filter_category = "Total excluding Further Education"
             AND nonsubject_filter_category = "Route into teaching"
+            ORDER BY (
+              CASE WHEN nonsubject_filter='Prefer not to say' THEN 4
+                   WHEN nonsubject_filter='Unknown' THEN 3
+                   WHEN nonsubject_filter='Other' OR nonsubject_filter='Others' THEN 2
+                   ELSE 1
+              END
+            )
+            , nonsubject_filter ASC
           SQL
         )
         .and_return(results)
@@ -331,6 +339,14 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
             AND cycle_week = 7
             AND subject_filter_category = "Primary subject"
             AND nonsubject_filter_category = "Total"
+            ORDER BY (
+              CASE WHEN subject_filter='Prefer not to say' THEN 4
+                   WHEN subject_filter='Unknown' THEN 3
+                   WHEN subject_filter='Other' OR subject_filter='Others' THEN 2
+                   ELSE 1
+              END
+            )
+            , subject_filter ASC
           SQL
         )
         .and_return(results)


### PR DESCRIPTION
## Context

Sort order on 'Route into teaching' and 'Primary specialist subject' tables is not alphabetical by the first column in the way the other tables are

![](https://github.trello.services/images/mini-trello-icon.png) [Minor: Correct the sorting on "Route into teaching" and "Primary specialist subject" tables](https://trello.com/c/2BuR8Yqt/994-minor-correct-the-sorting-on-route-into-teaching-and-primary-specialist-subject-tables)

The reports will need to be generated again for this change to be reflected on the montlys stats page.

### Before
<img width="445" alt="Screenshot 2023-11-27 at 12 04 47" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/ce5e7445-0218-40e1-85c8-018ca32e812f">
<img width="489" alt="Screenshot 2023-11-27 at 12 04 52" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/53abd263-2b85-4314-b233-d1c2b1caaf42">


### After
<img width="355" alt="Screenshot 2023-11-27 at 13 31 56" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/64c98a61-e5f5-4a38-8a09-d51217dcc3a3">
<img width="479" alt="Screenshot 2023-11-27 at 12 16 24" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/70ca00fc-57e5-4e77-bba3-1105db3171e9">

