### PR TITLE
Use update! instead of touch

### DIFF
--- a/app/services/mark_inactive_application.rb
+++ b/app/services/mark_inactive_application.rb
@@ -10,7 +10,7 @@ class MarkInactiveApplication
   def call
     ActiveRecord::Base.transaction do
       @state_change.inactivate!
-      application_choice.touch(:inactive_at)
+      application_choice.update!(inactive_at: Time.zone.now)
     end
   end
 end

--- a/spec/services/mark_inactive_application_spec.rb
+++ b/spec/services/mark_inactive_application_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe MarkInactiveApplication do
     end
 
     it 'updates inactive at field', time: Time.zone.local(2023, 11, 10) do
-      expect { mark_inactive_application.call }.to change(application_choice, :inactive_at).from(nil).to(Time.zone.local(2023, 11, 10))
+      mark_inactive_application.call
+      expect(application_choice.reload.inactive_at).to eq(Time.zone.local(2023, 11, 10))
     end
   end
 end


### PR DESCRIPTION
The touch method doesn't trigger callbacks then we don't send the inactive at to BigQuery.

Calling the update! makes the event to be sent so let's change to that



<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
