### PR TITLE
Remove one personal statement flag from db and analytics

### DIFF
--- a/app/services/data_migrations/remove_one_personal_statement_feature_flag.rb
+++ b/app/services/data_migrations/remove_one_personal_statement_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class RemoveOnePersonalStatementFeatureFlag
+    TIMESTAMP = 20240108135715
+    MANUAL_RUN = false
+
+    def change
+      Feature.where(name: :one_personal_statementt).delete_all
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveOnePersonalStatementFeatureFlag',
   'DataMigrations::SetMissingWorkHistoryStatusValues',
   'DataMigrations::UpdateDeclineByDefaultAtFromCurrentCycle',
   'DataMigrations::RemoveDbdFromCurrentCycle',

--- a/spec/services/data_migrations/remove_one_personal_statement_feature_flag_spec.rb
+++ b/spec/services/data_migrations/remove_one_personal_statement_feature_flag_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveOnePersonalStatementFeatureFlag do
+  context 'when the feature flag exists' do
+    before do
+      create(:feature, name: 'one_personal_statement')
+      create(:feature, name: 'foo')
+    end
+
+    it 'removes the relevant feature flag' do
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: 'one_personal_statement')).to be_none
+      expect(Feature.where(name: 'foo')).to be_present
+    end
+  end
+
+  context 'when the feature flags have already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end


### PR DESCRIPTION
## Context

The single personal statement logic was removed as part of [#8926](https://github.com/DFE-Digital/apply-for-teacher-training/pull/8926/files).

We need to remove it from the DB as well, and stop it from being sent as part of DfE analytics.

## Changes proposed in this pull request

- Migration to remove the feature flag
- Removal from `analytics.yml`