### PR TITLE
Create new chaser emails to get candidates to accept offers

### DIFF
--- a/app/lib/time_limit_config.rb
+++ b/app/lib/time_limit_config.rb
@@ -1,24 +1,4 @@
 class TimeLimitConfig
-  class Days
-    attr_reader :count, :type
-
-    def initialize(count:, type:)
-      raise ArgumentError, 'Argument is not an integer' unless count.is_a?(Integer)
-      raise ArgumentError, 'Argument is not :calendar or :working' unless (type == :calendar) || (type == :working)
-
-      @count = count
-      @type = type
-    end
-
-    def to_days
-      type == :calendar ? count.days : count.business_days
-    end
-
-    def to_s
-      "#{@count} #{@type} #{'day'.pluralize(@count)}"
-    end
-  end
-
   Rule = Struct.new(:from_date, :to_date, :limit)
 
   def self.minimum_hours_between_chaser_emails

--- a/app/lib/time_limit_config.rb
+++ b/app/lib/time_limit_config.rb
@@ -1,5 +1,7 @@
 class TimeLimitConfig
-  Rule = Struct.new(:from_date, :to_date, :limit)
+  def self.limits_for(rule)
+    rules[rule.to_sym]
+  end
 
   def self.minimum_hours_between_chaser_emails
     48
@@ -19,6 +21,12 @@ class TimeLimitConfig
 
   def self.additional_reference_chase_calendar_days
     28
+  end
+
+  Rule = Struct.new(:from_date, :to_date, :limit)
+
+  def self.new_rule(...)
+    Rule.new(...)
   end
 
   def self.stale_application_rules
@@ -42,7 +50,6 @@ class TimeLimitConfig
     }
   end
 
-  def self.limits_for(rule)
-    rules[rule.to_sym]
-  end
+  private_constant 'Rule'
+  private_class_method :rules, :stale_application_rules
 end

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -262,6 +262,18 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def offer_20_day(application_choice)
+    @first_name = application_choice.application_form.first_name
+    @course_name = application_choice.current_course_option.course.name
+    @candidate = application_choice.application_form.candidate
+    @provider_name = application_choice.current_course_option.provider.name
+
+    email_for_candidate(
+      application_choice.application_form,
+      subject: I18n.t!('candidate_mailer.offer_day.subject', provider_name: @provider_name),
+    )
+  end
+
   def declined_by_default(application_form)
     @declined_courses = application_form.application_choices.select(&:declined_by_default?)
     @declined_course_names = @declined_courses.map { |application_choice| "#{application_choice.current_course_option.course.name_and_code} at #{application_choice.current_course_option.course.provider.name}" }

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -286,6 +286,18 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def offer_40_day(application_choice)
+    @first_name = application_choice.application_form.first_name
+    @course_name = application_choice.current_course_option.course.name
+    @candidate = application_choice.application_form.candidate
+    @provider_name = application_choice.current_course_option.provider.name
+
+    email_for_candidate(
+      application_choice.application_form,
+      subject: I18n.t!('candidate_mailer.offer_day.subject', provider_name: @provider_name),
+    )
+  end
+
   def declined_by_default(application_form)
     @declined_courses = application_form.application_choices.select(&:declined_by_default?)
     @declined_course_names = @declined_courses.map { |application_choice| "#{application_choice.current_course_option.course.name_and_code} at #{application_choice.current_course_option.course.provider.name}" }

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -250,6 +250,18 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def offer_10_day(application_choice)
+    @first_name = application_choice.application_form.first_name
+    @course_name = application_choice.current_course_option.course.name
+    @candidate = application_choice.application_form.candidate
+    @provider_name = application_choice.current_course_option.provider.name
+
+    email_for_candidate(
+      application_choice.application_form,
+      subject: I18n.t!('candidate_mailer.offer_day.subject', provider_name: @provider_name),
+    )
+  end
+
   def declined_by_default(application_form)
     @declined_courses = application_form.application_choices.select(&:declined_by_default?)
     @declined_course_names = @declined_courses.map { |application_choice| "#{application_choice.current_course_option.course.name_and_code} at #{application_choice.current_course_option.course.provider.name}" }

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -274,6 +274,18 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def offer_30_day(application_choice)
+    @first_name = application_choice.application_form.first_name
+    @course_name = application_choice.current_course_option.course.name
+    @candidate = application_choice.application_form.candidate
+    @provider_name = application_choice.current_course_option.provider.name
+
+    email_for_candidate(
+      application_choice.application_form,
+      subject: I18n.t!('candidate_mailer.offer_day.subject', provider_name: @provider_name),
+    )
+  end
+
   def declined_by_default(application_form)
     @declined_courses = application_form.application_choices.select(&:declined_by_default?)
     @declined_course_names = @declined_courses.map { |application_choice| "#{application_choice.current_course_option.course.name_and_code} at #{application_choice.current_course_option.course.provider.name}" }

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -298,6 +298,18 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def offer_50_day(application_choice)
+    @first_name = application_choice.application_form.first_name
+    @course_name = application_choice.current_course_option.course.name
+    @candidate = application_choice.application_form.candidate
+    @provider_name = application_choice.current_course_option.provider.name
+
+    email_for_candidate(
+      application_choice.application_form,
+      subject: I18n.t!('candidate_mailer.offer_50_day.subject', provider_name: @provider_name),
+    )
+  end
+
   def declined_by_default(application_form)
     @declined_courses = application_form.application_choices.select(&:declined_by_default?)
     @declined_course_names = @declined_courses.map { |application_choice| "#{application_choice.current_course_option.course.name_and_code} at #{application_choice.current_course_option.course.provider.name}" }

