### PR TITLE
Remove old rule from reject by default

### DIFF
--- a/app/lib/time_limit_config.rb
+++ b/app/lib/time_limit_config.rb
@@ -30,10 +30,8 @@ class TimeLimitConfig
   end
 
   def self.stale_application_rules
-    working_days = FeatureFlag.active?(:continuous_applications) ? 30 : 40
-
     [
-      Rule.new(nil, nil, working_days),
+      Rule.new(nil, nil, 30),
       Rule.new(Time.zone.local(RecruitmentCycle.current_year, 6, 30, 23, 59, 59), nil, 20),
     ]
   end

--- a/spec/lib/time_limit_config_spec.rb
+++ b/spec/lib/time_limit_config_spec.rb
@@ -10,12 +10,8 @@ RSpec.describe TimeLimitConfig do
       expect(described_class.limits_for(:chase_candidate_before_dbd).first.limit).to eq(5)
     end
 
-    it ':reject_by_default returns a default limit of 30 days when continuous applications', :continuous_applications do
+    it ':reject_by_default returns a default limit of 30 days when continuous applications' do
       expect(described_class.limits_for(:reject_by_default).first.limit).to eq(30)
-    end
-
-    it ':reject_by_default returns a default limit of 40 days non continuous applications', continuous_applications: false do
-      expect(described_class.limits_for(:reject_by_default).first.limit).to eq(40)
     end
 
     it ':reject_by_default returns a limit of 20 days date is after June in the current cycle' do


### PR DESCRIPTION
## Context

Delete old rbd 40 days from calculating our time limits.

## Trello card

https://trello.com/c/wZvyArdr/1069-catd-time-limit-config
