### PR TITLE
Include inactive in the state inferrer

### DIFF
--- a/app/services/application_form_state_inferrer.rb
+++ b/app/services/application_form_state_inferrer.rb
@@ -17,7 +17,7 @@ class ApplicationFormStateInferrer
       :never_signed_in
     elsif application_choices.empty? || all_states_are?('unsubmitted') || all_states_are?('application_not_sent')
       as_new?(application_form) ? :unsubmitted_not_started_form : :unsubmitted_in_progress
-    elsif any_state_is?('awaiting_provider_decision') || any_state_is?('interviewing')
+    elsif any_state_is?('awaiting_provider_decision') || any_state_is?('interviewing') || any_state_is?('inactive')
       :awaiting_provider_decisions
     elsif any_state_is?('offer')
       # Offer, but no awaiting means we're waiting on the candidate
@@ -30,6 +30,8 @@ class ApplicationFormStateInferrer
       :offer_deferred
     elsif (states.uniq.map(&:to_sym) - ApplicationStateChange::UNSUCCESSFUL_STATES).empty?
       :ended_without_success
+    elsif any_state_is?('unsubmitted')
+      :unsubmitted_in_progress
     else
       :unknown_state
     end

--- a/spec/services/application_form_state_inferrer_spec.rb
+++ b/spec/services/application_form_state_inferrer_spec.rb
@@ -88,5 +88,14 @@ RSpec.describe ApplicationFormStateInferrer do
 
       expect(state).to be(:ended_without_success)
     end
+
+    it 'is awaiting provider decision when the application is inactive' do
+      application_form = create(:application_form)
+      create(:application_choice, :inactive, application_form:)
+
+      state = described_class.new(application_form).state
+
+      expect(state).to be(:awaiting_provider_decisions)
+    end
   end
 end


### PR DESCRIPTION
## Context

We’re rendering an Unknown! status on support for certain application states.

## Changes proposed in this pull request

New `elsif` branch to show `unsubmitted_in_progress` if at least one application is unsubmitted.
|Before|After|
|---|---|
|![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/3c853796-9cc8-452d-98f4-d994f82eb1dc)|![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/100ab143-07a0-43bf-84d6-52c6b8bf24b3)|

Include inactive in the `elsif` branch for `awaiting_provider_decisions`
|Before|After|
|---|---|
|![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/6b48b04c-e648-47b1-9805-4cb59e059b4b)|![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/71b7fc36-15d4-4884-988c-dafcc84e26b6)|

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/6wGVEKf9/733-apply-support-console-review-and-fix-the-unknown-status

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
