### PR TITLE
Copy an application to another candidate

### DIFF
--- a/app/services/copy_incident_application_to_new_account.rb
+++ b/app/services/copy_incident_application_to_new_account.rb
@@ -39,7 +39,9 @@ class CopyIncidentApplicationToNewAccount
       original_application_choice = original_application_form.application_choices.find_by(course_option: application_choice.course_option)
       next unless original_application_choice.awaiting_provider_decision?
 
-      CandidateInterface::ContinuousApplications::SubmitApplicationChoice.new(application_choice).call
+      if CandidateInterface::ContinuousApplications::ApplicationChoiceSubmission.new(application_choice:).valid?
+        CandidateInterface::ContinuousApplications::SubmitApplicationChoice.new(application_choice).call
+      end
     end
 
     new_application_form

--- a/app/services/copy_incident_application_to_new_account.rb
+++ b/app/services/copy_incident_application_to_new_account.rb
@@ -1,0 +1,43 @@
+class CopyIncidentApplicationToNewAccount
+  attr_reader :original_application_form, :candidate_email_address
+
+  def initialize(original_application_form:, candidate_email_address:)
+    @original_application_form = original_application_form
+    @candidate_email_address = candidate_email_address
+  end
+
+  def call
+    candidate = Candidate.find_by(email_address: candidate_email_address)
+
+    if candidate.blank?
+      CandidateInterface::SignUpForm.new(email_address: candidate_email_address).save
+    end
+
+    candidate = Candidate.find_by!(email_address: candidate_email_address)
+
+    new_application_form = DuplicateApplication.new(
+      @original_application_form,
+      target_phase: 'apply_1',
+      candidate_id: candidate.id,
+    ).duplicate
+
+    CandidateInterface::ReferenceSectionCompleteForm.new(
+      application_form: new_application_form,
+      completed: original_application_form.references_completed?.to_s, # section complete form expect a string
+    ).save(new_application_form, :references_completed) #  need to pass the new application_form again
+
+    original_application_form.application_choices.each do |original_application_choice|
+      course_option = original_application_choice.course_option
+      new_application_form.application_choices.new.configure_initial_course_choice!(course_option)
+    end
+
+    new_application_form.application_choices.each do |application_choice|
+      original_application_choice = original_application_form.application_choices.find_by(course_option: application_choice.course_option)
+      next unless original_application_choice.awaiting_provider_decision?
+
+      CandidateInterface::ContinuousApplications::SubmitApplicationChoice.new(application_choice).call
+    end
+
+    new_application_form
+  end
+end

--- a/app/services/copy_incident_application_to_new_account.rb
+++ b/app/services/copy_incident_application_to_new_account.rb
@@ -9,11 +9,13 @@ class CopyIncidentApplicationToNewAccount
   def call!
     # Create a new Candidate
     # this will not create a duplicate if they already exist
+    log('Creating a new candidate if they do not exist')
     CandidateInterface::SignUpForm.new(email_address: candidate_email_address).save
     candidate = Candidate.find_by!(email_address: candidate_email_address)
 
     # Copy the Application Form to the new Candidate
     # `target_phase` is always `"apply_1"`
