### PR TITLE
Remove flakey redundant mailer tests on main

### DIFF
--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -30,56 +30,6 @@ RSpec.describe CandidateMailer do
     magic_link_stubbing(candidate)
   end
 
-  describe '.new_offer_single_offer' do
-    let(:email) { mailer.new_offer_single_offer(application_choices.first) }
-    let(:application_choices) { [application_choice_with_offer] }
-
-    before do
-      allow(CourseOption).to receive(:find_by).with(id: application_choice_with_offer.current_course_option_id).and_return(application_choice_with_offer.current_course_option)
-    end
-
-    it_behaves_like(
-      'a mail with subject and content',
-      'Successful application for Brighthurst Technical College',
-      'heading' => 'Dear Bob',
-      'decline by default date' => "Respond by #{10.business_days.from_now.to_fs(:govuk_date)}",
-      'first_condition' => 'Be cool',
-      'deferral_guidance' => 'You can defer your offer and start your course a year later.',
-    )
-
-    context 'when the provider offers the candidate a different course option' do
-      let(:other_course) { build_stubbed(:course, name: 'Computer Science', code: 'X0FO', provider: other_provider) }
-      let(:other_option) { build_stubbed(:course_option, course: other_course) }
-      let(:application_choice_with_offer) { build_stubbed(:application_choice, :offered, offer:, current_course_option: other_option, course_option:) }
-
-      it_behaves_like(
-        'a mail with subject and content',
-        'Successful application for Falconholt Technical College',
-        'heading' => 'Dear Bob',
-        'course and provider' => 'offer from Falconholt Technical College to study Computer Science (X0FO)',
-        'decline by default date' => "Respond by #{10.business_days.from_now.to_fs(:govuk_date)}",
-        'deferral_guidance' => 'You can defer your offer and start your course a year later.',
-      )
-    end
-  end
-
-  describe '.new_offer_multiple_offers' do
-    let(:email) { mailer.new_offer_multiple_offers(application_choices.first) }
-    let(:application_choice_with_other_offer) { build_stubbed(:application_choice, :offered, offer: other_offer, course_option: other_option) }
-    let(:application_choices) { [application_choice_with_offer, application_choice_with_other_offer] }
-
-    it_behaves_like(
-      'a mail with subject and content',
-      'Successful application for Brighthurst Technical College',
-      'heading' => 'Dear Bob',
-      'decline by default date' => "Respond by #{10.business_days.from_now.to_fs(:govuk_date)}",
-      'first_condition' => 'Be cool',
-      'first_offer' => 'Applied Science (Psychology) (3TT5) at Brighthurst Technical College',
-      'second_offers' => 'Forensic Science (E0FO) at Falconholt Technical College',
-      'deferral_guidance' => 'You can defer your offer and start your course a year later.',
-    )
-  end
-
   describe '.new_offer_decisions_pending' do
     let(:email) { mailer.new_offer_decisions_pending(application_choices.first) }
     let(:application_choices) { [application_choice_with_offer, awaiting_decision] }

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -109,59 +109,6 @@ RSpec.describe CandidateMailer do
     end
   end
 
-  describe 'Candidate decision chaser email' do
-    let(:email) { mailer.chase_candidate_decision(application_form) }
-    let(:offer) do
-      build_stubbed(:application_choice, :offered,
-                    sent_to_provider_at: Time.zone.today,
-                    course_option:)
-    end
-    let(:course_option) do
-      build_stubbed(:course_option, course: build_stubbed(:course,
-                                                          name: 'Applied Science (Psychology)',
-                                                          code: '3TT5', provider:))
-    end
-    let(:provider) { build_stubbed(:provider, name: 'Brighthurst Technical College') }
-
-    context 'when a candidate has one appication choice with offer' do
-      let(:application_choices) { [offer] }
-
-      it_behaves_like(
-        'a mail with subject and content',
-        I18n.t!('candidate_mailer.chase_candidate_decision.subject_singular'),
-        'heading' => 'Dear Fred',
-        'dbd date' => "respond by #{10.business_days.from_now.to_fs(:govuk_date)}",
-        'course name and code' => ' Applied Science (Psychology)',
-        'provider name' => 'Brighthurst Technical College',
-      )
-    end
-
-    context 'when a candidate has multiple application choices with offer' do
-      let(:second_offer) do
-        build_stubbed(:application_choice, :offered,
-                      sent_to_provider_at: Time.zone.today,
-                      course_option: second_course_option)
-      end
-      let(:second_course_option) do
-        build_stubbed(:course_option, course: build_stubbed(:course,
-                                                            name: 'Code Refactoring',
-                                                            code: 'CRF5',
-                                                            provider: other_provider))
-      end
-      let(:other_provider) { build_stubbed(:provider, name: 'Ting University') }
-      let(:application_choices) { [offer, second_offer] }
-
-      it_behaves_like(
-        'a mail with subject and content',
-        I18n.t!('candidate_mailer.chase_candidate_decision.subject_plural'),
-        'first course with offer' => 'Applied Science (Psychology)',
-        'first course provider with offer' => 'Brighthurst Technical College',
-        'second course with offer' => 'Code Refactoring',
-        'second course provider with offer' => 'Ting University',
-      )
-    end
-  end
-
   describe '.decline_by_default' do
     let(:email) { mailer.declined_by_default(application_form) }
 


### PR DESCRIPTION
## Context

These tests are currently failing on main. They are redundant and we are in the process of removing the old flow.


- The new continuous applications emails were merged in this PR: https://github.com/DFE-Digital/apply-for-teacher-training/pull/8598

- The chasers were disabled for the continuous applications flow in this PR: https://github.com/DFE-Digital/apply-for-teacher-training/pull/8551

## Guidance to review

Confirm the specs are indeed redundant.

- https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/app/services/send_new_offer_email_to_candidate.rb

- https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/app/services/send_chase_email_to_candidate.rb