### PR TITLE
Remove remaining `open_on_apply` SupportInterface

### DIFF
--- a/app/queries/get_courses_ratified_by_provider.rb
+++ b/app/queries/get_courses_ratified_by_provider.rb
@@ -1,7 +1,7 @@
 class GetCoursesRatifiedByProvider
   def self.call(provider:, previous_cycle: false)
     courses_scope = provider.accredited_courses
-    course_cycle_scope = previous_cycle ? courses_scope.previous_cycle : courses_scope.current_cycle.open_on_apply
+    course_cycle_scope = previous_cycle ? courses_scope.previous_cycle : courses_scope.current_cycle.open
     course_cycle_scope.joins(:course_options).distinct.where.not(provider:)
   end
 end

--- a/app/services/generate_test_applications_for_provider.rb
+++ b/app/services/generate_test_applications_for_provider.rb
@@ -78,7 +78,7 @@ private
     @_courses_run_by_provider ||= if previous_cycle
                                     Course.previous_cycle.with_course_options_run_by_provider(provider)
                                   else
-                                    Course.current_cycle.open_on_apply.with_course_options_run_by_provider(provider)
+                                    Course.current_cycle.open.with_course_options_run_by_provider(provider)
                                   end
   end
 

--- a/app/views/support_interface/providers/applications.html.erb
+++ b/app/views/support_interface/providers/applications.html.erb
@@ -1,5 +1,5 @@
 <%= render 'provider_navigation', title: 'Applications' %>
-<% if HostingEnvironment.sandbox_mode? && @provider.courses.open_on_apply.any? %>
+<% if HostingEnvironment.sandbox_mode? && @provider.courses.open.any? %>
   <%= render SandboxFeatureComponent.new(
     description: 'This task generates 100 new applications for the current provider, with one course choice per application.',
   ) do %>

--- a/app/views/support_interface/providers/ratified_courses.html.erb
+++ b/app/views/support_interface/providers/ratified_courses.html.erb
@@ -2,7 +2,7 @@
 
 <% RecruitmentCycle.years_visible_in_support.each do |year| %>
   <% if @ratified_courses[year] %>
-    <h2 class="govuk-heading-m"><%= year %>: ratifies <%= pluralize(@ratified_courses[year].size, 'course') %> (<%= @ratified_courses[year].count(&:open_on_apply?) %> on DfE Apply)</h2>
+    <h2 class="govuk-heading-m"><%= year %>: ratifies <%= pluralize(@ratified_courses[year].size, 'course') %> (<%= @ratified_courses[year].count(&:open?) %> on DfE Apply)</h2>
 
     <%= render(SupportInterface::ProviderCoursesTableComponent.new(provider: @provider, courses: @ratified_courses[year])) %>
   <% else %>

--- a/spec/forms/support_interface/application_forms/pick_course_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/pick_course_form_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SupportInterface::ApplicationForms::PickCourseForm, type: :model 
     let(:first_site) { build(:site) }
     let(:second_site) { build(:site) }
     let(:provider) { build(:provider, sites: [first_site, second_site]) }
-    let(:course) { build(:course, :open_on_apply, code: 'ABC', provider:) }
+    let(:course) { build(:course, :open, code: 'ABC', provider:) }
 
     it 'returns course options that have already been added to an application form' do
       course_option = build(:course_option, site: first_site, course:)
@@ -42,7 +42,7 @@ RSpec.describe SupportInterface::ApplicationForms::PickCourseForm, type: :model 
     let(:first_site) { build(:site) }
     let(:second_site) { build(:site) }
     let(:provider) { build(:provider, sites: [first_site, second_site]) }
-    let(:course) { build(:course, :open_on_apply, code: 'ABC', provider:) }
+    let(:course) { build(:course, :open, code: 'ABC', provider:) }
 
     it 'returns course options that do and do not have vacancies' do
       course_option_with_vacancies = create(:course_option, site: first_site, course:)
@@ -61,8 +61,8 @@ RSpec.describe SupportInterface::ApplicationForms::PickCourseForm, type: :model 
     end
 
     it 'returns only course options from current cycle' do
-      course = create(:course, :open_on_apply, code: 'ABC', provider:)
-      same_course_from_another_cycle = create(:course, :open_on_apply, code: course.code, provider:, recruitment_cycle_year: RecruitmentCycle.previous_year, accredited_provider_id: provider.id)
+      course = create(:course, :open, code: 'ABC', provider:)
+      same_course_from_another_cycle = create(:course, :open, code: course.code, provider:, recruitment_cycle_year: RecruitmentCycle.previous_year, accredited_provider_id: provider.id)
       course_option_current_cycle = create(:course_option, site: first_site, course:)
       create(:course_option, :previous_year, site: second_site, course: same_course_from_another_cycle)
       application_form = create(:application_form)
@@ -84,14 +84,14 @@ RSpec.describe SupportInterface::ApplicationForms::PickCourseForm, type: :model 
 
       provider1 = application_choice.provider
       site1 = create(:site, provider: provider1)
-      course1 = create(:course, :open_on_apply, provider: provider1, name: 'A', code: 'A123')
+      course1 = create(:course, :open, provider: provider1, name: 'A', code: 'A123')
 
       provider2 = create(:provider)
       site2 = create(:site, provider: provider2)
 
-      course2 = create(:course, :open_on_apply, provider: provider2, accredited_provider: provider1, code: 'A123', name: 'B')
+      course2 = create(:course, :open, provider: provider2, accredited_provider: provider1, code: 'A123', name: 'B')
 
-      course3 = create(:course, :open_on_apply, code: 'A123')
+      course3 = create(:course, :open, code: 'A123')
 
       course_option_with_the_same_provider = create(:course_option, site: site1, course: course1)
       course_option_with_the_same_accrediting_provider = create(:course_option, site: site2, course: course2)
@@ -126,7 +126,7 @@ RSpec.describe SupportInterface::ApplicationForms::PickCourseForm, type: :model 
 
     it 'returns course options for courses marked not_in_find' do
       application_form = build_stubbed(:completed_application_form)
