### PR TITLE
Add withdraw application service to support playbook

### DIFF
--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -220,6 +220,50 @@ In this case, other applications belonging to the candidate may be automatically
 
 [Withdraw Offer Service](../app/services/withdraw_offer.rb)
 
+## Withdrawn an application
+
+We offer a convenient service called the "Withdraw Application Service" that
+facilitates the withdrawal of an application.
+
+This service ensures the following actions are taken:
+
+1. The application status is changed to "withdrawn."
+2. The withdrawal timestamp is set to the current time.
+3. Any upcoming interviews associated with the application are canceled.
+4. An email is sent to the candidate if it is their last successful application.
+5. Emails are dispatched to all provider users associated with the application choice.
+
+To call the service:
+
+```ruby
+  application_choice = ApplicationChoice.find(ID_OF_THE_APPLICATION)
+  WithdrawApplication.new(application_choice:).save!
+```
+
+If you prefer not to execute any of the aforementioned actions automatically,
+you can manually withdraw the application by following these steps:
+
+```ruby
+# Fetch the application choice
+application_choice = ApplicationChoice.find(ID_OF_THE_APPLICATION)
+
+# Verify the application form ID
+application_form_id = application_choice.application_form.id
+
+# Verify the candidate's email address
+candidate_email = application_choice.application_form.c
+
+# application choice status is updated to "withdrawn" and
+# we provide an audit comment.
+# It also records the timestamp of the withdrawal and specifies that
+# it was not withdrawn or declined by the provider on behalf of the candidate.
+application_choice.update!(
+  status: 'withdrawn',
+  audit_comment: 'Some audit comment',
+  withdrawn_at: Time.zone.now,
+  withdrawn_or_declined_for_candidate_by_provider: false,
+)
+```
 
 ### Revert a rejection
 


### PR DESCRIPTION
## Context

From the incident, there was no documentation how to withdraw an application so I added one now.

## Trello

https://trello.com/c/Qb8tB6Br/1430-add-to-the-support-playbook-documentation-how-to-withdrawn-an-application