### PR TITLE
1268 tech debt fix styles and markup to match gds for application page updates

### DIFF
--- a/app/components/candidate_interface/application_choice_item_component.html.erb
+++ b/app/components/candidate_interface/application_choice_item_component.html.erb
@@ -6,10 +6,10 @@
       </div>
       <div class="app-application-item__details">
         <div class="app-application-item__provider_id">
-          <h3 class="govuk-heading-s">
+          <h2 class="govuk-heading-s">
             <%= provider_name %>
-          </h3>
-          <p class="govuk-body-s govuk-hint govuk-!-margin-left-2 govuk-!-font-size-16"><%= application_id %></p>
+          </h2>
+          <p class="govuk-body-s"><%= application_id %></p>
         </div>
         <p class="govuk-body-s"><%= course_name %> - <%= study_mode %> at <%= site_name %></p>
       </div>

--- a/app/components/candidate_interface/continuous_applications/application_review_component.html.erb
+++ b/app/components/candidate_interface/continuous_applications/application_review_component.html.erb
@@ -5,37 +5,33 @@
 <%= render SummaryListComponent.new(rows: rows) %>
 
 <% if show_what_happens_next? %>
-  <div class="govuk-!-margin-bottom-6">
-    <h2 class="govuk-heading-m govuk-!-margin-bottom-1">What happens next</h2>
-    <% if application_choice.awaiting_provider_decision? %>
-      <p class="govuk-body">The provider will review your application and let your know when they have a made a decision. In the meantime, you can:</p>
-      <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-8">
-        <li>contact the provider directly if you have any questions</li>
-        <li>find out more about <%= govuk_link_to('funding your training', t('get_into_teaching.url_funding_and_support'), target: '_blank') %></li>
-        <li>get help from a <%= govuk_link_to('teacher training advisor', t('get_into_teaching.url_get_an_adviser_signup'), target: '_blank') %></li>
-      </ul>
-    <% elsif application_choice.interviewing? %>
-      <p class="govuk-body">Congratulations on being invited for an interview! This is an important stage in successfully getting a place on a teacher training course.</p>
-      <p class="govuk-body">Learn more about what to expect and <%= govuk_link_to 'how to prepare for an interview', t('get_into_teaching.url_teacher_training_interview'), target: '_blank' %>.</p>
-    <% elsif application_choice.inactive? %>
-      <p class="govuk-body">The provider will review your application and let you know when they have made a decision. In the meantime, you can:</p>
-      <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-8">
-        <% if can_add_more_choices? %>
-          <li><%= govuk_link_to 'submit another application', candidate_interface_continuous_applications_do_you_know_the_course_path %> while you wait for a decision on this one</li>
-        <% end %>
-        <li>contact the provider directly if you have any questions</li>
-        <li>find out more about <%= govuk_link_to 'funding your training', t('get_into_teaching.url_funding_and_support'), target: '_blank' %></li>
-        <li>get help from a <%= govuk_link_to 'teacher training adviser', t('get_into_teaching.url_get_an_adviser_signup'), target: '_blank' %></li>
-      </ul>
-    <% end %>
-  </div>
+  <h2 class="govuk-heading-m">What happens next</h2>
+  <% if application_choice.awaiting_provider_decision? %>
+    <p class="govuk-body">The provider will review your application and let your know when they have a made a decision. In the meantime, you can:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>contact the provider directly if you have any questions</li>
+      <li>find out more about <%= govuk_link_to('funding your training', t('get_into_teaching.url_funding_and_support'), target: '_blank') %></li>
+      <li>get help from a <%= govuk_link_to('teacher training advisor', t('get_into_teaching.url_get_an_adviser_signup'), target: '_blank') %></li>
+    </ul>
+  <% elsif application_choice.interviewing? %>
+    <p class="govuk-body">Congratulations on being invited for an interview! This is an important stage in successfully getting a place on a teacher training course.</p>
+    <p class="govuk-body">Learn more about what to expect and <%= govuk_link_to 'how to prepare for an interview', t('get_into_teaching.url_teacher_training_interview'), target: '_blank' %>.</p>
+  <% elsif application_choice.inactive? %>
+    <p class="govuk-body">The provider will review your application and let you know when they have made a decision. In the meantime, you can:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <% if can_add_more_choices? %>
+        <li><%= govuk_link_to 'submit another application', candidate_interface_continuous_applications_do_you_know_the_course_path %> while you wait for a decision on this one</li>
+      <% end %>
+      <li>contact the provider directly if you have any questions</li>
+      <li>find out more about <%= govuk_link_to 'funding your training', t('get_into_teaching.url_funding_and_support'), target: '_blank' %></li>
+      <li>get help from a <%= govuk_link_to 'teacher training adviser', t('get_into_teaching.url_get_an_adviser_signup'), target: '_blank' %></li>
+    </ul>
+  <% end %>
 <% end %>
 
 <% if show_withdraw? %>
