### PR TITLE
[1163] Remove the `support_user_revert_withdrawn_offer` feature flag

### DIFF
--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -203,7 +203,7 @@ module SupportInterface
             text: 'Reinstate offer',
           },
         }
-      elsif FeatureFlag.active?(:support_user_revert_withdrawn_offer) && application_choice.withdrawn? && !any_successful_application_choices?(application_choice)
+      elsif application_choice.withdrawn? && !any_successful_application_choices?(application_choice)
         {
           action: {
             href: support_interface_application_form_application_choice_revert_withdrawal_path(application_form_id: @application_choice.application_form.id, application_choice_id: @application_choice.id),

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -27,7 +27,6 @@ class FeatureFlag
 
   TEMPORARY_FEATURE_FLAGS = [
     [:support_user_reinstate_offer, 'Allows a support users to reinstate a declined course choice offer', 'James Glenn'],
-    [:support_user_revert_withdrawn_offer, 'Allows a support user to revert an application withdrawn by the candidate', 'James Glenn'],
     [:draft_vendor_api_specification, 'The specification for Draft Vendor API v1.1', 'Abeer Salameh'],
     [:reference_nudges, 'Nudge emails for candidates that have incomplete references', 'Steve Hook'],
     [:sample_applications_factory, 'An alternate generator for test/sample applications, uses `SampleApplicationsFactory` in place of `TestApplications.new`', 'Elliot Crosby-McCullough + Tomas Destefi'],

--- a/spec/components/support_interface/application_choice_component_spec.rb
+++ b/spec/components/support_interface/application_choice_component_spec.rb
@@ -219,9 +219,7 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
     let(:application_form) { create(:completed_application_form) }
     let(:withdrawn_application) { create(:application_choice, :withdrawn, application_form:) }
 
-    it 'renders a link to revert the withdrawn application when `revert_withdrawn_offer` flag is active' do
-      FeatureFlag.activate(:support_user_revert_withdrawn_offer)
-
+    it 'renders a link to revert the withdrawn application' do
       result = render_inline(described_class.new(withdrawn_application))
 
       expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(
@@ -235,7 +233,6 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
 
     it 'does not render a link to revert the withdrawn application when the candidate has accepted an offer' do
       create(:application_choice, :accepted, application_form:)
-      FeatureFlag.activate(:support_user_revert_withdrawn_offer)
 
       render_inline(described_class.new(withdrawn_application))
 

--- a/spec/system/support_interface/revert_application_choice_withdrawn_by_candidate_spec.rb
+++ b/spec/system/support_interface/revert_application_choice_withdrawn_by_candidate_spec.rb
@@ -5,7 +5,6 @@ RSpec.feature 'Revert a withdrawn application choice' do
 
   scenario 'Support user can reverse a course choice that has been withdrawn in error' do
     given_i_am_a_support_user
-    and_the_revert_withdrawal_feature_flag_is_on
     and_there_is_a_withdrawn_application_in_the_system
     and_i_visit_the_support_page
 
@@ -34,10 +33,6 @@ RSpec.feature 'Revert a withdrawn application choice' do
 
   def given_i_am_a_support_user
     sign_in_as_support_user
-  end
-
-  def and_the_revert_withdrawal_feature_flag_is_on
-    FeatureFlag.activate(:support_user_revert_withdrawn_offer)
   end
 
   def and_there_is_a_withdrawn_application_in_the_system


### PR DESCRIPTION
## Context

Removing the `support_user_revert_withdrawn_offer` feature flag as its been active in production since October 2021.

The data migration to remove the feature flag will be done in a follow up.

## Changes proposed in this pull request

See commits.

## Link to Trello card

https://trello.com/c/73luzRVw/1163-apply-remove-the-supportuserrevertwithdrawnoffer-feature-flag

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
