### PR TITLE
[1029] Remove non continuous application flow from `MakeService`

### DIFF
--- a/app/services/make_offer.rb
+++ b/app/services/make_offer.rb
@@ -28,11 +28,7 @@ class MakeOffer
             other_fields: { offered_at: Time.zone.now },
           )
 
-          if application_choice.continuous_applications?
-            SetDeclineByDefaultToEndOfCycle.new(application_choice: application_choice).call
-          else
-            SetDeclineByDefault.new(application_form: application_form).call
-          end
+          SetDeclineByDefaultToEndOfCycle.new(application_choice: application_choice).call
         end
 
         CancelUpcomingInterviews.new(
@@ -52,10 +48,6 @@ private
 
   def auth
     @auth ||= ProviderAuthorisation.new(actor:)
-  end
-
-  def application_form
-    @application_form ||= application_choice.application_form
   end
 
   def offer

--- a/spec/services/make_offer_spec.rb
+++ b/spec/services/make_offer_spec.rb
@@ -58,13 +58,13 @@ RSpec.describe MakeOffer do
     end
 
     describe 'if the provided details are correct' do
-      it 'then calls various services', continuous_applications: false do
-        set_declined_by_default = instance_double(SetDeclineByDefault, call: true)
+      it 'then calls various services' do
+        set_declined_by_default_to_end_of_cycle = instance_double(SetDeclineByDefaultToEndOfCycle, call: true)
         send_new_offer_email_to_candidate = instance_double(SendNewOfferEmailToCandidate, call: true)
 
-        allow(SetDeclineByDefault)
-            .to receive(:new).with(application_form: application_choice.application_form)
-                    .and_return(set_declined_by_default)
+        allow(SetDeclineByDefaultToEndOfCycle)
+            .to receive(:new).with(application_choice: application_choice)
+                    .and_return(set_declined_by_default_to_end_of_cycle)
         allow(SendNewOfferEmailToCandidate)
             .to receive(:new).with(application_choice:)
                     .and_return(send_new_offer_email_to_candidate)
@@ -72,8 +72,8 @@ RSpec.describe MakeOffer do
 
         make_offer.save!
 
-        expect(SetDeclineByDefault).to have_received(:new)
-        expect(set_declined_by_default).to have_received(:call)
+        expect(SetDeclineByDefaultToEndOfCycle).to have_received(:new)
+        expect(set_declined_by_default_to_end_of_cycle).to have_received(:call)
         expect(send_new_offer_email_to_candidate).to have_received(:call)
         expect(update_conditions_service).to have_received(:save)
         expect(application_choice).to have_received(:update_course_option_and_associated_fields!)
@@ -87,18 +87,6 @@ RSpec.describe MakeOffer do
              .and_return(cancel_upcoming_interviews)
         make_offer.save!
         expect(cancel_upcoming_interviews).to have_received(:call!)
-      end
-
-      context 'when the application form is in continuous application cycle', :continuous_applications do
-        let(:application_choice) { create(:application_choice, :awaiting_provider_decision, :continuous_applications) }
-
-        it 'calls DeclineByDefaultToEndOfCycle' do
-          allow(SetDeclineByDefaultToEndOfCycle)
-            .to receive(:new).and_return(instance_double(SetDeclineByDefaultToEndOfCycle, call: true))
-          make_offer.save!
-
-          expect(SetDeclineByDefaultToEndOfCycle).to have_received(:new)
-        end
       end
     end
 


### PR DESCRIPTION
## Context

Continuous applications was built using a feature flag. Now we’ve launched it we’re left with a lot of redundant code relating to the “old flow”. We are removing that now. 

This PR deals with the `MakeOffer` service.

## Changes proposed in this pull request

- Remove the old flow

## Guidance to review

- Is it all gone?

## Link to Trello card

https://trello.com/c/VhDH0FsK/1029-catd-make-offer-service

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
