### PR TITLE
[995] Reactivate our nudge emails

### DIFF
--- a/app/queries/get_incomplete_course_choice_applications_ready_to_nudge.rb
+++ b/app/queries/get_incomplete_course_choice_applications_ready_to_nudge.rb
@@ -13,11 +13,6 @@ class GetIncompleteCourseChoiceApplicationsReadyToNudge
       .with_completion(COMPLETION_ATTRS)
       .current_cycle
       .has_not_received_email(MAILER, MAIL_TEMPLATE)
-      .where(
-        'NOT EXISTS (:application_choices)',
-        application_choices: ApplicationChoice
-          .select(1)
-          .where('application_choices.application_form_id = application_forms.id'),
-      )
+      .where.missing(:application_choices)
   end
 end

--- a/app/queries/get_incomplete_personal_statement_applications_ready_to_nudge.rb
+++ b/app/queries/get_incomplete_personal_statement_applications_ready_to_nudge.rb
@@ -3,7 +3,6 @@ class GetIncompletePersonalStatementApplicationsReadyToNudge
   MAIL_TEMPLATE = 'nudge_unsubmitted_with_incomplete_personal_statement'.freeze
   COMPLETION_ATTRS = %w[
     references_completed
-    course_choices_completed
   ].freeze
   INCOMPLETION_ATTRS = %w[
     becoming_a_teacher_completed
@@ -17,5 +16,6 @@ class GetIncompletePersonalStatementApplicationsReadyToNudge
       .current_cycle
       .where(INCOMPLETION_ATTRS.map { |attr| "#{attr} = false" }.join(' AND '))
       .has_not_received_email(MAILER, MAIL_TEMPLATE)
+      .includes(:application_choices).where('application_choices.status': 'unsubmitted')
   end
 end

--- a/app/queries/get_incomplete_reference_applications_ready_to_nudge.rb
+++ b/app/queries/get_incomplete_reference_applications_ready_to_nudge.rb
@@ -16,17 +16,17 @@ class GetIncompleteReferenceApplicationsReadyToNudge
       .with_completion(COMMON_COMPLETION_ATTRS)
       .has_not_received_email(MAILER, MAIL_TEMPLATE)
       .and(ApplicationForm
-      .where(science_gcse_completed: true)
-      .or(
-        ApplicationForm.where(
-          'NOT EXISTS (:primary)',
-          primary: ApplicationChoice
-            .select(1)
-            .joins(:course)
-            .where('application_choices.application_form_id = application_forms.id')
-            .where('courses.level': 'primary'),
-        ),
-      ))
+        .where(science_gcse_completed: true)
+        .or(
+          ApplicationForm.where(
+            'NOT EXISTS (:primary)',
+            primary: ApplicationChoice
+              .select(1)
+              .joins(:course)
+              .where('application_choices.application_form_id = application_forms.id')
+              .where('courses.level': 'primary'),
+          ),
+        ))
     .and(ApplicationForm
       .where(efl_completed: true)
       .or(
@@ -37,7 +37,10 @@ class GetIncompleteReferenceApplicationsReadyToNudge
     .joins(
       "LEFT OUTER JOIN \"references\" ON \"references\".application_form_id = application_forms.id AND \"references\".feedback_status IN ('feedback_requested', 'feedback_provided')",
     )
+    .joins(
+      "LEFT OUTER JOIN \"application_choices\" ON \"application_choices\".application_form_id = application_forms.id AND \"application_choices\".status = 'unsubmitted'",
+    )
     .group('application_forms.id')
-    .having('count("references".id) < 2')
+    .having('count("references".id) < 2 AND count("application_choices".id) > 0')
   end
 end

--- a/app/queries/get_unsubmitted_applications_ready_to_nudge.rb
+++ b/app/queries/get_unsubmitted_applications_ready_to_nudge.rb
@@ -1,7 +1,7 @@
 class GetUnsubmittedApplicationsReadyToNudge
   MAILER = 'candidate_mailer'.freeze
   MAIL_TEMPLATE = 'nudge_unsubmitted'.freeze
-  COMMON_COMPLETION_ATTRS = (ApplicationForm::SECTION_COMPLETED_FIELDS - %w[science_gcse efl])
+  COMMON_COMPLETION_ATTRS = (ApplicationForm::SECTION_COMPLETED_FIELDS - %w[science_gcse efl course_choices])
     .map { |field| "#{field}_completed" }.freeze
 
   def call
@@ -16,6 +16,7 @@ class GetUnsubmittedApplicationsReadyToNudge
       .with_completion(COMMON_COMPLETION_ATTRS)
       .current_cycle
       .has_not_received_email(MAILER, MAIL_TEMPLATE)
+      .includes(:application_choices).where('application_choices.status': 'unsubmitted')
       .and(ApplicationForm
         .where(science_gcse_completed: true)
         .or(

--- a/app/workers/nudge_candidates_worker.rb
+++ b/app/workers/nudge_candidates_worker.rb
@@ -5,6 +5,11 @@ class NudgeCandidatesWorker
   Nudge = Struct.new(:query_class, :mailer_action, :feature_flag)
   NUDGES = [
     Nudge.new(
+      GetUnsubmittedApplicationsReadyToNudge,
+      :nudge_unsubmitted,
+      nil,
+    ),
+    Nudge.new(
       GetIncompleteCourseChoiceApplicationsReadyToNudge,
       :nudge_unsubmitted_with_incomplete_courses,
       nil,

--- a/spec/queries/get_incomplete_course_choice_applications_ready_to_nudge_spec.rb
+++ b/spec/queries/get_incomplete_course_choice_applications_ready_to_nudge_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe GetIncompleteCourseChoiceApplicationsReadyToNudge do
       :completed_application_form,
       :with_completed_references,
       submitted_at: nil,
-      course_choices_completed: false,
     )
     application_form.update_columns(
       updated_at: 10.days.ago,
@@ -20,12 +19,11 @@ RSpec.describe GetIncompleteCourseChoiceApplicationsReadyToNudge do
       :completed_application_form,
       :with_completed_references,
       submitted_at: nil,
-      course_choices_completed: false,
     )
+    create(:application_choice, application_form:)
     application_form.update_columns(
       updated_at: 10.days.ago,
     )
-    create(:application_choice, application_form:)
 
     expect(described_class.new.call).to eq([])
   end
@@ -35,8 +33,8 @@ RSpec.describe GetIncompleteCourseChoiceApplicationsReadyToNudge do
       :completed_application_form,
       :with_completed_references,
       submitted_at: Time.zone.now,
-      course_choices_completed: false,
     )
+    create(:application_choice, status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER.sample, application_form:)
     application_form.update_columns(
       updated_at: 10.days.ago,
     )
@@ -49,7 +47,6 @@ RSpec.describe GetIncompleteCourseChoiceApplicationsReadyToNudge do
       :completed_application_form,
       :with_completed_references,
       submitted_at: nil,
-      course_choices_completed: false,
     )
     application_form.update_columns(
       references_completed: false,
@@ -64,7 +61,6 @@ RSpec.describe GetIncompleteCourseChoiceApplicationsReadyToNudge do
       :completed_application_form,
       :with_completed_references,
       submitted_at: nil,
-      course_choices_completed: false,
     )
     application_form.update_columns(
       becoming_a_teacher_completed: false,

--- a/spec/queries/get_incomplete_personal_statement_applications_ready_to_nudge_spec.rb
+++ b/spec/queries/get_incomplete_personal_statement_applications_ready_to_nudge_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe GetIncompletePersonalStatementApplicationsReadyToNudge do
       submitted_at: nil,
       becoming_a_teacher_completed: false,
     )
+    create(:application_choice, application_form:)
     application_form.update_columns(
       updated_at: 10.days.ago,
     )
@@ -22,6 +23,7 @@ RSpec.describe GetIncompletePersonalStatementApplicationsReadyToNudge do
       becoming_a_teacher_completed: true,
       references_completed: false,
     )
+    create(:application_choice, application_form:)
     application_form.update_columns(
       updated_at: 10.days.ago,
     )
@@ -36,6 +38,7 @@ RSpec.describe GetIncompletePersonalStatementApplicationsReadyToNudge do
       submitted_at: nil,
       becoming_a_teacher_completed: true,
     )
+    create(:application_choice, application_form:)
     application_form.update_columns(
       updated_at: 8.days.ago,
     )
@@ -50,6 +53,7 @@ RSpec.describe GetIncompletePersonalStatementApplicationsReadyToNudge do
       submitted_at: nil,
       becoming_a_teacher_completed: false,
     )
