### PR TITLE
Stop sending subject_knowledge to dfe analytics

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -121,8 +121,6 @@ shared:
     - safeguarding_issues_status
     - science_gcse_completed
     - second_nationality
-    - subject_knowledge
-    - subject_knowledge_completed
     - submitted_at
     - support_reference
     - third_nationality
@@ -150,7 +148,6 @@ shared:
     - references_completed_at
     - safeguarding_issues_completed_at
     - science_gcse_completed_at
-    - subject_knowledge_completed_at
     - training_with_a_disability_completed_at
     - volunteering_completed_at
     - work_history_completed_at

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -1,201 +1,204 @@
 ---
 :shared:
   :audits:
-    - id
-    - auditable_id
-    - auditable_type
-    - associated_id
-    - associated_type
-    - user_id
-    - user_type
-    - username
-    - action
-    - audited_changes
-    - version
-    - comment
-    - remote_address
-    - request_uuid
-    - created_at
-  :candidates:
-    - email_address
-    - magic_link_token
-    - fraud_match_id
-    - unsubscribed_from_emails
-    - submission_blocked
-    - account_locked
-  :application_choices:
-    - provider_ids
-    - current_recruitment_cycle_year
-  :application_forms:
-    - first_name
-    - last_name
-    - phone_number
-    - address_line1
-    - address_line2
-    - address_line3
-    - address_line4
-    - safeguarding_issues
-    - address_type
-    - latitude
-    - longitude
-    - feedback_form_complete
-  :authentication_tokens:
-    - id
-    - hashed_token
-    - created_at
-    - updated_at
-    - user_id
-    - user_type
-    - used_at
-    - path
-  :fraud_matches:
-    - id
-    - candidate_last_contacted_at
-    - recruitment_cycle_year
-    - last_name
-    - date_of_birth
-    - postcode
-    - blocked
-    - created_at
-    - updated_at
-    - resolved
-  :find_feedback:
-    - email_address
-  :english_proficiencies:
-    - no_qualification_details
-  :emails:
-    - to
-    - body
-  :vendor_api_users:
-    - id
-    - full_name
-    - email_address
-    - vendor_user_id
-    - vendor_api_token_id
-    - created_at
-    - updated_at
-  :data_exports:
-    - id
-    - name
-    - data
-    - completed_at
-    - initiator_type
-    - initiator_id
-    - created_at
-    - updated_at
-    - export_type
-  :data_migrations:
-    - id
-    - service_name
-    - timestamp
-    - created_at
-    - updated_at
-  :support_users:
-    - id
-    - dfe_sign_in_uid
-    - created_at
-    - updated_at
-    - email_address
-    - last_signed_in_at
-    - first_name
-    - last_name
-    - discarded_at
-  :site_settings:
-    - id
-    - name
-    - value
-    - created_at
-    - updated_at
-  :references:
-    - email_address
-    - name
-    - relationship
-    - safeguarding_concerns
-    - relationship_correction
-  :features:
-    - id
-    - name
-    - active
-    - created_at
-    - updated_at
-  provider_user_notifications:
-    - chase_provider_decision
-  :provider_users:
-    - email_address
-    - first_name
-    - last_name
-  :validation_errors:
-    - details
-  :vendor_api_tokens:
-    - hashed_token
-  :vendor_api_requests:
-    - request_body
-  :interviews:
-    - additional_details
-    - cancellation_reason
-  :application_feedback:
-    - section
-  :monthly_statistics_reports:
-    - id
-    - created_at
-    - updated_at
-    - statistics
-    - month
-    - generation_date
-    - publication_date
-  :blazer_dashboards:
-    - id
-    - creator_id
-    - name
-    - created_at
-    - updated_at
-  :blazer_dashboard_queries:
-    - id
-    - dashboard_id
-    - query_id
-    - position
-    - created_at
-    - updated_at
-  :blazer_checks:
-    - id
-    - creator_id
-    - query_id
-    - state
-    - schedule
-    - emails
-    - slack_channels
-    - check_type
-    - message
-    - last_run_at
-    - created_at
-    - updated_at
-  :blazer_audits:
-    - id
-    - user_id
-    - query_id
-    - statement
-    - data_source
-    - created_at
+  - id
+  - auditable_id
+  - auditable_type
+  - associated_id
+  - associated_type
+  - user_id
+  - user_type
+  - username
+  - action
+  - audited_changes
+  - version
+  - comment
+  - remote_address
+  - request_uuid
+  - created_at
   :blazer_queries:
