### PR TITLE
Open on apply provider interface

### DIFF
--- a/app/components/provider_interface/provider_partner_permission_breakdown_component.rb
+++ b/app/components/provider_interface/provider_partner_permission_breakdown_component.rb
@@ -39,14 +39,14 @@ module ProviderInterface
 
     def training_provider_partner_ids_where(permission_applies:)
       provider.ratifying_provider_permissions
-              .providers_have_open_course
+              .providers_with_current_cycle_course
               .where("ratifying_provider_can_#{permission}" => permission_applies)
               .pluck(:training_provider_id)
     end
 
     def ratifying_provider_partner_ids_where(permission_applies:)
       provider.training_provider_permissions
-              .providers_have_open_course
+              .providers_with_current_cycle_course
               .where("training_provider_can_#{permission}" => permission_applies)
               .pluck(:ratifying_provider_id)
     end

--- a/app/components/provider_interface/provider_user_permissions_form_component.rb
+++ b/app/components/provider_interface/provider_user_permissions_form_component.rb
@@ -13,7 +13,7 @@ module ProviderInterface
   private
 
     def provider_has_no_relationships?
-      ProviderRelationshipPermissions.all_relationships_for_providers([provider]).providers_have_open_course.none?
+      ProviderRelationshipPermissions.all_relationships_for_providers([provider]).providers_with_current_cycle_course.none?
     end
 
     def form_legend

--- a/app/components/provider_interface/user_permission_summary_component.rb
+++ b/app/components/provider_interface/user_permission_summary_component.rb
@@ -19,7 +19,7 @@ module ProviderInterface
     end
 
     def self_ratifying_provider?
-      ProviderRelationshipPermissions.all_relationships_for_providers([@provider]).providers_have_open_course.none?
+      ProviderRelationshipPermissions.all_relationships_for_providers([@provider]).providers_with_current_cycle_course.none?
     end
 
     def can_perform_permission_y_n?(permission)

--- a/app/controllers/provider_interface/organisation_permissions_controller.rb
+++ b/app/controllers/provider_interface/organisation_permissions_controller.rb
@@ -67,7 +67,7 @@ module ProviderInterface
     end
 
     def provider_relationships_to_display
-      ProviderRelationshipPermissions.includes(:training_provider, :ratifying_provider).all_relationships_for_providers([provider]).providers_have_open_course
+      ProviderRelationshipPermissions.includes(:training_provider, :ratifying_provider).all_relationships_for_providers([provider]).providers_with_current_cycle_course
     end
 
     def sort_relationships_by_provider_name(relationships, provider)

--- a/app/controllers/provider_interface/start_page_controller.rb
+++ b/app/controllers/provider_interface/start_page_controller.rb
@@ -8,7 +8,6 @@ module ProviderInterface
 
     def show
       @provider_and_courses_cache_key = PROVIDERS_AND_COURSES_COUNT_CACHE_KEY
-      @open_courses = Course.current_cycle.includes(:provider).open_on_apply
       session['post_dfe_sign_in_path'] = provider_interface_applications_path
     end
 

--- a/app/forms/provider_interface/reconfirm_deferred_offer_wizard.rb
+++ b/app/forms/provider_interface/reconfirm_deferred_offer_wizard.rb
@@ -35,14 +35,13 @@ module ProviderInterface
     end
 
     def course_option_still_available
-      if current_step != 'new'
-        errors.add(:course_option_in_new_cycle, "No matching course option in #{RecruitmentCycle.current_year}") unless course_option_in_new_cycle
-        errors.add(:course_option_in_new_cycle, 'New course option is not open on Apply') unless course_option_in_new_cycle&.course&.open_on_apply == true
+      if current_step != 'new' && !course_option_in_new_cycle
+        errors.add(:course_option_in_new_cycle, "No matching course option in #{RecruitmentCycle.current_year}")
       end
     end
 
     def applicable?
-      course_option_in_new_cycle&.course&.open_on_apply
+      course_option_in_new_cycle&.course.present?
     end
 
     def conditions_met?

--- a/app/models/provider_relationship_permissions.rb
+++ b/app/models/provider_relationship_permissions.rb
@@ -7,13 +7,13 @@ class ProviderRelationshipPermissions < ApplicationRecord
   validate :at_least_one_active_permission_in_pair, if: -> { setup_at.present? || validation_context == :setup }
   audited associated_with: :training_provider
 
