### PR TITLE
Redirect to post offer dashboard on course selection on accepted apps

### DIFF
--- a/app/controllers/candidate_interface/continuous_applications/course_choices/base_controller.rb
+++ b/app/controllers/candidate_interface/continuous_applications/course_choices/base_controller.rb
@@ -6,6 +6,7 @@ module CandidateInterface
         before_action :redirect_to_your_applications_if_maximum_amount_of_unsuccessful_applications_have_been_reached, only: %i[new create]
         before_action :redirect_to_your_applications_if_cycle_is_over
         before_action :redirect_to_your_applications_if_submitted, only: %i[edit update]
+        before_action :redirect_to_post_offer_dashboard_if_accepted_deferred_or_recruited
 
         def new
           @wizard = CourseSelectionWizard.new(

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_continuous_applications_feature_enabled_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_continuous_applications_feature_enabled_spec.rb
@@ -111,6 +111,9 @@ RSpec.feature 'Candidate accepts an offer', :continuous_applications do
     when_i_click_to_withdraw_my_application
     and_i_click_back
     then_i_see_the_new_dashboard_content
+
+    when_i_try_to_visit_the_course_selection
+    then_i_should_be_redirected_to_the_offer_dashboard
   end
 
   def given_i_am_signed_in
@@ -516,5 +519,13 @@ RSpec.feature 'Candidate accepts an offer', :continuous_applications do
     expect(
       back_link,
     ).to eq(candidate_interface_application_offer_dashboard_path)
+  end
+
+  def when_i_try_to_visit_the_course_selection
+    visit candidate_interface_continuous_applications_do_you_know_the_course_path
+  end
+
+  def then_i_should_be_redirected_to_the_offer_dashboard
+    expect(page).to have_current_path(candidate_interface_application_offer_dashboard_path)
   end
 end


### PR DESCRIPTION
## Context

The course selection doesn’t redirect to the offer dashboard after candidate accepted an offer.

We should redirect as the user shouldn't be allowed to add more courses and submit after accepting an offer

## Guidance to review

1. Have an accepted offer
2. Try to enter the course selection manually via URL (/candidate/application/continuous-applications/choose - or any other url in course selection) 

## Link to Trello card

https://trello.com/c/afuMkpXM/1013-candidates-can-add-courses-even-after-accepting-an-offer