### PR TITLE
ApplicationChoice updates: What happens next

### DIFF
--- a/app/components/candidate_interface/continuous_applications/application_review_component.html.erb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.html.erb
@@ -19,7 +19,7 @@
         <p class="govuk-body">The provider will review your application and let you know when they have made a decision. In the meantime, you can:</p>
         <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-8">
           <% if can_add_more_choices? %>
-          <li>submit another application while you wait for a decision on this one</li>
+          <li><%= govuk_link_to 'submit another application', candidate_interface_continuous_applications_do_you_know_the_course_path %> while you wait for a decision on this one</li>
           <% end %>
           <li>contact the provider directly if you have any questions</li>
           <li>find out more about <%= govuk_link_to 'funding your training', t('get_into_teaching.url_funding_and_support'), target: '_blank' %></li>

--- a/app/components/candidate_interface/continuous_applications/application_review_component.html.erb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.html.erb
@@ -3,29 +3,28 @@
 <% if show_what_happens_next? %>
   <div class="govuk-!-margin-bottom-6">
     <h2 class="govuk-heading-m govuk-!-margin-bottom-1">What happens next</h2>
-    <% case application_choice.status %>
-      <% when *%w(awaiting_provider_decision) %>
-        <p class="govuk-body">The provider will review your application and let your know when they have a made a decision. In the meantime, you can:</p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-8">
-          <li>contact the provider directly if you have any questions</li>
-          <li>find out more about <%= govuk_link_to('funding your training', t('get_into_teaching.url_funding_and_support'), target: '_blank') %></li>
-          <li>get help from a <%= govuk_link_to('teacher training advisor', t('get_into_teaching.url_get_an_adviser_signup'), target: '_blank') %></li>
-        </ul>
-      </div>
-      <% when *%w(interviewing) %>
-        <p class="govuk-body">Congratulations on being invited for an interview! This is an important stage in successfully getting a place on a teacher training course.</p>
-        <p class="govuk-body">Learn more about what to expect and <%= govuk_link_to 'how to prepare for an interview', t('get_into_teaching.url_teacher_training_interview'), target: '_blank' %>.</p>
-      <% when *%w(inactive) %>
-        <p class="govuk-body">The provider will review your application and let you know when they have made a decision. In the meantime, you can:</p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-8">
-          <% if can_add_more_choices? %>
-          <li><%= govuk_link_to 'submit another application', candidate_interface_continuous_applications_do_you_know_the_course_path %> while you wait for a decision on this one</li>
-          <% end %>
-          <li>contact the provider directly if you have any questions</li>
-          <li>find out more about <%= govuk_link_to 'funding your training', t('get_into_teaching.url_funding_and_support'), target: '_blank' %></li>
-          <li>get help from a <%= govuk_link_to 'teacher training adviser', t('get_into_teaching.url_get_an_adviser_signup'), target: '_blank' %></li>
-        </ul>
-  <% end %>
+    <% if application_choice.awaiting_provider_decision? %>
+      <p class="govuk-body">The provider will review your application and let your know when they have a made a decision. In the meantime, you can:</p>
+      <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-8">
+        <li>contact the provider directly if you have any questions</li>
+        <li>find out more about <%= govuk_link_to('funding your training', t('get_into_teaching.url_funding_and_support'), target: '_blank') %></li>
+        <li>get help from a <%= govuk_link_to('teacher training advisor', t('get_into_teaching.url_get_an_adviser_signup'), target: '_blank') %></li>
+      </ul>
+    <% elsif application_choice.interviewing? %>
+      <p class="govuk-body">Congratulations on being invited for an interview! This is an important stage in successfully getting a place on a teacher training course.</p>
+      <p class="govuk-body">Learn more about what to expect and <%= govuk_link_to 'how to prepare for an interview', t('get_into_teaching.url_teacher_training_interview'), target: '_blank' %>.</p>
+    <% elsif application_choice.inactive? %>
+      <p class="govuk-body">The provider will review your application and let you know when they have made a decision. In the meantime, you can:</p>
+      <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-8">
+        <% if can_add_more_choices? %>
+        <li><%= govuk_link_to 'submit another application', candidate_interface_continuous_applications_do_you_know_the_course_path %> while you wait for a decision on this one</li>
+        <% end %>
+        <li>contact the provider directly if you have any questions</li>
+        <li>find out more about <%= govuk_link_to 'funding your training', t('get_into_teaching.url_funding_and_support'), target: '_blank' %></li>
+        <li>get help from a <%= govuk_link_to 'teacher training adviser', t('get_into_teaching.url_get_an_adviser_signup'), target: '_blank' %></li>
+      </ul>
+    <% end %>
+    </div>
 <% end %>
 
 <% if show_withdraw? %>

