### PR TITLE
[1357] Apply fee visibility

### DIFF
--- a/app/components/candidate_interface/continuous_applications/application_review_component.rb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   module ContinuousApplications
     class ApplicationReviewComponent < ViewComponent::Base
+      include ContinuousApplications::CourseFeeRowHelper
       attr_reader :application_choice
       delegate :interviewing?,
                :unsubmitted?,
@@ -18,6 +19,7 @@ module CandidateInterface
           application_number_row,
           submitted_at_row,
           course_info_row,
+          course_fee_row(current_course),
           qualifications_row,
           course_length_row,
           study_mode_row,

--- a/app/components/candidate_interface/continuous_applications/course_fee_row_helper.rb
+++ b/app/components/candidate_interface/continuous_applications/course_fee_row_helper.rb
@@ -1,0 +1,38 @@
+module CandidateInterface
+  module ContinuousApplications
+    module CourseFeeRowHelper
+      def course_fee_row(course)
+        return unless course.fee?
+
+        {
+          key: I18n.t('course_fee_row_helper.course_fee'),
+          value: domestic_fee(course) + international_fee(course),
+        }
+      end
+
+      def domestic_fee(course)
+        return '' if course.fee_domestic.blank?
+
+        tag.p(
+          I18n.t(
+            'course_fee_row_helper.domestic_fee',
+            fee: number_to_currency(course.fee_domestic),
+          ),
+          class: 'govuk-body',
+        )
+      end
+
+      def international_fee(course)
+        return '' if course.fee_international.blank?
+
+        tag.p(
+          I18n.t(
+            'course_fee_row_helper.international_fee',
+            fee: number_to_currency(course.fee_international),
+          ),
+          class: 'govuk-body',
+        )
+      end
+    end
+  end
+end

--- a/app/components/candidate_interface/continuous_applications/course_review_component.rb
+++ b/app/components/candidate_interface/continuous_applications/course_review_component.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   module ContinuousApplications
     class CourseReviewComponent < CourseChoicesReviewComponent
+      include ContinuousApplications::CourseFeeRowHelper
       attr_reader :application_choice
 
       def initialize(application_choice:)
@@ -11,6 +12,7 @@ module CandidateInterface
       def rows
         [
           course_row(application_choice),
+          course_fee_row(application_choice.current_course),
           application_number_row(application_choice),
           study_mode_row(application_choice),
           location_row(application_choice),

--- a/config/locales/components/course_fee_row_helper.yml
+++ b/config/locales/components/course_fee_row_helper.yml
@@ -1,0 +1,5 @@
+en:
+  course_fee_row_helper:
+    course_fee: Course fee
+    domestic_fee: "UK students: %{fee}"
+    international_fee: "International students: %{fee}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -582,3 +582,8 @@ en:
       long: "%e %B %Y %H:%M"
       long_with_seconds: "%e %B %Y %H:%M:%S"
       time: "%H:%M"
+  number:
+    currency:
+      format:
+        unit: "£"
+        precision: 0

--- a/spec/components/candidate_interface/continuous_applications/course_review_component_spec.rb
+++ b/spec/components/candidate_interface/continuous_applications/course_review_component_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::ContinuousApplications::CourseReviewComponent do
+  describe 'course_fee' do
+    let(:application_choice) do
+      create(:application_choice,
+             current_course_option: create(:course_option,
+                                           course: create(:course, funding_type:, fee_domestic:, fee_international:)))
+    end
+
+    context 'when course is not fee based' do
+      let(:fee_domestic) { 9250 }
+      let(:fee_international) { 23820 }
+      let(:funding_type) { %w[salary apprenticeship].sample }
+
+      it 'does not show the course fee row' do
+        result = render_inline(described_class.new(application_choice:))
+        expect(result.text).not_to include 'Course fee'
+        expect(result.text).not_to include 'UK students: £9,250'
+        expect(result.text).not_to include 'International students: £23,820'
+      end
+    end
+
+    context 'where domestic and international fees present' do
+      let(:fee_domestic) { 9250 }
+      let(:fee_international) { 23820 }
+      let(:funding_type) { 'fee' }
+
+      it 'shows both domestic and international fees' do
+        result = render_inline(described_class.new(application_choice:))
+        expect(result.text).to include 'Course fee'
+        expect(result.text).to include 'UK students: £9,250'
+        expect(result.text).to include 'International students: £23,820'
+      end
+    end
+
+    context 'where only domestic fees are present' do
+      let(:fee_domestic) { 9250 }
+      let(:fee_international) { nil }
+      let(:funding_type) { 'fee' }
+
+      it 'shows only domestic fees' do
+        result = render_inline(described_class.new(application_choice:))
+        expect(result.text).to include 'Course fee'
+        expect(result.text).to include 'UK students: £9,250'
+        expect(result.text).not_to include 'International students:'
+      end
+    end
+
+    context 'where only international fees are present' do
+      let(:fee_domestic) { nil }
+      let(:fee_international) { 23820 }
+      let(:funding_type) { 'fee' }
+
+      it 'shows only international fees' do
+        result = render_inline(described_class.new(application_choice:))
+        expect(result.text).to include 'Course fee'
+        expect(result.text).not_to include 'UK students:'
+        expect(result.text).to include 'International students: £23,820'
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

From the trello ticket: We believe that better highlighting the fees for both international and domestic candidates could contribute to reduced number of candidates withdrawing due to costs reasons. To do that we need to add course fees on apply service, to all application statuses

Include only the fee for UK and/or International, we don’t need to include ‘Fee details’. 

## Changes proposed in this pull request

- Row helper applied to both the course review component and application review component to show the appropriate fees. (only show the fee category if it exists)
- Locale for formatting currency

## Guidance to review

- Sign into apply as a candidate
- View existing applications and check you see the course fee
- Create a new application and check you see the course fee row on review page

## Link to Trello card
https://trello.com/c/38bDR7Ok

## Screen shots
<img width="837" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/44073106/1728d2fe-04b5-4a8f-b577-941331924471">

<img width="808" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/44073106/acc91c82-8a23-45ac-b050-5ad0832d543a">


