### PR TITLE
Show more show less on long personal statements when viewing the application

### DIFF
--- a/app/components/candidate_interface/continuous_applications/application_review_component.rb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.rb
@@ -120,7 +120,7 @@ module CandidateInterface
           value = value
             .then { |text| sanitize(text, class: 'govuk-body') } # Sanitizes text before handling html safe
             .then { |text| text.truncate_words(40, omission: ' ') }
-            .then { |text| "#{text} <span id='show-more-show-less-text' class='govuk-visually-hidden'>#{value[text.size..-1]}</span>" }
+            .then { |text| "#{text} <span id='show-more-show-less-text' tabindex='-1' class='govuk-visually-hidden'>#{value[text.size..-1]}</span>" }
             .then { |text| "#{text} #{govuk_link_to('Show more', '#', id: 'show-more-show-less')}" }
             .then(&:html_safe)
         end

--- a/app/components/candidate_interface/continuous_applications/application_review_component.rb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.rb
@@ -108,26 +108,9 @@ module CandidateInterface
       end
 
       def personal_statement_row
-        value = if unsubmitted?
-                  @application_choice.application_form.becoming_a_teacher
-                else
-                  @application_choice.personal_statement
-                end
-
-        number_of_words = value.to_s.split.size
-
-        if number_of_words > 40
-          value = value
-            .then { |text| sanitize(text, class: 'govuk-body') } # Sanitizes text before handling html safe
-            .then { |text| text.truncate_words(40, omission: ' ') }
-            .then { |text| "#{text} <span id='show-more-show-less-text' tabindex='-1' class='govuk-visually-hidden'>#{value[text.size..-1]}</span>" }
-            .then { |text| "#{text} #{govuk_link_to('Show more', '#', id: 'show-more-show-less')}" }
-            .then(&:html_safe)
-        end
-
         {
           key: 'Personal statement',
-          value:,
+          value: render(PersonalStatementSummaryComponent.new(application_choice:)),
         }
       end
 

--- a/app/components/candidate_interface/continuous_applications/application_review_component.rb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.rb
@@ -114,9 +114,20 @@ module CandidateInterface
                   @application_choice.personal_statement
                 end
 
+        number_of_words = value.to_s.split.size
+
+        if number_of_words > 40
+          value = value
+            .then { |text| sanitize(text, class: 'govuk-body') } # Sanitizes text before handling html safe
+            .then { |text| text.truncate_words(40, omission: ' ') }
+            .then { |text| "#{text} <span id='show-more-show-less-text' class='govuk-visually-hidden'>#{value[text.size..-1]}</span>" }
+            .then { |text| "#{text} #{govuk_link_to('Show more', '#', id: 'show-more-show-less')}" }
+            .then(&:html_safe)
+        end
+
         {
           key: 'Personal statement',
-          value: value,
+          value:,
         }
       end
 

--- a/app/components/candidate_interface/continuous_applications/personal_statement_summary_component.html.erb
+++ b/app/components/candidate_interface/continuous_applications/personal_statement_summary_component.html.erb
@@ -1,0 +1,9 @@
+<% if full_personal_statement? %>
+  <%= personal_statement %>
+<% else %>
+  <%= personal_statement_short_version %>
+  <span id="app-remaining-personal-statement" tabindex='-1' class='govuk-visually-hidden'>
+    <%= personal_statement_remaining_version %>
+  </span>
+  <%= govuk_link_to('Show more', '#', class: 'app-show-more-show-less', data: { container: 'app-remaining-personal-statement', 'show-more': 'Show more', 'show-less': 'Show less' }) %>
+<% end %>

--- a/app/components/candidate_interface/continuous_applications/personal_statement_summary_component.html.erb
+++ b/app/components/candidate_interface/continuous_applications/personal_statement_summary_component.html.erb
@@ -5,5 +5,10 @@
   <span id="app-remaining-personal-statement" tabindex='-1' class='govuk-visually-hidden'>
     <%= personal_statement_remaining_version %>
   </span>
+
   <%= govuk_link_to('Show more', '#', class: 'app-show-more-show-less', data: { container: 'app-remaining-personal-statement', 'show-more': 'Show more', 'show-less': 'Show less' }) %>
+
+  <noscript>
+    <%= personal_statement_remaining_version %>
+  </noscript>
 <% end %>

