### PR TITLE
[937] Move kubelogin install before get-cluster-credentials

### DIFF
--- a/.github/workflows/database-backup-aks.yml
+++ b/.github/workflows/database-backup-aks.yml
@@ -50,15 +50,15 @@ jobs:
       with:
         version: 'v1.26.1' # default is latest stable
 
+    - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
+      with:
+        azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+
     - name: K8 setup
       shell: bash
       run: |
         make ci production_aks get-cluster-credentials
         make install-konduit
-
-    - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
-      with:
-        azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
 
     - name: Back up Azure database
       shell: bash

--- a/.github/workflows/restore-production-snapshot-aks.yml
+++ b/.github/workflows/restore-production-snapshot-aks.yml
@@ -68,6 +68,10 @@ jobs:
           az config set core.only_show_errors=true
           az storage azcopy blob download --container ${BACKUP_CONTAINER} --source ${BACKUP_ARCHIVE_NAME} --destination ${BACKUP_ARCHIVE_NAME}
 
+      - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
+        with:
+          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+
       - name: K8 setup
         shell: bash
         run: |
@@ -75,10 +79,6 @@ jobs:
           make install-konduit
         env:
           ENVIRONMENT=${{ github.event.inputs.environment }}
-
-      - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
-        with:
-          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Restore backup to AKS snapshot database
         shell: bash


### PR DESCRIPTION
## Context
Fix error in DB backup workflow: https://github.com/DFE-Digital/apply-for-teacher-training/actions/runs/7720188919/job/21044662286

## Changes proposed in this pull request
Move kubelogin install before get-cluster-credentials in the workflows

## Guidance to review
Code review: get-cluster-credentials calls kubelogin

## Link to Trello card
https://trello.com/c/3m8PNLG6

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