--- a/app/models/chaser_sent.rb
+++ b/app/models/chaser_sent.rb
@@ -2,26 +2,69 @@ class ChaserSent < ApplicationRecord
   belongs_to :chased, polymorphic: true
 
   enum chaser_type: {
-    reference_request: 'reference_request',
-    referee_reference_request: 'referee_reference_request',
-    candidate_reference_request: 'candidate_reference_request',
-    reference_replacement: 'reference_replacement',
-    follow_up_missing_references: 'follow_up_missing_references',
-    candidate_follow_up_missing_references: 'candidate_follow_up_missing_references',
-    referee_follow_up_missing_references: 'referee_follow_up_missing_references',
-    reminder_reference_nudge: 'reminder_reference_nudge',
-    candidate_decision_request: 'candidate_decision_request',
-    course_unavailable_notification: 'course_unavailable_notification',
-    course_unavailable_slack_notification: 'course_unavailable_slack_notification',
+    ######################################
+    ####     Service availability     ####
+    ######################################
+
+    ## ProviderMailer ##
+    apply_service_is_now_open: 'apply_service_is_now_open',
+    find_service_is_now_open: 'find_service_is_now_open',
+    find_service_open_organisation_notification: 'find_service_open_organisation_notification',
+
+    ## CandidateMailer ##
     eoc_deadline_reminder: 'eoc_deadline_reminder',
     find_has_opened: 'find_has_opened',
     new_cycle_has_started: 'new_cycle_has_started',
-    set_up_organisation_permissions: 'set_up_organisation_permissions',
-    apply_service_is_now_open: 'apply_service_is_now_open',
-    find_service_is_now_open: 'find_service_is_now_open',
+
+    #### DEPRECATED ####
     apply_service_open_organisation_notification: 'apply_service_open_organisation_notification',
-    find_service_open_organisation_notification: 'find_service_open_organisation_notification',
+
+    ######################################
+    ####          References          ####
+    ######################################
+
+    #### RefereeMailer ####
+    referee_follow_up_missing_references: 'referee_follow_up_missing_references',
+    referee_reference_request: 'referee_reference_request',
+    reminder_reference_nudge: 'reminder_reference_nudge',
+
+    ### CandidateMailer ####
+    candidate_follow_up_missing_references: 'candidate_follow_up_missing_references',
+    candidate_reference_request: 'candidate_reference_request',
+    reference_replacement: 'reference_replacement',
+
+    #### DEPRECATED ####
+    reference_request: 'reference_request',
+    follow_up_missing_references: 'follow_up_missing_references',
+
+    ######################################
+    ####           Inactive           ####
+    ######################################
+
+    #### CandidateMailer ####
     apply_to_another_course_after_30_working_days: 'apply_to_another_course_after_30_working_days',
     apply_to_multiple_courses_after_30_working_days: 'apply_to_multiple_courses_after_30_working_days',
+
+    ######################################
+    ####            Offer             ####
+    ######################################
+
+    #### CandidateMailer ####
+    candidate_decision_request: 'candidate_decision_request',
+
+    ######################################
+    ####      Course unavailable      ####
+    ######################################
+
+    #### CandidateMailer ####
+    course_unavailable_notification: 'course_unavailable_notification',
+    course_unavailable_slack_notification: 'course_unavailable_slack_notification',
+
+    ######################################
+    ####         Permissions          ####
+    ######################################
+
+    #### ProviderMailer ####
+    set_up_organisation_permissions: 'set_up_organisation_permissions',
   }
 end

--- a/app/models/chaser_sent.rb
+++ b/app/models/chaser_sent.rb
@@ -51,6 +51,11 @@ class ChaserSent < ApplicationRecord
 
     #### CandidateMailer ####
     candidate_decision_request: 'candidate_decision_request',
+    offer_10_day: 'offer_10_day',
+    offer_20_day: 'offer_20_day',
+    offer_30_day: 'offer_30_day',
+    offer_40_day: 'offer_40_day',
+    offer_50_day: 'offer_50_day',
 
     ######################################
     ####      Course unavailable      ####

--- a/app/queries/offers_to_chase_query.rb
+++ b/app/queries/offers_to_chase_query.rb
@@ -2,18 +2,10 @@
 # within an interval and whose candidates have not received emails chasing a
 # decision
 class OffersToChaseQuery
-  VALID_INTERVALS = [10, 20, 30, 40, 50].freeze
-
-  def self.call(days:)
-    raise ArgumentError unless days.in?(VALID_INTERVALS)
-
-    chaser_type = "offer_#{days}_day"
-    offset = 10
-    range = ((days + offset).days.ago..days.days.ago)
-
+  def self.call(chaser_type:, date_range:)
     ApplicationChoice
       .joins(:offer)
       .where.not(id: ChaserSent.send(chaser_type).select(:chased_id).where(chased_type: 'ApplicationChoice'))
-      .where('offers.created_at': range)
+      .where('offers.created_at': date_range)
   end
 end

--- a/app/queries/offers_to_chase_query.rb
+++ b/app/queries/offers_to_chase_query.rb
@@ -1,0 +1,19 @@
+# Query to return ApplicationChoices with offers whose offers have been issued
+# within an interval and whose candidates have not received emails chasing a
+# decision
+class OffersToChaseQuery
+  VALID_INTERVALS = [10, 20, 30, 40, 50].freeze
+
+  def self.call(days:)
+    raise ArgumentError unless days.in?(VALID_INTERVALS)
+
+    chaser_type = "offer_#{days}_day"
+    offset = 10
+    range = ((days + offset).days.ago..days.days.ago)
+
+    ApplicationChoice
+      .joins(:offer)
+      .where.not(id: ChaserSent.send(chaser_type).select(:chased_id).where(chased_type: 'ApplicationChoice'))
+      .where('offers.created_at': range)
+  end
+end

--- a/app/services/chasers/candidate.rb
+++ b/app/services/chasers/candidate.rb
@@ -9,6 +9,10 @@ module Chasers
       offer_50_day: [60, 50],
     }.freeze
 
+    def self.chaser_types
+      OFFER_CHASERS_TO_INTERVALS.keys
+    end
+
     def self.chaser_to_date_range
       OFFER_CHASERS_TO_INTERVALS.each_with_object({}) do |(chaser_type, (start, ending)), object|
         object[chaser_type] = (start.days.ago..ending.days.ago)

--- a/app/services/chasers/candidate.rb
+++ b/app/services/chasers/candidate.rb
@@ -16,8 +16,6 @@ module Chasers
     def self.chaser_to_date_range
       OFFER_CHASERS_TO_INTERVALS.each_with_object({}) do |(chaser_type, (start, ending)), object|
         object[chaser_type] = (start.days.ago..ending.days.ago)
-
-        yield chaser_type, start.days.ago, ending.days.ago if block_given?
       end
     end
   end

