### PR TITLE
Fix submission validation bug

### DIFF
--- a/app/presenters/candidate_interface/application_form_sections.rb
+++ b/app/presenters/candidate_interface/application_form_sections.rb
@@ -25,13 +25,13 @@ module CandidateInterface
       sections_with_completion.find { |section| section[0] == section_name }&.second
     end
 
-    delegate :incomplete_sections, to: :presenter
-
-  private
-
     def primary_course?
       application_choice.current_course.primary_course?
     end
+
+    delegate :incomplete_sections, to: :presenter
+
+  private
 
     def science_gcse?
       ->(section) { section.name == :science_gcse }

--- a/app/services/candidate_interface/continuous_applications/application_choice_submission.rb
+++ b/app/services/candidate_interface/continuous_applications/application_choice_submission.rb
@@ -9,9 +9,9 @@ module CandidateInterface
                 immigration_status: true,
                 applications_closed: { if: :validate_choice? },
                 course_unavailable: { if: :validate_choice? },
-                incomplete_details: { if: :validate_choice? },
                 incomplete_primary_course_details: { if: :validate_choice? },
                 incomplete_including_primary_course_details: { if: :validate_choice? },
+                incomplete_details: { if: :validate_choice? },
                 can_add_more_choices: true
 
     private

--- a/app/validators/incomplete_details_validator.rb
+++ b/app/validators/incomplete_details_validator.rb
@@ -1,6 +1,10 @@
 class IncompleteDetailsValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, application_choice)
-    return unless details_incomplete_and_science_gcse_not_needed?(application_choice)
+    sections = CandidateInterface::ApplicationFormSections.new(
+      application_form: application_choice.application_form,
+      application_choice:,
+    )
+    return if sections.all_completed?
 
     record.errors.add(
       attribute,
@@ -20,11 +24,5 @@ private
       include ActionView::Helpers::UrlHelper
       include GovukLinkHelper
     end.new
-  end
-
-  def details_incomplete_and_science_gcse_not_needed?(application_choice)
-    sections = CandidateInterface::ApplicationFormSections.new(application_form: application_choice.application_form, application_choice:)
-
-    sections.incomplete_sections.present? && sections.incomplete_sections.none? { |section| section.name == :science_gcse }
   end
 end

--- a/spec/services/candidate_interface/continuous_applications/application_choice_submission/incomplete_including_primary_course_form_spec.rb
+++ b/spec/services/candidate_interface/continuous_applications/application_choice_submission/incomplete_including_primary_course_form_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Incomplete details including primary course form details', time:
     end
   end
 
-  context 'science gcse section and other details incomplete' do
+  context 'science gcse section incomplete and other details incomplete' do
     let(:application_form) { create(:application_form, :completed, degrees_completed: false, science_gcse_completed: false) }
     let(:application_choice) { create(:application_choice, :unsubmitted, course_option:, application_form:) }
 

--- a/spec/system/candidate_interface/continuous_applications/submitting/candidate_tries_to_bypass_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/submitting/candidate_tries_to_bypass_submitting_application_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate submits the application', :continuous_applications do
+  include CandidateHelper
+
+  scenario 'Candidate with incomplete application seeing the error message' do
+    given_i_am_signed_in
+
+    and_i_have_incomplete_sections_on_my_personal_statement
+    and_i_have_a_primary_and_secondary_application_choice
+    when_i_go_to_secondary_review_page
+    then_i_should_be_seeing_an_error_message
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_have_incomplete_sections_on_my_personal_statement
+    current_candidate.application_forms.delete_all
+    current_candidate.application_forms << build(:application_form, :minimum_info, submitted_at: nil, becoming_a_teacher: 'I want to teach')
+  end
+
+  def and_i_have_a_primary_and_secondary_application_choice
+    secondary = create(:course, :with_course_options, :open_on_apply, :secondary, funding_type: 'fee', can_sponsor_student_visa: true)
+    primary = create(:course, :with_course_options, :open_on_apply, :primary, funding_type: 'fee', can_sponsor_student_visa: true)
+
+    secondary_course_option = create(:course_option, course: secondary)
+    primary_course_option = create(:course_option, course: primary)
+
+    @secondary_application_choice = create(:application_choice, :unsubmitted, course_option: secondary_course_option, application_form: current_candidate.current_application)
+    @primary_application_choice = create(:application_choice, :unsubmitted, course_option: primary_course_option, application_form: current_candidate.current_application)
+  end
+
+  def when_i_go_to_secondary_review_page
+    visit candidate_interface_continuous_applications_course_review_path(@secondary_application_choice)
+  end
+
+  def then_i_should_be_seeing_an_error_message
+    expect(page).to have_content('You cannot submit this application until you complete your details.')
+  end
+end


### PR DESCRIPTION
## Context

After investigating [this Sentry alert](https://dfe-teacher-services.sentry.io/issues/4814990519/?alert_rule_id=4434951&alert_type=issue&environment=production&notification_uuid=d35eac63-30ed-4501-b589-0c5cc82628d3&project=1765973&referrer=slack) we've discovered It's possible to bypass our submission validations if you add primary and then a secondary course. This is because the science GCSE is not needed for a secondary course, and the validation was being checked with a "&" statement.

## Changes proposed in this pull request

To avoid this scenarios the incomplete validators have been moved down the line and then **all** the sections are validated as completed, to avoid any possible scenario to bypass the submission.

## Guidance to review

To replicate the error scenario on main:
- Create a new candidate locally
- Access your sign in link with `tail -f log/mail.log`
- Don't complete any of the sections and add a primary course choice and then a secondary
- Submit the secondary course choice and you'll get the `undefined method 'scan' for nil:NilClass (ActionView::Template::Error)` error
- add something to personal statement
- You'll now be able to submit your application with no section completed

Attempt this again on this branch and you should see the validation message.