### PR TITLE
Minor tweak to attribute type

### DIFF
--- a/app/views/api_docs/vendor_api_docs/reference/_v1_4_changes.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/_v1_4_changes.html.erb
@@ -11,6 +11,6 @@
 </p>
 <ul class="govuk-list govuk-list--bullet">
   <li><code>currently_completing_qualification</code> (boolean, optional)</li>
-  <li><code>missing_explanation</code>  (text, optional)</li>
+  <li><code>missing_explanation</code>  (string, optional)</li>
   <li><code>other_uk_qualification_type</code> (string, optional)</li>
 </ul>

--- a/app/views/api_docs/vendor_api_docs/reference/draft.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/draft.html.erb
@@ -83,7 +83,7 @@
 </p>
 <ul class="govuk-list govuk-list--bullet">
   <li><code>currently_completing_qualification</code> (boolean, optional)</li>
-  <li><code>missing_explanation</code>  (text, optional)</li>
+  <li><code>missing_explanation</code>  (string, optional)</li>
   <li><code>other_uk_qualification_type</code> (string, optional)</li>
 </ul>
 


### PR DESCRIPTION
## Context

Small tweak from `text` to `string`

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="859" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/5a4c12ec-2c8f-4a0b-8cb0-654e202c38f5">|<img width="848" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/6907fa12-a371-4b69-9c3f-22b8f388a677">|
