### PR TITLE
Enable and schedule EntityTableCheckJob

### DIFF
--- a/config/clock.rb
+++ b/config/clock.rb
@@ -45,6 +45,7 @@ class Clock
   every(1.day, 'NudgeCandidatesWorker', at: '10:00') { NudgeCandidatesWorker.perform_async }
   every(1.day, 'SendApplyToAnotherCourseWhenInactiveEmailToCandidatesWorker', at: '10:00') { SendApplyToAnotherCourseWhenInactiveEmailToCandidatesWorker.perform_async }
   every(1.day, 'SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesWorker', at: '10:00') { SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesWorker.perform_async }
+  every(1.day, 'DfE::Analytics::EntityTableCheckJob', at: '00:30') { DfE::Analytics::EntityTableCheckJob.perform_later }
 
   # every(1.day, 'CancelUnsubmittedApplicationsWorker', at: '11:00') { CancelUnsubmittedApplicationsWorker.perform_async }
 

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -28,6 +28,9 @@ DfE::Analytics.configure do |config|
   #
   config.bigquery_api_json_key = ENV['BIG_QUERY_API_JSON_KEY']
 
+  # Enables the EntityTableCheckJob
+  config.entity_table_checks_enabled = true
+
   # Passed directly to the retries: option on the BigQuery client
   #
   # config.bigquery_retries = 3


### PR DESCRIPTION
## Context

EntityTableCheck is a job which sends a row_count, a checksum and a timestamp for each entity table sent to Big Query and it’s purpose is to serve as a tool for confirming database tables match Big Query tables and then help to debug where they don’t match.

## Changes proposed in this pull request

This PR enables the job and schedules it to run daily at 00:30

## Guidance to review

As I am not familiar with Apply - please check the scheduling looks correct and advise if there is a better time for the job to run. I went for perform_later in clock as the job in dfe-analytics is agnostic and does not include Sidekiq worker so perform async was not available to me here.

## Link to Trello card

N/A

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
