### PR TITLE
[1435] Correct heading style for degree review page

### DIFF
--- a/app/views/candidate_interface/degrees/review/show.html.erb
+++ b/app/views/candidate_interface/degrees/review/show.html.erb
@@ -5,9 +5,9 @@
   <%= f.govuk_error_summary %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <fieldset class="govuk-fieldset govuk-fieldset__legend--l">
+      <h1 class="govuk-heading-xl">
         <%= t('page_titles.degree') %>
-      </fieldset>
+      </h1>
 
       <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application: @application_form) %>
 


### PR DESCRIPTION
## Context

We aren't using a heading style for the heading on the degrees review page.

## Changes proposed in this pull request

| Before    | After    |
| -------- | ------- |
| ![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/44073106/d9e2bceb-e3ef-4948-abde-045924c7cedf)  | ![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/44073106/74b31b40-1908-4c78-9f89-bfd85955b119)   |

## Guidance to review


## Link to Trello card

https://trello.com/c/QpiVK8JR

