### PR TITLE
Add 404 pages to support interface

### DIFF
--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -3,6 +3,7 @@ module SupportInterface
     layout 'support_layout'
     before_action :authenticate_support_user!
     before_action :set_user_context
+    rescue_from ActiveRecord::RecordNotFound, with: :render_404
 
     helper_method :current_support_user, :dfe_sign_in_user
 


### PR DESCRIPTION
Some pages in the support interface are incorrectly serving 500 errors instead of the expected 404 errors. It also improves the user experience on production environments, where stack traces are not visible.

### Before:
<img width="1242" alt="Screenshot 2023-12-08 at 15 58 46" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/15dee7a1-1e29-4caa-b212-b3a86d7af3e7">

### After:
<img width="807" alt="Screenshot 2023-12-08 at 15 58 30" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/48e61ad7-e454-447e-9ca3-6387de54fbd9">