-  scope :providers_have_open_course, lambda {
+  scope :providers_with_current_cycle_course, lambda {
     course_joins_sql = <<-SQL
       JOIN courses
       ON provider_relationship_permissions.training_provider_id = courses.provider_id
       AND provider_relationship_permissions.ratifying_provider_id = courses.accredited_provider_id
     SQL
-    joins(course_joins_sql).merge(Course.current_cycle.open_on_apply).distinct
+    joins(course_joins_sql).merge(Course.current_cycle).distinct
   }
 
   def self.all_relationships_for_providers(providers)
@@ -45,8 +45,8 @@ class ProviderRelationshipPermissions < ApplicationRecord
     end
   end
 
-  def providers_have_open_course?
-    Course.current_cycle.open_on_apply.exists?(provider: training_provider, accredited_provider: ratifying_provider)
+  def providers_have_current_cycle_course?
+    Course.current_cycle.exists?(provider: training_provider, accredited_provider: ratifying_provider)
   end
 
 private

--- a/app/models/support_interface/provider_onboarding_monitor.rb
+++ b/app/models/support_interface/provider_onboarding_monitor.rb
@@ -15,7 +15,7 @@ module SupportInterface
 
     def permissions_not_set_up
       @permissions_not_set_up ||= ProviderRelationshipPermissions
-                                    .providers_have_open_course
+                                    .providers_with_current_cycle_course
                                     .where(setup_at: nil)
     end
 

--- a/app/services/confirm_deferred_offer_validations.rb
+++ b/app/services/confirm_deferred_offer_validations.rb
@@ -4,14 +4,7 @@ class ConfirmDeferredOfferValidations
   attr_accessor :application_choice, :course_option
 
   validates :course_option, presence: true
-  validate :course_open_in_apply, if: :course_option
   validate :course_exists_in_current_cycle, if: :course_option
-
-  def course_open_in_apply
-    if !course_option.course.open_on_apply
-      errors.add(:course_option, :not_open_on_apply)
-    end
-  end
 
   def course_exists_in_current_cycle
     if course_option.course.recruitment_cycle_year != RecruitmentCycle.current_year

--- a/app/services/provider_setup.rb
+++ b/app/services/provider_setup.rb
@@ -28,7 +28,7 @@ class ProviderSetup
 
   def relationships_pending
     manageable_relationships.select do |relationship|
-      (relationship.setup_at.blank? || relationship.invalid?) && relationship.providers_have_open_course?
+      (relationship.setup_at.blank? || relationship.invalid?) && relationship.providers_have_current_cycle_course?
     end
   end
 

--- a/app/views/provider_interface/organisation_settings/show.html.erb
+++ b/app/views/provider_interface/organisation_settings/show.html.erb
@@ -13,7 +13,7 @@
             <%= t('page_titles.provider.users') %><span class="govuk-visually-hidden"> <%= provider.name %></span>
           <% end %>
         </li>
-        <% if ProviderRelationshipPermissions.all_relationships_for_providers([provider]).providers_have_open_course.any? %>
+        <% if ProviderRelationshipPermissions.all_relationships_for_providers([provider]).providers_with_current_cycle_course.any? %>
           <li>
             <%= govuk_link_to provider_interface_organisation_settings_organisation_organisation_permissions_path(provider) do %>
               <%= t('page_titles.provider.organisation_permissions') %><span class="govuk-visually-hidden"> <%= provider.name %></span>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -26,13 +26,13 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "b66efa91e04d1b02e4521f8a617809adda7a0dc470daa75fa2e22770d8e0c538",
+      "fingerprint": "28d64e5d66c0dce5bb41ca5b85a1751bdd7190b07aa55b1af003c090e7f8863a",
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/services/notifications_list.rb",
-      "line": 23,
+      "line": 26,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "application_choice.provider.provider_users.joins(:notification_preferences).where(\"provider_user_notifications.#{{ :application_received => ([:application_submitted]), :application_withdrawn => ([:application_withdrawn]), :application_rejected_by_default => ([:application_rejected_by_default]), :offer_accepted => ([:offer_accepted, :unconditional_offer_accepted]), :offer_declined => ([:declined, :declined_by_default]), :reference_received => ([:reference_received]) }.select do\n k if event.in?(v)\n end.keys.first}\" => true)",
+      "code": "application_choice.provider.provider_users.or(application_choice.accredited_provider.provider_users).joins(:notification_preferences).where(\"provider_user_notifications.#{{ :application_received => ([:application_submitted]), :application_withdrawn => ([:application_withdrawn]), :application_rejected_by_default => ([:application_rejected_by_default]), :offer_accepted => ([:offer_accepted, :unconditional_offer_accepted]), :offer_declined => ([:declined, :declined_by_default]), :reference_received => ([:reference_received]) }.select do\n k if event.in?(v)\n end.keys.first}\" => true)",
       "render_path": null,
       "location": {
         "type": "method",
@@ -40,52 +40,6 @@
         "method": "s(:self).for"
       },
       "user_input": "{ :application_received => ([:application_submitted]), :application_withdrawn => ([:application_withdrawn]), :application_rejected_by_default => ([:application_rejected_by_default]), :offer_accepted => ([:offer_accepted, :unconditional_offer_accepted]), :offer_declined => ([:declined, :declined_by_default]), :reference_received => ([:reference_received]) }.select do\n k if event.in?(v)\n end.keys.first",
-      "confidence": "Weak",
-      "cwe_id": [
-        89
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "1cee5ab174657cbdebb3e1ac4432c226aef489c6961a8c1512d187d1ff62ed08",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/components/provider_interface/provider_partner_permission_breakdown_component.rb",
-      "line": 43,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "provider.ratifying_provider_permissions.providers_have_open_course.where(\"ratifying_provider_can_#{permission}\" => permission_applies)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "ProviderInterface::ProviderPartnerPermissionBreakdownComponent",
-        "method": "training_provider_partner_ids_where"
-      },
-      "user_input": "permission",
-      "confidence": "Weak",
-      "cwe_id": [
-        89
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "2f2a4ac33ee8b6f5ab24b525613cbcd62fde4c7ec1a9d6956ab0012dd08ef828",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/services/provider_interface/sort_application_choices.rb",
-      "line": 16,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "application_choices.from(\"(\\n  SELECT a.*,\\n    CASE\\n      WHEN #{awaiting_provider_decision_urgent} THEN 1\\n      WHEN #{deferred_offers_pending_reconfirmation} THEN 2\\n      WHEN #{about_to_be_rejected_automatically} THEN 3\\n      WHEN #{give_feedback_for_rbd} THEN 4\\n      WHEN #{awaiting_provider_decision_non_urgent} THEN 5\\n      WHEN #{interviewing_non_urgent} THEN 6\\n      WHEN #{pending_conditions_previous_cycle} THEN 7\\n      WHEN #{waiting_on_candidate} THEN 8\\n      WHEN #{pending_conditions_current_cycle} THEN 9\\n      WHEN #{successful_candidates} THEN 10\\n      WHEN #{deferred_offers_current_cycle} THEN 11\\n      ELSE 999\\n    END AS task_view_group,\\n    #{pg_days_left_to_respond} AS pg_days_left_to_respond\\n\\n    FROM application_choices a\\n) AS application_choices\\n\".squish)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "ProviderInterface::SortApplicationChoices",
-        "method": "s(:self).for_task_view"
-      },
-      "user_input": "awaiting_provider_decision_urgent",
       "confidence": "Weak",
       "cwe_id": [
         89
@@ -141,20 +95,20 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "28d64e5d66c0dce5bb41ca5b85a1751bdd7190b07aa55b1af003c090e7f8863a",
+      "fingerprint": "384f45931b605f924ee51295a701f7c00e52715b7437d1f864bda1271c150af7",
       "check_name": "SQL",
       "message": "Possible SQL injection",
-      "file": "app/services/notifications_list.rb",
-      "line": 26,
+      "file": "app/components/provider_interface/provider_partner_permission_breakdown_component.rb",
+      "line": 43,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "application_choice.provider.provider_users.or(application_choice.accredited_provider.provider_users).joins(:notification_preferences).where(\"provider_user_notifications.#{{ :application_received => ([:application_submitted]), :application_withdrawn => ([:application_withdrawn]), :application_rejected_by_default => ([:application_rejected_by_default]), :offer_accepted => ([:offer_accepted, :unconditional_offer_accepted]), :offer_declined => ([:declined, :declined_by_default]), :reference_received => ([:reference_received]) }.select do\n k if event.in?(v)\n end.keys.first}\" => true)",
+      "code": "provider.ratifying_provider_permissions.providers_with_current_cycle_course.where(\"ratifying_provider_can_#{permission}\" => permission_applies)",
       "render_path": null,
       "location": {
         "type": "method",
-        "class": "NotificationsList",
-        "method": "s(:self).for"
+        "class": "ProviderInterface::ProviderPartnerPermissionBreakdownComponent",
+        "method": "training_provider_partner_ids_where"
       },
-      "user_input": "{ :application_received => ([:application_submitted]), :application_withdrawn => ([:application_withdrawn]), :application_rejected_by_default => ([:application_rejected_by_default]), :offer_accepted => ([:offer_accepted, :unconditional_offer_accepted]), :offer_declined => ([:declined, :declined_by_default]), :reference_received => ([:reference_received]) }.select do\n k if event.in?(v)\n end.keys.first",
+      "user_input": "permission",
       "confidence": "Weak",
       "cwe_id": [
         89
@@ -348,13 +302,36 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "b55ce37e4d245f02f20918d612a3abfcbff43d41f0a114e8a31907157e65121a",
+      "fingerprint": "b66efa91e04d1b02e4521f8a617809adda7a0dc470daa75fa2e22770d8e0c538",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/services/notifications_list.rb",
+      "line": 23,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "application_choice.provider.provider_users.joins(:notification_preferences).where(\"provider_user_notifications.#{{ :application_received => ([:application_submitted]), :application_withdrawn => ([:application_withdrawn]), :application_rejected_by_default => ([:application_rejected_by_default]), :offer_accepted => ([:offer_accepted, :unconditional_offer_accepted]), :offer_declined => ([:declined, :declined_by_default]), :reference_received => ([:reference_received]) }.select do\n k if event.in?(v)\n end.keys.first}\" => true)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "NotificationsList",
+        "method": "s(:self).for"
+      },
+      "user_input": "{ :application_received => ([:application_submitted]), :application_withdrawn => ([:application_withdrawn]), :application_rejected_by_default => ([:application_rejected_by_default]), :offer_accepted => ([:offer_accepted, :unconditional_offer_accepted]), :offer_declined => ([:declined, :declined_by_default]), :reference_received => ([:reference_received]) }.select do\n k if event.in?(v)\n end.keys.first",
+      "confidence": "Weak",
+      "cwe_id": [
+        89
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "baee8f95666b7ed7fee05665c97f0ba1a818683e958f940ccf8c7ffd980fdb64",
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/components/provider_interface/provider_partner_permission_breakdown_component.rb",
       "line": 50,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "provider.training_provider_permissions.providers_have_open_course.where(\"training_provider_can_#{permission}\" => permission_applies)",
+      "code": "provider.training_provider_permissions.providers_with_current_cycle_course.where(\"training_provider_can_#{permission}\" => permission_applies)",
       "render_path": null,
       "location": {
         "type": "method",
@@ -415,6 +392,6 @@
       "note": ""
     }
   ],
-  "updated": "2023-11-21 11:44:41 +0000",
-  "brakeman_version": "6.0.1"
+  "updated": "2024-03-15 09:07:25 +0000",
+  "brakeman_version": "6.1.2"
 }

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -116,8 +116,6 @@ en:
               too_many: Select no more than %{count} languages
         offer_validations:
           attributes:
-            course_option:
-              not_open_on_apply: The requested course is not open for applications via the Apply service
             conditions:
               too_many: Offer has over %{count} conditions
               too_long: "Condition %{index} must be %{limit} characters or fewer"

--- a/spec/components/previews/provider_interface/provider_partner_permission_breakdown_component_preview.rb
+++ b/spec/components/previews/provider_interface/provider_partner_permission_breakdown_component_preview.rb
@@ -15,7 +15,7 @@ module ProviderInterface
                           training_provider_can_make_decisions: false,
                           ratifying_provider: provider,
                           ratifying_provider_can_make_decisions: true)
