### PR TITLE
Increase postgres prod alert window to 15m

### DIFF
--- a/terraform/aks/database.tf
+++ b/terraform/aks/database.tf
@@ -20,4 +20,5 @@ module "postgres" {
   azure_enable_high_availability = var.postgres_enable_high_availability
   azure_maintenance_window       = var.azure_maintenance_window
   azure_extensions               = ["PG_BUFFERCACHE", "PG_STAT_STATEMENTS", "PGCRYPTO", "UNACCENT"]
+  alert_window_size              = var.alert_window_size
 }

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -64,6 +64,13 @@ variable "redis_server_version" {
   default = "6"
 }
 
+variable "alert_window_size" {
+  type        = string
+  nullable    = false
+  default     = "PT5M"
+  description = "The period of time that is used to monitor alert activity e.g PT1M, PT5M, PT15M, PT30M, PT1H, PT6H or PT12H"
+}
+
 locals {
   app_name_suffix = var.app_name_suffix != null ? var.app_name_suffix : var.paas_app_environment
 

--- a/terraform/aks/workspace_variables/production_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/production_aks.tfvars.json
@@ -25,6 +25,7 @@
   "postgres_flexible_server_storage_mb": 65536,
   "pdb_min_available": "50%",
   "enable_alerting": true,
+  "alert_window_size": "PT15M",
   "azure_maintenance_window": {
     "day_of_week": 0,
     "start_hour": 3,


### PR DESCRIPTION
## Context

We inadvertently reset the prod postgres monitor alert window from 15m to 5m
This PR changes it back to 15m.

## Changes proposed in this pull request

Set window size to PT15M for prod

## Guidance to review

make qa deploy-plan (no change)
make production deploy-plan (update to metrics)

## Link to Trello card

https://trello.com/c/qBBBJoMM/1638-apply-postgres-alerts

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