+    log("Copying application form #{@original_application_form.id} from candidate #{@original_application_form.candidate_id} to candidate #{candidate.id}")
     new_application_form = DuplicateApplication.new(
       @original_application_form,
       target_phase: 'apply_1',
@@ -22,12 +24,14 @@ class CopyIncidentApplicationToNewAccount
 
     # Update the Reference section
     # This is only needed if the original Application Form had the Reference Section completed
+    log('Mark references section as complete')
     CandidateInterface::ReferenceSectionCompleteForm.new(
       application_form: new_application_form,
       completed: original_application_form.references_completed?.to_s, # section complete form expect a string
     ).save(new_application_form, :references_completed) #  need to pass the new application_form again
 
     # Create copies of the original Application Choices all in Draft
+    log("Copying #{original_application_form.application_choices.count} application choices to application form #{new_application_form.id}")
     original_application_form.application_choices.each do |original_application_choice|
       course_option = original_application_choice.course_option
       new_application_form.application_choices.new.configure_initial_course_choice!(course_option)
@@ -35,6 +39,7 @@ class CopyIncidentApplicationToNewAccount
 
     # Submit application choices - only from awaiting provider decisions - from
     # original application form
+    log("Submit #{original_application_form.application_choices.awaiting_provider_decision.count} application choices to application form #{new_application_form.id}")
     new_application_form.application_choices.each do |application_choice|
       original_application_choice = original_application_form.application_choices.find_by(course_option: application_choice.course_option)
       next unless original_application_choice.awaiting_provider_decision?
@@ -45,5 +50,11 @@ class CopyIncidentApplicationToNewAccount
     end
 
     new_application_form
+  end
+
+  def log(message)
+    Rails.logger.info('=' * 80)
+    Rails.logger.info(message)
+    Rails.logger.info('=' * 80)
   end
 end

--- a/app/services/copy_incident_application_to_new_account.rb
+++ b/app/services/copy_incident_application_to_new_account.rb
@@ -44,7 +44,9 @@ class CopyIncidentApplicationToNewAccount
       original_application_choice = original_application_form.application_choices.find_by(course_option: application_choice.course_option)
       next unless original_application_choice.awaiting_provider_decision?
 
-      if CandidateInterface::ContinuousApplications::ApplicationChoiceSubmission.new(application_choice:).valid?
+      application_choice_submission = CandidateInterface::ContinuousApplications::ApplicationChoiceSubmission.new(application_choice:)
+      log("Submit application choice #{application_choice.id}. Valid?: #{application_choice_submission.valid?}")
+      if application_choice_submission.valid?
         CandidateInterface::ContinuousApplications::SubmitApplicationChoice.new(application_choice).call
       end
     end

--- a/app/services/copy_incident_application_to_new_account.rb
+++ b/app/services/copy_incident_application_to_new_account.rb
@@ -6,31 +6,35 @@ class CopyIncidentApplicationToNewAccount
     @candidate_email_address = candidate_email_address
   end
 
-  def call
-    candidate = Candidate.find_by(email_address: candidate_email_address)
-
-    if candidate.blank?
-      CandidateInterface::SignUpForm.new(email_address: candidate_email_address).save
-    end
-
+  def call!
+    # Create a new Candidate
+    # this will not create a duplicate if they already exist
+    CandidateInterface::SignUpForm.new(email_address: candidate_email_address).save
     candidate = Candidate.find_by!(email_address: candidate_email_address)
 
+    # Copy the Application Form to the new Candidate
+    # `target_phase` is always `"apply_1"`
     new_application_form = DuplicateApplication.new(
       @original_application_form,
       target_phase: 'apply_1',
       candidate_id: candidate.id,
     ).duplicate
 
+    # Update the Reference section
+    # This is only needed if the original Application Form had the Reference Section completed
     CandidateInterface::ReferenceSectionCompleteForm.new(
       application_form: new_application_form,
       completed: original_application_form.references_completed?.to_s, # section complete form expect a string
     ).save(new_application_form, :references_completed) #  need to pass the new application_form again
 
+    # Create copies of the original Application Choices all in Draft
     original_application_form.application_choices.each do |original_application_choice|
       course_option = original_application_choice.course_option
       new_application_form.application_choices.new.configure_initial_course_choice!(course_option)
     end
 
+    # Submit application choices - only from awaiting provider decisions - from
+    # original application form
     new_application_form.application_choices.each do |application_choice|
       original_application_choice = original_application_form.application_choices.find_by(course_option: application_choice.course_option)
       next unless original_application_choice.awaiting_provider_decision?

--- a/app/services/copy_incident_application_to_new_account.rb
+++ b/app/services/copy_incident_application_to_new_account.rb
@@ -3,7 +3,7 @@ class CopyIncidentApplicationToNewAccount
 
   def initialize(original_application_form:, candidate_email_address:)
     @original_application_form = original_application_form
-    @candidate_email_address = candidate_email_address
+    @candidate_email_address = candidate_email_address.downcase
   end
 
   def call!

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -22,13 +22,10 @@ class DuplicateApplication
     )
 
     if @candidate_id.present?
-      attrs['candidate_id'] = @candidate_id
       candidate = Candidate.find(@candidate_id)
