### PR TITLE
Add Contact training provider to ApplicationReviewComponent

### DIFF
--- a/app/components/candidate_interface/continuous_applications/application_review_component.html.erb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.html.erb
@@ -24,7 +24,21 @@
         <li>get help from a <%= govuk_link_to 'teacher training adviser', t('get_into_teaching.url_get_an_adviser_signup'), target: '_blank' %></li>
       </ul>
     <% end %>
-    </div>
+  </div>
+<% end %>
+
+<% if show_provider_contact_details? %>
+  <div class="provider-contact-details govuk-!-margin-bottom-6">
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Contact training provider</h2>
+    <p class="govuk-body">Contact <%= application_choice.current_course.provider.name %> if you have any questions about your application.</p>
+    <% if provider.phone_number && provider.email_address %>
+      <p class="govuk-body">Call on <%= link_to(provider.phone_number, "tel:#{provider.phone_number}") %> or email at <%= mail_to(provider.email_address) %></p>
+    <% elsif provider.phone_number %>
+      <p class="govuk-body">Call on <%= link_to(provider.phone_number, "tel:#{provider.phone_number}") %></p>
+    <% elsif provider.email_address %>
+      <p class="govuk-body">Email at <%= mail_to(provider.email_address) %></p>
+    <% end %>
+  </div>
 <% end %>
 
 <% if show_withdraw? %>

--- a/app/components/candidate_interface/continuous_applications/application_review_component.html.erb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.html.erb
@@ -17,7 +17,7 @@
       <p class="govuk-body">The provider will review your application and let you know when they have made a decision. In the meantime, you can:</p>
       <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-8">
         <% if can_add_more_choices? %>
-        <li><%= govuk_link_to 'submit another application', candidate_interface_continuous_applications_do_you_know_the_course_path %> while you wait for a decision on this one</li>
+          <li><%= govuk_link_to 'submit another application', candidate_interface_continuous_applications_do_you_know_the_course_path %> while you wait for a decision on this one</li>
         <% end %>
         <li>contact the provider directly if you have any questions</li>
         <li>find out more about <%= govuk_link_to 'funding your training', t('get_into_teaching.url_funding_and_support'), target: '_blank' %></li>
@@ -27,23 +27,13 @@
   </div>
 <% end %>
 
-<% if show_provider_contact_details? %>
-  <div class="provider-contact-details govuk-!-margin-bottom-6">
-    <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Contact training provider</h2>
-    <p class="govuk-body">Contact <%= application_choice.current_course.provider.name %> if you have any questions about your application.</p>
-    <% if provider.phone_number && provider.email_address %>
-      <p class="govuk-body">Call on <%= link_to(provider.phone_number, "tel:#{provider.phone_number}") %> or email at <%= mail_to(provider.email_address) %></p>
-    <% elsif provider.phone_number %>
-      <p class="govuk-body">Call on <%= link_to(provider.phone_number, "tel:#{provider.phone_number}") %></p>
-    <% elsif provider.email_address %>
-      <p class="govuk-body">Email at <%= mail_to(provider.email_address) %></p>
-    <% end %>
-  </div>
-<% end %>
-
 <% if show_withdraw? %>
   <div class="govuk-!-margin-bottom-6">
     <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Withdraw your application</h2>
     <p class="govuk-body">You can <%= govuk_link_to 'withdraw this application', candidate_interface_withdraw_path(application_choice) %> if you no longer wish to be considered for this course.</p>
   </div>
+<% end %>
+
+<% if show_provider_contact_component? %>
+  <%= render(CandidateInterface::ProviderContactInformationComponent.new(provider:)) %>
 <% end %>

--- a/app/components/candidate_interface/continuous_applications/application_review_component.rb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.rb
@@ -157,8 +157,18 @@ module CandidateInterface
         ApplicationStateChange.new(@application_choice).can_withdraw?
       end
 
+      def show_provider_contact_details?
+        return false unless provider.email_address || provider.phone_number
+
+        application_choice.status.in?(%w[offer awaiting_provider_decision inactive interviewing])
+      end
+
       def can_add_more_choices?
         application_choice.application_form.can_add_more_choices?
+      end
+
+      def provider
+        application_choice.current_provider
       end
     end
   end

--- a/app/components/candidate_interface/continuous_applications/application_review_component.rb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.rb
@@ -159,8 +159,14 @@ module CandidateInterface
 
       def show_provider_contact_details?
         return false unless provider.email_address || provider.phone_number
