### PR TITLE
[1376] Change vacancy status on course options to reflect study mode changes

### DIFF
--- a/app/services/teacher_training_public_api/sync_sites.rb
+++ b/app/services/teacher_training_public_api/sync_sites.rb
@@ -24,6 +24,7 @@ module TeacherTrainingPublicAPI
       sites.each do |site_from_api|
         site = sync_site(site_from_api)
         create_course_options_for_site(site, site_from_api.location_status)
+        close_course_options_that_do_not_match_study_mode
       end
 
       handle_course_options_with_invalid_sites(sites)
@@ -51,6 +52,18 @@ module TeacherTrainingPublicAPI
     def create_course_options_for_site(site, site_status)
       study_modes(course).each do |study_mode|
         create_course_options(site, study_mode, site_status)
+      end
+    end
+
+    def close_course_options_that_do_not_match_study_mode
+      # Close part_time course options if the course is full_time
+      if course.full_time? && course.course_options.part_time.any?
+        course.course_options.part_time.update_all(vacancy_status: :no_vacancies)
+      end
+
+      # Close full_time course options if the course is part_time
+      if course.part_time? && course.course_options.full_time.any?
+        course.course_options.full_time.update_all(vacancy_status: :no_vacancies)
       end
     end
 

--- a/spec/system/teacher_training_public_api/study_mode_changes_spec.rb
+++ b/spec/system/teacher_training_public_api/study_mode_changes_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe 'Sync from Teacher Training API' do
 
     when_sync_provider_is_called
     then_the_part_time_course_option_is_set_to_no_vacancies
+    and_the_full_time_course_option_is_set_to_have_vacancies
+
+    given_the_course_becomes_part_time
+    when_sync_provider_is_called
+    then_the_full_time_course_option_is_set_to_no_vacancies
+    and_then_part_time_course_option_is_set_to_have_vacancies
   end
 
   def given_there_is_a_full_time_course_on_the_teacher_training_api
@@ -70,10 +76,31 @@ RSpec.describe 'Sync from Teacher Training API' do
                                                vacancy_status: 'full_time_vacancies')
   end
 
+  def given_the_course_becomes_part_time
+    stub_teacher_training_api_course_with_site(provider_code: 'ABC',
+                                               course_code: 'ABC1',
+                                               course_attributes: [{ accredited_body_code: nil, study_mode: 'part_time' }],
+                                               site_code: 'A',
+                                               vacancy_status: 'part_time_vacancies')
+  end
+
   def then_the_part_time_course_option_is_set_to_no_vacancies
     expect(@course.course_options.count).to eq 2
-    expect(@course.course_options.last.study_mode).to eq 'part_time'
-    # All new courses are being set to having vacancies due to Find changes
-    expect(@course.course_options.last.vacancy_status).to eq 'vacancies'
+    expect(@course.course_options.part_time.last.no_vacancies?).to be true
+  end
+
+  def and_the_full_time_course_option_is_set_to_have_vacancies
+    expect(@course.course_options.count).to eq 2
+    expect(@course.course_options.full_time.last.vacancies?).to be true
+  end
+
+  def then_the_full_time_course_option_is_set_to_no_vacancies
+    expect(@course.course_options.count).to eq 2
+    expect(@course.course_options.full_time.last.no_vacancies?).to be true
+  end
+
+  def and_then_part_time_course_option_is_set_to_have_vacancies
+    expect(@course.course_options.count).to eq 2
+    expect(@course.course_options.part_time.last.vacancies?).to be true
   end
 end


### PR DESCRIPTION
## Context
When a provider changes a course mode of study, we need to close any irrelevant course_options. In other words, if a course goes from being "full time and part time" to just "part time", then the full time course option should be closed (have no vacancies).

## Changes proposed in this pull request
- Additional logic in the `TeacherTrainingPublicApi:: SyncSites` job to update course options to match the current mode of study.

## Guidance to review

Will this effect anything else?

## Link to Trello card

[Card for this task](https://trello.com/c/rAuO1EaZ)

[Course option update epic with more information](https://trello.com/c/6POpYyCZ)

## Video / Screenshots

https://github.com/DFE-Digital/apply-for-teacher-training/assets/44073106/cd76af80-f107-448b-94ec-63b9010c27d7


