### PR TITLE
[1438] Bug fix: Initialise english_proficiency if doesn't exist on edit

### DIFF
--- a/app/controllers/candidate_interface/english_foreign_language/start_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/start_controller.rb
@@ -6,7 +6,7 @@ module CandidateInterface
       end
 
       def edit
-        @start_form = EnglishForeignLanguage::StartForm.new.fill(current_application.english_proficiency)
+        @start_form = EnglishForeignLanguage::StartForm.new.fill(current_application.english_proficiency || current_application.build_english_proficiency)
         @return_to = return_to_after_edit(default: candidate_interface_english_foreign_language_review_path)
       end
 

--- a/spec/system/candidate_interface/entering_details/candidate_updating_english_proficiency_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_updating_english_proficiency_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate updating english proficiency' do
+  include CandidateHelper
+
+  scenario 'When application form does not have an english proficiency associations' do
+    given_i_am_signed_in_as_a_candidate
+    and_i_do_not_have_an_english_proficiency_attached_to_my_application_form
+    when_i_visit_the_english_proficiency_edit_path
+    then_i_am_able_to_create_an_english_proficiency_record
+  end
+
+  def given_i_am_signed_in_as_a_candidate
+    create_and_sign_in_candidate
+  end
+
+  def and_i_do_not_have_an_english_proficiency_attached_to_my_application_form
+    create(:completed_application_form, candidate: current_candidate)
+    expect(current_candidate.current_application.english_proficiency).to be_nil
+  end
+
+  def when_i_visit_the_english_proficiency_edit_path
+    visit candidate_interface_english_foreign_language_edit_start_path(current_candidate)
+  end
+
+  def then_i_am_able_to_create_an_english_proficiency_record
+    choose 'Yes'
+    complete_efl_form_with_ielts_details
+    expect(current_candidate.current_application.english_proficiency).not_to be_nil
+  end
+
+  def complete_efl_form_with_ielts_details
+    choose 'Yes'
+    click_on 'Continue'
+    choose 'International English Language Testing System (IELTS)'
+    click_on 'Continue'
+    fill_in 'Test report form (TRF) number', with: '02GB0674SOOM599A'
+    fill_in 'Overall band score', with: '7.5'
+    fill_in 'When did you complete the assessment?', with: '2020'
+    click_on 'Save and continue'
+    choose 'Yes, I have completed this section'
+    click_on 'Continue'
+  end
+end


### PR DESCRIPTION
## Context
**Sentry error**: https://dfe-teacher-services.sentry.io/issues/4331005649/?referrer=slack&notification_uuid=8b2a7ac5-0cb5-43bb-b541-b38baecd420a&alert_rule_id=853774&alert_type=issue

This error has affected four users, each had an application rolled over from August 2023 where efl_completed is true, but who have no associated english_proficiency record.

I have not been able to replicate the error exactly, in the sense that I haven’t been able to click through and make the error happen. But if I go directly to the edit english_proficieny link (candidate/application/english-as-a-foreign-language/edit), then I can recreate / fix the error.

## Changes proposed in this pull request
- Instantiate a new english_proficiency record when candidate user tries to edit one that doesn't exist.
- Specs

## Guidance to review
Any other implications that I don't understand? 

## Link to Trello card

https://trello.com/c/lYLUR9HX

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