-        FactoryBot.create(:course, :open_on_apply, provider: training_provider, accredited_provider: provider)
+        FactoryBot.create(:course, :open, provider: training_provider, accredited_provider: provider)
       end
 
       allowed_ratifying_providers.each do |training_provider|
@@ -24,7 +24,7 @@ module ProviderInterface
                           ratifying_provider_can_make_decisions: false,
                           training_provider: provider,
                           training_provider_can_make_decisions: true)
-        FactoryBot.create(:course, :open_on_apply, provider:, accredited_provider: training_provider)
+        FactoryBot.create(:course, :open, provider:, accredited_provider: training_provider)
       end
 
       prohibited_training_providers.each do |training_provider|
@@ -33,7 +33,7 @@ module ProviderInterface
                           training_provider:,
                           training_provider_can_make_decisions: true,
                           ratifying_provider_can_make_decisions: false)
-        FactoryBot.create(:course, :open_on_apply, provider: training_provider, accredited_provider: provider)
+        FactoryBot.create(:course, :open, provider: training_provider, accredited_provider: provider)
       end
 
       prohibited_ratifying_providers.each do |training_provider|
@@ -42,7 +42,7 @@ module ProviderInterface
                           training_provider: provider,
                           training_provider_can_make_decisions: false,
                           ratifying_provider_can_make_decisions: true)
-        FactoryBot.create(:course, :open_on_apply, provider:, accredited_provider: training_provider)
+        FactoryBot.create(:course, :open, provider:, accredited_provider: training_provider)
       end
 
       render ProviderPartnerPermissionBreakdownComponent.new(
@@ -62,7 +62,7 @@ module ProviderInterface
                           training_provider_can_make_decisions: false,
                           ratifying_provider: provider,
                           ratifying_provider_can_make_decisions: true)
-        FactoryBot.create(:course, :open_on_apply, provider: training_provider, accredited_provider: provider)
+        FactoryBot.create(:course, :open, provider: training_provider, accredited_provider: provider)
       end
 
       allowed_ratifying_providers.each do |training_provider|
@@ -71,7 +71,7 @@ module ProviderInterface
                           ratifying_provider_can_make_decisions: false,
                           training_provider: provider,
                           training_provider_can_make_decisions: true)
