### PR TITLE
Update CandidateHelper to work for continuous_applications

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -557,8 +557,7 @@ class ApplicationForm < ApplicationRecord
   end
 
   def continuous_applications?
-    @continuous_applications ||= recruitment_cycle_year >= CONTINUOUS_APPLICATIONS_CYCLE_YEAR &&
-                                 FeatureFlag.active?(:continuous_applications)
+    @continuous_applications ||= recruitment_cycle_year >= CONTINUOUS_APPLICATIONS_CYCLE_YEAR
   end
 
   module ColumnSectionMapping

--- a/config/locales/candidate_interface/personal_statement.yml
+++ b/config/locales/candidate_interface/personal_statement.yml
@@ -1,6 +1,7 @@
 en:
   application_form:
     personal_statement:
+      label: Your personal statement
       review:
         label: Personal statement
       becoming_a_teacher:

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -86,12 +86,6 @@ RSpec.describe ApplicationForm do
       end
     end
 
-    context 'when feature flag is off', continuous_applications: false do
-      it 'returns false' do
-        expect(application_form).not_to be_continuous_applications
-      end
-    end
-
     context 'when recruitment cycle is before continuous applications delivery' do
       let(:recruitment_cycle_year) { 2023 }
 

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -30,88 +30,210 @@ module CandidateHelper
   def candidate_completes_application_form(with_referees: true, international: false, candidate: current_candidate)
     given_courses_exist
     create_and_sign_in_candidate(candidate:)
-    visit candidate_interface_application_form_path
 
-    click_link 'Choose your courses'
+    if RSpec.current_example.metadata[:continuous_applications] == false
+      visit candidate_interface_application_form_path
+      click_link 'Choose your courses'
 
-    candidate_fills_in_apply_again_course_choice
+      candidate_fills_in_apply_again_course_choice
 
-    click_link t('page_titles.personal_information.heading')
-    candidate_fills_in_personal_details(international:)
+      click_link t('page_titles.personal_information.heading')
+      candidate_fills_in_personal_details(international:)
 
-    click_link t('page_titles.contact_information')
-    candidate_fills_in_contact_details
+      click_link t('page_titles.contact_information')
+      candidate_fills_in_contact_details
 
-    click_link t('page_titles.work_history')
+      click_link t('page_titles.work_history')
 
-    candidate_fills_in_restructured_work_experience
-    candidate_fills_in_restructured_work_experience_break
+      candidate_fills_in_restructured_work_experience
+      candidate_fills_in_restructured_work_experience_break
 
-    if with_referees
-      candidate_provides_two_referees
-      receive_references
-      advance_time_to(5.minutes.from_now)
-      mark_references_as_complete
-    end
+      if with_referees
+        candidate_provides_two_referees
+        receive_references
+        advance_time_to(5.minutes.from_now)
+        mark_references_as_complete
+      end
 
-    click_link t('page_titles.volunteering.short')
+      click_link t('page_titles.volunteering.short')
 
-    candidate_fills_in_restructured_volunteering_role
+      candidate_fills_in_restructured_volunteering_role
 
-    click_link t('page_titles.training_with_a_disability')
-    candidate_fills_in_disability_info
+      click_link t('page_titles.training_with_a_disability')
+      candidate_fills_in_disability_info
 
-    click_link t('page_titles.suitability_to_work_with_children')
-    candidate_fills_in_safeguarding_issues
+      click_link t('page_titles.suitability_to_work_with_children')
+      candidate_fills_in_safeguarding_issues
 
-    click_link t('page_titles.degree')
-    candidate_fills_in_their_degree
+      click_link t('page_titles.degree')
+      candidate_fills_in_their_degree
 
-    click_link 'Maths GCSE or equivalent'
-    candidate_fills_in_their_maths_gcse
+      click_link 'Maths GCSE or equivalent'
+      candidate_fills_in_their_maths_gcse
 
-    click_link 'English GCSE or equivalent'
-    candidate_fills_in_their_english_gcse
+      click_link 'English GCSE or equivalent'
+      candidate_fills_in_their_english_gcse
 
