### PR TITLE
1419 bug duplicating apllications

### DIFF
--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -190,6 +190,20 @@ class ApplicationQualification < ApplicationRecord
       REQUIRED_GCSE_SUBJECTS.include?(subject)
   end
 
+  # We are doing almost a similar as set public id but forcing generation
+  # of new ids for constituent_grades.
+  # This should be deleted after the incident
+  #
+  def update_constituent_grades_public_ids
+    if constituent_grades.present? && subject != SCIENCE_TRIPLE_AWARD
+      grades_with_ids = constituent_grades.transform_values do |grade|
+        grade.merge({ public_id: next_available_public_id })
+      end
+
+      update(constituent_grades: grades_with_ids)
+    end
+  end
+
 private
 
   def set_public_id

--- a/app/services/copy_incident_application_to_new_account.rb
+++ b/app/services/copy_incident_application_to_new_account.rb
@@ -30,7 +30,25 @@ class CopyIncidentApplicationToNewAccount
       completed: original_application_form.references_completed?.to_s, # section complete form expect a string
     ).save(new_application_form, :references_completed) #  need to pass the new application_form again
 
-    # Create copies of the original Application Choices all in Draft
+    # When a qualification has constituent_grades the public id is generated for
+    # each grade therefore on the Vendor API we need to show this public id for
+    # each of constituent grade.
+    #
+    #   Constituent grades
+    #    {"english_single_award"=>{"grade"=>"C", "public_id"=>121847}
+    #    {"english_double_award"=>{"grade"=>"C:D", "public_id"=>121840}
+    #
+    # When a qualification does not have a constituent grade we have the public
+    # id and the grade to be look upon.
+    #
+    #    grade: 'B', public_id: '3009'
+    #
+    # For the incident we need to force the generation of the public ids
+    # for constituent grades because the set public id on qualification
+    # models doesn't generate a new one
+    #
+    new_application_form.application_qualifications.each(&:update_constituent_grades_public_ids)
+
     log("Copying #{original_application_form.application_choices.count} application choices to application form #{new_application_form.id}")
     original_application_form.application_choices.each do |original_application_choice|
       course_option = original_application_choice.course_option

--- a/spec/services/copy_incident_application_to_new_account_spec.rb
+++ b/spec/services/copy_incident_application_to_new_account_spec.rb
@@ -116,6 +116,8 @@ RSpec.describe CopyIncidentApplicationToNewAccount do
 
         expect(duplicate_application_form.application_choices.awaiting_provider_decision.count).to be 2
         expect(duplicate_application_form.application_choices.unsubmitted.count).to be 1
+
+        expect(duplicate_application_form.application_choices.reload.pluck(:personal_statement)).to contain_exactly(@unsubmitted_choice.personal_statement, @first_choice.personal_statement, @second_choice.personal_statement)
       end
     end
 

--- a/spec/services/copy_incident_application_to_new_account_spec.rb
+++ b/spec/services/copy_incident_application_to_new_account_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe CopyIncidentApplicationToNewAccount do
     travel_temporarily_to(-1.day) do
       @original_application_form = create(
         :completed_application_form,
-        :with_gcses,
         work_experiences_count: 1,
         volunteering_experiences_count: 1,
         full_work_history: true,
@@ -128,6 +127,31 @@ RSpec.describe CopyIncidentApplicationToNewAccount do
           candidate_email_address: 'some.email@example.com',
         ).call!
         expect(duplicate_application_form.application_choices).to be_empty
+      end
+    end
+
+    context 'when qualification has constituent grades' do
+      it 'generates a new public id for each constituent grade' do
+        create(
+          :gcse_qualification,
+          :multiple_english_gcses,
+          constituent_grades: {
+            english_language: { grade: 'A', public_id: 120282 },
+            english_literature: { grade: 'D', public_id: 120283 },
+          },
+          application_form: @original_application_form,
+        )
+
+        duplicate_application_form = described_class.new(
+          original_application_form: @original_application_form,
+          candidate_email_address: 'some.email@example.com',
+        ).call!
+
+        expect(duplicate_application_form.application_qualifications.gcses.count).to be 1
+        expect(
+          duplicate_application_form.application_qualifications.gcses.first.constituent_grades['english_language']['public_id'],
+        ).not_to be 120282
+        expect(duplicate_application_form.application_qualifications.gcses.first.constituent_grades['english_literature']['public_id']).not_to be 120283
       end
     end
 


### PR DESCRIPTION
## Context

When copying over Applications from one Candidate to another, we noticed some data inconstancies.

The personal statement for each Application Choice was missing
The Qualifications on the new Application Choice had the same IDs (public_id) as the original

Some work history gaps were missing  - this was a bad data in QA.

## Guidance to review

1. Does it create new ids in the Vendor API for any GCSE (constituent grades and not constituent grades)?
2. Does it copy the **same** personal statement from original application choice to the new one?

## Link to Trello card

https://trello.com/c/v7wlitV6/1419-bug-duplicating-apllications
