### PR TITLE
1060 bug referee experiences 500 error

### DIFF
--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -112,7 +112,7 @@ module RefereeInterface
     def refuse_feedback
       @refuse_feedback_form = RefuseFeedbackForm.build_from_reference(reference:)
       @application = reference.application_form
-      @provider_name = @application.application_choices.select(&:accepted_choice?).first.provider.name
+      @accepted_choice = @application.application_choices.find(&:accepted_choice?)
     end
 
     def confirm_feedback_refusal

--- a/app/views/referee_interface/reference/refuse_feedback.html.erb
+++ b/app/views/referee_interface/reference/refuse_feedback.html.erb
@@ -13,10 +13,12 @@
         <%= t('referee.refuse_feedback.choice.heading', full_name: @application.full_name) %>
       </h1>
 
-      <p class="govuk-body">
-        <%= @application.full_name %> has accepted an offer from <%= @provider_name %> for a place on a teacher training course.
-        They’ve said that you can give them a reference.
-      <p>
+      <% if @accepted_choice.present? %>
+        <p class="govuk-body">
+          <%= @application.full_name %> has accepted an offer from <%= @accepted_choice.provider.name %> for a place on a teacher training course.
+          They’ve said that you can give them a reference.
+        <p>
+      <% end %>
 
       <p class="govuk-body">Your reference will not be sent to  <%= @application.full_name %>.</p>
 

--- a/app/views/referee_interface/reference/refuse_feedback.html.erb
+++ b/app/views/referee_interface/reference/refuse_feedback.html.erb
@@ -18,6 +18,10 @@
           <%= @application.full_name %> has accepted an offer from <%= @accepted_choice.provider.name %> for a place on a teacher training course.
           They’ve said that you can give them a reference.
         <p>
+      <% else %>
+        <p class="govuk-body">
+          <%= @application.full_name %> has said you can give them a reference for their teacher training application.
+        <p>
       <% end %>
 
       <p class="govuk-body">Your reference will not be sent to  <%= @application.full_name %>.</p>

--- a/app/views/referee_interface/reference/refuse_feedback.html.erb
+++ b/app/views/referee_interface/reference/refuse_feedback.html.erb
@@ -17,11 +17,11 @@
         <p class="govuk-body">
           <%= @application.full_name %> has accepted an offer from <%= @accepted_choice.provider.name %> for a place on a teacher training course.
           They’ve said that you can give them a reference.
-        <p>
+        </p>
       <% else %>
         <p class="govuk-body">
           <%= @application.full_name %> has said you can give them a reference for their teacher training application.
-        <p>
+        </p>
       <% end %>
 
       <p class="govuk-body">Your reference will not be sent to  <%= @application.full_name %>.</p>

--- a/spec/system/referee_interface/referee_can_submit_a_reference_from_an_application_in_any_state_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_from_an_application_in_any_state_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'Referee can submit reference in any application choice states', :
     given_i_am_a_referee_of_an_application
     and_i_received_the_initial_reference_request_email
     then_i_receive_an_email_with_a_reference_request
-    and_the_candidate_withdrawns_from_the_application
+    and_the_candidate_withdraws_from_the_application
 
     when_i_click_on_the_link_within_the_email
     then_i_should_see_a_message_about_the_candidate
@@ -51,7 +51,7 @@ RSpec.feature 'Referee can submit reference in any application choice states', :
     @application_choice = create(:application_choice, :accepted, application_form: @application)
   end
 