-
+      attrs = ActiveSupport::HashWithIndifferentAccess.new(attrs)
+      attrs['candidate_id'] = @candidate_id
       attrs['previous_application_form_id'] = candidate.application_forms.order(:created_at, :id).last&.id
-      # if we copy the application choices it should always be for the current
-      # cycle
-      # if we are in between cycles copying applications choices won't work.
     end
 
     ApplicationForm.create!(attrs).tap do |new_application_form|

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -1,10 +1,11 @@
 class DuplicateApplication
   attr_reader :original_application_form, :target_phase
 
-  def initialize(original_application_form, target_phase:, recruitment_cycle_year: RecruitmentCycle.current_year)
+  def initialize(original_application_form, target_phase:, recruitment_cycle_year: RecruitmentCycle.current_year, candidate_id: nil)
     @original_application_form = original_application_form
     @target_phase = target_phase
     @recruitment_cycle_year = recruitment_cycle_year
+    @candidate_id = candidate_id
   end
 
   IGNORED_ATTRIBUTES = %w[id created_at updated_at submitted_at course_choices_completed phase support_reference english_main_language english_language_details other_language_details feedback_form_complete].freeze
@@ -19,6 +20,8 @@ class DuplicateApplication
       recruitment_cycle_year: @recruitment_cycle_year,
       work_history_status: original_application_form.work_history_status || 'can_complete',
     )
+
+    attrs['candidate_id'] = @candidate_id if @candidate_id.present?
 
     ApplicationForm.create!(attrs).tap do |new_application_form|
       original_application_form.application_work_experiences.each do |w|

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -21,7 +21,15 @@ class DuplicateApplication
       work_history_status: original_application_form.work_history_status || 'can_complete',
     )
 
-    attrs['candidate_id'] = @candidate_id if @candidate_id.present?
+    if @candidate_id.present?
+      attrs['candidate_id'] = @candidate_id
+      candidate = Candidate.find(@candidate_id)
+
+      attrs['previous_application_form_id'] = candidate.application_forms.order(:created_at, :id).last&.id
+      # if we copy the application choices it should always be for the current
+      # cycle
+      # if we are in between cycles copying applications choices won't work.
+    end
 
     ApplicationForm.create!(attrs).tap do |new_application_form|
       original_application_form.application_work_experiences.each do |w|

--- a/spec/services/copy_incident_application_to_new_account_spec.rb
+++ b/spec/services/copy_incident_application_to_new_account_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe CopyIncidentApplicationToNewAccount do
     end
   end
 
