### PR TITLE
Rollback http gem fix version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
     ignore:
       - dependency-name: faker
       - dependency-name: sidekiq
-      - dependency-name: http
   - package-ecosystem: npm
     directory: "/"
     schedule:

--- a/Gemfile
+++ b/Gemfile
@@ -107,7 +107,7 @@ gem 'clockwork'
 gem 'rack-attack'
 
 # For outgoing http requests
-gem 'http', '5.2.0'
+gem 'http'
 
 # For DSI api integration
 gem 'jwt'

--- a/Gemfile
+++ b/Gemfile
@@ -107,7 +107,7 @@ gem 'clockwork'
 gem 'rack-attack'
 
 # For outgoing http requests
-gem 'http', '5.1.1'
+gem 'http', '5.2.0'
 
 # For DSI api integration
 gem 'jwt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -828,7 +828,7 @@ DEPENDENCIES
   grover
   guard-rspec
   holidays
-  http (= 5.2.0)
+  http
   humanize
   json-schema
   json_api_client

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -342,11 +342,12 @@ GEM
     holidays (8.7.1)
     html-attributes-utils (1.0.2)
       activesupport (>= 6.1.4.4)
-    http (5.1.1)
+    http (5.2.0)
       addressable (~> 2.8)
+      base64 (~> 0.1)
       http-cookie (~> 1.0)
       http-form_data (~> 2.2)
-      llhttp-ffi (~> 0.4.0)
+      llhttp-ffi (~> 0.5.0)
     http-accept (1.7.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
@@ -390,7 +391,7 @@ GEM
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    llhttp-ffi (0.4.0)
+    llhttp-ffi (0.5.0)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
     loofah (2.22.0)
@@ -827,7 +828,7 @@ DEPENDENCIES
   grover
   guard-rspec
   holidays
-  http (= 5.1.1)
+  http (= 5.2.0)
   humanize
   json-schema
   json_api_client


### PR DESCRIPTION
## Context

There was an issue with Manage where the providers can create new users. 

The problem is that DfE sign in team had a rule that on their API is expect us to send the user agent 'http/5.1' and this breaks when the gem got updated.

Yesterday evening the DfE sign in team removed that rule (you can check [here](https://ukgovernmentdfe.slack.com/archives/C5S500XB6/p1707318307829689)).

So now we can rollback and continue to keep the http gem updates without any issue.

## Link to Trello card

https://trello.com/c/v95zMAfi/1271-dfe-sign-in-issue-implement-and-then-remove-workaround