### PR TITLE
[547] Update study mode to full time or part time to match find and publish

### DIFF
--- a/app/components/candidate_interface/continuous_applications/application_review_component.rb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.rb
@@ -55,13 +55,13 @@ module CandidateInterface
 
       def study_mode_row
         {
-          key: 'Study mode',
+          key: 'Full time or part time',
           value: current_course_option.study_mode.humanize.to_s,
         }.tap do |row|
           if unsubmitted? && current_course.currently_has_both_study_modes_available?
             row[:action] = {
               href: candidate_interface_edit_continuous_applications_course_study_mode_path(application_choice.id, current_course.id),
-              visually_hidden_text: "study mode for #{current_course.name_and_code}",
+              visually_hidden_text: "full time or part time for #{current_course.name_and_code}",
             }
           end
         end

--- a/app/components/provider_interface/course_details_component.rb
+++ b/app/components/provider_interface/course_details_component.rb
@@ -5,7 +5,7 @@ module ProviderInterface
         { key: 'Training provider', value: provider_name },
         { key: 'Course', value: course_name_and_code },
         { key: 'Cycle', value: cycle },
-        { key: 'Full or part time', value: study_mode },
+        { key: 'Full time or part time', value: study_mode },
         { key: 'Location', value: preferred_location },
         { key: 'Accredited body', value: accredited_body },
         { key: 'Qualification', value: qualification },

--- a/app/components/support_interface/course_option_details_component.rb
+++ b/app/components/support_interface/course_option_details_component.rb
@@ -13,7 +13,7 @@ module SupportInterface
         { key: 'Training provider', value: govuk_link_to(course_option.course.provider.name_and_code, support_interface_provider_path(course_option.course.provider)) },
         { key: 'Course', value: render(SupportInterface::CourseNameAndStatusComponent.new(course_option:)) },
         { key: 'Cycle', value: course_option.course.recruitment_cycle_year },
-        { key: 'Full or part time', value: course_option.study_mode.humanize },
+        { key: 'Full time or part time', value: course_option.study_mode.humanize },
         { key: 'Location', value: course_option.site.name_and_code },
       ]
 

--- a/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
+++ b/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
       end
 
       it 'shows change link on study mode' do
-        expect(links).to include("Change study mode for #{application_choice.current_course.name_and_code}")
+        expect(links).to include("Change full time or part time for #{application_choice.current_course.name_and_code}")
       end
     end
 

--- a/spec/components/provider_interface/course_details_component_spec.rb
+++ b/spec/components/provider_interface/course_details_component_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe ProviderInterface::CourseDetailsComponent do
   it 'renders the study mode' do
     render_text = row_text_selector(:full_or_part_time, render)
 
-    expect(render_text).to include('Full or part time')
+    expect(render_text).to include('Full time or part time')
     expect(render_text).to include('Full time')
   end
 

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_edits_course_choices_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_edits_course_choices_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'Candidate edits course choices', :continuous_applications do
     given_i_am_signed_in
     and_there_is_a_course_with_one_course_option
     and_there_is_a_course_with_multiple_course_options
-    and_there_is_a_course_with_both_study_modes_but_one_site
+    and_there_is_a_course_with_both_full_time_and_part_time_but_one_site
 
     when_i_visit_my_application_page
     and_i_click_on_course_choices
@@ -16,7 +16,7 @@ RSpec.feature 'Candidate edits course choices', :continuous_applications do
     when_i_choose_that_i_know_where_i_want_to_apply
     and_i_choose_a_provider
     and_i_choose_the_third_course_as_my_first_course_choice
-    and_i_choose_the_full_time_study_mode
+    and_i_choose_full_time
     then_i_should_be_on_the_application_choice_review_page
 
     then_i_should_be_on_the_application_choice_review_page
@@ -28,28 +28,28 @@ RSpec.feature 'Candidate edits course choices', :continuous_applications do
 
     and_i_should_see_the_updated_change_course_link
     and_i_should_not_see_a_change_location_link
