### PR TITLE
Fix flakey spec on main

### DIFF
--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -62,6 +62,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_bachelor_degree do
+      after(:create) do |application_form, _|
+        create(:degree_qualification, :bachelor, application_form:)
+      end
+    end
+
     trait :with_degree do
       after(:create) do |application_form, _|
         create(:degree_qualification, application_form:)

--- a/spec/factories/application_qualification.rb
+++ b/spec/factories/application_qualification.rb
@@ -118,7 +118,7 @@ FactoryBot.define do
       end
 
       trait :bachelor do
-        qualification_type { Hesa::DegreeType.all.map(&:name).grep(/Bachelor/).first }
+        qualification_type { Hesa::DegreeType.where(level: :bachelor).first.name }
       end
     end
 

--- a/spec/factories/application_qualification.rb
+++ b/spec/factories/application_qualification.rb
@@ -116,6 +116,10 @@ FactoryBot.define do
         grade { Adviser::ApplicationFormValidations::APPLICABLE_DOMESTIC_DEGREE_GRADES.sample }
         qualification_level { Adviser::ApplicationFormValidations::APPLICABLE_DOMESTIC_DEGREE_LEVELS.sample }
       end
+
+      trait :bachelor do
+        qualification_type { Hesa::DegreeType.all.map(&:name).grep(/Bachelor/).first }
+      end
     end
 
     factory :non_uk_degree_qualification do

--- a/spec/system/candidate_interface/continuous_applications/entering_details/candidate_marking_section_complete_or_incomplete_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/entering_details/candidate_marking_section_complete_or_incomplete_spec.rb
@@ -82,7 +82,7 @@ RSpec.feature 'Marking section as complete or incomplete' do
       :completed,
       :with_gcses,
       :with_a_levels,
-      :with_degree,
+      :with_bachelor_degree,
       full_work_history: true,
       volunteering_experiences_count: 1,
       candidate: current_candidate,


### PR DESCRIPTION
## Context

We have a flakey spec: /spec/system/candidate_interface/continuous_applications/entering_details/candidate_marking_section_complete_or_incomplete_spec.rb[1:6]
‌

`with_degree` trait can create a degree of many different types. because the factory is using

```ruby
qualification_type { Hesa::DegreeType.all.sample.name }
```

This can create foundation degrees or any other degrees at random which makes the spec flakey

And on the degree wizard we don't show the complete section component if the candidate only has foundation degree for example

So forcing a bachelor or master will make the spec work

## Trello card

https://trello.com/c/NRpgI3k7/1275-investigate-and-fix-flakey-spec
