### PR TITLE
Show sent provider at in manage report

### DIFF
--- a/app/services/provider_interface/application_data_export.rb
+++ b/app/services/provider_interface/application_data_export.rb
@@ -10,7 +10,7 @@ module ProviderInterface
           'Application number' => application.id,
           'Recruitment cycle' => RecruitmentCycle.cycle_name(application.application_form.recruitment_cycle_year),
           'Status' => I18n.t("provider_application_states.#{application.status}", default: application.status),
-          'Received date' => application.application_form.submitted_at,
+          'Received date' => application.sent_to_provider_at,
           'Updated date' => application.updated_at,
           'First name' => application.application_form.first_name,
           'Last name' => application.application_form.last_name,

--- a/spec/services/provider_interface/application_data_export_spec.rb
+++ b/spec/services/provider_interface/application_data_export_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ProviderInterface::ApplicationDataExport do
         'Application number' => application_choice.id,
         'Recruitment cycle' => RecruitmentCycle.cycle_name(application_choice.application_form.recruitment_cycle_year),
         'Status' => I18n.t("provider_application_states.#{application_choice.status}", default: application_choice.status),
-        'Received date' => application_choice.application_form.submitted_at,
+        'Received date' => application_choice.sent_to_provider_at,
         'Updated date' => application_choice.updated_at,
         'First name' => application_choice.application_form.first_name,
         'Last name' => application_choice.application_form.last_name,


### PR DESCRIPTION
## Context

We should use the sent to provider at date on provider reports as continuous application the sent to provider at can be totally different from submitted_at

## Guidance to review

1. Have applications in two scenarios: where the submitted at is the same as the sent to provider and another application different
2. Go to provider interface
3. Sign in as a provider user in Manage
4. Click Reports tab
5. Click Export application data
6. Select 2023 to 2024 - current
7. All received at dates should be the sent to provider at AND not the submitted at date

## Link to Trello card

https://trello.com/c/DzWFcO1R/1287-fix-bug-on-data-report-in-manage
