### PR TITLE
ApplicationReviewComponent Updates

### DIFF
--- a/app/components/candidate_interface/continuous_applications/application_review_component.html.erb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.html.erb
@@ -1,16 +1,1 @@
 <%= render SummaryListComponent.new(rows: rows) %>
-
-<% if show_personal_statement? %>
-  <div class="app-summary-card govuk-!-margin-bottom-6">
-    <div class="app-summary-card__header govuk-body">
-      Personal statement
-    </div>
-    <div class="app-summary-card__body">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-three-quarters-from-desktop">
-          <%= simple_format(@application_choice.personal_statement, class: 'govuk-body') %>
-        </div>
-      </div>
-    </div>
-  </div>
-<% end %>

--- a/app/components/candidate_interface/continuous_applications/application_review_component.rb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.rb
@@ -8,10 +8,6 @@ module CandidateInterface
         @application_choice = application_choice
       end
 
-      def show_personal_statement?
-        @application_choice.submitted? && @application_choice.personal_statement.present?
-      end
-
       def rows
         [
           status_row,
@@ -22,6 +18,7 @@ module CandidateInterface
           course_length_row,
           study_mode_row,
           location_row,
+          personal_statement_row,
         ].compact
       end
 
@@ -104,6 +101,19 @@ module CandidateInterface
             }
           end
         end
+      end
+
+      def personal_statement_row
+        value = if unsubmitted?
+                  @application_choice.application_form.becoming_a_teacher
+                else
+                  @application_choice.personal_statement
+                end
+
+        {
+          key: 'Personal statement',
+          value: value,
+        }
       end
     end
   end

--- a/app/components/candidate_interface/continuous_applications/application_review_component.rb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.rb
@@ -19,6 +19,7 @@ module CandidateInterface
           submitted_at_row,
           course_info_row,
           qualifications_row,
+          course_length_row,
           study_mode_row,
           location_row,
         ].compact
@@ -67,6 +68,13 @@ module CandidateInterface
         {
           key: 'Qualifications',
           value: (current_course.qualifications || []).map(&:upcase).to_sentence,
+        }
+      end
+
+      def course_length_row
+        {
+          key: 'Course length',
+          value: DisplayCourseLength.call(course_length: current_course.course_length),
         }
       end
 

--- a/app/components/candidate_interface/continuous_applications/application_review_component.rb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.rb
@@ -24,6 +24,7 @@ module CandidateInterface
           location_row,
           personal_statement_row,
           interview_row,
+          rejection_reasons_row,
         ].compact
       end
 
@@ -129,6 +130,22 @@ module CandidateInterface
         {
           key: 'Interview',
           value: render(InterviewSummaryComponent.new(interview:)),
+        }
+      end
+
+      def rejection_reasons_row
+        return unless application_choice.rejected?
+        return unless application_choice.rejection_reason.present? || application_choice.structured_rejection_reasons.present?
+
+        {
+          key: 'Reasons for rejection',
+          value: render(
+            CandidateInterface::RejectionsComponent.new(
+              application_choice:,
+              render_link_to_find_when_rejected_on_qualifications: true,
+              feedback_button: true,
+            ),
+          ),
         }
       end
     end

--- a/app/components/candidate_interface/continuous_applications/application_review_component.rb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.rb
@@ -15,6 +15,7 @@ module CandidateInterface
       def rows
         [
           status_row,
+          application_number_row,
           submitted_at_row,
           course_info_row,
           study_mode_row,
@@ -31,6 +32,12 @@ module CandidateInterface
             ApplicationStatusTagComponent.new(application_choice:, display_info_text: false),
           ),
         }
+      end
+
+      def application_number_row
+        return unless application_choice.sent_to_provider_at
+
+        { key: 'Application number', value: application_choice.id }
       end
 
       def submitted_at_row

--- a/app/components/candidate_interface/continuous_applications/application_review_component.rb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.rb
@@ -51,7 +51,7 @@ module CandidateInterface
       def course_info_row
         {
           key: 'Course',
-          value: current_course.name_and_code,
+          value: govuk_link_to(current_course.name_and_code, current_course.find_url, { target: '_blank', rel: 'noopener' }),
         }.tap do |row|
           if unsubmitted?
             row[:action] = {

--- a/app/components/candidate_interface/continuous_applications/application_review_component.rb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.rb
@@ -67,7 +67,7 @@ module CandidateInterface
       def qualifications_row
         {
           key: 'Qualifications',
-          value: (current_course.qualifications || []).map(&:upcase).to_sentence,
+          value: current_course.qualifications_to_s,
         }
       end
 

--- a/app/components/candidate_interface/continuous_applications/application_review_component.rb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.rb
@@ -43,7 +43,9 @@ module CandidateInterface
       def submitted_at_row
         return unless application_choice.sent_to_provider_at
 
-        { key: 'Application submitted', value: application_choice.sent_to_provider_at.to_fs(:govuk_date_and_time) }
+        value = "#{application_choice.sent_to_provider_at.to_fs(:govuk_date_and_time)} (#{time_ago_in_words(application_choice.sent_to_provider_at)} ago)"
+
+        { key: 'Application submitted', value: }
       end
 
       def course_info_row

--- a/app/components/candidate_interface/continuous_applications/application_review_component.rb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.rb
@@ -18,6 +18,7 @@ module CandidateInterface
           application_number_row,
           submitted_at_row,
           course_info_row,
+          qualifications_row,
           study_mode_row,
           location_row,
         ].compact
@@ -60,6 +61,13 @@ module CandidateInterface
             }
           end
         end
+      end
+
+      def qualifications_row
+        {
+          key: 'Qualifications',
+          value: (current_course.qualifications || []).map(&:upcase).to_sentence,
+        }
       end
 
       def study_mode_row

--- a/app/components/candidate_interface/continuous_applications/application_review_component.rb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.rb
@@ -2,7 +2,11 @@ module CandidateInterface
   module ContinuousApplications
     class ApplicationReviewComponent < ViewComponent::Base
       attr_reader :application_choice
-      delegate :unsubmitted?, :current_course, :current_course_option, to: :application_choice
+      delegate :interviewing?,
+               :unsubmitted?,
+               :current_course,
+               :current_course_option,
+               to: :application_choice
 
       def initialize(application_choice:)
         @application_choice = application_choice
@@ -19,6 +23,7 @@ module CandidateInterface
           study_mode_row,
           location_row,
           personal_statement_row,
+          interview_row,
         ].compact
       end
 
@@ -113,6 +118,17 @@ module CandidateInterface
         {
           key: 'Personal statement',
           value: value,
+        }
+      end
+
+      def interview_row
+        return unless interviewing?
+
+        interview = application_choice.interviews.last
+
+        {
+          key: 'Interview',
+          value: render(InterviewSummaryComponent.new(interview:)),
         }
       end
     end

--- a/app/components/candidate_interface/continuous_applications/interview_summary_component.html.erb
+++ b/app/components/candidate_interface/continuous_applications/interview_summary_component.html.erb
@@ -1,0 +1,9 @@
+<p class="govuk-body">You have an interview scheduled for <%= date %> at <%= time %>.</p>
+<% if details || location %>
+  <p class="govuk-body">Information from provider:</p>
+  <div class="govuk-inset-text govuk-!-padding-bottom-0 govuk-!-padding-top-0 govuk-!-margin-bottom-0 govuk-!-margin-top-0">
+    <p class="govuk-body"><%= location %></p>
+    <p class="govuk-body"><%= details %></p>
+  </div>
+<% end %>
+<p class="govuk-body">The provider will send more details about the interview by email.</p>

--- a/app/components/candidate_interface/continuous_applications/interview_summary_component.html.erb
+++ b/app/components/candidate_interface/continuous_applications/interview_summary_component.html.erb
@@ -1,9 +1,13 @@
 <p class="govuk-body">You have an interview scheduled for <%= date %> at <%= time %>.</p>
 <% if details || location %>
   <p class="govuk-body">Information from provider:</p>
-  <div class="govuk-inset-text govuk-!-padding-bottom-0 govuk-!-padding-top-0 govuk-!-margin-bottom-0 govuk-!-margin-top-0">
-    <p class="govuk-body"><%= location %></p>
-    <p class="govuk-body"><%= details %></p>
+  <div class="govuk-inset-text govuk-!-margin-bottom-2 govuk-!-margin-top-0">
+    <% if location %>
+      <p class="govuk-body"><%= location %></p>
+    <% end %>
+    <% if details %>
+      <p class="govuk-body"><%= details %></p>
+    <% end %>
   </div>
 <% end %>
 <p class="govuk-body">The provider will send more details about the interview by email.</p>

--- a/app/components/candidate_interface/continuous_applications/interview_summary_component.rb
+++ b/app/components/candidate_interface/continuous_applications/interview_summary_component.rb
@@ -1,0 +1,25 @@
+module CandidateInterface
+  module ContinuousApplications
+    class InterviewSummaryComponent < ViewComponent::Base
+      attr_reader :interview
+
+      def initialize(interview:)
+        @interview = interview
+      end
+
+      delegate :location, to: :interview
+
+      def time
+        interview.date_and_time.to_fs(:govuk_time)
+      end
+
+      def date
+        interview.date_and_time.to_fs(:govuk_date)
+      end
+
+      def details
+        interview.additional_details
+      end
+    end
+  end
+end

--- a/app/components/candidate_interface/rejection_reasons/reasons_for_rejection_component.html.erb
+++ b/app/components/candidate_interface/rejection_reasons/reasons_for_rejection_component.html.erb
@@ -1,160 +1,183 @@
 <% if reasons.candidate_behaviour_y_n == 'Yes' %>
   <div class="app-rejection">
-    <h3 class="govuk-heading-s">Something you did</h3>
-    <ul class="govuk-list govuk-list--spaced">
-      <% reasons.candidate_behaviour_what_did_the_candidate_do.each do |reason| %>
-        <li>
-          <% if reason == 'other' %>
-            <%= simple_format(reasons.candidate_behaviour_other) %>
-            <%= simple_format(reasons.candidate_behaviour_what_to_improve) %>
-          <% else %>
-            <p><%= t("reasons_for_rejection.candidate_behaviour_what_did_the_candidate_do.#{reason}") %>.</p>
-          <% end %>
-        </li>
-      <% end %>
-    </ul>
+    <p class="govuk-body app-rejection__label">Something you did:</p>
+    <%= govuk_inset_text(classes: 'app-rejection__body govuk-!-margin-top-2') do %>
+      <ul class="govuk-list govuk-list--spaced">
+        <% reasons.candidate_behaviour_what_did_the_candidate_do.each do |reason| %>
+          <li>
+            <% if reason == 'other' %>
+              <%= simple_format(reasons.candidate_behaviour_other) %>
+              <%= simple_format(reasons.candidate_behaviour_what_to_improve) %>
+            <% else %>
+              <p><%= t("reasons_for_rejection.candidate_behaviour_what_did_the_candidate_do.#{reason}") %>.</p>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
   </div>
 <% end %>
 
 <% if reasons.quality_of_application_y_n == 'Yes' %>
   <div class="app-rejection">
