### PR TITLE
Set languages eligible for IRP

### DIFF
--- a/app/lib/ministerial_report.rb
+++ b/app/lib/ministerial_report.rb
@@ -138,6 +138,14 @@ module MinisterialReport
     '24' => :modern_foreign_languages,
   }.freeze
 
+  INTERNATIONAL_RELOCATION_PAYMENT_SUBJECTS = {
+    'F0' => :physics,
+    'F3' => :physics,
+    '15' => :french,
+    '17' => :german,
+    '22' => :spanish,
+  }.freeze
+
   APPLICATIONS_REPORT_STATUS_MAPPING = {
     unsubmitted: %i[applications],
     application_not_sent: %i[applications],

--- a/app/services/is_eligible_for_international_relocation_payment.rb
+++ b/app/services/is_eligible_for_international_relocation_payment.rb
@@ -1,7 +1,7 @@
 class IsEligibleForInternationalRelocationPayment
   delegate :application_form, to: :application_choice
 
-  ELIGIBLE_SUBJECTS = %i[physics].freeze
+  ELIGIBLE_SUBJECTS = %i[physics french german spanish].freeze
 
   def initialize(application_choice)
     @application_choice = application_choice
@@ -27,7 +27,7 @@ private
 
   def eligible_subject?
     subject_codes.any? do |code|
-      subject_mapping = MinisterialReport::SUBJECT_CODE_MAPPINGS[code]
+      subject_mapping = MinisterialReport::INTERNATIONAL_RELOCATION_PAYMENT_SUBJECTS[code]
       ELIGIBLE_SUBJECTS.include?(subject_mapping)
     end
   end

--- a/spec/services/is_eligible_for_international_relocation_payment_spec.rb
+++ b/spec/services/is_eligible_for_international_relocation_payment_spec.rb
@@ -30,10 +30,16 @@ RSpec.describe IsEligibleForInternationalRelocationPayment do
       it { is_expected.to be true }
     end
 
-    context 'subject is modern languages' do
-      let(:course_subject) { create(:subject, name: 'Spanish with Sichuanese', code: '15') }
+    context 'subject is modern foreign languages' do
+      let(:course_subject) { create(:subject, name: 'Russian', code: '21') }
 
       it { is_expected.to be false }
+    end
+
+    context 'subject is french' do
+      let(:course_subject) { create(:subject, name: 'French', code: '15') }
+
+      it { is_expected.to be true }
     end
 
     context 'subject not eligible' do


### PR DESCRIPTION
## Context

The International Relocation Payment criteria have changed. We need to amend our email notification that we send to provider users when a candidate applies for an eligible course subject. The eligible subjects are:

Physics, general science with physics, French, German, Spanish. We currently have it for physics

## Changes proposed in this pull request

We previously only introduced this for physics, due to how we map our foreign languages. I've introduced a new constant for IRP. Maybe this shouldn't belong in `MinisterialReport`... probably the reference gem, but I've placed it in there for now because this isn't working for providers and is creating additional work for the international team.

## Link to Trello card

https://trello.com/c/UxVYB8nA
