### PR TITLE
Revert "Bump omniauth from 2.1.1 to 2.1.2"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
     ignore:
       - dependency-name: faker
       - dependency-name: sidekiq
+      - dependency-name: omniauth
   - package-ecosystem: npm
     directory: "/"
     schedule:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -433,7 +433,7 @@ GEM
     oj (3.16.3)
       bigdecimal (>= 3.0)
     okcomputer (1.18.5)
-    omniauth (2.1.2)
+    omniauth (2.1.1)
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
       rack-protection
@@ -496,8 +496,8 @@ GEM
       httpclient
       json-jwt (>= 1.11.0)
       rack (>= 2.1.0)
-    rack-protection (3.1.0)
-      rack (~> 2.2, >= 2.2.4)
+    rack-protection (3.0.5)
+      rack
     rack-proxy (0.7.7)
       rack
     rack-test (2.1.0)


### PR DESCRIPTION
Reverts DFE-Digital/apply-for-teacher-training#8928

Broken local sign in:
<img width="722" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/c219c688-7715-4fc2-a2bc-525e8fc4df90">
