### PR TITLE
Update continuous application check to use v23 notation

### DIFF
--- a/app/controllers/candidate_interface/after_sign_in_controller.rb
+++ b/app/controllers/candidate_interface/after_sign_in_controller.rb
@@ -8,7 +8,7 @@ module CandidateInterface
     def interstitial
       current_candidate.update!(course_from_find_id: nil)
 
-      if current_application.submitted? && !current_application.continuous_applications?
+      if current_application.submitted? && current_application.v23?
         redirect_to candidate_interface_application_complete_path
       elsif current_application.contains_course?(course_from_find)
         flash[:warning] = "You have already added an application for #{course_from_find.name}. #{view_context.link_to('Find a different course to apply to', find_url, class: 'govuk-link')}."

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -43,11 +43,8 @@ module CandidateInterface
       @choices_controller ||= begin
         choices_controllers = Regexp.compile(APPLICATION_CHOICE_CONTROLLER_PATHS.join('|'))
 
-        if controller_path.match?(choices_controllers)
-          true
-        elsif controller_path.match('candidate_interface/guidance')
-          request.referer&.match?('choices')
-        end
+        controller_path.match?(choices_controllers) ||
+          (controller_path.match('candidate_interface/guidance') && request.referer&.match?('choices'))
       end
     end
 

--- a/app/controllers/candidate_interface/continuous_applications_controller.rb
+++ b/app/controllers/candidate_interface/continuous_applications_controller.rb
@@ -12,7 +12,7 @@ module CandidateInterface
     end
 
     def verify_continuous_applications
-      render_404 unless current_application&.continuous_applications?
+      render_404 if current_application&.v23?
     end
   end
 end

--- a/app/controllers/candidate_interface/decisions_controller.rb
+++ b/app/controllers/candidate_interface/decisions_controller.rb
@@ -72,7 +72,7 @@ module CandidateInterface
       if @withdrawal_feedback_form.save(@application_choice)
         flash[:success] = "Your application for #{@application_choice.current_course.name_and_code} at #{@application_choice.provider.name} has been withdrawn"
 
-        redirect_to applications_list_page
+        redirect_to your_applications_or_carry_over_page
       else
         track_validation_error(@withdrawal_feedback_form)
         @provider = @application_choice.provider
@@ -84,11 +84,11 @@ module CandidateInterface
 
   private
 
-    def applications_list_page
-      if @application_choice.continuous_applications?
-        candidate_interface_continuous_applications_choices_path
-      else
+    def your_applications_or_carry_over_page
+      if current_application.v23?
         candidate_interface_application_complete_path
+      else
+        candidate_interface_continuous_applications_choices_path
       end
     end
 

--- a/app/controllers/candidate_interface/section_controller.rb
+++ b/app/controllers/candidate_interface/section_controller.rb
@@ -2,12 +2,10 @@ module CandidateInterface
   class SectionController < CandidateInterfaceController
     before_action UnsuccessfulCarryOverFilter
     before_action CarryOverFilter
-    before_action :redirect_to_post_offer_dashboard_if_accepted_deferred_or_recruited, if: :continuous_applications?
+    before_action :redirect_to_post_offer_dashboard_if_accepted_deferred_or_recruited
     before_action :set_section_policy
     before_action :verify_edit_authorized_section, except: %i[show review]
     before_action :verify_delete_authorized_section, only: %i[destroy confirm_destroy]
-
-    delegate :continuous_applications?, to: :current_application
 
     def show; end
     def review; end

--- a/app/filters/already_carried_over_filter.rb
+++ b/app/filters/already_carried_over_filter.rb
@@ -6,6 +6,6 @@ class AlreadyCarriedOverFilter < ApplicationFilter
   def call
     return if current_application.carry_over?
 
-    redirect_to candidate_interface_continuous_applications_details_path if current_application.continuous_applications?
+    redirect_to candidate_interface_continuous_applications_details_path unless current_application.v23?
   end
 end

--- a/app/filters/unsuccessful_carry_over_filter.rb
+++ b/app/filters/unsuccessful_carry_over_filter.rb
@@ -4,6 +4,6 @@ class UnsuccessfulCarryOverFilter < ApplicationFilter
   def call
     return if CycleTimetable.can_add_course_choice?(current_application) || current_application.carry_over?
 
-    redirect_to candidate_interface_application_complete_path unless current_application.continuous_applications?
+    redirect_to candidate_interface_application_complete_path if current_application.v23?
   end
 end

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -68,8 +68,6 @@ class ApplicationChoice < ApplicationRecord
   scope :accepted, -> { where(status: ApplicationStateChange::ACCEPTED_STATES) }
   scope :inactive_past_day, -> { inactive.where(inactive_at: 1.day.ago..Time.zone.now) }
 
-  delegate :continuous_applications?, to: :application_form
-
   def submitted?
     !unsubmitted?
   end

--- a/app/models/application_dates.rb
+++ b/app/models/application_dates.rb
@@ -4,11 +4,9 @@ class ApplicationDates
   end
 
   def submitted_at
