### PR TITLE
Remove free of charge text on ENIC question

### DIFF
--- a/app/views/candidate_interface/degrees/degree/new_enic.html.erb
+++ b/app/views/candidate_interface/degrees/degree/new_enic.html.erb
@@ -34,7 +34,7 @@
         <% end %>
       <% end %>
       <%= f.govuk_radio_button :have_enic_reference, 'No', label: { text: 'No' } do %>
-        <p class="govuk-body">Ask your training provider if they need a <%= t('service_name.enic.short_name') %> statement of comparability. <%= govuk_link_to_with_utm_params 'Chat online', t('get_into_teaching.url_online_chat'), utm_campaign(params), current_application.phase %> to get a free statement (it usually costs £49.50 plus VAT) or call <%= t('service_name.get_into_teaching') %> for free on <%= t('get_into_teaching.tel') %>.</p>
+        <p class="govuk-body">Ask your training provider if they need a <%= t('service_name.enic.short_name') %> statement of comparability. <%= govuk_link_to_with_utm_params 'Chat online', t('get_into_teaching.url_online_chat'), utm_campaign(params), current_application.phase %> to get a free statement (it usually costs £49.50 plus VAT) or call <%= t('service_name.get_into_teaching') %>on <%= t('get_into_teaching.tel') %>.</p>
       <% end %>
     <% end %>
     <%= f.govuk_submit t('save_and_continue') %>

--- a/app/views/candidate_interface/degrees/degree/new_enic.html.erb
+++ b/app/views/candidate_interface/degrees/degree/new_enic.html.erb
@@ -34,7 +34,7 @@
         <% end %>
       <% end %>
       <%= f.govuk_radio_button :have_enic_reference, 'No', label: { text: 'No' } do %>
-        <p class="govuk-body">Ask your training provider if they need a <%= t('service_name.enic.short_name') %> statement of comparability. <%= govuk_link_to_with_utm_params 'Chat online', t('get_into_teaching.url_online_chat'), utm_campaign(params), current_application.phase %> to get a free statement (it usually costs £49.50 plus VAT) or call <%= t('service_name.get_into_teaching') %>on <%= t('get_into_teaching.tel') %>.</p>
+        <p class="govuk-body">Ask your training provider if they need a <%= t('service_name.enic.short_name') %> statement of comparability. <%= govuk_link_to_with_utm_params 'Chat online', t('get_into_teaching.url_online_chat'), utm_campaign(params), current_application.phase %> to get a free statement (it usually costs £49.50 plus VAT) or call <%= t('service_name.get_into_teaching') %> on <%= t('get_into_teaching.tel') %>.</p>
       <% end %>
     <% end %>
     <%= f.govuk_submit t('save_and_continue') %>

--- a/app/views/candidate_interface/gcse/enic/_form.html.erb
+++ b/app/views/candidate_interface/gcse/enic/_form.html.erb
@@ -16,7 +16,7 @@
     <% end %>
   <% end %>
   <%= f.govuk_radio_button :have_enic_reference, 'No', label: { text: 'No' } do %>
-    <p class="govuk-body">Ask your training provider if they need a <%= t('service_name.enic.short_name') %> statement of comparability. You can get a free statement (this usually costs £49.50 plus VAT) by calling <%= t('service_name.get_into_teaching') %> for free on <%= t('get_into_teaching.tel') %>. Or <%= govuk_link_to_with_utm_params 'chat to an adviser using the online chat service', t('get_into_teaching.url_online_chat'), utm_campaign(params), current_application.phase %>.</p>
+    <p class="govuk-body">Ask your training provider if they need a <%= t('service_name.enic.short_name') %> statement of comparability. You can get a free statement (this usually costs £49.50 plus VAT) by calling <%= t('service_name.get_into_teaching') %> on <%= t('get_into_teaching.tel') %>. Or <%= govuk_link_to_with_utm_params 'chat to an adviser using the online chat service', t('get_into_teaching.url_online_chat'), utm_campaign(params), current_application.phase %>.</p>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
## Context

We recently removed text telling candidates that calling our help number was free, it is not for international candidates adn this could be misleading.

## Changes proposed in this pull request

Removed 'for free' text on ENIC question for GCSEs and Degrees

### Before:

<img width="657" alt="Screenshot 2023-12-04 at 14 55 24" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/68232608/2bfc7f19-b6dc-42ff-a4c2-eca4b7e54beb">

### After

<img width="684" alt="Screenshot 2023-12-04 at 16 03 37" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/68232608/530e4e0a-8403-4b34-ac98-dda6336440d3">


## Link to Trello card

https://trello.com/c/YDQzMkxE/1045-apply-prompt-to-acquire-enic-statement-has-misleading-free-of-charge-phone-number

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
