### PR TITLE
[992] Update content on GCSE missing page

### DIFF
--- a/app/controllers/candidate_interface/gcse/missing_qualification_controller.rb
+++ b/app/controllers/candidate_interface/gcse/missing_qualification_controller.rb
@@ -15,7 +15,7 @@ module CandidateInterface
 
     def create
       @gcse_missing_form = GcseMissingForm.new(qualification_missing_params)
-
+      @gcse_missing_form.subject = @subject
       if @gcse_missing_form.save(current_qualification)
         redirect_to candidate_interface_gcse_review_path
       else
@@ -27,6 +27,7 @@ module CandidateInterface
 
     def update
       @gcse_missing_form = GcseMissingForm.new(qualification_missing_params)
+      @gcse_missing_form.subject = @subject
       @return_to = return_to_after_edit(default: candidate_interface_gcse_review_path)
 
       if @gcse_missing_form.save(current_qualification)

--- a/app/forms/candidate_interface/gcse_missing_form.rb
+++ b/app/forms/candidate_interface/gcse_missing_form.rb
@@ -1,10 +1,12 @@
 module CandidateInterface
   class GcseMissingForm
     include ActiveModel::Model
+    include GcseQualificationHelper
 
     attr_accessor :missing_explanation, :not_completed_explanation, :level, :subject, :qualification_type
 
-    validates :missing_explanation, word_count: { maximum: 200 }
+    validates :missing_explanation, word_count: { maximum: 50 }
+    validate :missing_explanation_presence
 
     def self.build_from_qualification(qualification)
       new(
@@ -30,6 +32,14 @@ module CandidateInterface
         )
       else
         qualification.update!(missing_explanation:)
+      end
+    end
+
+  private
+
+    def missing_explanation_presence
+      if missing_explanation.blank?
+        errors.add(:missing_explanation, "Enter evidence of any #{capitalize_english(subject)} skills you have at the required standard")
       end
     end
   end

--- a/app/forms/candidate_interface/gcse_missing_form.rb
+++ b/app/forms/candidate_interface/gcse_missing_form.rb
@@ -39,7 +39,7 @@ module CandidateInterface
 
     def missing_explanation_presence
       if missing_explanation.blank?
-        errors.add(:missing_explanation, "Enter evidence of any #{capitalize_english(subject)} skills you have at the required standard")
+        errors.add(:missing_explanation, :blank, subject: capitalize_english(@subject))
       end
     end
   end

--- a/app/views/candidate_interface/gcse/missing_qualification/_form.html.erb
+++ b/app/views/candidate_interface/gcse/missing_qualification/_form.html.erb
@@ -6,19 +6,19 @@
           <%= t('gcse_edit_type.page_titles.equivalency', subject: capitalize_english(@subject)) %>
         </h1>
 
-        <p class="govuk-body">You can still apply for teacher training if you do not have a qualification which demonstrates this.<p>
+        <p class="govuk-body">You can give other evidence to show you have <%= capitalize_english(@subject) %> skills that are equal to a GCSE in <%= capitalize_english(@subject) %> at grade 4(C) or above.<p>
 
-        <p class="govuk-body">Some providers may let you sit an equivalency test to show you have the required skills.</p>
+        <p class="govuk-body">Some training providers may let you do an equivalency test to show you have the required skills.</p>
 
         <% if adviser_sign_up.available? %>
-          <p class="govuk-body">For advice, contact your chosen training provider or <%= govuk_link_to_with_utm_params('get a teacher training adviser', new_candidate_interface_adviser_sign_up_path, utm_campaign(params)) %>. An adviser can help you understand the qualifications you need and how to get them.</p>
+          <p class="govuk-body">Contact a <%= govuk_link_to_with_utm_params('teacher training adviser', new_candidate_interface_adviser_sign_up_path, utm_campaign(params)) %> or your chosen training provider if you need help understanding the qualifications you need and how to get them.</p>
         <% elsif adviser_sign_up.waiting_to_be_assigned_to_an_adviser? || adviser_sign_up.already_assigned_to_an_adviser? %>
