### PR TITLE
Add paths to vendor API v1.4

### DIFF
--- a/app/controllers/api_docs/vendor_api_docs/openapi_controller.rb
+++ b/app/controllers/api_docs/vendor_api_docs/openapi_controller.rb
@@ -29,6 +29,10 @@ module APIDocs
         spec(version: VendorAPI::VERSION_1_3)
       end
 
+      def spec_1_4
+        spec(version: VendorAPI::VERSION_1_4)
+      end
+
     private
 
       def spec(**options)

--- a/app/controllers/api_docs/vendor_api_docs/reference_controller.rb
+++ b/app/controllers/api_docs/vendor_api_docs/reference_controller.rb
@@ -40,6 +40,8 @@ module APIDocs
           api_docs_spec_1_2_url
         when '1.3'
           api_docs_spec_1_3_url
+        when '1.4'
+          api_docs_spec_1_4_url
         end
       end
       helper_method :spec_url_for_current_version

--- a/config/routes/api/docs.rb
+++ b/config/routes/api/docs.rb
@@ -19,6 +19,7 @@ namespace :api_docs, path: nil do
     get '/spec-1.1.yml' => 'openapi#spec_1_1', as: :spec_1_1
     get '/spec-1.2.yml' => 'openapi#spec_1_2', as: :spec_1_2
     get '/spec-1.3.yml' => 'openapi#spec_1_3', as: :spec_1_3
+    get '/spec-1.4.yml' => 'openapi#spec_1_4', as: :spec_1_4
   end
 
   namespace :data_api_docs, path: '/data-api' do


### PR DESCRIPTION
The routes were not updated to have the 1.4 paths, but this was making the recently added test to redirect if the version does not exist fail.
There are other ways to make this pass, but we will need to add the paths anyway.