### PR TITLE
Add CandidateInterface::ApplicationChoiceItemComponent

### DIFF
--- a/app/components/candidate_interface/application_choice_item_component.html.erb
+++ b/app/components/candidate_interface/application_choice_item_component.html.erb
@@ -1,0 +1,18 @@
+<div class="app-application-item">
+  <a href="<%= candidate_interface_continuous_applications_course_review_path(application_choice.id) %>">
+    <div class="app-application-item__body">
+      <div class="app-application-item__status_tag">
+        <%= render(CandidateInterface::ContinuousApplications::ApplicationStatusTagComponent.new(application_choice:, display_info_text: false)) %>
+      </div>
+      <div class="app-application-item__details">
+        <div class="app-application-item__provider_id">
+          <h3 class="govuk-heading-s">
+            <%= provider_name %>
+          </h3>
+          <p class="govuk-body-s govuk-hint govuk-!-margin-left-2 govuk-!-font-size-16"><%= application_id %></p>
+        </div>
+        <p class="govuk-body-s"><%= course_name %> - <%= study_mode %> at <%= site_name %></p>
+      </div>
+    </div>
+  </a>
+</div>

--- a/app/components/candidate_interface/application_choice_item_component.rb
+++ b/app/components/candidate_interface/application_choice_item_component.rb
@@ -1,0 +1,27 @@
+class CandidateInterface::ApplicationChoiceItemComponent < ViewComponent::Base
+  def initialize(application_choice:)
+    @application_choice = application_choice
+  end
+  attr_reader :application_choice
+  delegate :status, to: :application_choice
+
+  def provider_name
+    application_choice.current_course.provider.name
+  end
+
+  def application_id
+    application_choice.id
+  end
+
+  def course_name
+    application_choice.current_course.name_and_code
+  end
+
+  def study_mode
+    application_choice.current_course_option.study_mode.humanize
+  end
+
+  def site_name
+    application_choice.site.name
+  end
+end

--- a/app/frontend/styles/_application-item.scss
+++ b/app/frontend/styles/_application-item.scss
@@ -1,0 +1,59 @@
+.app-application-item {
+  a {
+    text-decoration: none;
+  }
+
+  .govuk-heading-s {
+    @include govuk-link-common;
+    @include govuk-link-style-default;
+    color: $govuk-link-colour;
+    text-wrap: balance;
+  }
+
+  &__details .govuk-body-s {
+    margin-bottom: 0;
+  }
+
+  &__provider_id {
+    display: flex;
+    align-items: center;
+
+    & > * {
+      margin-bottom: 0;
+    }
+  }
+
+  &__choice_id {
+    color: govuk-color("mid-grey");
+  }
+
+  &__status_tag {
+    margin-bottom: govuk-spacing(2);
+  }
+}
+
+.app-application-item__body {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: govuk-spacing(4) 0;
+
+  @include govuk-media-query($from: tablet) {
+    flex-direction: row-reverse;
+    margin-bottom: 0;
+    margin-left: govuk-spacing(2);
+
+    &__status_tag {
+      margin-bottom: govuk-spacing(0);
+    }
+  }
+
+  // https://github.com/alphagov/govuk-frontend/blob/v5.0.0/packages/govuk-frontend/src/govuk/components/task-list/_index.scss#L4
+  &:hover {
+    background-color: govuk-colour("light-grey");
+  }
+
+  &:hover .govuk-heading-s {
+    color: $govuk-link-hover-colour;
+  }
+}

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -48,6 +48,7 @@ $govuk-new-link-styles: true;
 // Shared (custom components)
 @import "add_another";
 @import "application-card";
+@import "application-item";
 @import "autocomplete";
 @import "banner";
 @import "box";

