### PR TITLE
Change vacancy status on course options to reflect study mode changes

### DIFF
--- a/app/services/teacher_training_public_api/sync_sites.rb
+++ b/app/services/teacher_training_public_api/sync_sites.rb
@@ -24,6 +24,7 @@ module TeacherTrainingPublicAPI
       sites.each do |site_from_api|
         site = sync_site(site_from_api)
         create_course_options_for_site(site, site_from_api.location_status)
+        close_course_options_that_do_not_match_study_mode
       end
 
       handle_course_options_with_invalid_sites(sites)
@@ -51,6 +52,18 @@ module TeacherTrainingPublicAPI
     def create_course_options_for_site(site, site_status)
       study_modes(course).each do |study_mode|
         create_course_options(site, study_mode, site_status)
+      end
+    end
+
+    def close_course_options_that_do_not_match_study_mode
+      # Close part_time course options if the course is full_time
+      if course.full_time? && course.course_options.part_time.any?
+        course.course_options.part_time.update_all(vacancy_status: :no_vacancies)
+      end
+
+      # Close full_time course options if the course is part_time
+      if course.part_time? && course.course_options.full_time.any?
+        course.course_options.full_time.update_all(vacancy_status: :no_vacancies)
       end
     end
 

--- a/spec/system/teacher_training_public_api/study_mode_changes_spec.rb
+++ b/spec/system/teacher_training_public_api/study_mode_changes_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe 'Sync from Teacher Training API' do
 
     when_sync_provider_is_called
     then_the_part_time_course_option_is_set_to_no_vacancies
+    and_the_full_time_course_option_is_set_to_have_vacancies
+
+    given_the_course_becomes_part_time
+    when_sync_provider_is_called
+    then_the_full_time_course_option_is_set_to_no_vacancies
+    and_then_part_time_course_option_is_set_to_have_vacancies
   end
 
   def given_there_is_a_full_time_course_on_the_teacher_training_api
@@ -70,10 +76,31 @@ RSpec.describe 'Sync from Teacher Training API' do
                                                vacancy_status: 'full_time_vacancies')
   end
 
+  def given_the_course_becomes_part_time
+    stub_teacher_training_api_course_with_site(provider_code: 'ABC',
+                                               course_code: 'ABC1',
+                                               course_attributes: [{ accredited_body_code: nil, study_mode: 'part_time' }],
+                                               site_code: 'A',
+                                               vacancy_status: 'part_time_vacancies')
+  end
+
   def then_the_part_time_course_option_is_set_to_no_vacancies
     expect(@course.course_options.count).to eq 2
-    expect(@course.course_options.last.study_mode).to eq 'part_time'
-    # All new courses are being set to having vacancies due to Find changes
-    expect(@course.course_options.last.vacancy_status).to eq 'vacancies'
+    expect(@course.course_options.part_time.last.no_vacancies?).to be true
+  end
+
+  def and_the_full_time_course_option_is_set_to_have_vacancies
+    expect(@course.course_options.count).to eq 2
+    expect(@course.course_options.full_time.last.vacancies?).to be true
+  end
+
+  def then_the_full_time_course_option_is_set_to_no_vacancies
+    expect(@course.course_options.count).to eq 2
+    expect(@course.course_options.full_time.last.no_vacancies?).to be true
+  end
+
+  def and_then_part_time_course_option_is_set_to_have_vacancies
+    expect(@course.course_options.count).to eq 2
+    expect(@course.course_options.part_time.last.vacancies?).to be true
   end
 end


### PR DESCRIPTION
## Context
When a provider changes a course in Publish from “full time and part time“ to just “full time” or just “part time” we need to close the course options in apply.

We've had a lot of discussion about this ticket -- There is scope to make amendments to the journey so that candidates and providers are alerted if a course option changes when there are applications. But for now, this will at least keep the data in sync

## Changes proposed in this pull request

- When syncing course data, updates the vacancy status  on a course option to `:no_vacancies` if a course options ceases to be available. 
- Specs for the above scenario

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/rAuO1EaZ/1376-bug-ttapi-allow-closing-studymode-for-course

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
