### PR TITLE
Exclude events if the application is being set to inactive, not from

### DIFF
--- a/app/components/provider_interface/application_timeline_component.rb
+++ b/app/components/provider_interface/application_timeline_component.rb
@@ -29,14 +29,10 @@ module ProviderInterface
   private
 
     def map_activity_log_events_for(attr)
-      filtered = @activity_log_events
-        .select do |event|
-          event.application_status_at_event != 'interviewing' &&
-            event.changes.key?(attr) &&
-            !event.changes['status']&.include?('inactive')
-        end
-
-      filtered.map { |event| yield event }
+      @activity_log_events
+        .reject { |event| event.application_status_at_event == 'interviewing' }
+        .select { |event| event.changes.key?(attr) && event.changes['status']&.at(1) != 'inactive' }
+        .map { |event| yield(event) }
     end
 
     def timeline_events

--- a/spec/components/provider_interface/application_timeline_component_spec.rb
+++ b/spec/components/provider_interface/application_timeline_component_spec.rb
@@ -86,6 +86,27 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
     end
   end
 
+  context 'when an application has a status change from inactive' do
+    it 'renders the component including the inactive event' do
+      inactive_offer_audit = create(
+        :application_choice_audit,
+        :with_inactive_offer,
+        user: provider_user,
+        created_at: 3.days.ago,
+      )
+      application_choice = application_choice_with_audits([inactive_offer_audit])
+
+      rendered = render_inline(described_class.new(application_choice:))
+      expect(rendered.text).to include 'Timeline'
+      expect(rendered.text).to include 'Offer made'
+      expect(rendered.text).to include 'Bob Roberts'
+      expect(rendered.text).to include 3.days.ago.to_fs(:govuk_date_and_time)
+      expect(rendered.css('a').text).to include 'View offer'
+      expect(rendered.css('.govuk-visually-hidden').text).to eq "Offer made: Bob Roberts #{3.days.ago.to_fs(:govuk_date_and_time)}"
+      expect(rendered.css('a').attr('href').value).to eq provider_interface_application_choice_offer_path(application_choice)
+    end
+  end
+
   context 'for an application with a note' do
     let(:application_choice) { create(:application_choice) }
 

--- a/spec/factories/application_choice_audit.rb
+++ b/spec/factories/application_choice_audit.rb
@@ -92,6 +92,16 @@ FactoryBot.define do
       end
     end
 
+    trait :with_inactive_offer do
+      application_choice factory: %i[application_choice offered]
+
+      changes do
+        {
+          'status' => %w[inactive offer],
+        }
+      end
+    end
+
     trait :with_withdrawn_offer do
       application_choice factory: %i[application_choice offer_withdrawn]
 


### PR DESCRIPTION
## Context

A provider has flagged that they couldn't see timeline events for a withdrawn application. This is because the application had been marked as `inactive` before the candidate withdrew it, and we exclude all events that include a status of `inactive`.

We still want to show changes if something happens to an inactive application e.g. they withdraw, get rejected, get an offer.

## Changes proposed in this pull request

**Note – The screenshot is showing as "Apply support" because I was impersonating the provider user locally.**

|Before|After|
|---|---|
|<img width="658" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/afa06a12-f26d-48ab-95ce-60d48f98f26f">|<img width="673" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/eadf2ef2-bf60-4d37-974d-1ee004438653">|

For proof – the most recent two account events:
<img width="895" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/d7fba2e6-c47f-453f-9ac3-6e3df7afd5ec">