### PR TITLE
[849] Add content relating to the limit on withdrawing applications

### DIFF
--- a/app/views/candidate_interface/decisions/withdraw.html.erb
+++ b/app/views/candidate_interface/decisions/withdraw.html.erb
@@ -9,7 +9,13 @@
 
     <%= render(SummaryListComponent.new(rows: course_choice_rows)) %>
 
-    <p class="govuk-body">Any upcoming interviews will be cancelled.</p>
+    <p class="govuk-body">Once you have a total of <%= ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS %> unsuccessful or withdrawn applications, you will not be able to apply for any more courses until October <%= RecruitmentCycle.real_current_year %>.</p>
+
+    <p class="govuk-body">Do not withdraw if you need to change information on your application. Tell your training provider instead.</p>
+
+    <% if @application_choice.interviewing? %>
+      <p class="govuk-body">If you do withdraw, your scheduled interview for this application will be cancelled.</p>
+    <% end %>
 
     <%= govuk_button_to t('decisions.withdraw.confirm'), candidate_interface_withdraw_path, warning: true %>
   </div>

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_withdraws_spec.rb
@@ -70,8 +70,8 @@ RSpec.feature 'A candidate withdraws her application', :bullet, continuous_appli
   end
 
   def then_i_see_a_confirmation_page
-    expect(page).to have_content('Are you sure you want to withdraw this application?')
-    expect(page).to have_content('Any upcoming interviews will be cancelled.')
+    expect(page).to have_content("Once you have a total of 15 unsuccessful or withdrawn applications, you will not be able to apply for any more courses until October #{RecruitmentCycle.real_current_year}")
+    expect(page).to have_content('Do not withdraw if you need to change information on your application. Tell your training provider instead.')
   end
 
   def when_i_click_to_confirm_withdrawal


### PR DESCRIPTION
## Context

Since the new cycle started, we’ve seen a large amount of applications from international candidates and this is overwhelming providers.

One solution is to place a ‘limit’ on the number of applications a candidate can submit and then withdraw. In this PR we explain that limit when the candidate withdraws.

## Changes proposed in this pull request

- Update the content.
- Conditionally render the last line only if the application choice is in the interviewing state. 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/HEF3Fust/849-add-content-on-withdrawal-page-to-explain-limit-on-withdrawing-applications

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