+        application_states = %w[
+          awaiting_provider_decision
+          inactive
+          interviewing
+          offer
+        ]
 
-        application_choice.status.in?(%w[offer awaiting_provider_decision inactive interviewing])
+        application_choice.status.in?(application_states)
       end
 
       def can_add_more_choices?

--- a/app/components/candidate_interface/continuous_applications/application_review_component.rb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.rb
@@ -157,8 +157,7 @@ module CandidateInterface
         ApplicationStateChange.new(@application_choice).can_withdraw?
       end
 
-      def show_provider_contact_details?
-        return false unless provider.email_address || provider.phone_number
+      def show_provider_contact_component?
         application_states = %w[
           awaiting_provider_decision
           inactive

--- a/app/components/candidate_interface/provider_contact_information_component.html.erb
+++ b/app/components/candidate_interface/provider_contact_information_component.html.erb
@@ -1,0 +1,11 @@
+<div class="govuk-!-margin-bottom-6">
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Contact training provider</h2>
+  <p class="govuk-body">Contact <%= provider.name %> if you have any questions about your application.</p>
+  <% if show_email_and_phone? %>
+    <p class="govuk-body">Call on <%= govuk_link_to(provider.phone_number, "tel:#{provider.phone_number}") %> or email at <%= govuk_mail_to(provider.email_address) %></p>
+  <% elsif show_only_phone? %>
+    <p class="govuk-body">Call on <%= govuk_link_to(provider.phone_number, "tel:#{provider.phone_number}") %></p>
+  <% elsif show_only_email? %>
+    <p class="govuk-body">Email at <%= govuk_mail_to(provider.email_address) %></p>
+  <% end %>
+</div>

--- a/app/components/candidate_interface/provider_contact_information_component.rb
+++ b/app/components/candidate_interface/provider_contact_information_component.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class CandidateInterface::ProviderContactInformationComponent < ViewComponent::Base
+  def initialize(provider:)
+    @provider = provider
+  end
+
+  attr_reader :provider
+
+  def show_email_and_phone?
+    provider.email_address.present? && provider.phone_number.present?
+  end
+
+  def show_only_phone?
+    provider.email_address.blank? && provider.phone_number.present?
+  end
+
+  def show_only_email?
+    provider.email_address.present? && provider.phone_number.blank?
+  end
+
+  def render?
+    provider.email_address.present? || provider.phone_number.present?
+  end
+end

--- a/app/controllers/candidate_interface/offer_dashboard_controller.rb
+++ b/app/controllers/candidate_interface/offer_dashboard_controller.rb
@@ -10,6 +10,15 @@ module CandidateInterface
       @application_choice = choices.pending_conditions.first || choices.recruited.first || choices.offer_deferred.first
       @provider_name = @application_choice.current_provider.name
       @course_name_and_code = @application_choice.current_course.name_and_code
+      @provider = @application_choice.current_provider
+    end
+
+    helper_method def show_provider_contact_component?
+      @application_choice.status.in?(%w[
+        offer_deferred
+        pending_conditions
+        recruited
+      ])
     end
 
   private

--- a/app/controllers/candidate_interface/offer_dashboard_controller.rb
+++ b/app/controllers/candidate_interface/offer_dashboard_controller.rb
@@ -8,9 +8,8 @@ module CandidateInterface
       @application_form = current_application
       choices = current_application.application_choices.includes(:offer, course_option: [course: :provider])
       @application_choice = choices.pending_conditions.first || choices.recruited.first || choices.offer_deferred.first
-      @provider_name = @application_choice.current_provider.name
-      @course_name_and_code = @application_choice.current_course.name_and_code
       @provider = @application_choice.current_provider
+      @course_name_and_code = @application_choice.current_course.name_and_code
     end
 
     helper_method def show_provider_contact_component?

--- a/app/views/candidate_interface/offer_dashboard/_offer_deferred.html.erb
+++ b/app/views/candidate_interface/offer_dashboard/_offer_deferred.html.erb
@@ -1,7 +1,7 @@
 <h1 class="govuk-heading-xl">Your deferred offer for <%= @course_name_and_code %></h1>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">You’ve chosen to defer your offer from <%= @provider_name %> to study <%= @course_name_and_code %>.</p>
+    <p class="govuk-body">You’ve chosen to defer your offer from <%= @provider.name %> to study <%= @course_name_and_code %>.</p>
     <p class="govuk-body">Your training will now start in <%= @application_choice.course.start_date.to_fs(:month_and_year) %>.</p>
     <p class="govuk-body">Your place will be confirmed once they have:</p>
     <ul class="govuk-list govuk-list--bullet">

--- a/app/views/candidate_interface/offer_dashboard/_pending_conditions.html.erb
+++ b/app/views/candidate_interface/offer_dashboard/_pending_conditions.html.erb
@@ -1,7 +1,7 @@
 <h1 class="govuk-heading-xl">Your offer for <%= @course_name_and_code %></h1>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">You’ve accepted an offer from <%= @provider_name %> to study <%= @course_name_and_code %>.</p>
+    <p class="govuk-body">You’ve accepted an offer from <%= @provider.name %> to study <%= @course_name_and_code %>.</p>
     <p class="govuk-body">Your place will be confirmed once they have:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>received your references</li>

--- a/app/views/candidate_interface/offer_dashboard/_recruited.html.erb
+++ b/app/views/candidate_interface/offer_dashboard/_recruited.html.erb
@@ -1,7 +1,7 @@
 <h1 class="govuk-heading-xl">Your offer for <%= @course_name_and_code %></h1>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">You’ve accepted an offer from <%= @provider_name %> to study <%= @course_name_and_code %>.</p>
+    <p class="govuk-body">You’ve accepted an offer from <%= @provider.name %> to study <%= @course_name_and_code %>.</p>
 
     <%= yield %>
   </div>

--- a/app/views/candidate_interface/offer_dashboard/_references_and_conditions.html.erb
+++ b/app/views/candidate_interface/offer_dashboard/_references_and_conditions.html.erb
@@ -1,6 +1,6 @@
 <h2 class="govuk-heading-m">References</h2>
 
-<%= render CandidateInterface::ReferenceConditionHeaderComponent.new(reference_condition: @application_choice.offer.reference_condition, provider_name: @provider_name) %>
+<%= render CandidateInterface::ReferenceConditionHeaderComponent.new(reference_condition: @application_choice.offer.reference_condition, provider_name: @provider.name) %>
 
 <%= render CandidateInterface::ReferencesComponent.new(application_form: @application_form, reference_condition: @application_choice.offer.reference_condition) %>
 
@@ -16,7 +16,7 @@
 <% unless @application_choice.unconditional_offer? %>
   <h2 class="govuk-heading-m">Offer conditions</h2>
   <% unless @application_choice.recruited? && @application_choice.all_conditions_met? %>
-    <p class="govuk-body"><%= @provider_name %> will mark these conditions as met once you’ve completed them.</p>
+    <p class="govuk-body"><%= @provider.name %> will mark these conditions as met once you’ve completed them.</p>
   <% end %>
   <%= render CandidateInterface::ConditionsComponent.new(application_choice: @application_choice) %>
 <% end %>

--- a/app/views/candidate_interface/offer_dashboard/show.html.erb
+++ b/app/views/candidate_interface/offer_dashboard/show.html.erb
@@ -1,3 +1,7 @@
 <%= render @application_choice.status do %>
   <%= render 'references_and_conditions' %>
+
+  <% if show_provider_contact_component? %>
+    <%= render(CandidateInterface::ProviderContactInformationComponent.new(provider: @provider)) %>
+  <% end %>
 <% end %>

--- a/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
+++ b/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
@@ -121,12 +121,8 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
       expect(result.text).not_to include('withdraw this application')
     end
 
-    describe 'does not show provider contact information' do
-      context 'when provider has phone and email' do
-        it 'show provider contact information' do
-          expect(result.text).not_to include('Contact training provider')
-        end
-      end
+    it 'does not show provider contact information' do
+      expect(result.text).not_to include('Contact training provider')
     end
   end
 
@@ -210,36 +206,8 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
       expect(result.text).to include('withdraw this application')
     end
 
-    describe 'show provider contact information' do
-      context 'when provider has phone and email' do
-        it 'show provider contact information' do
-          expect(result.text).to include('Contact training provider',
-                                         "Call on #{provider.phone_number}",
-                                         "email at #{provider.email_address}")
-        end
-      end
-
-      context 'when provider has only phone' do
-        let(:provider) do
-          create(:provider, email_address: nil)
-        end
-
-        it 'show provider phone number' do
-          expect(result.text).to include('Contact training provider',
-                                         "Call on #{provider.phone_number}")
-        end
-      end
-
-      context 'when provider has only email' do
-        let(:provider) do
-          create(:provider, phone_number: nil)
-        end
-
-        it 'show provider contact information' do
-          expect(result.text).to include('Contact training provider',
-                                         "Email at #{provider.email_address}")
-        end
-      end
+    it 'shows provider contact information' do
+      expect(result.text).to include('Contact training provider')
     end
   end
 
@@ -261,36 +229,8 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
       expect(result.text).to include('withdraw this application')
     end
 
-    describe 'show provider contact information' do
-      context 'when provider has phone and email' do
-        it 'show provider contact information' do
-          expect(result.text).to include('Contact training provider',
-                                         "Call on #{provider.phone_number}",
-                                         "email at #{provider.email_address}")
-        end
-      end
-
-      context 'when provider has only phone' do
-        let(:provider) do
-          create(:provider, email_address: nil)
-        end
-
-        it 'show provider phone number' do
-          expect(result.text).to include('Contact training provider',
-                                         "Call on #{provider.phone_number}")
-        end
-      end
-
-      context 'when provider has only email' do
-        let(:provider) do
-          create(:provider, phone_number: nil)
-        end
-
-        it 'show provider contact information' do
-          expect(result.text).to include('Contact training provider',
-                                         "Email at #{provider.email_address}")
-        end
-      end
+    it 'shows provider contact information' do
+      expect(result.text).to include('Contact training provider')
     end
   end
 
@@ -321,36 +261,8 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
       expect(result.text).to include('withdraw this application')
     end
 
-    describe 'show provider contact information' do
-      context 'when provider has phone and email' do
-        it 'show provider contact information' do
-          expect(result.text).to include('Contact training provider',
-                                         "Call on #{provider.phone_number}",
-                                         "email at #{provider.email_address}")
-        end
-      end
-
-      context 'when provider has only phone' do
-        let(:provider) do
-          create(:provider, email_address: nil)
-        end
-
-        it 'show provider phone number' do
-          expect(result.text).to include('Contact training provider',
-                                         "Call on #{provider.phone_number}")
-        end
-      end
-
-      context 'when provider has only email' do
-        let(:provider) do
-          create(:provider, phone_number: nil)
-        end
-
-        it 'show provider contact information' do
-          expect(result.text).to include('Contact training provider',
-                                         "Email at #{provider.email_address}")
-        end
-      end
+    it 'shows provider contact information' do
+      expect(result.text).to include('Contact training provider')
     end
   end
 
@@ -371,12 +283,8 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
       expect(result.text).not_to include('withdraw this application')
     end
 
-    describe 'does not show provider contact information' do
-      context 'when provider has phone and email' do
-        it 'show provider contact information' do
-          expect(result.text).not_to include('Contact training provider')
-        end
-      end
+    it 'does not show provider contact information' do
+      expect(result.text).not_to include('Contact training provider')
     end
   end
 end

--- a/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
+++ b/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
@@ -44,9 +44,9 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
   let(:application_choice) do
     create(:application_choice, :awaiting_provider_decision, personal_statement:, sent_to_provider_at: 1.week.ago, course:)
   end
-  let(:course) { create(:course, :with_course_options, course_length:) }
+  let(:provider) { create(:provider) }
+  let(:course) { create(:course, :with_course_options, course_length:, provider:) }
   let(:course_length) { 'OneYear' }
-  let(:provider) { application_choice.current_provider }
   let(:links) { result.css('a').map(&:text) }
   let(:personal_statement) { 'some personal statement' }
 
@@ -119,6 +119,14 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
 
     it 'does not show withdraw CTA' do
       expect(result.text).not_to include('withdraw this application')
+    end
+
+    describe 'does not show provider contact information' do
+      context 'when provider has phone and email' do
+        it 'show provider contact information' do
+          expect(result.text).not_to include('Contact training provider')
+        end
+      end
     end
   end
 
@@ -201,11 +209,43 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
     it 'shows withdraw CTA' do
       expect(result.text).to include('withdraw this application')
     end
+
+    describe 'show provider contact information' do
+      context 'when provider has phone and email' do
+        it 'show provider contact information' do
+          expect(result.text).to include('Contact training provider',
+                                         "Call on #{provider.phone_number}",
+                                         "email at #{provider.email_address}")
+        end
+      end
+
+      context 'when provider has only phone' do
+        let(:provider) do
+          create(:provider, email_address: nil)
+        end
+
+        it 'show provider phone number' do
+          expect(result.text).to include('Contact training provider',
+                                         "Call on #{provider.phone_number}")
+        end
+      end
+
+      context 'when provider has only email' do
+        let(:provider) do
+          create(:provider, phone_number: nil)
+        end
+
+        it 'show provider contact information' do
+          expect(result.text).to include('Contact training provider',
+                                         "Email at #{provider.email_address}")
+        end
+      end
+    end
   end
 
   context 'when application is interviewing' do
     let(:application_choice) do
-      create(:application_choice, :interviewing, interviews: [create(:interview)])
+      create(:application_choice, :interviewing, interviews: [create(:interview)], course:)
     end
 
     it 'shows interview row' do
@@ -220,11 +260,43 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
     it 'shows withdraw CTA' do
       expect(result.text).to include('withdraw this application')
     end
+
+    describe 'show provider contact information' do
+      context 'when provider has phone and email' do
+        it 'show provider contact information' do
+          expect(result.text).to include('Contact training provider',
+                                         "Call on #{provider.phone_number}",
+                                         "email at #{provider.email_address}")
+        end
+      end
+
+      context 'when provider has only phone' do
+        let(:provider) do
+          create(:provider, email_address: nil)
+        end
+
+        it 'show provider phone number' do
+          expect(result.text).to include('Contact training provider',
+                                         "Call on #{provider.phone_number}")
+        end
+      end
+
+      context 'when provider has only email' do
+        let(:provider) do
+          create(:provider, phone_number: nil)
+        end
+
+        it 'show provider contact information' do
+          expect(result.text).to include('Contact training provider',
+                                         "Email at #{provider.email_address}")
+        end
+      end
+    end
   end
 
   context 'when application is inactive' do
     let(:application_choice) do
-      create(:application_choice, :inactive)
+      create(:application_choice, :inactive, course:)
     end
 
     context 'when application cannot make more choices' do
@@ -248,11 +320,43 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
     it 'shows withdraw CTA' do
       expect(result.text).to include('withdraw this application')
     end
+
+    describe 'show provider contact information' do
+      context 'when provider has phone and email' do
+        it 'show provider contact information' do
+          expect(result.text).to include('Contact training provider',
+                                         "Call on #{provider.phone_number}",
+                                         "email at #{provider.email_address}")
+        end
+      end
+
+      context 'when provider has only phone' do
+        let(:provider) do
+          create(:provider, email_address: nil)
+        end
+
+        it 'show provider phone number' do
+          expect(result.text).to include('Contact training provider',
+                                         "Call on #{provider.phone_number}")
+        end
+      end
+
+      context 'when provider has only email' do
+        let(:provider) do
+          create(:provider, phone_number: nil)
+        end
+
+        it 'show provider contact information' do
+          expect(result.text).to include('Contact training provider',
+                                         "Email at #{provider.email_address}")
+        end
+      end
+    end
   end
 
   context 'when application is rejected' do
     let(:application_choice) do
-      create(:application_choice, :rejected_reasons)
+      create(:application_choice, :rejected_reasons, course:)
     end
 
     it 'shows reasons for rejection row' do
@@ -265,6 +369,14 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
 
     it 'does not show withdraw CTA' do
       expect(result.text).not_to include('withdraw this application')
+    end
+
+    describe 'does not show provider contact information' do
+      context 'when provider has phone and email' do
+        it 'show provider contact information' do
+          expect(result.text).not_to include('Contact training provider')
+        end
+      end
     end
   end
 end

--- a/spec/components/candidate_interface/provider_contact_information_component_spec.rb
+++ b/spec/components/candidate_interface/provider_contact_information_component_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::ProviderContactInformationComponent do
+  let(:component) { described_class.new(provider:) }
+  let(:provider) { build(:provider) }
+  let(:result) { render_inline(component) }
+
+  context 'when provider has phone and email' do
+    it 'show provider contact information' do
+      expect(result.text).to include('Contact training provider',
+                                     "Call on #{provider.phone_number}",
+                                     "email at #{provider.email_address}")
+    end
+  end
+
+  context 'when provider has only phone' do
+    let(:provider) do
+      create(:provider, email_address: nil)
+    end
+
+    it 'show provider phone number' do
+      expect(result.text).to include('Contact training provider',
+                                     "Call on #{provider.phone_number}")
+      expect(result.text).not_to include('email at')
+    end
+  end
+
+  context 'when provider has only email' do
+    let(:provider) do
+      create(:provider, phone_number: nil)
+    end
+
+    it 'show provider contact information' do
+      expect(result.text).to include('Contact training provider',
+                                     "Email at #{provider.email_address}")
+    end
+  end
+
+  context 'when provider has no contact information' do
+    let(:provider) do
+      create(:provider, email_address: nil, phone_number: nil)
+    end
+
+    it 'show provider contact information' do
+      expect(result.text).to be_blank
+    end
+  end
+end

--- a/spec/components/previews/candidate_interface/provider_contact_information_component_preview.rb
+++ b/spec/components/previews/candidate_interface/provider_contact_information_component_preview.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class CandidateInterface::ProviderContactInformationComponentPreview < ViewComponent::Preview
+  def default
+    provider = Provider.new(email_address: 'email@gmail.com', phone_number: '0800 123 4567')
+
+    render(CandidateInterface::ProviderContactInformationComponent.new(provider:))
+  end
+end

--- a/spec/system/candidate_interface/post_offer/offer_deferred_spec.rb
+++ b/spec/system/candidate_interface/post_offer/offer_deferred_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+require_relative 'post_offer_helper'
+
+RSpec.feature 'Post-offer dashboard' do
+  include CandidateHelper
+  include PostOfferHelper
+
+  scenario 'Candidate offer is deferred' do
+    given_i_am_signed_in
+    and_i_have_an_accepted_offer_deferred
+
+    when_i_visit_the_application_dashboard
+    then_i_see_that_i_have_deferred_my_offer
+    and_i_should_see_my_references
+    and_i_see_my_offer_conditions
+    and_i_see_the_publisher_contact_information
+    and_i_see_a_link_to_view_the_application
+    and_i_see_a_link_to_withdraw_from_the_course
+  end
+
+  def and_i_have_an_accepted_offer_deferred
+    @application_form = create(:completed_application_form, candidate: @candidate)
+
+    @application_choice = create(
+      :application_choice,
+      :offer_deferred,
+      application_form: @application_form,
+    )
+  end
+
+  def then_i_see_that_i_have_deferred_my_offer
+    expect(page).to have_content("Your deferred offer for #{@application_choice.current_course.name_and_code}")
+    expect(page).to have_content("You’ve chosen to defer your offer from #{@application_choice.course_option.course.provider.name} to study #{@application_choice.course.name_and_code}.")
+  end
+end

--- a/spec/system/candidate_interface/post_offer/pending_conditions_spec.rb
+++ b/spec/system/candidate_interface/post_offer/pending_conditions_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+require_relative 'post_offer_helper'
+
+RSpec.feature 'Post-offer dashboard' do
+  include CandidateHelper
+  include PostOfferHelper
+
+  scenario 'Candidate offer is pending conditions' do
+    given_i_am_signed_in
+    and_i_have_an_accepted_offer_pending_conditions
+
+    when_i_visit_the_application_dashboard
+    then_i_see_that_i_have_accepted_my_offer
+    and_i_should_see_my_references
+    and_i_see_my_offer_conditions
+    and_i_see_the_publisher_contact_information
+    and_i_see_a_link_to_view_the_application
+    and_i_see_a_link_to_withdraw_from_the_course
+  end
+
+  def and_i_have_an_accepted_offer_pending_conditions
+    @application_form = create(:completed_application_form, candidate: @candidate)
+
+    @application_choice = create(
+      :application_choice,
+      :pending_conditions,
+      application_form: @application_form,
+    )
+  end
+end

--- a/spec/system/candidate_interface/post_offer/post_offer_helper.rb
+++ b/spec/system/candidate_interface/post_offer/post_offer_helper.rb
@@ -1,0 +1,36 @@
+module PostOfferHelper
+  def given_i_am_signed_in
+    @candidate = create(:candidate)
+    login_as(@candidate)
+  end
+
+  def when_i_visit_the_application_dashboard
+    visit candidate_interface_application_complete_path
+  end
+
+  def and_i_should_see_my_references
+    expect(page).to have_content('References')
+  end
+
+  def and_i_see_my_offer_conditions
+    expect(page).to have_content('Offer conditions')
+    expect(page).to have_content("#{@application_choice.offer.conditions.first.text} Pending", normalize_ws: true)
+  end
+
+  def then_i_see_that_i_have_accepted_my_offer
+    expect(page).to have_content("Your offer for #{@application_choice.current_course.name_and_code}")
+    expect(page).to have_content("You’ve accepted an offer from #{@application_choice.course_option.course.provider.name} to study #{@application_choice.course.name_and_code}.")
+  end
+
+  def and_i_see_the_publisher_contact_information
+    expect(page).to have_content("Contact #{@application_choice.current_provider.name} if you have any questions")
+  end
+
+  def and_i_see_a_link_to_view_the_application
+    expect(page).to have_link('View application')
+  end
+
+  def and_i_see_a_link_to_withdraw_from_the_course
+    expect(page).to have_link('Withdraw from the course')
+  end
+end

--- a/spec/system/candidate_interface/post_offer/recruited_spec.rb
+++ b/spec/system/candidate_interface/post_offer/recruited_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+require_relative 'post_offer_helper'
+
+RSpec.feature 'Post-offer dashboard' do
+  include CandidateHelper
+  include PostOfferHelper
+
+  scenario 'Candidate is recruited' do
+    given_i_am_signed_in
+    and_i_have_been_recruited
+
+    when_i_visit_the_application_dashboard
+    then_i_see_that_i_have_accepted_my_offer
+    and_i_should_see_my_references
+    and_i_see_my_offer_conditions
+    and_i_see_the_publisher_contact_information
+    and_i_see_a_link_to_view_the_application
+    and_i_see_a_link_to_withdraw_from_the_course
+  end
+
+  def and_i_have_been_recruited
+    @application_form = create(:completed_application_form, candidate: @candidate)
+
+    @application_choice = create(
+      :application_choice,
+      :recruited,
+      application_form: @application_form,
+    )
+  end
+end

--- a/spec/system/candidate_interface/references/candidate_views_their_references_on_the_post_offer_dashboard_continuous_applications_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_views_their_references_on_the_post_offer_dashboard_continuous_applications_spec.rb
@@ -9,6 +9,7 @@ RSpec.feature 'Post-offer references', :with_audited do
 
     when_i_visit_the_application_dashboard
     then_i_should_see_the_post_offer_dashboard
+    and_i_see_the_provider_contact_information
 
     when_i_click_on_my_requested_reference
     then_i_see_my_referee_information
@@ -72,6 +73,10 @@ RSpec.feature 'Post-offer references', :with_audited do
     expect(page).to have_content(@pending_reference.email_address)
     expect(page).to have_content(@pending_reference.referee_type.humanize)
     expect(page).to have_content(@pending_reference.relationship)
+  end
+
+  def and_i_see_the_provider_contact_information
+    expect(page).to have_content("Contact #{@application_choice.current_provider.name} if you have")
   end
 
   def and_my_available_actions


### PR DESCRIPTION
## Context

As part of the update to the candidate interfaces application choices index and show, we want to give the candidate access to the contact information for the provider of the course they are applying to. We are showing the candidate the email address and the phone number of the provider on the application show page and on their offer page.

## Changes proposed in this pull request

As part of the update to the candidate interfaces application choices index and show, we want to give the candidate contact information for the provider of the course.

The information appears on these pages, with these statuses:

**Application review page** statuses:
    `awaiting_provider_decision`, `inactive`, `interviewing` or `offer`,

**Your offer page** statuses:
    `offer_deferred`, `pending_conditions` or `recruited`,

## Guidance to review

New pattern introduced to the system specs:
  create a local helper file and `require_relative`.
  The helpers will be specific to the directory so no need to mix them in with RSpec globally or use shared examples

### Screenshots

_The spacing of the elements shown here are due to change in a later PR aimed at standardising the CSS and markup applied to these elements. These screenhots show that the relevant information is displayed with the correct content on the right pages._

|Application Page|Offer Page|
|---|---|
|![Screenshot from 2024-02-07 14-55-33](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/aa7a5a74-a451-4ba0-afaa-2b197e08aa0a)|![Screenshot from 2024-02-07 14-24-16](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/6b02adf5-e391-420b-9644-66927f0e3cc2)|
## Link to Trello card

[Trello Ticket](https://trello.com/c/BPUIGcx7/1172-apply-contact-training-provider-section-part-32)