--- a/app/components/candidate_interface/continuous_applications/application_review_component.html.erb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.html.erb
@@ -18,7 +18,9 @@
       <% when *%w(inactive) %>
         <p class="govuk-body">The provider will review your application and let you know when they have made a decision. In the meantime, you can:</p>
         <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-8">
+          <% if can_add_more_choices? %>
           <li>submit another application while you wait for a decision on this one</li>
+          <% end %>
           <li>contact the provider directly if you have any questions</li>
           <li>find out more about <%= govuk_link_to 'funding your training', t('get_into_teaching.url_funding_and_support'), target: '_blank' %></li>
           <li>get help from a <%= govuk_link_to 'teacher training adviser', t('get_into_teaching.url_get_an_adviser_signup'), target: '_blank' %></li>

--- a/app/components/candidate_interface/continuous_applications/application_review_component.html.erb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.html.erb
@@ -1,5 +1,31 @@
 <%= render SummaryListComponent.new(rows: rows) %>
 
+<% if show_what_happens_next? %>
+  <div class="govuk-!-margin-bottom-6">
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-1">What happens next</h2>
+    <% case application_choice.status %>
+      <% when *%w(awaiting_provider_decision) %>
+        <p class="govuk-body">The provider will review your application and let your know when they have a made a decision. In the meantime, you can:</p>
+        <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-8">
+          <li>contact the provider directly if you have any questions</li>
+          <li>find out more about <%= govuk_link_to('funding your training', "#{application_choice.current_course.find_url}#section-financial-support", target: '_blank') %></li>
+          <li>get help from a <%= govuk_link_to('teacher training advisor', t('get_into_teaching.url_get_an_adviser_signup'), target: '_blank') %></li>
+        </ul>
+      </div>
+      <% when *%w(interviewing) %>
+        <p class="govuk-body">Congratulations on being invited for an interview! This is an important stage in successfully getting a place on a teacher training course.</p>
+        <p class="govuk-body">Learn more about what to expect and <%= govuk_link_to 'how to prepare for an interview',  'https://getintoteaching.education.gov.uk/how-to-apply-for-teacher-training/teacher-training-interview', target: '_blank' %>.</p>
+      <% when *%w(inactive) %>
+        <p class="govuk-body">The provider will review your application and let you know when they have made a decision. In the meantime, you can:</p>
+        <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-8">
+          <li>submit another application while you wait for a decision on this one</li>
+          <li>contact the provider directly if you have any questions</li>
+          <li>find out more about <%= govuk_link_to 'funding your training', 'https://getintoteaching.education.gov.uk/funding-and-support', target: '_blank' %></li>
+          <li>get help from a <%= govuk_link_to 'teacher training adviser', 'https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/identity', target: '_blank' %></li>
+        </ul>
+  <% end %>
+<% end %>
+
 <% if show_withdraw? %>
   <div class="govuk-!-margin-bottom-6">
     <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Withdraw your application</h2>

--- a/app/components/candidate_interface/continuous_applications/application_review_component.html.erb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.html.erb
@@ -8,20 +8,20 @@
         <p class="govuk-body">The provider will review your application and let your know when they have a made a decision. In the meantime, you can:</p>
         <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-8">
           <li>contact the provider directly if you have any questions</li>
