### PR TITLE
Fix 5.1.1 version for DfE sign in API works

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
     ignore:
       - dependency-name: faker
       - dependency-name: sidekiq
+      - dependency-name: http
   - package-ecosystem: npm
     directory: "/"
     schedule:

--- a/Gemfile
+++ b/Gemfile
@@ -107,7 +107,7 @@ gem 'clockwork'
 gem 'rack-attack'
 
 # For outgoing http requests
-gem 'http', '5.2.0'
+gem 'http', '5.1.1'
 
 # For DSI api integration
 gem 'jwt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -342,12 +342,11 @@ GEM
     holidays (8.7.1)
     html-attributes-utils (1.0.2)
       activesupport (>= 6.1.4.4)
-    http (5.2.0)
+    http (5.1.1)
       addressable (~> 2.8)
-      base64 (~> 0.1)
       http-cookie (~> 1.0)
       http-form_data (~> 2.2)
-      llhttp-ffi (~> 0.5.0)
+      llhttp-ffi (~> 0.4.0)
     http-accept (1.7.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
@@ -391,7 +390,7 @@ GEM
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    llhttp-ffi (0.5.0)
+    llhttp-ffi (0.4.0)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
     loofah (2.22.0)
@@ -828,7 +827,7 @@ DEPENDENCIES
   grover
   guard-rspec
   holidays
-  http (= 5.2.0)
+  http (= 5.1.1)
   humanize
   json-schema
   json_api_client


### PR DESCRIPTION
## Context

This is a short term solution until DfE sign in team removes the rule where the user agent is 'http.rb/5.1.1'.
Because of this rule when the gem got updated, it broke the integration.

## Trello card

https://trello.com/c/v95zMAfi/1271-dfe-sign-in-issue-created-the-card-so-we-keep-an-extra-eye-on-it