### PR TITLE
[1162] Data migration to drop `support_user_reinstate_offer` feature flag

### DIFF
--- a/app/services/data_migrations/remove_support_user_reinstate_offer_feature_flag.rb
+++ b/app/services/data_migrations/remove_support_user_reinstate_offer_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class RemoveSupportUserReinstateOfferFeatureFlag
+    TIMESTAMP = 20240115115953
+    MANUAL_RUN = false
+
+    def change
+      Feature.where(name: :support_user_reinstate_offer).first&.destroy
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveSupportUserReinstateOfferFeatureFlag',
   'DataMigrations::RemoveSupportUserRevertWithdrawnOfferFeatureFlag',
   'DataMigrations::RemoveWithdrawAtCandidatesRequestFeatureFlag',
   'DataMigrations::RemoveProviderActivityLogFeatureFlag',

--- a/spec/services/data_migrations/remove_support_user_reinstate_offer_feature_flag_spec.rb
+++ b/spec/services/data_migrations/remove_support_user_reinstate_offer_feature_flag_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveSupportUserReinstateOfferFeatureFlag do
+  context 'when the feature flag exists' do
+    it 'removes the feature flag' do
+      create(:feature, name: 'support_user_reinstate_offer')
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: 'support_user_reinstate_offer')).to be_blank
+    end
+  end
+
+  context 'when the feature flag has already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end


### PR DESCRIPTION
## Context

Following on from #8992. This is the data migration to drop the feature flag.


## Link to Trello card

https://trello.com/c/7e89k5ST/1162-apply-remove-the-supportuserreinstateoffer-feature-flag

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
