### PR TITLE
Add a document to outline the various Apply APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Regenerate this diagram with `bundle exec rake erd`.
 
 [See detailed documentation here](docs/states.md)
 
+### Apply APIs
+
+This app provides several APIs for programmatic access to the Apply service. [Read about them here](/docs/apply-apis.md).
+
 ## Dependencies
 
 ### Production dependencies

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ A service for candidates to [apply for teacher training](https://www.apply-for-t
 
 ## Live environments
 
-| Name       | URL                                                                  | Description                                                          | AKS namespace    | PaaS application |
-| ---------- | -------------------------------------------------------------------- | -------------------------------------------------------------------- | ------------- |----------------- |
-| Production | [www](https://www.apply-for-teacher-training.service.gov.uk)         | Public site                                                          | `bat-production`    | `apply-prod`     |
-| Sandbox    | [sandbox](https://sandbox.apply-for-teacher-training.service.gov.uk) | Demo environment for software vendors who integrate with our API     | `bat-production`    | `apply-sandbox`  |
-| Staging    | [staging](https://staging.apply-for-teacher-training.service.gov.uk) | For internal use by DfE to test deploys                              | `bat-staging` | `apply-staging`  |
-| QA         | [qa](https://qa.apply-for-teacher-training.service.gov.uk)           | For internal use by DfE for testing. Automatically deployed from main| `bat-qa`      | `apply-qa`       |
+| Name       | URL                                                                  | Description                                                           | AKS namespace    | PaaS application |
+| ---------- | -------------------------------------------------------------------- | --------------------------------------------------------------------- | ---------------- | ---------------- |
+| Production | [www](https://www.apply-for-teacher-training.service.gov.uk)         | Public site                                                           | `bat-production` | `apply-prod`     |
+| Sandbox    | [sandbox](https://sandbox.apply-for-teacher-training.service.gov.uk) | Demo environment for software vendors who integrate with our API      | `bat-production` | `apply-sandbox`  |
+| Staging    | [staging](https://staging.apply-for-teacher-training.service.gov.uk) | For internal use by DfE to test deploys                               | `bat-staging`    | `apply-staging`  |
+| QA         | [qa](https://qa.apply-for-teacher-training.service.gov.uk)           | For internal use by DfE for testing. Automatically deployed from main | `bat-qa`         | `apply-qa`       |
 
 ## Table of Contents
 
@@ -73,7 +73,6 @@ Regenerate this diagram with `bundle exec rake erd`.
 
 [See detailed documentation here](docs/states.md)
 
-
 ## Dependencies
 
 ### Production dependencies
@@ -131,7 +130,7 @@ Once those dependencies are installed, run `bundle install` to install required 
 1. Start the postgres service: `sudo service postgresql start` on Linux or `brew services start postgresql` on Mac
 1. Populate the `DB_` relevant environment variables with the correct values (those are: `DB_USERNAME`, `DB_PASSWORD`, `DB_HOSTNAME` and `DB_PORT`)
 1. Then local development databases and data can be set up: `bundle exec rake db:setup`
-(You may wish to [set up development data](#development-data) at this point)
+   (You may wish to [set up development data](#development-data) at this point)
 
 #### Running the app
 

--- a/docs/apply-apis.md
+++ b/docs/apply-apis.md
@@ -1,0 +1,46 @@
+# Apply APIs
+
+The Apply service has four different APIs, each of which cater for different audiences and use cases.
+
+1. [Candidate API](#candidate-api)
+2. [Data API](#data-api)
+3. [Register API](#register-api)
+4. [Vendor API](#vendor-api)
+
+## Candidate API
+
+📖 [Candidate API docs](https://www.apply-for-teacher-training.service.gov.uk/candidate-api)
+<br>
+🔐 Authenticate with [ServiceAPIUser](/app/models/service_api_user.rb)
+
+The Candidate API provides candidate information to other services. It's currently only used by the CRM team in Get Into Teaching (GIT).
+
+## Data API
+
+📖 [Data API docs](https://www.apply-for-teacher-training.service.gov.uk/data-api)
+<br>
+🔐 Authenticate with [ServiceAPIUser](/app/models/service_api_user.rb)
+
+The Data API provides data extracts and reporting about the Apply service. Responses are in CSV format. It's used by the Teacher Analysis Division (TAD) team.
+
+## Register API
+
+📖 [Register API docs](https://www.apply-for-teacher-training.service.gov.uk/register-api)
+<br>
+🥸 Also known as the [Recruits API](https://github.com/DFE-Digital/register-trainee-teachers/pull/3618)
+<br>
+🔐 Authenticate with [ServiceAPIUser](/app/models/service_api_user.rb)
+
+The Register API provides the details of successful applications. It's currently only used by the Register service.
+
+At the point an application is retrieved by Register, Register becomes the "source of truth" for that candidate.
+
+## Vendor API
+
+📖 [Vendor API docs](https://www.apply-for-teacher-training.service.gov.uk/api-docs)
+<br>
+🔐 Authenticate with [VendorAPIToken](/app/models/vendor_api_token.rb)
+
+The Vendor API allows providers to manage applications programmatically: fetch applications, make offers, reject applications, etc. It makes the key functionality of Manage available via API to vendor Student Record Systems (SRS).
+
+Users of this API authenticate with a Vendor API token. These can be issued and revoked in the support console under [Providers > API tokens](https://www.apply-for-teacher-training.service.gov.uk/support/tokens).


### PR DESCRIPTION
## Context

I tried learning about the APIs that Apply has, but I had a hard time working out where to start: there wasn't a documented list of APIs.

It turns out there are four APIs in total, but they're not easy or obvious to find information about. I had to trawl through the `config/routes.rb` file to find out where the API docs are hosted, and then read the API controllers to work out how they're authenticated.

I'm hoping to save others from needing to do the same in future by documenting it.

## Changes proposed in this pull request

I've added a high level document which outlines the four APIs that Apply has, included their intended use cases and how users authenticate to it.

## Guidance to review

✨ [Read the formatted documented](https://github.com/DFE-Digital/apply-for-teacher-training/blob/add-api-doc/docs/apply-apis.md) ✨ 