### PR TITLE
Vendor API v1.4: Add GCSE qualifications data

### DIFF
--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -54,5 +54,8 @@ module VendorAPI
       Changes::MarkPhaseAsDeprecated,
       Changes::RemoveReferencesWhenApplicationIsUnsuccessful,
     ],
+    '1.4pre' => [
+      Changes::V14::AddGcseCompletingQualificationData,
+    ],
   }.freeze
 end

--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -5,7 +5,8 @@ module VendorAPI
   VERSION_1_1 = '1.1'.freeze
   VERSION_1_2 = '1.2'.freeze
   VERSION_1_3 = '1.3'.freeze
-  VERSION = VERSION_1_3
+  VERSION_1_4 = '1.4pre'.freeze
+  VERSION = VERSION_1_4
 
   VERSIONS = {
     '1.0' => [

--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -6,7 +6,7 @@ module VendorAPI
   VERSION_1_2 = '1.2'.freeze
   VERSION_1_3 = '1.3'.freeze
   VERSION_1_4 = '1.4pre'.freeze
-  VERSION = VERSION_1_4
+  VERSION = VERSION_1_3
 
   VERSIONS = {
     '1.0' => [

--- a/app/lib/vendor_api/changes/v14/add_gcse_completing_qualification_data.rb
+++ b/app/lib/vendor_api/changes/v14/add_gcse_completing_qualification_data.rb
@@ -1,0 +1,11 @@
+module VendorAPI
+  module Changes
+    module V14
+      class AddGcseCompletingQualificationData < VersionChange
+        description 'Add GCSE completing qualification data'
+
+        resource ApplicationPresenter, [ApplicationPresenter::AddGcseCompletingQualificationData]
+      end
+    end
+  end
+end

--- a/app/presenters/concerns/qualification_api_data.rb
+++ b/app/presenters/concerns/qualification_api_data.rb
@@ -154,7 +154,7 @@ private
 
     {
       currently_completing_qualification: qualification[:currently_completing_qualification],
-      not_completed_explanation: qualification[:not_completed_explanation],
+      missing_explanation: qualification[:missing_explanation],
       other_uk_qualification_type: qualification[:other_uk_qualification_type],
     }
   end

--- a/app/presenters/concerns/qualification_api_data.rb
+++ b/app/presenters/concerns/qualification_api_data.rb
@@ -61,6 +61,10 @@ module QualificationAPIData
     false
   end
 
+  def include_completing_qualification?
+    false
+  end
+
   def qualifications_of_level(level)
     application_form.application_qualifications.select do |qualification|
       qualification.level == level
@@ -84,7 +88,9 @@ module QualificationAPIData
       institution_details: institution_details(qualification),
       awarding_body: nil,
       equivalency_details: qualification.composite_equivalency_details,
-    }.merge(HesaQualificationFieldsPresenter.new(qualification).to_hash)
+    }
+    .merge(HesaQualificationFieldsPresenter.new(qualification).to_hash)
+    .merge(completing_qualification(qualification))
   end
 
   def subject_code(qualification)
@@ -139,5 +145,17 @@ module QualificationAPIData
                                                  grade: hash['grade'],
                                                  id: hash['public_id'])
     end
+  end
+
+private
+
+  def completing_qualification(qualification)
+    return {} unless include_completing_qualification? && qualification.gcse?
+
+    {
+      currently_completing_qualification: qualification[:currently_completing_qualification],
+      not_completed_explanation: qualification[:not_completed_explanation],
+      other_uk_qualification_type: qualification[:other_uk_qualification_type],
+    }
   end
 end

--- a/app/presenters/vendor_api/application_presenter/add_gcse_completing_qualification_data.rb
+++ b/app/presenters/vendor_api/application_presenter/add_gcse_completing_qualification_data.rb
@@ -1,0 +1,5 @@
+module VendorAPI::ApplicationPresenter::AddGcseCompletingQualificationData
+  def include_completing_qualification?
+    true
+  end
+end

--- a/app/views/api_docs/vendor_api_docs/reference/_v1_4_changes.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/_v1_4_changes.html.erb
@@ -11,6 +11,6 @@
 </p>
 <ul class="govuk-list govuk-list--bullet">
   <li><code>currently_completing_qualification</code> (boolean, optional)</li>
-  <li><code>not_completed_explanation</code>  (text, optional)</li>
+  <li><code>missing_explanation</code>  (text, optional)</li>
   <li><code>other_uk_qualification_type</code> (string, optional)</li>
 </ul>

--- a/app/views/api_docs/vendor_api_docs/reference/_v1_4_changes.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/_v1_4_changes.html.erb
@@ -1,0 +1,16 @@
+<h2 class="govuk-heading-l" id="important">Version 1.4 changes</h2>
+
+<p class="govuk-heading-s">Add GCSE qualifications data</p>
+
+<p class="govuk-body">
+  Ensure we send the following fields over the API, as part of the "qualifications"."gcses" object:
+</p>
+
+<p class="govuk-body">
+  The following fields have been added to the <%= govuk_link_to 'qualifications', '#qualifications-object' %> objects, under the <code>gcses</code> array:
+</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li><code>currently_completing_qualification</code> (boolean, optional)</li>
+  <li><code>not_completed_explanation</code>  (text, optional)</li>
+  <li><code>other_uk_qualification_type</code> (string, optional)</li>
+</ul>

--- a/app/views/api_docs/vendor_api_docs/reference/draft.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/draft.html.erb
@@ -10,17 +10,17 @@
 <ol class="app-contents-list__list">
   <li class="app-contents-list__list-item app-contents-list__list-item--parent"><%= govuk_link_to 'API Versions', '#versions', class: 'app-contents-list__link' %></li>
   <li class="app-contents-list__list-item app-contents-list__list-item--parent"><%= govuk_link_to 'Testing draft changes', '#testing-draft', class: 'app-contents-list__link' %></li>
-  <li class="app-contents-list__list-item app-contents-list__list-item--parent"><%= govuk_link_to 'Version 1.3 changes', '#changes', class: 'app-contents-list__link' %></li>
+  <li class="app-contents-list__list-item app-contents-list__list-item--parent"><%= govuk_link_to 'Version 1.4 changes', '#changes', class: 'app-contents-list__link' %></li>
   <li class="app-contents-list__list-item app-contents-list__list-item--parent"><%= govuk_link_to 'Developing on the API', '#developing', class: 'app-contents-list__link' %></li>
   <li class="app-contents-list__list-item app-contents-list__list-item--parent">
     <%= govuk_link_to 'Endpoints', '#endpoints', class: 'app-contents-list__link' %>
 
     <ol class="app-contents-list__nested-list">
-    <% @api_reference.operations.each do |operation| %>
-      <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
-        <%= govuk_link_to operation.name, "##{operation.anchor}", class: 'app-contents-list__link' %>
-      </li>
-    <% end %>
+      <% @api_reference.operations.each do |operation| %>
+        <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
+          <%= govuk_link_to operation.name, "##{operation.anchor}", class: 'app-contents-list__link' %>
+        </li>
+      <% end %>
     </ol>
   </li>
   <li class="app-contents-list__list-item app-contents-list__list-item--parent">
@@ -52,86 +52,39 @@
   <li>using the correct version of the API</li>
 </ul>
 
-<h3 class="govuk-heading-l" id="testing-draft">Testing draft version 1.3</h3>
+<h3 class="govuk-heading-l" id="testing-draft">Testing draft version 1.4</h3>
 
 <p class="govuk-body">
   When an API version is in draft, you can test it using our sandbox test environment.
 </p>
 
 <p class="govuk-body">
-  You can test draft version <code>1.3</code> by using:
+  You can test draft version <code>1.4</code> by using:
 </p>
 <ul class="govuk-list govuk-list--bullet">
-  <li>the sandbox URL for the version, which is <%= govuk_link_to 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.3', 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.3' %></li>
+  <li>the sandbox URL for the version, which is <%= govuk_link_to 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.4', 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.4' %></li>
   <li>your sandbox API token - email <%= govuk_mail_to 'becomingateacher@digital.education.gov.uk' %> if you do not have one</li>
 </ul>
 
 <p class="govuk-body">
-  After version <code>1.3</code> has been released it will also be available in the sandbox on <%= govuk_link_to 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1', 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1' %>.
+  After version <code>1.4</code> has been released it will also be available in the sandbox on <%= govuk_link_to 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1', 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1' %>.
 </p>
 
-<h2 class="govuk-heading-l" id="changes">Version 1.3 changes</h2>
+<h2 class="govuk-heading-l" id="changes">Version 1.4 changes</h2>
 
-<p class="govuk-heading-s">Show referee details before offer acceptance</p>
+<p class="govuk-heading-s">Add GCSE qualifications data</p>
 
 <p class="govuk-body">
-  Referee details will appear as soon as a reference is added by the candidate,
-  but reference feedback will only be included once a candidate has accepted
-  an offer and has received a reference.
+  Ensure we send the following fields over the API, as part of the "qualifications"."gcses" object:
 </p>
 
 <p class="govuk-body">
-  As such the following fields have been marked as optional in the <%= govuk_link_to 'reference', '#reference-object' %> objects:
+  The following fields have been added to the <%= govuk_link_to 'qualifications', '#qualifications-object' %> objects, under the <code>gcses</code> array:
 </p>
 <ul class="govuk-list govuk-list--bullet">
-  <li><code>reference</code></li>
-  <li><code>safeguarding_concerns</code></li>
-</ul>
-
-<p class="govuk-body">
-  References will not appear if their application is unsuccessful (e.g. offer declined, application rejected).
-</p>
-
-<p class="govuk-heading-s">Add missing fields to work/volunteering experience</p>
-
-<p class="govuk-body">
-  The following object types have been added:
-</p>
-<ul class="govuk-list govuk-list--bullet">
-  <li><%= govuk_link_to 'Month', '#month-object' %></li>
-</ul>
-
-<p class="govuk-body">
-  The following fields have been added to the <%= govuk_link_to 'work (and volunteering) experience', '#workexperience-object' %> objects:
-</p>
-<ul class="govuk-list govuk-list--bullet">
-  <li><code>skills_relevant_to_teaching</code> (boolean, optional)</li>
-  <li><code>start_month</code> (<%= govuk_link_to 'Month', '#month-object' %>)</li>
-  <li><code>end_month</code> (<%= govuk_link_to 'Month', '#month-object' %>, optional)</li>
-</ul>
-
-<p class="govuk-body">
-  The following fields have been deprecated in the <%= govuk_link_to 'work (and volunteering) experience', '#workexperience-object' %> objects:
-</p>
-<ul class="govuk-list govuk-list--bullet">
-  <li><code>start_date</code></li>
-  <li><code>end_date</code></li>
-</ul>
-
-<p class="govuk-body">
-  The following fields have been marked as optional in the <%= govuk_link_to 'work (and volunteering) experience', '#workexperience-object' %> objects:
-</p>
-<ul class="govuk-list govuk-list--bullet">
-  <li><code>description</code></li>
-</ul>
-
-<p class="govuk-heading-s">Mark fields as deprecated in <%= govuk_link_to 'application attributes', '#applicationattributes-object' %></p>
-
-<p class="govuk-body">
-  The following fields have been marked as deprecated and will be removed in a future release:
-</p>
-<ul class="govuk-list govuk-list--bullet">
-  <li><code>phase</code></li>
+  <li><code>currently_completing_qualification</code> (boolean, optional)</li>
+  <li><code>not_completed_explanation</code>  (text, optional)</li>
+  <li><code>other_uk_qualification_type</code> (string, optional)</li>
 </ul>
 
 <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-6 govuk-!-margin-bottom-6">
@@ -150,10 +103,10 @@
 
 <p class="govuk-body">
   We have a production environment and a sandbox environment.
-  When version 1.3 is launched initially for testing, it will only be accessible
+  When version 1.4 is launched initially for testing, it will only be accessible
   in the sandbox environment by determining the version in the URL as so:
-  <%= govuk_link_to 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.3',
-                    'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.3' %>.
+  <%= govuk_link_to 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.4',
+                    'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.4' %>.
   Only after testing is complete, the production environment will automatically upgrade
   to the latest minor version without the need to update the URL.
 </p>

--- a/app/views/api_docs/vendor_api_docs/reference/draft.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/draft.html.erb
@@ -83,7 +83,7 @@
 </p>
 <ul class="govuk-list govuk-list--bullet">
   <li><code>currently_completing_qualification</code> (boolean, optional)</li>
-  <li><code>not_completed_explanation</code>  (text, optional)</li>
+  <li><code>missing_explanation</code>  (text, optional)</li>
   <li><code>other_uk_qualification_type</code> (string, optional)</li>
 </ul>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -254,7 +254,7 @@ en:
         release_notes: Release notes
         lifecycle: Lifecycle
         alpha_release_notes: Alpha release notes
-        draft: Draft Version 1.3
+        draft: Draft Version 1.4
       register_api_docs:
         reference: Apply for teacher training - Register API
     provider:

--- a/config/vendor_api/draft.yml
+++ b/config/vendor_api/draft.yml
@@ -1,70 +1,30 @@
 ---
 openapi: 3.0.0
 info:
-  version: v1.3
+  version: v1.4
 servers:
-- description: Sandbox (test environment for vendors)
-  url: https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.3
-- description: Production
-  url: https://www.apply-for-teacher-training.service.gov.uk/api/v1.3
+  - description: Sandbox (test environment for vendors)
+    url: https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.4
+  - description: Production
+    url: https://www.apply-for-teacher-training.service.gov.uk/api/v1.4
 components:
   schemas:
-    ApplicationAttributes:
-      properties:
-        phase:
-          deprecated: true
-        references:
-          description: |
-            Referee details will appear as soon as a reference is added by the candidate.
-            Reference feedback will only be included once a candidate has accepted an offer and has received a reference.
-            References will not appear if their application is unsuccessful (e.g. offer declined, application rejected).
-            There is no limit to the number of references.
-    Reference:
-      properties:
-        reference:
-          nullable: true
-        safeguarding_concerns:
-          nullable: true
-    Month:
+    Qualification:
       type: object
       additionalProperties: false
-      required:
-      - estimated
-      - month
-      - year
       properties:
-        estimated:
+        currently_completing_qualification:
           type: boolean
-          description: Whether the candidate stated this is an estimate
+          description: The response to the “Are you currently studying to retake your GCSE?” question.
           example: true
           nullable: true
-        month:
-          type: string
-          description: The zero-padded month number
-          example: "05"
-        year:
-          type: string
-          description: The year number
-          example: "2020"
-    WorkExperience:
-      properties:
-        description:
-          nullable: true
-        start_date:
-          deprecated: true
-        end_date:
-          deprecated: true
-        start_month:
-          description: The month the position began
-          oneOf:
-          - "$ref": "#/components/schemas/Month"
-        end_month:
-          description: The month the position ended
-          anyOf:
-          - type: null
-          - "$ref": "#/components/schemas/Month"
-        skills_relevant_to_teaching:
-          type: boolean
-          nullable: true
-          description: 'Did the candidate use skills relevant to teaching?'
+        missing_explanation:
+          type: text
+          description: The explanation if "currently_completing_qualification" is false
           example: true
+          nullable: true
+        other_uk_qualification_type:
+          type: text
+          description: The response to "Another UK qualification" - "Qualification name"
+          example: true
+          nullable: true

--- a/config/vendor_api/v1.4.yml
+++ b/config/vendor_api/v1.4.yml
@@ -1,0 +1,38 @@
+---
+openapi: 3.0.0
+info:
+  version: v1.4
+  title: Apply API
+  contact:
+    name: DfE
+    email: becomingateacher@digital.education.gov.uk
+  description: |
+    API for DfE’s Apply for teacher training service.
+    Endpoints with the `/applications` prefix are considered stable.
+    Experimental endpoints prefixed with `/test-data` may change or be removed.
+servers:
+  - description: Sandbox (test environment for vendors)
+    url: https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.4
+  - description: Production
+    url: https://www.apply-for-teacher-training.service.gov.uk/api/v1.4
+components:
+  schemas:
+    Qualification:
+      type: object
+      additionalProperties: false
+      properties:
+        currently_completing_qualification:
+          type: boolean
+          description: The response to the “Are you currently studying to retake your GCSE?” question.
+          example: true
+          nullable: true
+        not_completed_explanation:
+          type: text
+          description: The explanation if "currently_completing_qualification" is false
+          example: true
+          nullable: true
+        other_uk_qualification_type:
+          type: text
+          description: The response to "Another UK qualification" - "Qualification name"
+          example: true
+          nullable: true

--- a/config/vendor_api/v1.4.yml
+++ b/config/vendor_api/v1.4.yml
@@ -26,7 +26,7 @@ components:
           description: The response to the “Are you currently studying to retake your GCSE?” question.
           example: true
           nullable: true
-        not_completed_explanation:
+        missing_explanation:
           type: text
           description: The explanation if "currently_completing_qualification" is false
           example: true

--- a/docs/versioning_vendor_api.md
+++ b/docs/versioning_vendor_api.md
@@ -9,10 +9,11 @@ Incrementing the API to major versions is currently not supported.
 Minor version updates are only for non-breaking changes. A key design principle is maintaining backwards compatibility with all prior minor versions.
 
 When incrementing a minor version, the following changes can be introduced:
- - Adding fields to an existing schema
- - Adding a new action to an existing controller
- - Adding a new nested resource
- - Adding metadata fields
+
+- Adding fields to an existing schema
+- Adding a new action to an existing controller
+- Adding a new nested resource
+- Adding metadata fields
 
 Fields, routes and endpoints cannot be removed once they have been introduced.
 
@@ -41,6 +42,7 @@ When introducing a new field or changing the behavior of existing fields, create
 The presenter module needs to implement the `schema` method, and deep merge into the returned value.
 
 For example, to add a new `date_and_time` field to an existing `InterviewPresenter` schema, there are three key steps:
+
 1. Introduce a new presenter module
 2. Create a change class
 3. Include the change class in the Vendor API
@@ -390,6 +392,7 @@ end
 ### Add tests for the controller changes
 
 For each new controller action, add a request spec:
+
 - `spec/requests/vendor_api/v1.2/post_create_feedback_spec.rb`
 - `spec/requests/vendor_api/v1.2/post_update_feedback_spec.rb`
 

--- a/spec/presenters/vendor_api/v1.4/application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.4/application_presenter_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe 'ApplicationPresenter' do
+  let(:application_presenter) { VendorAPI::ApplicationPresenter }
+  let(:version) { '1.4' }
+  let(:application_json) { application_presenter.new(version, application_choice).as_json }
+  let(:attributes) { application_json[:attributes] }
+  let(:application_form) { create(:application_form, :submitted) }
+  let(:application_choice) { create(:application_choice, application_form:) }
+
+  describe '#GCSEs' do
+    subject(:gcse) { attributes[:qualifications][:gcses].first }
+
+    context 'when the application has a missing_and_currently_completing qualification' do
+      before do
+        create(
+          :gcse_qualification,
+          currently_completing_qualification: true,
+          not_completed_explanation: 'I will be taking an equivalency test in a few weeks',
+          other_uk_qualification_type: 'Equivalency test',
+          application_form: application_form,
+        )
+      end
+
+      it 'returns the correct GCSEs fields' do
+        expect(gcse[:currently_completing_qualification]).to be true
+        expect(gcse[:not_completed_explanation]).to eq 'I will be taking an equivalency test in a few weeks'
+        expect(gcse[:other_uk_qualification_type]).to eq 'Equivalency test'
+      end
+    end
+  end
+end

--- a/spec/presenters/vendor_api/v1.4/application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.4/application_presenter_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'ApplicationPresenter' do
         create(
           :gcse_qualification,
           currently_completing_qualification: true,
-          not_completed_explanation: 'I will be taking an equivalency test in a few weeks',
+          missing_explanation: 'I will be taking an equivalency test in a few weeks',
           other_uk_qualification_type: 'Equivalency test',
           application_form: application_form,
         )
@@ -24,7 +24,7 @@ RSpec.describe 'ApplicationPresenter' do
 
       it 'returns the correct GCSEs fields' do
         expect(gcse[:currently_completing_qualification]).to be true
-        expect(gcse[:not_completed_explanation]).to eq 'I will be taking an equivalency test in a few weeks'
+        expect(gcse[:missing_explanation]).to eq 'I will be taking an equivalency test in a few weeks'
         expect(gcse[:other_uk_qualification_type]).to eq 'Equivalency test'
       end
     end

--- a/spec/requests/api_docs/get_spec_spec.rb
+++ b/spec/requests/api_docs/get_spec_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe 'API Docs - GET /api-docs/spec*.yml' do
   let(:latest_released_version) { AllowedCrossNamespaceUsage::VendorAPIInfo.released_version }
 
+  before do
+    allow(HostingEnvironment).to receive(:production?).and_return(true)
+  end
+
   describe 'GET /api-docs/spec.yml' do
     it 'returns the most recent spec in YAML format' do
       get '/api-docs/spec.yml'

--- a/spec/requests/api_docs/get_spec_spec.rb
+++ b/spec/requests/api_docs/get_spec_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe 'API Docs - GET /api-docs/spec*.yml' do
 
   describe 'GET /api-docs/spec-draft.yml' do
     context 'when the draft feature flag is active' do
+      let(:development_version) { AllowedCrossNamespaceUsage::VendorAPIInfo.development_version }
+
       around do |example|
         FeatureFlag.activate(:draft_vendor_api_specification) { example.run }
       end
@@ -28,7 +30,7 @@ RSpec.describe 'API Docs - GET /api-docs/spec*.yml' do
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to match('openapi: 3.0.0')
-        expect(response.body).to match(/version: v#{latest_released_version}$/)
+        expect(response.body).to match(/version: v#{development_version}$/)
       end
     end
 

--- a/spec/requests/vendor_api/v1.4/get_qualification_fields_from_application_spec.rb
+++ b/spec/requests/vendor_api/v1.4/get_qualification_fields_from_application_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe 'Vendor API - GET /api/v1.4/applications' do
+  include VendorAPISpecHelpers
+
+  before do
+    application_choice = create_application_choice_for_currently_authenticated_provider
+
+    create(
+      :gcse_qualification,
+      currently_completing_qualification: true,
+      not_completed_explanation: 'I will be taking an equivalency test in a few weeks',
+      other_uk_qualification_type: 'Equivalency test',
+      application_form: application_choice.application_form,
+    )
+
+    get_api_request "/api/v1.4/applications/#{application_choice.id}"
+  end
+
+  describe 'get completing qualifications fields' do
+    subject(:gcse) { parsed_response['data']['attributes']['qualifications']['gcses'].last }
+
+    it 'returns the correct GCSEs fields' do
+      expect(gcse['currently_completing_qualification']).to be true
+      expect(gcse['not_completed_explanation']).to eq 'I will be taking an equivalency test in a few weeks'
+      expect(gcse['other_uk_qualification_type']).to eq 'Equivalency test'
+    end
+  end
+end

--- a/spec/requests/vendor_api/v1.4/get_qualification_fields_from_application_spec.rb
+++ b/spec/requests/vendor_api/v1.4/get_qualification_fields_from_application_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Vendor API - GET /api/v1.4/applications' do
     create(
       :gcse_qualification,
       currently_completing_qualification: true,
-      not_completed_explanation: 'I will be taking an equivalency test in a few weeks',
+      missing_explanation: 'I will be taking an equivalency test in a few weeks',
       other_uk_qualification_type: 'Equivalency test',
       application_form: application_choice.application_form,
     )
@@ -22,7 +22,7 @@ RSpec.describe 'Vendor API - GET /api/v1.4/applications' do
 
     it 'returns the correct GCSEs fields' do
       expect(gcse['currently_completing_qualification']).to be true
-      expect(gcse['not_completed_explanation']).to eq 'I will be taking an equivalency test in a few weeks'
+      expect(gcse['missing_explanation']).to eq 'I will be taking an equivalency test in a few weeks'
       expect(gcse['other_uk_qualification_type']).to eq 'Equivalency test'
     end
   end


### PR DESCRIPTION
We need to update our Vendor API to represent the latest implementation of qualifications in our process.

Ensure we send the following fields over the API, as part of the GCSE object:

- currently_completing_qualification - stores the boolean response to the “Are you currently studying to retake your GCSE?” question.
- not_completed_explanation - stores the free text explanation if the above is false
- other_uk_qualification_type - stores the response to “Another UK qualification” - “Qualification name”

![](https://github.trello.services/images/mini-trello-icon.png) [Vendor API v1.4: Add GCSE qualifications data](https://trello.com/c/LLVnaJb7/791-vendor-api-v14-add-gcse-qualifications-data)

<img width="812" alt="Screenshot 2023-12-14 at 11 08 01" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/7b2b8bfd-4183-4a2a-b184-23da7696362c">
