### PR TITLE
Fix omniauth bypass routing issue

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
   draw 'api/vendor'
 
   get '/auth/dfe/callback' => 'dfe_sign_in#callback'
-  post '/auth/developer/callback' => 'dfe_sign_in#bypass_callback'
+  get '/auth/developer/callback' => 'dfe_sign_in#bypass_callback'
   get '/auth/dfe/sign-out' => 'dfe_sign_in#redirect_after_dsi_signout'
 
   direct :find do


### PR DESCRIPTION
The latest version on OmniAuth changes the default method of the `:developer strategy` to GET via [:method option](https://github.com/omniauth/omniauth/blob/master/lib/omniauth/form.rb#L10) that replaces the default `post` value. That means the callback was failing because the route was expecting a POST request and OmniAuth was sending a GET request.

Closes https://github.com/DFE-Digital/apply-for-teacher-training/pull/8932