-  context 'when candidate does not have an application form' do
-    it 'assigns the original application to the candidate in current cycle' do
+  context 'when candidate does not have an existing application form' do
+    it 'copies the original application to the new candidate in current recruitment cycle' do
       another_candidate = create(:candidate)
       another_candidate.application_forms.delete_all
       duplicate_application_form = described_class.new(
@@ -34,7 +34,7 @@ RSpec.describe CopyIncidentApplicationToNewAccount do
   end
 
   context 'when candidate does have an application form in previous cycle' do
-    it 'assigns the original application to the candidate in current cycle' do
+    it 'copies the original application to the new candidate in current recruitment cycle with a link to their previous application' do
       another_candidate = create(:candidate)
       previous_cycle_application_form = create(:application_form, becoming_a_teacher_completed: false, recruitment_cycle_year: RecruitmentCycle.previous_year, candidate: another_candidate)
       duplicate_application_form = described_class.new(

--- a/spec/services/copy_incident_application_to_new_account_spec.rb
+++ b/spec/services/copy_incident_application_to_new_account_spec.rb
@@ -78,11 +78,6 @@ RSpec.describe CopyIncidentApplicationToNewAccount do
         @first_choice = create(:application_choice, :awaiting_provider_decision, application_form: @original_application_form)
         @second_choice = create(:application_choice, :awaiting_provider_decision, application_form: @original_application_form)
         @unsubmitted_choice = create(:application_choice, :unsubmitted, application_form: @original_application_form)
-
-        @duplicate_application_form = described_class.new(
-          original_application_form: @original_application_form,
-          candidate_email_address: 'some.email@example.com',
-        ).call!
       end
 
       it 'creates new candidate with new emails address' do

--- a/spec/services/copy_incident_application_to_new_account_spec.rb
+++ b/spec/services/copy_incident_application_to_new_account_spec.rb
@@ -1,0 +1,147 @@
+require 'rails_helper'
+
+RSpec.describe CopyIncidentApplicationToNewAccount do
+  before do
+    travel_temporarily_to(-1.day) do
+      @original_application_form = create(
+        :completed_application_form,
+        :with_gcses,
+        work_experiences_count: 1,
+        volunteering_experiences_count: 1,
+        full_work_history: true,
+        recruitment_cycle_year: RecruitmentCycle.current_year,
+        references_count: 0,
+      )
+      create_list(:reference, 2, feedback_status: :feedback_provided, application_form: @original_application_form)
+      create(:reference, feedback_status: :feedback_refused, application_form: @original_application_form)
+    end
+  end
+
+  context 'when candidate does not have an application form' do
+    it 'assigns the original application to the candidate in current cycle' do
+      another_candidate = create(:candidate)
+      another_candidate.application_forms.delete_all
+      duplicate_application_form = described_class.new(
+        original_application_form: @original_application_form,
+        candidate_email_address: another_candidate.email_address,
+      ).call
+
+      expect(duplicate_application_form).to be_becoming_a_teacher_completed
+      expect(duplicate_application_form.candidate_id).to be(another_candidate.id)
+      expect(duplicate_application_form.recruitment_cycle_year).to be(RecruitmentCycle.current_year)
+      expect(another_candidate.current_application.previous_application_form).to be_nil
+    end
+  end
+
+  context 'when candidate does have an application form in previous cycle' do
+    it 'assigns the original application to the candidate in current cycle' do
+      another_candidate = create(:candidate)
+      previous_cycle_application_form = create(:application_form, becoming_a_teacher_completed: false, recruitment_cycle_year: RecruitmentCycle.previous_year, candidate: another_candidate)
+      duplicate_application_form = described_class.new(
+        original_application_form: @original_application_form,
+        candidate_email_address: another_candidate.email_address,
+      ).call
+
+      expect(duplicate_application_form).to be_becoming_a_teacher_completed
+      expect(duplicate_application_form.candidate_id).to be(another_candidate.id)
+      expect(duplicate_application_form.recruitment_cycle_year).to be(RecruitmentCycle.current_year)
+      expect(duplicate_application_form.previous_application_form_id).to eq(previous_cycle_application_form.id)
+      expect(duplicate_application_form.previous_application_form).to eq(previous_cycle_application_form)
+      expect(another_candidate.current_application.previous_application_form).to eq(previous_cycle_application_form)
+    end
+  end
+
+  context 'when candidate does have an application form in current cycle' do
+    it 'assigns the original application as current application for the candidate in current cycle' do
+      another_candidate = create(:candidate)
+      current_cycle_application_form = create(:application_form, becoming_a_teacher_completed: false, created_at: 1.day.ago, candidate: another_candidate)
+
+      duplicate_application_form = described_class.new(
+        original_application_form: @original_application_form,
+        candidate_email_address: another_candidate.email_address,
+      ).call
+
+      expect(duplicate_application_form).to be_becoming_a_teacher_completed
+      expect(duplicate_application_form.candidate_id).to be(another_candidate.id)
+      expect(duplicate_application_form.recruitment_cycle_year).to be(RecruitmentCycle.current_year)
+
+      expect(duplicate_application_form.created_at).to be > current_cycle_application_form.created_at
+      expect(another_candidate.current_application).to eq(duplicate_application_form)
+      expect(duplicate_application_form.previous_application_form_id).to eq(current_cycle_application_form.id)
+      expect(another_candidate.current_application.previous_application_form).to eq(current_cycle_application_form)
+    end
+  end
+
+  context 'when candidate account does not exist' do
+    context 'when has application choices' do
+      before do
+        @first_choice = create(:application_choice, :awaiting_provider_decision, application_form: @original_application_form)
+        @second_choice = create(:application_choice, :awaiting_provider_decision, application_form: @original_application_form)
+        @unsubmitted_choice = create(:application_choice, :unsubmitted, application_form: @original_application_form)
+
+        @duplicate_application_form = described_class.new(
+          original_application_form: @original_application_form,
+          candidate_email_address: 'some.email@example.com',
+        ).call
+      end
+
+      it 'creates new candidate with new emails address' do
+        duplicate_application_form = described_class.new(
+          original_application_form: @original_application_form,
+          candidate_email_address: 'some.email@example.com',
+        ).call
+        expect(duplicate_application_form.candidate).to be_persisted
+        expect(duplicate_application_form.candidate.email_address).to eq('some.email@example.com')
+      end
+
+      it 'copies application choices in awaiting provider decision' do
+        duplicate_application_form = described_class.new(
+          original_application_form: @original_application_form,
+          candidate_email_address: 'some.email@example.com',
+        ).call
+
+        expect(duplicate_application_form.application_choices.map(&:current_course).map(&:name)).to contain_exactly(@first_choice.current_course.name, @second_choice.current_course.name, @unsubmitted_choice.current_course.name)
+        expect(duplicate_application_form.application_choices.map(&:provider)).to contain_exactly(@first_choice.provider, @second_choice.provider, @unsubmitted_choice.provider)
+
+        expect(duplicate_application_form.application_choices.awaiting_provider_decision.count).to be 2
+        expect(duplicate_application_form.application_choices.unsubmitted.count).to be 1
+      end
+    end
+
+    context 'when does not have application choices' do
+      it 'does not create application choices' do
+        duplicate_application_form = described_class.new(
+          original_application_form: @original_application_form,
+          candidate_email_address: 'some.email@example.com',
+        ).call
+        expect(duplicate_application_form.application_choices).to be_empty
+      end
+    end
+
+    context 'when references section is completed on original application form' do
+      it 'marks as references section as completed' do
+        @original_application_form.update!(references_completed: true)
+
+        duplicate_application_form = described_class.new(
+          original_application_form: @original_application_form,
+          candidate_email_address: 'some.email@example.com',
+        ).call
+
+        expect(duplicate_application_form).to be_references_completed
+      end
+    end
+
+    context 'when references section is not completed on original application form' do
+      it 'marks as references section as incomplete' do
+        @original_application_form.update!(references_completed: false)
+
+        duplicate_application_form = described_class.new(
+          original_application_form: @original_application_form,
+          candidate_email_address: 'some.email@example.com',
+        ).call
+
+        expect(duplicate_application_form).not_to be_references_completed
+      end
+    end
+  end
+end

--- a/spec/services/copy_incident_application_to_new_account_spec.rb
+++ b/spec/services/copy_incident_application_to_new_account_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe CopyIncidentApplicationToNewAccount do
       duplicate_application_form = described_class.new(
         original_application_form: @original_application_form,
         candidate_email_address: another_candidate.email_address,
-      ).call
+      ).call!
 
       expect(duplicate_application_form).to be_becoming_a_teacher_completed
       expect(duplicate_application_form.candidate_id).to be(another_candidate.id)
@@ -40,7 +40,7 @@ RSpec.describe CopyIncidentApplicationToNewAccount do
       duplicate_application_form = described_class.new(
         original_application_form: @original_application_form,
         candidate_email_address: another_candidate.email_address,
-      ).call
+      ).call!
 
       expect(duplicate_application_form).to be_becoming_a_teacher_completed
       expect(duplicate_application_form.candidate_id).to be(another_candidate.id)
