### PR TITLE
Fix flakey spec

### DIFF
--- a/spec/requests/vendor_api/v1.4/get_qualification_fields_from_application_spec.rb
+++ b/spec/requests/vendor_api/v1.4/get_qualification_fields_from_application_spec.rb
@@ -3,9 +3,8 @@ require 'rails_helper'
 RSpec.describe 'Vendor API - GET /api/v1.4/applications' do
   include VendorAPISpecHelpers
 
-  before do
-    application_choice = create_application_choice_for_currently_authenticated_provider
-
+  let(:application_choice) { create_application_choice_for_currently_authenticated_provider }
+  let!(:gcse_qualification) do
     create(
       :gcse_qualification,
       currently_completing_qualification: true,
@@ -13,14 +12,17 @@ RSpec.describe 'Vendor API - GET /api/v1.4/applications' do
       other_uk_qualification_type: 'Equivalency test',
       application_form: application_choice.application_form,
     )
+  end
 
+  before do
     get_api_request "/api/v1.4/applications/#{application_choice.id}"
   end
 
   describe 'get completing qualifications fields' do
-    subject(:gcse) { parsed_response['data']['attributes']['qualifications']['gcses'].last }
-
     it 'returns the correct GCSEs fields' do
+      gcses = parsed_response['data']['attributes']['qualifications']['gcses']
+      gcse = gcses.find { |item| item['id'] == gcse_qualification.public_id }
+
       expect(gcse['currently_completing_qualification']).to be true
       expect(gcse['missing_explanation']).to eq 'I will be taking an equivalency test in a few weeks'
       expect(gcse['other_uk_qualification_type']).to eq 'Equivalency test'


### PR DESCRIPTION
The spec was failing sometimes because the order of the fields returned by the API was not guaranteed. This commit fixes the spec by selecting the correct field via ID.

E.g. https://github.com/DFE-Digital/apply-for-teacher-training/pull/8968#issuecomment-1885100859