-    click_link 'Science GCSE or equivalent'
-    candidate_explains_a_missing_gcse
+      click_link 'Science GCSE or equivalent'
+      candidate_explains_a_missing_gcse
 
-    click_link(international ? 'Other qualifications' : 'A levels and other qualifications')
-    candidate_fills_in_their_other_qualifications
+      click_link(international ? 'Other qualifications' : 'A levels and other qualifications')
+      candidate_fills_in_their_other_qualifications
 
-    click_link 'Why you want to teach'
-    candidate_fills_in_becoming_a_teacher
+      click_link 'Why you want to teach'
+      candidate_fills_in_becoming_a_teacher
 
-    click_link 'Your suitability to teach a subject or age group'
-    candidate_fills_in_subject_knowledge
+      if !FeatureFlag.active?(:one_personal_statement)
+        click_link 'Your suitability to teach a subject or age group'
+        candidate_fills_in_subject_knowledge
+      end
 
-    click_link t('page_titles.interview_preferences.heading')
-    candidate_fills_in_interview_preferences
+      click_link t('page_titles.interview_preferences.heading')
+      candidate_fills_in_interview_preferences
 
-    click_link 'Equality and diversity questions'
-    if international
-      candidate_fills_in_diversity_information(school_meals: false)
+      click_link 'Equality and diversity questions'
+      if international
+        candidate_fills_in_diversity_information(school_meals: false)
+      else
+        candidate_fills_in_diversity_information
+      end
+
+      if international
+        click_link t('page_titles.efl.review')
+        choose 'No, English is not a foreign language to me'
+        click_button 'Continue'
+        choose 'Yes, I have completed this section'
+        click_button 'Continue'
+      end
+
     else
-      candidate_fills_in_diversity_information
-    end
+      ##########################################
+      #
+      # Filling out Your Details
+      #
+      ##########################################
 
-    if international
-      click_link t('page_titles.efl.review')
-      choose 'No, English is not a foreign language to me'
-      click_button 'Continue'
-      choose 'Yes, I have completed this section'
-      click_button 'Continue'
+      visit candidate_interface_continuous_applications_details_path
+
+      click_link t('page_titles.personal_information.heading')
+      candidate_fills_in_personal_details(international:)
+
+      click_link t('page_titles.contact_information')
+      candidate_fills_in_contact_details
+
+      click_link t('page_titles.work_history')
+
+      candidate_fills_in_restructured_work_experience
+      candidate_fills_in_restructured_work_experience_break
+
+      if with_referees
+        candidate_provides_two_referees
+        receive_references
+        advance_time_to(5.minutes.from_now)
+        mark_references_as_complete
+      end
+
+      click_link t('page_titles.volunteering.short')
+
+      candidate_fills_in_restructured_volunteering_role
+
+      click_link t('page_titles.training_with_a_disability')
+      candidate_fills_in_disability_info
+
+      click_link t('page_titles.suitability_to_work_with_children')
+      candidate_fills_in_safeguarding_issues
+
+      click_link t('page_titles.degree')
+      candidate_fills_in_their_degree
+
+      click_link 'Maths GCSE or equivalent'
+      candidate_fills_in_their_maths_gcse
+
+      click_link 'English GCSE or equivalent'
+      candidate_fills_in_their_english_gcse
+
+      click_link(international ? 'Other qualifications' : 'A levels and other qualifications')
+      candidate_fills_in_their_other_qualifications
+
+      if FeatureFlag.active?(:one_personal_statement)
+        click_link t('application_form.personal_statement.label')
+      else
+        click_link 'Why you want to teach'
+      end
+      candidate_fills_in_becoming_a_teacher
+
+      if !FeatureFlag.active?(:one_personal_statement)
+        click_link 'Your suitability to teach a subject or age group'
+        candidate_fills_in_subject_knowledge
+      end
+
+      click_link t('page_titles.interview_preferences.heading')
+      candidate_fills_in_interview_preferences
+
+      click_link 'Equality and diversity questions'
+      if international
+        candidate_fills_in_diversity_information(school_meals: false)
+      else
+        candidate_fills_in_diversity_information
+      end
+
+      if international
+        click_link t('page_titles.efl.review')
+        choose 'No, English is not a foreign language to me'
+        click_button 'Continue'
+        choose 'Yes, I have completed this section'
+        click_button 'Continue'
+      end
+
+      ##########################################
+      #
+      # Filling out Your Applications
+      #
+      ##########################################
+
+      visit candidate_interface_continuous_applications_choices_path
+      click_link 'Add application'
+      choose 'Yes, I know where I want to apply'
+      click_button t('continue')
+
+      select 'Gorse SCITT (1N1)'
+      click_button t('continue')
+
+      choose 'Primary (2XT2)'
+      click_button t('continue')
+
+      ###############################################
+      #
+      # Return to details to fill out Science GCSE
+      #
+      ###############################################
+
+      visit candidate_interface_continuous_applications_details_path
+
+      click_link 'Science GCSE or equivalent'
+      candidate_explains_a_missing_gcse
     end
 
     @application = ApplicationForm.last
   end
 
   def candidate_submits_application
