### PR TITLE
Increase konduit timeout for db backup to 7200

### DIFF
--- a/.github/workflows/database-backup-aks.yml
+++ b/.github/workflows/database-backup-aks.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Back up Azure database
       shell: bash
       run: |
-        bin/konduit.sh apply-production -- pg_dump -E utf8 --compress=1 --clean --if-exists --no-owner --verbose --no-password -f ${BACKUP_FILE_NAME}.sql.gz
+        bin/konduit.sh -t 7200 apply-production -- pg_dump -E utf8 --compress=1 --clean --if-exists --no-owner --verbose --no-password -f ${BACKUP_FILE_NAME}.sql.gz
 
     - name: Set Connection String
       run: |


### PR DESCRIPTION
## Context

Daily backup can take over 60 minutes, and this causes the backup to fail as the konduit timeout default is 3600 seconds for backups.

## Changes proposed in this pull request

Increase timeout to 7200 (2 hours)

## Guidance to review

review code update.

## Link to Trello card

https://trello.com/c/Qi29K6sZ/1591-bug-apply-db-backups-are-failing

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