-    <h3 class="govuk-heading-s">Quality of application</h3>
-    <ul class="govuk-list govuk-list--spaced">
-      <% reasons.quality_of_application_which_parts_needed_improvement.each do |reason| %>
-        <li>
-          <% if reason == 'other' %>
-            <%= simple_format(reasons.quality_of_application_other_details)%>
-            <%= simple_format(reasons.quality_of_application_other_what_to_improve)%>
-          <% else %>
-            <%= simple_format(t("reasons_for_rejection.quality_of_application.#{reason}"))%>
-            <%= simple_format(reasons.send(:"quality_of_application_#{reason}_what_to_improve"))%>
-          <% end %>
-        </li>
-      <% end %>
-    </ul>
+    <p class="govuk-body app-rejection__label">Quality of application:</p>
+    <%= govuk_inset_text(classes: 'app-rejection__body govuk-!-margin-top-2') do %>
+      <ul class="govuk-list govuk-list--spaced">
+        <% reasons.quality_of_application_which_parts_needed_improvement.each do |reason| %>
+          <li>
+            <% if reason == 'other' %>
+              <%= simple_format(reasons.quality_of_application_other_details)%>
+              <%= simple_format(reasons.quality_of_application_other_what_to_improve)%>
+            <% else %>
+              <%= simple_format(t("reasons_for_rejection.quality_of_application.#{reason}"))%>
+              <%= simple_format(reasons.send(:"quality_of_application_#{reason}_what_to_improve"))%>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
   </div>
 <% end %>
 
 <% if reasons.qualifications_y_n == 'Yes' %>
   <div class="app-rejection">
-    <h3 class="govuk-heading-s">Qualifications</h3>
-    <ul class="govuk-list govuk-list--spaced">
-      <% reasons.qualifications_which_qualifications.each do |reason| %>
-        <li>
-          <% if reason == 'other' %>
-            <%= simple_format(reasons.qualifications_other_details)%>
-          <% else %>
-            <p><%= t("reasons_for_rejection.qualifications_which_qualifications.#{reason}") %>.</p>
-          <% end %>
-        </li>
-      <% end %>
-      <%= link_to_find_when_rejected_on_qualifications(application_choice) if @render_link_to_find_when_rejected_on_qualifications %>
-    </ul>
+    <p class="govuk-body app-rejection__label">Qualifications:</p>
+    <%= govuk_inset_text(classes: 'app-rejection__body govuk-!-margin-top-2') do %>
+      <ul class="govuk-list govuk-list--spaced">
+        <% reasons.qualifications_which_qualifications.each do |reason| %>
+          <li>
+            <% if reason == 'other' %>
+              <%= simple_format(reasons.qualifications_other_details)%>
+            <% else %>
+              <p><%= t("reasons_for_rejection.qualifications_which_qualifications.#{reason}") %>.</p>
+            <% end %>
+          </li>
+        <% end %>
+        <%= link_to_find_when_rejected_on_qualifications(application_choice) if @render_link_to_find_when_rejected_on_qualifications %>
+      </ul>
+    <% end %>
   </div>
 <% end %>
 
 <% if reasons.performance_at_interview_y_n == 'Yes' %>
   <div class="app-rejection">
-    <h3 class="govuk-heading-s">Performance at interview</h3>
-    <%= simple_format(reasons.performance_at_interview_what_to_improve, class: 'govuk-body govuk-!-margin-bottom-3') %>
+    <p class="govuk-body app-rejection__label">Performance at interview:</p>
+    <%= govuk_inset_text(classes: 'app-rejection__body govuk-!-margin-top-2') do %>
+      <%= simple_format(reasons.performance_at_interview_what_to_improve, class: 'govuk-body govuk-!-margin-bottom-3') %>
+    <% end %>
   </div>
 <% end %>
 
 <% if reasons.course_full_y_n == 'Yes' %>
   <div class="app-rejection">
-    <h3 class="govuk-heading-s">Course full</h3>
-    <p><%= t('reasons_for_rejection.full_course.reason') %> </p>
+    <p class="govuk-body app-rejection__label">Course full:</p>
+    <%= govuk_inset_text(classes: 'app-rejection__body govuk-!-margin-top-2') do %>
+      <p><%= t('reasons_for_rejection.full_course.reason') %> </p>
+    <% end %>
   </div>
 <% end %>
 
 <% if reasons.offered_on_another_course_y_n == 'Yes' %>
   <div class="app-rejection">
-    <h3 class="govuk-heading-s">They offered you a place on another course</h3>
-    <%= simple_format(reasons.offered_on_another_course_details) %>
+    <p class="govuk-body app-rejection__label">They offered you a place on another course:</p>
+    <%= govuk_inset_text(classes: 'app-rejection__body govuk-!-margin-top-2') do %>
+      <%= simple_format(reasons.offered_on_another_course_details) %>
+    <% end %>
   </div>
 <% end %>
 
 <% if reasons.honesty_and_professionalism_y_n == 'Yes' %>
   <div class="app-rejection">
-    <h3 class="govuk-heading-s">Honesty and professionalism</h3>
-    <ul class="govuk-list govuk-list--spaced">
-      <% if reasons.honesty_and_professionalism_concerns_information_false_or_inaccurate_details.present? %>
-        <li>
-
-    <%= simple_format(reasons.honesty_and_professionalism_concerns_information_false_or_inaccurate_details) %>
-        </li>
-      <% end %>
-      <% if reasons.honesty_and_professionalism_concerns_plagiarism_details.present? %>
-        <li>
-    <%= simple_format(reasons.honesty_and_professionalism_concerns_plagiarism_details) %>
-        </li>
-      <% end %>
-      <% if reasons.honesty_and_professionalism_concerns_references_details.present? %>
-        <li>
-    <%= simple_format(reasons.honesty_and_professionalism_concerns_references_details) %>
-        </li>
-      <% end %>
-      <% if reasons.honesty_and_professionalism_concerns_other_details.present? %>
-        <li>
-          <%= simple_format(reasons.honesty_and_professionalism_concerns_other_details) %>
-        </li>
-      <% end %>
-    </ul>
+    <p class="govuk-body app-rejection__label">Honesty and professionalism:</p>
+    <%= govuk_inset_text(classes: 'app-rejection__body govuk-!-margin-top-2') do %>
+      <ul class="govuk-list govuk-list--spaced">
+        <% if reasons.honesty_and_professionalism_concerns_information_false_or_inaccurate_details.present? %>
+          <li>
+            <%= simple_format(reasons.honesty_and_professionalism_concerns_information_false_or_inaccurate_details) %>
+          </li>
+        <% end %>
+        <% if reasons.honesty_and_professionalism_concerns_plagiarism_details.present? %>
+          <li>
+            <%= simple_format(reasons.honesty_and_professionalism_concerns_plagiarism_details) %>
+          </li>
+        <% end %>
+        <% if reasons.honesty_and_professionalism_concerns_references_details.present? %>
+          <li>
+            <%= simple_format(reasons.honesty_and_professionalism_concerns_references_details) %>
+          </li>
+        <% end %>
+        <% if reasons.honesty_and_professionalism_concerns_other_details.present? %>
+          <li>
+            <%= simple_format(reasons.honesty_and_professionalism_concerns_other_details) %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
   </div>
 <% end %>
 
 <% if reasons.safeguarding_y_n == 'Yes' %>
   <div class="app-rejection">
-    <h3 class="govuk-heading-s">Safeguarding issues</h3>
-    <ul class="govuk-list govuk-list--spaced">
-      <% if reasons.safeguarding_concerns_candidate_disclosed_information_details.present? %>
-        <li>
-          <%= simple_format(reasons.safeguarding_concerns_candidate_disclosed_information_details) %>
-        </li>
-      <% end %>
-      <% if reasons.safeguarding_concerns_vetting_disclosed_information_details.present? %>
-        <li>
-          <%= simple_format(reasons.safeguarding_concerns_vetting_disclosed_information_details) %>
-        </li>
-      <% end %>
-      <% if reasons.safeguarding_concerns_other_details.present? %>
-        <li>
-          <%= simple_format(reasons.safeguarding_concerns_other_details) %>
-        </li>
-      <% end %>
-    </ul>
+    <p class="govuk-body app-rejection__label">Safeguarding issues:</p>
+    <%= govuk_inset_text(classes: 'app-rejection__body govuk-!-margin-top-2') do %>
+      <ul class="govuk-list govuk-list--spaced">
+        <% if reasons.safeguarding_concerns_candidate_disclosed_information_details.present? %>
+          <li>
+            <%= simple_format(reasons.safeguarding_concerns_candidate_disclosed_information_details) %>
+          </li>
+        <% end %>
+        <% if reasons.safeguarding_concerns_vetting_disclosed_information_details.present? %>
+          <li>
+            <%= simple_format(reasons.safeguarding_concerns_vetting_disclosed_information_details) %>
+          </li>
+        <% end %>
+        <% if reasons.safeguarding_concerns_other_details.present? %>
+          <li>
+            <%= simple_format(reasons.safeguarding_concerns_other_details) %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
   </div>
 <% end %>
 
 <% if reasons.cannot_sponsor_visa_y_n == 'Yes' %>
   <div class="app-rejection">
-    <h3 class="govuk-heading-s"><%= I18n.t('reasons_for_rejection.cannot_sponsor_visa.title') %></h3>
-    <%= simple_format(reasons.cannot_sponsor_visa_details, class: 'govuk-body govuk-!-margin-bottom-3') %>
+    <p class="govuk-body app-rejection__label"><%= I18n.t('reasons_for_rejection.cannot_sponsor_visa.title') %>:</p>
+    <%= govuk_inset_text(classes: 'app-rejection__body govuk-!-margin-top-2') do %>
+      <%= simple_format(reasons.cannot_sponsor_visa_details, class: 'govuk-body govuk-!-margin-bottom-3') %>
+    <% end %>
   </div>
 <% end %>
 
 <% if reasons.why_are_you_rejecting_this_application.present? %>
   <div class="app-rejection">
-    <h3 class="govuk-heading-s"><%= I18n.t('reasons_for_rejection.why_are_you_rejecting_this_application.title') %></h3>
-    <%= simple_format(reasons.why_are_you_rejecting_this_application, class: 'govuk-body govuk-!-margin-bottom-3') %>
+    <p class="govuk-body app-rejection__label"><%= I18n.t('reasons_for_rejection.why_are_you_rejecting_this_application.title') %>:</p>
+    <%= govuk_inset_text(classes: 'app-rejection__body govuk-!-margin-top-2') do %>
+      <%= simple_format(reasons.why_are_you_rejecting_this_application, class: 'govuk-body govuk-!-margin-bottom-3') %>
+    <% end %>
   </div>
 <% end %>
 
 <% if reasons.other_advice_or_feedback_y_n == 'Yes' %>
   <div class="app-rejection">