--- a/app/services/chasers/candidate.rb
+++ b/app/services/chasers/candidate.rb
@@ -1,0 +1,20 @@
+module Chasers
+  module Candidate
+    # chaser: [days_ago, days_ago]
+    OFFER_CHASERS_TO_INTERVALS = {
+      offer_10_day: [20, 10],
+      offer_20_day: [30, 20],
+      offer_30_day: [40, 30],
+      offer_40_day: [50, 40],
+      offer_50_day: [60, 50],
+    }.freeze
+
+    def self.chaser_to_date_range
+      OFFER_CHASERS_TO_INTERVALS.each_with_object({}) do |(chaser_type, (start, ending)), object|
+        object[chaser_type] = (start.days.ago..ending.days.ago)
+
+        yield chaser_type, start.days.ago, ending.days.ago if block_given?
+      end
+    end
+  end
+end

--- a/app/services/chasers/candidate/offer_email_service.rb
+++ b/app/services/chasers/candidate/offer_email_service.rb
@@ -1,0 +1,10 @@
+module Chasers
+  module Candidate
+    class OfferEmailService
+      def self.call(application_choice:, mailer:, chaser_type:)
+        CandidateMailer.send(mailer, application_choice).deliver_now
+        ChaserSent.create!(chased: application_choice, chaser_type:)
+      end
+    end
+  end
+end

--- a/app/views/candidate_mailer/offer_10_day.text.erb
+++ b/app/views/candidate_mailer/offer_10_day.text.erb
@@ -1,0 +1,11 @@
+Hello <%= @first_name %>
+
+Congratulations! 10 days ago, you received an offer for a place on the course, <%= @course_name %> at <%= @provider_name %>.
+
+You should respond to your offer as soon as you can. Most candidates respond to their offer in 15 working days.
+
+[Sign in to your account to respond to your offer](<%= candidate_magic_link(@candidate) %>).
+
+Accepting your offer is your first step to becoming an amazing teacher and making a positive difference.
+
+If you have any questions about your training, you can contact the training provider.

--- a/app/views/candidate_mailer/offer_20_day.text.erb
+++ b/app/views/candidate_mailer/offer_20_day.text.erb
@@ -1,0 +1,9 @@
+Hello <%= @first_name %>
+
+20 days ago, you received an offer for a place on the course, <%= @course_name %> at <%= @provider_name %>.
+
+You must respond to your offer as soon as you can. Most candidates respond to their offer in 15 working days.
+
+[Sign in to your account to respond to your offer](<%= candidate_magic_link(@candidate) %>).
+
+If you have any questions about your training, you can contact the training provider.

--- a/app/views/candidate_mailer/offer_30_day.text.erb
+++ b/app/views/candidate_mailer/offer_30_day.text.erb
@@ -1,0 +1,17 @@
+Hello <%= @first_name %>
+
+30 days ago, you received an offer for a place on the course, <%= @course_name %> at <%= @provider_name %>.
+
+You must respond to your offer as soon as you can. This will allow other candidates the chance to apply for a place on the course.
+
+[Sign in to your account to respond to your offer now](<%= candidate_magic_link(@candidate) %>).
+
+If you are waiting on other offers or are unsure about accepting this offer, contact the training provider.
+
+# If you’re not able to start training yet
+
+You can defer your offer and start your course a year later.
+
+Contact <%= @provider_name %> to ask if it’s possible to defer, this will not affect your existing offer.
+
+If your training provider agrees, you’ll need to accept the offer first.

--- a/app/views/candidate_mailer/offer_40_day.text.erb
+++ b/app/views/candidate_mailer/offer_40_day.text.erb
@@ -1,0 +1,17 @@
+Hello <%= @first_name %>
+
+40 days ago, you received an offer for a place on the course, <%= @course_name %> at <%= @provider_name %>.
+
+You must respond to your offer, even if you decline it. This will allow other candidates the chance to apply for a place on the course.
+
+[Sign in to your account to respond to your offer now](<%= candidate_magic_link(@candidate) %>).
+
+If you are waiting on other offers or are unsure about accepting this offer, contact the training provider.
+
+# If you’re not able to start training yet
+
+You can defer your offer and start your course a year later.
+
+Contact <%= @provider_name %> to ask if it’s possible to defer, this will not affect your existing offer.
+
+If your training provider agrees, you’ll need to accept the offer first.

--- a/app/views/candidate_mailer/offer_50_day.text.erb
+++ b/app/views/candidate_mailer/offer_50_day.text.erb
@@ -1,0 +1,17 @@
+Hello <%= @first_name %>
+
+50 days ago, you received an offer for a place on the course, <%= @course_name %> at <%= @provider_name %>.
+
+Respond to your offer, even if you decline it. This will allow other candidates the opportunity to apply for a place on the course.
+
+[Sign in to your account to respond to your offer now](<%= candidate_magic_link(@candidate) %>).
+
+If you are waiting on other offers or are unsure about accepting this offer, contact the training provider.
+
+# If you’re not able to start training yet
+
+You can defer your offer and start your course a year later.
+
+Contact <%= @provider_name %> to ask if it’s possible to defer, this will not affect your existing offer.
+
+If your training provider agrees, you’ll need to accept the offer first.

--- a/app/workers/chasers/candidate/offer_worker.rb
+++ b/app/workers/chasers/candidate/offer_worker.rb
@@ -1,0 +1,25 @@
+module Chasers
+  module Candidate
+    class OfferWorker
+      include Sidekiq::Worker
+
+      DAYS_TO_CHASER_MAPPING = {
+        10 => :offer_10_day,
+        20 => :offer_20_day,
+        30 => :offer_30_day,
+        40 => :offer_40_day,
+        50 => :offer_50_day,
+      }.freeze
+
+      def perform
+        OffersToChaseQuery::VALID_INTERVALS.each do |days|
+          chaser_type = mailer = DAYS_TO_CHASER_MAPPING.fetch(days)
+
+          OffersToChaseQuery.call(days:).find_each do |application_choice|
+            Chasers::Candidate::OfferEmailService.call(mailer:, chaser_type:, application_choice:)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/workers/chasers/candidate/offer_worker.rb
+++ b/app/workers/chasers/candidate/offer_worker.rb
@@ -3,19 +3,11 @@ module Chasers
     class OfferWorker
       include Sidekiq::Worker
 
