### PR TITLE
Introduce Provider#phone_number and #email_address

### DIFF
--- a/app/services/teacher_training_public_api/sync_provider.rb
+++ b/app/services/teacher_training_public_api/sync_provider.rb
@@ -34,6 +34,8 @@ module TeacherTrainingPublicAPI
         region_code: provider_from_api.region_code&.strip,
         postcode: provider_from_api.postcode&.strip,
         name: provider_from_api.name,
+        phone_number: provider_from_api.telephone,
+        email_address: provider_from_api.email,
         provider_type: provider_from_api.provider_type,
         latitude: provider_from_api.try(:latitude),
         longitude: provider_from_api.try(:longitude),

--- a/app/views/support_interface/providers/show.html.erb
+++ b/app/views/support_interface/providers/show.html.erb
@@ -15,6 +15,8 @@
 <%= render(SummaryListComponent.new(rows: {
   'Name' => @provider.name,
   'Code' => @provider.code,
+  'Phone number' => @provider.phone_number,
+  'Email address' => @provider.email_address,
   'Provider type' => render(SupportInterface::ProviderTypeTagComponent.new(provider: @provider)),
   'Last updated' => @provider.updated_at.to_fs(:govuk_date_and_time),
   'Data sharing agreement' => dsa,

--- a/spec/examples/teacher_training_api/provider_list_response.json
+++ b/spec/examples/teacher_training_api/provider_list_response.json
@@ -14,6 +14,8 @@
         "created_at": "2019-06-13T10:44:31Z",
         "postcode": "SK2 6AA",
         "name": "Long School",
+        "telephone": "01243 832768",
+        "email": "Teachingschool@bishopluffa.org.uk",
         "provider_type": "scitt",
         "region_code": "south_west",
         "street_address_1": "Long College",

--- a/spec/examples/teacher_training_api/single_provider_response.json
+++ b/spec/examples/teacher_training_api/single_provider_response.json
@@ -13,6 +13,8 @@
       "created_at": "2019-06-13T10:44:31Z",
       "postcode": "SK2 6AA",
       "name": "Long School",
+      "telephone": "01243 832768",
+      "email": "Teachingschool@bishopluffa.org.uk",
       "provider_type": "scitt",
       "region_code": "south_west",
       "street_address_1": "Long College",

--- a/spec/factories/provider.rb
+++ b/spec/factories/provider.rb
@@ -2,6 +2,8 @@ FactoryBot.define do
   factory :provider do
     code { Faker::Alphanumeric.unique.alphanumeric(number: 3).upcase }
     name { Faker::University.name }
+    phone_number { Faker::PhoneNumber.phone_number }
+    email_address { Faker::Internet.email }
     region_code { 'london' }
 
     transient do


### PR DESCRIPTION
## Context

We added `Provider#phone_number` and `#email_address` to the provider model [here](https://github.com/DFE-Digital/apply-for-teacher-training/pull/9043).

This change makes use of the new attributes.

## Changes proposed in this pull request

- Show Phone number and Email address of provider in the support interface
- Add `phone_number` and `email_address` to the Provider attributes to be imported via the TTAPI Sync.

### Screenshot

![Screenshot from 2024-01-31 17-08-32](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/244956a4-1add-4ec4-8509-9e85a736ddfb)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

[Trello Ticket](https://trello.com/c/1nrcpoUh/1245-apply-introduce-providerphonenumber-and-emailaddress) 

