### PR TITLE
Replace 'PGCE with QTS' with 'QTS with PGCE'

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -135,7 +135,7 @@ module CandidateInterface
     def type_row(application_choice)
       {
         key: 'Type',
-        value: application_choice.current_course.description,
+        value: application_choice.current_course.description_to_s,
       }
     end
 

--- a/app/components/candidate_interface/offer_review_component.rb
+++ b/app/components/candidate_interface/offer_review_component.rb
@@ -92,7 +92,7 @@ module CandidateInterface
     def course_row_value
       if CycleTimetable.find_down?
         tag.p(@course_choice.current_course.name_and_code, class: 'govuk-!-margin-bottom-0') +
-          tag.p(@course_choice.current_course.description, class: 'govuk-body')
+          tag.p(@course_choice.current_course.description_to_s, class: 'govuk-body')
       else
         govuk_link_to(
           @course_choice.current_course.name_and_code,
@@ -100,7 +100,7 @@ module CandidateInterface
           target: '_blank',
           rel: 'noopener',
         ) +
-          tag.p(@course_choice.current_course.description, class: 'govuk-body')
+          tag.p(@course_choice.current_course.description_to_s, class: 'govuk-body')
       end
     end
 

--- a/app/components/support_interface/course_details_component.rb
+++ b/app/components/support_interface/course_details_component.rb
@@ -40,7 +40,7 @@ module SupportInterface
         },
         {
           key: 'Description',
-          value: course.description,
+          value: course.description_to_s,
         },
         {
           key: 'Start date',

--- a/app/forms/candidate_interface/pick_course_form.rb
+++ b/app/forms/candidate_interface/pick_course_form.rb
@@ -13,7 +13,7 @@ module CandidateInterface
       @radio_available_courses ||= available_courses.map do |course|
         label = course.name_and_code
         label += ' – No vacancies' unless course.available?
-        hint = course.description
+        hint = course.description_to_s
 
         RadioOption.new(course.id, label, hint)
       end

--- a/app/helpers/qualification_value_helper.rb
+++ b/app/helpers/qualification_value_helper.rb
@@ -2,6 +2,6 @@ module QualificationValueHelper
   def qualification_text(course_option)
     return if course_option.course.qualifications.nil?
 
-    course_option.course.qualifications.reverse.map(&:upcase).join(' with ')
+    course_option.course.qualifications.map(&:upcase).join(' with ')
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -68,11 +68,11 @@ class Course < ApplicationRecord
   }
 
   def name_and_description
-    "#{name} #{description}"
+    "#{name} #{description_to_s}"
   end
 
   def name_provider_and_description
-    "#{name} #{accredited_provider&.name} #{description}"
+    "#{name} #{accredited_provider&.name} #{description_to_s}"
   end
 
   def year_name_and_code
@@ -84,7 +84,7 @@ class Course < ApplicationRecord
   end
 
   def name_code_and_description
-    "#{name} (#{code}) – #{description}"
+    "#{name} (#{code}) – #{description_to_s}"
   end
 
   def name_code_and_provider
@@ -96,7 +96,7 @@ class Course < ApplicationRecord
   end
 
   def name_description_provider_and_age_range
-    "#{name} #{description} #{accredited_provider&.name} #{age_range}"
+    "#{name} #{description_to_s} #{accredited_provider&.name} #{age_range}"
   end
 
   def provider_and_name_code
@@ -104,7 +104,7 @@ class Course < ApplicationRecord
   end
 
   def description_and_accredited_provider
-    accredited_provider ? "#{description} - #{accredited_provider&.name}" : description.to_s
+    accredited_provider ? "#{description_to_s} - #{accredited_provider&.name}" : description_to_s
   end
 
   def currently_has_both_study_modes_available?
@@ -181,11 +181,17 @@ class Course < ApplicationRecord
     return '' if qualifications.blank?
 
     case qualifications.sort
-    in ['pgce', 'qts'] then 'PGCE with QTS'
+    in ['pgce', 'qts'] then 'QTS with PGCE'
     in ['pgde', 'qts'] then 'PGDE with QTS'
     else
       qualifications.first.upcase
     end
+  end
+
+  def description_to_s
+    # This terminology comes directly from Publish API inside the description
+    # and we need to invert when we show in Apply.
+    @description_to_s ||= description.to_s.gsub('PGCE with QTS', 'QTS with PGCE')
   end
 
 private

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, :mid_cycle, typ
       result = render_inline(described_class.new(application_form:, show_status: true))
 
       expect(result.css('.govuk-summary-list__key').text).to include('Type')
