### PR TITLE
Fix issue Provider can't make offers if candidate has other applications with conditions_not_met

### DIFF
--- a/app/services/offer_validations.rb
+++ b/app/services/offer_validations.rb
@@ -99,7 +99,9 @@ private
   end
 
   def any_accepted_offers?
-    (application_choice.self_and_siblings - [application_choice]).map(&:status).map(&:to_sym).intersect?(ApplicationStateChange::ACCEPTED_STATES)
+    (application_choice.self_and_siblings - [application_choice])
+      .map(&:status).map(&:to_sym)
+      .intersect?(ApplicationStateChange::ACCEPTED_STATES - [:conditions_not_met])
   end
 
   def candidate_in_apply_2?

--- a/app/services/offer_validations.rb
+++ b/app/services/offer_validations.rb
@@ -75,7 +75,7 @@ class OfferValidations
       errors.add(:base, :application_rejected_by_default)
     end
 
-    if any_accepted_offers?
+    if can_not_receive_other_offers?
       errors.add(:base, :other_offer_already_accepted)
     end
 
@@ -98,7 +98,7 @@ private
     end
   end
 
-  def any_accepted_offers?
+  def can_not_receive_other_offers?
     (application_choice.self_and_siblings - [application_choice])
       .map(&:status).map(&:to_sym)
       .intersect?(ApplicationStateChange::ACCEPTED_STATES - [:conditions_not_met])

--- a/spec/services/offer_validations_spec.rb
+++ b/spec/services/offer_validations_spec.rb
@@ -138,12 +138,12 @@ RSpec.describe OfferValidations, type: :model do
         end
       end
 
-      context 'when a provider attemps to make an offer with other application as conditions not met' do
+      context 'when a provider attempts to make an offer when conditions not met sibling exists' do
         let!(:application_form) { create(:application_form, application_choices: [application_choice, other_application_choice]) }
         let(:application_choice) { build(:application_choice, :offered, current_course_option: course_option) }
         let!(:other_application_choice) { build(:application_choice, :conditions_not_met) }
 
-        it 'be valid' do
+        it 'is valid' do
           expect(offer).to be_valid
         end
       end

--- a/spec/services/offer_validations_spec.rb
+++ b/spec/services/offer_validations_spec.rb
@@ -138,6 +138,16 @@ RSpec.describe OfferValidations, type: :model do
         end
       end
 
+      context 'when a provider attemps to make an offer with other application as conditions not met' do
+        let!(:application_form) { create(:application_form, application_choices: [application_choice, other_application_choice]) }
+        let(:application_choice) { build(:application_choice, :offered, current_course_option: course_option) }
+        let!(:other_application_choice) { build(:application_choice, :conditions_not_met) }
+
+        it 'be valid' do
+          expect(offer).to be_valid
+        end
+      end
+
       context 'when a provider attempts to revert a rejection on an application that is not the last one on apply_2' do
         let(:candidate) { create(:candidate) }
         let(:application_choice) { build(:application_choice, :rejected, current_course_option: course_option, created_at: 1.day.ago) }


### PR DESCRIPTION
## Context

If candidate accepts an offer from application choice (e.g 1) and application choice 1 endup in conditions not met

And the candidate applies to another application choice (e.g 2) they should be able to receive offers from any other choice

## Impact

There are 22 candidates with conditions not met and they can't progress with their other applications.

## How many times it happen?

41 times in this month 
https://dfe-teacher-services.sentry.io/issues/4385529849/?alert_rule_id=4434951&alert_type=issue&environment=production&notification_uuid=1277a5dd-1927-4fab-8e62-c9f4a8b3ad3b&project=1765973&referrer=slack

## Example in QA

https://qa.apply-for-teacher-training.service.gov.uk/support/applications/36807

## Guidance to review

1. Have a candidate with two applications: 1 in conditions not met and other awaiting provider decision
2. Make an offer to the awaiting provider decision and the offer should reach the candidate

## Link to Trello card

Support ticket:
https://trello.com/c/21xhaeAD/2725-issue-around-making-offer-to-candidate

Candidate ticket:
https://trello.com/c/4wVNbRwy/1359-fix-provider-not-being-able-to-make-an-offer
