### PR TITLE
[1161] Remove the `unconditional_offers_via_api` feature flag

### DIFF
--- a/app/services/accept_offer.rb
+++ b/app/services/accept_offer.rb
@@ -8,9 +8,7 @@ class AcceptOffer
   def save!
     return unless valid?
 
-    if FeatureFlag.active?(:unconditional_offers_via_api) && unconditional_offer?
-      return AcceptUnconditionalOffer.new(application_choice:).save!
-    end
+    return AcceptUnconditionalOffer.new(application_choice:).save! if unconditional_offer?
 
     ActiveRecord::Base.transaction do
       ApplicationStateChange.new(application_choice).accept!

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -27,7 +27,6 @@ class FeatureFlag
 
   TEMPORARY_FEATURE_FLAGS = [
     [:provider_activity_log, 'Show provider users a log of all application activity', 'Michael Nacos'],
-    [:unconditional_offers_via_api, 'Activates the ability to accept unconditional offers via the API', 'Steve Laing'],
     [:support_user_reinstate_offer, 'Allows a support users to reinstate a declined course choice offer', 'James Glenn'],
     [:withdraw_at_candidates_request, "Allows providers to withdraw an application at the candidate's request", 'Steve Laing'],
     [:support_user_revert_withdrawn_offer, 'Allows a support user to revert an application withdrawn by the candidate', 'James Glenn'],

--- a/spec/services/accept_offer_spec.rb
+++ b/spec/services/accept_offer_spec.rb
@@ -76,9 +76,7 @@ RSpec.describe AcceptOffer do
     }.to change { application_choice.accepted_at }.to(Time.zone.now)
   end
 
-  it 'calls AcceptUnconditionalOffer when the feature is enabled and the offer is unconditional' do
-    FeatureFlag.activate(:unconditional_offers_via_api)
-
+  it 'calls AcceptUnconditionalOffer when the offer is unconditional' do
     application_choice = create(:application_choice,
                                 :offered,
                                 offer: build(:unconditional_offer))

--- a/spec/system/vendor_api/vendor_makes_unconditional_offer_spec.rb
+++ b/spec/system/vendor_api/vendor_makes_unconditional_offer_spec.rb
@@ -4,8 +4,6 @@ RSpec.feature 'Vendor makes unconditional offer', time: CycleTimetableHelper.mid
   include CandidateHelper
 
   scenario 'A vendor makes an unconditional offer and this is accepted by the candidate' do
-    FeatureFlag.activate(:unconditional_offers_via_api)
-
     given_a_candidate_has_submitted_their_application
     when_i_make_an_unconditional_offer_for_the_application_over_the_api
     then_i_can_see_the_offer_was_made_successfully


### PR DESCRIPTION
## Context

Removing the `unconditional_offers_via_api` feature flag as its been active in production since March 2021.

## Changes proposed in this pull request

See commits

## Link to Trello card

https://trello.com/c/Xj3L5cwh/1161-apply-remove-the-unconditionaloffersviaapi-feature-flag

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
