### PR TITLE
Show correct country for international qualifications

### DIFF
--- a/app/components/shared/qualification_row_component.rb
+++ b/app/components/shared/qualification_row_component.rb
@@ -8,6 +8,12 @@ class QualificationRowComponent < ViewComponent::Base
   end
 
   def country
-    qualification.international? ? COUNTRIES_AND_TERRITORIES[qualification.institution_country] : 'United Kingdom'
+    international? ? COUNTRIES_AND_TERRITORIES[qualification.institution_country] : 'United Kingdom'
+  end
+
+private
+
+  def international?
+    qualification.international? || qualification.non_uk_qualification_type?
   end
 end

--- a/spec/system/support_interface/editing_other_qualification_spec.rb
+++ b/spec/system/support_interface/editing_other_qualification_spec.rb
@@ -67,7 +67,7 @@ RSpec.feature 'Editing other qualification' do
 
   def and_an_application_exists_with_an_other_level_qualification
     @form = create(:completed_application_form)
-    create(:other_qualification, application_form: @form)
+    create(:other_qualification, :non_uk, application_form: @form, institution_country: 'US')
   end
 
   def when_i_visit_the_application_page
@@ -81,7 +81,7 @@ RSpec.feature 'Editing other qualification' do
   end
 
   def then_i_should_see_that_the_other_qualification_radio_has_been_preselected
-    expect(find_by_id('support-interface-application-forms-edit-other-qualification-form-qualification-type-other-field')).to be_checked
+    expect(find_by_id('support-interface-application-forms-edit-other-qualification-form-qualification-type-non-uk-field')).to be_checked
   end
 
   def and_i_fill_in_the_as_level_details
@@ -170,6 +170,7 @@ RSpec.feature 'Editing other qualification' do
       within(all('tr.govuk-table__row')[0]) do
         expect(find_all('td.govuk-table__cell')[0]).to have_text('random qual from non uk country')
         expect(find_all('td.govuk-table__cell')[1]).to have_text('Waec')
+        expect(find_all('td.govuk-table__cell')[2]).to have_text('United States')
         expect(find_all('td.govuk-table__cell')[4]).to have_text('G')
         expect(find_all('td.govuk-table__cell')[3]).to have_text('2019')
       end


### PR DESCRIPTION
Fixes the bug where international qualifications were showing as UK.

I am only changing the way it gets displayed in the support interface, although the ticket suggests that the `international` boolean should be true. It does seem to be used for degrees, but not for other qualifications. If we decide to use it for other qualifications, we should add a migration to set it to true for all existing international qualifications.

![](https://github.trello.services/images/mini-trello-icon.png) [International qualifications showing as UK](https://trello.com/c/6CNKWG88/989-international-qualifications-showing-as-uk)

### Before
<img width="766" alt="Screenshot 2023-11-29 at 12 50 28" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/56aa4d31-49c3-483a-8b0f-b243f92f59f1">

### After
<img width="748" alt="Screenshot 2023-11-29 at 12 50 14" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/9dda0838-1d04-424c-bbc5-220cdadc1ac0">