-        FactoryBot.create(:course, :open_on_apply, provider:, accredited_provider: training_provider)
+        FactoryBot.create(:course, :open, provider:, accredited_provider: training_provider)
       end
 
       render ProviderPartnerPermissionBreakdownComponent.new(
@@ -91,7 +91,7 @@ module ProviderInterface
                           training_provider:,
                           training_provider_can_make_decisions: true,
                           ratifying_provider_can_make_decisions: false)
-        FactoryBot.create(:course, :open_on_apply, provider: training_provider, accredited_provider: provider)
+        FactoryBot.create(:course, :open, provider: training_provider, accredited_provider: provider)
       end
 
       prohibited_ratifying_providers.each do |training_provider|
@@ -100,7 +100,7 @@ module ProviderInterface
                           training_provider: provider,
                           training_provider_can_make_decisions: false,
                           ratifying_provider_can_make_decisions: true)
-        FactoryBot.create(:course, :open_on_apply, provider:, accredited_provider: training_provider)
+        FactoryBot.create(:course, :open, provider:, accredited_provider: training_provider)
       end
 
       render ProviderPartnerPermissionBreakdownComponent.new(

--- a/spec/components/previews/provider_interface/provider_user_permissions_form_component_preview.rb
+++ b/spec/components/previews/provider_interface/provider_user_permissions_form_component_preview.rb
@@ -27,7 +27,7 @@ module ProviderInterface
 
     def setup_relationship_for(provider)
       relationship = FactoryBot.create(:provider_relationship_permissions, training_provider: provider)
-      FactoryBot.create(:course, :open_on_apply, provider:, accredited_provider: relationship.ratifying_provider)
+      FactoryBot.create(:course, :open, provider:, accredited_provider: relationship.ratifying_provider)
     end
 
     def form_model_for(provider)

--- a/spec/components/previews/provider_interface/user_permission_summary_component_preview.rb
+++ b/spec/components/previews/provider_interface/user_permission_summary_component_preview.rb
@@ -50,7 +50,7 @@ module ProviderInterface
                           training_provider_can_view_diversity_information: random_boolean_value,
                           ratifying_provider_can_view_diversity_information: !random_boolean_value)
 
-        FactoryBot.create(:course, :open_on_apply, provider: training_provider, accredited_provider: provider)
+        FactoryBot.create(:course, :open, provider: training_provider, accredited_provider: provider)
       end
 
       other_providers.each do |training_provider|
@@ -64,7 +64,7 @@ module ProviderInterface
                           training_provider_can_view_diversity_information: !other_random_boolean_value,
                           ratifying_provider_can_view_diversity_information: other_random_boolean_value)
 
-        FactoryBot.create(:course, :open_on_apply, provider: training_provider, accredited_provider: provider)
+        FactoryBot.create(:course, :open, provider: training_provider, accredited_provider: provider)
       end
 
       provider_user

--- a/spec/components/provider_interface/application_card_component_spec.rb
+++ b/spec/components/provider_interface/application_card_component_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
 
     context 'for any other year' do
       let(:course_option) do
-        course = create(:course, :open_on_apply, recruitment_cycle_year: RecruitmentCycle.previous_year - 1)
+        course = create(:course, :open, recruitment_cycle_year: RecruitmentCycle.previous_year - 1)
         create(:course_option, course:)
       end
 

--- a/spec/components/provider_interface/application_header_components/deferred_offer_component_spec.rb
+++ b/spec/components/provider_interface/application_header_components/deferred_offer_component_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe ProviderInterface::ApplicationHeaderComponents::DeferredOfferComp
 
   describe '#deferred_offer_in_current_cycle?' do
     it 'is true for a deferred offer without an open offered option' do
-      course_option = instance_double(CourseOption, course: instance_double(Course, open_on_apply: false))
+      course_option = instance_double(CourseOption, course: instance_double(Course))
       application_choice = instance_double(ApplicationChoice, status: 'offer_deferred', recruitment_cycle: RecruitmentCycle.current_year)
       allow(course_option).to receive(:in_next_cycle).and_return(false)
       allow(application_choice).to receive(:current_course_option).and_return(course_option)
@@ -85,7 +85,7 @@ RSpec.describe ProviderInterface::ApplicationHeaderComponents::DeferredOfferComp
     end
 
     it 'is false for a deferred offer with an open offered option' do
-      course_option = instance_double(CourseOption, course: instance_double(Course, open_on_apply: false))
+      course_option = instance_double(CourseOption, course: instance_double(Course))
       application_choice = instance_double(ApplicationChoice, status: 'offer_deferred', recruitment_cycle: RecruitmentCycle.current_year)
       allow(course_option).to receive(:in_next_cycle).and_return(course_option)
       allow(application_choice).to receive(:current_course_option).and_return(course_option)
@@ -94,7 +94,7 @@ RSpec.describe ProviderInterface::ApplicationHeaderComponents::DeferredOfferComp
     end
 
     it 'is false for a deferred offer from the previous cycle' do
-      course_option = instance_double(CourseOption, course: instance_double(Course, open_on_apply: false))
+      course_option = instance_double(CourseOption, course: instance_double(Course))
       application_choice = instance_double(ApplicationChoice, status: 'offer_deferred', recruitment_cycle: RecruitmentCycle.previous_year)
       allow(course_option).to receive(:in_next_cycle).and_return(course_option)
       allow(application_choice).to receive(:current_course_option).and_return(course_option)

--- a/spec/components/provider_interface/provider_partner_permission_breakdown_component_spec.rb
+++ b/spec/components/provider_interface/provider_partner_permission_breakdown_component_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ProviderInterface::ProviderPartnerPermissionBreakdownComponent do
       "#{partner_provider_type}_provider_can_#{permission}": !permission_applies,
     )
     if course_open
-      create(:course, :open_on_apply, provider: relationship.training_provider, accredited_provider: relationship.ratifying_provider)
+      create(:course, :open, provider: relationship.training_provider, accredited_provider: relationship.ratifying_provider)
     end
 
     partner_provider

--- a/spec/components/provider_interface/provider_user_permissions_form_component_spec.rb
+++ b/spec/components/provider_interface/provider_user_permissions_form_component_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe ProviderInterface::ProviderUserPermissionsFormComponent do
   context 'when the provider has partner organisations' do
     before do
       relationship = create(:provider_relationship_permissions, training_provider: provider)
