### PR TITLE
Bug: Scope offer chaser emails to those with open offers

### DIFF
--- a/app/queries/offers_to_chase_query.rb
+++ b/app/queries/offers_to_chase_query.rb
@@ -4,8 +4,10 @@
 class OffersToChaseQuery
   def self.call(chaser_type:, date_range:)
     ApplicationChoice
+      .offer
       .joins(:offer)
       .where.not(id: ChaserSent.send(chaser_type).select(:chased_id).where(chased_type: 'ApplicationChoice'))
+      .where(current_recruitment_cycle_year: CycleTimetable.current_year)
       .where('offers.created_at': date_range)
   end
 end

--- a/app/queries/offers_to_chase_query.rb
+++ b/app/queries/offers_to_chase_query.rb
@@ -5,9 +5,8 @@ class OffersToChaseQuery
   def self.call(chaser_type:, date_range:)
     ApplicationChoice
       .offer
-      .joins(:offer)
       .where.not(id: ChaserSent.send(chaser_type).select(:chased_id).where(chased_type: 'ApplicationChoice'))
       .where(current_recruitment_cycle_year: CycleTimetable.current_year)
-      .where('offers.created_at': date_range)
+      .where('application_choices.offered_at': date_range)
   end
 end

--- a/app/services/chasers/candidate.rb
+++ b/app/services/chasers/candidate.rb
@@ -2,11 +2,11 @@ module Chasers
   module Candidate
     # chaser: [days_ago, days_ago]
     OFFER_CHASERS_TO_INTERVALS = {
-      offer_10_day: [20, 10],
-      offer_20_day: [30, 20],
-      offer_30_day: [40, 30],
-      offer_40_day: [50, 40],
-      offer_50_day: [60, 50],
+      offer_10_day: [19, 10],
+      offer_20_day: [29, 20],
+      offer_30_day: [39, 30],
+      offer_40_day: [49, 40],
+      offer_50_day: [59, 50],
     }.freeze
 
     def self.chaser_types

--- a/app/services/chasers/candidate.rb
+++ b/app/services/chasers/candidate.rb
@@ -1,21 +1,21 @@
 module Chasers
   module Candidate
