### PR TITLE
Bug fix Science gcse validation on secondary courses

### DIFF
--- a/app/presenters/candidate_interface/application_form_sections.rb
+++ b/app/presenters/candidate_interface/application_form_sections.rb
@@ -5,6 +5,18 @@ module CandidateInterface
       @application_choice = application_choice
     end
 
+    def science_gcse_incomplete_and_others?
+      primary_course? &&
+        incomplete_sections.size > 1 &&
+        incomplete_sections.any?(science_gcse?)
+    end
+
+    def only_science_gcse_incomplete?
+      primary_course? &&
+        incomplete_sections? &&
+        incomplete_sections.all?(science_gcse?)
+    end
+
     def all_completed?
       all_sections.map(&:second).all?
     end
@@ -16,6 +28,18 @@ module CandidateInterface
     delegate :incomplete_sections, to: :presenter
 
   private
+
+    def primary_course?
+      application_choice.current_course.primary_course?
+    end
+
+    def science_gcse?
+      ->(section) { section.name == :science_gcse }
+    end
+
+    def incomplete_sections?
+      incomplete_sections.present?
+    end
 
     attr_reader :application_form, :application_choice
 

--- a/app/presenters/candidate_interface/application_form_sections.rb
+++ b/app/presenters/candidate_interface/application_form_sections.rb
@@ -13,7 +13,7 @@ module CandidateInterface
 
     def only_science_gcse_incomplete?
       primary_course? &&
-        incomplete_sections? &&
+        incomplete_sections.present? &&
         incomplete_sections.all?(science_gcse?)
     end
 
@@ -35,10 +35,6 @@ module CandidateInterface
 
     def science_gcse?
       ->(section) { section.name == :science_gcse }
-    end
-
-    def incomplete_sections?
-      incomplete_sections.present?
     end
 
     attr_reader :application_form, :application_choice

--- a/app/validators/incomplete_including_primary_course_details_validator.rb
+++ b/app/validators/incomplete_including_primary_course_details_validator.rb
@@ -1,6 +1,10 @@
 class IncompleteIncludingPrimaryCourseDetailsValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, application_choice)
-    return unless science_gcse_incomplete_and_others?(application_choice)
+    application_form_sections = CandidateInterface::ApplicationFormSections.new(
+      application_choice:,
+      application_form: application_choice.application_form,
+    )
+    return unless application_form_sections.science_gcse_incomplete_and_others?
 
     record.errors.add(
       attribute,
@@ -20,14 +24,5 @@ private
       include ActionView::Helpers::UrlHelper
       include GovukLinkHelper
     end.new
-  end
-
-  def science_gcse_incomplete_and_others?(application_choice)
-    sections(application_choice).incomplete_sections.length > 1 &&
-      sections(application_choice).incomplete_sections.any? { |section| section.name == :science_gcse }
-  end
-
-  def sections(application_choice)
-    CandidateInterface::ApplicationFormSections.new(application_form: application_choice.application_form, application_choice:)
   end
 end

--- a/app/validators/incomplete_primary_course_details_validator.rb
+++ b/app/validators/incomplete_primary_course_details_validator.rb
@@ -1,6 +1,10 @@
 class IncompletePrimaryCourseDetailsValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, application_choice)
