### PR TITLE
Redirect to the latest production version of the API

### DIFF
--- a/app/controllers/api_docs/vendor_api_docs/reference_controller.rb
+++ b/app/controllers/api_docs/vendor_api_docs/reference_controller.rb
@@ -4,7 +4,7 @@ module APIDocs
       include VersioningHelpers
 
       def reference
-        return redirect_to(api_docs_production_version_reference_path, status: :moved_permanently) if api_version_param.nil?
+        return redirect_to(api_docs_production_version_reference_path, status: :moved_permanently) if incorrect_version?
 
         @api_reference = APIReference.new(VendorAPISpecification.new(version:).as_hash, version:)
       end
@@ -43,6 +43,10 @@ module APIDocs
         end
       end
       helper_method :spec_url_for_current_version
+
+      def incorrect_version?
+        api_version_param.nil? || spec_url_for_current_version.nil?
+      end
     end
   end
 end

--- a/spec/system/api_docs/api_docs_spec.rb
+++ b/spec/system/api_docs/api_docs_spec.rb
@@ -4,6 +4,9 @@ RSpec.feature 'API docs' do
   scenario 'User browses through the API docs' do
     given_i_am_a_vendor
     i_can_browse_the_api_docs
+
+    when_i_enter_an_incorrect_api_version_in_the_url
+    then_i_get_redirected_to_the_latest_production_version
   end
 
   def given_i_am_a_vendor
@@ -32,5 +35,13 @@ RSpec.feature 'API docs' do
 
     click_link 'When emails are sent'
     expect(page).to have_content 'we send these notifications'
+  end
+
+  def when_i_enter_an_incorrect_api_version_in_the_url
+    visit api_docs_versioned_reference_path(api_version: 'v1.1.1')
+  end
+
+  def then_i_get_redirected_to_the_latest_production_version
+    expect(page).to have_current_path api_docs_versioned_reference_path(api_version: "v#{VendorAPI::VERSION}"), ignore_query: true
   end
 end


### PR DESCRIPTION
If the API version in the URL is not released yet, redirect to the latest production version.

**Avoids:**
<img width="1071" alt="Screenshot 2023-12-16 at 18 31 36" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/43feebbb-56eb-48be-9f21-46bdc5fa547c">