-      DAYS_TO_CHASER_MAPPING = {
-        10 => :offer_10_day,
-        20 => :offer_20_day,
-        30 => :offer_30_day,
-        40 => :offer_40_day,
-        50 => :offer_50_day,
-      }.freeze
-
       def perform
-        OffersToChaseQuery::VALID_INTERVALS.each do |days|
-          chaser_type = mailer = DAYS_TO_CHASER_MAPPING.fetch(days)
+        Chasers::Candidate.chaser_to_date_range.each do |chaser_type, date_range|
+          mailer = chaser_type
 
-          OffersToChaseQuery.call(days:).find_each do |application_choice|
+          OffersToChaseQuery.call(chaser_type:, date_range:).find_each do |application_choice|
             Chasers::Candidate::OfferEmailService.call(mailer:, chaser_type:, application_choice:)
           end
         end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -26,6 +26,8 @@ class Clock
   every(1.hour, 'DetectInvariantsHourlyCheck', at: '**:30') { DetectInvariantsHourlyCheck.perform_async }
 
   # Daily jobs
+  every(1.day, 'Chasers::Candidate::OfferWorker', at: '10:30') { Chasers::Candidate::OfferWorker.perform_async }
+
   every(1.day, 'DetectInvariantsDailyCheck', at: '07:00') { DetectInvariantsDailyCheck.perform_async }
 
   every(1.day, 'Generate export for TAD', at: '23:59') { DataAPI::TADExport.run_daily }

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -12,6 +12,8 @@ en:
       subject: "%{referee_name} has not replied to your request for a reference"
     chase_reference_again:
       subject: "%{referee_name} has not replied to your request for a reference"
+    offer_day:
+      subject: Respond to your teacher training offer from %{provider_name}
     offer_withdrawn:
       subject: "Offer withdrawn by %{provider_name}"
     offer_accepted:

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -14,6 +14,8 @@ en:
       subject: "%{referee_name} has not replied to your request for a reference"
     offer_day:
       subject: Respond to your teacher training offer from %{provider_name}
+    offer_50_day:
+      subject: You must respond to your teacher training offer from %{provider_name}
     offer_withdrawn:
       subject: "Offer withdrawn by %{provider_name}"
     offer_accepted:

--- a/spec/lib/time_limit_config_spec.rb
+++ b/spec/lib/time_limit_config_spec.rb
@@ -10,15 +10,17 @@ RSpec.describe TimeLimitConfig do
       expect(described_class.limits_for(:chase_candidate_before_dbd).first.limit).to eq(5)
     end
 
-    context 'when continuous applications', :continuous_applications do
-      it ':reject_by_default returns a default limit of 30 days' do
-        expect(described_class.limits_for(:reject_by_default).first.limit).to eq(30)
-      end
+    it ':reject_by_default returns a default limit of 30 days when continuous applications', :continuous_applications do
+      expect(described_class.limits_for(:reject_by_default).first.limit).to eq(30)
     end
 
-    context 'when not continuous applications', continuous_applications: false do
-      it ':reject_by_default returns a default limit of 40 days' do
-        expect(described_class.limits_for(:reject_by_default).first.limit).to eq(40)
+    it ':reject_by_default returns a default limit of 40 days non continuous applications', continuous_applications: false do
+      expect(described_class.limits_for(:reject_by_default).first.limit).to eq(40)
+    end
+
+    it ':reject_by_default returns a limit of 20 days date is after June in the current cycle' do
+      TestSuiteTimeMachine.travel_permanently_to(Date.new(RecruitmentCycle.current_year, 7, 1)) do
+        expect(described_class.limits_for(:reject_by_default).first.limit).to eq(20)
       end
     end
   end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -109,8 +109,7 @@ RSpec.describe CandidateMailer do
     end
   end
 
-  describe 'Candidate offer 10 day mailer' do
-    let(:email) { mailer.offer_10_day(offer) }
+  describe 'Offer X day mailers' do
     let(:offer) do
       build_stubbed(:application_choice, :offered,
                     sent_to_provider_at: Time.zone.today,
@@ -123,11 +122,10 @@ RSpec.describe CandidateMailer do
                                                           code: '3TT5', provider:))
     end
     let(:provider) { build_stubbed(:provider, name: 'Brighthurst Technical College') }
+    let(:application_choices) { [offer] }
 
-    delegate :name, to: :provider, prefix: true
-
-    context 'when a candidate has one appication choice with offer' do
-      let(:application_choices) { [offer] }
+    describe 'Offer 10 day mailer' do
+      let(:email) { mailer.offer_10_day(offer) }
 
       it_behaves_like(
         'a mail with subject and content',
@@ -136,27 +134,9 @@ RSpec.describe CandidateMailer do
         'provider name' => 'Brighthurst Technical College',
       )
     end
-  end
 
-  describe 'Candidate offer 20 day mailer' do
-    let(:email) { mailer.offer_20_day(offer) }
-    let(:offer) do
-      build_stubbed(:application_choice, :offered,
-                    sent_to_provider_at: Time.zone.today,
-                    application_form: build_stubbed(:application_form, first_name: 'Fred'),
-                    course_option:)
-    end
-    let(:course_option) do
-      build_stubbed(:course_option, course: build_stubbed(:course,
-                                                          name: 'Applied Science (Psychology)',
-                                                          code: '3TT5', provider:))
-    end
-    let(:provider) { build_stubbed(:provider, name: 'Brighthurst Technical College') }
-
-    delegate :name, to: :provider, prefix: true
-
-    context 'when a candidate has one appication choice with offer' do
-      let(:application_choices) { [offer] }
+    describe 'Offer 20 day mailer' do
+      let(:email) { mailer.offer_20_day(offer) }
 
       it_behaves_like(
         'a mail with subject and content',
@@ -165,27 +145,9 @@ RSpec.describe CandidateMailer do
         'provider name' => 'Brighthurst Technical College',
       )
     end
-  end
 