-          <p class="govuk-body">For advice, contact your chosen training provider or speak to your teacher training adviser. Your adviser can help you understand the qualifications you need and how to get them.</p>
+          <p class="govuk-body">Contact your teacher training adviser or your chosen training provider if you need help understanding the qualifications you need and how to get them.</p>
         <% else %>
-          <p class="govuk-body">For advice, contact your chosen training provider or a <%= govuk_link_to_with_utm_params('teacher training adviser', I18n.t('get_into_teaching.url_get_an_adviser_start'), utm_campaign(params)) %>. An adviser can help you understand the qualifications you need and how to get them.</p>
+          <p class="govuk-body">Contact a <%= govuk_link_to_with_utm_params('teacher training adviser', I18n.t('get_into_teaching.url_get_an_adviser_start'), utm_campaign(params)) %> or your chosen training provider if you need help understanding the qualifications you need and how to get them.</p>
         <% end %>
 
-        <%= f.govuk_text_area :missing_explanation, label: { text: "If you have other evidence of having #{capitalize_english(@subject)} skills at the required standard, give details (optional)", size: 'm' }, rows: 12, max_words: 200, threshold: 90 do %>
+        <%= f.govuk_text_area :missing_explanation, label: { text: "Give evidence of having #{capitalize_english(@subject)} skills at the required standard", size: 'm' }, rows: 4, max_words: 50 do %>
         <% end %>
 
         <%= f.govuk_submit t('save_and_continue') %>

--- a/config/locales/candidate_interface/gcse.yml
+++ b/config/locales/candidate_interface/gcse.yml
@@ -158,3 +158,4 @@ en:
           attributes:
             missing_explanation:
               too_many_words: Evidence must be %{maximum} words or less
+              blank: Enter evidence of any %{subject} skills you have at the required standard

--- a/spec/forms/candidate_interface/gcse_missing_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_missing_form_spec.rb
@@ -2,11 +2,17 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::GcseMissingForm, type: :model do
   describe 'validations' do
-    valid_text = Faker::Lorem.sentence(word_count: 200)
-    long_text = Faker::Lorem.sentence(word_count: 201)
+    let(:valid_text) { Faker::Lorem.sentence(word_count: 50) }
+    let(:long_text) { Faker::Lorem.sentence(word_count: 51) }
+    let(:form) { described_class.new(missing_explanation: nil, subject: 'english') }
 
     it { is_expected.to allow_value(valid_text).for(:missing_explanation) }
     it { is_expected.not_to allow_value(long_text).for(:missing_explanation) }
+
+    it 'validates presence of missing explanation with the subject in the error message' do
+      form.valid?
+      expect(form.errors[:missing_explanation]).to include('Enter evidence of any English skills you have at the required standard')
+    end
   end
 
   describe '#build_from_qualification' do

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_without_pass_grade_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_without_pass_grade_spec.rb
@@ -94,7 +94,7 @@ RSpec.feature 'Candidate entering GCSE details but without a pass grade' do
   end
 
   def when_i_fill_in_the_explanation
-    fill_in 'If you have other evidence of having maths skills at the required standard, give details (optional)', with: 'Hard work and dedication'
+    fill_in 'Give evidence of having maths skills at the required standard', with: 'Hard work and dedication'
   end
 
   def and_i_fill_in_the_year


### PR DESCRIPTION
## Context

Attempt to encourage candidates to fill out the missing explanation about their GCSE qualifications so that providers can assess them quicker and easier.

## Changes proposed in this pull request

- Update the content on the GCSE missing page.
- Add a presence validation to the evidence text box.

## Screenshot (before)

<img width="848" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/50492247/f0618bce-1f43-442b-8ec7-fffb531794d2">

## Screenshot (after)

<img width="684" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/50492247/712d5297-4c17-4d90-8fea-426bc137613a">

<img width="819" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/50492247/d00f3ebc-9139-4798-b1d9-4ef95999dc04">


## Link to Trello card

https://trello.com/c/mpDS3ByL/992-ca-improvements-to-no-qualifications-in-english-maths-science-gcses

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
