### PR TITLE
Amend our support footer content on emails

### DIFF
--- a/app/views/layouts/candidate_email_with_support_footer.text.erb
+++ b/app/views/layouts/candidate_email_with_support_footer.text.erb
@@ -2,6 +2,6 @@
 
 # Get help
 
-If you need support with your application, you can speak to a teacher training adviser before applying again. Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'support_footer_on_all_emails', @application_form.phase %>).
+If you need support with your application, you can speak to a teacher training adviser. Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'support_footer_on_all_emails', @application_form.phase %>).
 
 <%= t('get_into_teaching.opening_times') %>.


### PR DESCRIPTION
## Context

We had a previous pull request where we created new rejection emails for continuous applications. We had content for a specific support footer for those rejection emails.

https://github.com/DFE-Digital/apply-for-teacher-training/pull/8578/

However, our codebase currently only supports a generic footer for all candidate emails. That means the new copy is being sent on all emails, which is not right.

![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/35870975/a329dc02-b1ad-45fe-9ed0-59b35d4abb34)

Here is an example of where this looks odd:
![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/35870975/49feae06-b079-42bc-a76f-ffecbfd9bdfd)


## Changes proposed in this pull request

Remove the phrase - 'before applying again'.

## Guidance to review

Should we remove more than this and simply go back to how the content was? Until we can think of a better, long term solution (such as having specific footers in this instance)?

## Link to Trello card

https://trello.com/c/5jNVO9g8/1061-review-our-email-footers-the-get-help-section

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
