### PR TITLE
Remove feedback helpful survey feature flag from the db

### DIFF
--- a/app/services/data_migrations/remove_feedback_helpful_feature_flag.rb
+++ b/app/services/data_migrations/remove_feedback_helpful_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class RemoveFeedbackHelpfulFeatureFlag
+    TIMESTAMP = 20240108154507
+    MANUAL_RUN = false
+
+    def change
+      Feature.where(name: :is_this_feedback_helpful_survey).first&.destroy
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveFeedbackHelpfulFeatureFlag',
   'DataMigrations::RemoveOnePersonalStatementFeatureFlag',
   'DataMigrations::SetMissingWorkHistoryStatusValues',
   'DataMigrations::UpdateDeclineByDefaultAtFromCurrentCycle',

--- a/spec/services/data_migrations/remove_feedback_helpful_feature_flag_spec.rb
+++ b/spec/services/data_migrations/remove_feedback_helpful_feature_flag_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveFeedbackHelpfulFeatureFlag do
+  context 'when the feature flag exists' do
+    before do
+      create(:feature, name: 'is_this_feedback_helpful_survey')
+      create(:feature, name: 'foo')
+    end
+
+    it 'removes the relevant feature flag' do
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: 'is_this_feedback_helpful_survey')).to be_none
+      expect(Feature.where(name: 'foo')).to be_present
+    end
+  end
+
+  context 'when the feature flags have already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end


### PR DESCRIPTION
## Context

Following [#8961](https://github.com/DFE-Digital/apply-for-teacher-training/pull/8961) we can now remove it from the db.