-      create(:course, :open_on_apply, provider:, accredited_provider: relationship.ratifying_provider)
+      create(:course, :open, provider:, accredited_provider: relationship.ratifying_provider)
 
       allow(ProviderInterface::ProviderPartnerPermissionBreakdownComponent).to receive(:new).with(provider:, permission: anything).and_call_original
     end

--- a/spec/components/provider_interface/user_permission_summary_component_spec.rb
+++ b/spec/components/provider_interface/user_permission_summary_component_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe ProviderInterface::UserPermissionSummaryComponent, type: :control
                setup_at: nil)
       end
 
-      create(:course, :open_on_apply, provider: allowed_providers.first, accredited_provider: provider)
+      create(:course, :open, provider: allowed_providers.first, accredited_provider: provider)
     end
 
     describe 'rendering details about each permission' do

--- a/spec/forms/provider_interface/reconfirm_deferred_offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/reconfirm_deferred_offer_wizard_spec.rb
@@ -59,12 +59,6 @@ RSpec.describe ProviderInterface::ReconfirmDeferredOfferWizard do
         expect(wizard_for(this_state)).not_to be_valid
       end
 
-      it 'is not valid if equivalent option exists but is not open on Apply' do
-        application_choice.current_course.in_next_cycle.update(open_on_apply: false)
-        this_state = state_store_for(application_choice_id: application_choice.id)
-        expect(wizard_for(this_state)).not_to be_valid
-      end
-
       it 'requires confirmed status of conditions' do
         this_state = state_store_for(application_choice_id: application_choice.id)
         expect(wizard_for(this_state)).not_to be_valid_for_current_step

--- a/spec/models/provider_relationship_permissions_spec.rb
+++ b/spec/models/provider_relationship_permissions_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe ProviderRelationshipPermissions do
     end
   end
 
-  describe '#providers_have_open_course?' do
+  describe '#providers_have_current_cycle_course?' do
     let(:training_provider) { create(:provider) }
     let(:ratifying_provider) { create(:provider) }
     let!(:relationship) do
@@ -160,41 +160,32 @@ RSpec.describe ProviderRelationshipPermissions do
 
     context 'there are no courses' do
       it 'returns false' do
-        expect(relationship.providers_have_open_course?).to be(false)
+        expect(relationship.providers_have_current_cycle_course?).to be(false)
       end
     end
 
-    context 'there is an unopened course' do
+    context 'there is a course' do
       let!(:course) { create(:course, provider: training_provider, accredited_provider: ratifying_provider) }
 
       it 'returns false' do
-        expect(relationship.providers_have_open_course?).to be(false)
-      end
-    end
-
-    context 'there is an open course' do
-      let!(:course) { create(:course, :open_on_apply, provider: training_provider, accredited_provider: ratifying_provider) }
-
-      it 'returns false' do
-        expect(relationship.providers_have_open_course?).to be(true)
+        expect(relationship.providers_have_current_cycle_course?).to be(true)
       end
     end
   end
 
-  describe '.providers_have_open_course' do
+  describe '.providers_with_current_cycle_course' do
     def create_relationship_with_course(course_traits: [])
       relationship = create(:provider_relationship_permissions)
       create(:course, *course_traits, provider: relationship.training_provider, accredited_provider: relationship.ratifying_provider)
       relationship
     end
 
+    let!(:course_relationship) { create_relationship_with_course }
     let!(:no_course_relationship) { create(:provider_relationship_permissions) }
-    let!(:unopened_course_relationship) { create_relationship_with_course }
-    let!(:open_course_relationship) { create_relationship_with_course(course_traits: [:open_on_apply]) }
-    let!(:open_course_in_previous_cycle_relationship) { create_relationship_with_course(course_traits: %i[open_on_apply previous_year]) }
+    let!(:course_in_previous_cycle_relationship) { create_relationship_with_course(course_traits: %i[previous_year]) }
 
-    it 'only returns the open_course_relationship' do
-      expect(described_class.providers_have_open_course).to eq([open_course_relationship])
+    it 'only returns the existing course_relationship' do
+      expect(described_class.providers_with_current_cycle_course).to eq([course_relationship])
     end
   end
 end

--- a/spec/requests/provider_interface/condition_statuses/checks_controller_spec.rb
+++ b/spec/requests/provider_interface/condition_statuses/checks_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ProviderInterface::ConditionStatuses::ChecksController do
   let(:provider_user) { create(:provider_user, :with_dfe_sign_in, :with_make_decisions) }
   let(:provider) { provider_user.providers.first }
   let(:application_form) { build(:application_form, :minimum_info) }
-  let(:course) { build(:course, :open_on_apply, provider:) }
+  let(:course) { build(:course, :open, provider:) }
   let(:course_option) { build(:course_option, course:) }
 
   before do

--- a/spec/requests/provider_interface/condition_statuses_controller_spec.rb
+++ b/spec/requests/provider_interface/condition_statuses_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ProviderInterface::ConditionStatusesController do
   let(:provider_user) { create(:provider_user, :with_dfe_sign_in, :with_make_decisions) }
   let(:provider) { provider_user.providers.first }
   let(:application_form) { build(:application_form, :minimum_info) }
-  let(:course) { build(:course, :open_on_apply, provider:) }
+  let(:course) { build(:course, :open, provider:) }
   let(:course_option) { build(:course_option, course:) }
 
   before do

--- a/spec/requests/provider_interface/courses_controller_spec.rb
+++ b/spec/requests/provider_interface/courses_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ProviderInterface::CoursesController do
   let(:provider_user) { create(:provider_user, :with_dfe_sign_in, :with_make_decisions) }
   let(:provider) { provider_user.providers.first }
   let(:application_form) { build(:application_form, :minimum_info) }
-  let(:course) { create(:course, :open_on_apply, provider:) }
+  let(:course) { create(:course, :open, provider:) }
   let(:course_option) { create(:course_option, course:) }
   let(:wizard_attrs) { {} }
   let(:request) { put provider_interface_application_choice_course_path(application_choice) }

--- a/spec/requests/provider_interface/decisions_controller_spec.rb
+++ b/spec/requests/provider_interface/decisions_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ProviderInterface::DecisionsController do
   let(:provider_user) { create(:provider_user, :with_dfe_sign_in, :with_make_decisions) }
   let(:provider) { provider_user.providers.first }
   let(:application_form) { build(:application_form, :minimum_info) }