-    return @application_form.submitted_at unless @application_form.continuous_applications?
+    first_pending_condition = @application_form.application_choices.pending_conditions.first
 
-    sent_to_provider_at = @application_form.application_choices.pending_conditions.first&.sent_to_provider_at
-
-    sent_to_provider_at || @application_form.submitted_at
+    first_pending_condition&.sent_to_provider_at || @application_form.submitted_at
   end
 
   def reject_by_default_at

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -555,8 +555,8 @@ class ApplicationForm < ApplicationRecord
     end
   end
 
-  def continuous_applications?
-    @continuous_applications ||= recruitment_cycle_year >= CONTINUOUS_APPLICATIONS_CYCLE_YEAR
+  def v23?
+    @v23 ||= recruitment_cycle_year < CONTINUOUS_APPLICATIONS_CYCLE_YEAR
   end
 
   module ColumnSectionMapping

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,84 +1,84 @@
 <% case try(:current_namespace) %>
 <% when 'candidate_interface' %>
   <%= render(HeaderComponent.new(
-    classes: "app-header--#{HostingEnvironment.environment_name} app-header--full-border",
-    service_name: service_name,
-    service_link: service_link,
-  )) %>
+              classes: "app-header--#{HostingEnvironment.environment_name} app-header--full-border",
+              service_name: service_name,
+              service_link: service_link,
+            )) %>
   <%= render PhaseBannerComponent.new(no_border: current_candidate.present?) %>
   <% if current_candidate %>
-    <% if current_candidate.current_application.continuous_applications? %>
+    <% if current_candidate.current_application.v23? %>
       <%= render(PrimaryNavigationComponent.new(
-        items: NavigationItems.candidate_primary_navigation(current_candidate:, current_controller: controller),
-        items_right: [NavigationItems::NavigationItem.new('Sign out', candidate_interface_sign_out_path)],
-      )) %>
+                  items: NavigationItems.for_candidate_primary_nav(current_candidate, controller),
+                  items_right: [NavigationItems::NavigationItem.new('Sign out', candidate_interface_sign_out_path)],
+                )) %>
     <% else %>
       <%= render(PrimaryNavigationComponent.new(
-        items: NavigationItems.for_candidate_primary_nav(current_candidate, controller),
-        items_right: [NavigationItems::NavigationItem.new('Sign out', candidate_interface_sign_out_path)],
-      )) %>
+                  items: NavigationItems.candidate_primary_navigation(current_candidate:, current_controller: controller),
+                  items_right: [NavigationItems::NavigationItem.new('Sign out', candidate_interface_sign_out_path)],
+                )) %>
+    <% end %>
   <% end %>