-  def and_the_candidate_withdrawns_from_the_application
+  def and_the_candidate_withdraws_from_the_application
     @application_choice.update!(
       status: 'withdrawn',
       withdrawn_at: Time.zone.now,

--- a/spec/system/referee_interface/referee_can_submit_a_reference_from_an_application_in_any_state_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_from_an_application_in_any_state_spec.rb
@@ -1,0 +1,168 @@
+require 'rails_helper'
+
+RSpec.feature 'Referee can submit reference in any application choice states', :with_audited, time: CycleTimetableHelper.mid_cycle do
+  include CandidateHelper
+
+  it 'Referee submits a reference' do
+    given_i_am_a_referee_of_an_application
+    and_i_received_the_initial_reference_request_email
+    then_i_receive_an_email_with_a_reference_request
+    and_the_candidate_withdrawns_from_the_application
+
+    when_i_click_on_the_link_within_the_email
+    and_i_select_yes_to_giving_a_reference
+    then_i_am_asked_to_confirm_my_relationship_with_the_candidate
+
+    when_i_click_on_save_and_continue
+    when_i_confirm_that_the_described_relationship_is_correct
+    and_i_click_on_save_and_continue
+    then_i_see_the_safeguarding_page
+    when_i_choose_the_candidate_is_suitable_for_working_with_children
+    and_i_click_on_save_and_continue
+    then_i_see_the_reference_comment_page
+    when_i_fill_in_the_reference_field
+    and_i_click_on_save
+    then_i_see_the_reference_review_page
+
+    and_i_click_the_submit_reference_button
+    then_i_see_am_told_i_submitted_my_reference
+    then_i_see_the_confirmation_page
+    and_i_receive_an_email_confirmation
+    and_the_candidate_receives_a_notification
+
+    when_i_choose_to_be_contactable
+    and_i_click_the_finish_button
+    then_i_see_the_thank_you_page
+    and_i_am_told_i_will_be_contacted
+
+    when_i_retry_to_edit_the_feedback
+    then_i_see_the_thank_you_page
+  end
+
+  def given_i_am_a_referee_of_an_application
+    @reference = create(:reference, :feedback_requested, referee_type: :academic, email_address: 'terri@example.com', name: 'Terri Tudor')
+    @application = create(
+      :completed_application_form,
+      references_count: 0,
+      application_references: [@reference],
+      candidate: current_candidate,
+    )
+    @application_choice = create(:application_choice, :accepted, application_form: @application)
+  end
+
+  def and_the_candidate_withdrawns_from_the_application
+    @application_choice.update!(
+      status: 'withdrawn',
+      withdrawn_at: Time.zone.now,
+      withdrawn_or_declined_for_candidate_by_provider: false,
+    )
+  end
+
+  def and_i_received_the_initial_reference_request_email
+    RefereeMailer.reference_request_email(@reference).deliver_now
+  end
+
+  def then_i_receive_an_email_with_a_reference_request
+    open_email('terri@example.com')
+  end
+
+  def when_i_click_on_the_link_within_the_email
+    click_sign_in_link(current_email)
+  end
+
+  def and_i_select_yes_to_giving_a_reference
+    choose 'Yes, I can give them a reference'
+    click_button t('continue')
+  end
+
+  def then_i_am_asked_to_confirm_my_relationship_with_the_candidate
+    expect(page).to have_content("Confirm how #{@application.full_name} knows you")
+  end
+
+  def when_i_click_on_save_and_continue
+    click_button t('save_and_continue')
+  end
+
+  def when_i_confirm_that_the_described_relationship_is_correct
+    within_fieldset('Is this description accurate?') do
+      choose 'Yes'
+    end
+  end
+
+  def then_i_see_the_safeguarding_page
+    expect(page).to have_content("Why #{@application.full_name} should not work with children")
+  end
+
+  def when_i_choose_the_candidate_is_suitable_for_working_with_children
+    within_fieldset("Do you know any reason why #{@application.full_name} should not work with children?") do
+      choose 'No'
+    end
+  end
+
+  def and_i_click_on_save_and_continue
+    click_button t('save_and_continue')
+  end
+
+  def and_i_click_on_save
+    click_button t('save')
+  end
+
+  def then_i_see_the_reference_comment_page
+    expect(page).to have_content('when their course started and ended')
+    expect(page).to have_content('their academic record')
+  end
+
+  def when_i_fill_in_the_reference_field
+    fill_in 'Reference', with: 'This is a reference for the candidate.'
+  end
+
+  def then_i_see_the_reference_review_page
+    expect(page).to have_content("Check your reference for #{@application.full_name}")
+  end
+
+  def and_i_click_the_submit_reference_button
+    click_button t('referee.review.submit')
+  end
+
+  def and_i_click_the_finish_button
+    click_button t('referee.questionnaire.submit')
+  end
+
+  def then_i_see_am_told_i_submitted_my_reference
+    expect(page).to have_content("Your reference for #{@application.full_name}")
+  end
+
+  def and_i_receive_an_email_confirmation
+    open_email('terri@example.com')
+
+    expect(current_email.subject).to have_content(t('reference_confirmation_email.subject', candidate_name: @application.full_name))
+  end
+
+  def and_the_candidate_receives_a_notification
+    open_email(current_candidate.email_address)
+
+    expect(current_email.subject).to end_with('Terri Tudor has given you a reference')
+  end
+
+  def then_i_see_the_thank_you_page
+    expect(page).to have_content('Thank you')
+    expect(page).not_to have_content('You do not need to give a reference anymore.')
+  end
+
+  def and_i_am_told_i_will_be_contacted
+    expect(page).to have_content('Our user research team will contact you shortly')
+  end
+
+  def when_i_retry_to_edit_the_feedback
+    visit @reference_feedback_url
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_current_path(referee_interface_confirmation_path(token: @token))
+  end
+
+  def when_i_choose_to_be_contactable
+    choose t('referee.questionnaire.consent_to_be_contacted.yes.label')
+    fill_in 'Please let us know when you’re available', with: 'anytime 012345 678900'
+  end
+end

--- a/spec/system/referee_interface/referee_can_submit_a_reference_from_an_application_in_any_state_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_from_an_application_in_any_state_spec.rb
@@ -10,6 +10,7 @@ RSpec.feature 'Referee can submit reference in any application choice states', :
     and_the_candidate_withdrawns_from_the_application
 
     when_i_click_on_the_link_within_the_email
+    then_i_should_see_a_message_about_the_candidate
     and_i_select_yes_to_giving_a_reference
     then_i_am_asked_to_confirm_my_relationship_with_the_candidate
 
@@ -68,6 +69,10 @@ RSpec.feature 'Referee can submit reference in any application choice states', :
 
   def when_i_click_on_the_link_within_the_email
     click_sign_in_link(current_email)
+  end
+
+  def then_i_should_see_a_message_about_the_candidate
+    expect(page).to have_content("#{current_candidate.current_application.full_name} has said you can give them a reference for their teacher training application.")
   end
 
   def and_i_select_yes_to_giving_a_reference


### PR DESCRIPTION
## Context

Numerous Sentry Errors indicate there is a problem with the code related to Referees to give feedback.

The Referee receives the “Teacher training reference needed” email requesting a reference for the Candidate.

The Referee visits the URL /references?token=<token> and it triggers a 500 response to the referee.

## The problem

1. Candidate "X" accepts an offer and adds "Y" as a referee.
2. "Y" receives the email to provide a reference but is super busy and postpone to another time.
3. "X" decides to withdraw the accepted offer.
4. "Y" clicks on the link on the email and see an error page.

## Why the application error?

Because we have a content on the referee page:

"X has accepted an offer from "some provider" for a place on a teacher training course. They've said that you can give them a reference."

If there are no accepted offers (because candidate withdrew) then the app errors.