### PR TITLE
Remove the upload of artifacts on GitHub workflow builds

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -258,14 +258,6 @@ jobs:
           DEFAULT_FEATURE_FLAG_STATE: ${{ matrix.feature-flags }}
           TEST_DATE_AND_TIME: ${{ matrix.offset-date }}
 
-      - name: Upload failure screenshots and pages
-        if: failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: failure-uploads
-          path: /app/tmp/failures/
-          retention-days: 5
-
       - name: Read flakey test results
         id: set_flakey_test_results_var
         run: |

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -140,29 +140,8 @@ RSpec.configure do |config|
   config.include(Clockwork::Test::RSpec::Matchers)
   config.after(:each, :clockwork) { Clockwork::Test.clear! }
 
-  config.after do |example|
-    if example.metadata[:js] && example.exception
-      save_failure_files(Capybara.page, example.metadata)
-    end
-  end
-
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
   # config.profile_examples = 10
-end
-
-def save_failure_files(page, meta)
-  filename = File.basename(meta[:file_path])
-  line_number = meta[:line_number]
-
-  file_name = "#{filename}-#{line_number}"
-  screenshot_path = Rails.root.join('tmp', 'failures', 'screenshots', "#{file_name}.png")
-  page_path = Rails.root.join('tmp', 'failures', 'pages', "#{file_name}.html")
-
-  page.save_screenshot(screenshot_path)
-  page.save_page(page_path)
-
-  puts "\n Screenshot: #{screenshot_path}"
-  puts "\n Page: #{page_path}"
 end


### PR DESCRIPTION
The artifacts upload [is deprecated and has to be updated](https://github.com/DFE-Digital/apply-for-teacher-training/pull/8909), but because it's not useful for us, we can just remove it.

I added it so we can debug flakey specs, unfortunately, it only works if the tests is running with `:js`. We have very few specs running with `:js` and it's not worth the effort to keep it.