### PR TITLE
Update PIM request link in aks-cheatsheet.md

### DIFF
--- a/docs/aks-cheatsheet.md
+++ b/docs/aks-cheatsheet.md
@@ -8,15 +8,16 @@ All examples below show qa usage and you should adapt accordingly.
 
 ### Raising a PIM request
 
-You need to activate the role in the desired cluster below:
-<https://portal.azure.com/?Microsoft_Azure_PIMCommon=true#view/Microsoft_Azure_PIMCommon/ActivationMenuBlade/~/azurerbac>
+You need to activate the group role in the desired cluster below:
+
+<https://portal.azure.com/?Microsoft_Azure_PIMCommon=true&feature.msaljs=true#view/Microsoft_Azure_PIMCommon/ActivationMenuBlade/~/aadgroup/provider/aadgroup>
 
 Example: Activate `*-teacher-services-cloud-test`. It will be approved automatically after a few seconds
 
 ### Azure setup
 
 ```sh
-az login
+az login --use-device-code
 ```
 
 Get access credentials for a managed Kubernetes cluster (passing the


### PR DESCRIPTION
## Context

RBAC changes now require users to request a Group PIM instead of just resource specific PIM.

The link to the azure page where users make the PIM request has been updated in the docs.

## Changes proposed in this pull request

Update PIM request link in aks-cheatsheet.md
