### PR TITLE
[1164] Remove `withdraw_at_candidates_request` feature flag

### DIFF
--- a/app/controllers/provider_interface/decline_or_withdraw_controller.rb
+++ b/app/controllers/provider_interface/decline_or_withdraw_controller.rb
@@ -1,6 +1,5 @@
 module ProviderInterface
   class DeclineOrWithdrawController < ProviderInterfaceController
-    before_action :render_404_unless_feature_flag_active
     before_action :set_application_choice
     before_action :requires_make_decisions_permission
     before_action :redirect_to_application_choice_if_not_withdrawable_or_declinable
@@ -23,10 +22,6 @@ module ProviderInterface
     end
 
   private
-
-    def render_404_unless_feature_flag_active
-      render_404 unless FeatureFlag.active?(:withdraw_at_candidates_request)
-    end
 
     def redirect_to_application_choice_if_not_withdrawable_or_declinable
       return if withdrawable_or_declinable?

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -28,7 +28,6 @@ class FeatureFlag
   TEMPORARY_FEATURE_FLAGS = [
     [:provider_activity_log, 'Show provider users a log of all application activity', 'Michael Nacos'],
     [:support_user_reinstate_offer, 'Allows a support users to reinstate a declined course choice offer', 'James Glenn'],
-    [:withdraw_at_candidates_request, "Allows providers to withdraw an application at the candidate's request", 'Steve Laing'],
     [:support_user_revert_withdrawn_offer, 'Allows a support user to revert an application withdrawn by the candidate', 'James Glenn'],
     [:draft_vendor_api_specification, 'The specification for Draft Vendor API v1.1', 'Abeer Salameh'],
     [:reference_nudges, 'Nudge emails for candidates that have incomplete references', 'Steve Hook'],

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -21,7 +21,7 @@
 <p class="govuk-body govuk-!-display-none-print govuk-!-width-two-thirds"><%= @application_choice.application_form.full_name %> will be able to edit some sections of their application. You’ll get a notification if they add any new information.</p>
 
 <p class="govuk-body govuk-!-display-none-print">
-  <% if FeatureFlag.active?(:withdraw_at_candidates_request) && application_withdrawable? %>
+  <% if application_withdrawable? %>
     <%= govuk_link_to(
       'Withdraw at candidate’s request',
       provider_interface_decline_or_withdraw_edit_path(@application_choice),

--- a/spec/system/provider_interface/withdraw_an_application_at_candidates_request_spec.rb
+++ b/spec/system/provider_interface/withdraw_an_application_at_candidates_request_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe "withdrawing an application at the candidate's request", type: :f
 
   before do
     given_i_am_a_provider_user_with_dfe_sign_in
-    and_the_withdraw_at_candidates_request_feature_flag_is_enabled
     and_i_am_permitted_to_make_decisions_for_my_provider
   end
 
@@ -39,10 +38,6 @@ RSpec.describe "withdrawing an application at the candidate's request", type: :f
 
   def given_i_am_a_provider_user_with_dfe_sign_in
     provider_exists_in_dfe_sign_in
-  end
-
-  def and_the_withdraw_at_candidates_request_feature_flag_is_enabled
-    FeatureFlag.activate(:withdraw_at_candidates_request)
   end
 
   def and_i_am_permitted_to_make_decisions_for_my_provider


### PR DESCRIPTION
## Context

Removing the `withdraw_at_candidates_request` feature flag as its been active in production since July 2021. 

The Data migration will be merged as a follow up to this PR.

## Changes proposed in this pull request

See commits.

## Link to Trello card

https://trello.com/c/8DYUyt2D/1164-apply-remove-the-withdrawatcandidatesrequest-feature-flag

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