-    return unless only_science_gcse_incomplete?(application_choice)
+    application_form_sections = CandidateInterface::ApplicationFormSections.new(
+      application_choice:,
+      application_form: application_choice.application_form,
+    )
+    return unless application_form_sections.only_science_gcse_incomplete?
 
     record.errors.add(
       attribute,
@@ -20,13 +24,5 @@ private
       include ActionView::Helpers::UrlHelper
       include GovukLinkHelper
     end.new
-  end
-
-  def only_science_gcse_incomplete?(application_choice)
-    sections(application_choice).incomplete_sections.present? && sections(application_choice).incomplete_sections.all? { |section| section.name == :science_gcse }
-  end
-
-  def sections(application_choice)
-    CandidateInterface::ApplicationFormSections.new(application_form: application_choice.application_form, application_choice:)
   end
 end

--- a/spec/factories/course.rb
+++ b/spec/factories/course.rb
@@ -36,6 +36,14 @@ FactoryBot.define do
       accredited_provider { create(:provider) }
     end
 
+    trait :primary do
+      level { 'primary' }
+    end
+
+    trait :secondary do
+      level { 'secondary' }
+    end
+
     trait :with_provider_relationship_permissions do
       with_accredited_provider
 

--- a/spec/services/candidate_interface/continuous_applications/application_choice_submission/incomplete_including_primary_course_form_spec.rb
+++ b/spec/services/candidate_interface/continuous_applications/application_choice_submission/incomplete_including_primary_course_form_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe 'Incomplete details including primary course form details', time:
       include GovukLinkHelper
     end.new
   end
-  let(:course) { create(:course, :open_on_apply, level: 'primary') }
-  let(:course_option) { create(:course_option, :open_on_apply) }
+  let(:course) { create(:course, :open_on_apply, :primary) }
+  let(:course_option) { create(:course_option, :open_on_apply, course:) }
   let(:application_form) { create(:application_form, :completed) }
   let(:application_choice) { create(:application_choice, :unsubmitted, application_form:, course_option:) }
 
@@ -29,9 +29,21 @@ RSpec.describe 'Incomplete details including primary course form details', time:
     let(:application_form) { create(:application_form, :completed, degrees_completed: false, science_gcse_completed: false) }
     let(:application_choice) { create(:application_choice, :unsubmitted, course_option:, application_form:) }
 
-    it 'adds error to application choice' do
-      expect(application_choice_submission).not_to be_valid
-      expect(application_choice_submission.errors[:application_choice]).to include(message)
+    context 'when primary courses' do
+      it 'adds error to application choice' do
+        expect(application_choice_submission).not_to be_valid
+        expect(application_choice_submission.errors[:application_choice]).to include(message)
+      end
+    end
+
+    context 'when secondary courses' do
+      let(:course) { create(:course, :open_on_apply, :secondary) }
+
+      it 'does not add an error to incomplete science GCSE' do
+        application_choice_submission.valid?
+
+        expect(application_choice_submission.errors.map(&:type)).to eq([:incomplete_details])
+      end
     end
   end
 

--- a/spec/services/candidate_interface/continuous_applications/application_choice_submission/incomplete_primary_course_form_spec.rb
+++ b/spec/services/candidate_interface/continuous_applications/application_choice_submission/incomplete_primary_course_form_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Incomplete primary course form details', time: CycleTimetableHel
       include GovukLinkHelper
     end.new
   end
-  let(:course) { create(:course, :open_on_apply, :with_course_options) }
+  let(:course) { create(:course, :open_on_apply, :primary, :with_course_options) }
   let(:application_form) { create(:application_form, :completed) }
   let(:application_choice) { create(:application_choice, :unsubmitted, application_form:, course:) }
 
@@ -22,14 +22,27 @@ RSpec.describe 'Incomplete primary course form details', time: CycleTimetableHel
   end
 
   context 'only science gcse section incomplete' do
-    let(:course) { create(:course, :open_on_apply) }
     let(:course_option) { create(:course_option, course:) }
     let(:application_form) { create(:application_form, :completed, science_gcse_completed: false) }
     let(:application_choice) { create(:application_choice, :unsubmitted, course_option:, application_form:) }
 
-    it 'adds error to application choice' do
-      expect(application_choice_submission).not_to be_valid
-      expect(application_choice_submission.errors[:application_choice]).to include(message)
+    context 'when primary course choice' do
+      let(:course) { create(:course, :open_on_apply, :primary) }
+
+      it 'adds error to application choice' do
+        expect(application_choice_submission).not_to be_valid
+        expect(application_choice_submission.errors[:application_choice]).to include(message)
+      end
+    end
+
+    context 'when secondary course choice' do
+      let(:course) { create(:course, :open_on_apply, :secondary) }
+
+      it 'valid application choice' do
+        application_choice_submission.valid?
+
+        expect(application_choice_submission.errors).to be_empty
+      end
     end
   end
 

--- a/spec/system/candidate_interface/entering_details/candidate_viewing_a_science_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_viewing_a_science_gcse_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate viewing Science GCSE', :continuous_applications, skip: 'Fix secondary courses' do
+RSpec.feature 'Candidate viewing Science GCSE', :continuous_applications do
   include CandidateHelper
 
   it 'Candidate views a Science GCSE only when a primary course is chosen' do
@@ -90,5 +90,16 @@ RSpec.feature 'Candidate viewing Science GCSE', :continuous_applications, skip: 
     visit candidate_interface_continuous_applications_choices_path
     click_link 'Add application'
     candidate_fills_in_primary_course_choice_without_science_gcse
+  end
+
+  def candidate_fills_in_primary_course_choice_without_science_gcse
+    choose 'Yes, I know where I want to apply'
+    click_button t('continue')
+
+    select 'Gorse SCITT (1N1)'
+    click_button t('continue')
+
+    choose 'Primary (2XT2)'
+    click_button t('continue')
   end
 end

--- a/spec/system/candidate_interface/entering_details/candidate_viewing_a_science_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_viewing_a_science_gcse_spec.rb
@@ -11,11 +11,11 @@ RSpec.feature 'Candidate viewing Science GCSE', :continuous_applications do
     when_i_complete_your_details
     then_i_dont_see_science_gcse_is_incomplete_below_the_section
 
-    when_i_choose_a_secondary_course
-    then_i_dont_see_a_science_gcse_validation_error
-
     when_i_choose_a_primary_course
     then_i_see_science_gcse_is_incomplete_below_the_section
+
+    when_i_choose_a_secondary_course
+    then_i_dont_see_a_science_gcse_validation_error
 
     and_i_am_on_your_application_page
     then_i_see_science_gcse


### PR DESCRIPTION
## Context

There is a bug when we are showing the Science GCSE validation on submission for secondary courses. This happens when the user adds a primary course in draft, then a secondary course later.

The secondary course should be possible to be submitted without science GCSE (which before this PR is not possible!).

## Guidance to review: How to test the bugfix on review app

1. Add a primary course (in draft)
2. Have Science GCSE section incomplete!
3. Add a secondary course and try to submit (if you can submit then this PR is good!)
4. The primary course option should not be possible to submit though.

## Link to Trello card

https://trello.com/c/QwRTwy2z/1140-bug-science-gcse-validation-on-secondary-courses
