### PR TITLE
Remove incorrect reference to Teach First from ITT external report content

### DIFF
--- a/app/views/publications/monthly_statistics/v2/show.html.erb
+++ b/app/views/publications/monthly_statistics/v2/show.html.erb
@@ -212,7 +212,6 @@
 
     <ul class="govuk-list govuk-list--bullet">
       <li>made directly to training providers</li>
-      <li>to Teach First</li>
       <li>for undergraduate teacher training</li>
     </ul>
     <p class="govuk-body">Candidates may make different applications to more than one route into teaching. These candidates are counted under all routes that apply. This means that the total of these rows does not equal the total in the ‘Candidate headline statistics’ section.</p>


### PR DESCRIPTION
## Context

We previously agreed not to state that ITT external report data does not include Teach First applications since in many cases it does!

## Changes proposed in this pull request

Remove the one bullet point in the content that refers to this

## Guidance to review

See Slack thread for original decision from Elliot Fox: https://ukgovernmentdfe.slack.com/archives/C05QNPLAL9L/p1699889363535759

## Link to Trello card

n/a