-      expect(result.css('.govuk-summary-list__value').to_html).to include('PGCE with QTS part time')
+      expect(result.css('.govuk-summary-list__value').to_html).to include('QTS with PGCE part time')
     end
   end
 

--- a/spec/components/provider_interface/completed_offer_summary_component_spec.rb
+++ b/spec/components/provider_interface/completed_offer_summary_component_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe ProviderInterface::CompletedOfferSummaryComponent do
     expect(row_text_selector(:location, render)).to include(course_option.site.full_address("\n"))
     expect(row_text_selector(:full_or_part_time, render)).to include(course_option.study_mode.humanize)
     expect(row_text_selector(:accredited_provider, render)).to include(course_option.course.accredited_provider.name_and_code)
-    expect(row_text_selector(:qualification, render)).to include('PGCE with QTS')
+    expect(row_text_selector(:qualification, render)).to include('QTS with PGCE')
     expect(row_text_selector(:funding_type, render)).to include(course_option.course.funding_type.humanize)
   end
 

--- a/spec/components/provider_interface/course_details_component_spec.rb
+++ b/spec/components/provider_interface/course_details_component_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe ProviderInterface::CourseDetailsComponent do
     render_text = row_text_selector(:qualification, render)
 
     expect(render_text).to include('Qualification')
-    expect(render_text).to include('PGCE with QTS')
+    expect(render_text).to include('QTS with PGCE')
   end
 
   it 'renders financing funding type of a course' do

--- a/spec/components/provider_interface/course_summary_component_spec.rb
+++ b/spec/components/provider_interface/course_summary_component_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe ProviderInterface::CourseSummaryComponent do
     render_text = row_text_selector(:qualification, render)
 
     expect(render_text).to include('Qualification')
-    expect(render_text).to include('PGCE with QTS')
+    expect(render_text).to include('QTS with PGCE')
   end
 
   it 'renders the funding type' do

--- a/spec/components/provider_interface/offer_summary_component_spec.rb
+++ b/spec/components/provider_interface/offer_summary_component_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe ProviderInterface::OfferSummaryComponent do
     expect(row_text_selector(:course, render)).to include(course_option.course.name_and_code)
     expect(row_text_selector(:location, render)).to include(course_option.site.full_address("\n"))
     expect(row_text_selector(:full_or_part_time, render)).to include(course_option.study_mode.humanize)
-    expect(row_text_selector(:qualification, render)).to include('PGCE with QTS')
+    expect(row_text_selector(:qualification, render)).to include('QTS with PGCE')
     expect(row_text_selector(:funding_type, render)).to include(course_option.course.funding_type.humanize)
   end
 

--- a/spec/components/provider_interface/read_only_completed_offer_summary_component_spec.rb
+++ b/spec/components/provider_interface/read_only_completed_offer_summary_component_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe ProviderInterface::ReadOnlyCompletedOfferSummaryComponent do
     expect(row_text_selector(:course, render)).to include(course_option.course.name_and_code)
     expect(row_text_selector(:location, render)).to include(course_option.site.name_and_address)
     expect(row_text_selector(:full_or_part_time, render)).to include(course_option.study_mode.humanize)
-    expect(row_text_selector(:qualification, render)).to include('PGCE with QTS')
+    expect(row_text_selector(:qualification, render)).to include('QTS with PGCE')
     expect(row_text_selector(:funding_type, render)).to include(course_option.course.funding_type.humanize)
   end
 

--- a/spec/forms/candidate_interface/pick_course_form_spec.rb
+++ b/spec/forms/candidate_interface/pick_course_form_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe CandidateInterface::PickCourseForm do
       )
 
       expect(form.radio_available_courses.map(&:hint)).to contain_exactly(
-        'PGCE with QTS full time',
+        'QTS with PGCE full time',
         'Custom description',
-        'PGCE with QTS full time',
+        'QTS with PGCE full time',
       )
     end
   end
@@ -42,7 +42,7 @@ RSpec.describe CandidateInterface::PickCourseForm do
         :open,
         name: 'English',
         code: '456',
