### PR TITLE
Fix console error by requiring the webchat only when necessary

### DIFF
--- a/app/frontend/packs/application-provider.js
+++ b/app/frontend/packs/application-provider.js
@@ -5,7 +5,6 @@ import filter from './components/paginated_filter'
 import checkboxSearchFilter from './components/checkbox_search_filter'
 import '../styles/application-provider.scss'
 import cookieBanners from './cookies/cookie-banners'
-import userSupportWebchat from './user_support_webchat'
 
 require.context('govuk-frontend/govuk/assets')
 
@@ -15,4 +14,3 @@ initAddFurtherConditions()
 checkboxSearchFilter('subject', 'Search for subject')
 filter()
 cookieBanners()
-userSupportWebchat()

--- a/app/frontend/packs/user-support-webchat.js
+++ b/app/frontend/packs/user-support-webchat.js
@@ -1,0 +1,3 @@
+import userSupportWebchat from './user_support_webchat'
+
+userSupportWebchat()

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -67,8 +67,11 @@
     <% when 'support_interface' %>
       <%= javascript_pack_tag 'application-support' %>
     <% when 'provider_interface' %>
-      <%= render 'shared/zendesk_snippet' if FeatureFlag.active?(:enable_chat_support) %>
       <%= javascript_pack_tag 'application-provider' %>
+      <% if FeatureFlag.active?(:enable_chat_support) %>
+        <%= render 'shared/zendesk_snippet' %>
+        <%= javascript_pack_tag 'user-support-webchat' %>
+      <% end %>
     <% when 'publications' %>
       <%= javascript_pack_tag 'application-publications' %>
     <% when /api_docs/ %>


### PR DESCRIPTION
The webchat js file is required even if the feature is disabled, which causes a console error.

<img width="760" alt="Screenshot 2024-01-11 at 14 49 51" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/ab5f797d-d7af-4220-a32d-a4beec83db36">