-  describe 'Candidate offer 30 day mailer' do
-    let(:email) { mailer.offer_30_day(offer) }
-    let(:offer) do
-      build_stubbed(:application_choice, :offered,
-                    sent_to_provider_at: Time.zone.today,
-                    application_form: build_stubbed(:application_form, first_name: 'Fred'),
-                    course_option:)
-    end
-    let(:course_option) do
-      build_stubbed(:course_option, course: build_stubbed(:course,
-                                                          name: 'Applied Science (Psychology)',
-                                                          code: '3TT5', provider:))
-    end
-    let(:provider) { build_stubbed(:provider, name: 'Brighthurst Technical College') }
-
-    delegate :name, to: :provider, prefix: true
-
-    context 'when a candidate has one appication choice with offer' do
-      let(:application_choices) { [offer] }
+    describe 'Offer 30 day mailer' do
+      let(:email) { mailer.offer_30_day(offer) }
 
       it_behaves_like(
         'a mail with subject and content',
@@ -194,27 +156,9 @@ RSpec.describe CandidateMailer do
         'provider name' => 'Brighthurst Technical College',
       )
     end
-  end
 
-  describe 'Candidate offer 40 day mailer' do
-    let(:email) { mailer.offer_40_day(offer) }
-    let(:offer) do
-      build_stubbed(:application_choice, :offered,
-                    sent_to_provider_at: Time.zone.today,
-                    application_form: build_stubbed(:application_form, first_name: 'Fred'),
-                    course_option:)
-    end
-    let(:course_option) do
-      build_stubbed(:course_option, course: build_stubbed(:course,
-                                                          name: 'Applied Science (Psychology)',
-                                                          code: '3TT5', provider:))
-    end
-    let(:provider) { build_stubbed(:provider, name: 'Brighthurst Technical College') }
-
-    delegate :name, to: :provider, prefix: true
-
-    context 'when a candidate has one appication choice with offer' do
-      let(:application_choices) { [offer] }
+    describe 'Offer 40 day mailer' do
+      let(:email) { mailer.offer_40_day(offer) }
 
       it_behaves_like(
         'a mail with subject and content',
@@ -223,27 +167,9 @@ RSpec.describe CandidateMailer do
         'provider name' => 'Brighthurst Technical College',
       )
     end
-  end
 