-      course_not_in_find = create(:course, :open_on_apply, provider:, exposed_in_find: false)
+      course_not_in_find = create(:course, :open, provider:, exposed_in_find: false)
       course_option = create(:course_option, course: course_not_in_find)
 
       form_data = {

--- a/spec/models/support_interface/provider_onboarding_monitor_spec.rb
+++ b/spec/models/support_interface/provider_onboarding_monitor_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe SupportInterface::ProviderOnboardingMonitor do
   let!(:provider) { create(:provider, :no_users) }
-  let!(:course) { create(:course, :open_on_apply, provider:) }
+  let!(:course) { create(:course, :open, provider:) }
   let!(:user) { create(:provider_user, providers: [provider], last_signed_in_at: 1.day.ago) }
 
   describe '.providers_with_no_users' do
@@ -20,7 +20,7 @@ RSpec.describe SupportInterface::ProviderOnboardingMonitor do
       end
 
       context 'when a provider only has courses in the previous year' do
-        let!(:course) { create(:course, :open_on_apply, :previous_year, provider:) }
+        let!(:course) { create(:course, :open, :previous_year, provider:) }
 
         it 'does not return the provider' do
           expect(described_class.new.providers_with_no_users).to be_empty
@@ -28,7 +28,7 @@ RSpec.describe SupportInterface::ProviderOnboardingMonitor do
       end
 
       context 'when a provider has multiple courses in the current year' do
-        let!(:another_course) { create(:course, :open_on_apply, provider:) }
+        let!(:another_course) { create(:course, :open, provider:) }
 
         it 'returns the provider and no duplicates' do
           expect(described_class.new.providers_with_no_users).to contain_exactly(provider)
@@ -54,7 +54,7 @@ RSpec.describe SupportInterface::ProviderOnboardingMonitor do
       end
 
       context 'when a provider only has courses in the previous year' do
-        let!(:course) { create(:course, :open_on_apply, :previous_year, provider:) }
+        let!(:course) { create(:course, :open, :previous_year, provider:) }
 
         it 'does not return the provider' do
           expect(described_class.new.providers_where_no_user_has_logged_in).to be_empty
@@ -141,7 +141,7 @@ RSpec.describe SupportInterface::ProviderOnboardingMonitor do
     end
 
     context 'when a provider only has courses in the previous year' do
-      let!(:course) { create(:course, :open_on_apply, :previous_year, provider:) }
+      let!(:course) { create(:course, :open, :previous_year, provider:) }
       let!(:application) { create(:application_choice, course_option: build(:course_option, course:), offered_at: 3.weeks.ago) }
 
       it 'does not return the provider' do

--- a/spec/models/support_interface/providers_filter_spec.rb
+++ b/spec/models/support_interface/providers_filter_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SupportInterface::ProvidersFilter do
   describe '#filter_records' do
     it 'filters by having one or more courses' do
       provider_with_course = create(:provider, :unsigned)
-      create(:course, :open_on_apply, provider: provider_with_course)
+      create(:course, :open, provider: provider_with_course)
       create(:provider, :unsigned)
       providers = Provider.all
       filter = described_class.new(params: { onboarding_stages: %w[with_courses] })

--- a/spec/queries/get_courses_ratified_by_provider_spec.rb
+++ b/spec/queries/get_courses_ratified_by_provider_spec.rb
@@ -5,25 +5,25 @@ RSpec.describe GetCoursesRatifiedByProvider do
   let(:previous_cycle) { false }
 
   it 'returns courses in the current year' do
-    course_current_year = create(:course, :open_on_apply, accredited_provider: provider)
+    course_current_year = create(:course, :open, accredited_provider: provider)
     create_list(:course_option, 3, course: course_current_year)
 
-    create(:course_option, course: create(:course, :open_on_apply, :previous_year, accredited_provider: provider))
+    create(:course_option, course: create(:course, :open, :previous_year, accredited_provider: provider))
 
     result = described_class.call(provider:, previous_cycle:)
     expect(result).to contain_exactly(course_current_year)
   end
 
   it 'only returns courses with a course option' do
-    create(:course, :open_on_apply, accredited_provider: provider)
+    create(:course, :open, accredited_provider: provider)
 
     result = described_class.call(provider:, previous_cycle:)
     expect(result).to be_empty
   end
 
   it 'excludes courses a provider runs' do
-    create(:course, :open_on_apply, provider:, accredited_provider: provider)
-    create(:course, :open_on_apply, provider:)
+    create(:course, :open, provider:, accredited_provider: provider)
+    create(:course, :open, provider:)
 
     result = described_class.call(provider:, previous_cycle:)
     expect(result).to be_empty
@@ -41,7 +41,7 @@ RSpec.describe GetCoursesRatifiedByProvider do
     course_previous_year = create(:course, :previous_year, accredited_provider: provider)
     create_list(:course_option, 3, course: course_previous_year)
 
-    create(:course_option, course: create(:course, :open_on_apply, accredited_provider: provider))
+    create(:course_option, course: create(:course, :open, accredited_provider: provider))
 
     result = described_class.call(provider:, previous_cycle:)
     expect(result).to contain_exactly(course_previous_year)

--- a/spec/requests/support_interface/provider_test_data_controller_spec.rb
+++ b/spec/requests/support_interface/provider_test_data_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe SupportInterface::ProviderTestDataController do
   let!(:provider) { create(:provider) }
-  let!(:course) { create(:course, :open_on_apply, provider:) }
+  let!(:course) { create(:course, :open, provider:) }
   let!(:course_option) { create(:course_option, course:) }
   let(:support_user) do
     SupportUser.new(

--- a/spec/requests/vendor_api/v1.0/post_test_data_generate_spec.rb
+++ b/spec/requests/vendor_api/v1.0/post_test_data_generate_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Vendor API - POST /api/v1.0/test-data/generate', :sidekiq do
   include VendorAPISpecHelpers
 
   it 'generates test data' do
-    create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
+    create(:course_option, course: create(:course, :open, provider: currently_authenticated_provider))
 
     post_api_request '/api/v1.0/test-data/generate?count=1'
 
@@ -26,7 +26,7 @@ RSpec.describe 'Vendor API - POST /api/v1.0/test-data/generate', :sidekiq do
 
   describe 'next_cycle' do
     it 'generates test data in the next cycle' do
-      create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
+      create(:course_option, course: create(:course, :open, provider: currently_authenticated_provider))
 
       post_api_request '/api/v1.0/test-data/generate?count=1&next_cycle=true'
 
@@ -35,7 +35,7 @@ RSpec.describe 'Vendor API - POST /api/v1.0/test-data/generate', :sidekiq do
     end
 
     it 'ignores the previous cycle param' do
-      create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
+      create(:course_option, course: create(:course, :open, provider: currently_authenticated_provider))
 
       post_api_request '/api/v1.0/test-data/generate?count=1&next_cycle=true&previous_cycle=false'
 
@@ -46,8 +46,8 @@ RSpec.describe 'Vendor API - POST /api/v1.0/test-data/generate', :sidekiq do
   end
 
   it 'respects the courses_per_application= parameter' do
-    create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
-    create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
+    create(:course_option, course: create(:course, :open, provider: currently_authenticated_provider))
+    create(:course_option, course: create(:course, :open, provider: currently_authenticated_provider))
 
     post_api_request '/api/v1.0/test-data/generate?count=1&courses_per_application=2'
 
@@ -57,9 +57,9 @@ RSpec.describe 'Vendor API - POST /api/v1.0/test-data/generate', :sidekiq do
   end
 
   it 'does not generate more than three application_choices per application' do
-    create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
-    create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
-    create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
+    create(:course_option, course: create(:course, :open, provider: currently_authenticated_provider))
+    create(:course_option, course: create(:course, :open, provider: currently_authenticated_provider))
+    create(:course_option, course: create(:course, :open, provider: currently_authenticated_provider))
 
     post_api_request '/api/v1.0/test-data/generate?count=1&courses_per_application=99'
 
@@ -68,8 +68,8 @@ RSpec.describe 'Vendor API - POST /api/v1.0/test-data/generate', :sidekiq do
   end
 
   it 'generates applications only to courses that the provider ratifies when for_training_courses=true' do
-    create(:course_option, course: create(:course, :open_on_apply, accredited_provider: currently_authenticated_provider))
-    expected_option = create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
+    create(:course_option, course: create(:course, :open, accredited_provider: currently_authenticated_provider))
+    expected_option = create(:course_option, course: create(:course, :open, provider: currently_authenticated_provider))
 
     post_api_request '/api/v1.0/test-data/generate?count=1&courses_per_application=1&for_training_courses=true'
 
@@ -93,8 +93,8 @@ RSpec.describe 'Vendor API - POST /api/v1.0/test-data/generate', :sidekiq do
   end
 
   it 'generates applications only to courses that the provider ratifies when for_ratified_courses=true' do
-    create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
-    expected_option = create(:course_option, course: create(:course, :open_on_apply, accredited_provider: currently_authenticated_provider))
+    create(:course_option, course: create(:course, :open, provider: currently_authenticated_provider))
+    expected_option = create(:course_option, course: create(:course, :open, accredited_provider: currently_authenticated_provider))
 
     post_api_request '/api/v1.0/test-data/generate?count=1&courses_per_application=1&for_ratified_courses=true'
 
@@ -131,8 +131,8 @@ RSpec.describe 'Vendor API - POST /api/v1.0/test-data/generate', :sidekiq do
   end
 
   it 'generates applications only to courses that the provider ratifies when for_test_provider_courses=true' do
-    create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
-    create(:course_option, course: create(:course, :open_on_apply, accredited_provider: currently_authenticated_provider))
+    create(:course_option, course: create(:course, :open, provider: currently_authenticated_provider))
+    create(:course_option, course: create(:course, :open, accredited_provider: currently_authenticated_provider))
 
     post_api_request '/api/v1.0/test-data/generate?count=1&for_test_provider_courses=true'
 
@@ -141,7 +141,7 @@ RSpec.describe 'Vendor API - POST /api/v1.0/test-data/generate', :sidekiq do
   end
 
   it 'returns responses conforming to the schema' do
-    create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
+    create(:course_option, course: create(:course, :open, provider: currently_authenticated_provider))
 
     post_api_request '/api/v1.0/test-data/generate?count=1'
 
@@ -149,7 +149,7 @@ RSpec.describe 'Vendor API - POST /api/v1.0/test-data/generate', :sidekiq do
   end
 
   it 'returns error responses on invalid input' do
-    create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
+    create(:course_option, course: create(:course, :open, provider: currently_authenticated_provider))
 
     post_api_request '/api/v1.0/test-data/generate?count=1&courses_per_application=2'
 
@@ -157,7 +157,7 @@ RSpec.describe 'Vendor API - POST /api/v1.0/test-data/generate', :sidekiq do
   end
 
   it 'returns error when you ask for zero courses per application' do
-    create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
+    create(:course_option, course: create(:course, :open, provider: currently_authenticated_provider))
 
     post_api_request '/api/v1.0/test-data/generate?count=1&courses_per_application=0'
 

--- a/spec/services/generate_test_applications_for_provider_spec.rb
+++ b/spec/services/generate_test_applications_for_provider_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe GenerateTestApplicationsForProvider, :sidekiq do
   end
 
   before do
-    create(:course_option)
-    3.times { create(:course_option, course: create(:course, :open_on_apply, provider:)) }
-    3.times { create(:course_option, course: create(:course, :open_on_apply, accredited_provider: provider)) }
+    training_provider = create(:provider)
+    3.times { create(:course_option, course: create(:course, :open, provider:)) }
+    3.times { create(:course_option, course: create(:course, :open, provider: training_provider, accredited_provider: provider)) }
     3.times { create(:course_option, course: create(:course, :previous_year, provider:)) }
   end
 

--- a/spec/services/support_interface/tad_provider_stats_export_spec.rb
+++ b/spec/services/support_interface/tad_provider_stats_export_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SupportInterface::TADProviderStatsExport, :bullet do
   describe 'documentation' do
     before do
       provider = create(:provider)
-      course_option_for_provider(provider:, course: create(:course, :open_on_apply, provider:))
+      course_option_for_provider(provider:, course: create(:course, :open, provider:))
     end
 
     it_behaves_like 'a data export'
@@ -50,10 +50,10 @@ RSpec.describe SupportInterface::TADProviderStatsExport, :bullet do
       provider_one = create(:provider, code: 'ABC1', name: 'Tehanu')
       provider_two = create(:provider, code: 'DEF2', name: 'Anarres')
 
-      course_option_for_provider(provider: provider_one, course: create(:course, :open_on_apply, name: 'History', provider: provider_one, code: 'XYZ'))
-      course_option_for_provider(provider: provider_one, course: create(:course, :open_on_apply, name: 'Biology', provider: provider_one))
-      course_option_for_provider(provider: provider_two, course: create(:course, :open_on_apply, name: 'Science book', provider: provider_two))
-      course_option_for_provider(provider: provider_two, course: create(:course, :open_on_apply, name: 'French I took', provider: provider_two))
+      course_option_for_provider(provider: provider_one, course: create(:course, :open, name: 'History', provider: provider_one, code: 'XYZ'))
+      course_option_for_provider(provider: provider_one, course: create(:course, :open, name: 'Biology', provider: provider_one))
+      course_option_for_provider(provider: provider_two, course: create(:course, :open, name: 'Science book', provider: provider_two))
+      course_option_for_provider(provider: provider_two, course: create(:course, :open, name: 'French I took', provider: provider_two))
       course_option_for_provider(provider: provider_two, recruitment_cycle_year: RecruitmentCycle.previous_year)
       course_option_for_provider(provider: provider_two, recruitment_cycle_year: RecruitmentCycle.previous_year)
       # we get a row per course

--- a/spec/system/support_interface/adding_a_new_provider_user_spec.rb
+++ b/spec/system/support_interface/adding_a_new_provider_user_spec.rb
@@ -44,9 +44,9 @@ RSpec.feature 'Managing provider users v2' do
 
   def and_providers_exist
     @provider = create(:provider, name: 'Example provider', code: 'ABC')
-    create(:course, :open_on_apply, provider: @provider)
+    create(:course, :open, provider: @provider)
     @provider2 = create(:provider, name: 'Another provider', code: 'DEF')
-    create(:course, :open_on_apply, provider: @provider2)
+    create(:course, :open, provider: @provider2)
     create(:provider, name: 'Not shown provider', code: 'GHI')
   end
 

--- a/spec/system/support_interface/adding_a_new_provider_user_spec.rb
+++ b/spec/system/support_interface/adding_a_new_provider_user_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'Managing provider users v2' do
     when_i_click_on_a_provider
     and_i_click_on_users
     and_i_click_add_user
-    then_i_should_see_the_add_user_form
+    then_i_see_the_add_user_form
 
     when_i_submit_the_form
     then_i_see_blank_validation_errors
@@ -30,8 +30,8 @@ RSpec.feature 'Managing provider users v2' do
     and_i_check_permission_to_make_decisions
     and_i_check_permission_to_view_diversity_information
     and_i_submit_the_form
-    then_i_should_see_the_provider_user_has_been_successfully_added
-    and_the_user_should_be_sent_a_welcome_email
+    then_i_see_the_provider_user_has_been_successfully_added
+    and_the_user_is_sent_a_welcome_email
   end
 
   def given_dfe_signin_is_configured
@@ -129,11 +129,11 @@ RSpec.feature 'Managing provider users v2' do
     when_i_enter_the_users_email_and_name
   end
 
-  def then_i_should_see_the_add_user_form
+  def then_i_see_the_add_user_form
     expect(page).to have_content('Add user to Example provider')
   end
 
-  def then_i_should_see_the_provider_user_has_been_successfully_added
+  def then_i_see_the_provider_user_has_been_successfully_added
     expect(page).to have_content('User Harrison Bergeron added')
   end
 
@@ -145,7 +145,7 @@ RSpec.feature 'Managing provider users v2' do
     click_link_or_button 'Apply filters'
   end
 
-  def and_i_should_see_the_user_i_created
+  def and_i_see_the_user_i_created
     expect(page).to have_content('harrison@example.com')
   end
 
@@ -155,7 +155,7 @@ RSpec.feature 'Managing provider users v2' do
     click_link_or_button 'Apply filters'
   end
 
-  def and_the_user_should_be_sent_a_welcome_email
+  def and_the_user_is_sent_a_welcome_email
     open_email('harrison@example.com')
     expect(current_email.subject).to have_content t('provider_mailer.permissions_granted_by_support.subject', organisation: @provider.name)
   end

--- a/spec/system/support_interface/adding_provider_to_existing_provider_user_spec.rb
+++ b/spec/system/support_interface/adding_provider_to_existing_provider_user_spec.rb
@@ -34,8 +34,8 @@ RSpec.feature 'Managing provider users v2' do
     @provider_one = create(:provider, name: 'Example provider one', code: 'ABC')
     @provider_two = create(:provider, name: 'Example provider two', code: 'DEF')
 
-    create(:course, :open_on_apply, provider: @provider_one)
-    create(:course, :open_on_apply, provider: @provider_two)
+    create(:course, :open, provider: @provider_one)
+    create(:course, :open, provider: @provider_two)
   end
 
   def and_a_provider_user_exists_for_the_first_provider

--- a/spec/system/support_interface/adding_provider_to_existing_provider_user_spec.rb
+++ b/spec/system/support_interface/adding_provider_to_existing_provider_user_spec.rb
@@ -12,13 +12,13 @@ RSpec.feature 'Managing provider users v2' do
 
     when_i_visit_the_second_provider_page
     and_i_click_on_users
-    then_i_should_not_see_the_provider_user_listed
+    then_i_do_not_see_the_provider_user_listed
 
     when_i_click_add_user
     and_i_enter_the_users_details
     and_i_check_permissions
     and_i_submit_the_form
-    then_i_should_see_the_provider_user_has_been_successfully_added
+    then_i_see_the_provider_user_has_been_successfully_added
     and_the_provider_user_is_now_associated_with_both_providers
   end
 
@@ -50,7 +50,7 @@ RSpec.feature 'Managing provider users v2' do
     click_link_or_button 'Users'
   end
 
-  def then_i_should_not_see_the_provider_user_listed
+  def then_i_do_not_see_the_provider_user_listed
     expect(page).to have_no_content("#{@provider_user.first_name} #{@provider_user.last_name}")
   end
 
@@ -74,7 +74,7 @@ RSpec.feature 'Managing provider users v2' do
     click_link_or_button 'Add user'
   end
 
-  def then_i_should_see_the_provider_user_has_been_successfully_added
+  def then_i_see_the_provider_user_has_been_successfully_added
     expect(page).to have_content("User #{@provider_user.first_name} #{@provider_user.last_name} added")
   end
 

--- a/spec/system/support_interface/bulk_upload_a_single_provider_user_spec.rb
+++ b/spec/system/support_interface/bulk_upload_a_single_provider_user_spec.rb
@@ -12,24 +12,24 @@ RSpec.feature 'bulk upload provider users' do
     when_i_visit_the_providers_page
     and_i_click_on_users
     and_i_click_add_multiple_users
-    then_i_should_see_the_add_multiple_user_form
+    then_i_see_the_add_multiple_user_form
 
     when_i_click_continue
-    then_i_should_see_a_user_details_form_validation_error
+    then_i_see_a_user_details_form_validation_error
 
     when_i_enter_the_provider_users_details
     and_i_click_continue
-    then_i_should_see_the_permissions_form_for_the_provider_user
+    then_i_see_the_permissions_form_for_the_provider_user
 
     when_i_click_back
-    then_i_should_see_the_add_multiple_user_form
+    then_i_see_the_add_multiple_user_form
 
     when_i_click_continue
-    then_i_should_see_the_permissions_form_for_the_provider_user
+    then_i_see_the_permissions_form_for_the_provider_user
 
     when_i_remove_the_provider_users_first_name
     and_i_click_continue
-    then_i_should_see_a_first_name_blank_validation_error
+    then_i_see_a_first_name_blank_validation_error
 
     when_i_enter_a_new_email_address_for_the_first_user
     and_i_add_permissions_for_the_first_user
@@ -37,13 +37,13 @@ RSpec.feature 'bulk upload provider users' do
     then_i_can_see_the_check_users_page
 
     when_i_click_back
-    then_i_should_see_the_permissions_form_for_the_provider_user
+    then_i_see_the_permissions_form_for_the_provider_user
 
     when_i_click_continue
     then_i_can_see_the_check_users_page
 
     when_i_click_change_within_the_provider_user_summary
-    then_i_should_see_the_permissions_form_for_the_provider_user
+    then_i_see_the_permissions_form_for_the_provider_user
     and_the_permissions_i_selected_are_checked
 
     when_i_edit_permissions_for_the_first_user
@@ -81,7 +81,7 @@ RSpec.feature 'bulk upload provider users' do
     click_link_or_button 'Add multiple users'
   end
 
-  def then_i_should_see_the_add_multiple_user_form
+  def then_i_see_the_add_multiple_user_form
     expect(page).to have_content("Add users to #{@provider.name}")
   end
 
@@ -94,7 +94,7 @@ RSpec.feature 'bulk upload provider users' do
     fill_in 'support_interface_create_single_provider_user_form[first_name]', with: nil
   end
 
-  def then_i_should_see_a_first_name_blank_validation_error
+  def then_i_see_a_first_name_blank_validation_error
     expect(page).to have_content('Enter a first name')
   end
 
@@ -106,11 +106,11 @@ RSpec.feature 'bulk upload provider users' do
     and_i_click_continue
   end
 
-  def then_i_should_see_a_user_details_form_validation_error
+  def then_i_see_a_user_details_form_validation_error
     expect(page).to have_content("Enter the users' details")
   end
 
-  def then_i_should_see_the_permissions_form_for_the_provider_user
+  def then_i_see_the_permissions_form_for_the_provider_user
     expect(page).to have_content('Add user (1 of 1)')
     expect(page).to have_content(@provider.name)
     expect(page).to have_field('support_interface_create_single_provider_user_form[last_name]', with: 'Smith')
@@ -138,7 +138,7 @@ RSpec.feature 'bulk upload provider users' do
     click_link_or_button 'Back'
   end
 
-  def then_i_should_see_the_provider_user_review_page
+  def then_i_see_the_provider_user_review_page
     expect(page).to have_content("#{@provder_name} Check details and add users")
     expect(page).to have_content('first_name_one')
     expect(page).to have_content('first_name_two')

--- a/spec/system/support_interface/bulk_upload_a_single_provider_user_spec.rb
+++ b/spec/system/support_interface/bulk_upload_a_single_provider_user_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature 'bulk upload provider users' do
   def and_a_provider_exists
     @provider = create(:provider, name: 'Gorse SCITT', code: 'ABC')
 
-    create(:course, :open_on_apply, provider: @provider)
+    create(:course, :open, provider: @provider)
   end
 
   def when_i_visit_the_providers_page

--- a/spec/system/support_interface/bulk_upload_multiple_provider_users_spec.rb
+++ b/spec/system/support_interface/bulk_upload_multiple_provider_users_spec.rb
@@ -12,40 +12,40 @@ RSpec.feature 'bulk upload provider users' do
     when_i_visit_the_providers_page
     and_i_click_on_users
     and_i_click_add_multiple_users
-    then_i_should_see_the_add_multiple_user_form
+    then_i_see_the_add_multiple_user_form
 
     when_i_click_continue
-    then_i_should_see_a_form_validation_error
+    then_i_see_a_form_validation_error
 
     when_i_enter_the_users_details
     and_i_click_continue
-    then_i_should_see_the_permissions_form_for_the_first_user
+    then_i_see_the_permissions_form_for_the_first_user
 
     when_i_click_back
-    then_i_should_see_the_add_multiple_user_form
+    then_i_see_the_add_multiple_user_form
 
     when_i_click_continue
     and_i_edit_the_email_address_for_the_first_user
     and_i_add_permissions_for_the_first_user
     and_i_click_continue
-    then_i_should_see_the_permissions_form_for_the_second_user
+    then_i_see_the_permissions_form_for_the_second_user
 
     when_i_click_back
-    then_i_should_see_the_permissions_form_for_the_first_user
+    then_i_see_the_permissions_form_for_the_first_user
 
     when_i_click_continue
     and_i_add_permissions_for_the_second_user
     and_i_click_continue
-    then_i_should_see_the_provider_user_review_page
+    then_i_see_the_provider_user_review_page
 
     when_i_click_back
-    then_i_should_see_the_permissions_form_for_the_second_user
+    then_i_see_the_permissions_form_for_the_second_user
 
     when_i_click_continue
     then_i_can_see_the_check_users_page
 
     when_i_click_change_within_the_second_user_summary
-    then_i_should_see_the_edit_permissions_form_for_the_second_user
+    then_i_see_the_edit_permissions_form_for_the_second_user
     and_the_permissions_i_selected_are_checked
 
     when_i_click_back
@@ -87,7 +87,7 @@ RSpec.feature 'bulk upload provider users' do
     click_link_or_button 'Add multiple users'
   end
 
-  def then_i_should_see_the_add_multiple_user_form
+  def then_i_see_the_add_multiple_user_form
     expect(page).to have_content("Add users to #{@provider.name}")
   end
 
@@ -104,11 +104,11 @@ RSpec.feature 'bulk upload provider users' do
     and_i_click_continue
   end
 
-  def then_i_should_see_a_form_validation_error
+  def then_i_see_a_form_validation_error
     expect(page).to have_content("Enter the users' details")
   end
 
-  def then_i_should_see_the_permissions_form_for_the_first_user
+  def then_i_see_the_permissions_form_for_the_first_user
     expect(page).to have_content('Add user (1 of 2)')
     expect(page).to have_content(@provider.name)
     expect(page).to have_field('support_interface_create_single_provider_user_form[first_name]', with: 'first_name_one')
@@ -123,13 +123,13 @@ RSpec.feature 'bulk upload provider users' do
     check 'Access diversity information'
   end
 
-  def then_i_should_see_the_permissions_form_for_the_second_user
+  def then_i_see_the_permissions_form_for_the_second_user
     expect(page).to have_content('Add user (2 of 2)')
     expect(page).to have_content(@provider.name)
     expect(page).to have_field('support_interface_create_single_provider_user_form[last_name]', with: 'last_name_two')
   end
 
-  def then_i_should_see_the_edit_permissions_form_for_the_second_user
+  def then_i_see_the_edit_permissions_form_for_the_second_user
     expect(page).to have_content('Add user (2 of 2)')
     expect(page).to have_content(@provider.name)
     expect(page).to have_field('support_interface_create_single_provider_user_form[last_name]', with: 'last_name_two')
@@ -156,7 +156,7 @@ RSpec.feature 'bulk upload provider users' do
     click_link_or_button 'Back'
   end
 
-  def then_i_should_see_the_provider_user_review_page
+  def then_i_see_the_provider_user_review_page
     expect(page).to have_content("#{@provder_name} Check details and add users")
     expect(page).to have_content('first_name_one')
     expect(page).to have_content('first_name_two')

--- a/spec/system/support_interface/bulk_upload_multiple_provider_users_spec.rb
+++ b/spec/system/support_interface/bulk_upload_multiple_provider_users_spec.rb
@@ -72,7 +72,7 @@ RSpec.feature 'bulk upload provider users' do
   def and_a_provider_exists
     @provider = create(:provider, name: 'Gorse SCITT', code: 'ABC')
 
-    create(:course, :open_on_apply, provider: @provider)
+    create(:course, :open, provider: @provider)
   end
 
   def when_i_visit_the_providers_page

--- a/spec/system/support_interface/change_course_choice_for_a_deferred_application_spec.rb
+++ b/spec/system/support_interface/change_course_choice_for_a_deferred_application_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature 'Change course choice for a deferred application' do
   end
 
   def and_i_enter_a_course_code_for_a_course
-    @course_option = create(:course_option, course: create(:course, :open_on_apply, funding_type: 'fee', provider: @application_choice.provider))
+    @course_option = create(:course_option, course: create(:course, :open, funding_type: 'fee', provider: @application_choice.provider))
     @course_code = @course_option.course.code
     fill_in('Provider code', with: @application_choice.provider.code)
     fill_in('Course code', with: @course_code)

--- a/spec/system/support_interface/change_course_choice_for_a_deferred_application_spec.rb
+++ b/spec/system/support_interface/change_course_choice_for_a_deferred_application_spec.rb
@@ -12,14 +12,14 @@ RSpec.feature 'Change course choice for a deferred application' do
 
   scenario 'Support user changes offered course for a submitted application' do
     when_i_click_on_change_offered_course
-    then_i_should_see_the_change_course_page
+    then_i_see_the_change_course_page
     and_i_enter_a_course_code_for_a_course
     and_i_provide_a_valid_zendesk_ticket
     and_i_confirm_changing_the_offer
     and_i_click_change
 
     then_i_am_redirected_to_the_application_form_page
-    and_i_should_see_new_course_has_been_offered
+    and_i_see_new_course_has_been_offered
   end
 
   def given_i_am_a_support_user
@@ -43,7 +43,7 @@ RSpec.feature 'Change course choice for a deferred application' do
     click_link_or_button 'Change course choice'
   end
 
-  def then_i_should_see_the_change_course_page
+  def then_i_see_the_change_course_page
     expect(page).to have_current_path support_interface_application_form_change_course_choice_path(
       application_form_id: @application_form.id,
       application_choice_id: @application_choice.id,
@@ -75,7 +75,7 @@ RSpec.feature 'Change course choice for a deferred application' do
     expect(page).to have_current_path support_interface_application_form_path(application_form_id: @application_form.id)
   end
 
-  def and_i_should_see_new_course_has_been_offered
+  def and_i_see_new_course_has_been_offered
     expect(page).to have_current_path support_interface_application_form_path(application_form_id: @application_form.id)
     expect(page).to have_content("#{RecruitmentCycle.current_year}: #{@course_option.course.name} (#{@course_option.course.code})")
   end

--- a/spec/system/support_interface/change_offered_course_for_a_submitted_application_spec.rb
+++ b/spec/system/support_interface/change_offered_course_for_a_submitted_application_spec.rb
@@ -110,7 +110,7 @@ RSpec.feature 'Add course to submitted application' do
   end
 
   def when_i_fill_in_the_course_code_for_a_course_that_is_not_associated_with_the_ratifying_provider
-    @other_providers_course_option = create(:course_option, course: create(:course, :open_on_apply))
+    @other_providers_course_option = create(:course_option, course: create(:course, :open))
     @course_code = @other_providers_course_option.course.code
     fill_in('Course code', with: @course_code)
   end
@@ -138,13 +138,13 @@ RSpec.feature 'Add course to submitted application' do
   end
 
   def and_i_enter_a_course_code_for_a_course_that_has_the_same_ratifying_provider
-    @course_option = create(:course_option, course: create(:course, :open_on_apply, provider: @application_choice.provider))
+    @course_option = create(:course_option, course: create(:course, :open, provider: @application_choice.provider))
     @course_code = @course_option.course.code
     fill_in('Course code', with: @course_code)
   end
 
   def and_i_enter_a_course_code_for_a_course_that_has_no_vacancies
-    @course_option = create(:course_option, :no_vacancies, course: create(:course, :open_on_apply, funding_type: 'fee', provider: @application_choice.provider))
+    @course_option = create(:course_option, :no_vacancies, course: create(:course, :open, funding_type: 'fee', provider: @application_choice.provider))
     @course_code = @course_option.course.code
     fill_in('Course code', with: @course_code)
   end
@@ -231,9 +231,9 @@ RSpec.feature 'Add course to submitted application' do
   end
 
   def and_i_enter_a_course_code_which_is_available_at_the_same_provider_and_at_other_providers
-    course_at_same_provider = create(:course, :open_on_apply, funding_type: 'fee', provider: @application_choice.provider)
+    course_at_same_provider = create(:course, :open, funding_type: 'fee', provider: @application_choice.provider)
     @course_code = course_at_same_provider.code
-    course_at_different_provider = create(:course, :open_on_apply, funding_type: 'fee', provider: create(:provider), code: @course_code)
+    course_at_different_provider = create(:course, :open, funding_type: 'fee', provider: create(:provider), code: @course_code)
 
     @course_option_same_provider = create(:course_option, course: course_at_same_provider)
     @course_option_different_provider = create(:course_option, course: course_at_different_provider)

--- a/spec/system/support_interface/change_offered_course_for_a_submitted_application_spec.rb
+++ b/spec/system/support_interface/change_offered_course_for_a_submitted_application_spec.rb
@@ -12,22 +12,22 @@ RSpec.feature 'Add course to submitted application' do
 
   scenario 'Support user adds course to submitted application' do
     when_i_click_on_change_offered_course
-    then_i_should_see_the_change_offered_course_search_page
+    then_i_see_the_change_offered_course_search_page
 
     when_i_click_search
-    then_i_should_see_a_course_code_blank_validation_error
+    then_i_see_a_course_code_blank_validation_error
 
     when_i_fill_in_the_course_code_for_a_course_that_is_not_associated_with_the_ratifying_provider
     and_i_click_search
-    then_i_should_see_the_course_results_page_with_results
+    then_i_see_the_course_results_page_with_results
 
     when_i_click_back
     and_i_enter_a_course_code_for_a_course_that_has_the_same_ratifying_provider
     and_i_click_search
-    then_i_should_see_the_course_results_page_with_results
+    then_i_see_the_course_results_page_with_results
 
     when_i_click_to_change_the_offered_course
-    then_i_should_see_an_add_course_validation_error
+    then_i_see_an_add_course_validation_error
 
     when_i_select_a_course
     and_i_click_to_change_the_offered_course
@@ -38,15 +38,15 @@ RSpec.feature 'Add course to submitted application' do
     and_i_confirm_changing_the_offer
     and_i_click_continue
     then_i_am_redirected_to_the_application_form_page
-    and_i_should_see_new_course_has_been_offered
+    and_i_see_new_course_has_been_offered
   end
 
   scenario 'Support user changes offered course for a submitted application to a course with no vacancies' do
     when_i_click_on_change_offered_course
-    then_i_should_see_the_change_offered_course_search_page
+    then_i_see_the_change_offered_course_search_page
     and_i_enter_a_course_code_for_a_course_that_has_no_vacancies
     and_i_click_search
-    then_i_should_see_the_course_results_page_with_results
+    then_i_see_the_course_results_page_with_results
 
     when_i_select_a_course_with_no_vacancies
     and_i_click_to_change_the_offered_course
@@ -62,15 +62,15 @@ RSpec.feature 'Add course to submitted application' do
     when_i_confirm_changing_the_course
     and_i_click_continue
     then_i_am_redirected_to_the_application_form_page
-    and_i_should_see_new_course_with_no_vacancies_has_been_offered
+    and_i_see_new_course_with_no_vacancies_has_been_offered
   end
 
   scenario 'Support user changes offered course where the new course is also available at other providers' do
     when_i_click_on_change_offered_course
     and_i_enter_a_course_code_which_is_available_at_the_same_provider_and_at_other_providers
     and_i_click_search
-    then_i_should_see_the_course_results_page_with_results_for_the_same_provider
-    and_i_should_see_the_course_results_page_with_results_for_other_providers
+    then_i_see_the_course_results_page_with_results_for_the_same_provider
+    and_i_see_the_course_results_page_with_results_for_other_providers
   end
 
   def given_i_am_a_support_user
@@ -94,7 +94,7 @@ RSpec.feature 'Add course to submitted application' do
     click_link_or_button 'Change offered course'
   end
 
-  def then_i_should_see_the_change_offered_course_search_page
+  def then_i_see_the_change_offered_course_search_page
     expect(page).to have_current_path support_interface_application_form_application_choice_change_offered_course_search_path(
       application_form_id: @application_form.id,
       application_choice_id: @application_choice.id,
@@ -105,7 +105,7 @@ RSpec.feature 'Add course to submitted application' do
     click_link_or_button 'Search'
   end
 
-  def then_i_should_see_a_course_code_blank_validation_error
+  def then_i_see_a_course_code_blank_validation_error
     expect(page).to have_content 'Please enter a course code'
   end
 
@@ -119,7 +119,7 @@ RSpec.feature 'Add course to submitted application' do
     when_i_click_search
   end
 
-  def then_i_should_see_the_course_results_page_with_no_results
+  def then_i_see_the_course_results_page_with_no_results
     expect(page).to have_current_path support_interface_application_form_application_choice_choose_offered_course_option_path(
       application_form_id: @application_form.id,
       application_choice_id: @application_choice.id,
@@ -149,7 +149,7 @@ RSpec.feature 'Add course to submitted application' do
     fill_in('Course code', with: @course_code)
   end
 
-  def then_i_should_see_the_course_results_page_with_results
+  def then_i_see_the_course_results_page_with_results
     expect(page).to have_current_path support_interface_application_form_application_choice_choose_offered_course_option_path(
       application_form_id: @application_form.id,
       application_choice_id: @application_choice.id,
@@ -159,7 +159,7 @@ RSpec.feature 'Add course to submitted application' do
     expect(page).to have_content "Choose a course to replace #{@application_choice.course.name_and_code}"
   end
 
-  def then_i_should_see_an_add_course_validation_error
+  def then_i_see_an_add_course_validation_error
     expect(page).to have_content('Please select a course')
   end
 
@@ -212,11 +212,11 @@ RSpec.feature 'Add course to submitted application' do
     expect(page).to have_current_path support_interface_application_form_path(application_form_id: @application_form.id)
   end
 
-  def and_i_should_see_new_course_has_been_offered
+  def and_i_see_new_course_has_been_offered
     expect(page).to have_current_path support_interface_application_form_path(application_form_id: @application_form.id)
     expect(page).to have_content("#{RecruitmentCycle.current_year}: #{@course_option.course.name} (#{@course_option.course.code})")
   end
-  alias_method :and_i_should_see_new_course_with_no_vacancies_has_been_offered, :and_i_should_see_new_course_has_been_offered
+  alias_method :and_i_see_new_course_with_no_vacancies_has_been_offered, :and_i_see_new_course_has_been_offered
 
   def then_i_see_a_warning_message
     expect(page).to have_content(I18n.t('support_interface.errors.messages.course_full_error'))
@@ -241,7 +241,7 @@ RSpec.feature 'Add course to submitted application' do
     fill_in('Course code', with: @course_code)
   end
 
-  def then_i_should_see_the_course_results_page_with_results_for_the_same_provider
+  def then_i_see_the_course_results_page_with_results_for_the_same_provider
     expect(page).to have_content("Choose a course to replace #{@application_choice.course.name_and_code}")
 
     expect(page).to have_content("Courses from the same provider (#{@application_choice.provider.name_and_code})")
@@ -250,7 +250,7 @@ RSpec.feature 'Add course to submitted application' do
     end
   end
 
-  def and_i_should_see_the_course_results_page_with_results_for_other_providers
+  def and_i_see_the_course_results_page_with_results_for_other_providers
     expect(page).to have_content('Courses from other providers')
     within '.other-providers' do
       expect(page).to have_content("#{@course_option_different_provider.course.provider.name_and_code} – #{@course_option_different_provider.course.name_and_code}")

--- a/spec/system/support_interface/editing_permissions_for_a_provider_user_spec.rb
+++ b/spec/system/support_interface/editing_permissions_for_a_provider_user_spec.rb
@@ -39,8 +39,8 @@ RSpec.feature 'Managing provider users v2' do
     @provider_one = create(:provider, name: 'Example provider one', code: 'ABC')
     @provider_two = create(:provider, name: 'Example provider two', code: 'DEF')
 
-    create(:course, :open_on_apply, provider: @provider_one)
-    create(:course, :open_on_apply, provider: @provider_two)
+    create(:course, :open, provider: @provider_one)
+    create(:course, :open, provider: @provider_two)
   end
 
   def and_a_provider_user_exists_for_both_provider

--- a/spec/system/support_interface/editing_permissions_for_a_provider_user_spec.rb
+++ b/spec/system/support_interface/editing_permissions_for_a_provider_user_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature 'Managing provider users v2' do
 
     when_i_visit_the_first_provider_page
     and_i_click_on_users
-    then_i_should_see_the_provider_user_listed
+    then_i_see_the_provider_user_listed
 
     when_i_click_update_permissions
     then_i_see_the_edit_permissions_form
@@ -22,7 +22,7 @@ RSpec.feature 'Managing provider users v2' do
     and_i_check_permission_to_access_diversity_information_for_the_second_provider
     and_i_click_save_permissions
     then_i_can_see_the_provider_user_page
-    then_i_should_see_the_provider_user_has_been_successfully_added
+    then_i_see_the_provider_user_has_been_successfully_added
     and_the_provider_user_has_manage_user_permissions_for_the_first_provider
     and_access_diversity_info_permissions_for_the_second_provider
   end
@@ -55,7 +55,7 @@ RSpec.feature 'Managing provider users v2' do
     click_link_or_button 'Users'
   end
 
-  def then_i_should_see_the_provider_user_listed
+  def then_i_see_the_provider_user_listed
     expect(page).to have_content("#{@provider_user.first_name} #{@provider_user.last_name}")
   end
 
@@ -104,7 +104,7 @@ RSpec.feature 'Managing provider users v2' do
     end
   end
 
-  def then_i_should_see_the_provider_user_has_been_successfully_added
+  def then_i_see_the_provider_user_has_been_successfully_added
     expect(page).to have_content("User #{@provider_user.first_name} #{@provider_user.last_name} updated")
   end
 

--- a/spec/system/support_interface/generate_test_data_for_provider_spec.rb
+++ b/spec/system/support_interface/generate_test_data_for_provider_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Generate test data for provider via support', :sandbox, sidekiq: 
     when_i_visit_the_support_provider_applications_page
     then_i_will_not_see_the_generate_test_data_button
 
-    when_the_provider_has_courses_open_on_apply
+    when_the_provider_has_courses_open
     and_i_visit_the_support_provider_applications_page
     then_i_see_the_generate_test_data_button
 
@@ -35,8 +35,8 @@ RSpec.feature 'Generate test data for provider via support', :sandbox, sidekiq: 
     expect(page).to have_no_button 'Generate test applications'
   end
 
-  def when_the_provider_has_courses_open_on_apply
-    course = create(:course, :open_on_apply, provider: @provider)
+  def when_the_provider_has_courses_open
+    course = create(:course, :open, provider: @provider)
     create(:course_option, course:)
   end
 

--- a/spec/system/support_interface/provider_onboarding_spec.rb
+++ b/spec/system/support_interface/provider_onboarding_spec.rb
@@ -13,10 +13,10 @@ RSpec.feature 'Provider onboarding monitoring page' do
 
     and_i_visit_the_provider_onboarding_page
 
-    then_i_should_see_the_provider_with_no_users
-    and_i_should_see_the_provider_with_users_that_have_never_signed_in
-    and_i_should_see_the_provider_who_has_not_set_up_relationship_permissions
-    and_i_should_see_the_provider_who_has_not_made_a_decision_in_the_last_7_days
+    then_i_see_the_provider_with_no_users
+    and_i_see_the_provider_with_users_that_have_never_signed_in
+    and_i_see_the_provider_who_has_not_set_up_relationship_permissions
+    and_i_see_the_provider_who_has_not_made_a_decision_in_the_last_7_days
   end
 
   def given_i_am_a_support_user
@@ -54,25 +54,25 @@ RSpec.feature 'Provider onboarding monitoring page' do
     create(:application_choice, :rejected_by_default, course:, rejected_at: 1.day.ago)
   end
 
-  def then_i_should_see_the_provider_with_no_users
+  def then_i_see_the_provider_with_no_users
     within('[data-qa="no-users"]') do
       expect(page).to have_link 'No users'
     end
   end
 
-  def and_i_should_see_the_provider_with_users_that_have_never_signed_in
+  def and_i_see_the_provider_with_users_that_have_never_signed_in
     within('[data-qa="no-users-logged-in"]') do
       expect(page).to have_link 'Users have not signed in'
     end
   end
 
-  def and_i_should_see_the_provider_who_has_not_set_up_relationship_permissions
+  def and_i_see_the_provider_who_has_not_set_up_relationship_permissions
     within('[data-qa="permissions-not-set-up"]') do
       expect(page).to have_content 'Relationships not set up'
     end
   end
 
-  def and_i_should_see_the_provider_who_has_not_made_a_decision_in_the_last_7_days
+  def and_i_see_the_provider_who_has_not_made_a_decision_in_the_last_7_days
     within('[data-qa="no-decisions"]') do
       expect(page).to have_content 'No decisions made'
     end

--- a/spec/system/support_interface/provider_onboarding_spec.rb
+++ b/spec/system/support_interface/provider_onboarding_spec.rb
@@ -48,7 +48,7 @@ RSpec.feature 'Provider onboarding monitoring page' do
   def and_there_is_a_provider_who_has_not_made_a_decision_in_the_last_7_days
     provider = create(:provider, :with_vendor, name: 'No decisions made')
     create(:provider_user, providers: [provider], last_signed_in_at: 1.day.ago)
-    course = create(:course, :with_course_options, :open_on_apply, provider:)
+    course = create(:course, :with_course_options, :open, provider:)
 
     create(:application_choice, course:, offered_at: 8.days.ago)
     create(:application_choice, :rejected_by_default, course:, rejected_at: 1.day.ago)

--- a/spec/system/support_interface/removing_a_provider_user_spec.rb
+++ b/spec/system/support_interface/removing_a_provider_user_spec.rb
@@ -32,8 +32,8 @@ RSpec.feature 'Managing provider users v2' do
     @provider_one = create(:provider, name: 'Example provider one', code: 'ABC')
     @provider_two = create(:provider, name: 'Example provider two', code: 'DEF')
 
-    create(:course, :open_on_apply, provider: @provider_one)
-    create(:course, :open_on_apply, provider: @provider_two)
+    create(:course, :open, provider: @provider_one)
+    create(:course, :open, provider: @provider_two)
   end
 
   def and_a_provider_user_exists_for_both_providers

--- a/spec/workers/detect_invariants_hourly_check_spec.rb
+++ b/spec/workers/detect_invariants_hourly_check_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe DetectInvariantsHourlyCheck do
     end
 
     it 'ignores withdrawn and rejected application choices submitted with the same course' do
-      course = create(:course)
+      course = create(:course, :open)
       course_option1 = create(:course_option, course:)
       course_option2 = create(:course_option, course:)
       course_option3 = create(:course_option, course:)


### PR DESCRIPTION
## Context

Migration of `SupportInterface` code from using `open_on_apply` was incomplete in this PR https://github.com/DFE-Digital/apply-for-teacher-training/pull/9162

This completes the task of migrating the concept of open in the `SupportInterface` entirely to depending on `application_status` along with `exposed_in_find` and `applications_open_from`.

## Changes proposed in this pull request

Finish the removal of `open_on_apply` from the `SupportInterface`.

## Guidance to review

 - Are all the places using `open` and `open?` appropriate?
 - Are there any other `open_on_apply` remaining in the `SupportInterface`?

## Link to Trello card

[Trello Ticket](https://trello.com/c/A2pH42nq/1366-openonapply-replace-openonapply-in-supportinterface)