-    <h3 class="govuk-heading-s">Additional feedback</h3>
-    <%= simple_format(reasons.other_advice_or_feedback_details, class: 'govuk-body govuk-!-margin-bottom-3') %>
+    <p class="govuk-body app-rejection__label">Additional feedback:</p>
+    <%= govuk_inset_text(classes: 'app-rejection__body govuk-!-margin-top-2') do %>
+      <%= simple_format(reasons.other_advice_or_feedback_details, class: 'govuk-body govuk-!-margin-bottom-3') %>
+    <% end %>
   </div>
 <% end %>
 
 <% if %w[Yes No].include?(reasons.interested_in_future_applications_y_n) %>
   <div class="app-rejection">
-    <h3 class="govuk-heading-s">Future applications</h3>
-    <p class="govuk-body">
-      <%= I18n.t(
-        "reasons_for_rejection.interested_in_future_applications.reason.#{reasons.interested_in_future_applications_y_n.downcase}",
-        provider_name: application_choice.provider.name,
-      ) %>
-    </p>
+    <p class="govuk-body app-rejection__label">Future applications:</p>
+    <%= govuk_inset_text(classes: 'app-rejection__body govuk-!-margin-top-2') do %>
+      <p class="govuk-body">
+        <%= I18n.t(
+          "reasons_for_rejection.interested_in_future_applications.reason.#{reasons.interested_in_future_applications_y_n.downcase}",
+          provider_name: application_choice.provider.name,
+        ) %>
+      </p>
+    <% end %>
   </div>
 <% end %>

--- a/app/components/candidate_interface/rejection_reasons/reasons_for_rejection_component.html.erb
+++ b/app/components/candidate_interface/rejection_reasons/reasons_for_rejection_component.html.erb
@@ -1,0 +1,160 @@
+<% if reasons.candidate_behaviour_y_n == 'Yes' %>
+  <div class="app-rejection">
+    <h3 class="govuk-heading-s">Something you did</h3>
+    <ul class="govuk-list govuk-list--spaced">
+      <% reasons.candidate_behaviour_what_did_the_candidate_do.each do |reason| %>
+        <li>
+          <% if reason == 'other' %>
+            <%= simple_format(reasons.candidate_behaviour_other) %>
+            <%= simple_format(reasons.candidate_behaviour_what_to_improve) %>
+          <% else %>
+            <p><%= t("reasons_for_rejection.candidate_behaviour_what_did_the_candidate_do.#{reason}") %>.</p>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<% if reasons.quality_of_application_y_n == 'Yes' %>
+  <div class="app-rejection">
+    <h3 class="govuk-heading-s">Quality of application</h3>
+    <ul class="govuk-list govuk-list--spaced">
+      <% reasons.quality_of_application_which_parts_needed_improvement.each do |reason| %>
+        <li>
+          <% if reason == 'other' %>
+            <%= simple_format(reasons.quality_of_application_other_details)%>
+            <%= simple_format(reasons.quality_of_application_other_what_to_improve)%>
+          <% else %>
+            <%= simple_format(t("reasons_for_rejection.quality_of_application.#{reason}"))%>
+            <%= simple_format(reasons.send(:"quality_of_application_#{reason}_what_to_improve"))%>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<% if reasons.qualifications_y_n == 'Yes' %>
+  <div class="app-rejection">
+    <h3 class="govuk-heading-s">Qualifications</h3>
+    <ul class="govuk-list govuk-list--spaced">
+      <% reasons.qualifications_which_qualifications.each do |reason| %>
+        <li>
+          <% if reason == 'other' %>
+            <%= simple_format(reasons.qualifications_other_details)%>
+          <% else %>
+            <p><%= t("reasons_for_rejection.qualifications_which_qualifications.#{reason}") %>.</p>
+          <% end %>
+        </li>
+      <% end %>
+      <%= link_to_find_when_rejected_on_qualifications(application_choice) if @render_link_to_find_when_rejected_on_qualifications %>
+    </ul>
+  </div>
+<% end %>
+
+<% if reasons.performance_at_interview_y_n == 'Yes' %>
+  <div class="app-rejection">
+    <h3 class="govuk-heading-s">Performance at interview</h3>
+    <%= simple_format(reasons.performance_at_interview_what_to_improve, class: 'govuk-body govuk-!-margin-bottom-3') %>
+  </div>
+<% end %>
+
+<% if reasons.course_full_y_n == 'Yes' %>
+  <div class="app-rejection">
+    <h3 class="govuk-heading-s">Course full</h3>
+    <p><%= t('reasons_for_rejection.full_course.reason') %> </p>
+  </div>
+<% end %>
+
+<% if reasons.offered_on_another_course_y_n == 'Yes' %>
+  <div class="app-rejection">
+    <h3 class="govuk-heading-s">They offered you a place on another course</h3>
+    <%= simple_format(reasons.offered_on_another_course_details) %>
+  </div>
+<% end %>
+
+<% if reasons.honesty_and_professionalism_y_n == 'Yes' %>
+  <div class="app-rejection">
+    <h3 class="govuk-heading-s">Honesty and professionalism</h3>
+    <ul class="govuk-list govuk-list--spaced">
+      <% if reasons.honesty_and_professionalism_concerns_information_false_or_inaccurate_details.present? %>
+        <li>
+
+    <%= simple_format(reasons.honesty_and_professionalism_concerns_information_false_or_inaccurate_details) %>
+        </li>
+      <% end %>
+      <% if reasons.honesty_and_professionalism_concerns_plagiarism_details.present? %>
+        <li>
+    <%= simple_format(reasons.honesty_and_professionalism_concerns_plagiarism_details) %>
+        </li>
+      <% end %>
+      <% if reasons.honesty_and_professionalism_concerns_references_details.present? %>
+        <li>
+    <%= simple_format(reasons.honesty_and_professionalism_concerns_references_details) %>
+        </li>
+      <% end %>
+      <% if reasons.honesty_and_professionalism_concerns_other_details.present? %>
+        <li>
+          <%= simple_format(reasons.honesty_and_professionalism_concerns_other_details) %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<% if reasons.safeguarding_y_n == 'Yes' %>
+  <div class="app-rejection">
+    <h3 class="govuk-heading-s">Safeguarding issues</h3>
+    <ul class="govuk-list govuk-list--spaced">
+      <% if reasons.safeguarding_concerns_candidate_disclosed_information_details.present? %>
+        <li>
+          <%= simple_format(reasons.safeguarding_concerns_candidate_disclosed_information_details) %>
+        </li>
+      <% end %>
+      <% if reasons.safeguarding_concerns_vetting_disclosed_information_details.present? %>
+        <li>
+          <%= simple_format(reasons.safeguarding_concerns_vetting_disclosed_information_details) %>
+        </li>
+      <% end %>
+      <% if reasons.safeguarding_concerns_other_details.present? %>
+        <li>
+          <%= simple_format(reasons.safeguarding_concerns_other_details) %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<% if reasons.cannot_sponsor_visa_y_n == 'Yes' %>
+  <div class="app-rejection">
+    <h3 class="govuk-heading-s"><%= I18n.t('reasons_for_rejection.cannot_sponsor_visa.title') %></h3>
+    <%= simple_format(reasons.cannot_sponsor_visa_details, class: 'govuk-body govuk-!-margin-bottom-3') %>
+  </div>
+<% end %>
+
+<% if reasons.why_are_you_rejecting_this_application.present? %>
+  <div class="app-rejection">
+    <h3 class="govuk-heading-s"><%= I18n.t('reasons_for_rejection.why_are_you_rejecting_this_application.title') %></h3>
+    <%= simple_format(reasons.why_are_you_rejecting_this_application, class: 'govuk-body govuk-!-margin-bottom-3') %>
+  </div>
+<% end %>
+
+<% if reasons.other_advice_or_feedback_y_n == 'Yes' %>
+  <div class="app-rejection">
+    <h3 class="govuk-heading-s">Additional feedback</h3>
+    <%= simple_format(reasons.other_advice_or_feedback_details, class: 'govuk-body govuk-!-margin-bottom-3') %>
+  </div>
+<% end %>
+
+<% if %w[Yes No].include?(reasons.interested_in_future_applications_y_n) %>
+  <div class="app-rejection">
+    <h3 class="govuk-heading-s">Future applications</h3>
+    <p class="govuk-body">
+      <%= I18n.t(
+        "reasons_for_rejection.interested_in_future_applications.reason.#{reasons.interested_in_future_applications_y_n.downcase}",
+        provider_name: application_choice.provider.name,
+      ) %>
+    </p>
+  </div>
+<% end %>

--- a/app/components/candidate_interface/rejection_reasons/reasons_for_rejection_component.html.erb
+++ b/app/components/candidate_interface/rejection_reasons/reasons_for_rejection_component.html.erb
@@ -26,11 +26,11 @@
         <% reasons.quality_of_application_which_parts_needed_improvement.each do |reason| %>
           <li>
             <% if reason == 'other' %>
-              <%= simple_format(reasons.quality_of_application_other_details)%>
-              <%= simple_format(reasons.quality_of_application_other_what_to_improve)%>
+              <%= simple_format(reasons.quality_of_application_other_details) %>
+              <%= simple_format(reasons.quality_of_application_other_what_to_improve) %>
             <% else %>
-              <%= simple_format(t("reasons_for_rejection.quality_of_application.#{reason}"))%>
-              <%= simple_format(reasons.send(:"quality_of_application_#{reason}_what_to_improve"))%>
+              <%= simple_format(t("reasons_for_rejection.quality_of_application.#{reason}")) %>
+              <%= simple_format(reasons.send(:"quality_of_application_#{reason}_what_to_improve")) %>
             <% end %>
           </li>
         <% end %>
@@ -47,7 +47,7 @@
         <% reasons.qualifications_which_qualifications.each do |reason| %>
           <li>
             <% if reason == 'other' %>
-              <%= simple_format(reasons.qualifications_other_details)%>
+              <%= simple_format(reasons.qualifications_other_details) %>
             <% else %>
               <p><%= t("reasons_for_rejection.qualifications_which_qualifications.#{reason}") %>.</p>
             <% end %>

--- a/app/components/candidate_interface/rejection_reasons/reasons_for_rejection_component.html.erb
+++ b/app/components/candidate_interface/rejection_reasons/reasons_for_rejection_component.html.erb
@@ -53,7 +53,7 @@
             <% end %>
           </li>
         <% end %>
-        <%= link_to_find_when_rejected_on_qualifications(application_choice) if @render_link_to_find_when_rejected_on_qualifications %>
+        <%= link_to_find_when_rejected_on_qualifications if @render_link_to_find_when_rejected_on_qualifications %>
       </ul>
     <% end %>
   </div>

