### PR TITLE
Bug fix: Add reached_reapplication_limit to non-editable path list

### DIFF
--- a/app/forms/candidate_interface/continuous_applications/concerns/course_selection_step_helper.rb
+++ b/app/forms/candidate_interface/continuous_applications/concerns/course_selection_step_helper.rb
@@ -5,7 +5,7 @@ module CandidateInterface
         delegate :application_choice, to: :store
 
         def next_edit_step_path(next_step_klass)
-          return next_step_path(next_step_klass) if next_step == :course_review
+          return next_step_path(next_step_klass) if %i[course_review reached_reapplication_limit].include?(next_step)
 
           route_name = next_step_klass.model_name.singular_route_key
           url_helpers.public_send(

--- a/app/forms/candidate_interface/continuous_applications/concerns/course_selection_step_helper.rb
+++ b/app/forms/candidate_interface/continuous_applications/concerns/course_selection_step_helper.rb
@@ -5,7 +5,7 @@ module CandidateInterface
         delegate :application_choice, to: :store
 
         def next_edit_step_path(next_step_klass)
-          return next_step_path(next_step_klass) if %i[course_review reached_reapplication_limit].include?(next_step)
+          return next_step_path(next_step_klass) if next_step.in?(%i[course_review reached_reapplication_limit])
 
           route_name = next_step_klass.model_name.singular_route_key
           url_helpers.public_send(

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_changes_course_and_reaches_limit_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_changes_course_and_reaches_limit_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.feature 'Changing a course' do
+  include CandidateHelper
+
+  it 'Candidate changes course to one they have already been rejected from twice' do
+    given_i_am_signed_in
+    and_there_are_course_options
+    and_i_have_two_rejected_application_to_a_course
+
+    when_i_visit_the_site
+    and_i_click_on_course_choices
+    and_i_choose_that_i_know_where_i_want_to_apply
+    and_i_choose_the_same_provider
+    then_i_see_the_courses_and_their_descriptions
+
+    when_i_choose_a_different_course
+    and_i_return_to_the_course_selection_for_application
+    and_i_choose_the_rejected_course
+    then_i_am_on_the_reached_reapplication_limit_page
+  end
+
+  def given_i_am_signed_in
+    @candidate = create(:candidate)
+    create_and_sign_in_candidate(candidate: @candidate)
+  end
+
+  def and_there_are_course_options
+    @provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
+    @course = create(:course, :open_on_apply, name: 'Primary', code: '2XT2', provider: @provider)
+    create(:course_option, course: @course)
+    @another_course = create(:course, :open_on_apply, name: 'Primary with Science', code: '4MM5', provider: @provider)
+    create(:course_option, course: @another_course)
+  end
+
+  def and_i_have_two_rejected_application_to_a_course
+    create(:application_choice, :rejected, course_option: @course.course_options.first, application_form: @candidate.current_application)
+    create(:application_choice, :rejected, course_option: @course.course_options.first, application_form: @candidate.current_application)
+  end
+
+  def and_i_choose_the_same_provider
+    select 'Gorse SCITT (1N1)'
+    click_link_or_button t('continue')
+  end
+
+  def and_i_click_on_course_choices
+    click_link_or_button 'Your application'
+    click_link_or_button 'Add application'
+  end
+
+  def and_i_choose_that_i_know_where_i_want_to_apply
+    choose 'Yes, I know where I want to apply'
+    click_link_or_button t('continue')
+  end
+
+  def then_i_see_the_courses_and_their_descriptions
+    expect(page).to have_content(@course.name_and_code)
+    expect(page).to have_content(@course.description)
+    expect(page).to have_content(@another_course.name_and_code)
+    expect(page).to have_content(@another_course.description)
+  end
+
+  def when_i_choose_a_different_course
+    choose 'Primary with Science (4MM5)'
+    click_link_or_button t('continue')
+  end
+
+  def and_i_return_to_the_course_selection_for_application
+    click_on 'Change'
+  end
+
+  def and_i_choose_the_rejected_course
+    choose 'Primary (2XT2)'
+    click_link_or_button t('continue')
+  end
+
+  def then_i_am_on_the_reached_reapplication_limit_page
+    expect(page.current_url).to end_with(candidate_interface_continuous_applications_reached_reapplication_limit_path(provider_id: @provider.id, course_id: @course.id))
+  end
+
+  def when_i_visit_the_site
+    visit candidate_interface_continuous_applications_details_path
+  end
+end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_changes_course_and_reaches_limit_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_changes_course_and_reaches_limit_spec.rb
@@ -6,16 +6,16 @@ RSpec.feature 'Changing a course' do
   it 'Candidate changes course to one they have already been rejected from twice' do
     given_i_am_signed_in
     and_there_are_course_options
-    and_i_have_two_rejected_application_to_a_course
+    and_i_have_two_rejected_applications_to_a_course
 
-    when_i_visit_the_site
-    and_i_click_on_course_choices
+    when_i_visit_my_details_page
+    and_i_add_another_application
     and_i_choose_that_i_know_where_i_want_to_apply
     and_i_choose_the_same_provider
     then_i_see_the_courses_and_their_descriptions
 
     when_i_choose_a_different_course
-    and_i_return_to_the_course_selection_for_application
+    and_i_return_to_the_course_selection_page
     and_i_choose_the_rejected_course
     then_i_am_on_the_reached_reapplication_limit_page
   end
@@ -33,7 +33,7 @@ RSpec.feature 'Changing a course' do
     create(:course_option, course: @another_course)
   end
 
-  def and_i_have_two_rejected_application_to_a_course
+  def and_i_have_two_rejected_applications_to_a_course
     create(:application_choice, :rejected, course_option: @course.course_options.first, application_form: @candidate.current_application)
     create(:application_choice, :rejected, course_option: @course.course_options.first, application_form: @candidate.current_application)
   end
@@ -43,7 +43,7 @@ RSpec.feature 'Changing a course' do
     click_link_or_button t('continue')
   end
 
-  def and_i_click_on_course_choices
+  def and_i_add_another_application
     click_link_or_button 'Your application'
     click_link_or_button 'Add application'
   end
@@ -65,7 +65,7 @@ RSpec.feature 'Changing a course' do
     click_link_or_button t('continue')
   end
 
-  def and_i_return_to_the_course_selection_for_application
+  def and_i_return_to_the_course_selection_page
     click_on 'Change'
   end
 
@@ -78,7 +78,7 @@ RSpec.feature 'Changing a course' do
     expect(page.current_url).to end_with(candidate_interface_continuous_applications_reached_reapplication_limit_path(provider_id: @provider.id, course_id: @course.id))
   end
 
-  def when_i_visit_the_site
+  def when_i_visit_my_details_page
     visit candidate_interface_continuous_applications_details_path
   end
 end


### PR DESCRIPTION
## Context
[Sentry Error](https://dfe-teacher-services.sentry.io/issues/5076372603/?referrer=slack&notification_uuid=971019e9-c997-4394-8c13-6f070096924a&alert_rule_id=853774&alert_type=issue)

### Steps to recreate

- Login as a candidate that has been rejected twice for the same course
- Create a new application choice,
- Chose a different course (same provider) and click continue
- Change the course to the original (already been rejected) course
- You’ll get an error

### Expected behaviour
GIVEN I am a candidate who has been rejected twice from a course
AND I create a new application choice with a *different* course from the *same* provider. 
WHEN I edit the course selection
AND I chose the original course, that I've already been rejected from
THEN I see the reapplication error page

## Changes proposed in this pull request

- Added `reached_reapplication_limit` to the list of non-editable paths. 
- Spec covering this scenarios

## Guidance to review


## Link to Trello card

[Trello Card](https://trello.com/c/yv6e8Zti/1439-course-already-applied-when-candidate-changes-their-course?filter=member:baileylori) 

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
