### PR TITLE
Remove insetting of Applications page instructions

### DIFF
--- a/app/views/candidate_interface/continuous_applications_choices/index.html.erb
+++ b/app/views/candidate_interface/continuous_applications_choices/index.html.erb
@@ -45,26 +45,20 @@
 
           <%= render CandidateInterface::ApplicationsLeftMessageComponent.new(@application_form_presenter.application_form) %>
 
-          <div class="govuk-inset-text">
-            <p class="govuk-body">Training providers offer places on courses as people apply throughout the year. Courses stay open until they are full.</p>
+          <p class="govuk-body">Training providers offer places on courses as people apply throughout the year. Courses stay open until they are full.</p>
 
-            <p class="govuk-body">Courses can fill up quickly, so you should apply as soon as you’re ready rather than putting it off.</p>
+          <p class="govuk-body">Courses can fill up quickly, so you should apply as soon as you’re ready rather than putting it off.</p>
 
-            <p class="govuk-body">
-              <%= govuk_link_to 'Read how the application process works', candidate_interface_guidance_path %>.
-            </p>
-          </div>
+          <p class="govuk-body">
+          <%= govuk_link_to 'Read how the application process works', candidate_interface_guidance_path %>.
+          </p>
 
           <% if CycleTimetable.can_add_course_choice?(@application_form_presenter.application_form) && @application_form_presenter.can_add_more_choices? %>
             <%= govuk_button_link_to t('section_items.add_application'), candidate_interface_continuous_applications_do_you_know_the_course_path %>
           <% else %>
-            <div class="govuk-grid-row">
-              <section class="govuk-!-margin-bottom-8">
-                <p class="govuk-body">
-                  You can find courses from 9am on <%= CycleTimetable.find_reopens.to_fs(:govuk_date) %>. You can keep making changes to your application until then.
-                </p>
-              </section>
-            </div>
+            <p class="govuk-body">
+              You can find courses from 9am on <%= CycleTimetable.find_reopens.to_fs(:govuk_date) %>. You can keep making changes to your application until then.
+            </p>
           <% end %>
         <% end %>
       <% end %>


### PR DESCRIPTION
## Context

As part of the design revision of the Application choices page, we have decided to make the text communicating instructions to the candidate set, as opposed to inset. 

## Changes proposed in this pull request

Remove insetting of text

## Guidance to review

## Screenshots

|When apply is not open|When apply is open|
|---|---|
|![Screenshot from 2024-02-07 15-45-17](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/f250ff0f-2482-45f1-b16c-58c447e315b6)|![Screenshot from 2024-02-07 15-45-32](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/bf53e892-6e27-4578-933c-cd5c4b50cafa)|


## Link to Trello card

[Trello Ticket](https://trello.com/c/DJ65NGAy/1269-apply-remove-insetting-from-your-applications-page-instructions-part-61)