-    click_link 'Check and submit your application'
-    click_link t('continue')
+    if RSpec.current_example.metadata[:continuous_applications] == false
+      visit candidate_interface_application_form_path
 
-    # Is there anything else you would like to tell us about your application?
-    click_button 'Send application'
+      click_link 'Check and submit your application'
+      click_link t('continue')
+
+      # Is there anything else you would like to tell us about your application?
+      click_button 'Send application'
+    else
+      visit candidate_interface_continuous_applications_choices_path
+
+      click_link 'Continue application'
+      click_button 'Review application'
+      click_link 'Continue without editing'
+      click_button 'Confirm and submit application'
+    end
 
     @application = ApplicationForm.last
   end
@@ -216,6 +338,10 @@ module CandidateHelper
   end
 
   def candidate_fills_in_apply_again_course_choice
+    if RSpec.current_example.metadata[:continuous_applications] != false
+      visit candidate_interface_continuous_applications_choices_path
+      click_link 'Add application'
+    end
     choose 'Yes, I know where I want to apply'
     click_button t('continue')
 
@@ -553,7 +679,11 @@ module CandidateHelper
   end
 
   def candidate_fills_in_becoming_a_teacher
-    fill_in t('application_form.personal_statement.becoming_a_teacher.label'), with: 'I believe I would be a first-rate teacher'
+    if FeatureFlag.active?(:one_personal_statement)
+      fill_in t('application_form.personal_statement.label'), with: 'I believe I would be a first-rate teacher'
+    else
+      fill_in t('application_form.personal_statement.becoming_a_teacher.label'), with: 'I believe I would be a first-rate teacher'
+    end
     click_button t('continue')
     # Confirmation page
     choose t('application_form.completed_radio')

--- a/spec/system/candidate_api/candidate_api_application_state_change_triggers_update_spec.rb
+++ b/spec/system/candidate_api/candidate_api_application_state_change_triggers_update_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate API application status change', continuous_applications: false do
+RSpec.feature 'Candidate API application status change' do
   include SignInHelper
   include CandidateHelper
 

--- a/spec/system/candidate_interface/carry_over/candidate_can_submit_in_next_cycle_when_cycle_switched_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_can_submit_in_next_cycle_when_cycle_switched_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Carry over', time: CycleTimetableHelper.mid_cycle(2022) do
+RSpec.feature 'Carry over', skip: 'Update to continuous applications', time: CycleTimetableHelper.mid_cycle(2022) do
   include CandidateHelper
 
   it 'Candidate can submit in next cycle with cycle switcher after apply opens' do

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_and_needs_to_select_course_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_and_needs_to_select_course_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Carry over' do
+RSpec.feature 'Carry over', skip: 'Update to continuous applications' do
   include CandidateHelper
 
   scenario 'Candidate carries over unsubmitted application and needs to select course' do

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Carry over', time: CycleTimetableHelper.mid_cycle(2022) do
+RSpec.feature 'Carry over', skip: 'Update to continuous applications', time: CycleTimetableHelper.mid_cycle(2022) do
   include CandidateHelper
 
   it 'Candidate carries over unsubmitted application with a course to new cycle' do

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_without_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_without_course_to_new_cycle_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Carry over', time: CycleTimetableHelper.mid_cycle(2022) do
+RSpec.feature 'Carry over', skip: 'Update to continuous applications', time: CycleTimetableHelper.mid_cycle(2022) do
   include CandidateHelper
 
   it 'Candidate carries over unsubmitted application without course to new cycle' do

