### PR TITLE
Add descriptive labels for the multiple English grade form

### DIFF
--- a/app/views/candidate_interface/gcse/english/grade/_multiple_grade_form.html.erb
+++ b/app/views/candidate_interface/gcse/english/grade/_multiple_grade_form.html.erb
@@ -15,26 +15,26 @@
 
   <%= f.govuk_check_boxes_fieldset :english_gcses, legend: { text: t('multiple_gcse_edit_grade.question'), size: 'm' } do %>
     <%= f.govuk_check_box :english_gcses, 'english_single_award', label: { text: t('multiple_gcse_edit_grade.answers.english_single_award') }, link_errors: true do %>
-      <%= f.govuk_text_field :grade_english_single, label: { text: 'Grade' }, hint: { text: t('multiple_gcse_edit_grade.hints.single_award') }, width: 2 %>
+      <%= f.govuk_text_field :grade_english_single, label: { text: 'Grade for English (Single award)' }, hint: { text: t('multiple_gcse_edit_grade.hints.single_award') }, width: 2 %>
     <% end %>
     <%= f.govuk_check_box :english_gcses, 'english_double_award', label: { text: t('multiple_gcse_edit_grade.answers.english_double_award') } do %>
-      <%= f.govuk_text_field :grade_english_double, label: { text: 'Grade' }, hint: { text: t('multiple_gcse_edit_grade.hints.double_award') }, width: 4 %>
+      <%= f.govuk_text_field :grade_english_double, label: { text: 'Grade for English (Double award)' }, hint: { text: t('multiple_gcse_edit_grade.hints.double_award') }, width: 4 %>
     <% end %>
     <%= f.govuk_check_box :english_gcses, 'english_language', label: { text: t('multiple_gcse_edit_grade.answers.english_language') } do %>
-      <%= f.govuk_text_field :grade_english_language, label: { text: 'Grade' }, hint: { text: t('multiple_gcse_edit_grade.hints.single_award') }, width: 2 %>
+      <%= f.govuk_text_field :grade_english_language, label: { text: 'Grade for English Language' }, hint: { text: t('multiple_gcse_edit_grade.hints.single_award') }, width: 2 %>
     <% end %>
     <%= f.govuk_check_box :english_gcses, 'english_literature', label: { text: t('multiple_gcse_edit_grade.answers.english_literature') } do %>
-      <%= f.govuk_text_field :grade_english_literature, label: { text: 'Grade' }, hint: { text: t('multiple_gcse_edit_grade.hints.single_award') }, width: 2 %>
+      <%= f.govuk_text_field :grade_english_literature, label: { text: 'Grade for English Literature' }, hint: { text: t('multiple_gcse_edit_grade.hints.single_award') }, width: 2 %>
     <% end %>
     <%= f.govuk_check_box :english_gcses, 'english_studies_single_award', label: { text: t('multiple_gcse_edit_grade.answers.english_studies_single_award') } do %>
-      <%= f.govuk_text_field :grade_english_studies_single, label: { text: 'Grade' }, hint: { text: t('multiple_gcse_edit_grade.hints.single_award') }, width: 2 %>
+      <%= f.govuk_text_field :grade_english_studies_single, label: { text: 'Grade for English Studies (Single award)' }, hint: { text: t('multiple_gcse_edit_grade.hints.single_award') }, width: 2 %>
     <% end %>
     <%= f.govuk_check_box :english_gcses, 'english_studies_double_award', label: { text: t('multiple_gcse_edit_grade.answers.english_studies_double_award') } do %>
-      <%= f.govuk_text_field :grade_english_studies_double, label: { text: 'Grade' }, hint: { text: t('multiple_gcse_edit_grade.hints.double_award') }, width: 4 %>
+      <%= f.govuk_text_field :grade_english_studies_double, label: { text: 'Grade for English Studies (Double award)' }, hint: { text: t('multiple_gcse_edit_grade.hints.double_award') }, width: 4 %>
     <% end %>
     <%= f.govuk_check_box :english_gcses, 'other_english_gcse', label: { text: t('multiple_gcse_edit_grade.answers.other_english_gcse') } do %>
       <%= f.govuk_text_field :other_english_gcse_name, label: { text: t('multiple_gcse_edit_grade.answers.other_english_gcse_name') } %>
-      <%= f.govuk_text_field :grade_other_english_gcse, label: { text: 'Grade' }, hint: { text: t('multiple_gcse_edit_grade.hints.single_award') }, width: 2 %>
+      <%= f.govuk_text_field :grade_other_english_gcse, label: { text: 'Grade for other English GCSE' }, hint: { text: t('multiple_gcse_edit_grade.hints.single_award') }, width: 2 %>
     <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
## Context

The form elements that conditionally reveal on the ‘English GCSE or equivalent’ page within the ‘Qualifications’ section of Apply do not contain a descriptive name, and therefore doesn’t pass WCAG 2.1 AA.

This means a person navigating the page with a screenreader will struggle to orient themselves, and understand what information is required of them.

We should be using `aria-labelledby` but this isn't currently supported by govuk-form-builder, so our interim solution is to just update the visible label text.

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="473" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/e561e0f5-180c-442b-a05d-9e259b908f18">|<img width="453" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/4b12c848-43a6-4644-a5c3-f49fca9a2050">|

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/fBOnfzK1

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