@@ -59,7 +59,7 @@ RSpec.describe CopyIncidentApplicationToNewAccount do
       duplicate_application_form = described_class.new(
         original_application_form: @original_application_form,
         candidate_email_address: another_candidate.email_address,
-      ).call
+      ).call!
 
       expect(duplicate_application_form).to be_becoming_a_teacher_completed
       expect(duplicate_application_form.candidate_id).to be(another_candidate.id)
@@ -82,14 +82,14 @@ RSpec.describe CopyIncidentApplicationToNewAccount do
         @duplicate_application_form = described_class.new(
           original_application_form: @original_application_form,
           candidate_email_address: 'some.email@example.com',
-        ).call
+        ).call!
       end
 
       it 'creates new candidate with new emails address' do
         duplicate_application_form = described_class.new(
           original_application_form: @original_application_form,
           candidate_email_address: 'some.email@example.com',
-        ).call
+        ).call!
         expect(duplicate_application_form.candidate).to be_persisted
         expect(duplicate_application_form.candidate.email_address).to eq('some.email@example.com')
       end
@@ -98,7 +98,7 @@ RSpec.describe CopyIncidentApplicationToNewAccount do
         duplicate_application_form = described_class.new(
           original_application_form: @original_application_form,
           candidate_email_address: 'some.email@example.com',
-        ).call
+        ).call!
 
         expect(duplicate_application_form.application_choices.map(&:current_course).map(&:name)).to contain_exactly(@first_choice.current_course.name, @second_choice.current_course.name, @unsubmitted_choice.current_course.name)
         expect(duplicate_application_form.application_choices.map(&:provider)).to contain_exactly(@first_choice.provider, @second_choice.provider, @unsubmitted_choice.provider)