+    create(:application_choice, application_form:)
     application_form.update_columns(
       updated_at: 6.days.ago,
     )
@@ -63,7 +67,6 @@ RSpec.describe GetIncompletePersonalStatementApplicationsReadyToNudge do
       :with_completed_references,
       submitted_at: nil,
       becoming_a_teacher_completed: false,
-      course_choices_completed: false,
     )
     application_form.update_columns(
       updated_at: 10.days.ago,
@@ -79,6 +82,7 @@ RSpec.describe GetIncompletePersonalStatementApplicationsReadyToNudge do
       submitted_at: nil,
       becoming_a_teacher_completed: false,
     )
+    create(:application_choice, application_form:)
     application_form.update_columns(
       updated_at: 10.days.ago,
     )

--- a/spec/queries/get_incomplete_reference_applications_ready_to_nudge_spec.rb
+++ b/spec/queries/get_incomplete_reference_applications_ready_to_nudge_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
       submitted_at: nil,
       references_count: 0,
     )
+    create(:application_choice, application_form:)
     application_form.update_columns(
       updated_at: 10.days.ago,
     )
@@ -21,6 +22,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
       references_count: 1,
       references_state: :feedback_requested,
     )
+    create(:application_choice, application_form:)
     application_form.update_columns(
       updated_at: 10.days.ago,
     )