-  <div class="govuk-!-margin-bottom-6">
-    <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Withdraw your application</h2>
-    <p class="govuk-body">You can <%= govuk_link_to 'withdraw this application', candidate_interface_withdraw_path(application_choice) %> if you no longer wish to be considered for this course.</p>
-  </div>
+  <h2 class="govuk-heading-m">Withdraw your application</h2>
+  <p class="govuk-body">You can <%= govuk_link_to 'withdraw this application', candidate_interface_withdraw_path(application_choice) %> if you no longer wish to be considered for this course.</p>
 <% end %>
 
 <% if show_provider_contact_component? %>

--- a/app/components/candidate_interface/provider_contact_information_component.html.erb
+++ b/app/components/candidate_interface/provider_contact_information_component.html.erb
@@ -1,11 +1,9 @@
-<div class="govuk-!-margin-bottom-6">
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Contact training provider</h2>
-  <p class="govuk-body">Contact <%= provider.name %> if you have any questions about your application.</p>
-  <% if show_email_and_phone? %>
-    <p class="govuk-body">Call on <%= govuk_link_to(provider.phone_number, "tel:#{provider.phone_number}") %> or email at <%= govuk_mail_to(provider.email_address) %></p>
-  <% elsif show_only_phone? %>
-    <p class="govuk-body">Call on <%= govuk_link_to(provider.phone_number, "tel:#{provider.phone_number}") %></p>
-  <% elsif show_only_email? %>
-    <p class="govuk-body">Email at <%= govuk_mail_to(provider.email_address) %></p>
-  <% end %>
-</div>
+<h2 class="govuk-heading-m">Contact training provider</h2>
+<p class="govuk-body">Contact <%= provider.name %> if you have any questions about your application.</p>
+<% if show_email_and_phone? %>
+  <p class="govuk-body">Call on <%= govuk_link_to(provider.phone_number, "tel:#{provider.phone_number}") %> or email at <%= govuk_mail_to(provider.email_address) %></p>
+<% elsif show_only_phone? %>
+  <p class="govuk-body">Call on <%= govuk_link_to(provider.phone_number, "tel:#{provider.phone_number}") %></p>
+<% elsif show_only_email? %>
+  <p class="govuk-body">Email at <%= govuk_mail_to(provider.email_address) %></p>
+<% end %>

--- a/app/frontend/styles/_application-item.scss
+++ b/app/frontend/styles/_application-item.scss
@@ -26,6 +26,13 @@
     }
   }
 
+  &__provider_id .govuk-body-s {
+    margin-bottom: 0;
+    margin-left: govuk-spacing(1);
+
+    color: $govuk-secondary-text-colour;
+  }
+
   &__choice_id {
     color: govuk-color("mid-grey");
   }

--- a/app/views/candidate_interface/continuous_applications_choices/index.html.erb
+++ b/app/views/candidate_interface/continuous_applications_choices/index.html.erb
@@ -1,12 +1,12 @@
 <%= render ServiceInformationBanner.new(namespace: :candidate) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
+    <h1 class="govuk-heading-xl">
       <%= t('page_titles.continuous_applications.your_applications') %>
     </h1>
 
     <% if CycleTimetable.today_is_between_apply_1_deadline_and_find_reopens? %>
-      <p class="govuk-body govuk-!-margin-top-6">Applications for courses starting in September <%= RecruitmentCycle.current_year %> are closed.</p>
+      <p class="govuk-body">Applications for courses starting in September <%= RecruitmentCycle.current_year %> are closed.</p>
       <p class="govuk-body"> From <%= CycleTimetable.find_reopens.to_fs(:govuk_time_and_date) %>, you can <%= govuk_link_to(
         'find postgraduate teacher training courses',
         t('find_postgraduate_teacher_training.production_url'),
@@ -63,6 +63,6 @@
     <% end %>
 
     <%= render CandidateInterface::ContinuousApplications::ApplicationChoiceListComponent.new(application_form: current_application, application_choices: @application_choices, current_tab_name: params[:current_tab_name]) %>
-    <% end %>
+  <% end %>
   </div>
 </div>


### PR DESCRIPTION
## Context

Lots of override / bespoke styling was added to the application pages to match designs exactly instead of using standard govuk classes and styles.

## Changes proposed in this pull request

- Removal of styles for the application index / show pages that are prefaced with `govuk-!-*` 
- Additional class for rendering the application id next to the provider name on the index page. 

## Guidance to review
Click around make sure nothing is amiss.

## Link to Trello card

https://trello.com/c/yBf9ku4z

## Screenshots
| Before | After |
| ------  | ----- |
| <img width="1012" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/44073106/da24d157-3cbf-4ddc-9817-b0d5a756be32"> | <img width="1065" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/44073106/f7aa3115-b962-4d8a-a5e3-cea2ce083445"> |
| <img width="861" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/44073106/b3a4db18-0169-4d13-9ee9-62cda6f5f2c3"> | <img width="903" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/44073106/ac174345-d76f-4440-b420-c06ca075c593"> |