-    # chaser: [days_ago, days_ago]
-    OFFER_CHASERS_TO_INTERVALS = {
-      offer_10_day: [19, 10],
-      offer_20_day: [29, 20],
-      offer_30_day: [39, 30],
-      offer_40_day: [49, 40],
-      offer_50_day: [59, 50],
+    # chaser: days_ago
+    OFFER_CHASERS = {
+      offer_10_day: 10,
+      offer_20_day: 20,
+      offer_30_day: 30,
+      offer_40_day: 40,
+      offer_50_day: 50,
     }.freeze
 
     def self.chaser_types
-      OFFER_CHASERS_TO_INTERVALS.keys
+      OFFER_CHASERS.keys
     end
 
     def self.chaser_to_date_range
-      OFFER_CHASERS_TO_INTERVALS.each_with_object({}) do |(chaser_type, (start, ending)), object|
-        object[chaser_type] = (start.days.ago..ending.days.ago)
+      OFFER_CHASERS.transform_values do |day|
+        day.days.ago.all_day
       end
     end
   end

--- a/spec/queries/offers_to_chase_query_spec.rb
+++ b/spec/queries/offers_to_chase_query_spec.rb
@@ -2,13 +2,12 @@ require 'rails_helper'
 
 RSpec.describe OffersToChaseQuery do
   let(:application_choice_without_offer) { create(:application_choice, :awaiting_provider_decision) }
-  let(:application_choice_with_offer_not_in_offer_status) { create(:application_choice, :recruited, offer: create(:offer, created_at: inside_range)) }
-  let(:application_choice_offer_from_last_cycle) { create(:application_choice, current_recruitment_cycle_year: CycleTimetable.previous_year, offer: create(:offer, created_at: inside_range)) }
+  let(:application_choice_with_offer_not_in_offer_status) { create(:application_choice, :recruited, offered_at: Time.zone.now) }
+  let(:application_choice_offer_from_last_cycle) { create(:application_choice, current_recruitment_cycle_year: CycleTimetable.previous_year, offered_at: inside_range) }
 
   let(:application_choice_with_chaser) { create(:application_choice, :offer, chasers_sent: [create(:chaser_sent, chaser_type: "offer_#{days}_day")]) }
 
   let(:application_choice_without_chaser) { create(:application_choice, :offer, current_recruitment_cycle_year:) }
-  let(:offer_without_chaser) { application_choice_without_chaser.offer }
   let(:current_recruitment_cycle_year) { CycleTimetable.current_year }
 
   let(:chaser_type) { :offer_10_day }
@@ -26,27 +25,27 @@ RSpec.describe OffersToChaseQuery do
     end
   end
 
-  context 'when offers are made before the chaser sent range for offer_10_day' do
+  context 'when offers are made 9 days ago for offer_10_day' do
     let(:offset) { outside_range }
 
     it 'returns empty collection' do
-      expect(offer_without_chaser.created_at).to be > 10.days.ago
+      expect(9.days.ago.all_day).to cover(application_choice_without_chaser.offered_at)
       expect(described_class.call(chaser_type:, date_range:)).to be_empty
     end
   end
 
-  context 'when offers are made inside the range 20 to 10 days ago and chaser_type is offer_10_day' do
+  context 'when offers are made 10 days ago and chaser_type is offer_10_day' do
     let(:days) { 10 }
     let(:offset) { inside_range }
 
     it 'returns the application choice without a chaser' do
-      expect(date_range).to cover(offer_without_chaser.created_at)
+      expect(date_range).to cover(application_choice_without_chaser.offered_at)
 
       expect(described_class.call(chaser_type:, date_range:)).to contain_exactly(application_choice_without_chaser)
     end
   end
 
-  describe 'when the range is 20 to 30 days ago and offers are made inside the range' do
+  describe 'when the range is 20 days ago and offers are made 20 days ago' do
     let(:days) { 20 }
 
     context 'and chaser_type is offer_20_day and chaser has been sent for offer_20_day' do
@@ -54,7 +53,7 @@ RSpec.describe OffersToChaseQuery do
       let(:chaser_type) { :offer_20_day }
 
       it 'returns the application choice without a chaser sent' do
-        expect(date_range).to cover(offer_without_chaser.created_at)
+        expect(date_range).to cover(application_choice_without_chaser.offered_at)
 
         expect(described_class.call(chaser_type:, date_range:)).to contain_exactly(application_choice_without_chaser)
       end
@@ -65,14 +64,14 @@ RSpec.describe OffersToChaseQuery do
       let(:chaser_type) { :offer_10_day }
 
       it 'returns the application choice no chaser sent and one with old chaser sent' do
-        expect(date_range).to cover(offer_without_chaser.created_at)
+        expect(date_range).to cover(application_choice_without_chaser.offered_at)
 
         expect(described_class.call(chaser_type:, date_range:)).to contain_exactly(application_choice_without_chaser, application_choice_with_chaser)
       end
     end
   end
 
-  describe 'when the range is 10 to 20 days ago and offers are made inside the range' do
+  describe 'when the range is 10 days ago and offers are made 10 days ago' do
     let(:days) { 10 }
 
     context 'and the application is from the previous recruitment cycle' do
@@ -81,7 +80,7 @@ RSpec.describe OffersToChaseQuery do
       let(:current_recruitment_cycle_year) { CycleTimetable.previous_year }
 
       it 'excludes applications from previous cycle' do
-        expect(date_range).to cover(offer_without_chaser.created_at)
+        expect(date_range).to cover(application_choice_without_chaser.offered_at)
 
         expect(described_class.call(chaser_type:, date_range:)).to be_empty
       end

--- a/spec/queries/offers_to_chase_query_spec.rb
+++ b/spec/queries/offers_to_chase_query_spec.rb
@@ -2,23 +2,26 @@ require 'rails_helper'
 
 RSpec.describe OffersToChaseQuery do
   let(:application_choice_without_offer) { create(:application_choice, :awaiting_provider_decision) }
-  let(:application_choice_with_chaser) { create(:application_choice, :offer) }
-  let(:chaser_sent) { create(:chaser_sent, chased: application_choice_with_chaser, chaser_type: "offer_#{spread[1]}_day") }
+  let(:application_choice_with_offer_not_in_offer_status) { create(:application_choice, :recruited, offer: create(:offer, created_at: inside_range)) }
+  let(:application_choice_offer_from_last_cycle) { create(:application_choice, current_recruitment_cycle_year: CycleTimetable.previous_year, offer: create(:offer, created_at: inside_range)) }
 
-  let(:application_choice_without_chaser) { create(:application_choice, :offer) }
+  let(:application_choice_with_chaser) { create(:application_choice, :offer, chasers_sent: [create(:chaser_sent, chaser_type: "offer_#{spread[1]}_day")]) }
+
+  let(:application_choice_without_chaser) { create(:application_choice, :offer, current_recruitment_cycle_year:) }
   let(:offer_without_chaser) { application_choice_without_chaser.offer }
+  let(:current_recruitment_cycle_year) { CycleTimetable.current_year }
 
   let(:chaser_type) { :offer_10_day }
 
   let(:spread) { [20, 10] }
   let(:date_range) { (spread[0].days.ago..spread[1].days.ago) }
+  let(:inside_range) { date_range.max - 1.day }
   let(:offset) { 0 }
 
   before do
     TestSuiteTimeMachine.travel_temporarily_to(spread[1].days.ago + offset) do
       application_choice_without_offer
       application_choice_with_chaser
-      chaser_sent
       application_choice_without_chaser
     end
   end
@@ -65,6 +68,22 @@ RSpec.describe OffersToChaseQuery do
         expect(date_range).to cover(offer_without_chaser.created_at)
 
         expect(described_class.call(chaser_type:, date_range:)).to contain_exactly(application_choice_without_chaser, application_choice_with_chaser)
+      end
+    end
+  end
+
+  describe 'when the range is 10 to 20 days ago and offers are made inside the range' do
+    let(:spread) { [20, 10] }
+
+    context 'and the application is from the previous recruitment cycle' do
+      let(:offset) { -10.seconds }
+      let(:chaser_type) { :offer_10_day }
+      let(:current_recruitment_cycle_year) { CycleTimetable.previous_year }
+
+      it 'excludes applications from previous cycle' do
+        expect(date_range).to cover(offer_without_chaser.created_at)
+
+        expect(described_class.call(chaser_type:, date_range:)).to be_empty
       end
     end
   end

--- a/spec/queries/offers_to_chase_query_spec.rb
+++ b/spec/queries/offers_to_chase_query_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe OffersToChaseQuery do
   let(:application_choice_with_offer_not_in_offer_status) { create(:application_choice, :recruited, offer: create(:offer, created_at: inside_range)) }
   let(:application_choice_offer_from_last_cycle) { create(:application_choice, current_recruitment_cycle_year: CycleTimetable.previous_year, offer: create(:offer, created_at: inside_range)) }
 
-  let(:application_choice_with_chaser) { create(:application_choice, :offer, chasers_sent: [create(:chaser_sent, chaser_type: "offer_#{spread[1]}_day")]) }
+  let(:application_choice_with_chaser) { create(:application_choice, :offer, chasers_sent: [create(:chaser_sent, chaser_type: "offer_#{days}_day")]) }
 
   let(:application_choice_without_chaser) { create(:application_choice, :offer, current_recruitment_cycle_year:) }
   let(:offer_without_chaser) { application_choice_without_chaser.offer }
@@ -13,13 +13,13 @@ RSpec.describe OffersToChaseQuery do
 
   let(:chaser_type) { :offer_10_day }
 
-  let(:spread) { [20, 10] }
-  let(:date_range) { (spread[0].days.ago..spread[1].days.ago) }
-  let(:inside_range) { date_range.max - 1.day }
-  let(:offset) { 0 }
+  let(:days) { 10 }
+  let(:date_range) { days.days.ago.all_day }
+  let(:inside_range) { date_range.max - 1.hour }
+  let(:outside_range) { date_range.max + 1.hour }
 
   before do
-    TestSuiteTimeMachine.travel_temporarily_to(spread[1].days.ago + offset) do
+    TestSuiteTimeMachine.travel_temporarily_to(offset) do
       application_choice_without_offer
       application_choice_with_chaser
       application_choice_without_chaser
@@ -27,7 +27,7 @@ RSpec.describe OffersToChaseQuery do
   end
 
   context 'when offers are made before the chaser sent range for offer_10_day' do
-    let(:offset) { 10.seconds }
+    let(:offset) { outside_range }
 
     it 'returns empty collection' do
       expect(offer_without_chaser.created_at).to be > 10.days.ago
@@ -36,8 +36,8 @@ RSpec.describe OffersToChaseQuery do
   end
 
   context 'when offers are made inside the range 20 to 10 days ago and chaser_type is offer_10_day' do
-    let(:spread) { [20, 10] }
-    let(:offset) { -10.seconds }
+    let(:days) { 10 }
+    let(:offset) { inside_range }
 
     it 'returns the application choice without a chaser' do
       expect(date_range).to cover(offer_without_chaser.created_at)
@@ -47,10 +47,10 @@ RSpec.describe OffersToChaseQuery do
   end
 
   describe 'when the range is 20 to 30 days ago and offers are made inside the range' do
-    let(:spread) { [30, 20] }
+    let(:days) { 20 }
 
     context 'and chaser_type is offer_20_day and chaser has been sent for offer_20_day' do
-      let(:offset) { -10.seconds }
+      let(:offset) { inside_range }
       let(:chaser_type) { :offer_20_day }
 
       it 'returns the application choice without a chaser sent' do
@@ -61,7 +61,7 @@ RSpec.describe OffersToChaseQuery do
     end
 
     context 'and chaser_type is offer_20_day and chaser only sent for offer_10_day' do
-      let(:offset) { -10.seconds }
+      let(:offset) { inside_range }
       let(:chaser_type) { :offer_10_day }
 
       it 'returns the application choice no chaser sent and one with old chaser sent' do
@@ -73,10 +73,10 @@ RSpec.describe OffersToChaseQuery do
   end
 
   describe 'when the range is 10 to 20 days ago and offers are made inside the range' do
-    let(:spread) { [20, 10] }
+    let(:days) { 10 }
 
     context 'and the application is from the previous recruitment cycle' do
-      let(:offset) { -10.seconds }
+      let(:offset) { inside_range }
       let(:chaser_type) { :offer_10_day }
       let(:current_recruitment_cycle_year) { CycleTimetable.previous_year }
 

--- a/spec/services/chasers/candidate_spec.rb
+++ b/spec/services/chasers/candidate_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Chasers::Candidate do
   describe '.chaser_to_date_range' do
     it 'returns a chaser_type with respective date range' do
-      expected = { offer_10_day: (20.days.ago..10.days.ago) }
+      expected = { offer_10_day: 10.days.ago.all_day }
       expect(described_class.chaser_to_date_range).to include(expected)
     end
   end

--- a/spec/workers/chasers/candidate/offer_worker_spec.rb
+++ b/spec/workers/chasers/candidate/offer_worker_spec.rb
@@ -1,28 +1,93 @@
 require 'rails_helper'
 
 RSpec.describe Chasers::Candidate::OfferWorker do
-  let!(:application_choices) do
-    Chasers::Candidate.chaser_to_date_range.each_value do |date_range|
-      create(:application_choice, :offer).tap do |choice|
-        choice.offer.update(created_at: date_range.min)
+  describe '#perform' do
+    before do
+      allow(Chasers::Candidate::OfferEmailService).to receive(:call).and_call_original
+      allow(OffersToChaseQuery).to receive(:call).and_call_original
+    end
+
+    context 'when applications are offered in different periods' do
+      let!(:application_choices) do
+        Chasers::Candidate.chaser_to_date_range.each_value do |date_range|
+          create(:application_choice, :offer).tap do |choice|
+            choice.offer.update(created_at: date_range.min)
+          end
+        end
+      end
+      let(:chaser_types) do
+        Chasers::Candidate.chaser_types
+      end
+      let(:mailers) { chaser_types }
+      let(:groups) { application_choices.zip(chaser_types, mailers) }
+
+      it 'calls the service for each chaser interval' do
+        described_class.new.perform
+
+        expect(OffersToChaseQuery).to have_received(:call).with(chaser_type: Symbol, date_range: Range).exactly(5).times
+        groups do |application_choice, chaser_type, mailer|
+          expect(Chasers::Candidate::OfferEmailService).to have_received(:call).with(chaser_type:, mailer:, application_choice:)
+        end
       end
     end
-  end
-  let(:chaser_types) do
-    Chasers::Candidate.chaser_types
-  end
-  let(:mailers) { chaser_types }
-  let(:groups) { application_choices.zip(chaser_types, mailers) }
 
-  it 'calls the service for each chaser interval' do
-    allow(Chasers::Candidate::OfferEmailService).to receive(:call).and_call_original
-    allow(OffersToChaseQuery).to receive(:call).and_call_original
+    context 'when the same application received an offer without decision' do
+      it 'sends offer emails in the expected date ranges', time: Time.zone.local(2023, 12, 11) do
+        application_choice = create(:application_choice, :offer)
 
-    described_class.new.perform
+        described_class.new.perform
 
-    expect(OffersToChaseQuery).to have_received(:call).with(chaser_type: Symbol, date_range: Range).exactly(5).times
-    groups do |application_choice, chaser_type, mailer|
-      expect(Chasers::Candidate::OfferEmailService).to have_received(:call).with(chaser_type:, mailer:, application_choice:)
+        expect(Chasers::Candidate::OfferEmailService).not_to have_received(:call)
+
+        TestSuiteTimeMachine.advance_time_to(9.days.from_now)
+        described_class.new.perform
+        expect(application_choice.chasers_sent.count).to be 0
+
+        TestSuiteTimeMachine.advance_time_to(1.day.from_now)
+        described_class.new.perform
+        expect(application_choice.chasers_sent.count).to be 1
+        expect(application_choice.chasers_sent.pluck(:chaser_type)).to contain_exactly('offer_10_day')
+
+        TestSuiteTimeMachine.advance_time_to(9.days.from_now)
+        described_class.new.perform
+        expect(application_choice.chasers_sent.count).to be 1
+
+        TestSuiteTimeMachine.advance_time_to(1.day.from_now)
+        described_class.new.perform
+        expect(application_choice.chasers_sent.count).to be 2
+        expect(application_choice.chasers_sent.pluck(:chaser_type)).to contain_exactly('offer_10_day', 'offer_20_day')
+
+        TestSuiteTimeMachine.advance_time_to(9.days.from_now)
+        described_class.new.perform
+        expect(application_choice.chasers_sent.count).to be 2
+
+        TestSuiteTimeMachine.advance_time_to(1.day.from_now)
+        described_class.new.perform
+        expect(application_choice.chasers_sent.count).to be 3
+        expect(application_choice.chasers_sent.pluck(:chaser_type)).to contain_exactly('offer_10_day', 'offer_20_day', 'offer_30_day')
+
+        TestSuiteTimeMachine.advance_time_to(9.days.from_now)
+        described_class.new.perform
+        expect(application_choice.chasers_sent.count).to be 3
+
+        TestSuiteTimeMachine.advance_time_to(1.day.from_now)
+        described_class.new.perform
+        expect(application_choice.chasers_sent.count).to be 4
+        expect(application_choice.chasers_sent.pluck(:chaser_type)).to contain_exactly('offer_10_day', 'offer_20_day', 'offer_30_day', 'offer_40_day')
+
+        TestSuiteTimeMachine.advance_time_to(9.days.from_now)
+        described_class.new.perform
+        expect(application_choice.chasers_sent.count).to be 4
+
+        TestSuiteTimeMachine.advance_time_to(1.day.from_now)
+        described_class.new.perform
+        expect(application_choice.chasers_sent.count).to be 5
+        expect(application_choice.chasers_sent.pluck(:chaser_type)).to contain_exactly('offer_10_day', 'offer_20_day', 'offer_30_day', 'offer_40_day', 'offer_50_day')
+
+        TestSuiteTimeMachine.advance_time_to(1.day.from_now)
+        described_class.new.perform
+        expect(application_choice.chasers_sent.count).to be 5
+      end
     end
   end
 end

--- a/spec/workers/chasers/candidate/offer_worker_spec.rb
+++ b/spec/workers/chasers/candidate/offer_worker_spec.rb
@@ -10,9 +10,7 @@ RSpec.describe Chasers::Candidate::OfferWorker do
     context 'when applications are offered in different periods' do
       let!(:application_choices) do
         Chasers::Candidate.chaser_to_date_range.each_value do |date_range|
-          create(:application_choice, :offer).tap do |choice|
-            choice.offer.update(created_at: date_range.min)
-          end
+          create(:application_choice, :offer, offered_at: date_range.min)
         end
       end
       let(:chaser_types) do


### PR DESCRIPTION
## Context

A recent PR has required changes. This PR makes necessary amendments to the logic for choosing which offers to send chaser emails to.

## Changes proposed in this pull request

1. Sent an email to all Candidates who, at any time during the day, received an offer 10 days ago. 
2. The application must currently be in an `offer` status, not just have an associated offer record.
3. Constrain the query to only records in the current recruitment cycle.


## Guidance to review

Improved Spec coverage.
Does the implementation sufficiently cover the original specifications?

## Link to Trello card

[Trello Ticket](https://trello.com/c/cOamwWi7/1080-bug-scope-offer-chaser-emails-to-those-with-open-offers)