@@ -113,7 +113,7 @@ RSpec.describe CopyIncidentApplicationToNewAccount do
         duplicate_application_form = described_class.new(
           original_application_form: @original_application_form,
           candidate_email_address: 'some.email@example.com',
-        ).call
+        ).call!
         expect(duplicate_application_form.application_choices).to be_empty
       end
     end
@@ -125,7 +125,7 @@ RSpec.describe CopyIncidentApplicationToNewAccount do
         duplicate_application_form = described_class.new(
           original_application_form: @original_application_form,
           candidate_email_address: 'some.email@example.com',
-        ).call
+        ).call!
 
         expect(duplicate_application_form).to be_references_completed
       end
@@ -138,7 +138,7 @@ RSpec.describe CopyIncidentApplicationToNewAccount do
         duplicate_application_form = described_class.new(
           original_application_form: @original_application_form,
           candidate_email_address: 'some.email@example.com',
-        ).call
+        ).call!
 
         expect(duplicate_application_form).not_to be_references_completed
       end

--- a/spec/services/copy_incident_application_to_new_account_spec.rb
+++ b/spec/services/copy_incident_application_to_new_account_spec.rb
@@ -89,6 +89,22 @@ RSpec.describe CopyIncidentApplicationToNewAccount do
         expect(duplicate_application_form.candidate.email_address).to eq('some.email@example.com')
       end
 
