### PR TITLE
[1021] Data migration to backfill `work_history_status` when `nil`

### DIFF
--- a/app/services/data_migrations/set_missing_work_history_status_values.rb
+++ b/app/services/data_migrations/set_missing_work_history_status_values.rb
@@ -1,0 +1,20 @@
+module DataMigrations
+  class SetMissingWorkHistoryStatusValues
+    TIMESTAMP = 20231206202136
+    MANUAL_RUN = false
+
+    def change
+      application_forms.each do |application_form|
+        application_form.update(work_history_status: 'can_complete')
+      end
+    end
+
+  private
+
+    def application_forms
+      ApplicationForm.where(work_history_status: nil)
+                     .where(work_history_completed: true)
+                     .where(recruitment_cycle_year: 2024)
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::SetMissingWorkHistoryStatusValues',
   'DataMigrations::UpdateDeclineByDefaultAtFromCurrentCycle',
   'DataMigrations::RemoveDbdFromCurrentCycle',
   'DataMigrations::RemoveRecruitWithPendingConditionsFeatureFlag',

--- a/spec/services/data_migrations/set_missing_work_history_status_values_spec.rb
+++ b/spec/services/data_migrations/set_missing_work_history_status_values_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::SetMissingWorkHistoryStatusValues do
+  let(:application_form) do
+    create(
+      :application_form,
+      :minimum_info,
+      recruitment_cycle_year:,
+      work_history_status:,
+      work_history_completed:,
+    )
+  end
+
+  context 'when 2023 recruitment cycle, work history status is nil and work history is complete' do
+    let(:recruitment_cycle_year) { 2023 }
+    let(:work_history_status) { nil }
+    let(:work_history_completed) { true }
+
+    it 'does not update the application form' do
+      expect { described_class.new.change }.not_to(change { application_form.reload.work_history_status })
+    end
+  end
+
+  context 'when 2024 recruitment cycle' do
+    let(:recruitment_cycle_year) { 2024 }
+
+    context 'when work history status is not nil' do
+      let(:work_history_status) { 'can_not_complete' }
+
+      context 'when work history is not complete' do
+        let(:work_history_completed) { false }
+
+        it 'does not update the application form' do
+          expect { described_class.new.change }.not_to(change { application_form.reload.work_history_status })
+        end
+      end
+
+      context 'when work history is complete' do
+        let(:work_history_completed) { true }
+
+        it 'does not update the application form' do
+          expect { described_class.new.change }.not_to(change { application_form.reload.work_history_status })
+        end
+      end
+    end
+
+    context 'when work history status is nil' do
+      let(:work_history_status) { nil }
+
+      context 'when work history is not complete' do
+        let(:work_history_completed) { false }
+
+        it 'does not update the application form' do
+          expect { described_class.new.change }.not_to(change { application_form.reload.work_history_status })
+        end
+      end
+
+      context 'when work history is complete' do
+        let(:work_history_completed) { true }
+
+        it 'updates the application forms' do
+          expect { described_class.new.change }.to(
+            change { application_form.reload.work_history_status }
+              .from(nil)
+              .to('can_complete'),
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Some carried over applications have a `work_history_status` of nil. This is because they have been created before the `work_history_status` was added. This is preventing the "Add another job" button from rendering.

We fixed the issue in: https://github.com/DFE-Digital/apply-for-teacher-training/pull/8846

But we need to backfill the values for the applications forms that already have it set to `nil`.

### Changes proposed

- 78 application forms will be updated and the `work_history_status` will be set to `can_complete`

## Link to Trello card

https://trello.com/c/imZSqtjh/1026-data-migration-to-backfill-workhistorystatus-where-required

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
