### PR TITLE
Fix bug in reminder emails for inactive applications

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -506,7 +506,7 @@ class CandidateMailer < ApplicationMailer
       }
     end
 
-    @choices_remaining = ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES - application_choices.count
+    @choices_remaining = application_form.applications_left
     @submitted_at = application_choices.first.sent_to_provider_at.to_date.to_fs(:govuk_date)
 
     email_for_candidate(

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -924,7 +924,7 @@ RSpec.describe CandidateMailer do
       'a mail with subject and content',
       'Increase your chances of receiving an offer for teacher training',
       'greeting' => 'Hello Fred',
-      'content' => 'While you wait for a response on these applications',
+      'content' => 'While you wait for a response on these applications, you can apply to 4 more courses at different training providers',
     )
   end
 end


### PR DESCRIPTION
![](https://github.trello.services/images/mini-trello-icon.png) [Bug: Reminder emails for inactive applications counts the remaining choices incorrectly](https://trello.com/c/WMFgHWSS/1194-bug-reminder-emails-for-inactive-applications-counts-the-remaining-choices-incorrectly)