+      it 'creates one candidate with same emails address but in uppercase' do
+        duplicate_application_form = described_class.new(
+          original_application_form: @original_application_form,
+          candidate_email_address: 'some.email@example.com',
+        ).call!
+        described_class.new(
+          original_application_form: @original_application_form,
+          candidate_email_address: 'SOME.EMAIL@example.com',
+        ).call!
+        described_class.new(
+          original_application_form: @original_application_form,
+          candidate_email_address: 'SOME.EMAIL@example.com',
+        ).call!
+        expect(Candidate.pluck(:id)).to contain_exactly(@original_application_form.candidate_id, duplicate_application_form.candidate_id)
+      end
+
       it 'copies application choices in awaiting provider decision' do
         duplicate_application_form = described_class.new(
           original_application_form: @original_application_form,

--- a/spec/services/duplicate_application_spec.rb
+++ b/spec/services/duplicate_application_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe DuplicateApplication do
           another_candidate.application_forms.delete_all
           duplicate_application_form = described_class.new(
             @original_application_form,
-            target_phase: 'apply_2',
+            target_phase:,
             candidate_id: another_candidate.id,
           ).duplicate
 
@@ -140,7 +140,7 @@ RSpec.describe DuplicateApplication do
           previous_cycle_application_form = create(:application_form, becoming_a_teacher_completed: false, recruitment_cycle_year: RecruitmentCycle.previous_year, candidate: another_candidate)
           duplicate_application_form = described_class.new(
             @original_application_form,
-            target_phase: 'apply_2',
+            target_phase:,
             candidate_id: another_candidate.id,
           ).duplicate
 
@@ -160,7 +160,7 @@ RSpec.describe DuplicateApplication do
 
           duplicate_application_form = described_class.new(
             @original_application_form,
-            target_phase: 'apply_2',
+            target_phase:,
             candidate_id: another_candidate.id,
           ).duplicate
 

--- a/spec/services/duplicate_application_spec.rb
+++ b/spec/services/duplicate_application_spec.rb
@@ -59,6 +59,10 @@ RSpec.describe DuplicateApplication do
     it 'merges the personal statement' do
       expect(duplicate_application_form.becoming_a_teacher).to eq @original_application_form.becoming_a_teacher
     end
+
+    it 'assigns to the same candidate' do
+      expect(duplicate_application_form.candidate_id).to be(@original_application_form.candidate.id)
+    end
   end
 
   context 'when apply-again' do
@@ -108,6 +112,59 @@ RSpec.describe DuplicateApplication do
 
         it 'marks reference as complete' do
           expect(duplicate_application_form).to be_references_completed
+        end
+      end
+    end
+
+    context 'copying the application to another candidate' do
+      context 'when candidate does not have an application form' do
+        it 'assigns the original application to the candidate in current cycle' do
+          another_candidate = create(:candidate)
+          duplicate_application_form = described_class.new(
+            @original_application_form,
+            target_phase: 'apply_2',
+            candidate_id: another_candidate.id,
+          ).duplicate
+
+          expect(duplicate_application_form).to be_becoming_a_teacher_completed
+          expect(duplicate_application_form.candidate_id).to be(another_candidate.id)
+          expect(duplicate_application_form.recruitment_cycle_year).to be(RecruitmentCycle.current_year)
+        end
+      end
+
+      context 'when candidate does have an application form in previous cycle' do
+        it 'assigns the original application to the candidate in current cycle' do
+          another_candidate = create(:candidate)
+          create(:application_form, becoming_a_teacher_completed: false, recruitment_cycle_year: RecruitmentCycle.previous_year)
+          duplicate_application_form = described_class.new(
+            @original_application_form,
+            target_phase: 'apply_2',
+            candidate_id: another_candidate.id,
+          ).duplicate
+
+          expect(duplicate_application_form).to be_becoming_a_teacher_completed
+          expect(duplicate_application_form.candidate_id).to be(another_candidate.id)
+          expect(duplicate_application_form.recruitment_cycle_year).to be(RecruitmentCycle.current_year)
+        end
+      end
+
+      context 'when candidate does have an application form in current cycle' do
+        it 'assigns the original application as current application for the candidate in current cycle' do
+          another_candidate = create(:candidate)
+          current_cycle_application_form = create(:application_form, becoming_a_teacher_completed: false, created_at: 1.day.ago)
+
+          duplicate_application_form = described_class.new(
+            @original_application_form,
+            target_phase: 'apply_2',
+            candidate_id: another_candidate.id,
+          ).duplicate
+
+          expect(duplicate_application_form).to be_becoming_a_teacher_completed
+          expect(duplicate_application_form.candidate_id).to be(another_candidate.id)
+          expect(duplicate_application_form.recruitment_cycle_year).to be(RecruitmentCycle.current_year)
+
+          expect(duplicate_application_form.created_at).to be > current_cycle_application_form.created_at
+          expect(another_candidate.current_application).to eq(duplicate_application_form)
         end
       end
     end

--- a/spec/services/duplicate_application_spec.rb
+++ b/spec/services/duplicate_application_spec.rb
@@ -129,13 +129,14 @@ RSpec.describe DuplicateApplication do
           expect(duplicate_application_form).to be_becoming_a_teacher_completed
           expect(duplicate_application_form.candidate_id).to be(another_candidate.id)
           expect(duplicate_application_form.recruitment_cycle_year).to be(RecruitmentCycle.current_year)
+          expect(another_candidate.current_application.previous_application_form).to be_nil
         end
       end
 
       context 'when candidate does have an application form in previous cycle' do
         it 'assigns the original application to the candidate in current cycle' do
           another_candidate = create(:candidate)
-          create(:application_form, becoming_a_teacher_completed: false, recruitment_cycle_year: RecruitmentCycle.previous_year)
+          previous_cycle_application_form = create(:application_form, becoming_a_teacher_completed: false, recruitment_cycle_year: RecruitmentCycle.previous_year)
           duplicate_application_form = described_class.new(
             @original_application_form,
             target_phase: 'apply_2',
@@ -145,6 +146,8 @@ RSpec.describe DuplicateApplication do
           expect(duplicate_application_form).to be_becoming_a_teacher_completed
           expect(duplicate_application_form.candidate_id).to be(another_candidate.id)
           expect(duplicate_application_form.recruitment_cycle_year).to be(RecruitmentCycle.current_year)
+          expect(duplicate_application_form.previous_application_form).to eq(previous_cycle_application_form)
+          expect(another_candidate.current_application.previous_application_form).to eq(previous_cycle_application_form)
         end
       end
 
@@ -165,6 +168,8 @@ RSpec.describe DuplicateApplication do
 
           expect(duplicate_application_form.created_at).to be > current_cycle_application_form.created_at
           expect(another_candidate.current_application).to eq(duplicate_application_form)
+          expect(duplicate_application_form.previous_application_form_id).to eq(current_cycle_application_form.id)
+          expect(another_candidate.current_application.previous_application_form).to eq(current_cycle_application_form)
         end
       end
     end

--- a/spec/services/duplicate_application_spec.rb
+++ b/spec/services/duplicate_application_spec.rb
@@ -120,6 +120,7 @@ RSpec.describe DuplicateApplication do
       context 'when candidate does not have an application form' do
         it 'assigns the original application to the candidate in current cycle' do
           another_candidate = create(:candidate)
+          another_candidate.application_forms.delete_all
           duplicate_application_form = described_class.new(
             @original_application_form,
             target_phase: 'apply_2',
@@ -136,7 +137,7 @@ RSpec.describe DuplicateApplication do
       context 'when candidate does have an application form in previous cycle' do
         it 'assigns the original application to the candidate in current cycle' do
           another_candidate = create(:candidate)
-          previous_cycle_application_form = create(:application_form, becoming_a_teacher_completed: false, recruitment_cycle_year: RecruitmentCycle.previous_year)
+          previous_cycle_application_form = create(:application_form, becoming_a_teacher_completed: false, recruitment_cycle_year: RecruitmentCycle.previous_year, candidate: another_candidate)
           duplicate_application_form = described_class.new(
             @original_application_form,
             target_phase: 'apply_2',
@@ -146,6 +147,7 @@ RSpec.describe DuplicateApplication do
           expect(duplicate_application_form).to be_becoming_a_teacher_completed
           expect(duplicate_application_form.candidate_id).to be(another_candidate.id)
           expect(duplicate_application_form.recruitment_cycle_year).to be(RecruitmentCycle.current_year)
+          expect(duplicate_application_form.previous_application_form_id).to eq(previous_cycle_application_form.id)
           expect(duplicate_application_form.previous_application_form).to eq(previous_cycle_application_form)
           expect(another_candidate.current_application.previous_application_form).to eq(previous_cycle_application_form)
         end
@@ -154,7 +156,7 @@ RSpec.describe DuplicateApplication do
       context 'when candidate does have an application form in current cycle' do
         it 'assigns the original application as current application for the candidate in current cycle' do
           another_candidate = create(:candidate)
-          current_cycle_application_form = create(:application_form, becoming_a_teacher_completed: false, created_at: 1.day.ago)
+          current_cycle_application_form = create(:application_form, becoming_a_teacher_completed: false, created_at: 1.day.ago, candidate: another_candidate)
 
           duplicate_application_form = described_class.new(
             @original_application_form,


### PR DESCRIPTION
## Context

This is to solve the incident and to move one application form from one candidate account to another.

## Changes proposed in this pull request

Make duplication application service to move one application form to another (to be used only on exceptional circumstances)

## Gotchas

When we move one application form to another candidate, we need to make sure the previous application form is set correctly.

This graph shows the case and where we should link to the previous application form:

<img width="840" alt="Screenshot 2024-03-11 at 10 54 48" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/27509/238ca2f5-31c9-40c9-bec1-8d9f41505203">

The graph above is assuming that we called:

```ruby
  DuplicateApplication.new(
    fake_application_form,
    candidate_id: real_candidate.id,
  ).duplicate
```