### PR TITLE
Change location of remove link when adding conditions

### DIFF
--- a/app/frontend/styles/_add_another.scss
+++ b/app/frontend/styles/_add_another.scss
@@ -1,12 +1,16 @@
 .app-add-condition {
   &__item {
     margin: 0;
-    margin-top: govuk-spacing(6);
     padding: 0;
     position: relative;
 
     &:first-of-type {
       margin-top: 0;
+    }
+
+    .govuk-form-group,
+    .govuk-textarea {
+      margin-bottom: 10px;
     }
   }
 
@@ -17,12 +21,8 @@
   }
 
   &__remove-button {
-    position: absolute;
-    right: 0;
-    top: 0;
     color: govuk-colour("blue");
     padding: 0;
-    margin: 0;
     box-shadow: none;
     background: none;
     text-decoration: underline;


### PR DESCRIPTION
![](https://github.trello.services/images/mini-trello-icon.png) [Change location and wording of 'remove' link when adding conditions](https://trello.com/c/hhfpT73N/1099-change-location-and-wording-of-remove-link-when-adding-conditions)

We decided to only change the location of the link, and not the content, because the visually hidden text will show the correct value for screen readers. E.g. `Remove condition 1`

### Before
<img width="685" alt="Screenshot 2024-01-31 at 10 31 36" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/f6e1d268-4fd3-4a05-b8f4-6cc08e2f1e5d">

### After
<img width="716" alt="Screenshot 2024-01-30 at 16 55 43" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/1636476/d5730eb5-a0ca-4f82-87e9-ed353fbaf067">