--- a/app/components/candidate_interface/rejection_reasons/reasons_for_rejection_component.rb
+++ b/app/components/candidate_interface/rejection_reasons/reasons_for_rejection_component.rb
@@ -16,7 +16,7 @@ module CandidateInterface
     def link_to_find_when_rejected_on_qualifications(application_choice)
       link = govuk_link_to(
         'Find postgraduate teacher training courses',
-        "#{I18n.t('find_postgraduate_teacher_training.production_url')}course/#{application_choice.provider.code}/#{application_choice.course.code}#section-entry",
+        "#{application_choice.course.find_url}#section-entry",
       )
 
       "View the course requirements on #{link}.".html_safe

--- a/app/components/candidate_interface/rejection_reasons/reasons_for_rejection_component.rb
+++ b/app/components/candidate_interface/rejection_reasons/reasons_for_rejection_component.rb
@@ -13,10 +13,10 @@ module CandidateInterface
       @render_link_to_find_when_rejected_on_qualifications = render_link_to_find_when_rejected_on_qualifications
     end
 
-    def link_to_find_when_rejected_on_qualifications(application_choice)
+    def link_to_find_when_rejected_on_qualifications
       link = govuk_link_to(
         'Find postgraduate teacher training courses',
-        "#{application_choice.course.find_url}#section-entry",
+        "#{@application_choice.course.find_url}#section-entry",
       )
 
       "View the course requirements on #{link}.".html_safe

--- a/app/components/candidate_interface/rejection_reasons/reasons_for_rejection_component.rb
+++ b/app/components/candidate_interface/rejection_reasons/reasons_for_rejection_component.rb
@@ -1,0 +1,27 @@
+##
+# This component class supports the rendering of rejection reasons from the initial iteration of structured rejection reasons.
+# See https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/docs/reasons-for-rejection.md
+#
+class RejectionReasons::ReasonsForRejectionComponent < ViewComponent::Base
+  include ViewHelper
+
+  attr_reader :application_choice
+
+  def initialize(application_choice:, render_link_to_find_when_rejected_on_qualifications: false)
+    @application_choice = application_choice
+    @render_link_to_find_when_rejected_on_qualifications = render_link_to_find_when_rejected_on_qualifications
+  end
+
+  def link_to_find_when_rejected_on_qualifications(application_choice)
+    link = govuk_link_to(
+      'Find postgraduate teacher training courses',
+      "#{I18n.t('find_postgraduate_teacher_training.production_url')}course/#{application_choice.provider.code}/#{application_choice.course.code}#section-entry",
+    )
+
+    "View the course requirements on #{link}.".html_safe
+  end
+
+  def reasons
+    ::ReasonsForRejection.new(application_choice.structured_rejection_reasons)
+  end
+end

--- a/app/components/candidate_interface/rejection_reasons/reasons_for_rejection_component.rb
+++ b/app/components/candidate_interface/rejection_reasons/reasons_for_rejection_component.rb
@@ -2,26 +2,28 @@
 # This component class supports the rendering of rejection reasons from the initial iteration of structured rejection reasons.
 # See https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/docs/reasons-for-rejection.md
 #
-class RejectionReasons::ReasonsForRejectionComponent < ViewComponent::Base
-  include ViewHelper
+module CandidateInterface
+  class RejectionReasons::ReasonsForRejectionComponent < ViewComponent::Base
+    include ViewHelper
 
-  attr_reader :application_choice
+    attr_reader :application_choice
 
-  def initialize(application_choice:, render_link_to_find_when_rejected_on_qualifications: false)
-    @application_choice = application_choice
-    @render_link_to_find_when_rejected_on_qualifications = render_link_to_find_when_rejected_on_qualifications
-  end
+    def initialize(application_choice:, render_link_to_find_when_rejected_on_qualifications: false)
+      @application_choice = application_choice
+      @render_link_to_find_when_rejected_on_qualifications = render_link_to_find_when_rejected_on_qualifications
+    end
 
-  def link_to_find_when_rejected_on_qualifications(application_choice)
-    link = govuk_link_to(
-      'Find postgraduate teacher training courses',
-      "#{I18n.t('find_postgraduate_teacher_training.production_url')}course/#{application_choice.provider.code}/#{application_choice.course.code}#section-entry",
-    )
+    def link_to_find_when_rejected_on_qualifications(application_choice)
+      link = govuk_link_to(
+        'Find postgraduate teacher training courses',
+        "#{I18n.t('find_postgraduate_teacher_training.production_url')}course/#{application_choice.provider.code}/#{application_choice.course.code}#section-entry",
+      )
 
-    "View the course requirements on #{link}.".html_safe
-  end
+      "View the course requirements on #{link}.".html_safe
+    end
 
-  def reasons
-    ::ReasonsForRejection.new(application_choice.structured_rejection_reasons)
+    def reasons
+      ::ReasonsForRejection.new(application_choice.structured_rejection_reasons)
+    end
   end
 end

--- a/app/components/candidate_interface/rejection_reasons/rejection_reasons_component.html.erb
+++ b/app/components/candidate_interface/rejection_reasons/rejection_reasons_component.html.erb
@@ -1,4 +1,4 @@
-<% reasons.selected_reasons.each do |reason| %>
+<% reasons.each do |reason| %>
   <div class="app-rejection">
     <h3 class="govuk-heading-s"><%= reason.label %></h3>
     <% if reason.details&.text.present? %>

--- a/app/components/candidate_interface/rejection_reasons/rejection_reasons_component.html.erb
+++ b/app/components/candidate_interface/rejection_reasons/rejection_reasons_component.html.erb
@@ -22,7 +22,7 @@
       <% end %>
     <% end %>
     <% if render_link_to_find?(reason) %>
-      <p><%= link_to_find_when_rejected_on_qualifications(application_choice) %></p>
+      <p><%= link_to_find_when_rejected_on_qualifications %></p>
     <% end %>
   </div>
 <% end %>

--- a/app/components/candidate_interface/rejection_reasons/rejection_reasons_component.html.erb
+++ b/app/components/candidate_interface/rejection_reasons/rejection_reasons_component.html.erb
@@ -2,18 +2,14 @@
   <div class="app-rejection">
     <h3 class="govuk-heading-s"><%= reason.label %></h3>
     <% if reason.details&.text.present? %>
-      <% paragraphs(reason.details.text).each do |paragraph| %>
-        <p><%= paragraph %></p>
-      <% end %>
+      <%= simple_format(reason.details.text) %>
     <% elsif reason.selected_reasons.present? %>
       <ul class="govuk-list govuk-list--spaced">
         <% reason.selected_reasons.each do |nested_reason| %>
           <% if nested_reason.details %>
             <li>
               <p><%= nested_reason.label %>:</p>
-              <% paragraphs(nested_reason.details.text).each do |paragraph| %>
-                <p><%= paragraph %></p>
-              <% end %>
+              <%= simple_format(nested_reason.details.text) %>
             </li>
           <% else %>
             <li><%= nested_reason.label %></li>

--- a/app/components/candidate_interface/rejection_reasons/rejection_reasons_component.html.erb
+++ b/app/components/candidate_interface/rejection_reasons/rejection_reasons_component.html.erb
@@ -1,24 +1,28 @@
-<% reasons.each do |reason| %>
-  <div class="app-rejection">
-    <h3 class="govuk-heading-s"><%= reason.label %></h3>
-    <% if reason.details&.text.present? %>
-      <%= simple_format(reason.details.text) %>
-    <% elsif reason.selected_reasons.present? %>
-      <ul class="govuk-list govuk-list--spaced">
-        <% reason.selected_reasons.each do |nested_reason| %>
-          <% if nested_reason.details %>
-            <li>
-              <p><%= nested_reason.label %>:</p>
-              <%= simple_format(nested_reason.details.text) %>
-            </li>
-          <% else %>
-            <li><%= nested_reason.label %></li>
+<% reasons.selected_reasons.each do |reason| %>
+  <div class="app-rejection app-inset-text--narrow-border">
+    <p class="app-rejection__label govuk-body govuk-!-margin-bottom-0"><%= reason.label %>:</p>
+    <%= govuk_inset_text(classes: 'app-rejection__body govuk-!-margin-top-2') do %>
+      <% if reason.details&.text.present? %>
+        <%= simple_format(reason.details.text) %>
+      <% elsif reason.selected_reasons.present? %>
+        <ul class="govuk-list govuk-list--spaced">
+          <% reason.selected_reasons.each do |nested_reason| %>
+            <% if nested_reason.details %>
+              <li>
+                <p><%= nested_reason.label %>:</p>
+                <%= simple_format(nested_reason.details.text) %>
+              </li>
+            <% else %>
+              <li><%= nested_reason.label %></li>
+            <% end %>
           <% end %>
-        <% end %>
-      </ul>
-    <% else %>
-      <p><%= I18n.t("rejection_reasons.#{reason.id}.description") %></p>
+        </ul>
+      <% else %>
+        <p><%= I18n.t("rejection_reasons.#{reason.id}.description") %></p>
+      <% end %>
     <% end %>
-    <p><%= link_to_find_when_rejected_on_qualifications(application_choice) if render_link_to_find?(reason) %></p>
+    <% if render_link_to_find?(reason) %>
+      <p><%= link_to_find_when_rejected_on_qualifications(application_choice) %></p>
+    <% end %>
   </div>
 <% end %>

--- a/app/components/candidate_interface/rejection_reasons/rejection_reasons_component.rb
+++ b/app/components/candidate_interface/rejection_reasons/rejection_reasons_component.rb
@@ -1,6 +1,31 @@
 module CandidateInterface
   module RejectionReasons
-    class RejectionReasonsComponent < ::RejectionReasons::RejectionReasonsComponent
+    class RejectionReasonsComponent < ViewComponent::Base
+      include ViewHelper
+
+      attr_reader :application_choice
+
+      def initialize(application_choice:, render_link_to_find_when_rejected_on_qualifications: false)
+        @application_choice = application_choice
+        @render_link_to_find_when_rejected_on_qualifications = render_link_to_find_when_rejected_on_qualifications
+      end
+
+      def link_to_find_when_rejected_on_qualifications(application_choice)
+        link = govuk_link_to(
+          'Find postgraduate teacher training courses',
+          "#{application_choice.course.find_url}#section-entry",
+        )
+
+        "View the course requirements on #{link}.".html_safe
+      end
+
+      def reasons
+        ::RejectionReasons.new(application_choice.structured_rejection_reasons)
+      end
+
+      def render_link_to_find?(reason)
+        reason.id == 'qualifications' && @render_link_to_find_when_rejected_on_qualifications
+      end
     end
   end
 end

--- a/app/components/candidate_interface/rejection_reasons/rejection_reasons_component.rb
+++ b/app/components/candidate_interface/rejection_reasons/rejection_reasons_component.rb
@@ -10,10 +10,10 @@ module CandidateInterface
         @render_link_to_find_when_rejected_on_qualifications = render_link_to_find_when_rejected_on_qualifications
       end
 
-      def link_to_find_when_rejected_on_qualifications(application_choice)
+      def link_to_find_when_rejected_on_qualifications
         link = govuk_link_to(
           'Find postgraduate teacher training courses',
-          "#{application_choice.course.find_url}#section-entry",
+          "#{@application_choice.course.find_url}#section-entry",
         )
 
         "View the course requirements on #{link}.".html_safe