-<% end %>
 <% when 'support_interface' %>
   <%= render(HeaderComponent.new(
-    classes: "app-header--#{HostingEnvironment.environment_name} app-header--full-border app-header--wide-logo",
-    product_name: service_name,
-    homepage_url: service_link,
-    service_link: service_link,
-    phase_tag: true,
-    navigation_items: NavigationItems.for_support_account_nav(try(:current_support_user)),
-    navigation_classes: 'govuk-header__navigation--end',
-  )) %>
+        classes: "app-header--#{HostingEnvironment.environment_name} app-header--full-border app-header--wide-logo",
+        product_name: service_name,
+        homepage_url: service_link,
+        service_link: service_link,
+        phase_tag: true,
+        navigation_items: NavigationItems.for_support_account_nav(try(:current_support_user)),
+        navigation_classes: 'govuk-header__navigation--end',
+      )) %>
   <%= render(PrimaryNavigationComponent.new(
-    items: NavigationItems.for_support_primary_nav(try(:current_support_user), controller),
-  )) %>
+        items: NavigationItems.for_support_primary_nav(try(:current_support_user), controller),
+      )) %>
   <%= yield(:navigation) if content_for?(:navigation) %>
 <% when 'provider_interface' %>
   <%= render(HeaderComponent.new(
-    classes: "app-header--#{HostingEnvironment.environment_name} app-header--full-border app-header--wide-logo",
-    product_name: service_name,
-    homepage_url: service_link,
-    service_link: service_link,
-    navigation_items: NavigationItems.for_provider_account_nav(try(:current_provider_user), controller, performing_setup: @provider_setup&.pending?),
-    navigation_classes: 'govuk-header__navigation--end',
-  )) %>
+      classes: "app-header--#{HostingEnvironment.environment_name} app-header--full-border app-header--wide-logo",
+      product_name: service_name,
+      homepage_url: service_link,
+      service_link: service_link,
+      navigation_items: NavigationItems.for_provider_account_nav(try(:current_provider_user), controller, performing_setup: @provider_setup&.pending?),
+      navigation_classes: 'govuk-header__navigation--end',
+    )) %>
   <% if controller.controller_name == 'start_page' %>
     <%= render(PhaseBannerComponent.new(
-      feedback_link: ProviderInterface::FEEDBACK_LINK,
-    )) %>
+        feedback_link: ProviderInterface::FEEDBACK_LINK,
+      )) %>
   <% elsif controller.controller_name.in? %w[sessions provider_agreements] %>
     <%= render(PhaseBannerComponent.new(
-      feedback_link: ProviderInterface::FEEDBACK_LINK,
-    )) %>
+        feedback_link: ProviderInterface::FEEDBACK_LINK,
+      )) %>
   <% else %>
     <%= render(PhaseBannerComponent.new(
-      no_border: true,
-      feedback_link: ProviderInterface::FEEDBACK_LINK,
-    )) %>
+        no_border: true,
+        feedback_link: ProviderInterface::FEEDBACK_LINK,
+      )) %>
     <%= render(PrimaryNavigationComponent.new(
-      items: NavigationItems.for_provider_primary_nav(try(:current_provider_user), controller, performing_setup: @provider_setup&.pending?),
-    )) %>
+        items: NavigationItems.for_provider_primary_nav(try(:current_provider_user), controller, performing_setup: @provider_setup&.pending?),
+      )) %>
   <% end %>
 <% when 'vendor_api_docs' %>
   <%= render(HeaderComponent.new(
-    classes: "app-header--#{HostingEnvironment.environment_name} app-header--full-border app-header--wide-logo",
-    product_name: service_name,
-    service_link: service_link,
-    phase_tag: true,
-  )) %>
+      classes: "app-header--#{HostingEnvironment.environment_name} app-header--full-border app-header--wide-logo",
+      product_name: service_name,
+      service_link: service_link,
+      phase_tag: true,
+    )) %>
   <%= render(PrimaryNavigationComponent.new(
-    items: NavigationItems.for_vendor_api_docs(controller),
-  )) %>
+      items: NavigationItems.for_vendor_api_docs(controller),
+    )) %>
 <% when 'register_api_docs' %>
   <%= render(HeaderComponent.new(
-    classes: "app-header--#{HostingEnvironment.environment_name} app-header--full-border app-header--wide-logo",
-    product_name: service_name,
-    service_link: service_link,
-    phase_tag: true,
-  )) %>
+      classes: "app-header--#{HostingEnvironment.environment_name} app-header--full-border app-header--wide-logo",
+      product_name: service_name,
+      service_link: service_link,
+      phase_tag: true,
+    )) %>
   <%= render(PrimaryNavigationComponent.new(
-    items: NavigationItems.for_register_api_docs(controller),
-  )) %>
+      items: NavigationItems.for_register_api_docs(controller),
+    )) %>
 <% else %>
   <% components_url = '/rails/view_components' if request.path.match(/^\/rails\/view_components/) %>
   <% components_name = 'ViewComponent Previews' if request.path.match(/^\/rails\/view_components/) %>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -77,10 +77,10 @@
 
 <%= render LanguageSkillsComponent.new(application_form: @application_choice.application_form) %>
 
-<% if @application_choice.application_form.continuous_applications? %>
-  <%= render ProviderInterface::ChoicePersonalStatementComponent.new(application_choice: @application_choice) %>
-<% else %>
+<% if @application_choice.application_form.v23? %>
   <%= render PersonalStatementComponent.new(application_form: @application_choice.application_form) %>
+<% else %>
+  <%= render ProviderInterface::ChoicePersonalStatementComponent.new(application_choice: @application_choice) %>
 <% end %>
 
 <%= render ProviderInterface::TrainingWithDisabilityComponent.new(application_form: @application_choice.application_form) %>

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe ApplicationForm do
     end
   end
 
-  describe '#continuous_applications?' do
+  describe '#v23?' do
     subject(:application_form) do
       create(:application_form, recruitment_cycle_year:)
     end
@@ -53,7 +53,7 @@ RSpec.describe ApplicationForm do
       let(:recruitment_cycle_year) { 2024 }
 
       it 'returns true' do
-        expect(application_form).to be_continuous_applications
+        expect(application_form).not_to be_v23
       end
     end
 
@@ -61,7 +61,7 @@ RSpec.describe ApplicationForm do
       let(:recruitment_cycle_year) { 2023 }
 
       it 'returns false' do
-        expect(application_form).not_to be_continuous_applications
+        expect(application_form).to be_v23
       end
     end
   end

--- a/spec/services/interview_workflow_constraints_spec.rb
+++ b/spec/services/interview_workflow_constraints_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe InterviewWorkflowConstraints do
       let(:interview) { build(:interview, application_choice:, skip_application_choice_status_update: true) }
 
       it 'does not raises InterviewWorkflowError' do
-        expect { workflow_constraints.create! }.not_to raise_error(InterviewWorkflowConstraints::WorkflowError)
+        expect { workflow_constraints.create! }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
This will reverse the logic of the continuous application check to use the pre-continuous application timeline and rename the method to `v23?` to reflect the version of the timeline. This means that most conditionals' branches need to be interchanged.

It is part of a series of PRs related to the Par4 4 of the continuous applications refactor.

![](https://github.trello.services/images/mini-trello-icon.png) [CATD: Part 4 - Move behaviour from continuous applications to the new normal](https://trello.com/c/ysJmKydI/1189-catd-part-4-move-behaviour-from-continuous-applications-to-the-new-normal)