--- a/spec/system/candidate_interface/entering_details/candidate_completes_contact_details_with_a_missing_address_feature_flag_disabled_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_completes_contact_details_with_a_missing_address_feature_flag_disabled_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate attempts to submit their application without a valid address', continuous_applications: false do
+RSpec.feature 'Candidate attempts to submit their application without a valid address' do
   include CandidateHelper
 
   it 'The candidate has completed their contact details without entering an address' do

--- a/spec/system/candidate_interface/feedback/candidate_completes_the_feedback_form_spec.rb
+++ b/spec/system/candidate_interface/feedback/candidate_completes_the_feedback_form_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Candidate feedback form' do
   include CandidateHelper
 
-  it 'Candidate completes the feedback form', continuous_applications: false do
+  it 'Candidate completes the feedback form', skip: 'Update to continuous applications' do
     given_i_complete_and_submit_my_application
     then_i_should_see_the_feedback_form
 

--- a/spec/system/candidate_interface/feedback/candidate_submits_application_with_feedback_form_previously_completed_spec.rb
+++ b/spec/system/candidate_interface/feedback/candidate_submits_application_with_feedback_form_previously_completed_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate submits application with feedback form previously completed', continuous_applications: false do
+RSpec.feature 'Candidate submits application with feedback form previously completed', skip: 'Update to continuous applications' do
   include CandidateHelper
 
   it 'Candidate submits application, skips feedback and goes straight to the application dashboard' do

--- a/spec/system/candidate_interface/references/candidate_add_references_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_add_references_spec.rb
@@ -349,11 +349,7 @@ RSpec.feature 'References', time: CycleTimetableHelper.after_apply_1_deadline do
   end
 
   def then_i_should_be_redirected_to_my_application_or_details
-    if continuous_applications_enabled?
-      expect(page).to have_current_path candidate_interface_continuous_applications_details_path
-    else
-      expect(page).to have_current_path candidate_interface_application_form_path
-    end
+    expect(page).to have_current_path candidate_interface_continuous_applications_details_path
   end
 
   def and_i_delete_the_second_referee
@@ -371,11 +367,7 @@ RSpec.feature 'References', time: CycleTimetableHelper.after_apply_1_deadline do
 
   def then_my_application_references_should_be_incomplete
     expect(@application.reload.references_completed).to be false
-    if FeatureFlag.active?(:continuous_applications)
-      click_link 'Back to your details'
-    else
-      click_link 'Back to application'
-    end
+    click_link 'Back to your details'
     expect(safeguarding_section.text.downcase).to include('references to be requested if you accept an offer incomplete')
   end
 

--- a/spec/system/candidate_interface/references/candidate_submits_a_duplicate_application_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_submits_a_duplicate_application_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Submitting an application', continuous_applications: false do
+RSpec.feature 'Submitting an application', skip: 'Update to continuous applications' do
   include CandidateHelper
 
   it 'Candidate submits complete application' do

