### PR TITLE
1200-bug-where-candidate-saw-add-another-job-button

### DIFF
--- a/app/views/candidate_interface/restructured_work_history/review/show.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/review/show.html.erb
@@ -8,7 +8,7 @@
 
   <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application:) %>
 
-  <% if @application_form.can_complete? %>
+  <% if @application_form.can_complete? && @section_policy.can_edit? %>
     <div class="govuk-!-width-two-thirds">
       <p class="govuk-body">Enter all the jobs you have had since you left school.</p>
       <p class="govuk-body">Explain any gaps in your work history. For example, raising children, unemployment or illness.</p>

--- a/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_cannot_add_jobs_if_they_have_a_submitted_application_spec.rb
+++ b/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_cannot_add_jobs_if_they_have_a_submitted_application_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.feature 'Trying to enter work history' do
+  include CandidateHelper
+
+  scenario 'Candidate does not see Add job or Add another job buttons' do
+    given_i_am_signed_in
+    and_i_have_completed_work_history
+    and_i_have_a_submitted_application
+    when_i_view_work_history
+    then_i_do_not_see_an_option_to_add_another_job
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_have_completed_work_history
+    @application_form_can_complete_work_history = create(:completed_application_form,
+                                                         full_work_history: true,
+                                                         candidate: @current_candidate,
+                                                         work_history_status: :can_complete)
+  end
+
+  def when_i_view_work_history
+    visit candidate_interface_continuous_applications_details_path
+    click_on 'Work history'
+  end
+
+  def and_i_have_a_submitted_application
+    create(:application_choice, :awaiting_provider_decision, application_form: @application_form_can_complete_work_history)
+  end
+
+  def then_i_do_not_see_an_option_to_add_another_job
+    expect(page).to have_content 'Work history'
+    expect(page).to have_no_content 'Add another job'
+    expect(page).to have_no_content 'Add job'
+  end
+end


### PR DESCRIPTION
## Context

We received a support ticket from a user who clicked on the 'Add another job' button but was then redirected to the person details page.

In practice, the user should not have seen the 'Add another job' button at all. 

## Changes proposed in this pull request

- Check section_policy to ensure the work history is editable before rendering action buttons
- Spec so we won't have regression. 

## Guidance to review

- When entering work history, chose ‘can complete’
- Enter at least one job
- Complete all other Candidate details
- Complete an application choice and submit it
- Click ‘Work history’
- You should no longer see the "Add another job" button

## Link to Trello card

[Trello card](https://trello.com/c/anrUka9x)
