### PR TITLE
[1514] Part 1 add unique index to Vender name

### DIFF
--- a/db/migrate/20240404154616_add_index_to_vender_name.rb
+++ b/db/migrate/20240404154616_add_index_to_vender_name.rb
@@ -1,0 +1,7 @@
+class AddIndexToVenderName < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :vendors, :name, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_21_154303) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_04_154616) do
   create_sequence "qualifications_public_id_seq", start: 120000
 
   # These are extensions that must be enabled in order to support this database
@@ -841,6 +841,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_21_154303) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_vendors_on_name"
   end
 
   add_foreign_key "application_choices", "application_forms", on_delete: :cascade


### PR DESCRIPTION
## Context

Currently, we store and validate the Vendor name as an enum on the Vendor model. There are problems with this: 

- Adding a new Vender requires a code change.
- This is also a potential security risk as all our vendors are located in our public repo.

We want to replace the enum with basic presence and uniqueness validation.

## Changes proposed in this pull request

- Migration to add a unique index to vendor name. I've checked in production that all of our vendors have unique names as it is (there are only 6). 

Once this has been merged in, I will open [the PR here](https://github.com/DFE-Digital/apply-for-teacher-training/pull/9261) which actually gets rid of the enum on the model


## Guidance to review


## Link to Trello card

https://trello.com/c/jMnBxRIb

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
