### PR TITLE
Update zendesk snippet URL

### DIFF
--- a/app/views/shared/_zendesk_snippet.html.erb
+++ b/app/views/shared/_zendesk_snippet.html.erb
@@ -4,6 +4,6 @@
   <script
     id="ze-snippet"
     nonce="<%= request.content_security_policy_nonce %>"
-    src=https://static.zdassets.com/ekr/snippet.js?key=904d04ae-8027-4ebb-ad39-d0e9f68d6ab1>
+    src=https://static.zdassets.com/ekr/snippet.js?key=3c3c63b0-8490-4d26-91f6-8e88f4be28f3>
   </script>
 <% end %>


### PR DESCRIPTION
## Context

Messaging is replacing chat on Zendesk support:
https://support.zendesk.com/hc/en-us/articles/5126341788442-What-is-the-difference-between-Chat-and-messaging-

We need to update the snippet – this is provided by zendesk

