### PR TITLE
Fix for the wrong clearance of the semantic logger

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ DSI_API_URL=https://test-api.signin.education.gov.uk
 DSI_API_SECRET=xxxxxxxxxxxx-xxxxx-xxxxxxxx-xxxxxxxx
 SANDBOX=false
 SKYLIGHT_AUTH_TOKEN=
+AUTHORISED_HOSTS=[]
 SKYLIGHT_ENABLE=false
 SKYLIGHT_ENV=development
 PORT=3000

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -26,9 +26,8 @@ class CustomLogFormatter < SemanticLogger::Formatters::Raw
     end
 
     # Remove post parameters if it's a PUT, POST, or PATCH request
-    if method_is_post_or_put_or_patch?
-      hash[:payload] ||= {}
-      hash[:payload][:params] = {} if hash[:payload].nil?
+    if method_is_post_or_put_or_patch? && hash.dig(:payload, :params).present?
+      hash[:payload][:params].clear
     end
 
     hash.to_json

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -40,13 +40,7 @@ private
   end
 end
 
-if HostingEnvironment.development?
-  SemanticLogger.add_appender(
-    file_name: Rails.root.join('log/development.log').to_s,
-    level: Rails.application.config.log_level,
-    formatter: CustomLogFormatter.new,
-  )
-else
+unless HostingEnvironment.development? || Rails.env.test?
   Clockwork.configure { |config| config[:logger] = SemanticLogger[Clockwork] if defined?(Clockwork) }
   SemanticLogger.add_appender(
     io: STDOUT,

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'request_store_rails'
 return unless defined? SemanticLogger
 
 class CustomLogFormatter < SemanticLogger::Formatters::Raw
@@ -40,7 +39,7 @@ private
   end
 end
 
-unless Rails.env.development? || Rails.env.test?
+unless Rails.env.local?
   Clockwork.configure { |config| config[:logger] = SemanticLogger[Clockwork] if defined?(Clockwork) }
   SemanticLogger.add_appender(
     io: STDOUT,

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -40,7 +40,7 @@ private
   end
 end
 
-unless HostingEnvironment.development? || Rails.env.test?
+unless Rails.env.development? || Rails.env.test?
   Clockwork.configure { |config| config[:logger] = SemanticLogger[Clockwork] if defined?(Clockwork) }
   SemanticLogger.add_appender(
     io: STDOUT,


### PR DESCRIPTION
## Context

As spotted by Iain, the line didn't look right. So removing and add what the line in the semantic logger should do.

No trello card.