### PR TITLE
Remove non continuous application update in support interface

### DIFF
--- a/app/forms/support_interface/application_forms/edit_becoming_a_teacher_form.rb
+++ b/app/forms/support_interface/application_forms/edit_becoming_a_teacher_form.rb
@@ -20,22 +20,10 @@ module SupportInterface
       def save(application_form)
         return false unless valid?
 
-        if application_form.continuous_applications?
-          application_form.update!(
-            becoming_a_teacher:,
-            audit_comment:,
-          )
-        else
-          ApplicationForm.transaction do
-            application_form.update!(
-              becoming_a_teacher:,
-              audit_comment:,
-            )
-            application_form
-              .application_choices
-              .all? { |ac| ac.update!(personal_statement: becoming_a_teacher) }
-          end
-        end
+        application_form.update!(
+          becoming_a_teacher:,
+          audit_comment:,
+        )
       end
     end
   end

--- a/spec/forms/support_interface/application_forms/edit_becoming_a_teacher_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/edit_becoming_a_teacher_form_spec.rb
@@ -41,18 +41,16 @@ RSpec.describe SupportInterface::ApplicationForms::EditBecomingATeacherForm, :wi
       expect(application_form.audits.last.comment).to eq 'It was on a zendesk ticket.'
     end
 
-    context 'continuous applications', :continuous_applications do
-      it 'doesnt update the associated ApplicationChoice' do
-        application_form = create(:application_form, :continuous_applications)
-        application_choice = create(:application_choice, application_form: application_form)
-        form = described_class.new(becoming_a_teacher: 'I really want to teach.', audit_comment: 'It was on a zendesk ticket.')
+    it 'doesnt update the associated ApplicationChoice' do
+      application_form = create(:application_form, :continuous_applications)
+      application_choice = create(:application_choice, application_form: application_form)
+      form = described_class.new(becoming_a_teacher: 'I really want to teach.', audit_comment: 'It was on a zendesk ticket.')
 
-        form.save(application_form)
+      form.save(application_form)
 
-        expect(application_choice.reload.personal_statement).not_to eq 'I really want to teach.'
-        expect(application_form.becoming_a_teacher).to eq 'I really want to teach.'
-        expect(application_form.audits.last.comment).to eq 'It was on a zendesk ticket.'
-      end
+      expect(application_choice.reload.personal_statement).not_to eq 'I really want to teach.'
+      expect(application_form.becoming_a_teacher).to eq 'I really want to teach.'
+      expect(application_form.audits.last.comment).to eq 'It was on a zendesk ticket.'
     end
 
     context 'when saving personal_statement records fails' do


### PR DESCRIPTION
## Context

The feature to update the application form AND **all** application choices was needed in old cycle. 
Not needed anymore in the current cycle.

Although I created another card for us to add the possibility to edit personal statement for *each* application choice: https://trello.com/c/3Ge4LhFB/1079-edit-personal-statement-in-application-choice-in-support

## Link to Trello card

https://trello.com/c/6FOR1pix/1042-catd-support-interface-becoming-a-teacher-form
