### PR TITLE
[1162] Remove the `support_user_reinstate_offer` feature flag

### DIFF
--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -196,7 +196,7 @@ module SupportInterface
     def status_action_link
       return {} unless @application_choice.application_form.editable?
 
-      if FeatureFlag.active?(:support_user_reinstate_offer) && application_choice.declined? && !application_choice.declined_by_default
+      if application_choice.declined? && !application_choice.declined_by_default
         {
           action: {
             href: support_interface_application_form_application_choice_reinstate_offer_path(application_form_id: @application_choice.application_form.id, application_choice_id: @application_choice.id),

--- a/app/controllers/support_interface/application_forms/application_choices/reinstate_declined_offer_controller.rb
+++ b/app/controllers/support_interface/application_forms/application_choices/reinstate_declined_offer_controller.rb
@@ -2,7 +2,7 @@ module SupportInterface
   module ApplicationForms
     module ApplicationChoices
       class ReinstateDeclinedOfferController < BaseController
-        before_action :build_application_form, :build_application_choice, :redirect_to_application_form_unless_declined_and_reinstate_offer_flag_active
+        before_action :build_application_form, :build_application_choice, :redirect_to_application_form_unless_declined
 
         def confirm_reinstate_offer
           @declined_course_choice = ReinstateDeclinedOfferForm.new
@@ -25,8 +25,8 @@ module SupportInterface
           params.require(:support_interface_application_forms_reinstate_declined_offer_form).permit(:status, :audit_comment_ticket, :accept_guidance)
         end
 
-        def redirect_to_application_form_unless_declined_and_reinstate_offer_flag_active
-          redirect_to support_interface_application_form_path(@application_form.id) unless FeatureFlag.active?(:support_user_reinstate_offer) && @application_choice.declined?
+        def redirect_to_application_form_unless_declined
+          redirect_to support_interface_application_form_path(@application_form.id) unless @application_choice.declined?
         end
       end
     end

--- a/app/controllers/support_interface/application_forms/application_choices_controller.rb
+++ b/app/controllers/support_interface/application_forms/application_choices_controller.rb
@@ -2,7 +2,7 @@ module SupportInterface
   module ApplicationForms
     class ApplicationChoicesController < SupportInterfaceController
       before_action :build_application_form, :build_application_choice
-      before_action :redirect_to_application_form_unless_declined_and_flag_active, only: %i[reinstate_offer confirm_reinstate_offer]
+      before_action :redirect_to_application_form_unless_declined, only: %i[reinstate_offer confirm_reinstate_offer]
 
       def confirm_reinstate_offer
         @declined_course_choice = ReinstateDeclinedOfferForm.new
@@ -89,10 +89,10 @@ module SupportInterface
       def build_application_choice
         @application_choice = @application_form.application_choices.find(params[:application_choice_id])
       end
-
-      def redirect_to_application_form_unless_declined_and_flag_active
-        redirect_to support_interface_application_form_path(@application_form.id) unless FeatureFlag.active?(:support_user_reinstate_offer) && @application_choice.declined?
-      end
     end
+  end
+
+  def redirect_to_application_form_unless_declined
+    redirect_to support_interface_application_form_path(@application_form.id) unless @application_choice.declined?
   end
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -26,7 +26,6 @@ class FeatureFlag
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = [
-    [:support_user_reinstate_offer, 'Allows a support users to reinstate a declined course choice offer', 'James Glenn'],
     [:draft_vendor_api_specification, 'The specification for Draft Vendor API v1.1', 'Abeer Salameh'],
     [:reference_nudges, 'Nudge emails for candidates that have incomplete references', 'Steve Hook'],
     [:sample_applications_factory, 'An alternate generator for test/sample applications, uses `SampleApplicationsFactory` in place of `TestApplications.new`', 'Elliot Crosby-McCullough + Tomas Destefi'],

--- a/spec/components/support_interface/application_choice_component_spec.rb
+++ b/spec/components/support_interface/application_choice_component_spec.rb
@@ -8,9 +8,7 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
       create(:application_choice, :with_completed_application_form, :declined)
     end
 
-    it 'Renders a link to the reinstate offer page when the reinstate flag is active' do
-      FeatureFlag.activate(:support_user_reinstate_offer)
-
+    it 'Renders a link to the reinstate offer page if the application choice is not declined by default' do
       result = render_inline(described_class.new(declined_offer))
 
       expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(
@@ -22,18 +20,8 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
       expect(result.css('.govuk-summary-list__actions').text.strip).to include('Reinstate offer')
     end
 
-    it 'Does not render a link to the reinstate offer page when the reinstate flag is not active' do
-      FeatureFlag.deactivate(:support_user_reinstate_offer)
-
-      render_inline(described_class.new(declined_offer))
-
-      expect(page).to have_no_css '.govuk-summary-list__actions a', text: 'Reinstate offer'
-    end
-
     it 'Does not render a link to the reinstate offer page if the application choice is declined by default' do
       application_choice = create(:application_choice, :with_completed_application_form, :declined_by_default)
-
-      FeatureFlag.activate(:support_user_reinstate_offer)
 
       render_inline(described_class.new(application_choice))
 

--- a/spec/system/support_interface/reinstate_offer_to_declined_course_choice_spec.rb
+++ b/spec/system/support_interface/reinstate_offer_to_declined_course_choice_spec.rb
@@ -5,7 +5,6 @@ RSpec.feature 'Reinstate offer to a declined course choice' do
 
   scenario 'Support user can reverse a course choice that has accidently been declined' do
     given_i_am_a_support_user
-    and_the_reinstate_offer_feature_flag_is_on
     and_there_is_a_submitted_application_in_the_system_with_a_declined_offer
     and_i_visit_the_support_page
 
@@ -34,10 +33,6 @@ RSpec.feature 'Reinstate offer to a declined course choice' do
 
   def given_i_am_a_support_user
     sign_in_as_support_user
-  end
-
-  def and_the_reinstate_offer_feature_flag_is_on
-    FeatureFlag.activate(:support_user_reinstate_offer)
   end
 
   def and_there_is_a_submitted_application_in_the_system_with_a_declined_offer


### PR DESCRIPTION
## Context

Removing the `support_user_reinstate_offer` feature flag as its been active in production since May 2021.

The Data migration will be merged after this PR, in #8991.

## Changes proposed in this pull request

See commits.

## Link to Trello card

https://trello.com/c/7e89k5ST/1162-apply-remove-the-supportuserreinstateoffer-feature-flag

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
