### PR TITLE
Add yarnclean to minimise docker image

### DIFF
--- a/.yarnclean
+++ b/.yarnclean
@@ -1,0 +1,3 @@
+*
+!puppeteer/
+!puppeteer-core/

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,10 @@ COPY . .
 RUN bundle exec rake assets:precompile && \
     rm -rf tmp/* log/* /tmp/*
 
+# Uses .yarnclean to filter node_module deletion 
+# https://classic.yarnpkg.com/lang/en/docs/cli/autoclean/
+RUN yarn autoclean -F 
+
 # Stage 2: production, copy application code and compiled assets to base ruby image.
 # Depends on assets-precompile stage which can be cached from a pre-built image
 # by specifying a fully qualified image name or will default to packages-prod thereby rebuilding all 3 stages above.

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,7 @@ RUN yarn install --check-files
 COPY . .
 
 RUN bundle exec rake assets:precompile && \
-    rm -rf tmp/* log/* node_modules /tmp/*
-
-RUN yarn add puppeteer
+    rm -rf tmp/* log/* /tmp/*
 
 # Stage 2: production, copy application code and compiled assets to base ruby image.
 # Depends on assets-precompile stage which can be cached from a pre-built image


### PR DESCRIPTION
## Context

Grover pdf library needs to persist the puppeteer npm libraries on disk. We usually delete the `node_modules` directory.
This PR introduces the `yarn autoclean` command to delete all unneeded `node_modules` after the assets have been compiled in the Dockerfile using `rails assets:precompile`.

## Changes proposed in this pull request

Add `.yarnclean` to the project which allows for node_modules to be cleaned selectively.

# Screenshot

Shows the docker image size is reduced by ~220mb

![Screenshot from 2024-01-12 09-52-30](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/8dc2868e-36a8-4b32-89c7-ad39bf7e2134)



## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
