### PR TITLE
Add descriptive error to change course

### DIFF
--- a/app/controllers/provider_interface/courses_controller.rb
+++ b/app/controllers/provider_interface/courses_controller.rb
@@ -18,9 +18,9 @@ module ProviderInterface
           flash[:success] = t('.success')
         rescue IdenticalCourseError
           @wizard.clear_state!
-          flash[:warning] = t('.failure')
+          flash[:warning] = [t('.failure'), 'the candidate has already applied to this course']
         rescue ExistingCourseError
-          flash[:warning] = t('.failure')
+          flash[:warning] = [t('.failure'), 'the candidate has already added this course to their application form']
         end
       else
         @wizard.clear_state!

--- a/app/controllers/provider_interface/courses_controller.rb
+++ b/app/controllers/provider_interface/courses_controller.rb
@@ -18,9 +18,9 @@ module ProviderInterface
           flash[:success] = t('.success')
         rescue IdenticalCourseError
           @wizard.clear_state!
-          flash[:warning] = [t('.failure'), 'the candidate has already applied to this course']
+          flash[:warning] = [t('.failure.title'), t('.failure.identical_course')]
         rescue ExistingCourseError
-          flash[:warning] = [t('.failure'), 'the candidate has already added this course to their application form']
+          flash[:warning] = [t('.failure.title'), t('.failure.existing_course')]
         end
       else
         @wizard.clear_state!

--- a/config/locales/provider_interface/change_course.yml
+++ b/config/locales/provider_interface/change_course.yml
@@ -24,7 +24,10 @@ en:
           submit: Update course
       update:
         success: Course updated
-        failure: Course not updated
+        failure:
+          title: The course could not be changed
+          identical_course: The candidate has already applied to the course you are trying to move them on to.
+          existing_course: The candidate is already applying to the course you are trying to move them on to.
   activemodel:
     errors:
       models:

--- a/spec/system/provider_interface/change_course/provider_can_change_course_of_interviewing_application_spec.rb
+++ b/spec/system/provider_interface/change_course/provider_can_change_course_of_interviewing_application_spec.rb
@@ -90,7 +90,6 @@ RSpec.feature 'Provider changes a course' do
 
     create(:provider_permissions, provider: @target_provider, provider_user: @provider_user, make_decisions: true, set_up_interviews: true)
 
-    binding.pry
     courses = [create(:course, study_mode: :full_time_or_part_time, provider: @target_provider, accredited_provider: @ratifying_provider),
                create(:course, :open, study_mode: :full_time_or_part_time, provider: @target_provider, accredited_provider: @ratifying_provider)]
     @target_course = courses.sample

--- a/spec/system/provider_interface/change_course/provider_can_change_course_of_interviewing_application_spec.rb
+++ b/spec/system/provider_interface/change_course/provider_can_change_course_of_interviewing_application_spec.rb
@@ -4,7 +4,19 @@ RSpec.feature 'Provider changes a course' do
   include DfESignInHelpers
   include ProviderUserPermissionsHelper
 
-  scenario 'Changing a course choice before point of offer' do
+  # Create 3 providers
+  # -- Permissions
+  # 1. Provider user is only directly associated with one (@source_provider)
+  # 2. Provider user has 'decisions' and 'interviews' permissions on the @target_provider
+  # 3. The provider user can change the course of a candidate from the provider
+  #    they are directly associated with to another provider which they have been
+  #    given permissions on
+  #
+  # -- What is being tested in the UI
+  # 1. Test that the provider user can change the provider, course, study_mode and location from @source_provider to @target_provider
+  # 2. Also demonstrate that the provider user can start the change from the course level
+  #
+  scenario 'Changing an interviewing application course' do
     given_i_am_a_provider_user
     and_i_am_permitted_to_make_decisions_for_my_provider
     and_i_sign_in_to_the_provider_interface
@@ -62,45 +74,50 @@ RSpec.feature 'Provider changes a course' do
   end
 
   def and_the_provider_user_can_offer_multiple_provider_courses
-    @selected_provider = create(:provider)
+    @target_provider = create(:provider)
 
-    @provider = @provider_user.providers.first
+    @source_provider = @provider_user.providers.first
     @ratifying_provider = create(:provider)
-    @course = build(:course, :full_time, provider: @provider, accredited_provider: @ratifying_provider)
+
+    @course = build(:course, :full_time, provider: @source_provider, accredited_provider: @ratifying_provider)
     @course_option = build(:course_option, course: @course)