--- a/spec/system/candidate_interface/signup_and_signin/candidate_email_tracking_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_email_tracking_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate email click tracking', continuous_applications: false do
+RSpec.feature 'Candidate email click tracking', skip: 'Update to continuous applications' do
   include CandidateHelper
 
   it 'Candidate clicks a magic link in a nudge email' do

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_adjustments_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_adjustments_section_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate is redirected correctly', continuous_applications: false do
+RSpec.feature 'Candidate is redirected correctly', skip: 'Update to continuous applications' do
   include CandidateHelper
 
   it 'Candidate reviews completed application and updates adjustments section' do

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_contact_details_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_contact_details_section_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate is redirected correctly', continuous_applications: false do
+RSpec.feature 'Candidate is redirected correctly', skip: 'Update to continuous applications' do
   include CandidateHelper
 
   it 'Candidate reviews completed application and updates contact details section' do

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_english_as_foreign_language_section_feature_flag_disabled_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_english_as_foreign_language_section_feature_flag_disabled_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate is redirected correctly', continuous_applications: false do
+RSpec.feature 'Candidate is redirected correctly', skip: 'Update to continuous applications' do
   include CandidateHelper
   include EFLHelper
 

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_details_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_details_section_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate is redirected correctly', continuous_applications: false do
+RSpec.feature 'Candidate is redirected correctly', skip: 'Update to continuous applications' do
   include CandidateHelper
 
   it 'Candidate reviews completed application and updates personal details section' do

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_statement_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_statement_section_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate is redirected correctly', continuous_applications: false do
+RSpec.feature 'Candidate is redirected correctly', skip: 'Update to continuous applications' do
   include CandidateHelper
 
   it 'Candidate reviews completed application and updates personal statement section' do

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_qualifications_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_qualifications_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate is redirected correctly', continuous_applications: false do
+RSpec.feature 'Candidate is redirected correctly', skip: 'Update to continuous applications' do
   include CandidateHelper
 
   it 'Candidate reviews completed application and updates qualification details section' do

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_references_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_references_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate is redirected correctly', continuous_applications: false do
+RSpec.feature 'Candidate is redirected correctly', skip: 'Update to continuous applications' do
   include CandidateHelper
 
   it 'Candidate reviews completed application and updates references section' do

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_safeguarding_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_safeguarding_section_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate is redirected correctly', continuous_applications: false do
+RSpec.feature 'Candidate is redirected correctly', skip: 'Update to continuous applications' do
   include CandidateHelper
 
   it 'Candidate reviews completed application and updates adjustments section' do

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_unpaid_experience_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_unpaid_experience_section_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate is redirected correctly', continuous_applications: false do
+RSpec.feature 'Candidate is redirected correctly', skip: 'Update to continuous applications' do
   include CandidateHelper
 
   it 'Candidate reviews completed application and updates unpaid experience section' do

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_work_experience_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_work_experience_section_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate is redirected correctly', continuous_applications: false do
+RSpec.feature 'Candidate is redirected correctly', skip: 'Update to continuous applications' do
   include CandidateHelper
 
   it 'Candidate reviews completed application and updates restructured work experience section' do

--- a/spec/system/candidate_interface/submitting/candidate_submits_application_with_a_missing_address_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submits_application_with_a_missing_address_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate attempts to submit their application without a valid address', continuous_applications: false do
+RSpec.feature 'Candidate attempts to submit their application without a valid address', skip: 'Update to continuous applications' do
   include CandidateHelper
 
   it 'The candidate has completed their contact details without entering an address' do

--- a/spec/system/candidate_interface/submitting/candidate_submits_application_with_a_removed_site_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submits_application_with_a_removed_site_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate attempts to submit their application with a removed site', continuous_applications: false do
+RSpec.feature 'Candidate attempts to submit their application with a removed site', skip: 'Update to continuous applications' do
   include CandidateHelper
 
   it 'The location that the candidate picked has been removed by the provider' do

--- a/spec/system/candidate_interface/submitting/candidate_submits_application_with_course_not_yet_available_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submits_application_with_course_not_yet_available_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate submits the application with a course that is not available and full', continuous_applications: false do
+RSpec.feature 'Candidate submits the application with a course that is not available and full', skip: 'Update to continuous applications' do
   include CandidateHelper
 
   it 'Candidate with a completed application form' do

