### PR TITLE
Update gems and tools

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,10 +1,11 @@
 ruby 3.2.2
-nodejs 20.10.0
+nodejs 20.11.0
 yarn 1.22.19
 cf 8.4.0
-azure-cli 2.56.0
+azure-cli 2.57.0
 jq 1.6
 make 4.2.1
 terraform 1.3.5
 redis 7.0.12
 postgres 14.7
+kubelogin 0.1.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,7 +147,7 @@ GEM
       erubi (~> 1.4)
       parser (>= 2.4)
       smart_properties
-    bigdecimal (3.1.5)
+    bigdecimal (3.1.6)
     bindata (2.4.15)
     bindex (0.8.1)
     blazer (3.0.3)
@@ -212,7 +212,7 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    diff-lcs (1.5.0)
+    diff-lcs (1.5.1)
     discard (1.3.0)
       activerecord (>= 4.2, < 8)
     docile (1.4.0)
@@ -230,8 +230,8 @@ GEM
       rubocop
       smart_properties
     erubi (1.12.0)
-    excon (0.108.0)
-    factory_bot (6.4.5)
+    excon (0.109.0)
+    factory_bot (6.4.6)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.4.3)
       factory_bot (~> 6.4)
@@ -417,18 +417,18 @@ GEM
     mime-types-data (3.2023.1205)
     mini_mime (1.1.5)
     mini_portile2 (2.8.5)
-    minitest (5.21.2)
+    minitest (5.22.2)
     multi_json (1.15.0)
     multipart-post (2.3.0)
     nenv (0.3.0)
-    net-imap (0.4.9)
+    net-imap (0.4.10)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.4.0)
+    net-smtp (0.4.0.1)
       net-protocol
     netrc (0.11.0)
     nio4r (2.7.0)
@@ -580,18 +580,18 @@ GEM
     retriable (3.1.2)
     rexml (3.2.6)
     rouge (4.2.0)
-    rspec (3.12.0)
-      rspec-core (~> 3.12.0)
-      rspec-expectations (~> 3.12.0)
-      rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.2)
-      rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.3)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.6)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
+      rspec-support (~> 3.13.0)
     rspec-rails (6.1.1)
       actionpack (>= 6.1)
       activesupport (>= 6.1)
@@ -600,7 +600,7 @@ GEM
       rspec-expectations (~> 3.12)
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
-    rspec-support (3.12.1)
+    rspec-support (3.13.0)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (1.60.2)
@@ -786,7 +786,7 @@ GEM
       anyway_config (>= 1.3, < 3)
       sidekiq
       yabeda (~> 0.6)
-    zeitwerk (2.6.12)
+    zeitwerk (2.6.13)
 
 PLATFORMS
   ruby
@@ -904,4 +904,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.5.3
+   2.5.6

--- a/docs/aks-cheatsheet.md
+++ b/docs/aks-cheatsheet.md
@@ -9,134 +9,136 @@ All examples below show qa usage and you should adapt accordingly.
 ### Raising a PIM request
 
 You need to activate the role in the desired cluster below:
-https://portal.azure.com/?Microsoft_Azure_PIMCommon=true#view/Microsoft_Azure_PIMCommon/ActivationMenuBlade/~/azurerbac
+<https://portal.azure.com/?Microsoft_Azure_PIMCommon=true#view/Microsoft_Azure_PIMCommon/ActivationMenuBlade/~/azurerbac>
 
 Example: Activate `*-teacher-services-cloud-test`. It will be approved automatically after a few seconds
 
 ### Azure setup
 
-```
-$ az login
+```sh
+az login
 ```
 
 Get access credentials for a managed Kubernetes cluster (passing the
 environment name):
 
-```
-$ make qa_aks get-cluster-credentials
+```sh
+make qa_aks get-cluster-credentials
 ```
 
 ## Show namespaces
 
-```
-$ kubectl get namespaces
+```sh
+kubectl get namespaces
 ```
 
 ## Show deployments
 
-```
-$ kubectl -n bat-qa get deployments
+```sh
+kubectl -n bat-qa get deployments
 ```
 
 ## Show pods
 
