### PR TITLE
Make sure the reinstate deferrals respects the transaction

### DIFF
--- a/app/services/reinstate_pending_conditions.rb
+++ b/app/services/reinstate_pending_conditions.rb
@@ -23,8 +23,8 @@ class ReinstatePendingConditions
             course_option,
             other_fields: { recruited_at: nil },
           )
-          CandidateMailer.reinstated_offer(application_choice).deliver_later
         end
+        CandidateMailer.reinstated_offer(application_choice).deliver_later
       end
     else
       raise ValidationException, deferred_offer.errors.map(&:message)

--- a/spec/services/reinstate_pending_conditions_spec.rb
+++ b/spec/services/reinstate_pending_conditions_spec.rb
@@ -65,4 +65,16 @@ RSpec.describe ReinstatePendingConditions do
   describe 'validations' do
     include_examples 'confirm deferred offer validations', :reinstate_pending_conditions
   end
+
+  context 'when sending the email' do
+    it 'sends reinstated offer email with correct content', :sidekiq do
+      new_course_option.course.update!(start_date: original_course.start_date + 1.year)
+
+      expect {
+        service.save!
+      }.to change { ActionMailer::Base.deliveries.count }.by(1)
+
+      expect(ActionMailer::Base.deliveries.first.body.raw_source).to include(new_course_option.course.start_date.to_fs(:month_and_year))
+    end
+  end
 end


### PR DESCRIPTION
## Context

A candidate has been sent a reinstated_offer email for a course they deferred on. However the date should have been a year later.

## Changes proposed in this pull request

Before this change the code was sending the email **BEFORE** the transaction were committed to the DB, which made the old course option object to be used in the mail content. Moving out of the transaction make the mailer to respect the commit transaction first

## Guidance to review

1. Does it send the right email content when confirming a deferral (for a pending conditions application!) in the review app?

## Link to Trello card

https://trello.com/c/QJnWSXaJ/1008-investigate-incorrect-start-date-for-the-deferred-course-email

