### PR TITLE
Manage mobile bugfix

### DIFF
--- a/app/frontend/styles/components/_paginated_filter.scss
+++ b/app/frontend/styles/components/_paginated_filter.scss
@@ -77,17 +77,12 @@
 .app-filter {
   @include govuk-media-query($from: tablet) {
     margin-bottom: govuk-spacing(3);
-  }
-}
-
-// Fix for fixed position of layout filters
-.js-enabled .moj-filter-layout__filter {
-  @include govuk-media-query($from: tablet) {
-    position: relative;
+    position: relative !important;
   }
 
+  // Fix for fixed position of layout filters for mobile
   @include govuk-media-query($from: mobile) {
-    position: relative;
+    position: relative !important;
   }
 }
 

--- a/app/frontend/styles/components/_paginated_filter.scss
+++ b/app/frontend/styles/components/_paginated_filter.scss
@@ -80,6 +80,17 @@
   }
 }
 
+// Fix for fixed position of layout filters
+.js-enabled .moj-filter-layout__filter {
+  @include govuk-media-query($from: tablet) {
+    position: relative;
+  }
+
+  @include govuk-media-query($from: mobile) {
+    position: relative;
+  }
+}
+
 // Apply GOV.UK focus styles - only needed with js.
 .js-enabled .app-filter:focus {
   outline: $govuk-focus-width solid $govuk-focus-colour;

--- a/app/frontend/styles/components/_paginated_filter.scss
+++ b/app/frontend/styles/components/_paginated_filter.scss
@@ -76,13 +76,18 @@
 
 .app-filter {
   @include govuk-media-query($from: tablet) {
-    margin-bottom: govuk-spacing(3);
+    // stylelint-disable declaration-no-important
     position: relative !important;
+    // stylelint-enable declaration-no-important
+
+    margin-bottom: govuk-spacing(3);
   }
 
   // Fix for fixed position of layout filters for mobile
   @include govuk-media-query($from: mobile) {
+    // stylelint-disable declaration-no-important
     position: relative !important;
+    // stylelint-enable declaration-no-important
   }
 }
 


### PR DESCRIPTION
## Context

A provider has reported that the ProviderInterface is unusable on mobile viewports.

## Changes proposed in this pull request

Because the position is fixed, when on mobile or tablet the filter content is not displayed in the page.
By transforming into position relative the page worked.

## Guidance to review

1. Does it work?
2. Does it affects the other pages?

## Link to Trello card

https://trello.com/c/NfwQ20pI/1475-bug-providerinterface-mobile-is-unusable