--- a/app/components/candidate_interface/rejections_component.rb
+++ b/app/components/candidate_interface/rejections_component.rb
@@ -23,7 +23,7 @@ module CandidateInterface
       when 'rejection_reasons', 'vendor_api_rejection_reasons'
         CandidateInterface::RejectionReasons::RejectionReasonsComponent.new(**structured_rejection_reasons_attrs)
       when 'reasons_for_rejection'
-        ::RejectionReasons::ReasonsForRejectionComponent.new(**structured_rejection_reasons_attrs)
+        CandidateInterface::RejectionReasons::ReasonsForRejectionComponent.new(**structured_rejection_reasons_attrs)
       else
         ::RejectionReasons::RejectionReasonComponent.new(application_choice:)
       end

--- a/app/components/shared/rejection_reasons/reasons_for_rejection_component.html.erb
+++ b/app/components/shared/rejection_reasons/reasons_for_rejection_component.html.erb
@@ -48,7 +48,7 @@
           <% end %>
         </li>
       <% end %>
-      <%= link_to_find_when_rejected_on_qualifications(application_choice) if @render_link_to_find_when_rejected_on_qualifications %>
+      <%= link_to_find_when_rejected_on_qualifications if @render_link_to_find_when_rejected_on_qualifications %>
     </ul>
   </div>
 <% end %>

--- a/app/components/shared/rejection_reasons/reasons_for_rejection_component.html.erb
+++ b/app/components/shared/rejection_reasons/reasons_for_rejection_component.html.erb
@@ -5,12 +5,8 @@
       <% reasons.candidate_behaviour_what_did_the_candidate_do.each do |reason| %>
         <li>
           <% if reason == 'other' %>
-            <% paragraphs(reasons.candidate_behaviour_other).each do |paragraph| %>
-              <p><%= paragraph %></p>
-            <% end %>
-            <% paragraphs(reasons.candidate_behaviour_what_to_improve).each do |paragraph| %>
-              <p><%= paragraph %></p>
-            <% end %>
+            <%= simple_format(reasons.candidate_behaviour_other) %>
+            <%= simple_format(reasons.candidate_behaviour_what_to_improve) %>
           <% else %>
             <p><%= t("reasons_for_rejection.candidate_behaviour_what_did_the_candidate_do.#{reason}") %>.</p>
           <% end %>
@@ -27,19 +23,11 @@
       <% reasons.quality_of_application_which_parts_needed_improvement.each do |reason| %>
         <li>
           <% if reason == 'other' %>
-            <% paragraphs(reasons.quality_of_application_other_details).each do |paragraph| %>
-              <p><%= paragraph %></p>
-            <% end %>
-            <% paragraphs(reasons.quality_of_application_other_what_to_improve).each do |paragraph| %>
-              <p><%= paragraph %></p>
-            <% end %>
+            <%= simple_format(reasons.quality_of_application_other_details) %>
+            <%= simple_format(reasons.quality_of_application_other_what_to_improve) %>
           <% else %>
-            <% paragraphs(t("reasons_for_rejection.quality_of_application.#{reason}")).each do |paragraph| %>
-              <p><%= paragraph %></p>
-            <% end %>
-            <% paragraphs(reasons.send(:"quality_of_application_#{reason}_what_to_improve")).each do |paragraph| %>
-              <p><%= paragraph %></p>
-            <% end %>
+            <%= simple_format(t("reasons_for_rejection.quality_of_application.#{reason}")) %>
+            <%= simple_format(reasons.send(:"quality_of_application_#{reason}_what_to_improve")) %>
           <% end %>
         </li>
       <% end %>
@@ -54,9 +42,7 @@
       <% reasons.qualifications_which_qualifications.each do |reason| %>
         <li>
           <% if reason == 'other' %>
-            <% paragraphs(reasons.qualifications_other_details).each do |paragraph| %>
-              <p><%= paragraph %></p>
-            <% end %>
+            <%= simple_format(reasons.qualifications_other_details) %>
           <% else %>
             <p><%= t("reasons_for_rejection.qualifications_which_qualifications.#{reason}") %>.</p>
           <% end %>
@@ -70,9 +56,7 @@
 <% if reasons.performance_at_interview_y_n == 'Yes' %>
   <div class="app-rejection">
     <h3 class="govuk-heading-s">Performance at interview</h3>
-    <% paragraphs(reasons.performance_at_interview_what_to_improve).each do |paragraph| %>
-      <p class="govuk-body govuk-!-margin-bottom-3"><%= paragraph %></p>
-    <% end %>
+    <%= simple_format(reasons.performance_at_interview_what_to_improve, class: 'govuk-body govuk-!-margin-bottom-3') %>
   </div>
 <% end %>
 
@@ -86,9 +70,7 @@
 <% if reasons.offered_on_another_course_y_n == 'Yes' %>
   <div class="app-rejection">
     <h3 class="govuk-heading-s">They offered you a place on another course</h3>
-    <% paragraphs(reasons.offered_on_another_course_details).each do |paragraph| %>
-      <p class="govuk-body govuk-!-margin-bottom-3"><%= paragraph %></p>
-    <% end %>
+    <%= simple_format(reasons.offered_on_another_course_details) %>
   </div>
 <% end %>
 
@@ -98,30 +80,23 @@
     <ul class="govuk-list govuk-list--spaced">
       <% if reasons.honesty_and_professionalism_concerns_information_false_or_inaccurate_details.present? %>
         <li>
-          <% paragraphs(reasons.honesty_and_professionalism_concerns_information_false_or_inaccurate_details).each do |paragraph| %>
-            <p><%= paragraph %></p>
-          <% end %>
+
+    <%= simple_format(reasons.honesty_and_professionalism_concerns_information_false_or_inaccurate_details) %>
         </li>
       <% end %>
       <% if reasons.honesty_and_professionalism_concerns_plagiarism_details.present? %>
         <li>
-          <% paragraphs(reasons.honesty_and_professionalism_concerns_plagiarism_details).each do |paragraph| %>
-            <p><%= paragraph %></p>
-          <% end %>
+    <%= simple_format(reasons.honesty_and_professionalism_concerns_plagiarism_details) %>
         </li>
       <% end %>
       <% if reasons.honesty_and_professionalism_concerns_references_details.present? %>
         <li>
-          <% paragraphs(reasons.honesty_and_professionalism_concerns_references_details).each do |paragraph| %>
-            <p><%= paragraph %></p>
-          <% end %>
+    <%= simple_format(reasons.honesty_and_professionalism_concerns_references_details) %>
         </li>
       <% end %>
       <% if reasons.honesty_and_professionalism_concerns_other_details.present? %>
         <li>
-          <% paragraphs(reasons.honesty_and_professionalism_concerns_other_details).each do |paragraph| %>
-            <p><%= paragraph %></p>
-          <% end %>
+          <%= simple_format(reasons.honesty_and_professionalism_concerns_other_details) %>
         </li>
       <% end %>
     </ul>
@@ -134,23 +109,17 @@
     <ul class="govuk-list govuk-list--spaced">
       <% if reasons.safeguarding_concerns_candidate_disclosed_information_details.present? %>
         <li>
-          <% paragraphs(reasons.safeguarding_concerns_candidate_disclosed_information_details).each do |paragraph| %>
-            <p><%= paragraph %></p>
-          <% end %>
+          <%= simple_format(reasons.safeguarding_concerns_candidate_disclosed_information_details) %>
         </li>
       <% end %>
       <% if reasons.safeguarding_concerns_vetting_disclosed_information_details.present? %>
         <li>
-          <% paragraphs(reasons.safeguarding_concerns_vetting_disclosed_information_details).each do |paragraph| %>
-            <p><%= paragraph %></p>
-          <% end %>
+          <%= simple_format(reasons.safeguarding_concerns_vetting_disclosed_information_details) %>
         </li>
       <% end %>
       <% if reasons.safeguarding_concerns_other_details.present? %>
         <li>
-          <% paragraphs(reasons.safeguarding_concerns_other_details).each do |paragraph| %>
-            <p><%= paragraph %></p>
-          <% end %>
+          <%= simple_format(reasons.safeguarding_concerns_other_details) %>
         </li>
       <% end %>
     </ul>
@@ -160,27 +129,21 @@
 <% if reasons.cannot_sponsor_visa_y_n == 'Yes' %>
   <div class="app-rejection">
     <h3 class="govuk-heading-s"><%= I18n.t('reasons_for_rejection.cannot_sponsor_visa.title') %></h3>
-    <% paragraphs(reasons.cannot_sponsor_visa_details).each do |paragraph| %>
-      <p class="govuk-body govuk-!-margin-bottom-3"><%= paragraph %></p>
-    <% end %>
+    <%= simple_format(reasons.cannot_sponsor_visa_details, class: 'govuk-body govuk-!-margin-bottom-3') %>
   </div>
 <% end %>
 
 <% if reasons.why_are_you_rejecting_this_application.present? %>
   <div class="app-rejection">
     <h3 class="govuk-heading-s"><%= I18n.t('reasons_for_rejection.why_are_you_rejecting_this_application.title') %></h3>
-    <% paragraphs(reasons.why_are_you_rejecting_this_application).each do |paragraph| %>
-      <p class="govuk-body govuk-!-margin-bottom-3"><%= paragraph %></p>
-    <% end %>
+    <%= simple_format(reasons.why_are_you_rejecting_this_application, class: 'govuk-body govuk-!-margin-bottom-3') %>
   </div>
 <% end %>
 
 <% if reasons.other_advice_or_feedback_y_n == 'Yes' %>
   <div class="app-rejection">
     <h3 class="govuk-heading-s">Additional feedback</h3>
-    <% paragraphs(reasons.other_advice_or_feedback_details).each do |paragraph| %>
-      <p class="govuk-body govuk-!-margin-bottom-3"><%= paragraph %></p>
-    <% end %>
+    <%= simple_format(reasons.other_advice_or_feedback_details, class: 'govuk-body govuk-!-margin-bottom-3') %>
   </div>
 <% end %>
 

--- a/app/components/shared/rejection_reasons/reasons_for_rejection_component.rb
+++ b/app/components/shared/rejection_reasons/reasons_for_rejection_component.rb
@@ -12,12 +12,6 @@ class RejectionReasons::ReasonsForRejectionComponent < ViewComponent::Base
     @render_link_to_find_when_rejected_on_qualifications = render_link_to_find_when_rejected_on_qualifications
   end
 
