### PR TITLE
Be possible to change address from previous cycles

### DIFF
--- a/app/forms/support_interface/application_forms/edit_address_details_form.rb
+++ b/app/forms/support_interface/application_forms/edit_address_details_form.rb
@@ -45,16 +45,21 @@ module SupportInterface
           audit_comment:,
         }
         attrs[:country] = 'GB' if uk?
-        application_form.update(attrs)
+
+        ApplicationForm.with_unsafe_application_choice_touches do
+          application_form.update(attrs)
+        end
       end
 
       def save_address_type(application_form)
         return false unless valid?(:address_type)
 
-        application_form.update(
-          address_type:,
-          country: country.presence,
-        )
+        ApplicationForm.with_unsafe_application_choice_touches do
+          application_form.update(
+            address_type:,
+            country: country.presence,
+          )
+        end
       end
 
       def uk?


### PR DESCRIPTION
## Context

This PR adds the possibility to change address via support from old cycles application forms

## Guidance to review

1. Possible to change address via support from applications from 2023 recruitment cycle?

## Link to Trello card

https://trello.com/c/nQ9Cc2mJ/2559-change-address