@@ -35,6 +37,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
       references_count: 1,
       references_state: :feedback_provided,
     )
+    create(:application_choice, application_form:)
     application_form.update_columns(
       updated_at: 10.days.ago,
     )
@@ -49,6 +52,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
       references_count: 2,
       references_state: :feedback_requested,
     )
+    create(:application_choice, application_form:)
     application_form.update_columns(
       updated_at: 10.days.ago,
     )
@@ -62,6 +66,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
       submitted_at: 10.days.ago,
       references_count: 0,
     )
+    create(:application_choice, status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER.sample, application_form:)
     application_form.update_columns(updated_at: 10.days.ago)
 
     expect(described_class.new.call).to eq([])
@@ -73,6 +78,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
       submitted_at: nil,
       references_count: 0,
     )
+    create(:application_choice, application_form:)
     application_form.update_columns(
       personal_details_completed: false,
       updated_at: 10.days.ago,
@@ -87,6 +93,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
       submitted_at: nil,
       references_count: 0,
     )
+    create(:application_choice, application_form:)
     application_form.update_columns(
       updated_at: 5.days.ago,
     )
@@ -102,6 +109,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
       efl_completed: false,
       references_count: 0,
     )
+    create(:application_choice, application_form:)
     application_form.update_columns(
       updated_at: 10.days.ago,
     )
@@ -117,6 +125,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
       efl_completed: false,
       references_count: 0,
     )
+    create(:application_choice, application_form:)
     application_form.update_columns(
       updated_at: 10.days.ago,
     )
@@ -179,6 +188,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
       recruitment_cycle_year: RecruitmentCycle.previous_year,
       references_count: 0,
     )
+    create(:application_choice, application_form:)
     application_form.update_columns(
       updated_at: 10.days.ago,
     )
@@ -192,12 +202,26 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
       submitted_at: nil,
       references_count: 0,
     )