--- a/spec/components/candidate_interface/application_choice_item_component_spec.rb
+++ b/spec/components/candidate_interface/application_choice_item_component_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::ApplicationChoiceItemComponent do
+  let(:application_choice) { create(:application_choice, status) }
+  let(:component) { described_class.new(application_choice:) }
+  let(:rendered) { render_inline(component) }
+
+  shared_examples 'application choice item' do
+    it 'displays correct message' do
+      expect(rendered.text).to include(t("continuous_applications.candidate_application_states.#{application_choice.status}"))
+      expect(rendered.text).to include(application_choice.current_course.provider.name)
+      expect(rendered.text).to include(application_choice.id.to_s)
+      expect(rendered.text).to include(application_choice.current_course.name_and_code)
+      expect(rendered.text).to include(application_choice.site.name)
+    end
+  end
+
+  it_behaves_like('application choice item') { let(:status) { :unsubmitted } }
+  it_behaves_like('application choice item') { let(:status) { :awaiting_provider_decision } }
+  it_behaves_like('application choice item') { let(:status) { :interviewing } }
+  it_behaves_like('application choice item') { let(:status) { :withdrawn } }
+
+  it_behaves_like('application choice item') { let(:status) { :offer } }
+
+  it_behaves_like('application choice item') { let(:status) { :pending_conditions } }
+  it_behaves_like('application choice item') { let(:status) { :offer_withdrawn } }
+
+  it_behaves_like('application choice item') { let(:status) { :rejected } }
+  it_behaves_like('application choice item') { let(:status) { :declined } }
+  it_behaves_like('application choice item') { let(:status) { :inactive } }
+end

--- a/spec/components/previews/candidate_interface/application_choice_item_component_preview.rb
+++ b/spec/components/previews/candidate_interface/application_choice_item_component_preview.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class CandidateInterface::ApplicationChoiceItemComponentPreview < ViewComponent::Preview
+  def unsubmitted
+    render_component(:unsubmitted)
+  end
+
+  def awaiting_provider_decision
+    render_component(:awaiting_provider_decision)
+  end
+
+  def rejected
+    render_component(:rejected)
+  end
+
+  def offer
+    render_component(:offer)
+  end
+
+  def pending_conditions
+    render_component(:pending_conditions)
+  end
+
+  def interviewing
+    render_component(:interviewing)
+  end
+
+  def withdrawn
+    render_component(:withdrawn)
+  end
+
+  def offer_withdrawn
+    render_component(:offer_withdrawn)
+  end
+
+  def declined
+    render_component(:declined)
+  end
+
+  def inactive
+    render_component(:inactive)
+  end
+
+private
+
+  def render_component(status)
+    choice = ApplicationChoice.where(status:).last
+
+    render(CandidateInterface::ApplicationChoiceItemComponent.new(application_choice: choice))
+  end
+end


### PR DESCRIPTION
## Context

The candidate applications page is being updated with new designs. This component will become the new representation of a candidates application choice on their 'Your applications' page.

The component is not rendered on that page in the PR. This just creates the component ready to be added to the page.

## Changes proposed in this pull request

  This component will appear as an item in the list of applications on
  the candidates application choices page.

  The statuses declared in previews and tests are those which might
  appear on that page. Post offer statuses will not.

  Styles here are implemented to mock the behaviour that we expect to be
  added when govuk-frontend version is updated to > 5.

## Screenshots

|Desktop| Desktop Hover|
|---|---|
|![Screenshot from 2024-02-09 12-09-16](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/05e1e753-01af-4584-80a2-4ba35794addd)|![Screenshot from 2024-02-09 12-09-00](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/2440bb26-c711-404e-aa58-3b828e53a378)|



_Problem with the width of the h3. It doesn't seem to change the width of the element with `text-wrap: balance`. So the application id looks way off. Any suggestions?_

|Mobile|Tablet|
|---|---|
|![Screenshot from 2024-02-09 12-04-14](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/caf43ef3-5145-47bc-9f78-5be59e7251a3)|![ipad](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/89fffc35-ac1b-41b8-8299-8d636c420cef)|


## Guidance to review


Have a look at the previews
[localhost](http://localhost:3000/rails/view_components/candidate_interface/application_choice_item_component)
[Review app](https://apply-review-9083.test.teacherservices.cloud/rails/view_components/candidate_interface/application_choice_item_component)

## Link to Trello card

[Trello Ticket](https://trello.com/c/eUNYqYzx/1169-apply-create-application-component-with-new-design-part-62)