-    - id
-    - creator_id
-    - name
-    - description
-    - statement
-    - data_source
-    - status
-    - created_at
-    - updated_at
+  - id
+  - creator_id
+  - name
+  - description
+  - statement
+  - data_source
+  - status
+  - created_at
+  - updated_at
+  :blazer_dashboard_queries:
+  - id
+  - dashboard_id
+  - query_id
+  - position
+  - created_at
+  - updated_at
+  :blazer_dashboards:
+  - id
+  - creator_id
+  - name
+  - created_at
+  - updated_at
+  :blazer_checks:
+  - id
+  - creator_id
+  - query_id
+  - state
+  - schedule
+  - emails
+  - slack_channels
+  - check_type
+  - message
+  - last_run_at
+  - created_at
+  - updated_at
+  :blazer_audits:
+  - id
+  - user_id
+  - query_id
+  - statement
+  - data_source
+  - created_at
+  :monthly_statistics_reports:
+  - id
+  - created_at
+  - updated_at
+  - statistics
+  - month
+  - generation_date
+  - publication_date
   :provider_mid_cycle_reports:
-    - id
-    - statistics
-    - publication_date
-    - provider_id
-    - created_at
-    - updated_at
+  - id
+  - statistics
+  - publication_date
+  - provider_id
+  - created_at
+  - updated_at
   :national_mid_cycle_reports:
-    - id
-    - statistics
-    - publication_date
-    - created_at
-    - updated_at
+  - id
+  - statistics
+  - publication_date
+  - created_at
+  - updated_at
+  :vendor_api_users:
+  - id
+  - full_name
+  - email_address
+  - vendor_user_id
+  - vendor_api_token_id
+  - created_at
+  - updated_at
+  :vendor_api_tokens:
+  - hashed_token
+  :vendor_api_requests:
+  - request_body
+  :validation_errors:
+  - details
+  :support_users:
+  - id
+  - dfe_sign_in_uid
+  - created_at
+  - updated_at
+  - email_address
+  - last_signed_in_at
+  - first_name
+  - last_name
+  - discarded_at
+  :provider_user_notifications:
+  - chase_provider_decision
+  :provider_users:
+  - email_address
+  - first_name
+  - last_name
+  :interviews:
+  - additional_details
+  - cancellation_reason
+  :find_feedback:
+  - email_address
+  :features:
+  - id
+  - name
+  - active
+  - created_at
+  - updated_at
+  :english_proficiencies:
+  - no_qualification_details
+  :emails:
+  - to
+  - body
+  :fraud_matches:
+  - id
+  - candidate_last_contacted_at
+  - recruitment_cycle_year
+  - last_name
+  - date_of_birth
+  - postcode
+  - blocked
+  - created_at
+  - updated_at
+  - resolved
+  :data_migrations:
+  - id
+  - service_name
+  - timestamp
+  - created_at
+  - updated_at
+  :data_exports:
+  - id
+  - name
+  - data
+  - completed_at
+  - initiator_type
+  - initiator_id
+  - created_at
+  - updated_at
+  - export_type
+  :authentication_tokens:
+  - id
+  - hashed_token
+  - created_at
+  - updated_at
+  - user_id
+  - user_type
+  - used_at
+  - path
+  :references:
+  - email_address
+  - name
+  - relationship
+  - safeguarding_concerns
+  - relationship_correction
+  :application_forms:
+  - first_name
+  - last_name
+  - phone_number
+  - address_line1
+  - address_line2
+  - address_line3
+  - address_line4
+  - subject_knowledge
+  - safeguarding_issues
+  - subject_knowledge_completed
+  - address_type
+  - latitude
+  - longitude
+  - subject_knowledge_completed_at
+  - feedback_form_complete
+  :application_feedback:
+  - section
+  :application_choices:
+  - provider_ids
+  - current_recruitment_cycle_year
+  :site_settings:
+  - id
+  - name
+  - value
+  - created_at
+  - updated_at
+  :candidates:
+  - email_address
+  - magic_link_token
+  - fraud_match_id
+  - unsubscribed_from_emails
+  - submission_blocked
+  - account_locked


### PR DESCRIPTION
## Context

We're removing the `one_personal_statement` feature flag from the DB as part of the personal statement clean up. We no longer need to send the `subject_knowledge` values to the D&I team, as this value is no longer being populated by candidates.

## Changes proposed in this pull request

Remove:
- `subject_knowledge`
- `subject_knowledge_completed`
- `subject_knowledge_completed_at`
from `analytics.yml`