### PR TITLE
[1037] Remove non continuous applications logic from candidate mailers

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -278,10 +278,6 @@ class CandidateMailer < ApplicationMailer
     @conditions = @application_choice.offer.all_conditions_text
     @course_option = @application_choice.course_option
     @current_course_option = @application_choice.current_course_option
-    @is_awaiting_decision = application_choice.self_and_siblings.decision_pending.any?
-    @offers = @application_choice.self_and_siblings.select(&:offer?).map do |choice|
-      "#{choice.current_course_option.course.name_and_code} at #{choice.current_course_option.course.provider.name}"
-    end
     @qualification = qualification_text(@current_course_option)
 
     email_for_candidate(

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -26,7 +26,6 @@ class CandidateMailer < ApplicationMailer
   def application_submitted(application_form)
     @candidate_magic_link = candidate_magic_link(application_form.candidate)
     @application_choice = application_form.application_choices.first
-    @reject_by_default_date = @application_choice.reject_by_default_at.to_fs(:govuk_date)
 
     email_for_candidate(
       application_form,

--- a/app/views/candidate_mailer/_offer_list.text.erb
+++ b/app/views/candidate_mailer/_offer_list.text.erb
@@ -1,5 +1,0 @@
-
-# Offers you've received
-<% @offers.each do |offer| %>
-  - <%= offer %>
-<% end %>

--- a/app/views/candidate_mailer/_reasons_for_rejection_intro.text.erb
+++ b/app/views/candidate_mailer/_reasons_for_rejection_intro.text.erb
@@ -1,8 +1,6 @@
 <% unless @application_choice.rejected_by_default? %>
 
-  <% course = @application_choice.continuous_applications? ? @course.name : @course.name_and_code %>
-
-  Thank you for your application to study <%= course %> at <%= @course.provider.name %>.
+  Thank you for your application to study <%= @course.name %> at <%= @course.provider.name %>.
 
   On this occasion, the provider is not offering you a place on this course.
 

--- a/app/views/candidate_mailer/_wait_or_respond.text.erb
+++ b/app/views/candidate_mailer/_wait_or_respond.text.erb
@@ -1,8 +1,0 @@
-You can wait to hear back about your other application(s) before accepting or declining any offers.
-
-When the last decision is in, you’ll have 10 working days to respond.
-
-You should not feel pressured to respond sooner than this.
-
-However, if you are ready to respond to your existing offer you can do so through [your account](<%= candidate_magic_link(@application_form.candidate) %>):
-

--- a/app/views/candidate_mailer/application_submitted.text.erb
+++ b/app/views/candidate_mailer/application_submitted.text.erb
@@ -25,7 +25,3 @@ Hello <%= @application_form.first_name %>
   Your training provider will contact you if they would like to organise an interview.
 
 <% end %>
-
-<% if FeatureFlag.inactive?(:continuous_applications) %>
-They have until <%= @reject_by_default_date %> to make a decision on your application.
-<% end %>

--- a/app/views/candidate_mailer/changed_offer.text.erb
+++ b/app/views/candidate_mailer/changed_offer.text.erb
@@ -19,28 +19,6 @@ The new offer is:
 <% end %>
 
 
-<% if FeatureFlag.inactive?(:continuous_applications) %>
-
-  <% if @is_awaiting_decision %>
-
-  # You can accept the offer or wait to hear back about other applications
-
-  <%= render "wait_or_respond" %>
-
-  <% else %>
-
-  # Make a decision by <%= @application_choice.decline_by_default_at.to_fs(:govuk_date) %>
-
-  If you do not respond by <%= @application_choice.decline_by_default_at.to_fs(:govuk_date) %>, your <%= 'offer'.pluralize(@offers.length) %> will be declined automatically.
-
-  <% if @offers.count > 1 %>
-  <%= render "offer_list" %>
-  <% end %>
-
-<% end %>
-
-<% end %>
-
 [Sign in to your account to respond to your offer](<%= candidate_magic_link(@application_choice.application_form.candidate) %>).
 
 Contact <%= @current_course_option.course.provider.name %> directly if you have any questions about this.

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe CandidateMailer do
 
     before { allow(EmailLogInterceptor).to receive(:generate_reference).and_return('fake-ref-123') }
 
-    context 'when the candidate receives a rejection and continuous applications', :continuous_applications do
+    context 'when the candidate receives a rejection' do
       it_behaves_like(
         'a mail with subject and content',
         I18n.t!('candidate_mailer.application_rejected.subject'),

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe CandidateMailer do
   subject(:mailer) { described_class }
 
   describe '.application_submitted' do
-    let(:application_choice) { build_stubbed(:application_choice, reject_by_default_at: 5.days.from_now) }
+    let(:application_choice) { build_stubbed(:application_choice) }
     let(:application_form) {
       build_stubbed(:application_form, first_name: 'Jimbo',
                                        candidate:,
@@ -46,20 +46,7 @@ RSpec.describe CandidateMailer do
     }
     let(:email) { mailer.application_submitted(application_form) }
 
-    context 'when not continuous applications', continuous_applications: false do
-      TestSuiteTimeMachine.travel_temporarily_to(mid_cycle(2023)) do
-        it_behaves_like(
-          'a mail with subject and content',
-          I18n.t!('candidate_mailer.application_submitted.subject'),
-          'intro' => 'You’ve submitted an application for',
-          'magic link to authenticate' => 'http://localhost:3000/candidate/sign-in/confirm?token=raw_token',
-          'dynamic paragraph' => 'Your training provider will contact you if they would like to organise an interview',
-          'reject_by_default date' => 5.days.from_now.to_fs(:govuk_date),
-        )
-      end
-    end
-
-    context 'when continuous applications', :continuous_applications do
+    context 'when the candidate submits an application' do
       it_behaves_like(
         'a mail with subject and content',
         I18n.t!('candidate_mailer.application_submitted.subject'),


### PR DESCRIPTION
## Context

Continuous applications was built using a feature flag. Now we’ve launched it we’re left with a lot of redundant code relating to the “old flow”. We are removing that now. 

This PR deals with the candidate mailers.

## Changes proposed in this pull request

See commits.

## Guidance to review

Recommend reveiwing commit by commit.

## Link to Trello card

https://trello.com/c/seACdtFF/1037-catd-candidate-mailers

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