+
     @application_form = build(:application_form, :minimum_info)
 
     @application_choice = create(:application_choice, :awaiting_provider_decision,
                                  application_form: @application_form,
                                  course_option: @course_option)
-    create(:provider_permissions, provider: @selected_provider, provider_user: @provider_user, make_decisions: true, set_up_interviews: true)
-    courses = [create(:course, study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: @ratifying_provider),
-               create(:course, :open, study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: @ratifying_provider)]
-    @selected_course = courses.sample
 
-    @one_mode_and_location_course = create(:course, :open, study_mode: :full_time, provider: @selected_provider, accredited_provider: @ratifying_provider)
+    create(:provider_permissions, provider: @target_provider, provider_user: @provider_user, make_decisions: true, set_up_interviews: true)
+
+    binding.pry
+    courses = [create(:course, study_mode: :full_time_or_part_time, provider: @target_provider, accredited_provider: @ratifying_provider),
+               create(:course, :open, study_mode: :full_time_or_part_time, provider: @target_provider, accredited_provider: @ratifying_provider)]
+    @target_course = courses.sample
+
+    @one_mode_and_location_course = create(:course, :open, study_mode: :full_time, provider: @target_provider, accredited_provider: @ratifying_provider)
     @one_mode_and_location_course_option = create(:course_option, :full_time, site: create(:site, provider: @one_mode_and_location_course.provider), course: @one_mode_and_location_course)
 
-    course_options = [create(:course_option, :part_time, course: @selected_course),
-                      create(:course_option, :full_time, course: @selected_course),
-                      create(:course_option, :full_time, course: @selected_course),
-                      create(:course_option, :part_time, course: @selected_course)]
+    course_options = [create(:course_option, :part_time, course: @target_course),
+                      create(:course_option, :full_time, course: @target_course),
+                      create(:course_option, :full_time, course: @target_course),
+                      create(:course_option, :part_time, course: @target_course)]
 
     create(
       :provider_relationship_permissions,
-      training_provider: @provider,
+      training_provider: @source_provider,
       ratifying_provider: @ratifying_provider,
       ratifying_provider_can_make_decisions: true,
     )
 
     create(
       :provider_relationship_permissions,
-      training_provider: @selected_provider,
+      training_provider: @target_provider,
       ratifying_provider: @ratifying_provider,
       ratifying_provider_can_make_decisions: true,
     )
 
-    @selected_course_option = course_options.sample
+    @target_course_option = course_options.sample
   end
 
   def when_i_visit_the_provider_interface
@@ -123,7 +140,7 @@ RSpec.feature 'Provider changes a course' do
   end
 
   def when_i_select_a_different_provider
-    choose @selected_provider.name_and_code
+    choose @target_provider.name_and_code
   end
 
   def and_i_click_continue
@@ -140,7 +157,7 @@ RSpec.feature 'Provider changes a course' do
   alias_method :then_i_am_taken_to_the_change_course_page, :then_i_see_a_list_of_courses_to_select_from
 
   def when_i_select_a_different_course
-    choose @selected_course.name_and_code
+    choose @target_course.name_and_code
   end
 
   def then_i_dont_see_the_study_mode_page
@@ -155,7 +172,7 @@ RSpec.feature 'Provider changes a course' do
   end
 
   def when_i_select_a_study_mode
-    choose @selected_course_option.study_mode.humanize
+    choose @target_course_option.study_mode.humanize
   end
 
   def then_i_am_taken_to_the_change_location_page
@@ -164,7 +181,7 @@ RSpec.feature 'Provider changes a course' do
   end
 
   def when_i_select_a_new_location
-    choose @selected_course_option.site_name
+    choose @target_course_option.site_name
   end
 
   def and_i_select_a_new_location
@@ -177,9 +194,6 @@ RSpec.feature 'Provider changes a course' do
   end
 
   def when_i_click_change_course
-    @selected_course = @provider_available_course
-    @selected_course_option = @provider_available_course_option
-
     within(all('.govuk-summary-list__row')[1]) do
       click_link_or_button 'Change'
     end