-  let(:course) { build(:course, :open_on_apply, provider:) }
+  let(:course) { build(:course, :open, provider:) }
   let(:course_option) { build(:course_option, course:) }
 
   let!(:application_choice) do

--- a/spec/requests/provider_interface/interviews/cancel_controller_spec.rb
+++ b/spec/requests/provider_interface/interviews/cancel_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ProviderInterface::Interviews::CancelController do
   let(:provider_user) { create(:provider_user, :with_dfe_sign_in, :with_make_decisions, :with_set_up_interviews) }
   let(:provider) { provider_user.providers.first }
   let(:application_form) { build(:application_form, :minimum_info) }
-  let(:course) { build(:course, :open_on_apply, provider:) }
+  let(:course) { build(:course, :open, provider:) }
   let(:course_option) { build(:course_option, course:) }
   let(:interview) { create(:interview, application_choice:) }
 

--- a/spec/requests/provider_interface/interviews/checks_controller_spec.rb
+++ b/spec/requests/provider_interface/interviews/checks_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ProviderInterface::Interviews::ChecksController do
   let(:provider_user) { create(:provider_user, :with_dfe_sign_in, :with_make_decisions, :with_set_up_interviews) }
   let(:provider) { provider_user.providers.first }
   let(:application_form) { build(:application_form, :minimum_info) }
-  let(:course) { build(:course, :open_on_apply, provider:) }
+  let(:course) { build(:course, :open, provider:) }
   let(:course_option) { build(:course_option, course:) }
   let!(:interview) { create(:interview, application_choice:) }
 
@@ -22,7 +22,7 @@ RSpec.describe ProviderInterface::Interviews::ChecksController do
         :course,
         :with_accredited_provider,
         :with_provider_relationship_permissions,
-        :open_on_apply,
+        :open,
         provider:,
       )
     end

--- a/spec/requests/provider_interface/interviews_controller_spec.rb
+++ b/spec/requests/provider_interface/interviews_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ProviderInterface::InterviewsController do
   let(:provider_user) { create(:provider_user, :with_dfe_sign_in, :with_make_decisions, :with_set_up_interviews) }
   let(:provider) { provider_user.providers.first }
   let(:application_form) { build(:application_form, :minimum_info) }
-  let(:course) { build(:course, :open_on_apply, provider:) }
+  let(:course) { build(:course, :open, provider:) }
   let(:course_option) { build(:course_option, course:) }
   let(:interview) { create(:interview, application_choice:) }
 

--- a/spec/requests/provider_interface/notes_controller_spec.rb
+++ b/spec/requests/provider_interface/notes_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ProviderInterface::NotesController do
 
   let(:provider_user) { create(:provider_user, :with_dfe_sign_in, :with_make_decisions) }
   let(:provider) { provider_user.providers.first }
-  let(:course) { build(:course, :open_on_apply, provider:) }
+  let(:course) { build(:course, :open, provider:) }
   let(:course_option) { build(:course_option, course:) }
   let(:application_choice) { create(:application_choice, course_option:) }
 

--- a/spec/requests/provider_interface/offers_controller_spec.rb
+++ b/spec/requests/provider_interface/offers_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ProviderInterface::OffersController do
   let(:provider_user) { create(:provider_user, :with_dfe_sign_in, :with_make_decisions) }
   let(:provider) { provider_user.providers.first }
   let(:application_form) { build(:application_form, :minimum_info) }
-  let(:course) { create(:course, :open_on_apply, provider:) }
+  let(:course) { create(:course, :open, provider:) }
   let(:course_option) { create(:course_option, course:) }
 
   before do

--- a/spec/requests/provider_interface/organisation_permissions_setup_controller_spec.rb
+++ b/spec/requests/provider_interface/organisation_permissions_setup_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ProviderInterface::OrganisationPermissionsSetupController do
 
   context 'when there are permissions requiring setup' do
     let(:ratifying_provider) { create(:provider) }
-    let!(:course) { create(:course, :open_on_apply, accredited_provider: ratifying_provider, provider:) }
+    let!(:course) { create(:course, :open, accredited_provider: ratifying_provider, provider:) }
     let(:store) { instance_double(WizardStateStores::RedisStore) }
     let(:wizard_store_value) { { 'relationship_ids' => [permissions.id] }.to_json }
     let!(:permissions) do
@@ -91,7 +91,7 @@ RSpec.describe ProviderInterface::OrganisationPermissionsSetupController do
 
   context 'when there are no permissions requiring setup' do
     let(:ratifying_provider) { create(:provider) }
