### PR TITLE
Add Withdraw CTA to ApplicationReviewComponent

### DIFF
--- a/app/components/candidate_interface/continuous_applications/application_review_component.html.erb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.html.erb
@@ -1,1 +1,8 @@
 <%= render SummaryListComponent.new(rows: rows) %>
+
+<% if show_withdraw? %>
+  <div class="govuk-!-margin-bottom-6">
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Withdraw your application</h2>
+    <p class="govuk-body">You can <%= govuk_link_to 'withdraw this application', candidate_interface_withdraw_path(application_choice) %> if you no longer wish to be considered for this course.</p>
+  </div>
+<% end %>

--- a/app/components/candidate_interface/continuous_applications/application_review_component.rb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.rb
@@ -148,6 +148,10 @@ module CandidateInterface
           ),
         }
       end
+
+      def show_withdraw?
+        ApplicationStateChange.new(@application_choice).can_withdraw?
+      end
     end
   end
 end

--- a/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
+++ b/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
@@ -110,6 +110,10 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
         expect(links).to include("Change location for #{application_choice.current_course.name_and_code}")
       end
     end
+
+    it 'does not show withdraw CTA' do
+      expect(result.text).not_to include('withdraw this application')
+    end
   end
 
   context 'when application is submitted' do
@@ -170,6 +174,10 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
       it 'does not show change links' do
         expect(result.css('govuk-summary-list__actions a')).to be_empty
       end
+
+      it 'shows withdraw CTA' do
+        expect(result.text).to include('withdraw this application')
+      end
     end
 
     context 'when course has multiple sites' do
@@ -192,6 +200,10 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
     it 'shows interview row' do
       expect(result.text).to include('InterviewYou have an interview scheduled')
     end
+
+    it 'shows withdraw CTA' do
+      expect(result.text).to include('withdraw this application')
+    end
   end
 
   context 'when application is rejected' do
@@ -201,6 +213,10 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
 
     it 'shows reasons for rejection row' do
       expect(result.text).to include('Reasons for rejection')
+    end
+
+    it 'does not show withdraw CTA' do
+      expect(result.text).not_to include('withdraw this application')
     end
   end
 end


### PR DESCRIPTION
## Context

Offer candidates the opportunity to withdraw their application on the ApplicationReview page.

## Changes proposed in this pull request

Add a CTA for candidates to withdraw their application if they do not wish to continue with their application.
The feature appears only when the application is in a "withdrawable" state.

## Guidance to review

|Link appears on review page|Link targets the withdraw page|
|---|---|
|![Screenshot from 2024-02-01 15-27-10](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/7a05905e-2005-4155-97f0-ee83f9a8288d)|![Screenshot from 2024-02-01 15-34-37](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/72e9aad6-62e0-4819-bc81-143b756d8d9f)|


## Link to Trello card

[Trello Ticket](https://trello.com/c/Jxl81L6q/1171-apply-withdraw-application-section-part-2)