### PR TITLE
1487 reflect the ske policy changes in our services

### DIFF
--- a/app/components/provider_interface/ske_conditions_component.rb
+++ b/app/components/provider_interface/ske_conditions_component.rb
@@ -20,7 +20,7 @@ module ProviderInterface
         {
           key: 'Length',
           value: "#{length} weeks",
-          action: length_editable ? { visually_hidden_text: 'change ske length', href: change_length_path } : {},
+          action: editable ? { visually_hidden_text: 'change ske length', href: change_length_path } : {},
         },
         {
           key: 'Reason',
@@ -68,14 +68,6 @@ module ProviderInterface
           application_choice,
         )
       end
-    end
-
-    def length_editable
-      editable && !religious_education_course?
-    end
-
-    def religious_education_course?
-      @application_choice.current_course.subjects.first&.code&.in?(Subject::SKE_RE_COURSES)
     end
 
     def offer_accepted?

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -162,10 +162,6 @@ module ProviderInterface
       subject_mapping.in?(Subject::SKE_PHYSICS_COURSES)
     end
 
-    def religious_education_course?
-      subject_mapping.in?(Subject::SKE_RE_COURSES)
-    end
-
     def ske_standard_course?
       subject_mapping.in?(Subject::SKE_STANDARD_COURSES)
     end
@@ -372,8 +368,6 @@ module ProviderInterface
         { study_mode: available_study_modes.first } if available_study_modes.length == 1
       when :locations
         { course_option_id: available_course_options.first.id } if available_course_options.length == 1
-      when :ske_length
-        { ske_conditions_attributes: { 0 => { length: '8' } } } if religious_education_course?
       end
     end
 

--- a/app/forms/support_interface/conditions_form.rb
+++ b/app/forms/support_interface/conditions_form.rb
@@ -103,11 +103,7 @@ module SupportInterface
     end
 
     def ske_length_options
-      if religious_education_course?
-        [CheckBoxOption.new(SkeCondition::SKE_LENGTHS.first.to_s, "#{SkeCondition::SKE_LENGTHS.first} weeks")]
-      else
-        SkeCondition::SKE_LENGTHS.map { |length| CheckBoxOption.new(length.to_s, "#{length} weeks") }
-      end
+      SkeCondition::SKE_LENGTHS.map { |length| CheckBoxOption.new(length.to_s, "#{length} weeks") }
     end
 
     def ske_reason_options(subject:)
@@ -139,10 +135,6 @@ module SupportInterface
 
     def physics_course?
       subject_mapping.in?(Subject::SKE_PHYSICS_COURSES)
-    end
-
-    def religious_education_course?
-      subject_mapping.in?(Subject::SKE_RE_COURSES)
     end
 
     def ske_standard_course?

--- a/app/models/ske_condition.rb
+++ b/app/models/ske_condition.rb
@@ -61,23 +61,13 @@ class SkeCondition < OfferCondition
   def length_for_ske_courses
     return if length.blank?
 
-    if religious_education_course? && length != SKE_LENGTHS.first.to_s
-      errors.add(
-        :length,
-        :invalid_length,
-        allowed_values: SkeCondition::SKE_LENGTHS.first,
-      )
-    elsif SKE_LENGTHS.exclude?(length.to_i)
+    if SKE_LENGTHS.exclude?(length.to_i)
       errors.add(
         :length,
         :invalid_length,
         allowed_values: SkeCondition::SKE_LENGTHS.to_sentence(last_word_connector: ' or '),
       )
     end
