### PR TITLE
Cancel builds in progress when new version pushed

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,7 +1,9 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
 name: Build and Deploy
-concurrency: build_and_deploy_${{ github.ref_name }}
+concurrency:
+  group: build_and_deploy_${{ github.ref_name }}
+  cancel-in-progress: true
 
 on:
   push:


### PR DESCRIPTION
## Context

When a build_and_deploy workflow runs, we often push changes before the workflow finishes. Normally we would expect the older version of the build to stop and the workflow to begin building the latest version immediately.

## Changes proposed in this pull request

Cancel in progress builds when a newer version of a ref is pushed

## Guidance to review

Is this safe to do for the main branch build?

![Screenshot from 2024-02-28 16-55-06](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/2e352f12-6f28-4491-be5d-85dade89f480)