-    let!(:course) { create(:course, :open_on_apply, accredited_provider: ratifying_provider, provider:) }
+    let!(:course) { create(:course, :open, accredited_provider: ratifying_provider, provider:) }
     let!(:permissions) do
       create(
         :provider_relationship_permissions,

--- a/spec/requests/provider_interface/provider_interface_controller_spec.rb
+++ b/spec/requests/provider_interface/provider_interface_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ProviderInterface::ProviderInterfaceController do
 
   context 'when there are permissions requiring setup' do
     let(:ratifying_provider) { create(:provider) }
-    let!(:course) { create(:course, :open_on_apply, accredited_provider: ratifying_provider, provider:) }
+    let!(:course) { create(:course, :open, accredited_provider: ratifying_provider, provider:) }
     let!(:permissions) do
       create(
         :provider_relationship_permissions,

--- a/spec/requests/provider_interface/rejections_controller_spec.rb
+++ b/spec/requests/provider_interface/rejections_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ProviderInterface::RejectionsController do
 
   let(:provider_user) { create(:provider_user, :with_dfe_sign_in, :with_make_decisions) }
   let(:provider) { provider_user.providers.first }
-  let(:course_option) { build(:course_option, course: build(:course, :open_on_apply, provider:)) }
+  let(:course_option) { build(:course_option, course: build(:course, :open, provider:)) }
   let(:application_choice) do
     create(:application_choice,
            status:,

--- a/spec/services/provider_setup_spec.rb
+++ b/spec/services/provider_setup_spec.rb
@@ -96,14 +96,6 @@ RSpec.describe ProviderSetup do
           expect(provider_setup.next_relationship_pending).to be_nil
         end
       end
-
-      context 'when the provider has no courses open on apply' do
-        let!(:course) { create(:course, accredited_provider: other_provider, provider: provider_for_user, open_on_apply: false) }
-
-        it 'returns nil' do
-          expect(provider_setup.next_relationship_pending).to be_nil
-        end
-      end
     end
 
     context 'when all permissions are set up already' do

--- a/spec/support/shared_examples/confirm_deferred_offer_validations.rb
+++ b/spec/support/shared_examples/confirm_deferred_offer_validations.rb
@@ -8,18 +8,6 @@ RSpec.shared_examples 'confirm deferred offer validations' do |transition_event|
     end
   end
 
-  context 'checks the course is open on apply' do
-    let(:new_course_option) do
-      create(:course_option,
-             course: create(:course, provider:, open_on_apply: false))
-    end
-
-    it 'raises a ValidationException' do
-      expect { service.save! }
-        .to raise_error(ValidationException, 'The requested course is not open for applications via the Apply service')
-    end
-  end
-
   context 'checks course option matches the current RecruitmentCycle' do
     let(:new_course_option) { previous_course_option }
 

--- a/spec/system/provider_interface/change_make_offer_spec.rb
+++ b/spec/system/provider_interface/change_make_offer_spec.rb
@@ -150,7 +150,7 @@ RSpec.feature 'Provider makes an offer' do
     @selected_provider = create(:provider)
     create(:provider_permissions, provider: @selected_provider, provider_user:, make_decisions: true)
     courses = [create(:course, study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: ratifying_provider),
-               create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: ratifying_provider)]
+               create(:course, :open, study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: ratifying_provider)]
     @selected_course = courses.sample
 
     course_options = [create(:course_option, :part_time, course: @selected_course),

--- a/spec/system/provider_interface/make_offer_spec.rb
+++ b/spec/system/provider_interface/make_offer_spec.rb
@@ -181,8 +181,8 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def given_the_provider_has_multiple_courses
-    @provider_available_course = create(:course, :open_on_apply, study_mode: :full_time, provider: provider, accredited_provider: ratifying_provider)
-    create(:course, :open_on_apply, provider: provider)
+    @provider_available_course = create(:course, :open, study_mode: :full_time, provider: provider, accredited_provider: ratifying_provider)
+    create(:course, :open, provider: provider)
     course_options = [create(:course_option, :full_time, course: @provider_available_course),
                       create(:course_option, :full_time, course: @provider_available_course),
                       create(:course_option, :full_time, course: @provider_available_course)]
@@ -219,7 +219,7 @@ RSpec.feature 'Provider makes an offer' do
     @available_provider = create(:provider)
     create(:provider_permissions, provider: @available_provider, provider_user: provider_user, make_decisions: true)
     courses = [create(:course, study_mode: :full_time_or_part_time, provider: @available_provider, accredited_provider: ratifying_provider),
-               create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @available_provider, accredited_provider: ratifying_provider)]
+               create(:course, :open, study_mode: :full_time_or_part_time, provider: @available_provider, accredited_provider: ratifying_provider)]
     @selected_provider_available_course = courses.sample
 
     course_options = [create(:course_option, :part_time, course: @selected_provider_available_course),

--- a/spec/system/provider_interface/make_offer_structured_conditions_spec.rb
+++ b/spec/system/provider_interface/make_offer_structured_conditions_spec.rb
@@ -188,8 +188,8 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def given_the_provider_has_multiple_courses
-    @provider_available_course = create(:course, :open_on_apply, study_mode: :full_time, provider: provider, accredited_provider: ratifying_provider)
-    create(:course, :open_on_apply, provider: provider)
+    @provider_available_course = create(:course, :open, study_mode: :full_time, provider: provider, accredited_provider: ratifying_provider)
+    create(:course, :open, provider: provider)
     course_options = [create(:course_option, :full_time, course: @provider_available_course),
                       create(:course_option, :full_time, course: @provider_available_course),
                       create(:course_option, :full_time, course: @provider_available_course)]
@@ -226,7 +226,7 @@ RSpec.feature 'Provider makes an offer' do
     @available_provider = create(:provider)
     create(:provider_permissions, provider: @available_provider, provider_user: provider_user, make_decisions: true)
     courses = [create(:course, study_mode: :full_time_or_part_time, provider: @available_provider, accredited_provider: ratifying_provider),
-               create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @available_provider, accredited_provider: ratifying_provider)]
+               create(:course, :open, study_mode: :full_time_or_part_time, provider: @available_provider, accredited_provider: ratifying_provider)]
     @selected_provider_available_course = courses.sample
 
     course_options = [create(:course_option, :part_time, course: @selected_provider_available_course),

--- a/spec/system/provider_interface/provider_accepts_data_sharing_agreement_spec.rb
+++ b/spec/system/provider_interface/provider_accepts_data_sharing_agreement_spec.rb
@@ -68,7 +68,7 @@ RSpec.feature 'Accept data sharing agreement' do
     provider = Provider.find_by(code: 'ABC')
     ratifying_provider = create(:provider)
     ratifying_provider.provider_users << provider_user
-    create(:course, :open_on_apply, provider:, accredited_provider: ratifying_provider)
+    create(:course, :open, provider:, accredited_provider: ratifying_provider)
     provider_user.provider_permissions.where(provider:).update_all(manage_organisations: true)
     create(:provider_relationship_permissions, setup_at: nil, training_provider: provider, ratifying_provider:)
   end

--- a/spec/system/provider_interface/provider_can_view_interview_schedule_spec.rb
+++ b/spec/system/provider_interface/provider_can_view_interview_schedule_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'A Provider user' do
   let(:provider_user) { create(:provider_user, :with_dfe_sign_in) }
   let(:provider) { provider_user.providers.first }
   let(:application_form) { create(:application_form) }
-  let(:course) { create(:course, :open_on_apply, provider:) }
+  let(:course) { create(:course, :open, provider:) }
 
   before do
     TestSuiteTimeMachine.travel_permanently_to(Time.zone.now.midday)

--- a/spec/system/provider_interface/provider_changes_a_course_before_point_of_offer_spec.rb
+++ b/spec/system/provider_interface/provider_changes_a_course_before_point_of_offer_spec.rb
@@ -83,10 +83,10 @@ RSpec.feature 'Provider changes a course' do
     @selected_provider = create(:provider)
     create(:provider_permissions, provider: @selected_provider, provider_user:, make_decisions: true, set_up_interviews: true)
     courses = [create(:course, study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: ratifying_provider),
-               create(:course, :open_on_apply, study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: ratifying_provider)]
+               create(:course, :open, study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: ratifying_provider)]
     @selected_course = courses.sample
 
