### PR TITLE
[1160] Remove `provider_activity_log` feature flag

### DIFF
--- a/app/controllers/provider_interface/activity_log_controller.rb
+++ b/app/controllers/provider_interface/activity_log_controller.rb
@@ -1,21 +1,11 @@
 module ProviderInterface
   class ActivityLogController < ProviderInterfaceController
-    before_action :requires_provider_activity_log
-
     def index
       @events = GetActivityLogEvents.call(
         application_choices: GetApplicationChoicesForProviders.call(
           providers: current_provider_user.providers,
         ),
       ).page(params[:page] || 1).per(50)
-    end
-
-  private
-
-    def requires_provider_activity_log
-      unless FeatureFlag.active?(:provider_activity_log)
-        redirect_to provider_interface_applications_path and return
-      end
     end
   end
 end

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -89,10 +89,7 @@ class NavigationItems
         items << NavigationItem.new('Applications', provider_interface_applications_path, active?(current_controller, %w[application_choices decisions offer_changes notes interviews offers feedback conditions reconfirm_deferred_offers]), [])
         items << NavigationItem.new('Interview schedule', provider_interface_interview_schedule_path, active?(current_controller, %w[interview_schedules]), [])
         items << NavigationItem.new('Reports', provider_interface_reports_path, active?(current_controller, %w[reports application_data_export hesa_export]))
-
-        if FeatureFlag.active?(:provider_activity_log)
-          items << NavigationItem.new('Activity log', provider_interface_activity_log_path, active?(current_controller, %w[activity_log]), [])
-        end
+        items << NavigationItem.new('Activity log', provider_interface_activity_log_path, active?(current_controller, %w[activity_log]), [])
       end
 
       items

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -26,7 +26,6 @@ class FeatureFlag
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = [
-    [:provider_activity_log, 'Show provider users a log of all application activity', 'Michael Nacos'],
     [:support_user_reinstate_offer, 'Allows a support users to reinstate a declined course choice offer', 'James Glenn'],
     [:withdraw_at_candidates_request, "Allows providers to withdraw an application at the candidate's request", 'Steve Laing'],
     [:support_user_revert_withdrawn_offer, 'Allows a support user to revert an application withdrawn by the candidate', 'James Glenn'],

--- a/spec/system/provider_interface/see_activity_log_spec.rb
+++ b/spec/system/provider_interface/see_activity_log_spec.rb
@@ -8,7 +8,6 @@ RSpec.feature 'See activity log' do
     given_i_am_a_provider_user_authenticated_with_dfe_sign_in
     and_i_have_a_manage_account
     and_my_organisation_has_applications
-    and_the_provider_activity_log_feature_flag_is_on
     and_i_sign_in_to_the_provider_interface
 
     when_i_click_on_the_activity_log_tab
@@ -52,10 +51,6 @@ RSpec.feature 'See activity log' do
 
     @choice5 = create(:application_choice, :offered, course_option: course_option5)
     create(:application_form_audit, application_choice: @choice5, changes: { 'date_of_birth' => %w[01-01-2000 01-02-2002] })
-  end
-
-  def and_the_provider_activity_log_feature_flag_is_on
-    FeatureFlag.activate(:provider_activity_log)
   end
 
   def and_i_should_see_the_applications_menu_item_highlighted


### PR DESCRIPTION
## Context

Removing the `requires_provider_activity_log` feature flag as its been active in production since December 2020. 

The Data migration will be merged after this PR, in #8990.

## Changes proposed in this pull request

See commits

## Link to Trello card

https://trello.com/c/OgMn5W4m/1160-apply-remove-the-provideractivitylog-feature-flag

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