-          <li>find out more about <%= govuk_link_to('funding your training', "#{application_choice.current_course.find_url}#section-financial-support", target: '_blank') %></li>
+          <li>find out more about <%= govuk_link_to('funding your training', t('get_into_teaching.url_funding_and_support'), target: '_blank') %></li>
           <li>get help from a <%= govuk_link_to('teacher training advisor', t('get_into_teaching.url_get_an_adviser_signup'), target: '_blank') %></li>
         </ul>
       </div>
       <% when *%w(interviewing) %>
         <p class="govuk-body">Congratulations on being invited for an interview! This is an important stage in successfully getting a place on a teacher training course.</p>
-        <p class="govuk-body">Learn more about what to expect and <%= govuk_link_to 'how to prepare for an interview',  'https://getintoteaching.education.gov.uk/how-to-apply-for-teacher-training/teacher-training-interview', target: '_blank' %>.</p>
+        <p class="govuk-body">Learn more about what to expect and <%= govuk_link_to 'how to prepare for an interview', t('get_into_teaching.url_teacher_training_interview'), target: '_blank' %>.</p>
       <% when *%w(inactive) %>
         <p class="govuk-body">The provider will review your application and let you know when they have made a decision. In the meantime, you can:</p>
         <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-8">
           <li>submit another application while you wait for a decision on this one</li>
           <li>contact the provider directly if you have any questions</li>
-          <li>find out more about <%= govuk_link_to 'funding your training', 'https://getintoteaching.education.gov.uk/funding-and-support', target: '_blank' %></li>
-          <li>get help from a <%= govuk_link_to 'teacher training adviser', 'https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/identity', target: '_blank' %></li>
+          <li>find out more about <%= govuk_link_to 'funding your training', t('get_into_teaching.url_funding_and_support'), target: '_blank' %></li>
+          <li>get help from a <%= govuk_link_to 'teacher training adviser', t('get_into_teaching.url_get_an_adviser_signup'), target: '_blank' %></li>
         </ul>
   <% end %>
 <% end %>

--- a/app/components/candidate_interface/continuous_applications/application_review_component.rb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.rb
@@ -156,6 +156,10 @@ module CandidateInterface
       def show_withdraw?
         ApplicationStateChange.new(@application_choice).can_withdraw?
       end
+
+      def can_add_more_choices?
+        application_choice.application_form.can_add_more_choices?
+      end
     end
   end
 end

--- a/app/components/candidate_interface/continuous_applications/application_review_component.rb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.rb
@@ -149,6 +149,10 @@ module CandidateInterface
         }
       end
 
+      def show_what_happens_next?
+        ApplicationStateChange::DECISION_PENDING_AND_INACTIVE_STATUSES.include?(@application_choice.status.to_sym)
+      end
+
       def show_withdraw?
         ApplicationStateChange.new(@application_choice).can_withdraw?
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,9 +36,11 @@ en:
     url: https://getintoteaching.education.gov.uk
     url_applying: https://getintoteaching.education.gov.uk/steps-to-become-a-teacher#step-5
     url_get_an_adviser_start: https://getintoteaching.education.gov.uk/teacher-training-advisers
+    url_get_an_adviser_signup: https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/identity
     url_events: https://getintoteaching.education.gov.uk/events/about-get-into-teaching-events
     url_international_candidates: https://getintoteaching.education.gov.uk/non-uk-teachers
     url_support_if_you_are_disabled: https://getintoteaching.education.gov.uk/funding-and-support/if-youre-disabled
+    url_funding_and_support: https://getintoteaching.education.gov.uk/funding-and-support
     url_online_chat: https://getintoteaching.education.gov.uk/help-and-support
     url_get_school_experience: https://getintoteaching.education.gov.uk/is-teaching-right-for-me/get-school-experience
     url_ways_to_train: https://getintoteaching.education.gov.uk/train-to-be-a-teacher
@@ -46,6 +48,7 @@ en:
     url_if_you_dont_have_a_degree: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/if-you-dont-have-a-degree
     url_subject_knowledge_enhancement: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement
     url_references: https://getintoteaching.education.gov.uk/how-to-apply-for-teacher-training/teacher-training-references
