### PR TITLE
Update the HESA export to use the application choice ID

### DIFF
--- a/app/services/provider_interface/hesa_data_export.rb
+++ b/app/services/provider_interface/hesa_data_export.rb
@@ -18,7 +18,7 @@ module ProviderInterface
       first_degree_end = year_to_iso8601 first_degree_year(application, :award_year)
 
       {
-        'id' => application.application_form.support_reference,
+        'id' => application.id,
         'status' => application.status,
         'first_name' => application.application_form.first_name,
         'last_name' => application.application_form.last_name,

--- a/spec/services/provider_interface/hesa_data_export_spec.rb
+++ b/spec/services/provider_interface/hesa_data_export_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ProviderInterface::HesaDataExport do
   shared_examples_for 'an exported HESA row' do
     it 'includes candidate and HESA data' do
-      expect(export_row['id']).to eq(application_with_offer.application_form.support_reference)
+      expect(export_row['id']).to eq(application_with_offer.id)
       expect(export_row['status']).to eq(application_with_offer.status)
       expect(export_row['first_name']).to eq(application_with_offer.application_form.first_name)
       expect(export_row['last_name']).to eq(application_with_offer.application_form.last_name)

--- a/spec/system/provider_interface/export_applications_in_hesa_format_spec.rb
+++ b/spec/system/provider_interface/export_applications_in_hesa_format_spec.rb
@@ -64,7 +64,7 @@ RSpec.feature 'Export applications in HESA format' do
                                  study_mode SBJCA QLAIM FIRSTDEG DEGTYPE DEGSBJ DEGCLSS institution_country DEGSTDT DEGENDDT
                                  institution_details sex disabilities ethnicity])
 
-    expect(csv['id'].sort).to eq(@applications.map { |a| a.application_form.support_reference }.sort)
+    expect(csv['id'].sort).to eq(@applications.map { |a| a.id.to_s }.sort)
     expect(csv['email'].sort).to eq(@applications.map { |a| a.application_form.candidate.email_address }.sort)
     expect(csv['provider_code'].sort).to eq(@applications.map { |a| a.provider.code }.sort)
     expect(csv['course_code'].sort).to eq(@applications.map { |a| a.course.code }.sort)
@@ -80,7 +80,7 @@ RSpec.feature 'Export applications in HESA format' do
                                  study_mode SBJCA QLAIM FIRSTDEG DEGTYPE DEGSBJ DEGCLSS institution_country DEGSTDT DEGENDDT
                                  institution_details sex disabilities ethnicity])
 
-    expect(csv['id'].sort).to eq(@last_years_applications.map { |a| a.application_form.support_reference }.sort)
+    expect(csv['id'].sort).to eq(@last_years_applications.map { |a| a.id.to_s }.sort)
     expect(csv['email'].sort).to eq(@last_years_applications.map { |a| a.application_form.candidate.email_address }.sort)
     expect(csv['provider_code'].sort).to eq(@last_years_applications.map { |a| a.provider.code }.sort)
     expect(csv['course_code'].sort).to eq(@last_years_applications.map { |a| a.course.code }.sort)


### PR DESCRIPTION
## Context

The HESA CSV export currently returns the candidates application form support reference.

Providers used to search for applications using the support reference, we replaced this with the application choice number, but it was missed from the HESA CSV export [#6826](https://github.com/DFE-Digital/apply-for-teacher-training/pull/6826/files). Providers now have no way to match back the support reference to an application.

## Changes proposed in this pull request

Replace `application_choice.application_form.support_reference` with `application_choice.id`

## Guidance to review

Generate the export on Manage

## Trello ticket

https://trello.com/c/2k4R8Z4t
