### PR TITLE
Prevent error triggered when the course has no availability

### DIFF
--- a/app/controllers/candidate_interface/continuous_applications/course_choices/concerns/full_course_redirect.rb
+++ b/app/controllers/candidate_interface/continuous_applications/course_choices/concerns/full_course_redirect.rb
@@ -1,0 +1,24 @@
+module CandidateInterface
+  module ContinuousApplications
+    module CourseChoices
+      module Concerns
+        module FullCourseRedirect
+          extend ActiveSupport::Concern
+
+          included do
+            before_action :redirect_full
+          end
+
+        private
+
+          def redirect_full
+            course = Course.find(params[:course_id])
+            return if course.available?
+
+            redirect_to candidate_interface_continuous_applications_full_course_selection_path(course.provider_id, course.id)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/candidate_interface/continuous_applications/course_choices/find_course_selection_controller.rb
+++ b/app/controllers/candidate_interface/continuous_applications/course_choices/find_course_selection_controller.rb
@@ -3,6 +3,7 @@ module CandidateInterface
     module CourseChoices
       class FindCourseSelectionController < BaseController
         include Concerns::DuplicateCourseRedirect
+        include Concerns::FullCourseRedirect
 
       private
 

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_only_open_on_apply_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_only_open_on_apply_spec.rb
@@ -12,6 +12,11 @@ RSpec.feature 'Candidate arrives from Find with provider and course params', :co
     given_i_am_signed_in
 
     when_i_follow_a_link_from_find
+    then_i_am_redirected_to_the_full_course_path
+
+    given_there_are_courses_available
+
+    when_i_follow_a_link_from_find
     then_i_am_redirected_to_the_course_confirm_selection_page
 
     when_i_confirm_the_course
@@ -21,6 +26,9 @@ RSpec.feature 'Candidate arrives from Find with provider and course params', :co
   def given_there_is_a_provider_with_a_course_that_is_only_accepting_applications_on_apply
     @provider = create(:provider, code: '8N5', name: 'Snape University')
     @course = create(:course, :open_on_apply, name: 'Potions', provider: @provider, recruitment_cycle_year: 2024)
+  end
+
+  def given_there_are_courses_available
     create(:course_option, course: @course)
   end
 
@@ -40,6 +48,13 @@ RSpec.feature 'Candidate arrives from Find with provider and course params', :co
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
+  end
+
+  def then_i_am_redirected_to_the_full_course_path
+    expect(page).to have_current_path candidate_interface_continuous_applications_full_course_selection_path(
+      @provider.id,
+      @course.id,
+    )
   end
 
   def then_i_am_redirected_to_the_course_confirm_selection_page


### PR DESCRIPTION
![](https://github.trello.services/images/mini-trello-icon.png) [Bug: Course selection with a nil new_course_option](https://trello.com/c/7sjvaXmd/1233-bug-course-selection-with-a-nil-newcourseoption)

I'm assuming [this error](https://dfe-teacher-services.sentry.io/issues/4493855871/?project=1765973) was triggered by candidates bookmarking the course selection page coming from Find and trying to submit when the course has no availability.

### Before
<img width="1056" alt="Screenshot 2024-01-29 at 17 12 33" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/10f4a8fd-521e-4188-8a5e-844babc7b3cc">

### After
<img width="632" alt="Screenshot 2024-01-29 at 17 12 02" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/993f8d61-ee3a-4fa3-85d9-9044c76b996a">