### PR TITLE
[1331] data migration to remove course_has_vacancies feature flag

### DIFF
--- a/app/services/data_migrations/remove_course_has_vacancies_feature_flag.rb
+++ b/app/services/data_migrations/remove_course_has_vacancies_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class RemoveCourseHasVacanciesFeatureFlag
+    TIMESTAMP = 20240304165105
+    MANUAL_RUN = false
+
+    def change
+      Feature.find_by(name: :course_has_vacancies)&.destroy
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveCourseHasVacanciesFeatureFlag',
   'DataMigrations::SetInstitutionCountryToGbOnUkDegrees',
   'DataMigrations::RemoveSupportUserReinstateOfferFeatureFlag',
   'DataMigrations::RemoveSupportUserRevertWithdrawnOfferFeatureFlag',

--- a/spec/services/data_migrations/remove_course_has_vacancies_feature_flag_spec.rb
+++ b/spec/services/data_migrations/remove_course_has_vacancies_feature_flag_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveCourseHasVacanciesFeatureFlag do
+  context 'when the feature flag exists' do
+    it 'removes the relevant feature flag' do
+      create(:feature, name: 'course_has_vacancies')
+      create(:feature, name: 'foo')
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: 'course_has_vacancies')).to be_none
+      expect(Feature.where(name: 'foo')).to be_present
+    end
+  end
+
+  context 'when the feature flag has already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end


### PR DESCRIPTION
## Context

This PR follows from the PR to remove uses of the `course_has_vacancies` feature flag from the code base / specs. [PR here](https://github.com/DFE-Digital/apply-for-teacher-training/pull/9170)

## Changes proposed in this pull request

Data migration for removing the feature flag 

## Guidance to review

## Link to Trello card

https://trello.com/c/l2Jp3oxl

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
