### PR TITLE
Remove todo

### DIFF
--- a/spec/requests/candidate_interface/personal_statement_spec.rb
+++ b/spec/requests/candidate_interface/personal_statement_spec.rb
@@ -1,6 +1,5 @@
 require 'rails_helper'
 
-# TODO: create and complete action
 RSpec.describe 'CandidateInterface::PersonalStatementController' do
   include Devise::Test::IntegrationHelpers
   let(:candidate) { create(:candidate) }


### PR DESCRIPTION
## Context

This has been done, so we can remove the `TODO`

## Link to Trello card

https://trello.com/c/QLzFo5LE/1081-tech-debt-action-todos-in-the-codebase
