### PR TITLE
Do not call notification service if there is nothing to notify

### DIFF
--- a/app/services/submit_reference.rb
+++ b/app/services/submit_reference.rb
@@ -27,6 +27,8 @@ class SubmitReference
 private
 
   def notify_provider_users
+    return if accepted_application.blank?
+
     NotificationsList.for(accepted_application, include_ratifying_provider: true, event: :reference_received).uniq.each do |provider_user|
       ProviderMailer.reference_received(
         provider_user: provider_user,

--- a/spec/services/submit_reference_spec.rb
+++ b/spec/services/submit_reference_spec.rb
@@ -67,6 +67,17 @@ RSpec.describe SubmitReference, :sidekiq do
       )
     end
 
+    context 'when there are no accepted applications' do
+      it 'does not call the notifications service' do
+        allow(NotificationsList).to receive(:for).and_call_original
+        application_choice = create(:application_choice, :withdrawn)
+        reference_one = create(:reference, :feedback_requested, application_form: application_choice.application_form)
+        described_class.new(reference: reference_one).save!
+
+        expect(NotificationsList).not_to have_received(:for)
+      end
+    end
+
     context 'when the second reference is received' do
       it 'does not alter the state of any outstanding references' do
         application_form = create(:application_form)


### PR DESCRIPTION
## Context

When the candidate withdraws an accepted application, there is no accepted application choice anymore to notify any provider about a reference received.

We need to make sure that we don't call the notification service to avoid unnecessary Sentry warnings. 
 
## Trello

https://trello.com/c/Lyvulg2d/1147-do-not-try-to-notify-providers-for-a-reference-received-when-there-is-no-accepted-application
