### PR TITLE
Add ability to evict specific candidate cookies conditionally

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -33,6 +33,7 @@ class FeatureFlag
     [:sample_applications_factory, 'An alternate generator for test/sample applications, uses `SampleApplicationsFactory` in place of `TestApplications.new`', 'Elliot Crosby-McCullough + Tomas Destefi'],
     [:structured_reference_condition, 'Structured reference condition that can be added as a condition to an offer', 'Tomas Destefi'],
     [:continuous_applications, 'The new continuous applications flow', 'James Glenn'],
+    [:incident_eviction, 'Evicting potential ghost users from affected candidate accounts', 'Lori Bailey'],
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -27,3 +27,34 @@ Devise.setup do |config|
 
   config.timeout_in = 7.days
 end
+
+Warden::Manager.after_set_user do |record, warden, options|
+  next unless FeatureFlag.active?(:incident_eviction)
+
+  # User is not affected
+  next unless record.id.in?(1..46) && record.instance_of?(Candidate)
+
+  scope = options[:scope]
+  lra = warden.session(scope)['last_request_at']
+
+  # The cookie must have a last_request_at in order to be relevant
+  next if lra.nil?
+
+  case lra
+  when Integer
+    last_request_at = Time.zone.at(lra)
+  when String
+    last_request_at = Time.zone.parse(lra)
+  end
+
+  # The cookie has already expired
+  next if Time.zone.now > Devise.timeout_in.since(last_request_at)
+
+  # The cookie has already been cleared once if last_request_at is after the feature flag was activated
+  next if Feature.find_by(name: 'incident_eviction').audits.empty?
+  next if last_request_at > Feature.find_by(name: 'incident_eviction').audits.last.created_at
+
+  # Set the last_request_at so that the session has timed out.
+  # Then Devise will log the user out.
+  warden.session(scope)['last_request_at'] = 2.weeks.ago.to_i
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -57,4 +57,5 @@ Warden::Manager.after_set_user do |record, warden, options|
   # Set the last_request_at so that the session has timed out.
   # Then Devise will log the user out.
   warden.session(scope)['last_request_at'] = 2.weeks.ago.to_i
+  Rails.logger.info "Candidate with id #{record.id} has been logged out"
 end

--- a/spec/system/candidate_interface/incident/affected_candidates_are_evicted_and_can_login_again_spec.rb
+++ b/spec/system/candidate_interface/incident/affected_candidates_are_evicted_and_can_login_again_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+require_relative 'incident_helper'
+
+RSpec.feature 'User gets logged out and can immediately log back in' do
+  include SignInHelper
+  include CandidateHelper
+  include IncidentHelper
+
+  context 'Feature flag is active on first sign in', :with_audited do
+    scenario 'Affected candidates can login without being logged out' do
+      given_i_am_a_candidate_with_a_rejected_id
+      and_the_feature_flag_is_activated
+
+      when_i_am_signed_in
+      and_i_visit_my_details
+      then_i_am_on_the_my_details_page
+
+      and_i_visit_my_applications
+      then_i_am_on_the_my_applications_page
+    end
+  end
+
+  context 'Feature flag is activated during a session', :with_audited do
+    scenario 'Affected candidates are signed out and can log back in' do
+      given_i_am_a_candidate_with_a_rejected_id
+      and_the_feature_flag_is_deactivated
+
+      when_i_am_signed_in
+      and_i_visit_my_details
+      then_i_am_on_the_my_details_page
+
+      and_the_feature_flag_is_activated
+
+      and_i_visit_my_details
+      then_i_am_logged_out_and_redirected_sign_in_or_sign_up
+
+      and_i_log_in_with_email
+      and_i_visit_my_details
+      then_i_am_on_the_my_details_page
+
+      and_i_visit_my_applications
+      then_i_am_on_the_my_applications_page
+
+      and_the_feature_flag_is_deactivated
+
+      and_i_visit_my_details
+      then_i_am_on_the_my_details_page
+
+      and_the_feature_flag_is_activated
+
+      and_i_visit_my_details
+      then_i_am_logged_out_and_redirected_sign_in_or_sign_up
+    end
+  end
+end

--- a/spec/system/candidate_interface/incident/incident_helper.rb
+++ b/spec/system/candidate_interface/incident/incident_helper.rb
@@ -1,0 +1,47 @@
+module IncidentHelper
+  def when_i_am_signed_in
+    login_as @candidate
+  end
+
+  def given_i_am_a_candidate_with_a_rejected_id
+    @candidate = create(:candidate, id: 1)
+    create(:application_form, candidate: @candidate)
+  end
+
+  def and_i_log_in_with_email
+    and_i_go_to_sign_in(candidate: @candidate)
+  end
+
+  def and_i_visit_my_details
+    visit candidate_interface_continuous_applications_details_path
+  end
+
+  def then_i_am_on_the_my_details_page
+    expect(page).to have_current_path(candidate_interface_continuous_applications_details_path)
+  end
+
+  def and_i_visit_my_applications
+    visit candidate_interface_continuous_applications_choices_path
+  end
+
+  def then_i_am_on_the_my_applications_page
+    expect(page).to have_current_path(candidate_interface_continuous_applications_choices_path)
+  end
+
+  def then_i_am_logged_out_and_redirected_to_sign_in
+    expect(page).to have_current_path(candidate_interface_sign_in_path)
+  end
+
+  def then_i_am_logged_out_and_redirected_sign_in_or_sign_up
+    expect(page).to have_current_path(candidate_interface_create_account_or_sign_in_path)
+  end
+
+  def and_the_feature_flag_is_activated
+    FeatureFlag.activate(:incident_eviction)
+    TestSuiteTimeMachine.advance
+  end
+
+  def and_the_feature_flag_is_deactivated
+    FeatureFlag.deactivate(:incident_eviction)
+  end
+end

--- a/spec/system/candidate_interface/incident/unaffected_users_sign_in_normally_spec.rb
+++ b/spec/system/candidate_interface/incident/unaffected_users_sign_in_normally_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+require_relative 'incident_helper'
+
+RSpec.feature 'User unaffected by incident' do
+  include SignInHelper
+  include CandidateHelper
+  include IncidentHelper
+
+  scenario 'user id > 46 behaves normally' do
+    given_i_am_a_candidate_with_a_non_incident_id
+    and_the_feature_flag_is_activated
+    when_i_am_signed_in
+    and_i_visit_my_details
+    then_i_am_on_the_my_details_page
+  end
+
+  def given_i_am_a_candidate_with_a_non_incident_id
+    @candidate = create(:candidate, id: 47)
+    create(:application_form, candidate: @candidate)
+  end
+end


### PR DESCRIPTION
## Context

As part of the incident 240306 we need to be able to guarantee that the users who hold cookies that allow them to access accounts they do not belong to have their access removed.

We can do this by targeting them by updating their cookie expiration to a time that logs them out, in conjunction with a Feature Flag.

On every request, the application checks the last request time of the user to see if it’s been too long since their last request and if it is, they are logged out.

## Changes proposed in this pull request

Add `Warden::Manager` callback on `after_set_user` to evict any Candidates whose last_request time is before the activation of the Feature Flag. Any candidates with requests after the activation time are not evicted

## Guidance to review

Thorough testing required

## Link to Trello card

[Trello Ticket](https://trello.com/c/b6dQQNlM/1412-incident-240306-evict-ghost-candidate-sessions)
