### PR TITLE
CourseSync updates the application_status attribute

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -25,6 +25,11 @@ class Course < ApplicationRecord
   SKE_GRADUATION_CUTOFF_THRESHOLD = 5.years
 
   # This enum is copied verbatim from Find to maintain consistency
+  enum application_status: {
+    closed: 0,
+    open: 1,
+  }, _prefix: :application_status
+
   enum level: {
     primary: 'Primary',
     secondary: 'Secondary',

--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -64,36 +64,36 @@ module TeacherTrainingPublicAPI
     end
 
     def assign_course_attributes(course, course_from_api, recruitment_cycle_year)
-      course.uuid = course_from_api.uuid
-      course.code = course_from_api.code
-      course.name = course_from_api.name
-      course.level = course_from_api.level
-      course.study_mode = study_mode(course_from_api)
-      course.description = course_from_api.summary
-      course.start_date = course_from_api.start_date
-      course.course_length = course_from_api.course_length
-      course.applications_open_from = course_from_api.applications_open_from
-      course.recruitment_cycle_year = recruitment_cycle_year
-      course.exposed_in_find = course_from_api.findable
-      course.can_sponsor_skilled_worker_visa = course_from_api.can_sponsor_skilled_worker_visa
-      course.can_sponsor_student_visa = course_from_api.can_sponsor_student_visa
-      course.funding_type = course_from_api.funding_type
-      course.program_type = course_from_api.program_type
-      course.age_range = age_range_in_years(course_from_api)
-      course.withdrawn = course_from_api.state == 'withdrawn'
-      course.qualifications = course_from_api.qualifications
-      course.degree_grade = course_from_api.degree_grade
-      course.degree_subject_requirements = course_from_api.degree_subject_requirements
-      course.accept_pending_gcse = course_from_api.accept_pending_gcse
-      course.accept_gcse_equivalency = course_from_api.accept_gcse_equivalency
       course.accept_english_gcse_equivalency = course_from_api.accept_english_gcse_equivalency
+      course.accept_gcse_equivalency = course_from_api.accept_gcse_equivalency
       course.accept_maths_gcse_equivalency = course_from_api.accept_maths_gcse_equivalency
+      course.accept_pending_gcse = course_from_api.accept_pending_gcse
       course.accept_science_gcse_equivalency = course_from_api.accept_science_gcse_equivalency
       course.additional_gcse_equivalencies = course_from_api.additional_gcse_equivalencies
+      course.age_range = age_range_in_years(course_from_api)
+      course.applications_open_from = course_from_api.applications_open_from
+      course.can_sponsor_skilled_worker_visa = course_from_api.can_sponsor_skilled_worker_visa
+      course.can_sponsor_student_visa = course_from_api.can_sponsor_student_visa
+      course.code = course_from_api.code
+      course.course_length = course_from_api.course_length
+      course.degree_grade = course_from_api.degree_grade
+      course.degree_subject_requirements = course_from_api.degree_subject_requirements
+      course.description = course_from_api.summary
+      course.exposed_in_find = course_from_api.findable
       course.fee_details = course_from_api.fee_details
-      course.fee_international = course_from_api.fee_international
       course.fee_domestic = course_from_api.fee_domestic
+      course.fee_international = course_from_api.fee_international
+      course.funding_type = course_from_api.funding_type
+      course.level = course_from_api.level
+      course.name = course_from_api.name
+      course.program_type = course_from_api.program_type
+      course.qualifications = course_from_api.qualifications
+      course.recruitment_cycle_year = recruitment_cycle_year
       course.salary_details = course_from_api.salary_details
+      course.start_date = course_from_api.start_date
+      course.study_mode = study_mode(course_from_api)
+      course.uuid = course_from_api.uuid
+      course.withdrawn = course_from_api.state == 'withdrawn'
       course_from_api.subject_codes.each do |code|
         subject = ::Subject.find_or_initialize_by(code:)
         course.subjects << subject unless course.course_subjects.exists?(subject_id: subject.id)

--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -72,6 +72,7 @@ module TeacherTrainingPublicAPI
       course.additional_gcse_equivalencies = course_from_api.additional_gcse_equivalencies
       course.age_range = age_range_in_years(course_from_api)
       course.applications_open_from = course_from_api.applications_open_from
+      course.application_status = course_from_api.application_status
       course.can_sponsor_skilled_worker_visa = course_from_api.can_sponsor_skilled_worker_visa
       course.can_sponsor_student_visa = course_from_api.can_sponsor_student_visa
       course.code = course_from_api.code

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1,16 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe Course do
-  describe 'a valid course' do
-    subject(:course) { create(:course) }
+  subject(:course) { build(:course) }
 
+  describe 'a valid course' do
     it { is_expected.to validate_presence_of :level }
     it { is_expected.to validate_uniqueness_of(:code).scoped_to(%i[recruitment_cycle_year provider_id]) }
+    it { is_expected.to be_application_status_closed }
   end
 
   describe '#currently_has_both_study_modes_available?' do
-    let(:course) { build(:course) }
-
     it 'is true when a course has full time and part time course options' do
       create(:course_option, :full_time, course:)
       create(:course_option, :part_time, course:)
@@ -27,8 +26,6 @@ RSpec.describe Course do
   end
 
   describe '#available_study_modes_with_vacancies' do
-    let(:course) { build(:course) }
-
     it 'returns an array of unique study modes for course options with available vacancies' do
       create_list(:course_option, 2, :no_vacancies, :full_time, course:)
       create(:course_option, :part_time, course:)

--- a/spec/system/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_courses_spec.rb
@@ -49,6 +49,7 @@ RSpec.feature 'Sync courses', :sidekiq do
           state: 'published',
           qualifications: %w[qts pgce],
           accredited_body_code: '',
+          application_status: 'open',
           uuid: @course_uuid,
           can_sponsor_skilled_worker_visa: false,
           can_sponsor_student_visa: false,
@@ -68,6 +69,7 @@ RSpec.feature 'Sync courses', :sidekiq do
           age_minimum: 3,
           state: 'published',
           qualifications: %w[qts pgce],
+          application_status: 'closed',
           accredited_body_code: 'DEF',
           can_sponsor_skilled_worker_visa: true,
           can_sponsor_student_visa: true,
@@ -103,6 +105,7 @@ RSpec.feature 'Sync courses', :sidekiq do
     expect(course).not_to be_nil
     expect(course.can_sponsor_skilled_worker_visa).to be true
     expect(course.can_sponsor_student_visa).to be true
+    expect(course.application_status).to eq 'closed'
   end
 
   def and_it_creates_a_corresponding_provider_relationship
@@ -118,6 +121,7 @@ RSpec.feature 'Sync courses', :sidekiq do
     expect(course.withdrawn).to be false
     expect(course.can_sponsor_skilled_worker_visa).to be false
     expect(course.can_sponsor_student_visa).to be false
+    expect(course.application_status).to eq 'open'
   end
 
   def and_it_sets_the_last_synced_timestamp


### PR DESCRIPTION
## Context

The new column on Course `application_status` is updated when the Publish sync worker runs.

## Changes proposed in this pull request

 - Add the `application_status` enum ['open', 'closed']
 - set the `application_status` property on Courses during the CourseSync

## Guidance to review

This PR only aims to update the `application_status` property. Following PRs will make use of the property throughout the application.

## Link to Trello card

[Trello Ticket](https://trello.com/c/JnDJRCbC/1330-openonapply-update-ttapi-sync-to-populate-openforapplications)
