### PR TITLE
Add kubectl to .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -8,3 +8,4 @@ terraform 1.7.4
 redis 7.0.12
 postgres 14.7
 kubelogin 0.1.0
+kubectl 1


### PR DESCRIPTION
## Context

Kubectl is needed to connect to the pods. Why not add it to tool versions.

use any 1.* version

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Is the version restriction suffcient?