-  def paragraphs(input)
-    return [] if input.blank?
-
-    input.split("\r\n")
-  end
-
   def link_to_find_when_rejected_on_qualifications(application_choice)
     link = govuk_link_to(
       'Find postgraduate teacher training courses',

--- a/app/components/shared/rejection_reasons/reasons_for_rejection_component.rb
+++ b/app/components/shared/rejection_reasons/reasons_for_rejection_component.rb
@@ -15,7 +15,7 @@ class RejectionReasons::ReasonsForRejectionComponent < ViewComponent::Base
   def link_to_find_when_rejected_on_qualifications(application_choice)
     link = govuk_link_to(
       'Find postgraduate teacher training courses',
-      "#{I18n.t('find_postgraduate_teacher_training.production_url')}course/#{application_choice.provider.code}/#{application_choice.course.code}#section-entry",
+      "#{application_choice.course.find_url}#section-entry",
     )
 
     "View the course requirements on #{link}.".html_safe

--- a/app/components/shared/rejection_reasons/reasons_for_rejection_component.rb
+++ b/app/components/shared/rejection_reasons/reasons_for_rejection_component.rb
@@ -12,10 +12,10 @@ class RejectionReasons::ReasonsForRejectionComponent < ViewComponent::Base
     @render_link_to_find_when_rejected_on_qualifications = render_link_to_find_when_rejected_on_qualifications
   end
 
-  def link_to_find_when_rejected_on_qualifications(application_choice)
+  def link_to_find_when_rejected_on_qualifications
     link = govuk_link_to(
       'Find postgraduate teacher training courses',
-      "#{application_choice.course.find_url}#section-entry",
+      "#{@application_choice.course.find_url}#section-entry",
     )
 
     "View the course requirements on #{link}.".html_safe

--- a/app/components/shared/rejection_reasons/rejection_reasons_component.html.erb
+++ b/app/components/shared/rejection_reasons/rejection_reasons_component.html.erb
@@ -1,5 +1,5 @@
 <dl class="govuk-summary-list">
-  <% reasons.selected_reasons.each do |reason| %>
+  <% reasons.each do |reason| %>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key"><%= reason.label %></dt>
       <dd class="govuk-summary-list__value">

--- a/app/components/shared/rejection_reasons/rejection_reasons_component.html.erb
+++ b/app/components/shared/rejection_reasons/rejection_reasons_component.html.erb
@@ -4,18 +4,14 @@
       <dt class="govuk-summary-list__key"><%= reason.label %></dt>
       <dd class="govuk-summary-list__value">
         <% if reason.details&.text.present? %>
-          <% paragraphs(reason.details.text).each do |paragraph| %>
-            <p><%= paragraph %></p>
-          <% end %>
+          <%= simple_format(reason.details.text) %>
         <% elsif reason.selected_reasons.present? %>
           <ul class="govuk-list govuk-list--spaced">
             <% reason.selected_reasons.each do |nested_reason| %>
               <% if nested_reason.details %>
                 <li>
                   <p><%= nested_reason.label %>:</p>
-                  <% paragraphs(nested_reason.details.text).each do |paragraph| %>
-                    <p><%= paragraph %></p>
-                  <% end %>
+                  <%= simple_format(nested_reason.details.text) %>
                 </li>
               <% else %>
                 <li><%= nested_reason.label %></li>

--- a/app/components/shared/rejection_reasons/rejection_reasons_component.html.erb
+++ b/app/components/shared/rejection_reasons/rejection_reasons_component.html.erb
@@ -21,7 +21,7 @@
         <% else %>
           <p><%= I18n.t("rejection_reasons.#{reason.id}.description") %></p>
         <% end %>
-        <%= link_to_find_when_rejected_on_qualifications(application_choice) if render_link_to_find?(reason) %>
+        <%= link_to_find_when_rejected_on_qualifications if render_link_to_find?(reason) %>
       </dd>
       <% if editable? %>
         <dd class="govuk-summary-list__actions">

--- a/app/components/shared/rejection_reasons/rejection_reasons_component.rb
+++ b/app/components/shared/rejection_reasons/rejection_reasons_component.rb
@@ -27,7 +27,7 @@ class RejectionReasons::RejectionReasonsComponent < ViewComponent::Base
   end
 
   def reasons
-    ::RejectionReasons.new(application_choice.structured_rejection_reasons)
+    ::RejectionReasons.new(application_choice.structured_rejection_reasons).selected_reasons
   end
 
   def render_link_to_find?(reason)

--- a/app/components/shared/rejection_reasons/rejection_reasons_component.rb
+++ b/app/components/shared/rejection_reasons/rejection_reasons_component.rb
@@ -13,10 +13,10 @@ class RejectionReasons::RejectionReasonsComponent < ViewComponent::Base
     @editable = editable
   end
 
-  def link_to_find_when_rejected_on_qualifications(application_choice)
+  def link_to_find_when_rejected_on_qualifications
     link = govuk_link_to(
       'Find postgraduate teacher training courses',
-      "#{application_choice.course.find_url}#section-entry",
+      "#{@application_choice.course.find_url}#section-entry",
     )
 
     "View the course requirements on #{link}.".html_safe

--- a/app/components/shared/rejection_reasons/rejection_reasons_component.rb
+++ b/app/components/shared/rejection_reasons/rejection_reasons_component.rb
@@ -13,12 +13,6 @@ class RejectionReasons::RejectionReasonsComponent < ViewComponent::Base
     @editable = editable
   end
 
-  def paragraphs(input)
-    return [] if input.blank?
-
-    input.split("\r\n")
-  end
-
   def link_to_find_when_rejected_on_qualifications(application_choice)
     link = govuk_link_to(
       'Find postgraduate teacher training courses',

--- a/app/components/shared/rejection_reasons/rejection_reasons_component.rb
+++ b/app/components/shared/rejection_reasons/rejection_reasons_component.rb
@@ -16,7 +16,7 @@ class RejectionReasons::RejectionReasonsComponent < ViewComponent::Base
   def link_to_find_when_rejected_on_qualifications(application_choice)
     link = govuk_link_to(
       'Find postgraduate teacher training courses',
-      "#{I18n.t('find_postgraduate_teacher_training.production_url')}course/#{application_choice.provider.code}/#{application_choice.course.code}#section-entry",
+      "#{application_choice.course.find_url}#section-entry",
     )
 
     "View the course requirements on #{link}.".html_safe

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -181,6 +181,17 @@ class Course < ApplicationRecord
     course_options.available.pluck(:site_id).uniq.many?
   end
 
+  def qualifications_to_s
+    return '' if qualifications.blank?
+
+    case qualifications.sort
+    in ['pgce', 'qts'] then 'PGCE with QTS'
+    in ['pgde', 'qts'] then 'PGDE with QTS'
+    else
+      qualifications.first.upcase
+    end
+  end
+
 private
 
   def touch_application_choices_and_forms

--- a/app/models/rejection_reasons.rb
+++ b/app/models/rejection_reasons.rb
@@ -14,17 +14,17 @@ class RejectionReasons
 
   class << self
     def from_config(config: configuration)
-      instance = new
-      instance.reasons = config[:reasons].map { |rattrs| Reason.new(rattrs) }
-      instance
+      new.tap do |instance|
+        instance.reasons = config[:reasons].map { |rattrs| Reason.new(rattrs) }
+      end
     end
 
     def inflate(model)
-      instance = new
-      instance.selected_reasons = from_config.reasons.dup
+      new.tap do |instance|
+        instance.selected_reasons = from_config.reasons.dup
         .select { |r| model.send(:selected_reasons)&.include?(r.id) }
         .map { |reason| reason.inflate(model) }
-      instance
+      end
     end
 
     def configuration
@@ -41,7 +41,7 @@ class RejectionReasons
 
     super(attrs)
 
-    @selected_reasons = attrs[:selected_reasons].map { |rattrs| Reason.new(rattrs) } if attrs.key?(:selected_reasons)
+    @selected_reasons = attrs[:selected_reasons]&.map { |rattrs| Reason.new(rattrs) }
   end
 
   def find(identifier)

--- a/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
+++ b/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
@@ -26,6 +26,10 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
       expect(links).to include(application_choice.current_course.name_and_code)
     end
 
+    it 'shows the course qualifications' do
+      expect(result.text).to include("Qualifications#{course.qualifications.map(&:upcase).to_sentence}")
+    end
+
     it 'does not show the application number' do
       expect(result.text).not_to include('Application number')
     end
@@ -76,6 +80,10 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
 
     it 'shows the application number' do
       expect(result.text).to include("Application number#{application_choice.id}")
+    end
+
+    it 'shows the course qualifications' do
+      expect(result.text).to include("Qualifications#{course.qualifications.map(&:upcase).to_sentence}")
     end
 
     it 'shows the duration since submitted' do

--- a/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
+++ b/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
       expect(links).to include("Change course for #{application_choice.current_course.name_and_code}")
     end
 
+    it 'does not show the application number' do
+      expect(result.text).not_to include('Application number')
+    end
+
     it 'does not show the personal statement' do
       expect(result.text).not_to include(personal_statement)
     end
@@ -66,6 +70,10 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
       expect(result.text).to include(personal_statement)
     end
 
+    it 'shows the application number' do
+      expect(result.text).to include("Application number#{application_choice.id}")
+    end
+
     context 'when course has multiple study modes' do
       before do
         create(
@@ -94,6 +102,7 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
       it 'does not show change links' do
         expect(result.css('a')).to be_empty
       end
+
     end
   end
 end

--- a/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
+++ b/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
     end
 
     it 'shows the course qualifications' do
-      expect(result.text).to include("Qualifications#{course.qualifications.map(&:upcase).to_sentence}")
+      expect(result.text).to include("Qualifications#{course.qualifications_to_s}")
     end
 
     it 'does not show the application number' do
@@ -122,7 +122,7 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
     end
 
     it 'shows the course qualifications' do
-      expect(result.text).to include("Qualifications#{course.qualifications.map(&:upcase).to_sentence}")
+      expect(result.text).to include("Qualifications#{course.qualifications_to_s}")
     end
 
     it 'shows the duration since submitted' do

--- a/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
+++ b/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
@@ -69,6 +69,10 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
       expect(result.text).to include("Qualifications#{course.qualifications_to_s}")
     end
 
+    it 'does not show the interview row' do
+      expect(result.text).not_to include('Interview')
+    end
+
     it 'does not show the application number' do
       expect(result.text).not_to include('Application number')
     end
@@ -111,6 +115,10 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
   context 'when application is submitted' do
     it_behaves_like 'course length row'
 
+    it 'shows the application status' do
+      expect(result.text).to include('StatusAwaiting decision')
+    end
+
     it 'does not show change links' do
       expect(result.css('govuk-summary-list__actions a')).to be_empty
     end
@@ -141,6 +149,10 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
       expect(result).to have_content("Personal statement\n#{personal_statement}")
     end
 
+    it 'does not show the interview row' do
+      expect(result.text).not_to include('Interview')
+    end
+
     context 'when course has multiple study modes' do
       before do
         create(
@@ -169,6 +181,16 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
       it 'does not show change links' do
         expect(result.css('govuk-summary-list__actions a')).to be_empty
       end
+    end
+  end
+
+  context 'when application is interviewing' do
+    let(:application_choice) do
+      create(:application_choice, :interviewing, interviews: [create(:interview)])
+    end
+
+    it 'shows interview row' do
+      expect(result.text).to include('InterviewYou have an interview scheduled')
     end
   end
 end

--- a/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
+++ b/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
@@ -49,8 +49,10 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
   let(:personal_statement) { 'some personal statement' }
 
   context 'when application is unsubmitted' do
+    let(:application_form) { create(:application_form, becoming_a_teacher:) }
+    let(:becoming_a_teacher) { 'becoming a teacher' }
     let(:application_choice) do
-      create(:application_choice, :unsubmitted, personal_statement:, course:)
+      create(:application_choice, :unsubmitted, personal_statement:, course:, application_form:)
     end
 
     it_behaves_like 'course length row'
@@ -71,8 +73,8 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
       expect(result.text).not_to include('Application number')
     end
 
-    it 'does not show the personal statement' do
-      expect(result.text).not_to include(personal_statement)
+    it 'shows the application forms becoming_a_teacher as the personal statement' do
+      expect(result.text).to include("Personal statement#{becoming_a_teacher}")
     end
 
     context 'when course has multiple study modes' do
@@ -133,6 +135,10 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
 
     it 'shows link to course on find' do
       expect(links).to include(application_choice.current_course.name_and_code)
+    end
+
+    it 'shows the personal statement' do
+      expect(result).to have_content("Personal statement\n#{personal_statement}")
     end
 
     context 'when course has multiple study modes' do

--- a/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
+++ b/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
   end
 
   let(:application_choice) do
-    create(:application_choice, :awaiting_provider_decision, personal_statement:)
+    create(:application_choice, :awaiting_provider_decision, personal_statement:, sent_to_provider_at: 1.week.ago)
   end
   let(:course) { application_choice.current_course }
   let(:provider) { application_choice.current_provider }
@@ -74,6 +74,12 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
       expect(result.text).to include("Application number#{application_choice.id}")
     end
 
+    it 'shows the duration since submitted' do
+      travel_temporarily_to('1 January 2024') do
+        expect(result.text).to include('Application submitted25 December 2023 at 12am (midnight) (7 days ago)')
+      end
+    end
+
     context 'when course has multiple study modes' do
       before do
         create(
@@ -102,7 +108,6 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
       it 'does not show change links' do
         expect(result.css('a')).to be_empty
       end
-
     end
   end
 end

--- a/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
+++ b/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
       expect(links).to include("Change course for #{application_choice.current_course.name_and_code}")
     end
 
+    it 'shows link to course on find' do
+      expect(links).to include(application_choice.current_course.name_and_code)
+    end
+
     it 'does not show the application number' do
       expect(result.text).not_to include('Application number')
     end
@@ -78,6 +82,10 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
       travel_temporarily_to('1 January 2024') do
         expect(result.text).to include('Application submitted25 December 2023 at 12am (midnight) (7 days ago)')
       end
+    end
+
+    it 'shows link to course on find' do
+      expect(links).to include(application_choice.current_course.name_and_code)
     end
 
     context 'when course has multiple study modes' do

--- a/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
+++ b/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
@@ -193,4 +193,14 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
       expect(result.text).to include('InterviewYou have an interview scheduled')
     end
   end
+
+  context 'when application is rejected' do
+    let(:application_choice) do
+      create(:application_choice, :rejected_reasons)
+    end
+
+    it 'shows reasons for rejection row' do
+      expect(result.text).to include('Reasons for rejection')
+    end
+  end
 end

--- a/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
+++ b/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
 
   context 'when application is submitted' do
     it 'does not show change links' do
-      expect(result.css('a')).to be_empty
+      expect(result.css('govuk-summary-list__actions a')).to be_empty
     end
 
     it 'shows personal statement' do
@@ -103,7 +103,7 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
       end
 
       it 'does not show change links' do
-        expect(result.css('a')).to be_empty
+        expect(result.css('govuk-summary-list__actions a')).to be_empty
       end
     end
 
@@ -114,7 +114,7 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
       end
 
       it 'does not show change links' do
-        expect(result.css('a')).to be_empty
+        expect(result.css('govuk-summary-list__actions a')).to be_empty
       end
     end
   end

--- a/spec/components/candidate_interface/continuous_applications/interview_summary_component_spec.rb
+++ b/spec/components/candidate_interface/continuous_applications/interview_summary_component_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::ContinuousApplications::InterviewSummaryComponent do
+  let(:interview) { create(:interview) }
+
+  subject(:component) do
+    render_inline(described_class.new(interview:))
+  end
+
+  it 'displays the date and time of the interview' do
+    expect(component.text).to include("You have an interview scheduled for #{interview.date_and_time.to_fs(:govuk_date)} at #{interview.date_and_time.to_fs(:govuk_time)}.")
+  end
+
+  context 'when there is no location or details' do
+    let(:interview) { create(:interview, additional_details: nil, location: nil) }
+
+    it 'does not show extra information' do
+      expect(component.text).not_to include('Information from provider:')
+    end
+  end
+
+  context 'when there is a location' do
+    let(:interview) { create(:interview, additional_details: nil, location: '123 Fake Street') }
+
+    it 'shows the location in inset text' do
+      expect(component).to have_content('Information from provider:')
+      expect(component.css('.govuk-inset-text')).to have_content('123 Fake Street')
+    end
+  end
+
+  context 'when there is a details' do
+    let(:interview) { create(:interview, additional_details: 'Bring your CV', location: nil) }
+
+    it 'shows the details in inset text' do
+      expect(component).to have_content('Information from provider:')
+      expect(component.css('.govuk-inset-text')).to have_content('Bring your CV')
+    end
+  end
+end

--- a/spec/components/candidate_interface/rejection_reasons/reasons_for_rejection_component_spec.rb
+++ b/spec/components/candidate_interface/rejection_reasons/reasons_for_rejection_component_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::RejectionReasons::ReasonsForRejectionComponent do
+  describe 'rendered component' do
+    let(:provider) { build_stubbed(:provider, name: 'The University of Metal') }
+    let(:course) { build_stubbed(:course, provider:) }
+    let(:application_choice) { build_stubbed(:application_choice, structured_rejection_reasons:) }
+    let(:future_applications) { 'Yes' }
+    let(:structured_rejection_reasons) do
+      {
+        candidate_behaviour_y_n: 'Yes',
+        candidate_behaviour_what_did_the_candidate_do: %w[other didnt_reply_to_interview_offer],
+        candidate_behaviour_other: 'Shouted a lot',
+        candidate_behaviour_what_to_improve: 'Speak calmly',
+        quality_of_application_y_n: 'Yes',
+        quality_of_application_which_parts_needed_improvement: %w[personal_statement subject_knowledge],
+        quality_of_application_personal_statement_what_to_improve: 'Do not refer to yourself in the third person',
+        quality_of_application_subject_knowledge_what_to_improve: 'Write in the first person',
+        qualifications_y_n: 'Yes',
+        qualifications_which_qualifications: %w[no_english_gcse no_science_gcse no_degree],
+        performance_at_interview_y_n: 'Yes',
+        performance_at_interview_what_to_improve: 'There was no need to do all those pressups',
+        course_full_y_n: 'No',
+        offered_on_another_course_y_n: 'Yes',
+        offered_on_another_course_details: 'We felt you would be better suited to Mathematics',
+        honesty_and_professionalism_y_n: 'No',
+        safeguarding_y_n: 'No',
+        cannot_sponsor_visa_y_n: 'No',
+        other_advice_or_feedback_y_n: 'Yes',
+        other_advice_or_feedback_details: 'That zoom background...',
+        interested_in_future_applications_y_n: future_applications,
+      }
+    end
+
+    before do
+      allow(application_choice).to receive_messages(provider: provider, course: course)
+    end
+
+    it 'renders rejection reason answers under headings' do
+      result = render_inline(described_class.new(application_choice:))
+      html = result.to_html
+
+      expect(result.css('.govuk-body.app-rejection__label').text).to include('Something you did:')
+      expect(html).to include('Didn’t reply to our interview offer')
+      expect(html).to include('Shouted a lot')
+      expect(html).to include('Speak calmly')
+
+      expect(result.css('.govuk-body.app-rejection__label').text).to include('Quality of application:')
+      expect(html).to include('Do not refer to yourself in the third person')
+      expect(html).to include('Write in the first person')
+
+      expect(result.css('.govuk-body.app-rejection__label').text).to include('Qualifications:')
+      expect(html).to include('No English GCSE grade 4 (C) or above, or valid equivalent')
+      expect(html).to include('No Science GCSE grade 4 (C) or above, or valid equivalent (for primary applicants)')
+      expect(html).to include('No degree')
+      expect(html).not_to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course_option.course.code}#section-entry")
+
+      expect(result.css('.govuk-body.app-rejection__label').text).to include('Performance at interview:')
+      expect(html).to include('There was no need to do all those pressups')
+
+      expect(result.css('.govuk-body.app-rejection__label').text).to include('They offered you a place on another course:')
+      expect(html).to include('We felt you would be better suited to Mathematics')
+
+      expect(result.css('.govuk-body.app-rejection__label').text).to include('Additional feedback')
+      expect(html).to include('That zoom background...')
+
+      expect(result.css('.govuk-body.app-rejection__label').text).to include('Future applications:')
+      expect(html).to include('The University of Metal would be interested in future applications from you.')
+    end
+
+    it 'renders link to course requirements when rejected on qualifications is true' do
+      result = render_inline(described_class.new(application_choice:, render_link_to_find_when_rejected_on_qualifications: true))
+      html = result.to_html
+
+      expect(result.css('.govuk-body.app-rejection__label').text).to include('Qualifications:')
+      expect(html).to include('No English GCSE grade 4 (C) or above, or valid equivalent')
+      expect(html).to include('No Science GCSE grade 4 (C) or above, or valid equivalent (for primary applicants)')
+      expect(html).to include('No degree')
+      expect(html).to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course.code}#section-entry")
+    end
+
+    context 'when future applications question is not given' do
+      let(:future_applications) { nil }
+
+      it 'does not render the answer' do
+        result = render_inline(described_class.new(application_choice:))
+
+        expect(result.css('.govuk-body.app-rejection__label').text).not_to include('Future applications:')
+      end
+    end
+  end
+end

--- a/spec/components/candidate_interface/rejection_reasons/rejection_reasons_component_spec.rb
+++ b/spec/components/candidate_interface/rejection_reasons/rejection_reasons_component_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::RejectionReasons::RejectionReasonsComponent do
+  describe 'rendered component' do
+    let(:provider) { build_stubbed(:provider, name: 'The University of Metal') }
+    let(:application_choice) { build_stubbed(:application_choice, structured_rejection_reasons:) }
+    let(:structured_rejection_reasons) do
+      { selected_reasons: [
+        { id: 'qualifications', label: 'Qualifications', selected_reasons: [
+          { id: 'no_maths_gcse', label: 'No maths GCSE at minimum grade 4 or C, or equivalent.' },
+          { id: 'no_english_gcse', label: 'No English GCSE at minimum grade 4 or C, or equivalent.' },
+          { id: 'no_science_gcse', label: 'No science GCSE at minimum grade 4 or C, or equivalent.' },
+          {
+            id: 'unsuitable_degree',
+            label: 'Degree does not meet course requirements',
+            details: {
+              id: 'unsuitable_degree_details',
+              label: 'Details',
+              text: 'A degree in falconry is no use.',
+            },
+          },
+        ] },
+        {
+          id: 'references',
+          label: 'References',
+          details: {
+            id: 'references_details',
+            label: 'Details',
+            text: 'A close family member, suchas your mother, cannot give a reference.',
+          },
+        },
+        { id: 'course_full', label: 'Course full', details: { id: 'course_full_details' } },
+        {
+          id: 'other',
+          label: 'Other',
+          details: {
+            id: 'other_details',
+            label: 'Details',
+            text: 'Here are some additional details',
+          },
+        },
+      ] }
+    end
+
+    before { allow(application_choice).to receive(:provider).and_return(provider) }
+
+    it 'renders rejection reasons as a summary list' do
+      result = render_inline(described_class.new(application_choice:))
+
+      expect(result.css('.app-rejection__label').map(&:text)).to eq([
+        'Qualifications:',
+        'References:',
+        'Course full:',
+        'Other:',
+      ])
+      expect(result.css('.app-rejection__body ul li').text).to include(
+        'No maths GCSE at minimum grade 4 or C, or equivalent.',
+        'No English GCSE at minimum grade 4 or C, or equivalent.',
+        'No science GCSE at minimum grade 4 or C, or equivalent.',
+      )
+      expect(result.css('.app-rejection__body ul li p').map(&:text).map(&:strip)).to eq([
+        'Degree does not meet course requirements:',
+        'A degree in falconry is no use.',
+      ])
+      expect(result.css('.app-rejection__body p').text).to include(
+        'A close family member, suchas your mother, cannot give a reference.',
+        'The course is full.',
+        'Here are some additional details',
+      )
+    end
+
+    it 'renders a link to find for qualifications' do
+      provider = build_stubbed(:provider)
+      course = build_stubbed(:course)
+      allow(application_choice).to receive_messages(course: course)
+      allow(course).to receive_messages(provider: provider)
+
+      result = render_inline(
+        described_class.new(
+          application_choice:,
+          render_link_to_find_when_rejected_on_qualifications: true,
+        ),
+      )
+
+      expect(result.css('.app-rejection__label').first.text).to eq('Qualifications:')
+      expect(result.css('.app-rejection').first.css('p').last.text).to include('View the course requirements on Find postgraduate teacher training courses')
+
+      expect(result.css('.govuk-link').size).to eq(1)
+      link_element = result.css('.app-rejection').first.css('.govuk-link').first
+      expect(link_element[:href]).to eq("#{course.find_url}#section-entry")
+      expect(link_element.text).to eq('Find postgraduate teacher training courses')
+    end
+  end
+end

--- a/spec/components/candidate_interface/rejections_component_spec.rb
+++ b/spec/components/candidate_interface/rejections_component_spec.rb
@@ -22,13 +22,12 @@ RSpec.describe CandidateInterface::RejectionsComponent do
     end
 
     it 'renders a link to find when rejected on qualifications' do
-      provider = build_stubbed(:provider)
       course = build_stubbed(:course)
-      allow(application_choice).to receive_messages(provider: provider, course: course)
+      allow(application_choice).to receive_messages(course: course)
 
       result = render_inline(described_class.new(application_choice:, render_link_to_find_when_rejected_on_qualifications: true))
       expect(result.text).to include('View the course requirements on')
-      expect(result.css('.govuk-link')[0][:href]).to eq("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{provider.code}/#{course.code}#section-entry")
+      expect(result.css('.govuk-link')[0][:href]).to eq("#{course.find_url}#section-entry")
       expect(result.css('.govuk-link')[0].text).to eq('Find postgraduate teacher training courses')
     end
   end

--- a/spec/components/candidate_interface/rejections_component_spec.rb
+++ b/spec/components/candidate_interface/rejections_component_spec.rb
@@ -48,13 +48,12 @@ RSpec.describe CandidateInterface::RejectionsComponent do
     end
 
     it 'renders a link to find when rejected on qualifications' do
-      provider = build_stubbed(:provider)
       course = build_stubbed(:course)
-      allow(application_choice).to receive_messages(provider: provider, course: course)
+      allow(application_choice).to receive_messages(course: course)
 
       result = render_inline(described_class.new(application_choice:, render_link_to_find_when_rejected_on_qualifications: true))
       expect(result.text).to include('View the course requirements on')
-      expect(result.css('.govuk-link')[0][:href]).to eq("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{provider.code}/#{course.code}#section-entry")
+      expect(result.css('.govuk-link')[0][:href]).to eq("#{course.find_url}#section-entry")
       expect(result.css('.govuk-link')[0].text).to eq('Find postgraduate teacher training courses')
     end
   end
@@ -73,13 +72,12 @@ RSpec.describe CandidateInterface::RejectionsComponent do
     end
 
     it 'renders a link to find when rejected on qualifications' do
-      provider = build_stubbed(:provider)
       course = build_stubbed(:course)
-      allow(application_choice).to receive_messages(provider: provider, course: course)
+      allow(application_choice).to receive_messages(course: course)
 
       result = render_inline(described_class.new(application_choice:, render_link_to_find_when_rejected_on_qualifications: true))
       expect(result.text).to include('View the course requirements on')
-      expect(result.css('.govuk-link')[0][:href]).to eq("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{provider.code}/#{course.code}#section-entry")
+      expect(result.css('.govuk-link')[0][:href]).to eq("#{course.find_url}#section-entry")
       expect(result.css('.govuk-link')[0].text).to eq('Find postgraduate teacher training courses')
     end
   end

--- a/spec/components/shared/rejection_reasons/rejection_reasons_component_spec.rb
+++ b/spec/components/shared/rejection_reasons/rejection_reasons_component_spec.rb
@@ -69,9 +69,8 @@ RSpec.describe RejectionReasons::RejectionReasonsComponent do
     end
 
     it 'renders a link to find for qualifications' do
-      provider = build_stubbed(:provider)
       course = build_stubbed(:course)
-      allow(application_choice).to receive_messages(provider: provider, course: course)
+      allow(application_choice).to receive_messages(course: course)
 
       result = render_inline(
         described_class.new(
@@ -85,7 +84,7 @@ RSpec.describe RejectionReasons::RejectionReasonsComponent do
 
       expect(result.css('.govuk-link').size).to eq(1)
       link_element = result.css('.govuk-summary-list__value').first.css('.govuk-link').first
-      expect(link_element[:href]).to eq("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{provider.code}/#{course.code}#section-entry")
+      expect(link_element[:href]).to eq("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{course.provider.code}/#{course.code}#section-entry")
       expect(link_element.text).to eq('Find postgraduate teacher training courses')
     end
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -158,6 +158,42 @@ RSpec.describe Course do
     end
   end
 
+  describe 'qualificaitons_to_s' do
+    subject { course.qualifications_to_s }
+
+    let(:course) { build(:course, qualifications:) }
+
+    context 'when nil' do
+      let(:qualifications) { nil }
+
+      it { is_expected.to eq('') }
+    end
+
+    context 'when [qts pgce]' do
+      let(:qualifications) { %w[qts pgce] }
+
+      it { is_expected.to eq('PGCE with QTS') }
+    end
+
+    context 'when [qts pgde]' do
+      let(:qualifications) { %w[qts pgde] }
+
+      it { is_expected.to eq('PGDE with QTS') }
+    end
+
+    context 'when [qts]' do
+      let(:qualifications) { %w[qts] }
+
+      it { is_expected.to eq('QTS') }
+    end
+
+    context 'when [pgce]' do
+      let(:qualifications) { %w[pgce] }
+
+      it { is_expected.to eq('PGCE') }
+    end
+  end
+
   describe '#ske_graduation_cutoff_date' do
     let(:course) { build(:course, start_date: Date.new(2023, 1, 1)) }
 


### PR DESCRIPTION
## Context

This is the first part of a significant redesign of the Candidates "Your applications" tab content, and the ApplicationSummaryComponent that shows a single application view.

A very challenging part of this task is to update parts of the application UI specific only to the areas specified in the ticket. This is difficult because the ViewComponents are being used in helpers and included in various contexts that are hard to track.

The approach taken here was to enthusiastically copy contents of Components into `CandidateInterface` namespace and remove as much inheritance as possible.



## Changes proposed in this pull request

Expand the rows visible to the Candidate when they "View Application" from the "Your applications" page.

 - Add 
   - Application number
   - Course length
   - Application submitted (relative time)
   - Course Link to Find
   - Interview
   - Qualifications
 - Alter
   - Move Personal Statement inline to table
   - Redesign "Feedback" to "Reasons for rejection" with inset text
   
I did not update the design of the "Feedback helpful?" component. This can be done in a later part of the updates.
## Guidance to review

**Guidance required regarding loading interview details:**

Under what circumstances should an interview be loaded? Should it be the last interview?

### Rejection Reasons
**PreContinuous apps:**
V1 & V2 : https://apply-review-9034.test.teacherservices.cloud/support/applications/1

V3 : https://apply-review-9034.test.teacherservices.cloud/support/applications/10

**PostContinuous Apps:**
V1 & V3 : https://apply-review-9034.test.teacherservices.cloud/support/applications/38


<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

[Trello Ticket](https://trello.com/c/6INKA4mE/1170-apply-summary-list-improvements-on-application-page-part-1)

## Screenshots
### View Application - main
|Before|After|
|---|---|
|![Screenshot from 2024-01-29 14-27-52](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/f3ac082a-67e7-4cfe-b1ed-202b15346483)|![Screenshot from 2024-01-29 14-28-10](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/a84fd64b-6eb2-444a-9cbf-06208cedc94a)|

### View Application - rejection reasons
|Rejection Reasons|Rejection Reason| Reasons for Rejection (pre-continuous applciations)|
|---|---|---|
|![Screenshot from 2024-01-29 14-30-53](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/3dc5b57f-63b9-4672-afac-da389602ad6b)|![Screenshot from 2024-01-29 14-33-30](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/9f53b3b1-3f4e-401a-a8db-e8805538b42c)|![Screenshot from 2024-01-29 14-34-38](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/74b1774c-7c70-4cb9-a637-c68a944e6e52)|

### Qualifications
![Screenshot from 2024-01-30 10-28-49](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/32da8124-c213-4d42-a3f5-d5a16892e005)



### Interview
|With just details or location|With location and details|With neither location or details|
|---|---|---|
|![Screenshot from 2024-02-01 12-50-41](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/6c9dc278-51fd-4263-a1d0-b370e317c05f)|![Screenshot from 2024-02-01 12-49-41](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/fd608b35-99fd-4106-a2de-87e43f3b7faf)|![Screenshot from 2024-02-01 12-52-13](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/27785d06-be2e-4b93-8e97-c2233dfa13d7)|