+    create(:application_choice, application_form:)
     application_form.update_columns(updated_at: 10.days.ago)
     create(
       :email,
       mailer: 'candidate_mailer',
       mail_template: 'nudge_unsubmitted_with_incomplete_references',
       application_form:,
+    )
+
+    expect(described_class.new.call).to eq([])
+  end
+
+  it 'omits applications without application choices' do
+    application_form = create(
+      :completed_application_form,
+      submitted_at: nil,
+      references_count: 0,
+    )
+    application_form.update_columns(
+      updated_at: 10.days.ago,
     )
 
     expect(described_class.new.call).to eq([])
@@ -219,6 +243,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
       recruitment_cycle_year: RecruitmentCycle.current_year,
       references_count: 0,
     )
+    create(:application_choice, application_form: application_form2)
     application_form2.update_columns(
       updated_at: 10.days.ago,
     )

--- a/spec/queries/get_unsubmitted_applications_ready_to_nudge_spec.rb
+++ b/spec/queries/get_unsubmitted_applications_ready_to_nudge_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe GetUnsubmittedApplicationsReadyToNudge do
       :with_completed_references,
       submitted_at: nil,
     )
+    create(:application_choice, application_form:)
     application_form.update_columns(updated_at: 10.days.ago)
 
     expect(described_class.new.call).to include(application_form)
@@ -18,6 +19,7 @@ RSpec.describe GetUnsubmittedApplicationsReadyToNudge do
       :with_completed_references,
       submitted_at: 10.days.ago,
     )
+    create(:application_choice, status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER.sample, application_form:)
     application_form.update_columns(updated_at: 10.days.ago)
 
     expect(described_class.new.call).to eq([])
@@ -29,6 +31,7 @@ RSpec.describe GetUnsubmittedApplicationsReadyToNudge do
       :with_completed_references,
       submitted_at: nil,
     )
+    create(:application_choice, application_form:)
     application_form.update_columns(
       references_completed: false,
       updated_at: 10.days.ago,
@@ -43,6 +46,7 @@ RSpec.describe GetUnsubmittedApplicationsReadyToNudge do
       :with_completed_references,
       submitted_at: nil,
     )
+    create(:application_choice, application_form:)
     application_form.update_columns(
       updated_at: 5.days.ago,
     )
@@ -58,6 +62,7 @@ RSpec.describe GetUnsubmittedApplicationsReadyToNudge do
       first_nationality: 'British',
       efl_completed: false,
     )
+    create(:application_choice, application_form:)
     application_form.update_columns(
       updated_at: 10.days.ago,
     )
@@ -73,6 +78,7 @@ RSpec.describe GetUnsubmittedApplicationsReadyToNudge do
       first_nationality: 'French',
       efl_completed: false,
     )
+    create(:application_choice, application_form:)
     application_form.update_columns(
       updated_at: 10.days.ago,
     )
@@ -155,6 +161,19 @@ RSpec.describe GetUnsubmittedApplicationsReadyToNudge do
       mail_template: 'nudge_unsubmitted',
       application_form:,
     )
+
+    expect(described_class.new.call).to eq([])
+  end
+
+  it 'omits applications without draft course choices' do
+    application_form = create(
+      :completed_application_form,
+      :with_completed_references,
+      submitted_at: nil,
+      first_nationality: 'British',
+      efl_completed: false,
+    )
+    application_form.update_columns(updated_at: 10.days.ago)
 
     expect(described_class.new.call).to eq([])
   end


### PR DESCRIPTION
## Context

One nudge email was disabled in the post-continuous applications world. 
Others have stopped working because they relied on a bool that no longer gets updated.
Our data showed that these had a (more than) modest impact on candidate engagement, including submission and offers.

## Changes proposed in this pull request
- Reinstate the `nudge_submitted` emails
- Remove the reliance on the `course_choices_completed` bool for determining if application_choices exist in the other nudges.

## Guidance to review


## Link to Trello card

https://trello.com/c/EBxd9DgU