-  end
-
-  def religious_education_course?
-    subject_code&.in?(Subject::SKE_RE_COURSES)
   end
 
   def subject_code

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -5,16 +5,12 @@ class Subject < ApplicationRecord
   validates :code, uniqueness: true
 
   SKE_STANDARD_COURSES = %w[
-    C1
     F1
     11
-    DT
-    Q3
     16
     G1
     F0
     F3
-    V6
   ].freeze
 
   SKE_LANGUAGE_COURSES = %w[
@@ -31,9 +27,5 @@ class Subject < ApplicationRecord
   SKE_PHYSICS_COURSES = %w[
     F0
     F3
-  ].freeze
-
-  SKE_RE_COURSES = %w[
-    V6
   ].freeze
 end

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -313,31 +313,6 @@ RSpec.describe ProviderInterface::OfferWizard do
       context 'when a ske condition is required' do
         let(:ske_conditions) { [SkeCondition.new] }
 
-        context 'and the course is religious education' do
-          let(:application_choice) { create(:application_choice) }
-          let(:application_choice_id) { application_choice.id }
-          let(:course_option_id) { application_choice.current_course_option.id }
-
-          before do
-            application_choice.course_option.course.subjects.delete_all
-            application_choice.course_option.course.subjects << build(:subject, code: 'V6', name: 'Religious Education')
-            allow(store).to receive(:write)
-          end
-
-          context 'and the current step is :ske_reason' do
-            let(:current_step) { :ske_reason }
-
-            it 'sets the SKE length to 8 weeks' do
-              wizard.next_step
-              expect(wizard.ske_conditions.first.length).to eq('8')
-            end
-
-            it 'skips the length step' do
-              expect(wizard.next_step).to eq(:conditions)
-            end
-          end
-        end
-
         context 'and the course is a modern language' do
           let(:current_step) { :select_option }
           let(:application_choice) { create(:application_choice) }
@@ -536,7 +511,7 @@ RSpec.describe ProviderInterface::OfferWizard do
         context 'when ske is required' do
           before do
             wizard.course_option.course.subjects.delete_all
-            wizard.course_option.course.subjects << build(:subject, code: 'C1', name: 'biology')
+            wizard.course_option.course.subjects << build(:subject, code: 'F1', name: 'Chemistry')
           end
 
           it 'returns :ske_requirements' do

--- a/spec/forms/support_interface/conditions_form_spec.rb
+++ b/spec/forms/support_interface/conditions_form_spec.rb
@@ -364,15 +364,5 @@ RSpec.describe SupportInterface::ConditionsForm do
     it 'returns a CheckBoxOption for each possible length' do
       expect(@form.ske_length_options.size).to eq(6)
     end
-
-    it 'returns a single CheckBoxOption for religious education courses' do
-      @application_choice.course_option.course.subjects.delete_all
-      @application_choice.course_option.course.subjects << build(
-        :subject,
-        code: 'V6',
-        name: 'Religious instruction',
-      )
-      expect(@form.ske_length_options.size).to eq(1)
-    end
   end
 end

--- a/spec/models/ske_condition_spec.rb
+++ b/spec/models/ske_condition_spec.rb
@@ -16,17 +16,5 @@ RSpec.describe SkeCondition do
       @ske_condition.length = '13'
       expect(@ske_condition.valid?).to be(false)
     end
-
-    context 'with a religious education course' do
-      before do
-        @ske_condition.offer.course.subjects.delete_all
-        @ske_condition.offer.course.subjects << build(:subject, :religious_education)
-      end
-
-      it 'is invalid when SKE length is not 8 weeks' do
-        @ske_condition.length = '12'
-        expect(@ske_condition.valid?).to be(false)
-      end
-    end
   end
 end

--- a/spec/system/provider_interface/change_existing_offer_ske_standard_flow_spec.rb
+++ b/spec/system/provider_interface/change_existing_offer_ske_standard_flow_spec.rb
@@ -75,7 +75,7 @@ RSpec.feature 'Provider changes an existing offer' do
     and_i_click_continue
 
     then_the_review_page_is_loaded
-    and_the_ske_conditions_should_be_displayed
+    and_the_ske_conditions_be_displayed
     and_i_can_confirm_the_changed_offer_details
 
     when_i_choose_to_edit_the_ske_condition
@@ -87,23 +87,23 @@ RSpec.feature 'Provider changes an existing offer' do
     and_i_click_continue
     and_i_click_continue
     then_the_review_page_is_loaded
-    and_the_modified_ske_conditions_should_be_displayed
+    and_the_modified_ske_conditions_be_displayed
     and_i_can_confirm_the_changed_offer_details
 
     when_i_send_the_offer
     then_i_see_that_the_offer_was_successfully_updated
-    and_the_modified_ske_conditions_should_be_displayed
+    and_the_modified_ske_conditions_be_displayed
 
     # Toggle the standard conditions and save
     when_i_choose_to_change_the_conditions
     and_i_click_continue
     then_the_review_page_is_loaded
-    and_the_modified_ske_conditions_should_be_displayed
+    and_the_modified_ske_conditions_be_displayed
 
     when_i_send_the_offer
     then_i_see_that_the_offer_was_successfully_updated
     and_i_can_see_the_new_offer_condition
-    and_the_modified_ske_conditions_should_be_displayed
+    and_the_modified_ske_conditions_be_displayed
 
     # Change provider and course to a subject that does NOT permit SKE conditions
     when_i_choose_to_change_the_course
@@ -119,12 +119,12 @@ RSpec.feature 'Provider changes an existing offer' do
     and_i_click_continue
 
     then_the_review_page_is_loaded
-    and_the_ske_conditions_should_not_be_displayed
+    and_the_ske_conditions_not_be_displayed
     and_i_can_confirm_the_changed_offer_details_for_the_non_ske_course
 
     when_i_send_the_offer
     then_i_see_that_the_offer_was_successfully_updated
-    and_the_ske_conditions_should_not_be_displayed
+    and_the_ske_conditions_not_be_displayed
   end
 
   def given_i_am_a_provider_user
@@ -142,7 +142,7 @@ RSpec.feature 'Provider changes an existing offer' do
   def given_the_provider_user_can_offer_multiple_provider_courses
     @selected_provider = create(:provider)
     create(:provider_permissions, provider: @selected_provider, provider_user:, make_decisions: true)
-    @ske_subject = create(:subject, code: 'C1', name: 'Biology')
+    @ske_subject = create(:subject, code: 'F1', name: 'Chemistry')
     @non_ske_subject = create(:subject, code: 'W1', name: 'Art and design')
     courses = create_list(:course, 2, subjects: [@ske_subject], study_mode: :full_time_or_part_time, provider: @selected_provider, accredited_provider: ratifying_provider)
     @selected_course = courses.sample
@@ -285,21 +285,21 @@ RSpec.feature 'Provider changes an existing offer' do
     choose '12 weeks'
   end
 
-  def and_the_ske_conditions_should_be_displayed
+  def and_the_ske_conditions_be_displayed
     expect(page).to have_content('Subject knowledge enhancement course')
     expect(page).to have_content("Subject\n#{@ske_subject.name}")
     expect(page).to have_content("Length\n8 weeks")
     expect(page).to have_content("Reason\nTheir degree subject was not #{@ske_subject.name}")
   end
 
-  def and_the_modified_ske_conditions_should_be_displayed
+  def and_the_modified_ske_conditions_be_displayed
     expect(page).to have_content('Subject knowledge enhancement course')
     expect(page).to have_content("Subject\n#{@ske_subject.name}")
     expect(page).to have_content("Length\n12 weeks")
     expect(page).to have_content("Reason\nTheir degree subject was not #{@ske_subject.name}")
   end
 
-  def and_the_ske_conditions_should_not_be_displayed
+  def and_the_ske_conditions_not_be_displayed
     expect(page).to have_no_content('Subject knowledge enhancement course')
   end
 

--- a/spec/system/provider_interface/make_offer_ske_standard_flow_spec.rb
+++ b/spec/system/provider_interface/make_offer_ske_standard_flow_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature 'Provider makes an offer with SKE enabled in standard courses' do
 
     then_the_ske_standard_flow_is_loaded
     when_i_dont_select_any_ske_answer
-    then_i_should_see_a_error_message_to_select_if_ske_required
+    then_i_see_a_error_message_to_select_if_ske_required
 
     when_i_select_no_ske_required
     and_i_click_continue
@@ -54,14 +54,14 @@ RSpec.feature 'Provider makes an offer with SKE enabled in standard courses' do
     then_the_ske_reason_page_is_loaded
 
     when_i_dont_give_a_ske_reason
-    then_i_should_see_a_error_message_to_give_a_reason_for_ske
+    then_i_see_a_error_message_to_give_a_reason_for_ske
 
     when_i_add_a_ske_reason
     and_i_click_continue
     then_the_ske_length_page_is_loaded
 
     when_i_dont_answer_ske_length
-    then_i_should_see_a_error_message_to_give_a_ske_course_length
+    then_i_see_a_error_message_to_give_a_ske_course_length
 
     when_i_answer_the_ske_length
     and_i_click_continue
@@ -115,7 +115,7 @@ RSpec.feature 'Provider makes an offer with SKE enabled in standard courses' do
   def given_the_course_subject_requires_ske
     application_choice.course_option.course.subjects.delete_all
     application_choice.course_option.course.subjects << build(
-      :subject, code: 'C1', name: 'Biology'
+      :subject, code: 'F1', name: 'Chemistry'
     )
   end
 
@@ -134,7 +134,7 @@ RSpec.feature 'Provider makes an offer with SKE enabled in standard courses' do
     click_link_or_button 'Continue'
   end
 
-  def then_i_should_see_a_error_message_to_select_if_ske_required
+  def then_i_see_a_error_message_to_select_if_ske_required
     expect(page).to have_content('There is a problem')
     expect(page).to have_content('Select whether you require the candidate to do a course')
   end
@@ -159,7 +159,7 @@ RSpec.feature 'Provider makes an offer with SKE enabled in standard courses' do
     click_link_or_button 'Continue'
   end
 
-  def then_i_should_see_a_error_message_to_give_a_reason_for_ske
+  def then_i_see_a_error_message_to_give_a_reason_for_ske
     expect(page).to have_content('There is a problem')
     expect(page).to have_content('Select why the candidate needs to take a course')
   end
@@ -176,7 +176,7 @@ RSpec.feature 'Provider makes an offer with SKE enabled in standard courses' do
     click_link_or_button 'Continue'
   end
 
-  def then_i_should_see_a_error_message_to_give_a_ske_course_length
+  def then_i_see_a_error_message_to_give_a_ske_course_length
     expect(page).to have_content('There is a problem')
     expect(page).to have_content('Select how long the course must be')
   end

--- a/spec/system/support_interface/change_offer_ske_conditions_spec.rb
+++ b/spec/system/support_interface/change_offer_ske_conditions_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Add course to submitted application' do
     and_i_visit_the_support_page
 
     when_i_click_on_the_application
-    then_i_should_see_the_current_conditions
+    then_i_see_the_current_conditions
 
     when_i_click_on_change_conditions
     then_i_see_the_condition_edit_form_with_a_warning
@@ -59,7 +59,7 @@ RSpec.feature 'Add course to submitted application' do
   def and_the_course_subject_requires_ske
     @application_choice.course_option.course.subjects.delete_all
     @application_choice.course_option.course.subjects << build(
-      :subject, code: 'C1', name: 'Biology'
+      :subject, code: 'F1', name: 'Chemistry'
     )
   end
 
@@ -71,7 +71,7 @@ RSpec.feature 'Add course to submitted application' do
     click_link_or_button 'Candy Dayte'
   end
 
-  def then_i_should_see_the_current_conditions
+  def then_i_see_the_current_conditions
     expect(page).to have_content("Conditions\nBe cool")
   end
 
@@ -87,7 +87,7 @@ RSpec.feature 'Add course to submitted application' do
 
   def when_i_add_a_new_ske_condition_and_click_update_conditions_without_a_support_ticket_url
     choose('Yes')
-    choose('Their degree subject was not Biology')
+    choose('Their degree subject was not Chemistry')
     choose('8 weeks')
     click_link_or_button 'Update conditions'
   end
@@ -100,7 +100,7 @@ RSpec.feature 'Add course to submitted application' do
   def when_i_add_a_new_ske_condition_and_click_update_conditions_with_a_support_ticket_url
     fill_in 'Zendesk ticket URL', with: 'becomingateacher.zendesk.com/agent/tickets/12345'
     choose('Yes')
-    choose('Their degree subject was not Biology')
+    choose('Their degree subject was not Chemistry')
     choose('8 weeks')
     click_link_or_button 'Update conditions'
   end
@@ -108,13 +108,13 @@ RSpec.feature 'Add course to submitted application' do
   def then_i_see_the_new_ske_condition
     expect(page).to have_content('Subject knowledge enhancement course')
     expect(page).to have_content("Length\n8 weeks")
-    expect(page).to have_content("Reason\nTheir degree subject was not Biology")
+    expect(page).to have_content("Reason\nTheir degree subject was not Chemistry")
   end
 
   def and_i_change_the_length_of_the_ske_condition
     fill_in 'Zendesk ticket URL', with: 'becomingateacher.zendesk.com/agent/tickets/12345'
     choose('Yes')
-    choose('Their degree subject was not Biology')
+    choose('Their degree subject was not Chemistry')
     choose('20 weeks')
     click_link_or_button 'Update conditions'
   end
@@ -122,7 +122,7 @@ RSpec.feature 'Add course to submitted application' do
   def then_i_see_the_updated_ske_condition
     expect(page).to have_content('Subject knowledge enhancement course')
     expect(page).to have_content("Length\n20 weeks")
-    expect(page).to have_content("Reason\nTheir degree subject was not Biology")
+    expect(page).to have_content("Reason\nTheir degree subject was not Chemistry")
   end
 
   def and_i_delete_the_ske_condition


### PR DESCRIPTION
## Important
Do NOT merge until 11 April. See [Trello card](https://trello.com/c/hUwTntvP) for details

## Context

Changes to the Subject Knowledge Enhancement (SKE) were announced last week.

From the 11th April, it means that some subjects will no longer be eligible for funding.

- Primary Maths (03),
- Design and Technology (DT),
- English (Q3),
- Biology (C1), and
- Religious education (V6) are the subjects where this policy applies.
- All other subjects, eligible for SKE, will continue to be funded.

We need to:

Remove references to SKE funding being available in said subjects. (Publish, Apply, Find)
Prevent providers from setting SKE as a condition of offer for the affected subjects. (Manage)

## Changes proposed in this pull request

NOTE: We are not doing a data migration to change any existing SKE conditions for these subjects. There will comms directly to providers about this and they will decide how they wish to proceed.

- Remove references to the subjects no longer receiving SKE funding
- Remove the religious education specific logic that is no longer needed (RE is no longer funded)
- Update all related specs. This included removing 'should' where required.

## Guidance to review

Are there other areas to consider? Anything I'm missing?

## Link to Trello card

https://trello.com/c/hUwTntvP

