### PR TITLE
[1056] Data migration to populate`institution_country` when `nil` and uk degree

### DIFF
--- a/app/services/data_migrations/set_institution_country_to_gb_on_uk_degrees.rb
+++ b/app/services/data_migrations/set_institution_country_to_gb_on_uk_degrees.rb
@@ -1,0 +1,20 @@
+module DataMigrations
+  class SetInstitutionCountryToGbOnUkDegrees
+    TIMESTAMP = 20240111093629
+    MANUAL_RUN = false
+
+    def change
+      application_qualifications.each do |application_qualification|
+        application_qualification.update(institution_country: 'GB')
+      end
+    end
+
+  private
+
+    def application_qualifications
+      ApplicationQualification.where(level: 'degree')
+                              .where(international: false)
+                              .where(institution_country: nil)
+    end
+  end
+end

--- a/app/services/data_migrations/set_institution_country_to_gb_on_uk_degrees.rb
+++ b/app/services/data_migrations/set_institution_country_to_gb_on_uk_degrees.rb
@@ -1,11 +1,11 @@
 module DataMigrations
   class SetInstitutionCountryToGbOnUkDegrees
     TIMESTAMP = 20240111093629
-    MANUAL_RUN = false
+    MANUAL_RUN = true
 
     def change
-      application_qualifications.each do |application_qualification|
-        application_qualification.update(institution_country: 'GB')
+      application_qualifications.find_each do |application_qualification|
+        application_qualification.update_columns(institution_country: 'GB')
       end
     end
 

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::SetInstitutionCountryToGbOnUkDegrees',
   'DataMigrations::RemoveSupportUserReinstateOfferFeatureFlag',
   'DataMigrations::RemoveSupportUserRevertWithdrawnOfferFeatureFlag',
   'DataMigrations::RemoveWithdrawAtCandidatesRequestFeatureFlag',

--- a/spec/services/data_migrations/set_institution_country_to_gb_on_uk_degrees_spec.rb
+++ b/spec/services/data_migrations/set_institution_country_to_gb_on_uk_degrees_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::SetInstitutionCountryToGbOnUkDegrees do
+  let(:degree_qualification) { create(:degree_qualification, institution_country:, international:) }
+
+  context 'when institution_country is nil and international is false' do
+    let(:institution_country) { nil }
+    let(:international) { false }
+
+    it 'updates the application qualifications' do
+      expect { described_class.new.change }.to(
+        change { degree_qualification.reload.institution_country }
+          .from(nil)
+          .to('GB'),
+      )
+    end
+  end
+
+  context 'when institution_country is nil and international is true' do
+    let(:institution_country) { nil }
+    let(:international) { true }
+
+    it 'does not update the application qualification' do
+      expect { described_class.new.change }.not_to(
+        change { degree_qualification.reload.institution_country },
+      )
+    end
+  end
+
+  context 'when institution_country is an empty string and international is false' do
+    let(:institution_country) { ' ' }
+    let(:international) { false }
+
+    it 'does not update the application qualification' do
+      expect { described_class.new.change }.not_to(
+        change { degree_qualification.reload.institution_country },
+      )
+    end
+  end
+
+  context 'when institution_country is abu dhabi' do
+    let(:institution_country) { 'AE-AZ' }
+    let(:international) { false }
+
+    it 'does not update the application qualification' do
+      expect { described_class.new.change }.not_to(
+        change { degree_qualification.reload.institution_country },
+      )
+    end
+  end
+
+  context 'when as level qualification and institution country is nil and international is false' do
+    let(:as_qualification) { create(:as_level_qualification, institution_country:, international:) }
+    let(:institution_country) { nil }
+    let(:international) { false }
+
+    it 'does not update the application qualification' do
+      expect { described_class.new.change }.not_to(
+        change { as_qualification.reload.institution_country },
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Context

There was a bug in the code which caused `institution_country` to be set to `nil` when adding a UK degree. It should have been set to 'GB'.

A fix for the logic will be merged first: https://github.com/DFE-Digital/apply-for-teacher-training/pull/8956

## Changes proposed in this pull request

- This is a data migration to fix 179269 records in production.

## Guidance to review

**records being updated**
```
ApplicationQualification.where(level: 'degree', international: false, institution_country: nil).count
=> 179269
```

**records where international is `false` but instution_country is not `nil`**

Some of these 8 records were manually edited via the rails console to have GB as the institution country. Others were added before 2022, which was before the degree wizard was added.

```
ApplicationQualification.where(level: 'degree', international: false).where.not(institution_country: nil).count
=> 8
```

## Link to Trello card

https://trello.com/c/jdPzTPQX/1056-bug-degree-institution-country-gb-showing-as-null

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