+    url_teacher_training_interview: https://getintoteaching.education.gov.uk/how-to-apply-for-teacher-training/teacher-training-interview
   train_to_teach_in_england:
     url: https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration
   register_of_sponsor_licences:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,20 +35,20 @@ en:
     opening_times: "Monday to Friday, 8:30am to 5:30pm (except public\u00A0holidays)"
     url: https://getintoteaching.education.gov.uk
     url_applying: https://getintoteaching.education.gov.uk/steps-to-become-a-teacher#step-5
-    url_get_an_adviser_start: https://getintoteaching.education.gov.uk/teacher-training-advisers
-    url_get_an_adviser_signup: https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/identity
-    url_events: https://getintoteaching.education.gov.uk/events/about-get-into-teaching-events
-    url_international_candidates: https://getintoteaching.education.gov.uk/non-uk-teachers
-    url_support_if_you_are_disabled: https://getintoteaching.education.gov.uk/funding-and-support/if-youre-disabled
-    url_funding_and_support: https://getintoteaching.education.gov.uk/funding-and-support
-    url_online_chat: https://getintoteaching.education.gov.uk/help-and-support
-    url_get_school_experience: https://getintoteaching.education.gov.uk/is-teaching-right-for-me/get-school-experience
-    url_ways_to_train: https://getintoteaching.education.gov.uk/train-to-be-a-teacher
     url_choose_your_referees: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/how-to-apply-for-teacher-training#choose-your-references
+    url_events: https://getintoteaching.education.gov.uk/events/about-get-into-teaching-events
+    url_funding_and_support: https://getintoteaching.education.gov.uk/funding-and-support
+    url_get_an_adviser_signup: https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/identity
+    url_get_an_adviser_start: https://getintoteaching.education.gov.uk/teacher-training-advisers
+    url_get_school_experience: https://getintoteaching.education.gov.uk/is-teaching-right-for-me/get-school-experience
     url_if_you_dont_have_a_degree: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/if-you-dont-have-a-degree
-    url_subject_knowledge_enhancement: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement
+    url_international_candidates: https://getintoteaching.education.gov.uk/non-uk-teachers
+    url_online_chat: https://getintoteaching.education.gov.uk/help-and-support
     url_references: https://getintoteaching.education.gov.uk/how-to-apply-for-teacher-training/teacher-training-references
+    url_subject_knowledge_enhancement: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement
+    url_support_if_you_are_disabled: https://getintoteaching.education.gov.uk/funding-and-support/if-youre-disabled
     url_teacher_training_interview: https://getintoteaching.education.gov.uk/how-to-apply-for-teacher-training/teacher-training-interview
+    url_ways_to_train: https://getintoteaching.education.gov.uk/train-to-be-a-teacher
   train_to_teach_in_england:
     url: https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration
   register_of_sponsor_licences:

--- a/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
+++ b/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
@@ -111,12 +111,16 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
       end
     end
 
+    it 'does not show what happens next information' do
+      expect(result.text).not_to include('What happens next')
+    end
+
     it 'does not show withdraw CTA' do
       expect(result.text).not_to include('withdraw this application')
     end
   end
 
-  context 'when application is submitted' do
+  context 'when application is submitted (awaiting_provider_decision)' do
     it_behaves_like 'course length row'
 
     it 'shows the application status' do
@@ -174,10 +178,6 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
       it 'does not show change links' do
         expect(result.css('govuk-summary-list__actions a')).to be_empty
       end
-
-      it 'shows withdraw CTA' do
-        expect(result.text).to include('withdraw this application')
-      end
     end
 
     context 'when course has multiple sites' do
@@ -190,6 +190,15 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
         expect(result.css('govuk-summary-list__actions a')).to be_empty
       end
     end
+
+    it 'show what happens next information' do
+      expect(result.text).to include('What happens next',
+                                     'The provider will review your application and let your know when they have a made a decision. In the meantime, you can:')
+    end
+
+    it 'shows withdraw CTA' do
+      expect(result.text).to include('withdraw this application')
+    end
   end
 
   context 'when application is interviewing' do
