### PR TITLE
Use the manage interface application  filter for the provider report

### DIFF
--- a/app/controllers/provider_interface/application_data_export_controller.rb
+++ b/app/controllers/provider_interface/application_data_export_controller.rb
@@ -14,7 +14,7 @@ module ProviderInterface
       if @application_data_export_form.valid?
         providers = @application_data_export_form.selected_providers
         cycle_years = @application_data_export_form.selected_years
-        statuses = @application_data_export_form.selected_statuses
+        status = @application_data_export_form.selected_statuses
 
         data = GetApplicationChoicesForProviders
           .call(
@@ -33,13 +33,19 @@ module ProviderInterface
               application_form: %i[candidate english_proficiency application_qualifications],
             ],
           )
-          .where('courses.recruitment_cycle_year' => cycle_years)
-          .where(status: statuses)
-          .where('candidates.hide_in_reporting': false)
+
+        application_choices = FilterApplicationChoicesForProviders.call(
+          application_choices: data,
+          filters: {
+            status:,
+            recruitment_cycle_year: cycle_years,
+            hide_in_reporting: false,
+          },
+        )
 
         filename = csv_filename(export_name: 'application-data', cycle_years:, providers:)
 
-        stream_csv(data:, filename:) do |row|
+        stream_csv(data: application_choices, filename:) do |row|
           ApplicationDataExport.export_row(row)
         end
       else

--- a/app/forms/provider_interface/application_data_export_form.rb
+++ b/app/forms/provider_interface/application_data_export_form.rb
@@ -12,7 +12,7 @@ module ProviderInterface
     validate :at_least_one_provider_is_selected, if: :actor_has_more_than_one_provider?
 
     def selected_years
-      recruitment_cycle_years.map(&:to_i)
+      recruitment_cycle_years.compact_blank
     end
 
     def providers_that_actor_belongs_to

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -5,6 +5,7 @@ class FilterApplicationChoicesForProviders
     return application_choices if filters.empty?
 
     combined_query = ApplicationChoice.includes(
+      :candidate,
       current_course_option: [
         :site,
         course: %i[provider accredited_provider course_subjects],
@@ -27,7 +28,7 @@ class FilterApplicationChoicesForProviders
       if candidate_application_number_match
         application_choices.where(id: candidate_application_number_match[0])
       else
-        application_choices.joins(:application_form).where("CONCAT(first_name, ' ', last_name) ILIKE ?", "%#{candidates_name_or_number.squish}%")
+        application_choices.joins(:application_form).where("CONCAT(application_forms.first_name, ' ', application_forms.last_name) ILIKE ?", "%#{candidates_name_or_number.squish}%")
       end
     end
 
@@ -85,6 +86,12 @@ class FilterApplicationChoicesForProviders
       application_choices.where(current_course_option: { study_mode: })
     end
 
+    def hide_in_reporting(application_choices, hide_in_reporting)
+      return application_choices if hide_in_reporting.nil?
+
+      application_choices.where(candidate: { hide_in_reporting: })
+    end
+
     def create_filter_query(application_choices, filters)
       filtered_application_choices = search(application_choices, filters[:candidate_name])
       filtered_application_choices = recruitment_cycle_year(filtered_application_choices, filters[:recruitment_cycle_year])
@@ -93,6 +100,7 @@ class FilterApplicationChoicesForProviders
       filtered_application_choices = status(filtered_application_choices, filters[:status])
       filtered_application_choices = course_subject(filtered_application_choices, filters[:subject])
       filtered_application_choices = study_mode(filtered_application_choices, filters[:study_mode])
+      filtered_application_choices = hide_in_reporting(filtered_application_choices, filters[:hide_in_reporting])
       provider_location(filtered_application_choices, filters[:provider_location])
     end
   end

--- a/spec/system/provider_interface/provider_user_exports_applications_to_csv_spec.rb
+++ b/spec/system/provider_interface/provider_user_exports_applications_to_csv_spec.rb
@@ -58,6 +58,12 @@ RSpec.feature 'Provider user exporting applications to a csv', mid_cycle: false 
     @application_second_provider = create(:application_choice,
                                           :accepted,
                                           course_option: create(:course_option, course: course_second_provider))
+
+    @application_deferred_submitted_previous_cycle_offered_current_cycle =
+      create(:application_choice,
+             :accepted,
+             course_option: create(:course_option, course: course_previous_year),
+             current_course_option: create(:course_option, course: course))
   end
 
   def when_i_visit_the_export_applications_page
@@ -92,6 +98,7 @@ RSpec.feature 'Provider user exporting applications to a csv', mid_cycle: false 
     expect_export_to_include_data_for_application(csv_data, @application_deferred)
     expect_export_to_include_data_for_application(csv_data, @application_declined)
     expect_export_to_include_data_for_application(csv_data, @application_withdrawn)
+    expect_export_to_include_data_for_application(csv_data, @application_deferred_submitted_previous_cycle_offered_current_cycle)
     expect(csv_data['Application number']).not_to include(@application_accepted_previous_cycle.id.to_s)
     expect(csv_data['Application number']).not_to include(@application_second_provider.id.to_s)
   end
@@ -113,6 +120,7 @@ RSpec.feature 'Provider user exporting applications to a csv', mid_cycle: false 
     expect_export_to_include_data_for_application(csv_data, @application_accepted)
     expect_export_to_include_data_for_application(csv_data, @application_deferred)
     expect_export_to_include_data_for_application(csv_data, @application_accepted_previous_cycle)
+    expect_export_to_include_data_for_application(csv_data, @application_deferred_submitted_previous_cycle_offered_current_cycle)
     expect(csv_data['Application number']).not_to include(@application_declined.id.to_s)
     expect(csv_data['Application number']).not_to include(@application_withdrawn.id.to_s)
     expect(csv_data['Application number']).not_to include(@application_second_provider.id.to_s)
@@ -122,7 +130,7 @@ RSpec.feature 'Provider user exporting applications to a csv', mid_cycle: false 
     expect(csv_data['Application number']).to include(application.id.to_s)
     expect(csv_data['Email address']).to include(application.application_form.candidate.email_address)
     expect(csv_data['Training provider code']).to include(application.provider.code)
-    expect(csv_data['Course code']).to include(application.course.code)
+    expect(csv_data['Course code']).to include(application.current_course.code)
   end
 
   def and_there_is_an_error_lurking_in_the_export


### PR DESCRIPTION
Use the same filter for file exports as the one used for the manage interface. This means that the numbers will match because the [filter will use](https://github.com/DFE-Digital/apply-for-teacher-training/blob/52de6201fc07eb30d96f7fc4782428d4c6b2ff7c/app/services/filter_application_choices_for_providers.rb#L9) `current_course_option_id` instead of the `course_option_id`.

![](https://github.trello.services/images/mini-trello-icon.png) [File export application count not matching manage numbers](https://trello.com/c/Dgyk01ii/1130-file-export-application-count-not-matching-manage-numbers)