### PR TITLE
[1417] Add 256 character limit to GCSE grade input forms

### DIFF
--- a/app/forms/candidate_interface/english_gcse_grade_form.rb
+++ b/app/forms/candidate_interface/english_gcse_grade_form.rb
@@ -26,6 +26,8 @@ module CandidateInterface
                   :award_year
 
     validates :grade, presence: true, on: :grade
+    validates :grade, length: { maximum: ApplicationQualification::MAX_QUALIFICATION_GRADE_LENGTH }
+    validates :other_grade, length: { maximum: ApplicationQualification::MAX_QUALIFICATION_GRADE_LENGTH }
     validates :other_grade, presence: true, if: :grade_is_other?
     validate :validate_grade_format, on: :grade, unless: :multiple_gcse? || :new_record?
     validate :validate_grades_format, on: :constituent_grades, if: :multiple_gcse?, unless: :new_record?

--- a/app/forms/candidate_interface/maths_gcse_grade_form.rb
+++ b/app/forms/candidate_interface/maths_gcse_grade_form.rb
@@ -4,6 +4,8 @@ module CandidateInterface
 
     attr_accessor :grade, :qualification_type, :other_grade
     validates :grade, :qualification_type, presence: true
+    validates :grade, length: { maximum: ApplicationQualification::MAX_QUALIFICATION_GRADE_LENGTH }
+    validates :other_grade, length: { maximum: ApplicationQualification::MAX_QUALIFICATION_GRADE_LENGTH }
     validates :other_grade, presence: true, if: :grade_is_other?
     validate :validate_grade_format
 

--- a/app/forms/candidate_interface/science_gcse_grade_form.rb
+++ b/app/forms/candidate_interface/science_gcse_grade_form.rb
@@ -16,6 +16,8 @@ module CandidateInterface
                   :physics_grade,
                   :chemistry_grade
     validates :other_grade, presence: true, if: :grade_is_other?
+    validates :other_grade, length: { maximum: ApplicationQualification::MAX_QUALIFICATION_GRADE_LENGTH }
+    validates :grade, length: { maximum: ApplicationQualification::MAX_QUALIFICATION_GRADE_LENGTH }
     validate :grade_length
     validate :grade_format, unless: :new_record?
     validate :triple_award_grade_format

--- a/app/forms/support_interface/english_gcse_form.rb
+++ b/app/forms/support_interface/english_gcse_form.rb
@@ -46,6 +46,7 @@ module SupportInterface
     validates_with ZendeskUrlValidator
 
     validates :grade, presence: true, unless: ->(record) { record.multiple_gcse? || record.missing_qualification? }
+    validates :grade, length: { maximum: ApplicationQualification::MAX_QUALIFICATION_GRADE_LENGTH }
     validates :other_grade, presence: true, if: :grade_is_other?
     validate :validate_grade_format, unless: :multiple_gcse?
     validate :validate_grades_format, if: :multiple_gcse?

--- a/app/forms/support_interface/math_gcse_form.rb
+++ b/app/forms/support_interface/math_gcse_form.rb
@@ -26,6 +26,7 @@ module SupportInterface
     validates_with ZendeskUrlValidator
 
     validates :grade, presence: true, unless: :missing_qualification?
+    validates :grade, length: { maximum: ApplicationQualification::MAX_QUALIFICATION_GRADE_LENGTH }
     validates :award_year, presence: true, year: { future: true }, unless: :missing_qualification?
     validates :award_year, o_level_award_year: true, unless: ->(c) { c.errors.attribute_names.include?(:award_year) }
 

--- a/app/forms/support_interface/science_gcse_form.rb
+++ b/app/forms/support_interface/science_gcse_form.rb
@@ -34,6 +34,7 @@ module SupportInterface
     validates_with ZendeskUrlValidator
 
     validates :grade, presence: true, unless: ->(record) { record.missing_qualification? || record.gcse? }
+    validates :grade, length: { maximum: ApplicationQualification::MAX_QUALIFICATION_GRADE_LENGTH }
     validates :award_year, presence: true, year: { future: true }, unless: :missing_qualification?
     validates :award_year, o_level_award_year: true, unless: ->(c) { c.errors.attribute_names.include?(:award_year) }
 

--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -48,6 +48,8 @@ class ApplicationQualification < ApplicationRecord
   ].freeze
   MAX_QUALIFICATION_TYPE_LENGTH = 256
 
