### PR TITLE
Add link to provider on provider users support page

### DIFF
--- a/app/components/support_interface/provider_user_permissions_summary_component.rb
+++ b/app/components/support_interface/provider_user_permissions_summary_component.rb
@@ -23,7 +23,7 @@ module SupportInterface
       else
         permissions.map do |permission|
           {
-            key: permission.provider.name_and_code,
+            key: "#{permission.provider.name_and_code}<br><br>(#{govuk_link_to('Provider permissions', support_interface_provider_relationships_path(permission.provider))})".html_safe,
             value: render(SupportInterface::PermissionsListComponent.new(permission)),
             actions: [
               {

--- a/spec/components/previews/support_interface/provider_user_permissions_summary_component_preview.rb
+++ b/spec/components/previews/support_interface/provider_user_permissions_summary_component_preview.rb
@@ -1,0 +1,9 @@
+module SupportInterface
+  class ProviderUserPermissionsSummaryComponentPreview < ViewComponent::Preview
+    def provider_user_permission_summary
+      provider_user = ProviderUserNotificationPreferences.limit(10).sample.provider_user
+
+      render SupportInterface::ProviderUserPermissionsSummaryComponent.new(provider_user)
+    end
+  end
+end

--- a/spec/components/support_interface/provider_user_permissions_summary_component_spec.rb
+++ b/spec/components/support_interface/provider_user_permissions_summary_component_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SupportInterface::ProviderUserPermissionsSummaryComponent do
 
     rendered_component = render_inline(described_class.new(provider_user))
 
-    expect(rendered_component.css('.govuk-summary-list__key').text).to eq("#{another_provider.name_and_code}#{provider.name_and_code}")
+    expect(rendered_component.css('.govuk-summary-list__key').text).to eq("#{another_provider.name_and_code}(Provider permissions)#{provider.name_and_code}(Provider permissions)")
   end
 
   it 'renders an empty state when there are no permissions' do


### PR DESCRIPTION
## Context

Add useful link from ProviderUser in SupportInterface to the page showing the Providers Relationship permissions.



## Changes proposed in this pull request

![linkprovider](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/c9d0cfb5-dd65-4d56-9474-dd44b176112f)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
