### PR TITLE
Release v1.4 to production

### DIFF
--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -5,8 +5,8 @@ module VendorAPI
   VERSION_1_1 = '1.1'.freeze
   VERSION_1_2 = '1.2'.freeze
   VERSION_1_3 = '1.3'.freeze
-  VERSION_1_4 = '1.4pre'.freeze
-  VERSION = VERSION_1_3
+  VERSION_1_4 = '1.4'.freeze
+  VERSION = VERSION_1_4
 
   VERSIONS = {
     '1.0' => [
@@ -55,7 +55,7 @@ module VendorAPI
       Changes::MarkPhaseAsDeprecated,
       Changes::RemoveReferencesWhenApplicationIsUnsuccessful,
     ],
-    '1.4pre' => [
+    '1.4' => [
       Changes::V14::AddGcseCompletingQualificationData,
     ],
   }.freeze

--- a/app/views/api_docs/vendor_api_docs/pages/release_notes.md
+++ b/app/views/api_docs/vendor_api_docs/pages/release_notes.md
@@ -1,3 +1,9 @@
+## v1.4 — 15th January 2024
+
+Minor Version Upgrade:
+
+Release API version `v1.4` to production. Please refer to the [API Reference](/api-docs/v1.4/reference) for details.
+
 ## v1.3 — 6th February 2023
 
 Minor Version Upgrade:

--- a/app/views/api_docs/vendor_api_docs/reference/reference.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/reference.html.erb
@@ -73,10 +73,10 @@
 
 <p class="govuk-body">
   We have a production environment and a sandbox environment.
-  When version 1.3 is launched initially for testing, it will only be accessible
-  in the sandbox environment by determining the version in the URL as so:
-  <%= govuk_link_to 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.3',
-                    'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.3' %>.
+  When version <%= version %> is initially launched for testing, it will only be accessible
+  within the sandbox environment. Use the version value as specified in the following URL:
+  <%= govuk_link_to "https://sandbox.apply-for-teacher-training.service.gov.uk/api/#{version}",
+  "https://sandbox.apply-for-teacher-training.service.gov.uk/api/#{version}" %>.
   Only after testing is complete, the production environment will automatically upgrade
   to the latest minor version without the need to update the URL.
 </p>


### PR DESCRIPTION
## Context

We released `v1.4` of the vendor API to our sandbox environment in December. No concerns have been raised during the testing phase, so we'll now be releasing this to our production environment.

## Changes proposed in this pull request

- Set 1.4 as the latest API version
- Update the release notes
- Minor changes to the API docs to interpolate whatever the latest version is set to

## Guidance to review

Test API calls without specifying the API version – this should automatically default to v1.4