-```
-$ kubectl -n bat-qa get pods
+```sh
+kubectl -n bat-qa get pods
 ```
 
 ## Get logs from a pod
 
 Without tail:
 
-```
-$ kubectl -n bat-qa logs apply-qa-some-number
+```sh
+kubectl -n bat-qa logs apply-qa-some-number
 ```
 
 Tail:
 
-```
-$ kubectl -n bat-qa logs apply-qa-some-number -f
+```sh
+kubectl -n bat-qa logs apply-qa-some-number -f
 ```
 
 Logs from the ingress:
 
-```
-$ kubectl logs deployment/ingress-nginx-controller -f
+```sh
+kubectl logs deployment/ingress-nginx-controller -f
 ```
 
 Alternatively you can install kubetail and run:
 
-```
-$ kubetail -n bat-qa apply-qa-*
+```sh
+kubetail -n bat-qa apply-qa-*
 ```
 
 ## Open a shell
 
-```
-$ kubectl -n bat-qa get deployments
-$ kubectl -n bat-qa exec -ti deployment/apply-loadtest -- sh
+```sh
+kubectl -n bat-qa get deployments
+kubectl -n bat-qa exec -ti deployment/apply-loadtest -- sh
 ```
 
 Alternatively you can enter directly on a pod:
 
-```
-$ kubectl -n bat-qa exec -ti apply-qa-some-number -- sh
+```sh
+kubectl -n bat-qa exec -ti apply-qa-some-number -- sh
 ```
 
 ## Show CPU / Memory Usage
 
 All pods in a namespace:
-```
+
+```sh
 kubectl -n bat-qa top pod
 ```
 
 All pods:
-```
+
+```sh
 kubectl top pod -A
 ```
 
 ## More info on a pod
 
-```
-$ kubectl -n bat-qa describe pods apply-somenumber-of-the-pod
+```sh
+kubectl -n bat-qa describe pods apply-somenumber-of-the-pod
 ```
 
 ## Scaling
 
 The app:
-```
-$ kubectl -n bat-qa scale deployment/apply-loadtest --replicas 2
+
+```sh
+kubectl -n bat-qa scale deployment/apply-loadtest --replicas 2
 ```
 
 The Nginx:
 
-```
-$ kubectl scale deployment/ingress-nginx-controller --replicas 2
+```sh
+kubectl scale deployment/ingress-nginx-controller --replicas 2
 ```
 
 ### Enter on console
 
-```
+```sh
 kubectl -n bat-qa exec -ti apply-loadtest-some-pod-number -- bundle exec rails c
 ```
 
-
 ### Running tasks
 
-```
+```sh
 kubectl -n bat-qa exec -ti apply-loadtest-some-pod-number -- bundle exec rake -T
 ```
 
 ### Access the DB
 
-```
+```sh
 make install-konduit
 bin/konduit.sh app-name -- psql
 ```
 
 Example of loading test:
 
-```
+```sh
 bin/konduit.sh apply-loadtest -- psql
 ```
 
@@ -144,25 +146,26 @@ bin/konduit.sh apply-loadtest -- psql
 
 To enter on a pod in QA using make:
 
-```
+```sh
 make qa shell
 ```
 
 And in production:
-```
-make production shell
+
+```sh
+CONFIRM_PRODUCTION=true make production shell
 ```
 
 Other environments:
 
-```
+```sh
 make staging shell
 make sandbox shell
 ```
 
 In case you see this error:
 
-```
+```sh
 User 'x' does not exist in MSAL token cache. Run `az login`.
 ```
 


### PR DESCRIPTION
I wanted to update the `azure-cli` version to test why I couldn't
connect to the AKS cluster. I managed to fix the errors locally by
installing `kubelogin`.

You ca do this by running:

```sh
brew install Azure/kubelogin/kubelogin
```

or using `asdf` by running the following commands:

```sh
asdf plugin add kubelogin
asdf install kubelogin latest
asdf global kubelogin latest
```

I also had to run to solve an error `No version is set for command az`:

```sh
asdf global azure-cli latest
```

I updated some gems and bundler.