### PR TITLE
Do not mention references for application not sent

### DIFF
--- a/app/components/candidate_interface/application_status_tag_component.html.erb
+++ b/app/components/candidate_interface/application_status_tag_component.html.erb
@@ -6,7 +6,7 @@
 <% if @display_info_text %>
   <% if @application_choice.application_not_sent? %>
     <p class="govuk-body govuk-!-margin-top-2">
-      Your application was not sent for this course because references were not given before the deadline.
+      Your application was not sent for this course because it was not submitted before the deadline.
     </p>
   <% elsif @application_choice.unsubmitted? && @application_choice.course_available? %>
     <p class="govuk-body govuk-!-margin-top-2">

--- a/spec/components/candidate_interface/application_status_tag_component_spec.rb
+++ b/spec/components/candidate_interface/application_status_tag_component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CandidateInterface::ApplicationStatusTagComponent, :continuous_ap
     it 'tells the candidate why their application was not sent to their provider(s)' do
       application_choice = create(:application_choice, :application_not_sent, course:)
       result = render_inline(described_class.new(application_choice:))
-      expect(result.text).to include('Your application was not sent for this course because references were not given before the deadline.')
+      expect(result.text).to include('Your application was not sent for this course because it was not submitted before the deadline.')
     end
   end
 


### PR DESCRIPTION
## Context

We have a task that we run at the end of the cycle. This moves `unsubmitted` applications into an `application_not_sent` status.

2023 applications with an `application_not_sent` status are currently being presented with incorrect content. We mention that references haven't been received before the deadline. This relates to the old references flow.

## Changes proposed in this pull request

|Before|After|
|---|---|
|<img width="681" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/8d89ddf4-2cb3-454c-bc38-a2a1c90528f6">|<img width="694" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/47917431/78c32f43-fb53-47f9-85ea-6b04e13454f3">|

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
