### PR TITLE
Adjust the tabs alignment in ITT monthly report

### DIFF
--- a/app/frontend/styles/publications/_itt_data_table.scss
+++ b/app/frontend/styles/publications/_itt_data_table.scss
@@ -26,6 +26,7 @@
       padding: govuk-spacing(2);
       border: govuk-spacing(0);
       background-color: transparent;
+      text-align: left;
     }
 
     // This is a hack to prevent the text from changing the size of the element when it becomes bold.


### PR DESCRIPTION
## Context

The alignment of the tabs in all the report looks odd with the last tab being slightly off to the right.

## Guidance to review

1. Is aligned correctly?

## Link to Trello card

https://trello.com/c/Ia0Vkt8r/978-fix-data-tabs-alignment-in-monthly-statistics-report