-    @one_mode_and_location_course = create(:course, :open_on_apply, study_mode: :full_time, provider: @selected_provider, accredited_provider: ratifying_provider)
+    @one_mode_and_location_course = create(:course, :open, study_mode: :full_time, provider: @selected_provider, accredited_provider: ratifying_provider)
     @one_mode_and_location_course_option = create(:course_option, :full_time, site: create(:site, provider: @one_mode_and_location_course.provider), course: @one_mode_and_location_course)
 
     course_options = [create(:course_option, :part_time, course: @selected_course),

--- a/spec/system/provider_interface/provider_edits_organisation_permissions_spec.rb
+++ b/spec/system/provider_interface/provider_edits_organisation_permissions_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature 'Provider edits organisation permissions' do
       training_provider: @training_provider,
       ratifying_provider: @ratifying_provider,
     )
-    create(:course, :open_on_apply, provider: @training_provider, accredited_provider: @ratifying_provider)
+    create(:course, :open, provider: @training_provider, accredited_provider: @ratifying_provider)
 
     @training_provider_users = create_list(:provider_user, 2, providers: [@training_provider])
     @training_provider_users.each { |user| user.provider_permissions.where(provider: @training_provider).update_all(manage_organisations: true) }

--- a/spec/system/provider_interface/provider_exits_journey_when_changing_a_course_before_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_exits_journey_when_changing_a_course_before_an_offer_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature 'Provider exits journey when changing a course' do
   end
 
   def and_the_provider_has_multiple_courses
-    @selected_course = create(:course, :open_on_apply, study_mode: :full_time, provider:, accredited_provider: ratifying_provider)
+    @selected_course = create(:course, :open, study_mode: :full_time, provider:, accredited_provider: ratifying_provider)
 
     create(:course_option, :full_time, course:)
     create(:course_option, :full_time, course: @selected_course)

--- a/spec/system/provider_interface/provider_reinstates_deferred_offer_spec.rb
+++ b/spec/system/provider_interface/provider_reinstates_deferred_offer_spec.rb
@@ -6,9 +6,9 @@ RSpec.feature 'Provider reinstates deferred offer' do
   include ProviderUserPermissionsHelper
 
   let(:provider) { Provider.find_by(code: 'ABC') }
-  let(:course_current_year) { create(:course, :open_on_apply, provider:) }
-  let(:course_previous_year) { create(:course, :open_on_apply, :previous_year, provider:) }
-  let(:course_previous_year_but_still_available) { create(:course, :open_on_apply, :previous_year_but_still_available, provider:) }
+  let(:course_current_year) { create(:course, :open, provider:) }
+  let(:course_previous_year) { create(:course, :open, :previous_year, provider:) }
+  let(:course_previous_year_but_still_available) { create(:course, :open, :previous_year_but_still_available, provider:) }
 
   let(:choices) do
     {

--- a/spec/system/provider_interface/provider_user_sets_up_organisation_permissions_spec.rb
+++ b/spec/system/provider_interface/provider_user_sets_up_organisation_permissions_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature 'Setting up organisation permissions' do
       ratifying_provider: @another_ratifying_provider,
       training_provider: @training_provider,
     )
-    create(:course, :open_on_apply, provider: @training_provider, accredited_provider: @another_ratifying_provider)
+    create(:course, :open, provider: @training_provider, accredited_provider: @another_ratifying_provider)
 
     @ratifying_provider_relationship = create(
       :provider_relationship_permissions,
@@ -74,7 +74,7 @@ RSpec.feature 'Setting up organisation permissions' do
       ratifying_provider: @ratifying_provider,
       training_provider: @another_training_provider,
     )
-    create(:course, :open_on_apply, provider: @another_training_provider, accredited_provider: @ratifying_provider)
+    create(:course, :open, provider: @another_training_provider, accredited_provider: @ratifying_provider)
   end
 
   alias_method :when_i_sign_in_to_the_provider_interface, :and_i_sign_in_to_the_provider_interface

--- a/spec/system/provider_interface/set_offer_conditions_js_spec.rb
+++ b/spec/system/provider_interface/set_offer_conditions_js_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Provider makes an offer with JS enabled', :js do
   let(:ratifying_provider) { create(:provider) }
 
   let(:application_form) { build(:application_form, :minimum_info) }
-  let(:course) { build(:course, :open_on_apply, provider:, accredited_provider: ratifying_provider) }
+  let(:course) { build(:course, :open, provider:, accredited_provider: ratifying_provider) }
   let(:course_option) { build(:course_option, course:) }
 
   scenario 'Setting offer conditions' do

--- a/spec/system/provider_interface/view_organisation_permissions_spec.rb
+++ b/spec/system/provider_interface/view_organisation_permissions_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature 'Organisation permissions' do
   end
 
   def create_open_course_for_relationship(relationship)
-    create(:course, :open_on_apply, provider: relationship.training_provider, accredited_provider: relationship.ratifying_provider)
+    create(:course, :open, provider: relationship.training_provider, accredited_provider: relationship.ratifying_provider)
   end
 
   def and_i_belong_to_a_provider_with_no_open_courses

--- a/spec/system/provider_interface/view_organisation_settings_spec.rb
+++ b/spec/system/provider_interface/view_organisation_settings_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature 'Organisation settings' do
   end
 
   def and_its_relationship_permissions_have_already_been_set_up
-    course = create(:course, :open_on_apply, :with_accredited_provider, provider: @first_provider)
+    course = create(:course, :open, :with_accredited_provider, provider: @first_provider)
     create(
       :provider_relationship_permissions,
       training_provider: @first_provider,


### PR DESCRIPTION
## Context

Part of the Epic to remove the concept of `open_on_apply` from the application.

## Changes proposed in this pull request

 - Change Course open_on_apply to `open` where appropriate
 -   Removal of `open_on_apply` changes the properties that dictate the
    relationship between Providers. A relationship used to exist only if
    a course existed in the current cycle and `open_on_apply` was true.
    Now only the course must exist.


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

[Trello Ticket](https://trello.com/c/sidcpRmp/1332-openonapply-replace-openonapply-with-openforapplications-or-delete)
