### PR TITLE
[1021] Remove "NEW" tag on reports tab

### DIFF
--- a/app/frontend/styles/_tag.scss
+++ b/app/frontend/styles/_tag.scss
@@ -3,10 +3,3 @@
   white-space: nowrap;
 }
 
-.app-tag--navbar {
-  font-size: 14px;
-  margin-top: -5px;
-  margin-left: 3px;
-  padding-left: 4px;
-  padding-right: 4px;
-}

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -88,11 +88,7 @@ class NavigationItems
       if current_provider_user && !performing_setup
         items << NavigationItem.new('Applications', provider_interface_applications_path, active?(current_controller, %w[application_choices decisions offer_changes notes interviews offers feedback conditions reconfirm_deferred_offers]), [])
         items << NavigationItem.new('Interview schedule', provider_interface_interview_schedule_path, active?(current_controller, %w[interview_schedules]), [])
-
-        reports_label = 'Reports'.html_safe
-        reports_label += ' <strong class="govuk-tag govuk-tag--blue app-tag--navbar">New</strong>'.html_safe
-
-        items << NavigationItem.new(reports_label, provider_interface_reports_path, active?(current_controller, %w[reports application_data_export hesa_export]))
+        items << NavigationItem.new('Reports', provider_interface_reports_path, active?(current_controller, %w[reports application_data_export hesa_export]))
 
         if FeatureFlag.active?(:provider_activity_log)
           items << NavigationItem.new('Activity log', provider_interface_activity_log_path, active?(current_controller, %w[activity_log]), [])


### PR DESCRIPTION
## Context

We introduced a ‘new’ label on our reports back in May. Now it’s November and the label is no longer new, so we are removing it

## Guidance to review

- Login to manage on the review app and have a look.

## Link to Trello card

https://trello.com/c/fYDTGdWb/1021-remove-new-tag-on-reports-as-theyre-no-longer-new

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