-    and_i_should_not_see_a_change_study_mode_link
+    and_i_should_not_see_a_change_full_time_or_part_time_link
 
     when_i_click_to_add_another_course
     and_i_choose_that_i_know_where_i_want_to_apply
     and_i_choose_a_provider
     and_i_choose_the_multi_site_course_as_my_second_course_choice
-    and_i_choose_the_full_time_study_mode
+    and_i_choose_full_time
     and_i_choose_the_first_site
     then_i_should_be_on_the_application_choice_review_page
 
     then_i_should_be_on_the_application_choice_review_page
     and_i_should_see_the_first_site
     and_i_should_see_a_change_location_link
-    and_i_should_see_a_change_study_mode_link
+    and_i_should_see_a_change_full_time_or_part_time_link
 
     when_i_click_to_add_another_course
     and_i_choose_that_i_know_where_i_want_to_apply
     and_i_choose_a_provider
     and_i_choose_the_single_site_course_as_my_third_course_choice
-    and_i_choose_the_full_time_study_mode
+    and_i_choose_full_time
     then_i_should_be_on_the_application_choice_review_page
-    and_i_should_see_another_change_study_mode_link
+    and_i_should_see_another_change_full_time_or_part_time_link
     and_i_should_not_see_another_change_location_link
 
     when_i_visit_my_application_page
@@ -59,19 +59,19 @@ RSpec.feature 'Candidate edits course choices', :continuous_applications do
     then_i_should_be_on_the_application_choice_review_page
     and_i_should_see_the_updated_site
 
-    when_i_click_to_change_the_study_mode_of_the_second_course_choice
-    and_i_choose_part_time_study_mode
+    when_i_click_to_change_full_time_or_part_time_of_the_second_course_choice
+    and_i_choose_part_time
     and_i_am_asked_to_select_site
-    and_i_choose_the_first_site_that_offers_part_time_study_mode
+    and_i_choose_the_first_site_that_offers_part_time
     then_i_should_be_on_the_application_choice_review_page
-    and_i_should_see_the_updated_study_mode_for_the_second_choice
+    and_i_should_see_the_updated_full_time_or_part_time_section_for_the_second_choice
 
     when_i_visit_my_application_page
     and_i_click_to_continue_my_third_course_choice
-    when_i_click_to_change_the_study_mode_of_the_third_course_choice
-    and_i_choose_part_time_study_mode
+    when_i_click_to_change_full_time_or_part_time_of_the_third_course_choice
+    and_i_choose_part_time
     then_i_should_be_on_the_application_choice_review_page
-    and_i_should_see_the_updated_study_mode_for_the_third_choice
+    and_i_should_see_the_updated_full_time_or_part_time_section_for_the_third_choice
   end
 
   def given_i_am_signed_in
@@ -97,7 +97,7 @@ RSpec.feature 'Candidate edits course choices', :continuous_applications do
     course_option_for_provider(provider: @provider, course: @provider.courses.second, study_mode: 'part_time')
   end
 
-  def and_there_is_a_course_with_both_study_modes_but_one_site
+  def and_there_is_a_course_with_both_full_time_and_part_time_but_one_site
     create(:course, :open_on_apply, :with_both_study_modes, name: 'Entomology', provider: @provider)
 
     site = create(:site, provider: @provider)
@@ -151,8 +151,8 @@ RSpec.feature 'Candidate edits course choices', :continuous_applications do
     expect(page).not_to have_content("Change location for #{@provider.courses.first.name}")
   end
 
-  def and_i_should_not_see_a_change_study_mode_link
-    expect(page).not_to have_content("Change study mode for #{@provider.courses.first.name}")
+  def and_i_should_not_see_a_change_full_time_or_part_time_link
+    expect(page).not_to have_content("Change full time or part time for #{@provider.courses.first.name}")
   end
 
   def when_i_click_to_add_another_course
@@ -168,7 +168,7 @@ RSpec.feature 'Candidate edits course choices', :continuous_applications do
     click_button t('continue')
   end
 
-  def and_i_choose_the_full_time_study_mode
+  def and_i_choose_full_time
     choose 'Full time'
     click_button t('continue')
   end
@@ -186,8 +186,8 @@ RSpec.feature 'Candidate edits course choices', :continuous_applications do
     expect(page).to have_content("Change location for #{@provider.courses.second.name}")
   end
 
