### PR TITLE
Take the slack webhook URL as an argument

### DIFF
--- a/app/workers/send_stats_summary_to_slack.rb
+++ b/app/workers/send_stats_summary_to_slack.rb
@@ -2,6 +2,6 @@ class SendStatsSummaryToSlack
   include Sidekiq::Worker
 
   def perform
-    SlackNotificationWorker.perform_async(StatsSummary.new.as_slack_message, nil, '#twd_find_and_apply')
+    SlackNotificationWorker.perform_async(StatsSummary.new.as_slack_message, nil, '#twd_find_and_apply', ENV['FIND_AND_APPLY_SLACK_URL'])
   end
 end

--- a/app/workers/send_weekly_stats_summary_to_slack.rb
+++ b/app/workers/send_weekly_stats_summary_to_slack.rb
@@ -2,6 +2,6 @@ class SendWeeklyStatsSummaryToSlack
   include Sidekiq::Worker
 
   def perform
-    SlackNotificationWorker.perform_async(WeeklyStatsSummary.new.as_slack_message, nil, '#twd_find_and_apply')
+    SlackNotificationWorker.perform_async(WeeklyStatsSummary.new.as_slack_message, nil, '#twd_find_and_apply', ENV['FIND_AND_APPLY_SLACK_URL'])
   end
 end

--- a/app/workers/slack_notification_worker.rb
+++ b/app/workers/slack_notification_worker.rb
@@ -3,14 +3,14 @@ require 'http'
 class SlackNotificationWorker
   include Sidekiq::Worker
 
-  def perform(text, url = nil, channel = nil)
+  def perform(text, url = nil, channel = nil, webhook_url = ENV['STATE_CHANGE_SLACK_URL'])
     return if HostingEnvironment.review?
 
-    @webhook_url = ENV['STATE_CHANGE_SLACK_URL']
+    @webhook_url = webhook_url
 
     if @webhook_url.present?
       message = url.present? ? hyperlink(text, url) : text
-      post_to_slack message, channel
+      post_to_slack(message, channel)
     end
   end
 


### PR DESCRIPTION
I'm introducing a new Slack app. `STATE_CHANGE_SLACK_UR` will still be the main workspace app, this new one is applicable just to find & apply.