### PR TITLE
Add manual data migration to update decline_by_default_at to EOC

### DIFF
--- a/app/services/data_migrations/update_decline_by_default_at_from_current_cycle.rb
+++ b/app/services/data_migrations/update_decline_by_default_at_from_current_cycle.rb
@@ -1,0 +1,24 @@
+module DataMigrations
+  class UpdateDeclineByDefaultAtFromCurrentCycle
+    TIMESTAMP = 20231204134841
+    MANUAL_RUN = true
+
+    def change
+      records.each do |application_choice|
+        application_choice.update_columns(
+          decline_by_default_at: CycleTimetable.date(:apply_1_deadline),
+          decline_by_default_days: nil,
+        )
+      end
+    end
+
+    def records
+      ApplicationChoice
+      .joins(:application_form)
+      .where('decline_by_default_at >= ?', CycleTimetable.date(:find_opens))
+      .where('decline_by_default_at < ?', CycleTimetable.date(:apply_1_deadline))
+      .where('application_forms.recruitment_cycle_year': 2024)
+      .where.not(declined_by_default: true)
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::UpdateDeclineByDefaultAtFromCurrentCycle',
   'DataMigrations::RemoveDbdFromCurrentCycle',
   'DataMigrations::RemoveRecruitWithPendingConditionsFeatureFlag',
   'DataMigrations::BackfillFeedbackFormComplete',

--- a/spec/services/data_migrations/update_decline_by_default_at_from_current_cycle_spec.rb
+++ b/spec/services/data_migrations/update_decline_by_default_at_from_current_cycle_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::UpdateDeclineByDefaultAtFromCurrentCycle do
+  let(:application_form) do
+    create(
+      :application_form,
+      :minimum_info,
+      recruitment_cycle_year: recruitment_cycle_year,
+    )
+  end
+
+  let!(:application_choice) do
+    create(
+      :application_choice,
+      application_form:,
+      decline_by_default_at:,
+      decline_by_default_days: 10,
+    )
+  end
+
+  context 'when 2023 recruitment cycle' do
+    let!(:recruitment_cycle_year) { 2023 }
+    let!(:decline_by_default_at) { CycleTimetable.find_opens(recruitment_cycle_year) }
+
+    it 'does not update records' do
+      expect { described_class.new.change }.not_to(change { application_choice.reload.decline_by_default_at })
+    end
+  end
+
+  context 'when 2024 recruitment cycle' do
+    let!(:recruitment_cycle_year) { 2024 }
+
+    context 'when application does not have a decline_by_default_at' do
+      let!(:decline_by_default_at) { nil }
+
+      it 'does not update records' do
+        expect { described_class.new.change }.not_to(change { application_choice.reload.decline_by_default_at })
+      end
+    end
+
+    context 'when application has a decline_by_default_at set to apply deadline' do
+      let!(:decline_by_default_at) { CycleTimetable.apply_1_deadline(recruitment_cycle_year) }
+
+      it 'does not update records' do
+        expect { described_class.new.change }.not_to(change { application_choice.reload.decline_by_default_at })
+      end
+    end
+
+    context 'when application has a decline_by_default_at set to before apply deadline' do
+      let!(:decline_by_default_at) { CycleTimetable.apply_1_deadline(recruitment_cycle_year) - 1.day }
+
+      it 'updates the records' do
+        expect { described_class.new.change }.to(
+          change { application_choice.reload.decline_by_default_at }
+            .from(CycleTimetable.apply_1_deadline(recruitment_cycle_year) - 1.day)
+            .to(CycleTimetable.apply_1_deadline(recruitment_cycle_year)),
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
We have a few candidates whose DBD date has been set earlier due to them having a withdrawn course, or am offered course change. This sets the decline_by_default_at to the end of the cycle for all the affected candidates.

![](https://github.trello.services/images/mini-trello-icon.png) [Update all candidate's Declined By Default (DBD) date to the "end of the cycle"](https://trello.com/c/wyOckvsk/987-update-all-candidates-dbd-date-to-the-end-of-the-cycle)