### PR TITLE
Make legitimate GCSE grades pass validation

### DIFF
--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -165,7 +165,7 @@ class ApplicationQualification < ApplicationRecord
     details.strip if details.present?
   end
 
-  GCSE_PASS_GRADES = %w[A* A B C A*A* A*A AA AB BB BC CC CD 9 8 7 6 5 4 9-9 9-8 8-8 8-7 7-7 7-6 6-6 6-5 5-5 5-4 4-4 4-3].freeze
+  GCSE_PASS_GRADES = %w[A* A B C A*A* A*A AA AB AC BB BC C* CC CD 9 8 7 6 5 4 9-9 9-8 8-8 8-7 7-7 7-6 6-6 6-5 5-5 5-4 4-4 4-3].freeze
   def failed_required_gcse?
     return true if required_gcse? && all_grades.present? && !pass_gcse?
 

--- a/config/initializers/qualifications/gcse_grades.rb
+++ b/config/initializers/qualifications/gcse_grades.rb
@@ -1,4 +1,4 @@
-SINGLE_GCSE_GRADES = %w[9 8 7 6 5 4 3 2 1 A* A B C D E F G U].freeze
+SINGLE_GCSE_GRADES = %w[9 8 7 6 5 4 3 2 1 A* A B C C* D E F G U].freeze
 DOUBLE_GCSE_GRADES = %w[
   9-8
   9-9
@@ -21,6 +21,7 @@ DOUBLE_GCSE_GRADES = %w[
   A*A*
   AA
   AB
+  AC
   BB
   BC
   CC


### PR DESCRIPTION
Adds `AC` and `C*` to the list of legitimate GCSE grades.

![](https://github.trello.services/images/mini-trello-icon.png) [Some legitimate GCSE grades don't pass validation (e.g. AC for Double Science and Northern Irish C*)](https://trello.com/c/9WgLEPPk/887-some-legitimate-gcse-grades-dont-pass-validation-eg-ac-for-double-science-and-northern-irish-c)

Before:
<img width="584" alt="Screenshot 2023-12-05 at 16 55 15" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/ee67e4ce-7534-408d-98c9-bd04be058d51">

After:
<img width="800" alt="Screenshot 2023-12-05 at 16 58 00" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/e7e2c475-74aa-40ab-aa6a-e14dd2301195">