-  describe 'Candidate offer 50 day mailer' do
-    let(:email) { mailer.offer_50_day(offer) }
-    let(:offer) do
-      build_stubbed(:application_choice, :offered,
-                    sent_to_provider_at: Time.zone.today,
-                    application_form: build_stubbed(:application_form, first_name: 'Fred'),
-                    course_option:)
-    end
-    let(:course_option) do
-      build_stubbed(:course_option, course: build_stubbed(:course,
-                                                          name: 'Applied Science (Psychology)',
-                                                          code: '3TT5', provider:))
-    end
-    let(:provider) { build_stubbed(:provider, name: 'Brighthurst Technical College') }
-
-    delegate :name, to: :provider, prefix: true
-
-    context 'when a candidate has one appication choice with offer' do
-      let(:application_choices) { [offer] }
+    describe 'Offer 50 day mailer' do
+      let(:email) { mailer.offer_50_day(offer) }
 
       it_behaves_like(
         'a mail with subject and content',

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -138,6 +138,35 @@ RSpec.describe CandidateMailer do
     end
   end
 
+  describe 'Candidate offer 20 day mailer' do
+    let(:email) { mailer.offer_20_day(offer) }
+    let(:offer) do
+      build_stubbed(:application_choice, :offered,
+                    sent_to_provider_at: Time.zone.today,
+                    application_form: build_stubbed(:application_form, first_name: 'Fred'),
+                    course_option:)
+    end
+    let(:course_option) do
+      build_stubbed(:course_option, course: build_stubbed(:course,
+                                                          name: 'Applied Science (Psychology)',
+                                                          code: '3TT5', provider:))
+    end
+    let(:provider) { build_stubbed(:provider, name: 'Brighthurst Technical College') }
+
+    delegate :name, to: :provider, prefix: true
+
+    context 'when a candidate has one appication choice with offer' do
+      let(:application_choices) { [offer] }
+
+      it_behaves_like(
+        'a mail with subject and content',
+        I18n.t!('candidate_mailer.offer_day.subject', provider_name: 'Brighthurst Technical College'),
+        'heading' => 'Hello Fred',
+        'provider name' => 'Brighthurst Technical College',
+      )
+    end
+  end
+
   describe '.decline_by_default' do
     let(:email) { mailer.declined_by_default(application_form) }
 

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -225,6 +225,35 @@ RSpec.describe CandidateMailer do
     end
   end
 
+  describe 'Candidate offer 50 day mailer' do
+    let(:email) { mailer.offer_50_day(offer) }
+    let(:offer) do
+      build_stubbed(:application_choice, :offered,
+                    sent_to_provider_at: Time.zone.today,
+                    application_form: build_stubbed(:application_form, first_name: 'Fred'),
+                    course_option:)
+    end
+    let(:course_option) do
+      build_stubbed(:course_option, course: build_stubbed(:course,
+                                                          name: 'Applied Science (Psychology)',
+                                                          code: '3TT5', provider:))
+    end
+    let(:provider) { build_stubbed(:provider, name: 'Brighthurst Technical College') }
+
+    delegate :name, to: :provider, prefix: true
+
+    context 'when a candidate has one appication choice with offer' do
+      let(:application_choices) { [offer] }
+
+      it_behaves_like(
+        'a mail with subject and content',
+        I18n.t!('candidate_mailer.offer_50_day.subject', provider_name: 'Brighthurst Technical College'),
+        'heading' => 'Hello Fred',
+        'provider name' => 'Brighthurst Technical College',
+      )
+    end
+  end
+
   describe '.decline_by_default' do
     let(:email) { mailer.declined_by_default(application_form) }
 

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -196,6 +196,35 @@ RSpec.describe CandidateMailer do
     end
   end
 
+  describe 'Candidate offer 40 day mailer' do
+    let(:email) { mailer.offer_40_day(offer) }
+    let(:offer) do
+      build_stubbed(:application_choice, :offered,
+                    sent_to_provider_at: Time.zone.today,
+                    application_form: build_stubbed(:application_form, first_name: 'Fred'),
+                    course_option:)
+    end
+    let(:course_option) do
+      build_stubbed(:course_option, course: build_stubbed(:course,
+                                                          name: 'Applied Science (Psychology)',
+                                                          code: '3TT5', provider:))
+    end
+    let(:provider) { build_stubbed(:provider, name: 'Brighthurst Technical College') }
+
+    delegate :name, to: :provider, prefix: true
+
+    context 'when a candidate has one appication choice with offer' do
+      let(:application_choices) { [offer] }
+
+      it_behaves_like(
+        'a mail with subject and content',
+        I18n.t!('candidate_mailer.offer_day.subject', provider_name: 'Brighthurst Technical College'),
+        'heading' => 'Hello Fred',
+        'provider name' => 'Brighthurst Technical College',
+      )
+    end
+  end
+
   describe '.decline_by_default' do
     let(:email) { mailer.declined_by_default(application_form) }
 

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -109,6 +109,35 @@ RSpec.describe CandidateMailer do
     end
   end
 
+  describe 'Candidate offer 10 day mailer' do
+    let(:email) { mailer.offer_10_day(offer) }
+    let(:offer) do
+      build_stubbed(:application_choice, :offered,
+                    sent_to_provider_at: Time.zone.today,
+                    application_form: build_stubbed(:application_form, first_name: 'Fred'),
+                    course_option:)
+    end
+    let(:course_option) do
+      build_stubbed(:course_option, course: build_stubbed(:course,
+                                                          name: 'Applied Science (Psychology)',
+                                                          code: '3TT5', provider:))
+    end
+    let(:provider) { build_stubbed(:provider, name: 'Brighthurst Technical College') }
+
+    delegate :name, to: :provider, prefix: true
+
+    context 'when a candidate has one appication choice with offer' do
+      let(:application_choices) { [offer] }
+
+      it_behaves_like(
+        'a mail with subject and content',
+        I18n.t!('candidate_mailer.offer_day.subject', provider_name: 'Brighthurst Technical College'),
+        'heading' => 'Hello Fred',
+        'provider name' => 'Brighthurst Technical College',
+      )
+    end
+  end
+
   describe '.decline_by_default' do
     let(:email) { mailer.declined_by_default(application_form) }
 

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -167,6 +167,35 @@ RSpec.describe CandidateMailer do
     end
   end
 
+  describe 'Candidate offer 30 day mailer' do
+    let(:email) { mailer.offer_30_day(offer) }
+    let(:offer) do
+      build_stubbed(:application_choice, :offered,
+                    sent_to_provider_at: Time.zone.today,
+                    application_form: build_stubbed(:application_form, first_name: 'Fred'),
+                    course_option:)
+    end
+    let(:course_option) do
+      build_stubbed(:course_option, course: build_stubbed(:course,
+                                                          name: 'Applied Science (Psychology)',
+                                                          code: '3TT5', provider:))
+    end
+    let(:provider) { build_stubbed(:provider, name: 'Brighthurst Technical College') }
+
+    delegate :name, to: :provider, prefix: true
+
+    context 'when a candidate has one appication choice with offer' do
+      let(:application_choices) { [offer] }
+
+      it_behaves_like(
+        'a mail with subject and content',
+        I18n.t!('candidate_mailer.offer_day.subject', provider_name: 'Brighthurst Technical College'),
+        'heading' => 'Hello Fred',
+        'provider name' => 'Brighthurst Technical College',
+      )
+    end
+  end
+
   describe '.decline_by_default' do
     let(:email) { mailer.declined_by_default(application_form) }
 

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -140,6 +140,12 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.offer_40_day(application_choice_with_offer)
   end
 
+  def offer_50_day
+    application_form_with_course_choices([application_choice_with_offer])
+
+    CandidateMailer.offer_50_day(application_choice_with_offer)
+  end
+
   def new_offer_made
     application_form_with_name = FactoryBot.build_stubbed(
       :application_form,

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -116,6 +116,12 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.interview_cancelled(application_choice, interview, 'You contacted us to say you didn’t want to apply for this course any more.')
   end
 
+  def offer_10_day
+    application_form_with_course_choices([application_choice_with_offer])
+
+    CandidateMailer.offer_10_day(application_choice_with_offer)
+  end
+
   def new_offer_made
     application_form_with_name = FactoryBot.build_stubbed(
       :application_form,

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -122,6 +122,12 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.offer_10_day(application_choice_with_offer)
   end
 
+  def offer_20_day
+    application_form_with_course_choices([application_choice_with_offer])
+
+    CandidateMailer.offer_20_day(application_choice_with_offer)
+  end
+
   def new_offer_made
     application_form_with_name = FactoryBot.build_stubbed(
       :application_form,

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -128,6 +128,12 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.offer_20_day(application_choice_with_offer)
   end
 
+  def offer_30_day
+    application_form_with_course_choices([application_choice_with_offer])
+
+    CandidateMailer.offer_30_day(application_choice_with_offer)
+  end
+
   def new_offer_made
     application_form_with_name = FactoryBot.build_stubbed(
       :application_form,

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -134,6 +134,12 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.offer_30_day(application_choice_with_offer)
   end
 
+  def offer_40_day
+    application_form_with_course_choices([application_choice_with_offer])
+
+    CandidateMailer.offer_40_day(application_choice_with_offer)
+  end
+
   def new_offer_made
     application_form_with_name = FactoryBot.build_stubbed(
       :application_form,

--- a/spec/queries/offers_to_chase_query_spec.rb
+++ b/spec/queries/offers_to_chase_query_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe OffersToChaseQuery do
   context 'when days is 20 and offer made more than 20 and less than 30 days ago' do
     let(:days_range) { (20..30) }
 
-    it 'returns the appliation choice without a chaser' do
+    it 'returns the application choice without a chaser' do
       TestSuiteTimeMachine.travel_permanently_to(min_of_range.days.from_now + 10.seconds)
 
       expect(Time.zone.now).to be_between(min_of_range.days.since(offer_without_chaser.created_at), max_of_range.days.since(offer_without_chaser.created_at))

--- a/spec/queries/offers_to_chase_query_spec.rb
+++ b/spec/queries/offers_to_chase_query_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe OffersToChaseQuery do
+  let!(:application_choice_without_offer) { create(:application_choice, :awaiting_provider_decision) }
+  let!(:application_choice_with_chaser) { create(:application_choice, :offer) }
+  let!(:chaser_sent) { create(:chaser_sent, chased: application_choice_with_chaser, chaser_type: "offer_#{min_of_range}_day") }
+
+  let!(:application_choice_without_chaser) { create(:application_choice, :offer) }
+  let(:offer_without_chaser) { application_choice_without_chaser.offer }
+
+  let(:days_range) { (10..20) }
+  let(:min_of_range) { days_range.min }
+  let(:max_of_range) { days_range.max }
+
+  before { chaser_sent }
+
+  context 'when days is not acceptable argument' do
+    let(:days_range) { (10..20) }
+
+    it 'raises an ArgumentError' do
+      expect { described_class.call(days: 3) }.to raise_error(ArgumentError)
+    end
+  end
+
+  context 'when days is 10 and offer made less than 10 days ago' do
+    let(:days_range) { (10..20) }
+
+    it 'returns empty collection' do
+      TestSuiteTimeMachine.travel_permanently_to(10.days.from_now - 1.second)
+      expect(offer_without_chaser.created_at).to be < 10.days.from_now
+      expect(described_class.call(days: 10)).to be_empty
+    end
+  end
+
+  context 'when days is 10 and offer made more than 10 and less than 20 days ago' do
+    let(:days_range) { (10..20) }
+
+    it 'returns the appliation choice without a chaser' do
+      TestSuiteTimeMachine.travel_permanently_to(min_of_range.days.from_now + 10.seconds)
+
+      expect(Time.zone.now).to be_between(min_of_range.days.since(offer_without_chaser.created_at), max_of_range.days.since(offer_without_chaser.created_at))
+
+      expect(described_class.call(days: min_of_range)).to contain_exactly(application_choice_without_chaser)
+    end
+  end
+
+  context 'when days is 20 and offer made more than 20 and less than 30 days ago' do
+    let(:days_range) { (20..30) }
+
+    it 'returns the appliation choice without a chaser' do
+      TestSuiteTimeMachine.travel_permanently_to(min_of_range.days.from_now + 10.seconds)
+
+      expect(Time.zone.now).to be_between(min_of_range.days.since(offer_without_chaser.created_at), max_of_range.days.since(offer_without_chaser.created_at))
+
+      expect(described_class.call(days: min_of_range)).to contain_exactly(application_choice_without_chaser)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -164,10 +164,8 @@ RSpec.configure do |config|
     if example.metadata[:continuous_applications].present?
       FeatureFlag.activate(:continuous_applications)
       set_time(mid_cycle(2024))
-      CycleTimetable.reset_holidays
     elsif example.metadata.key?(:continuous_applications) && example.metadata[:continuous_applications].blank?
       set_time(mid_cycle(2023))
-      CycleTimetable.reset_holidays
       FeatureFlag.deactivate(:continuous_applications)
     end
   end

--- a/spec/services/chasers/candidate/offer_email_service_spec.rb
+++ b/spec/services/chasers/candidate/offer_email_service_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe Chasers::Candidate::OfferEmailService do
   let(:chaser_type) { mailer }
 
   it 'sends an email and creates a ChaserSent' do
-    expect { described_class.call(chaser_type:, mailer:, application_choice:) }.to change { CandidateMailer.deliveries.count }.by(1).and change { ChaserSent.count }.by(1)
+    expect do
+      described_class.call(chaser_type:, mailer:, application_choice:)
+    end
+      .to change { CandidateMailer.deliveries.count }.by(1)
+      .and change { ChaserSent.count }.by(1)
   end
 end

--- a/spec/services/chasers/candidate/offer_email_service_spec.rb
+++ b/spec/services/chasers/candidate/offer_email_service_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Chasers::Candidate::OfferEmailService do
+  let(:application_choice) { create(:application_choice) }
+  let(:mailer) { :offer_10_day }
+  let(:chaser_type) { mailer }
+
+  it 'sends an email and creates a ChaserSent' do
+    expect { described_class.call(chaser_type:, mailer:, application_choice:) }.to change { CandidateMailer.deliveries.count }.by(1).and change { ChaserSent.count }.by(1)
+  end
+end

--- a/spec/services/chasers/candidate_spec.rb
+++ b/spec/services/chasers/candidate_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Chasers::Candidate do
+  describe '.chaser_to_date_range' do
+    it 'returns a chaser_type with respective date range' do
+      expected = { offer_10_day: (20.days.ago..10.days.ago) }
+      expect(described_class.chaser_to_date_range).to include(expected)
+    end
+
+    context 'when a block is passed' do
+      it 'yields the chaser_type, start and end' do
+        expected = [
+          [:offer_10_day, 20.days.ago, 10.days.ago],
+          [:offer_20_day, 30.days.ago, 20.days.ago],
+          [:offer_30_day, 40.days.ago, 30.days.ago],
+          [:offer_40_day, 50.days.ago, 40.days.ago],
+          [:offer_50_day, 60.days.ago, 50.days.ago],
+        ]
+        expect { |b| described_class.chaser_to_date_range(&b) }.to yield_successive_args(*expected)
+      end
+    end
+  end
+end

--- a/spec/services/chasers/candidate_spec.rb
+++ b/spec/services/chasers/candidate_spec.rb
@@ -6,18 +6,5 @@ RSpec.describe Chasers::Candidate do
       expected = { offer_10_day: (20.days.ago..10.days.ago) }
       expect(described_class.chaser_to_date_range).to include(expected)
     end
-
-    context 'when a block is passed' do
-      it 'yields the chaser_type, start and end' do
-        expected = [
-          [:offer_10_day, 20.days.ago, 10.days.ago],
-          [:offer_20_day, 30.days.ago, 20.days.ago],
-          [:offer_30_day, 40.days.ago, 30.days.ago],
-          [:offer_40_day, 50.days.ago, 40.days.ago],
-          [:offer_50_day, 60.days.ago, 50.days.ago],
-        ]
-        expect { |b| described_class.chaser_to_date_range(&b) }.to yield_successive_args(*expected)
-      end
-    end
   end
 end

--- a/spec/services/time_limit_calculator_spec.rb
+++ b/spec/services/time_limit_calculator_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe TimeLimitCalculator do
   it 'returns default value with just a default time limit' do
     allow(TimeLimitConfig).to receive(:limits_for).and_return(
       [
-        TimeLimitConfig::Rule.new(nil, nil, 20),
+        TimeLimitConfig.new_rule(nil, nil, 20),
       ],
     )
     calculator = described_class.new(
@@ -23,8 +23,8 @@ RSpec.describe TimeLimitCalculator do
   it 'returns value for rule with `from_date` when effective date matches rule' do
     allow(TimeLimitConfig).to receive(:limits_for).and_return(
       [
-        TimeLimitConfig::Rule.new(nil, nil, 20),
-        TimeLimitConfig::Rule.new(10.days.ago, nil, 10),
+        TimeLimitConfig.new_rule(nil, nil, 20),
+        TimeLimitConfig.new_rule(10.days.ago, nil, 10),
       ],
     )
     calculator = described_class.new(
@@ -41,8 +41,8 @@ RSpec.describe TimeLimitCalculator do
   it 'returns value for default rule rather than one with `from_date` when effective date does not match rule' do
     allow(TimeLimitConfig).to receive(:limits_for).and_return(
       [
-        TimeLimitConfig::Rule.new(nil, nil, 20),
-        TimeLimitConfig::Rule.new(10.days.from_now, nil, 10),
+        TimeLimitConfig.new_rule(nil, nil, 20),
+        TimeLimitConfig.new_rule(10.days.from_now, nil, 10),
       ],
     )
     calculator = described_class.new(
@@ -59,9 +59,9 @@ RSpec.describe TimeLimitCalculator do
   it 'returns value for rule with `to_date` and `from_date` when effective date matches rule' do
     allow(TimeLimitConfig).to receive(:limits_for).and_return(
       [
-        TimeLimitConfig::Rule.new(nil, nil, 20),
-        TimeLimitConfig::Rule.new(10.days.ago, nil, 10),
-        TimeLimitConfig::Rule.new(5.days.ago, 5.days.from_now, 5),
+        TimeLimitConfig.new_rule(nil, nil, 20),
+        TimeLimitConfig.new_rule(10.days.ago, nil, 10),
+        TimeLimitConfig.new_rule(5.days.ago, 5.days.from_now, 5),
       ],
     )
     calculator = described_class.new(

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -64,6 +64,11 @@ RSpec.feature 'Docs' do
       candidate_mailer-application_choice_submitted
       candidate_mailer-apply_to_another_course_after_30_working_days
       candidate_mailer-apply_to_multiple_courses_after_30_working_days
+      candidate_mailer-offer_10_day
+      candidate_mailer-offer_20_day
+      candidate_mailer-offer_30_day
+      candidate_mailer-offer_40_day
+      candidate_mailer-offer_50_day
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"

--- a/spec/workers/chasers/candidate/offer_worker_spec.rb
+++ b/spec/workers/chasers/candidate/offer_worker_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe Chasers::Candidate::OfferWorker do
   let!(:application_choices) do
-    Chasers::Candidate.chaser_to_date_range do |_chaser_type, start, _ending|
+    Chasers::Candidate.chaser_to_date_range.each_value do |date_range|
       create(:application_choice, :offer).tap do |choice|
-        choice.offer.update(created_at: start)
+        choice.offer.update(created_at: date_range.min)
       end
     end
   end

--- a/spec/workers/chasers/candidate/offer_worker_spec.rb
+++ b/spec/workers/chasers/candidate/offer_worker_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe Chasers::Candidate::OfferWorker do
+  let!(:application_choices) do
+    OffersToChaseQuery::VALID_INTERVALS.map do |interval|
+      create(:application_choice, :offer).tap do |choice|
+        choice.offer.update(created_at: (interval + 1).days.ago)
+      end
+    end
+  end
+  let(:chaser_types) do
+    %i[
+      offer_10_day
+      offer_20_day
+      offer_30_day
+      offer_40_day
+      offer_50_day
+    ]
+  end
+  let(:mailers) { chaser_types }
+  let(:groups) { application_choices.zip(chaser_types, mailers) }
+
+  it 'calls the service for each chaser interval' do
+    allow(Chasers::Candidate::OfferEmailService).to receive(:call).and_call_original
+
+    described_class.new.perform
+
+    groups do |application_choice, chaser_type, mailer|
+      expect(Chasers::Candidate::OfferEmailService).to have_received(:call).with(chaser_type:, mailer:, application_choice:)
+    end
+  end
+end


### PR DESCRIPTION
## Context

Candidates will no longer have 10 working days to accept an offer. Instead, they will have no time limit. We need to make sure they don’t sit on offers for a long time.

We need to create a new emails to chase them to accept offers.

## Changes proposed in this pull request

Add ability to send emails to candidates who have not responded to an offer from a Provider after specific thresholds of time has passed since the offer was made.

The process of sending these emails involves sending the email and creating a chaser sent record to mark the sending of the email. We could have queried the emails table for a record of this but it seems more appropriate to use the existing ChaserSent approach for consistency.

Create namespace `Chasers` for services, workers etc. namespace this further to `Candidate`.

Within the namespace create a worker that runs once a day. 

The worker collects all application choices which we want to send a chaser email to the candidate. The `Chasers::Candidate::OfferWorker` iterates over the intervals and sends emails to all candidates for each tranche.

I chose not to enqueue the email because if the email failed in the background process for some reason, the Chaser would be created anyway.

Here is a diagram of the system:
![Screenshot from 2023-12-05 12-34-01](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/381c1b3d-b176-4e92-b0a9-bbfc1843d283)



I've added `Chasers::Candidate` which takes the responsibility of handling the `chasers_type` and the number of days from the current moment that the chaser covers. It is responsible for rendering a date range and also the start and ending intervals of the range.


## Guidance to review

## Code Review Approach

Review each commit in turn to see the progression of the ticket. Starting [here](https://github.com/DFE-Digital/apply-for-teacher-training/pull/8860/commits/9822afa4ecc2445428b6e44000738e8fb6a0177f).

### Email Previews

Visit the Documentation in the app to see the email previews [here](https://apply-review-8860.test.teacherservices.cloud/support/docs/mailers)

![Screenshot from 2023-12-06 09-47-01](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/76a0de0d-0c26-4bca-bc0e-fdd65833bbd5)


## Link to Trello card

[Trello Ticket](https://trello.com/c/vJTzC6H4/471-create-new-chaser-emails-to-get-candidates-to-accept-offers)