### PR TITLE
Update the subject eligibility for our International Relocation Payment

### DIFF
--- a/app/services/is_eligible_for_international_relocation_payment.rb
+++ b/app/services/is_eligible_for_international_relocation_payment.rb
@@ -1,7 +1,7 @@
 class IsEligibleForInternationalRelocationPayment
   delegate :application_form, to: :application_choice
 
-  ELIGIBLE_SUBJECTS = %i[classics physics modern_foreign_languages].freeze
+  ELIGIBLE_SUBJECTS = %i[physics].freeze
 
   def initialize(application_choice)
     @application_choice = application_choice

--- a/spec/services/is_eligible_for_international_relocation_payment_spec.rb
+++ b/spec/services/is_eligible_for_international_relocation_payment_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe IsEligibleForInternationalRelocationPayment do
     let(:application_choice) { create(:application_choice, course_option:, application_form:) }
     let(:first_nationality) { 'Azeri' }
     let(:right_to_work_or_study) { 'yes' }
-    let(:course_subject) { create(:subject, name: 'Colloquial Amaraic', code: 'A0') }
+    let(:course_subject) { create(:subject, name: 'Quantum Mechanics', code: 'F0') }
 
     context 'application meets all criteria' do
       it { is_expected.to be true }
@@ -33,7 +33,7 @@ RSpec.describe IsEligibleForInternationalRelocationPayment do
     context 'subject is modern languages' do
       let(:course_subject) { create(:subject, name: 'Spanish with Sichuanese', code: '15') }
 
-      it { is_expected.to be true }
+      it { is_expected.to be false }
     end
 
     context 'subject not eligible' do


### PR DESCRIPTION
As quick fix, we are going to streamline this to just physics for now, as this is better than the current setup, which is wrong.

![](https://github.trello.services/images/mini-trello-icon.png) [Update the subject eligibility for our International Relocation Payment (IRP) email](https://trello.com/c/UxVYB8nA/1044-update-the-subject-eligibility-for-our-international-relocation-payment-irp-email)