### PR TITLE
Add Redis probe to Skylight

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -87,6 +87,7 @@ module ApplyForPostgraduateTeacherTraining
     config.middleware.use ServiceUnavailableMiddleware
     config.middleware.use VendorAPIRequestMiddleware
     config.middleware.use Grover::Middleware
+    config.skylight.probes += %w(redis)
     config.skylight.environments = ENV["SKYLIGHT_ENABLE"].to_s == "true" ? [Rails.env] : []
 
     config.after_initialize do |app|


### PR DESCRIPTION
## Context

Skylight is not tracking the performance of redis. We can update this by explicitly adding redis in the skylight probes.

**Docs**

https://www.skylight.io/support/advanced-setup#probes
## Changes proposed in this pull request

Skylight show the Redis commands in the Event Sequence.

## Guidance to review

![redis_probe](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/97d487d2-c078-444c-a5bc-9637a7a21fcb)


## Link to Trello card

[Trello Ticket](https://trello.com/c/GDiMiojm)