+  MAX_QUALIFICATION_GRADE_LENGTH = 256
+
   belongs_to :application_form, touch: true
   has_one :candidate, through: :application_form
 

--- a/spec/forms/candidate_interface/english_gcse_grade_form_spec.rb
+++ b/spec/forms/candidate_interface/english_gcse_grade_form_spec.rb
@@ -2,12 +2,15 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::EnglishGcseGradeForm, type: :model do
   describe 'validations' do
+    it { is_expected.to validate_length_of(:grade).is_at_most(256) }
+
     context 'when grade is "other"' do
       let(:form) { subject }
 
       before { allow(form).to receive(:grade_is_other?).and_return(true) }
 
       it { is_expected.to validate_presence_of(:other_grade) }
+      it { is_expected.to validate_length_of(:other_grade).is_at_most(256) }
     end
 
     context 'when qualification type is GCSE' do

--- a/spec/forms/candidate_interface/maths_gcse_grade_form_spec.rb
+++ b/spec/forms/candidate_interface/maths_gcse_grade_form_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe CandidateInterface::MathsGcseGradeForm, type: :model do
     let(:form) { described_class.new(grade: 'D', qualification_type: 'gcse') }
 
     it { is_expected.to validate_presence_of(:grade) }
+    it { is_expected.to validate_length_of(:grade).is_at_most(256) }
+    it { is_expected.to validate_length_of(:other_grade).is_at_most(256) }
 
     context 'when grade is "other"' do
       let(:form) { described_class.new(grade: 'other', other_grade: 'D', qualification_type: 'gcse') }

--- a/spec/forms/candidate_interface/science_gcse_grade_form_spec.rb
+++ b/spec/forms/candidate_interface/science_gcse_grade_form_spec.rb
@@ -2,12 +2,15 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
   describe 'validations' do
+    it { is_expected.to validate_length_of(:grade).is_at_most(256) }
+
     context 'when grade is "other"' do
       let(:form) { subject }
 
       before { allow(form).to receive(:grade_is_other?).and_return(true) }
 
       it { is_expected.to validate_presence_of(:other_grade) }
+      it { is_expected.to validate_length_of(:other_grade).is_at_most(256) }
     end
 
     context 'when qualification type is GCSE' do

--- a/spec/forms/support_interface/english_gcse_form_spec.rb
+++ b/spec/forms/support_interface/english_gcse_form_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::EnglishGcseForm do
+  let(:qualification) { create(:application_qualification) }
+
+  subject(:form) { described_class.build_from_qualification(qualification) }
+
+  describe 'validations' do
+    it { is_expected.to validate_length_of(:grade).is_at_most(256) }
+  end
+end

--- a/spec/forms/support_interface/math_gcse_form_spec.rb
+++ b/spec/forms/support_interface/math_gcse_form_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::MathGcseForm do
+  let(:qualification) { create(:application_qualification) }
+
+  subject(:form) { described_class.build_from_qualification(qualification) }
+
+  describe 'validations' do
+    it { is_expected.to validate_length_of(:grade).is_at_most(256) }
+  end
+end

--- a/spec/forms/support_interface/science_gcse_form_spec.rb
+++ b/spec/forms/support_interface/science_gcse_form_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ScienceGcseForm do
+  let(:qualification) { create(:application_qualification) }
+
+  subject(:form) { described_class.build_from_qualification(qualification) }
+
+  describe 'validations' do
+    it { is_expected.to validate_length_of(:grade).is_at_most(256) }
+  end
+end


### PR DESCRIPTION
## Context

Adding a 256 character limit to GCSE grade input forms. This is in line with our vendor API rules:

https://www.apply-for-teacher-training.service.gov.uk/api-docs/v1.4/reference#qualification-object

## Before

<img width="913" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/50492247/05c8c4d8-a9e7-458a-b57c-555f3ea664a3">

## After

<img width="752" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/50492247/b7fc9740-c28b-4349-866a-161b6b83baef">

## Guidance to review

- Try to add a GCSE grade that's over than 256 characters as many ways as you can (on the UI).
- It doesn't look like we need the `other_grade` validation on support.
- Should we add a 'back up' model level validation for this on `grade` and `other_grade`?

## Link to Trello card

https://trello.com/c/TgFxWX5c/1417-validate-gcse-grade-length

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
