### PR TITLE
Return unauthorised when authentication token does not exist

### DIFF
--- a/app/controllers/concerns/service_api_user_authentication.rb
+++ b/app/controllers/concerns/service_api_user_authentication.rb
@@ -19,7 +19,8 @@ module ServiceAPIUserAuthentication
   def authorized?
     authenticate_with_http_token do |token|
       @authenticating_token = AuthenticationToken.find_by_hashed_token(user_type: 'ServiceAPIUser', raw_token: token)
-      @authenticating_token.user_id == ServiceAPIUser.find_by(authorized_api: self.class.name.deconstantize).id
+
+      @authenticating_token.present? && @authenticating_token.user_id == ServiceAPIUser.find_by(authorized_api: self.class.name.deconstantize).id
     end
   end
 

--- a/app/controllers/concerns/service_api_user_authentication.rb
+++ b/app/controllers/concerns/service_api_user_authentication.rb
@@ -19,7 +19,6 @@ module ServiceAPIUserAuthentication
   def authorized?
     authenticate_with_http_token do |token|
       @authenticating_token = AuthenticationToken.find_by_hashed_token(user_type: 'ServiceAPIUser', raw_token: token)
-
       @authenticating_token.present? && @authenticating_token.user_id == ServiceAPIUser.find_by(authorized_api: self.class.name.deconstantize).id
     end
   end

--- a/spec/requests/register_api/get_multiple_applications_spec.rb
+++ b/spec/requests/register_api/get_multiple_applications_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'GET /register-api/applications' do
   include RegisterAPISpecHelper
 
-  it 'does not allow access when passing a non existent API token' do
+  it 'returns unauthorised when passing a non existent API token' do
     get_api_request "/register-api/applications?recruitment_cycle_year=#{RecruitmentCycle.current_year}", token: 'this-token-does-not-exist'
     expect(response).to have_http_status(:unauthorized)
     expect(parsed_response).to be_valid_against_openapi_schema('UnauthorizedResponse')

--- a/spec/requests/register_api/get_multiple_applications_spec.rb
+++ b/spec/requests/register_api/get_multiple_applications_spec.rb
@@ -3,6 +3,12 @@ require 'rails_helper'
 RSpec.describe 'GET /register-api/applications' do
   include RegisterAPISpecHelper
 
+  it 'does not allow access when passing a non existent API token' do
+    get_api_request "/register-api/applications?recruitment_cycle_year=#{RecruitmentCycle.current_year}", token: 'this-token-does-not-exist'
+    expect(response).to have_http_status(:unauthorized)
+    expect(parsed_response).to be_valid_against_openapi_schema('UnauthorizedResponse')
+  end
+
   it 'does not allow access to the API from other data users' do
     api_token = ServiceAPIUser.test_data_user.create_magic_link_token!
     get_api_request "/register-api/applications?recruitment_cycle_year=#{RecruitmentCycle.current_year}", token: api_token


### PR DESCRIPTION
## Context

We have Sentry errors, indicating issues with Register <-> Apply API integration. These are being posted to our _tech channel.

```
undefined method `user_id' for nil:NilClass (NoMethodError)
```

This is because when a wrong authentication token is passed, we were not verifying if exists or not. This commit solves this issue.

## Trello card 

https://trello.com/c/aP0c9QGW/1355-investigate-and-solve-error-on-apply-apis