--- a/spec/system/candidate_interface/submitting/candidate_submits_application_with_missing_references_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submits_application_with_missing_references_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate attempts to submit their application without valid references', continuous_applications: false do
+RSpec.feature 'Candidate attempts to submit their application without valid references', skip: 'Update to continuous applications' do
   include CandidateHelper
 
   it 'The candidate tries to complete application without entering references' do

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate submits the application', continuous_applications: false do
+RSpec.feature 'Candidate submits the application', skip: 'Update to continuous applications' do
   include CandidateHelper
 
   it 'Candidate with a completed application' do

--- a/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'International candidate submits the application', continuous_applications: false do
+RSpec.feature 'International candidate submits the application', skip: 'Update to continuous applications' do
   include CandidateHelper
   include EFLHelper
 

--- a/spec/system/provider_interface/provider_views_application_submitted_in_new_cycle_feature_flag_disabled_spec.rb
+++ b/spec/system/provider_interface/provider_views_application_submitted_in_new_cycle_feature_flag_disabled_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Provider views application submitted in new cycle' do
+RSpec.feature 'Provider views application submitted in new cycle', skip: 'Delete with feature flag' do
   include CandidateHelper
   include CourseOptionHelpers
   include DfESignInHelpers

--- a/spec/system/register_api/register_receives_application_spec.rb
+++ b/spec/system/register_api/register_receives_application_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 # This is an end-to-end test for the API response. To test complex logic in
 # the presenter, see spec/presenters/register_api/single_application_presenter_spec.rb.
-RSpec.feature 'Register receives an application data', continuous_applications: false, time: CycleTimetableHelper.mid_cycle(2023) do
+RSpec.feature 'Register receives an application data', time: CycleTimetableHelper.mid_cycle(2024) do
   include CandidateHelper
 
   it 'A candidate is recruited' do

--- a/spec/system/vendor_api/vendor_makes_unconditional_offer_spec.rb
+++ b/spec/system/vendor_api/vendor_makes_unconditional_offer_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Vendor makes unconditional offer', time: CycleTimetableHelper.mid_cycle(2021) do
+RSpec.feature 'Vendor makes unconditional offer' do
   include CandidateHelper
 
   scenario 'A vendor makes an unconditional offer and this is accepted by the candidate' do

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 # This is an end-to-end test for the API response. To test complex logic in
 # the presenter, see spec/presenters/vendor_api/single_application_presenter_spec.rb.
-RSpec.feature 'Vendor receives the application', time: CycleTimetableHelper.mid_cycle(2021) do
+RSpec.feature 'Vendor receives the application' do
   include CandidateHelper
 
   scenario 'A completed application is submitted with references' do


### PR DESCRIPTION
## Context

By removing the `continuous_applications` feature flag from `ApplicationForm`, and modifying the `CandidateHelper` to work with the continuous applications flow, we can speed up the cleanup of the RSpec metadata `continuous_applications` and all the FeatureFlag checks in the codebase.


The CI runner tests runs the test suite with all feature flags on and off (except where they are specified to be on or off at the example level).

With the FeatureFlag removed from ApplicationForm, the FeatureFlag is effectively always on. The purpose of the RSpec metadata value `:continuous_applications` was to force the RecruitmentCycle to be `> 2023` and have the FeatureFlag switched on.

The current recruitment cycle is 2024 and the FeatureFlag is never going to be turned off again.

The simplest approach to cleaning up the Test suite and the code base is to remove the FeatureFlag.

RSpec tests can be in 3 settings, 
 1. `continuous_applications: true`
 2. `continuous_applications: false`,
 3. No metadata

When the FeatureFlag is present and the RecruitmentCycle is 2023 then 2 and 3 are the same.
When the FeatureFlag is removed and the RecruitmentCycle is 2024 then 1 and 3 are the same.

We can now start to treat "No metadata" like `continuous_applications: true`

We can start to delete `continuous_applications: true` from all tests, it is redundant as of now.
**And we only need to focus on updating `continuous_applications: false`.**

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