--- a/app/components/candidate_interface/continuous_applications/personal_statement_summary_component.rb
+++ b/app/components/candidate_interface/continuous_applications/personal_statement_summary_component.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   module ContinuousApplications
     class PersonalStatementSummaryComponent < ViewComponent::Base
-      MAXIMUM_CHARACTERS_FULL_PERSONAL_STATEMENT = 40
+      MAXIMUM_WORDS_FULL_PERSONAL_STATEMENT = 40
       attr_reader :application_choice
       delegate :unsubmitted?,
                to: :application_choice
@@ -13,12 +13,12 @@ module CandidateInterface
       def full_personal_statement?
         number_of_words = personal_statement.to_s.split.size
 
-        number_of_words <= MAXIMUM_CHARACTERS_FULL_PERSONAL_STATEMENT
+        number_of_words <= MAXIMUM_WORDS_FULL_PERSONAL_STATEMENT
       end
 
       def personal_statement_short_version
         personal_statement.truncate_words(
-          MAXIMUM_CHARACTERS_FULL_PERSONAL_STATEMENT,
+          MAXIMUM_WORDS_FULL_PERSONAL_STATEMENT,
           omission: ' ',
         )
       end

--- a/app/components/candidate_interface/continuous_applications/personal_statement_summary_component.rb
+++ b/app/components/candidate_interface/continuous_applications/personal_statement_summary_component.rb
@@ -1,0 +1,39 @@
+module CandidateInterface
+  module ContinuousApplications
+    class PersonalStatementSummaryComponent < ViewComponent::Base
+      MAXIMUM_CHARACTERS_FULL_PERSONAL_STATEMENT = 40
+      attr_reader :application_choice
+      delegate :unsubmitted?,
+               to: :application_choice
+
+      def initialize(application_choice:)
+        @application_choice = application_choice
+      end
+
+      def full_personal_statement?
+        number_of_words = personal_statement.to_s.split.size
+
+        number_of_words <= MAXIMUM_CHARACTERS_FULL_PERSONAL_STATEMENT
+      end
+
+      def personal_statement_short_version
+        personal_statement.truncate_words(
+          MAXIMUM_CHARACTERS_FULL_PERSONAL_STATEMENT,
+          omission: ' ',
+        )
+      end
+
+      def personal_statement_remaining_version
+        personal_statement[personal_statement_short_version.size..]
+      end
+
+      def personal_statement
+        @personal_statement ||= if unsubmitted?
+                                  @application_choice.application_form.becoming_a_teacher
+                                else
+                                  @application_choice.personal_statement
+                                end
+      end
+    end
+  end
+end

--- a/app/frontend/packs/application-candidate.js
+++ b/app/frontend/packs/application-candidate.js
@@ -8,6 +8,7 @@ import nationalitiesComponent from './nationalities-component'
 import 'accessible-autocomplete/dist/accessible-autocomplete.min.css'
 import '../styles/application-candidate.scss'
 import cookieBanners from './cookies/cookie-banners'
+import showMoreShowLess from './components/show-more-show-less'
 
 require.context('govuk-frontend/govuk/assets')
 
