### PR TITLE
Add guard to protect against nil class error

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -133,7 +133,7 @@ class Course < ApplicationRecord
   end
 
   def open?
-    applications_open_from <= Time.zone.today && exposed_in_find && application_status_open?
+    applications_open_from.present? && applications_open_from <= Time.zone.today && exposed_in_find && application_status_open?
   end
 
   def open_for_applications?

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Course do
     end
 
     context 'when applications_open_from is nil' do
-      let(:course) { create(:course, applications_open_from: nil) }
+      let(:course) { create(:course, :open, applications_open_from: nil) }
 
       it 'returns false' do
         expect(course.open?).to be false

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe Course do
       end
     end
 
+    context 'when applications_open_from is nil' do
+      let(:course) { create(:course, applications_open_from: nil) }
+
+      it 'returns false' do
+        expect(course.open?).to be false
+      end
+    end
+
     context 'when applications_open_from is in the future' do
       let(:course) { create(:course, :open, applications_open_from: 1.day.from_now) }
 


### PR DESCRIPTION
## Context

Support are unable to access courses. This is because we are getting an error due to `applications_open_from` being `nil`. We need to add a guard. 

[Sentry error](https://dfe-teacher-services.sentry.io/issues/5044518049/?alert_rule_id=853774&alert_type=issue&notification_uuid=294b2ca1-cce6-4cf6-b5b1-5e3e7a99d8bd&project=1765973&referrer=slack)
