### PR TITLE
[938] Fix "Add another job" button not rendering (for carried over applications)

### DIFF
--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -17,6 +17,7 @@ class DuplicateApplication
       phase: target_phase,
       previous_application_form_id: original_application_form.id,
       recruitment_cycle_year: @recruitment_cycle_year,
+      work_history_status: original_application_form.work_history_status || 'can_complete',
     )
 
     ApplicationForm.create!(attrs).tap do |new_application_form|

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
@@ -22,6 +22,26 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
     then_i_can_add_course_choices
   end
 
+  scenario 'Candidate can see the add another job button in the new cycle' do
+    given_i_am_signed_in
+    and_i_have_an_application_with_a_rejection
+    and_the_apply2_deadline_passes
+    and_i_visit_my_application_complete_page
+    and_i_apply_again
+    and_the_next_cycle_opens
+    and_i_visit_my_application_complete_page
+    and_i_click_on_work_history
+    then_i_see_the_add_another_job_button
+  end
+
+  def and_i_click_on_work_history
+    click_link 'Work history'
+  end
+
+  def then_i_see_the_add_another_job_button
+    expect(page).to have_link('Add another job', href: '/candidate/application/restructured-work-history/new', class: 'govuk-button govuk-button--secondary')
+  end
+
   def given_i_am_signed_in
     @candidate = create(:candidate)
     login_as(@candidate)
@@ -30,6 +50,9 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   def and_i_have_an_application_with_a_rejection
     @application_form = create(:completed_application_form, :with_completed_references, candidate: @candidate)
     create(:application_choice, :rejected, application_form: @application_form)
+
+    job = create(:application_work_experience, application_form: @application_form)
+    @application_form.application_work_experiences << [job]
   end
 
   def when_the_apply2_deadline_passes
@@ -76,4 +99,8 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
     expect(page).to have_content 'You can apply for up to 4 courses'
     click_link 'Choose your courses'
   end
+
+  alias_method :and_the_apply2_deadline_passes, :when_the_apply2_deadline_passes
+  alias_method :and_i_apply_again, :when_i_click_apply_again
+  alias_method :and_the_next_cycle_opens, :when_the_next_cycle_opens
 end


### PR DESCRIPTION
## Context

There is a bug where `work_history_status` on `ApplicationForm` is set to `nil` when the application is carried over. This is preventing the "Add another job" button from rendering and the candidate is unable to add additional jobs to their application. 

This is currently affecting 72 candidates, so we will run a data migration in a separate PR to fix the issue for candidates who have already carried over their application. 

## Changes proposed in this pull request

Set `work_history_status` to `can_complete` when the original value is `nil`.

## Guidance to review

Is it ok to set the applications that are carried over where the `work_history_status` is `nil` to `can_complete`, this is the only way to render the "Add another job" button.

The other options are: `full_time_education`, `can_not_complete`. However the button will not render.

## Link to Trello card

https://trello.com/c/hJdVsWD8/938-bug-carried-over-applications-dont-have-a-workhistorystatus-value

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