@@ -201,8 +210,28 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
       expect(result.text).to include('InterviewYou have an interview scheduled')
     end
 
+    it 'show what happens next information' do
+      expect(result.text).to include('What happens next',
+                                     'Congratulations on being invited for an interview! This is an important stage in successfully getting a place on a teacher training course.')
+    end
+
     it 'shows withdraw CTA' do
       expect(result.text).to include('withdraw this application')
+    end
+  end
+
+  context 'when application is inactive' do
+    let(:application_choice) do
+      create(:application_choice, :inactive)
+    end
+
+    it 'show what happens next information' do
+      expect(result.text).to include('What happens next',
+                                         'The provider will review your application and let you know when they have made a decision. In the meantime, you can:')
+    end
+
+    it 'does not show withdraw CTA' do
+      expect(result.text).not_to include('withdraw this application')
     end
   end
 
@@ -213,6 +242,10 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
 
     it 'shows reasons for rejection row' do
       expect(result.text).to include('Reasons for rejection')
+    end
+
+    it 'does not show what happens next information' do
+      expect(result.text).not_to include('What happens next')
     end
 
     it 'does not show withdraw CTA' do

--- a/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
+++ b/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
@@ -36,8 +36,10 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
   end
 
   subject(:result) do
-    render_inline(described_class.new(application_choice:))
+    render_inline(component)
   end
+
+  let(:component) { described_class.new(application_choice:) }
 
   let(:application_choice) do
     create(:application_choice, :awaiting_provider_decision, personal_statement:, sent_to_provider_at: 1.week.ago, course:)
@@ -225,13 +227,26 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
       create(:application_choice, :inactive)
     end
 
-    it 'show what happens next information' do
-      expect(result.text).to include('What happens next',
-                                         'The provider will review your application and let you know when they have made a decision. In the meantime, you can:')
+    context 'when application cannot make more choices' do
+      it 'show what happens next information' do
+        expect(result.text).to include('What happens next',
+                                       'The provider will review your application and let you know when they have made a decision. In the meantime, you can:')
+      end
+
+      it 'does not hint to add more choices' do
+        allow(component).to receive(:can_add_more_choices?).and_return(false)
+        expect(result.text).not_to include('submit another')
+      end
     end
 
-    it 'does not show withdraw CTA' do
-      expect(result.text).not_to include('withdraw this application')
+    context 'when application can make more choices' do
+      it 'shows hint to add more choices' do
+        expect(result.text).to include('submit another')
+      end
+    end
+
+    it 'shows withdraw CTA' do
+      expect(result.text).to include('withdraw this application')
     end
   end
 


### PR DESCRIPTION
## Context

As part of the update to the candidate interfaces application choices index and show, we want to give the candidate information regarding the next steps in the application process. This information depends on the state of the application.

This information is shown if the application is Inactive, Awaiting decision or Interviewing.

## Changes proposed in this pull request

## Screenshots

|Awaiting decision|Interviewing|Inactive|
|---|---|---|
|![Screenshot from 2024-02-05 12-44-08](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/d11a3ead-e1ad-4332-ba3b-13f83ebdde1c)|![Screenshot from 2024-02-05 12-45-20](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/d1afefd7-3f5f-499f-9fa5-274bc3c6b137)|![Screenshot from 2024-02-05 12-44-46](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/24341b0e-263e-4a69-bba0-df231de82b8e)|

## Guidance to review

Arranging the test suite around statuses I think would make reading and writing tests much easier.

**Testing**
Links to applications with variant UI:
[Awaiting provider decision](https://apply-review-9063.test.teacherservices.cloud/candidate/application/continuous-applications/44/review)
[Interviewing](https://apply-review-9063.test.teacherservices.cloud/candidate/application/continuous-applications/26/review)
[Inactive](https://apply-review-9063.test.teacherservices.cloud/candidate/application/continuous-applications/45/review)

## Link to Trello card

[Trello Ticket](https://trello.com/c/WD6wJriY/1192-apply-what-happens-next-new-pattern-part-5)