-        description: 'PGCE with QTS full time',
+        description: 'QTS with PGCE full time',
         provider:,
       )
       create(
@@ -74,9 +74,9 @@ RSpec.describe CandidateInterface::PickCourseForm do
         expect(
           form.radio_available_courses.map(&:hint),
         ).to contain_exactly(
-          'PGCE with QTS full time',
+          'QTS with PGCE full time',
           'PGCE full time',
-          'PGCE with QTS full time',
+          'QTS with PGCE full time',
         )
       end
     end
@@ -86,7 +86,7 @@ RSpec.describe CandidateInterface::PickCourseForm do
         expect(
           form.dropdown_available_courses.map(&:name),
         ).to contain_exactly(
-          'English (456) – PGCE with QTS full time – No vacancies',
+          'English (456) – QTS with PGCE full time – No vacancies',
           'English (789) – PGCE full time – No vacancies',
           'Maths (123)',
         )
@@ -134,7 +134,7 @@ RSpec.describe CandidateInterface::PickCourseForm do
         expect(form.dropdown_available_courses.map(&:name)).to contain_exactly(
           'English (789)',
           'Maths (123) – PGCE full time',
-          'Maths (456) – PGCE with QTS full time',
+          'Maths (456) – QTS with PGCE full time',
         )
       end
     end
@@ -172,7 +172,7 @@ RSpec.describe CandidateInterface::PickCourseForm do
 
         expect(form.dropdown_available_courses.map(&:name)).to contain_exactly(
           'Maths (123) – PGCE full time',
-          'Maths (456) – PGCE with QTS full time',
+          'Maths (456) – QTS with PGCE full time',
         )
       end
     end
@@ -181,8 +181,8 @@ RSpec.describe CandidateInterface::PickCourseForm do
       it 'returns the course name_code_and_age_range' do
         provider = create(:provider)
         provider2 = create(:provider, name: 'BIG SCITT')
-        maths4to8 = create(:course, :open, name: 'Maths', code: '123', description: 'PGCE with QTS full time', provider:, accredited_provider: provider2)
-        maths8to12 = create(:course, :open, name: 'Maths', code: '456', age_range: '8 to 12', description: 'PGCE with QTS full time', provider:, accredited_provider: provider2)
+        maths4to8 = create(:course, :open, name: 'Maths', code: '123', description: 'QTS with PGCE full time', provider:, accredited_provider: provider2)
+        maths8to12 = create(:course, :open, name: 'Maths', code: '456', age_range: '8 to 12', description: 'QTS with PGCE full time', provider:, accredited_provider: provider2)
         create(:course_option, course: maths4to8)
         create(:course_option, course: maths8to12)
 
@@ -196,7 +196,7 @@ RSpec.describe CandidateInterface::PickCourseForm do
       it 'returns course name and code' do
         provider = create(:provider)
         provider2 = create(:provider, name: 'BIG SCITT')
-        maths123 = create(:course, :open, name: 'Maths', code: '123', description: 'PGCE with QTS full time', provider:, accredited_provider: provider2)
+        maths123 = create(:course, :open, name: 'Maths', code: '123', description: 'QTS with PGCE full time', provider:, accredited_provider: provider2)
         maths456 = create(:course, :open, name: 'Maths', code: '456', description: 'PGCE with QTS full time', provider:, accredited_provider: provider2)
         create(:course_option, course: maths123)
         create(:course_option, course: maths456)

--- a/spec/helpers/qualification_value_helper_spec.rb
+++ b/spec/helpers/qualification_value_helper_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe QualificationValueHelper do
       it 'capitalises and concatenates the values' do
         @course = build_stubbed(:course, qualifications: %w[qts pgce])
 
-        expect(qualification_text(course_option)).to eq 'PGCE with QTS'
+        expect(qualification_text(course_option)).to eq 'QTS with PGCE'
       end
     end
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe Course do
       let(:course) { build(:course, accredited_provider: build(:provider)) }
 
       it 'returns the accredited provider' do
-        result_string = "#{course.description} - #{course.accredited_provider.name}"
+        result_string = "#{course.description_to_s} - #{course.accredited_provider.name}"
 
         expect(course.description_and_accredited_provider).to eq(result_string)
       end
@@ -212,12 +212,36 @@ RSpec.describe Course do
       let(:course) { build(:course) }
 
       it 'returns the provider' do
-        expect(course.description_and_accredited_provider).to eq(course.description)
+        expect(course.description_and_accredited_provider).to eq(course.description_to_s)
       end
     end
   end
 
-  describe 'qualificaitons_to_s' do
+  describe '#description_to_s' do
+    subject { course.description_to_s }
+
+    let(:course) { build(:course, description:) }
+
+    context 'when nil' do
+      let(:description) { nil }
+
+      it { is_expected.to eq('') }
+    end
+
+    context 'when contains pgce with qts' do
+      let(:description) { 'PGCE with QTS, full time or part time' }
+
+      it { is_expected.to eq('QTS with PGCE, full time or part time') }
+    end
+
+    context 'when contains pgde with qts' do
+      let(:description) { 'PGDE with QTS, full time or part time' }
+
+      it { is_expected.to eq(course.description) }
+    end
+  end
+
+  describe '#qualifications_to_s' do
     subject { course.qualifications_to_s }
 
     let(:course) { build(:course, qualifications:) }
@@ -231,7 +255,7 @@ RSpec.describe Course do
     context 'when [qts pgce]' do
       let(:qualifications) { %w[qts pgce] }
 
-      it { is_expected.to eq('PGCE with QTS') }
+      it { is_expected.to eq('QTS with PGCE') }
     end
 
     context 'when [qts pgde]' do

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_changes_course_and_reaches_limit_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_changes_course_and_reaches_limit_spec.rb
@@ -55,9 +55,9 @@ RSpec.feature 'Changing a course' do
 
   def then_i_see_the_courses_and_their_descriptions
     expect(page).to have_content(@course.name_and_code)
-    expect(page).to have_content(@course.description)
+    expect(page).to have_content(@course.description_to_s)
     expect(page).to have_content(@another_course.name_and_code)
-    expect(page).to have_content(@another_course.description)
+    expect(page).to have_content(@another_course.description_to_s)
   end
 
   def when_i_choose_a_different_course

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_reaching_reapplication_limit_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_reaching_reapplication_limit_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature 'Selecting a course' do
 
   def then_i_see_a_course_and_its_description
     expect(page).to have_content(@course.name_and_code)
-    expect(page).to have_content(@course.description)
+    expect(page).to have_content(@course.description_to_s)
   end
 
   def when_i_choose_a_course_rejected_twice

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_reapplying_to_a_course_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_reapplying_to_a_course_spec.rb
@@ -60,7 +60,7 @@ RSpec.feature 'Selecting a course' do
 
   def then_i_see_the_course_and_its_description
     expect(page).to have_content(@course.name_and_code)
-    expect(page).to have_content(@course.description)
+    expect(page).to have_content(@course.description_to_s)
   end
 
   def and_i_choose_the_same_course

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_spec.rb
@@ -104,7 +104,7 @@ RSpec.feature 'Selecting a course' do
 
   def then_i_see_a_course_and_its_description
     expect(page).to have_content(@course.name_and_code)
-    expect(page).to have_content(@course.description)
+    expect(page).to have_content(@course.description_to_s)
   end
 
   def when_submit_without_choosing_a_course

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_that_is_full_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_that_is_full_spec.rb
@@ -55,7 +55,7 @@ RSpec.feature 'Selecting a course' do
 
   def then_i_see_a_course_and_its_description
     expect(page).to have_content(@course.name_and_code)
-    expect(page).to have_content(@course.description)
+    expect(page).to have_content(@course.description_to_s)
   end
 
   def and_i_choose_a_course_with_no_vacancies

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_duplicate_course_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_duplicate_course_spec.rb
@@ -60,7 +60,7 @@ RSpec.feature 'Selecting a course' do
 
   def then_i_see_a_course_and_its_description
     expect(page).to have_content(@course.name_and_code)
-    expect(page).to have_content(@course.description)
+    expect(page).to have_content(@course.description_to_s)
   end
 
   def and_i_choose_a_duplicate_course


### PR DESCRIPTION
## Context

There is inconsistency of terminology between GiT and Find. GiT use “QTS with PGCE” (which is more clear/intuitive) whereas Find uses “PGCE with QTS”.

## Changes proposed in this pull request

Replace "PGCE with QTS” with "QTS with PGCE".

## Gotcha

When it comes from qualifications is an easy change but because the terminology is inside of the course description from the TTAPI we need to replace part of the string.

## Guidance to review

1. All the places in Apply/Manage being replaced?

## Link to Trello card

https://trello.com/c/eftEZsWL/1283-review-and-replace-existing-instances-of-pgce-with-qts-with-the-correct-terminology-of-qts-with-pgce-in-ui-only