-  def and_i_should_see_a_change_study_mode_link
-    expect(page).to have_content("Change study mode for #{@provider.courses.second.name}")
+  def and_i_should_see_a_change_full_time_or_part_time_link
+    expect(page).to have_content("Change full time or part time for #{@provider.courses.second.name}")
   end
 
   def and_i_choose_the_single_site_course_as_my_third_course_choice
@@ -195,8 +195,8 @@ RSpec.feature 'Candidate edits course choices', :continuous_applications do
     click_button t('continue')
   end
 
-  def and_i_should_see_another_change_study_mode_link
-    expect(page).to have_content("Change study mode for #{@provider.courses.third.name}")
+  def and_i_should_see_another_change_full_time_or_part_time_link
+    expect(page).to have_content("Change full time or part time for #{@provider.courses.third.name}")
   end
 
   def and_i_should_not_see_another_change_location_link
@@ -216,11 +216,11 @@ RSpec.feature 'Candidate edits course choices', :continuous_applications do
     expect(page).to have_content(@provider.courses.second.course_options.second.site.name)
   end
 
-  def when_i_click_to_change_the_study_mode_of_the_second_course_choice
-    click_change_link "study mode for #{@provider.courses.second.name_and_code}"
+  def when_i_click_to_change_full_time_or_part_time_of_the_second_course_choice
+    click_change_link "full time or part time for #{@provider.courses.second.name_and_code}"
   end
 
-  def and_i_choose_part_time_study_mode
+  def and_i_choose_part_time
     choose 'Part time'
     click_button t('continue')
   end
@@ -230,21 +230,21 @@ RSpec.feature 'Candidate edits course choices', :continuous_applications do
     expect(page).to have_content('Which location are you interested in?')
   end
 
-  def and_i_choose_the_first_site_that_offers_part_time_study_mode
+  def and_i_choose_the_first_site_that_offers_part_time
     choose @provider.courses.second.course_options.third.site.name
     click_button t('continue')
   end
 
-  def and_i_should_see_the_updated_study_mode_for_the_second_choice
-    expect(page).to have_content("Study mode\nPart time")
+  def and_i_should_see_the_updated_full_time_or_part_time_section_for_the_second_choice
+    expect(page).to have_content("Full time or part time\nPart time")
   end
 
-  def when_i_click_to_change_the_study_mode_of_the_third_course_choice
-    click_change_link "study mode for #{@provider.courses.third.name_and_code}"
+  def when_i_click_to_change_full_time_or_part_time_of_the_third_course_choice
+    click_change_link "full time or part time for #{@provider.courses.third.name_and_code}"
   end
 
-  def and_i_should_see_the_updated_study_mode_for_the_third_choice
-    expect(page).to have_content("Study mode\nPart time")
+  def and_i_should_see_the_updated_full_time_or_part_time_section_for_the_third_choice
+    expect(page).to have_content("Full time or part time\nPart time")
   end
 
   def when_i_click_to_change_the_course_of_my_third_choice


### PR DESCRIPTION
## Context

Find and Publish changed the wording of ‘Study mode’ to ‘Full time or part time’. We should do the same on Apply, Manage and Support to match.

## Changes proposed in this pull request

- Update provider interface
- Update candidate interface
- Update support interface

## Before

### Provider

<img width="484" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/50492247/f7713427-3c6e-4fa7-a1a6-afb4655ae390">


### Support

<img width="825" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/50492247/102915c6-8e59-4167-975a-fe704983b28e">


### Candidate

<img width="769" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/50492247/979fbc51-c1d4-4ec7-a124-49eaec66edee">


## After

### Provider

<img width="522" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/50492247/47a182b5-786a-4951-b16b-074f1ae79194">


### Support

<img width="816" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/50492247/f2a449d2-d3ac-4c93-9eb9-c009900f7117">


### Candidate

<img width="836" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/50492247/3b4acb14-ca59-4efd-9f96-c6f31822fcab">


## Link to Trello card

https://trello.com/c/saVedFks/547-apply-and-manage-change-study-mode-to-full-time-or-part-time-to-match-find-publish

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