--- a/spec/system/provider_interface/change_course/provider_cannot_change_course_of_recruited_application_spec.rb
+++ b/spec/system/provider_interface/change_course/provider_cannot_change_course_of_recruited_application_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.feature 'Provider changes a course' do
+  include DfESignInHelpers
+  include ProviderUserPermissionsHelper
+
+  scenario 'Provider cannot change the course for recruited application' do
+    given_i_am_a_provider_user
+    and_i_am_permitted_to_make_decisions_for_my_provider
+    and_i_sign_in_to_the_provider_interface
+    and_the_provider_user_can_offer_multiple_provider_courses
+
+    when_i_visit_the_provider_interface
+    and_i_click_an_application_choice_that_is_recruited
+    then_i_cannot_change_the_course
+  end
+
+  def given_i_am_a_provider_user
+    @provider_user = create(:provider_user, :with_dfe_sign_in, :with_set_up_interviews)
+    user_exists_in_dfe_sign_in(email_address: @provider_user.email_address)
+  end
+
+  def and_i_am_permitted_to_make_decisions_for_my_provider
+    permit_make_decisions!
+  end
+
+  def and_i_sign_in_to_the_provider_interface
+    provider_signs_in_using_dfe_sign_in
+  end
+
+  def and_the_provider_user_can_offer_multiple_provider_courses
+    @provider = @provider_user.providers.first
+
+    @ratifying_provider = create(:provider)
+
+    @course = build(:course, :full_time, provider: @provider, accredited_provider: @ratifying_provider)
+
+    @course_option = build(:course_option, course: @course)
+    @recruited_application_choice = create(:application_choice, :with_completed_application_form, :recruited, course_option: @course_option)
+
+    create(
+      :provider_relationship_permissions,
+      training_provider: @provider,
+      ratifying_provider: @ratifying_provider,
+      ratifying_provider_can_make_decisions: true,
+    )
+  end
+
+  def when_i_visit_the_provider_interface
+    visit provider_interface_applications_path
+  end
+
+  def and_i_click_an_application_choice_that_is_recruited
+    click_link_or_button @recruited_application_choice.application_form.full_name
+  end
+
+  def then_i_cannot_change_the_course
+    within('[data-qa="course-details"]') do
+      expect(page).to have_no_content 'Change'
+    end
+  end
+
+  def then_i_dont_see_the_study_mode_page
+    expect(page.current_url).not_to include 'study-modes'
+  end
+
+  def and_i_select_a_new_location
+    choose @one_mode_course_options.site_name
+  end
+end

--- a/spec/system/provider_interface/provider_changes_a_course_before_point_of_offer_spec.rb
+++ b/spec/system/provider_interface/provider_changes_a_course_before_point_of_offer_spec.rb
@@ -17,17 +17,12 @@ RSpec.feature 'Provider changes a course' do
     build(:course, :full_time, provider:, accredited_provider: ratifying_provider)
   end
   let(:course_option) { build(:course_option, course:) }
-  let!(:recruited_application_choice) { create(:application_choice, :with_completed_application_form, :recruited, course_option:) }
 
   scenario 'Changing a course choice before point of offer' do
     given_i_am_a_provider_user
     and_i_am_permitted_to_make_decisions_for_my_provider
     and_i_sign_in_to_the_provider_interface
     and_the_provider_user_can_offer_multiple_provider_courses
-
-    when_i_visit_the_provider_interface
-    and_i_click_an_application_choice_that_is_recruited
-    then_i_cannot_change_the_course
 
     when_i_visit_the_provider_interface
     and_i_click_an_application_choice_that_is_interviewing
@@ -117,16 +112,6 @@ RSpec.feature 'Provider changes a course' do
 
   def and_i_click_an_application_choice_that_is_interviewing
     click_link_or_button application_choice.application_form.full_name
-  end
-
-  def and_i_click_an_application_choice_that_is_recruited
-    click_link_or_button recruited_application_choice.application_form.full_name
-  end
-
-  def then_i_cannot_change_the_course
-    within('[data-qa="course-details"]') do
-      expect(page).to have_no_content 'Change'
-    end
   end
 
   def and_i_click_on_change_the_training_provider


### PR DESCRIPTION
## Context

Providers sometimes can't understand why when they try to move a candidate from one course to another course (which the candidate is already applied, or the candidate already has the course on their application form) causes an error.

Add more explicit error message in this scenario.

There is an argument which says we should not offer a duplicate course as an option to the provider when they are changing  a candidates course.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review


![already_applied](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/607f1b22-05b4-4362-96e2-2dfd1d404e16)


## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
