### PR TITLE
Remove max-width property from status tags

### DIFF
--- a/app/frontend/styles/_tag.scss
+++ b/app/frontend/styles/_tag.scss
@@ -1,5 +1,6 @@
 .govuk-tag {
   vertical-align: middle;
   white-space: nowrap;
+  max-width: none;
 }
 


### PR DESCRIPTION
## Context

Status tags with text which is too long are appearing incorrectly, this is the fix.

## Screenshots

### Before

<img width="227" alt="Screenshot 2024-02-27 at 16 34 45" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/50492247/22dc4f0c-cc18-4dc3-98f3-fa0b6d3bc15e">

### After

<img width="219" alt="Screenshot 2024-02-27 at 16 36 32" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/50492247/ec3b6e5a-7420-4af7-a168-c6868202b0bf">


## Guidance to review

🚢 

## Link to Trello card

https://trello.com/c/ZcdFW7aY/1360-remove-max-width-property-from-status-tags