@@ -24,3 +25,4 @@ candidateAutosuggestInputs.forEach((autoSuggestInput) => {
 initWarnOnUnsavedChanges()
 nationalitiesComponent()
 cookieBanners()
+showMoreShowLess()

--- a/app/frontend/packs/components/show-more-show-less.js
+++ b/app/frontend/packs/components/show-more-show-less.js
@@ -4,9 +4,9 @@ function ShowMoreShowLess () {
   const context = this
 
   if (context.showMoreLinks.length) {
-    [].forEach.call(context.showMoreLinks, function(showMoreLink) {
+    [].forEach.call(context.showMoreLinks, function (showMoreLink) {
       context.setShowMoreLinkListener(showMoreLink)
-    });
+    })
   }
 }
 
@@ -17,13 +17,13 @@ ShowMoreShowLess.prototype.setShowMoreLinkListener = function (showMoreLink) {
 ShowMoreShowLess.prototype.expandContractTarget = function (event) {
   event.preventDefault()
 
-  const link = event.target;
+  const link = event.target
   const container = document.getElementById(link.getAttribute('data-container'))
   const lessText = link.getAttribute('data-show-less')
   const moreText = link.getAttribute('data-show-more')
   const isExpanded = link.getAttribute('aria-expanded')
 
-  if (isExpanded && isExpanded == 'true') {
+  if (isExpanded === 'true') {
     container.classList.add('govuk-visually-hidden')
     link.text = moreText
     link.setAttribute('aria-expanded', false)

--- a/app/frontend/packs/components/show-more-show-less.js
+++ b/app/frontend/packs/components/show-more-show-less.js
@@ -1,0 +1,35 @@
+function ShowMoreShowLess () {
+  this.link = document.getElementById('show-more-show-less')
+  this.container = document.getElementById('show-more-show-less-text');
+  this.isLess = true;
+  this.lessText = "Show less";
+  this.moreText = "Show more";
+
+  this.addButtonListener()
+}
+
+ShowMoreShowLess.prototype.addButtonListener = function () {
+  let context = this;
+
+  this.link.addEventListener('click', function (e) {
+    e.preventDefault()
+
+    if (context.isLess) {
+      context.isLess = false;
+     // context.container.style.display = 'block';
+      context.container.classList.remove('govuk-visually-hidden');
+      context.link.innerHTML = context.lessText;
+      context.container.focus();
+      context.link.setAttribute('aria-expanded', true);
+    } else {
+      context.isLess = true;
+      // context.container.style.display = 'none';
+      context.container.classList.add('govuk-visually-hidden');
+      context.link.innerHTML = context.moreText;
+      context.link.setAttribute('aria-expanded', false);
+    }
+  }, false)
+}
+
+const showMoreShowLess = () => new ShowMoreShowLess()
+export default showMoreShowLess

--- a/app/frontend/packs/components/show-more-show-less.js
+++ b/app/frontend/packs/components/show-more-show-less.js
@@ -1,34 +1,38 @@
 function ShowMoreShowLess () {
-  this.link = document.getElementById('show-more-show-less')
-  this.container = document.getElementById('show-more-show-less-text');
-  this.isLess = true;
-  this.lessText = "Show less";
-  this.moreText = "Show more";
+  this.showMoreLinks = document.getElementsByClassName('app-show-more-show-less')
 
-  this.addButtonListener()
+  const context = this
+
+  if (context.showMoreLinks.length) {
+    [].forEach.call(context.showMoreLinks, function(showMoreLink) {
+      context.setShowMoreLinkListener(showMoreLink)
+    });
+  }
 }
 
-ShowMoreShowLess.prototype.addButtonListener = function () {
-  let context = this;
+ShowMoreShowLess.prototype.setShowMoreLinkListener = function (showMoreLink) {
+  showMoreLink.addEventListener('click', this.expandContractTarget)
+}
 
-  this.link.addEventListener('click', function (e) {
-    e.preventDefault()
+ShowMoreShowLess.prototype.expandContractTarget = function (event) {
+  event.preventDefault()
 
-    if (context.isLess) {
-      context.isLess = false;
-     // context.container.style.display = 'block';
-      context.container.classList.remove('govuk-visually-hidden');
-      context.link.innerHTML = context.lessText;
-      context.container.focus();
-      context.link.setAttribute('aria-expanded', true);
-    } else {
-      context.isLess = true;
-      // context.container.style.display = 'none';
-      context.container.classList.add('govuk-visually-hidden');
-      context.link.innerHTML = context.moreText;
-      context.link.setAttribute('aria-expanded', false);
-    }
-  }, false)
+  const link = event.target;
+  const container = document.getElementById(link.getAttribute('data-container'))
+  const lessText = link.getAttribute('data-show-less')
+  const moreText = link.getAttribute('data-show-more')
+  const isExpanded = link.getAttribute('aria-expanded')
+
+  if (isExpanded && isExpanded == 'true') {
+    container.classList.add('govuk-visually-hidden')
+    link.text = moreText
+    link.setAttribute('aria-expanded', false)
+  } else {
+    container.classList.remove('govuk-visually-hidden')
+    link.text = lessText
+    container.focus()
+    link.setAttribute('aria-expanded', true)
+  }
 }
 
 const showMoreShowLess = () => new ShowMoreShowLess()

--- a/app/frontend/styles/application-candidate.scss
+++ b/app/frontend/styles/application-candidate.scss
@@ -1,4 +1,5 @@
 @import "application";
 @import "candidate/all";
 @import "components/tabs";
+@import "components/show_more_show_less";
 @import "dfe-autocomplete/src/dfe-autocomplete";

--- a/app/frontend/styles/components/_show_more_show_less.scss
+++ b/app/frontend/styles/components/_show_more_show_less.scss
@@ -1,0 +1,7 @@
+.app-show-more-show-less {
+  display: none;
+}
+
+.js-enabled .app-show-more-show-less {
+  display: block;
+}

--- a/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
+++ b/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
     end
 
     it 'shows the application forms becoming_a_teacher as the personal statement' do
-      expect(result.text).to include("Personal statement#{becoming_a_teacher}")
+      expect(result.text).to include("Personal statement  #{becoming_a_teacher}")
     end
 
     context 'when course has multiple study modes' do
@@ -160,7 +160,7 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
     end
 
     it 'shows the personal statement' do
-      expect(result).to have_content("Personal statement\n#{personal_statement}")
+      expect(result).to have_content("Personal statement\n  #{personal_statement}")
     end
 
     it 'does not show the interview row' do

--- a/spec/components/candidate_interface/continuous_applications/personal_statement_summary_component_spec.rb
+++ b/spec/components/candidate_interface/continuous_applications/personal_statement_summary_component_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::ContinuousApplications::PersonalStatementSummaryComponent do
+  subject(:result) do
+    render_inline(described_class.new(application_choice:))
+  end
+
+  context 'when showing full personal statement' do
+    context 'when unsubmitted application' do
+      let(:application_form) { create(:application_form, becoming_a_teacher: 'some text from application form') }
+      let(:application_choice) { create(:application_choice, :unsubmitted, application_form:) }
+
+      it 'returns personal statement from application form' do
+        expect(result.text).to include(application_form.becoming_a_teacher)
+      end
+    end
+
+    context 'when submitted application' do
+      let(:application_choice) { create(:application_choice, :awaiting_provider_decision, personal_statement: 'some text from application choice') }
+
+      it 'returns personal statement from application choice' do
+        expect(result.text).to include(application_choice.personal_statement)
+      end
+    end
+  end
+
+  context 'when showing short personal statement' do
+    let(:short_personal_statement) { 'a' * 40 }
+    let(:application_choice) do
+      create(:application_choice, :awaiting_provider_decision, personal_statement: "#{short_personal_statement} remaining text")
+    end
+
+    it 'returns personal statement from application choice' do
+      expect(result.text).to include(short_personal_statement)
+    end
+  end
+
+  context 'when personal_statement is blank' do
+    let(:application_form) { create(:application_form, becoming_a_teacher: nil) }
+    let(:application_choice) do
+      create(:application_choice, :unsubmitted, application_form:)
+    end
+
+    it 'renders nothing' do
+      expect(result.text.chomp.strip).to eq('')
+    end
+  end
+end

--- a/spec/system/candidate_interface/continuous_applications/viewing-application-choices/candidate_views_personal_statement_js_disabled_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/viewing-application-choices/candidate_views_personal_statement_js_disabled_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe 'Personal statement' do
+  include CandidateHelper
+
+  before do
+    create_and_sign_in_candidate
+    @application_form = create(:application_form, candidate: current_candidate)
+  end
+
+  scenario 'when application is unsubmitted and showing full personal statement' do
+    given_i_have_an_unsubmitted_application_with_long_personal_statement
+    when_i_visit_my_applications
+    when_i_click_to_view_my_application
+    then_i_should_see_the_full_personal_statement
+  end
+
+  def given_i_have_an_unsubmitted_application_with_long_personal_statement
+    @application_form.update!(becoming_a_teacher: long_personal_statement)
+    @application_choice = create(:application_choice, :unsubmitted, application_form: @application_form)
+  end
+
+  def first_part_long_personal_statement
+    number_of_words_to_display_the_show_more_link.times.map { 'long' }.join(' ')
+  end
+
+  def long_personal_statement
+    "#{first_part_long_personal_statement} #{remaining_personal_statement}"
+  end
+
+  def remaining_personal_statement
+    'remaining personal statement'
+  end
+
+  def then_i_should_see_the_full_personal_statement
+    expect(page).to have_content(long_personal_statement)
+  end
+
+  def number_of_words_to_display_the_show_more_link
+    CandidateInterface::ContinuousApplications::PersonalStatementSummaryComponent::MAXIMUM_WORDS_FULL_PERSONAL_STATEMENT
+  end
+end

--- a/spec/system/candidate_interface/continuous_applications/viewing-application-choices/candidate_views_personal_statement_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/viewing-application-choices/candidate_views_personal_statement_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+RSpec.describe 'Personal statement', :js do
+  include CandidateHelper
+
+  before do
+    create_and_sign_in_candidate
+    @application_form = create(:application_form, candidate: current_candidate)
+  end
+
+  scenario 'when application is unsubmitted and showing full personal statement' do
+    given_i_have_an_unsubmitted_application_with_short_personal_statement
+    when_i_visit_my_applications
+    when_i_click_to_view_my_application
+    then_i_should_see_the_full_personal_statement
+  end
+
+  scenario 'when application is unsubmitted and showing short personal statement version' do
+    given_i_have_an_unsubmitted_application_with_long_personal_statement
+    when_i_visit_my_applications
+    when_i_click_to_view_my_application
+    then_i_should_see_only_the_short_personal_statement
+    when_i_click_show_more
+    then_i_should_see_the_whole_personal_statement
+    when_i_click_show_less
+    then_i_should_see_only_the_short_personal_statement
+  end
+
+  scenario 'when application is submitted and showing full personal statement' do
+    given_i_have_an_submitted_application_with_short_personal_statement
+    when_i_visit_my_applications
+    when_i_click_to_view_my_application
+    then_i_should_see_the_full_personal_statement
+  end
+
+  scenario 'when application is submitted and showing short personal statement version' do
+    given_i_have_an_submitted_application_with_long_personal_statement
+    when_i_visit_my_applications
+    when_i_click_to_view_my_application
+    then_i_should_see_only_the_short_personal_statement
+
+    when_i_click_show_more
+    then_i_should_see_the_whole_personal_statement
+    when_i_click_show_less
+    then_i_should_see_only_the_short_personal_statement
+  end
+
+  def given_i_have_an_unsubmitted_application_with_short_personal_statement
+    @application_form.update!(becoming_a_teacher: short_personal_statement)
+    @application_choice = create(:application_choice, :unsubmitted, application_form: @application_form)
+  end
+
+  def given_i_have_an_unsubmitted_application_with_long_personal_statement
+    @application_form.update!(becoming_a_teacher: long_personal_statement)
+    @application_choice = create(:application_choice, :unsubmitted, application_form: @application_form)
+  end
+
+  def given_i_have_an_submitted_application_with_short_personal_statement
+    @application_choice = create(:application_choice, :awaiting_provider_decision, application_form: @application_form, personal_statement: short_personal_statement)
+  end
+
+  def given_i_have_an_submitted_application_with_long_personal_statement
+    @application_choice = create(:application_choice, :awaiting_provider_decision, application_form: @application_form, personal_statement: long_personal_statement)
+  end
+
+  def short_personal_statement
+    'short personal statement'
+  end
+
+  def long_personal_statement
+    "#{'long' * 40} #{remaining_personal_statement}"
+  end
+
+  def remaining_personal_statement
+    'remaining personal statement'
+  end
+
+  def then_i_should_see_the_full_personal_statement
+    expect(page).to have_content(short_personal_statement)
+  end
+
+  def then_i_should_see_only_the_short_personal_statement
+    expect(page).to have_content('long' * 40)
+    expect(page).not_to have_content(remaining_personal_statement)
+  end
+
+  def when_i_click_show_more
+    click_link_or_button 'Show more'
+  end
+
+  def then_i_should_see_the_whole_personal_statement
+    expect(page).to have_content('long' * 40)
+    expect(page).to have_content(remaining_personal_statement)
+  end
+
+  def when_i_click_show_less
+    click_link_or_button 'Show less'
+  end
+end

--- a/spec/system/candidate_interface/continuous_applications/viewing-application-choices/candidate_views_personal_statement_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/viewing-application-choices/candidate_views_personal_statement_spec.rb
@@ -106,6 +106,6 @@ RSpec.describe 'Personal statement', :js do
   end
 
   def remaining_personal_statement_element
-    page.find('#app-remaining-personal-statement')
+    page.find(id: 'app-remaining-personal-statement')
   end
 end

--- a/spec/system/candidate_interface/continuous_applications/viewing-application-choices/candidate_views_personal_statement_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/viewing-application-choices/candidate_views_personal_statement_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'Personal statement', :js do
 
   def then_i_should_see_only_the_short_personal_statement
     expect(page).to have_content(first_part_long_personal_statement)
-    expect(page).to have_no_content(remaining_personal_statement)
+    expect(remaining_personal_statement_element[:class]).to eq('govuk-visually-hidden')
   end
 
   def when_i_click_show_more
@@ -94,7 +94,7 @@ RSpec.describe 'Personal statement', :js do
 
   def then_i_should_see_the_whole_personal_statement
     expect(page).to have_content(first_part_long_personal_statement)
-    expect(page).to have_content(remaining_personal_statement)
+    expect(remaining_personal_statement_element[:class]).not_to include('govuk-visually-hidden')
   end
 
   def when_i_click_show_less
@@ -103,5 +103,9 @@ RSpec.describe 'Personal statement', :js do
 
   def number_of_words_to_display_the_show_more_link
     CandidateInterface::ContinuousApplications::PersonalStatementSummaryComponent::MAXIMUM_WORDS_FULL_PERSONAL_STATEMENT
+  end
+
+  def remaining_personal_statement_element
+    page.find('#app-remaining-personal-statement')
   end
 end

--- a/spec/system/candidate_interface/continuous_applications/viewing-application-choices/candidate_views_personal_statement_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/viewing-application-choices/candidate_views_personal_statement_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Personal statement', :js do
     then_i_should_see_the_full_personal_statement
   end
 
-  scenario 'when application is unsubmitted and showing short personal statement version' do
+  scenario 'when application is unsubmitted and personal statement is long' do
     given_i_have_an_unsubmitted_application_with_long_personal_statement
     when_i_visit_my_applications
     when_i_click_to_view_my_application
@@ -33,7 +33,7 @@ RSpec.describe 'Personal statement', :js do
     then_i_should_see_the_full_personal_statement
   end
 
-  scenario 'when application is submitted and showing short personal statement version' do
+  scenario 'when application is submitted and personal statement is long' do
     given_i_have_an_submitted_application_with_long_personal_statement
     when_i_visit_my_applications
     when_i_click_to_view_my_application
@@ -67,8 +67,12 @@ RSpec.describe 'Personal statement', :js do
     'short personal statement'
   end
 
+  def first_part_long_personal_statement
+    number_of_words_to_display_the_show_more_link.times.map { 'long' }.join(' ')
+  end
+
   def long_personal_statement
-    "#{'long' * 40} #{remaining_personal_statement}"
+    "#{first_part_long_personal_statement} #{remaining_personal_statement}"
   end
 
   def remaining_personal_statement
@@ -80,8 +84,8 @@ RSpec.describe 'Personal statement', :js do
   end
 
   def then_i_should_see_only_the_short_personal_statement
-    expect(page).to have_content('long' * 40)
-    expect(page).not_to have_content(remaining_personal_statement)
+    expect(page).to have_content(first_part_long_personal_statement)
+    expect(page).to have_no_content(remaining_personal_statement)
   end
 
   def when_i_click_show_more
@@ -89,11 +93,15 @@ RSpec.describe 'Personal statement', :js do
   end
 
   def then_i_should_see_the_whole_personal_statement
-    expect(page).to have_content('long' * 40)
+    expect(page).to have_content(first_part_long_personal_statement)
     expect(page).to have_content(remaining_personal_statement)
   end
 
   def when_i_click_show_less
     click_link_or_button 'Show less'
+  end
+
+  def number_of_words_to_display_the_show_more_link
+    CandidateInterface::ContinuousApplications::PersonalStatementSummaryComponent::MAXIMUM_WORDS_FULL_PERSONAL_STATEMENT
   end
 end


### PR DESCRIPTION
## Context

We need to change how personal statement is being displayed on application pages. We need it to be integrated into the other summary list row., and allow the personal statement to be expanded if needed by the user. It didn’t make sense to have a long personal statement being showed on each application, and it was taking up unnecessary space.

## Changes

Adding a link Show more/Show less if personal statement is over 40 words

![show-more](https://github.com/DFE-Digital/apply-for-teacher-training/assets/27509/0c74a4f8-0dbf-4321-a36c-38d1609a0731)
![show-less](https://github.com/DFE-Digital/apply-for-teacher-training/assets/27509/b55fc150-4220-423e-b68b-7a38008362e1)


## Trello card

https://trello.com/c/WQmYBEZ6/1179-apply-displaying-personal-statement-on-application-page-part-7