### PR TITLE
[1472] Update visa immigration options for EEA candidates

### DIFF
--- a/app/components/support_interface/personal_information_component.rb
+++ b/app/components/support_interface/personal_information_component.rb
@@ -142,7 +142,7 @@ module SupportInterface
     end
 
     def visa_or_immigration_status_text
-      includes_eu_eea_swiss?(application_form.nationalities) ? 'Immigration status' : 'Visa or immigration status'
+      'Visa or immigration status'
     end
   end
 end

--- a/app/components/support_interface/personal_information_component.rb
+++ b/app/components/support_interface/personal_information_component.rb
@@ -107,7 +107,7 @@ module SupportInterface
       return unless application_form.right_to_work_or_study == 'yes'
 
       row = {
-        key: visa_or_immigration_status_text,
+        key: I18n.t('support_interface.edit_immigration_status.visa_or_immigration_status_text'),
         value: FormatResidencyDetailsService.new(application_form:).residency_details_value,
       }
       return row unless editable?
@@ -115,7 +115,7 @@ module SupportInterface
       row.merge(
         action: {
           href: support_interface_application_form_edit_immigration_status_path(application_form),
-          visually_hidden_text: visa_or_immigration_status_text.downcase,
+          visually_hidden_text: I18n.t('support_interface.edit_immigration_status.visa_or_immigration_status_text').downcase,
         },
       )
     end
@@ -139,10 +139,6 @@ module SupportInterface
 
     def editable?
       application_form.editable?
-    end
-
-    def visa_or_immigration_status_text
-      'Visa or immigration status'
     end
   end
 end

--- a/app/forms/candidate_interface/immigration_status_form.rb
+++ b/app/forms/candidate_interface/immigration_status_form.rb
@@ -36,13 +36,5 @@ module CandidateInterface
     def other_immigration_status?
       immigration_status == 'other'
     end
-
-    def visa_or_immigration_status(application_form)
-      if includes_eu_eea_swiss?(application_form.nationalities)
-        'immigration_status'
-      else
-        'visa_or_immigration_status'
-      end
-    end
   end
 end

--- a/app/forms/support_interface/application_forms/immigration_status_form.rb
+++ b/app/forms/support_interface/application_forms/immigration_status_form.rb
@@ -40,14 +40,6 @@ module SupportInterface
       def other_immigration_status?
         immigration_status == 'other'
       end
-
-      def visa_or_immigration_status(application_form)
-        if includes_eu_eea_swiss?(application_form.nationalities)
-          'immigration_status'
-        else
-          'visa_or_immigration_status'
-        end
-      end
     end
   end
 end

--- a/app/presenters/candidate_interface/personal_details_review_presenter.rb
+++ b/app/presenters/candidate_interface/personal_details_review_presenter.rb
@@ -2,7 +2,6 @@ module CandidateInterface
   class PersonalDetailsReviewPresenter
     include ActionView::Helpers::TagHelper
     include Rails.application.routes.url_helpers
-    include CandidateDetailsHelper
 
     def initialize(personal_details_form:, nationalities_form:, right_to_work_form:, application_form:, editable: true, return_to_application_review: false)
       @personal_details_form = personal_details_form
@@ -103,26 +102,18 @@ module CandidateInterface
 
       if @application_form.immigration_status
         rows << {
-          key: I18n.t("application_form.personal_details.#{visa_or_immigration_status}.label"),
+          key: I18n.t('application_form.personal_details.visa_or_immigration_status.label'),
           value: formatted_immigration_status,
           action: if @editable && !@application_form.submitted_applications?
                     {
                       href: candidate_interface_edit_immigration_status_path(return_to_params),
-                      visually_hidden_text: I18n.t("application_form.personal_details.#{visa_or_immigration_status}.change_action"),
+                      visually_hidden_text: I18n.t('application_form.personal_details.visa_or_immigration_status.change_action'),
                     }
                   end,
-          html_attributes: { data: { qa: "personal_details_#{visa_or_immigration_status}" } },
+          html_attributes: { data: { qa: "personal_details_visa_or_immigration_status'}" } },
         }
       end
       rows
-    end
-
-    def visa_or_immigration_status
-      if includes_eu_eea_swiss?(@application_form.nationalities)
-        'immigration_status'
-      else
-        'visa_or_immigration_status'
-      end
     end
 
     def british_or_irish?

--- a/app/presenters/candidate_interface/personal_details_review_presenter.rb
+++ b/app/presenters/candidate_interface/personal_details_review_presenter.rb
@@ -110,7 +110,7 @@ module CandidateInterface
                       visually_hidden_text: I18n.t('application_form.personal_details.visa_or_immigration_status.change_action'),
                     }
                   end,
-          html_attributes: { data: { qa: "personal_details_visa_or_immigration_status'}" } },
+          html_attributes: { data: { qa: 'personal_details_visa_or_immigration_status' } },
         }
       end
       rows

--- a/app/views/candidate_interface/personal_details/immigration_status/_shared_form.html.erb
+++ b/app/views/candidate_interface/personal_details/immigration_status/_shared_form.html.erb
@@ -2,55 +2,43 @@
 
 <h1 class="govuk-heading-l"><%= t('page_titles.visa_or_immigration_status') %></h1>
 
-<% if @form.eu_nationality? %>
-  <%= f.govuk_radio_buttons_fieldset(
-    :immigration_status,
-    legend: { text: 'Select your visa or immigration status' },
-  ) do %>
+<%= f.govuk_radio_buttons_fieldset :immigration_status,
+  legend: { text: 'Select your visa or immigration status' } do %>
+
     <% scope = 'application_form.personal_details.immigration_status.values' %>
-    <%= f.govuk_radio_button :immigration_status, :eu_settled, label: { text: t('eu_settled', scope:) }, link_errors: true %>
-    <%= f.govuk_radio_button :immigration_status, :eu_pre_settled, label: { text: t('eu_pre_settled', scope:) } %>
+
+    <% if @form.eu_nationality? %>
+      <%= f.govuk_radio_button :immigration_status, :eu_settled, label: { text: t('eu_settled', scope:) }, link_errors: true %>
+      <%= f.govuk_radio_button :immigration_status, :eu_pre_settled, label: { text: t('eu_pre_settled', scope:) } %>
+    <% end %>
+
     <%= f.govuk_radio_button :immigration_status, :indefinite_leave_to_remain_in_the_uk, label: { text: t('indefinite_leave_to_remain_in_the_uk', scope:) } %>
     <%= f.govuk_radio_button :immigration_status, :student_visa, label: { text: t('student_visa', scope:) } %>
     <%= f.govuk_radio_button :immigration_status, :graduate_visa, label: { text: t('graduate_visa', scope:) } %>
     <%= f.govuk_radio_button :immigration_status, :skilled_worker_visa, label: { text: t('skilled_worker_visa', scope:) } %>
     <%= f.govuk_radio_button :immigration_status, :dependent_on_partners_or_parents_visa, label: { text: t('dependent_on_partners_or_parents_visa', scope:) } %>
     <%= f.govuk_radio_button :immigration_status, :family_visa, label: { text: t('family_visa', scope:) } %>
+
+    <% unless @form.eu_nationality? %>
+      <%= f.govuk_radio_button :immigration_status, :british_national_overseas_visa, label: { text: t('british_national_overseas_visa', scope:) } %>
+    <% end %>
     <%= f.govuk_radio_button :immigration_status, :uk_ancestry_visa, label: { text: t('uk_ancestry_visa', scope:) } %>
     <%= f.govuk_radio_button :immigration_status, :high_potential_individual_visa, label: { text: t('high_potential_individual_visa', scope:) } %>
     <%= f.govuk_radio_button :immigration_status, :youth_mobility_scheme, label: { text: t('youth_mobility_scheme', scope:) } %>
-    <%= f.govuk_radio_button :immigration_status, :refugee_status, label: { text: t('refugee_status', scope:) } %>
-    <%= f.govuk_radio_divider 'or' %>
-    <%= f.govuk_radio_button :immigration_status, 'other', label: { text: 'Other' } do %>
-      <%= f.govuk_text_field(:right_to_work_or_study_details, label: { text: 'Enter immigration status' }) %>
-    <% end %>
-  <% end %>
-<% else %>
 
-  <%= f.govuk_radio_buttons_fieldset :right_to_work_or_study_details,
-    legend: { text: 'Select your visa or immigration status' } do %>
-
-      <% scope = 'application_form.personal_details.immigration_status.values' %>
-      <%= f.govuk_radio_button :immigration_status, :indefinite_leave_to_remain_in_the_uk, label: { text: t('indefinite_leave_to_remain_in_the_uk', scope:) } %>
-      <%= f.govuk_radio_button :immigration_status, :student_visa, label: { text: t('student_visa', scope:) } %>
-      <%= f.govuk_radio_button :immigration_status, :graduate_visa, label: { text: t('graduate_visa', scope:) } %>
-      <%= f.govuk_radio_button :immigration_status, :skilled_worker_visa, label: { text: t('skilled_worker_visa', scope:) } %>
-      <%= f.govuk_radio_button :immigration_status, :dependent_on_partners_or_parents_visa, label: { text: t('dependent_on_partners_or_parents_visa', scope:) } %>
-      <%= f.govuk_radio_button :immigration_status, :family_visa, label: { text: t('family_visa', scope:) } %>
-      <%= f.govuk_radio_button :immigration_status, :british_national_overseas_visa, label: { text: t('british_national_overseas_visa', scope:) } %>
-      <%= f.govuk_radio_button :immigration_status, :uk_ancestry_visa, label: { text: t('uk_ancestry_visa', scope:) } %>
-      <%= f.govuk_radio_button :immigration_status, :high_potential_individual_visa, label: { text: t('high_potential_individual_visa', scope:) } %>
-      <%= f.govuk_radio_button :immigration_status, :youth_mobility_scheme, label: { text: t('youth_mobility_scheme', scope:) } %>
+    <% unless @form.eu_nationality? %>
       <%= f.govuk_radio_button :immigration_status, :india_young_professionals_scheme_visa, label: { text: t('india_young_professionals_scheme_visa', scope:) } %>
       <%= f.govuk_radio_button :immigration_status, :ukraine_family_scheme_or_ukraine_sponsorship_scheme_visa, label: { text: t('ukraine_family_scheme_or_ukraine_sponsorship_scheme_visa', scope:) } %>
       <%= f.govuk_radio_button :immigration_status, :afghan_citizens_resettlement_scheme_or_afghan_relocations_and_assistance_policy, label: { text: t('afghan_citizens_resettlement_scheme_or_afghan_relocations_and_assistance_policy', scope:) } %>
-      <%= f.govuk_radio_button :immigration_status, :refugee_status, label: { text: t('refugee_status', scope:) } %>
-      <%= f.govuk_radio_divider 'or' %>
+    <% end %>
 
-      <%= f.govuk_radio_button :immigration_status, :other, label: { text: t('other', scope:) } do %>
-        <%= f.govuk_text_field(:right_to_work_or_study_details, label: { text: 'Enter visa type or immigration status' }) %>
-      <% end %>
+    <%= f.govuk_radio_button :immigration_status, :refugee_status, label: { text: t('refugee_status', scope:) } %>
+    <%= f.govuk_radio_divider 'or' %>
 
-  <% end %>
+    <%= f.govuk_radio_button :immigration_status, :other, label: { text: t('other', scope:) } do %>
+      <%= f.govuk_text_field(:right_to_work_or_study_details, label: { text: 'Enter visa type or immigration status' }) %>
+    <% end %>
+
 <% end %>
+
 <%= f.govuk_submit t('save_and_continue') %>

--- a/app/views/candidate_interface/personal_details/immigration_status/_shared_form.html.erb
+++ b/app/views/candidate_interface/personal_details/immigration_status/_shared_form.html.erb
@@ -1,12 +1,25 @@
 <%= f.govuk_error_summary %>
 
+<h1 class="govuk-heading-l"><%= t('page_titles.visa_or_immigration_status') %></h1>
+
 <% if @form.eu_nationality? %>
   <%= f.govuk_radio_buttons_fieldset(
     :immigration_status,
-    legend: { text: t('page_titles.immigration_status'), size: 'l' },
+    legend: { text: 'Select your visa or immigration status' },
   ) do %>
-    <%= f.govuk_radio_button :immigration_status, 'eu_settled', label: { text: t('application_form.personal_details.immigration_status.values.eu_settled') }, link_errors: true %>
-    <%= f.govuk_radio_button :immigration_status, 'eu_pre_settled', label: { text: t('application_form.personal_details.immigration_status.values.eu_pre_settled') } %>
+    <% scope = 'application_form.personal_details.immigration_status.values' %>
+    <%= f.govuk_radio_button :immigration_status, :eu_settled, label: { text: t('eu_settled', scope:) }, link_errors: true %>
+    <%= f.govuk_radio_button :immigration_status, :eu_pre_settled, label: { text: t('eu_pre_settled', scope:) } %>
+    <%= f.govuk_radio_button :immigration_status, :indefinite_leave_to_remain_in_the_uk, label: { text: t('indefinite_leave_to_remain_in_the_uk', scope:) } %>
+    <%= f.govuk_radio_button :immigration_status, :student_visa, label: { text: t('student_visa', scope:) } %>
+    <%= f.govuk_radio_button :immigration_status, :graduate_visa, label: { text: t('graduate_visa', scope:) } %>
+    <%= f.govuk_radio_button :immigration_status, :skilled_worker_visa, label: { text: t('skilled_worker_visa', scope:) } %>
+    <%= f.govuk_radio_button :immigration_status, :dependent_on_partners_or_parents_visa, label: { text: t('dependent_on_partners_or_parents_visa', scope:) } %>
+    <%= f.govuk_radio_button :immigration_status, :family_visa, label: { text: t('family_visa', scope:) } %>
+    <%= f.govuk_radio_button :immigration_status, :uk_ancestry_visa, label: { text: t('uk_ancestry_visa', scope:) } %>
+    <%= f.govuk_radio_button :immigration_status, :high_potential_individual_visa, label: { text: t('high_potential_individual_visa', scope:) } %>
+    <%= f.govuk_radio_button :immigration_status, :youth_mobility_scheme, label: { text: t('youth_mobility_scheme', scope:) } %>
+    <%= f.govuk_radio_button :immigration_status, :refugee_status, label: { text: t('refugee_status', scope:) } %>
     <%= f.govuk_radio_divider 'or' %>
     <%= f.govuk_radio_button :immigration_status, 'other', label: { text: 'Other' } do %>
       <%= f.govuk_text_field(:right_to_work_or_study_details, label: { text: 'Enter immigration status' }) %>
@@ -14,7 +27,6 @@
   <% end %>
 <% else %>
 
-  <h1 class="govuk-heading-l"><%= t('page_titles.visa_or_immigration_status') %></h1>
   <%= f.govuk_radio_buttons_fieldset :right_to_work_or_study_details,
     legend: { text: 'Select your visa or immigration status' } do %>
 

--- a/app/views/candidate_interface/personal_details/immigration_status/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/immigration_status/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, title_with_error_prefix(t("page_titles.#{@form.visa_or_immigration_status(current_application)}"), @form.errors.any?) %>
+<% content_for :title, title_with_error_prefix(t('page_titles.visa_or_immigration_status'), @form.errors.any?) %>
 
 <% content_for :before_content, govuk_back_link_to(candidate_interface_personal_details_show_path, 'Back') %>
 

--- a/app/views/candidate_interface/personal_details/immigration_status/new.html.erb
+++ b/app/views/candidate_interface/personal_details/immigration_status/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, title_with_error_prefix(t("page_titles.#{@form.visa_or_immigration_status(current_application)}"), @form.errors.any?) %>
+<% content_for :title, title_with_error_prefix(t('page_titles.visa_or_immigration_status'), @form.errors.any?) %>
 
 <% content_for :before_content, govuk_back_link_to(candidate_interface_immigration_right_to_work_path, 'Back') %>
 

--- a/app/views/support_interface/application_forms/immigration_status/edit.html.erb
+++ b/app/views/support_interface/application_forms/immigration_status/edit.html.erb
@@ -1,17 +1,30 @@
-<% content_for :browser_title, title_with_error_prefix(t("support_interface.page_titles.#{@immigration_status_form.visa_or_immigration_status(@application_form)}"), @immigration_status_form.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix(t('support_interface.page_titles.visa_or_immigration_status'), @immigration_status_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(@application_form)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t('support_interface.page_titles.visa_or_immigration_status') %></h1>
+
     <%= form_with model: @immigration_status_form, url: support_interface_application_form_edit_immigration_status_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
       <% if @immigration_status_form.eu_nationality? %>
         <%= f.govuk_radio_buttons_fieldset(
         :immigration_status,
-        legend: { text: t('support_interface.page_titles.immigration_status'), size: 'l' },
+        legend: { text: 'Select your visa or immigration status' },
       ) do %>
-        <%= f.govuk_radio_button :immigration_status, :eu_settled, label: { text: t('support_interface.edit_immigration_status.values.eu_settled') }, link_errors: true %>
-        <%= f.govuk_radio_button :immigration_status, :eu_pre_settled, label: { text: t('support_interface.edit_immigration_status.values.eu_pre_settled') } %>
+      <% scope = 'support_interface.edit_immigration_status.values' %>
+        <%= f.govuk_radio_button :immigration_status, :eu_settled, label: { text: t('eu_settled', scope:) }, link_errors: true %>
+        <%= f.govuk_radio_button :immigration_status, :eu_pre_settled, label: { text: t('eu_pre_settled', scope:) } %>
+        <%= f.govuk_radio_button :immigration_status, :indefinite_leave_to_remain_in_the_uk, label: { text: t('indefinite_leave_to_remain_in_the_uk', scope:) } %>
+        <%= f.govuk_radio_button :immigration_status, :student_visa, label: { text: t('student_visa', scope:) } %>
+        <%= f.govuk_radio_button :immigration_status, :graduate_visa, label: { text: t('graduate_visa', scope:) } %>
+        <%= f.govuk_radio_button :immigration_status, :skilled_worker_visa, label: { text: t('skilled_worker_visa', scope:) } %>
+        <%= f.govuk_radio_button :immigration_status, :dependent_on_partners_or_parents_visa, label: { text: t('dependent_on_partners_or_parents_visa', scope:) } %>
+        <%= f.govuk_radio_button :immigration_status, :family_visa, label: { text: t('family_visa', scope:) } %>
+        <%= f.govuk_radio_button :immigration_status, :uk_ancestry_visa, label: { text: t('uk_ancestry_visa', scope:) } %>
+        <%= f.govuk_radio_button :immigration_status, :high_potential_individual_visa, label: { text: t('high_potential_individual_visa', scope:) } %>
+        <%= f.govuk_radio_button :immigration_status, :youth_mobility_scheme, label: { text: t('youth_mobility_scheme', scope:) } %>
+        <%= f.govuk_radio_button :immigration_status, :refugee_status, label: { text: t('refugee_status', scope:) } %>
         <%= f.govuk_radio_divider 'or' %>
         <%= f.govuk_radio_button :immigration_status, :other, label: { text: t('support_interface.edit_immigration_status.values.other') } do %>
           <%= f.govuk_text_field(
@@ -21,7 +34,6 @@
         <% end %>
       <% end %>
       <% else %>
-      <h1 class="govuk-heading-l"><%= t('support_interface.page_titles.visa_or_immigration_status') %></h1>
         <%= f.govuk_radio_buttons_fieldset :right_to_work_or_study_details,
         legend: { text: 'Select your visa or immigration status' } do %>
           <% scope = 'support_interface.edit_immigration_status.values' %>

--- a/app/views/support_interface/application_forms/immigration_status/edit.html.erb
+++ b/app/views/support_interface/application_forms/immigration_status/edit.html.erb
@@ -7,49 +7,35 @@
 
     <%= form_with model: @immigration_status_form, url: support_interface_application_form_edit_immigration_status_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
-      <% if @immigration_status_form.eu_nationality? %>
-        <%= f.govuk_radio_buttons_fieldset(
-        :immigration_status,
-        legend: { text: 'Select your visa or immigration status' },
-      ) do %>
-      <% scope = 'support_interface.edit_immigration_status.values' %>
-        <%= f.govuk_radio_button :immigration_status, :eu_settled, label: { text: t('eu_settled', scope:) }, link_errors: true %>
-        <%= f.govuk_radio_button :immigration_status, :eu_pre_settled, label: { text: t('eu_pre_settled', scope:) } %>
-        <%= f.govuk_radio_button :immigration_status, :indefinite_leave_to_remain_in_the_uk, label: { text: t('indefinite_leave_to_remain_in_the_uk', scope:) } %>
-        <%= f.govuk_radio_button :immigration_status, :student_visa, label: { text: t('student_visa', scope:) } %>
-        <%= f.govuk_radio_button :immigration_status, :graduate_visa, label: { text: t('graduate_visa', scope:) } %>
-        <%= f.govuk_radio_button :immigration_status, :skilled_worker_visa, label: { text: t('skilled_worker_visa', scope:) } %>
-        <%= f.govuk_radio_button :immigration_status, :dependent_on_partners_or_parents_visa, label: { text: t('dependent_on_partners_or_parents_visa', scope:) } %>
-        <%= f.govuk_radio_button :immigration_status, :family_visa, label: { text: t('family_visa', scope:) } %>
-        <%= f.govuk_radio_button :immigration_status, :uk_ancestry_visa, label: { text: t('uk_ancestry_visa', scope:) } %>
-        <%= f.govuk_radio_button :immigration_status, :high_potential_individual_visa, label: { text: t('high_potential_individual_visa', scope:) } %>
-        <%= f.govuk_radio_button :immigration_status, :youth_mobility_scheme, label: { text: t('youth_mobility_scheme', scope:) } %>
-        <%= f.govuk_radio_button :immigration_status, :refugee_status, label: { text: t('refugee_status', scope:) } %>
-        <%= f.govuk_radio_divider 'or' %>
-        <%= f.govuk_radio_button :immigration_status, :other, label: { text: t('support_interface.edit_immigration_status.values.other') } do %>
-          <%= f.govuk_text_field(
-                :right_to_work_or_study_details,
-                label: { text: 'Enter Immigration status' },
-              ) %>
-        <% end %>
-      <% end %>
-      <% else %>
-        <%= f.govuk_radio_buttons_fieldset :right_to_work_or_study_details,
+       <%= f.govuk_radio_buttons_fieldset :immigration_status,
         legend: { text: 'Select your visa or immigration status' } do %>
           <% scope = 'support_interface.edit_immigration_status.values' %>
+
+          <% if @immigration_status_form.eu_nationality? %>
+            <%= f.govuk_radio_button :immigration_status, :eu_settled, label: { text: t('eu_settled', scope:) }, link_errors: true %>
+            <%= f.govuk_radio_button :immigration_status, :eu_pre_settled, label: { text: t('eu_pre_settled', scope:) } %>
+          <% end %>
+
           <%= f.govuk_radio_button :immigration_status, :indefinite_leave_to_remain_in_the_uk, label: { text: t('indefinite_leave_to_remain_in_the_uk', scope:) } %>
           <%= f.govuk_radio_button :immigration_status, :student_visa, label: { text: t('student_visa', scope:) } %>
           <%= f.govuk_radio_button :immigration_status, :graduate_visa, label: { text: t('graduate_visa', scope:) } %>
           <%= f.govuk_radio_button :immigration_status, :skilled_worker_visa, label: { text: t('skilled_worker_visa', scope:) } %>
           <%= f.govuk_radio_button :immigration_status, :dependent_on_partners_or_parents_visa, label: { text: t('dependent_on_partners_or_parents_visa', scope:) } %>
           <%= f.govuk_radio_button :immigration_status, :family_visa, label: { text: t('family_visa', scope:) } %>
-          <%= f.govuk_radio_button :immigration_status, :british_national_overseas_visa, label: { text: t('british_national_overseas_visa', scope:) } %>
+
+          <% unless @immigration_status_form.eu_nationality? %>
+            <%= f.govuk_radio_button :immigration_status, :british_national_overseas_visa, label: { text: t('british_national_overseas_visa', scope:) } %>
+          <% end %>
           <%= f.govuk_radio_button :immigration_status, :uk_ancestry_visa, label: { text: t('uk_ancestry_visa', scope:) } %>
           <%= f.govuk_radio_button :immigration_status, :high_potential_individual_visa, label: { text: t('high_potential_individual_visa', scope:) } %>
           <%= f.govuk_radio_button :immigration_status, :youth_mobility_scheme, label: { text: t('youth_mobility_scheme', scope:) } %>
-          <%= f.govuk_radio_button :immigration_status, :india_young_professionals_scheme_visa, label: { text: t('india_young_professionals_scheme_visa', scope:) } %>
-          <%= f.govuk_radio_button :immigration_status, :ukraine_family_scheme_or_ukraine_sponsorship_scheme_visa, label: { text: t('ukraine_family_scheme_or_ukraine_sponsorship_scheme_visa', scope:) } %>
-          <%= f.govuk_radio_button :immigration_status, :afghan_citizens_resettlement_scheme_or_afghan_relocations_and_assistance_policy, label: { text: t('afghan_citizens_resettlement_scheme_or_afghan_relocations_and_assistance_policy', scope:) } %>
+
+          <% unless @immigration_status_form.eu_nationality? %>
+            <%= f.govuk_radio_button :immigration_status, :india_young_professionals_scheme_visa, label: { text: t('india_young_professionals_scheme_visa', scope:) } %>
+            <%= f.govuk_radio_button :immigration_status, :ukraine_family_scheme_or_ukraine_sponsorship_scheme_visa, label: { text: t('ukraine_family_scheme_or_ukraine_sponsorship_scheme_visa', scope:) } %>
+            <%= f.govuk_radio_button :immigration_status, :afghan_citizens_resettlement_scheme_or_afghan_relocations_and_assistance_policy, label: { text: t('afghan_citizens_resettlement_scheme_or_afghan_relocations_and_assistance_policy', scope:) } %>
+          <% end %>
+
           <%= f.govuk_radio_button :immigration_status, :refugee_status, label: { text: t('refugee_status', scope:) } %>
           <%= f.govuk_radio_divider 'or' %>
 
@@ -57,7 +43,6 @@
             <%= f.govuk_text_field(:right_to_work_or_study_details, label: { text: 'Enter visa type or immigration status' }) %>
           <% end %>
         <% end %>
-      <% end %>
 
       <%= f.govuk_text_field(
             :audit_comment,

--- a/config/locales/candidate_interface/personal_details.yml
+++ b/config/locales/candidate_interface/personal_details.yml
@@ -55,8 +55,8 @@ en:
           youth_mobility_scheme: Youth Mobility Scheme
           india_young_professionals_scheme_visa: India Young Professionals Scheme visa
           ukraine_family_scheme_or_ukraine_sponsorship_scheme_visa: Ukraine Family Scheme or Ukraine Sponsorship Scheme visa
-          afghan_citizens_resettlement_scheme_or_afghan_relocations_and_assistance_policy: Afghan citizens resettlement scheme or Afghan Relocations and Assistance Policy
-          refugee_status: Refugee Status
+          afghan_citizens_resettlement_scheme_or_afghan_relocations_and_assistance_policy: Afghan Citizens Resettlement Scheme (ACRS) or Afghan Relocations and Assistance Policy (ARAP)
+          refugee_status: Refugee status
           other: Other
 
   activemodel:

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -1,7 +1,6 @@
 en:
   support_interface:
     page_titles:
-      immigration_status: Edit applicant immigration status
       visa_or_immigration_status: Edit applicant visa or immigration status
 
     support_user:

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -56,6 +56,7 @@ en:
         afghan_citizens_resettlement_scheme_or_afghan_relocations_and_assistance_policy: Afghan Citizens Resettlement Scheme (ACRS) or Afghan Relocations and Assistance Policy (ARAP)
         refugee_status: Refugee status
         other: Other
+      visa_or_immigration_status_text: 'Visa or immigration status'
 
     audit_comment_ticket:
       label: 'Zendesk ticket URL'

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -53,8 +53,8 @@ en:
         youth_mobility_scheme: Youth Mobility Scheme
         india_young_professionals_scheme_visa: India Young Professionals Scheme visa
         ukraine_family_scheme_or_ukraine_sponsorship_scheme_visa: Ukraine Family Scheme or Ukraine Sponsorship Scheme visa
-        afghan_citizens_resettlement_scheme_or_afghan_relocations_and_assistance_policy: Afghan citizens resettlement scheme or Afghan Relocations and Assistance Policy
-        refugee_status: Refugee Status
+        afghan_citizens_resettlement_scheme_or_afghan_relocations_and_assistance_policy: Afghan Citizens Resettlement Scheme (ACRS) or Afghan Relocations and Assistance Policy (ARAP)
+        refugee_status: Refugee status
         other: Other
 
     audit_comment_ticket:

--- a/spec/components/support_interface/personal_information_component_spec.rb
+++ b/spec/components/support_interface/personal_information_component_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe SupportInterface::PersonalInformationComponent do
 
   it 'does not render right to work fields if nationality is British or Irish' do
     expect(result.text).not_to include('Has the right to work or study in the UK?')
-    expect(result.text).not_to include('Immigration status')
+    expect(result.text).not_to include('Visa or immigration status')
   end
 
   it 'shows change links' do
@@ -96,7 +96,7 @@ RSpec.describe SupportInterface::PersonalInformationComponent do
       end
 
       it 'renders the immigration status row' do
-        expect(result.css('.govuk-summary-list__key').text).to include('Immigration status')
+        expect(result.css('.govuk-summary-list__key').text).to include('Visa or immigration status')
         expect(result.css('.govuk-summary-list__value').text).to include('EU settled status')
       end
     end
@@ -109,7 +109,7 @@ RSpec.describe SupportInterface::PersonalInformationComponent do
       end
 
       it 'renders the residency_details_row' do
-        expect(result.css('.govuk-summary-list__key').text).to include('Immigration status')
+        expect(result.css('.govuk-summary-list__key').text).to include('Visa or immigration status')
         expect(result.css('.govuk-summary-list__value').text).to include('Indefinite leave to remain')
       end
     end
@@ -118,7 +118,7 @@ RSpec.describe SupportInterface::PersonalInformationComponent do
       before { application_form.right_to_work_or_study = 'no' }
 
       it 'does not render the immigration status row' do
-        expect(result.css('.govuk-summary-list__key').text).not_to include('Immigration status')
+        expect(result.css('.govuk-summary-list__key').text).not_to include('Visa or immigration status')
       end
     end
 
@@ -126,7 +126,7 @@ RSpec.describe SupportInterface::PersonalInformationComponent do
       before { application_form.right_to_work_or_study = 'decide_later' }
 
       it 'does not render the immigration status row' do
-        expect(result.css('.govuk-summary-list__key').text).not_to include('Immigration status')
+        expect(result.css('.govuk-summary-list__key').text).not_to include('Visa or immigration status')
       end
     end
   end

--- a/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
@@ -209,10 +209,10 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter, :mid_cycle do
       it "renders the label 'Immigration status'" do
         expect(expected_rows).to include(
           row_for(
-            :immigration_status,
+            :visa_or_immigration_status,
             'I have permanent residence',
             candidate_interface_edit_immigration_status_path('return-to' => 'application-review'),
-            'personal_details_immigration_status',
+            'personal_details_visa_or_immigration_status',
           ),
         )
       end
@@ -250,10 +250,10 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter, :mid_cycle do
         )
         expect(expected_rows).to include(
           row_for(
-            :immigration_status,
+            :visa_or_immigration_status,
             'I have permanent residence',
             nil,
-            'personal_details_immigration_status',
+            'personal_details_visa_or_immigration_status',
           ),
         )
       end

--- a/spec/system/candidate_interface/entering_details/candidate_choosing_visa_or_immigration_status_non_eu_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_choosing_visa_or_immigration_status_non_eu_spec.rb
@@ -64,14 +64,14 @@ RSpec.describe 'Choosing visa or immigration status' do
     then_i_see_the_correct_visa_in_the_summary('Ukraine Family Scheme or Ukraine Sponsorship Scheme visa')
 
     when_click_change_immigration_status
-    and_i_choose_the_visa('Afghan citizens resettlement scheme or Afghan Relocations and Assistance Policy')
+    and_i_choose_the_visa('Afghan Citizens Resettlement Scheme (ACRS) or Afghan Relocations and Assistance Policy (ARAP)')
     and_i_click_save_and_continue
-    then_i_see_the_correct_visa_in_the_summary('Afghan citizens resettlement scheme or Afghan Relocations and Assistance Policy')
+    then_i_see_the_correct_visa_in_the_summary('Afghan Citizens Resettlement Scheme (ACRS) or Afghan Relocations and Assistance Policy (ARAP)')
 
     when_click_change_immigration_status
-    and_i_choose_the_visa('Refugee Status')
+    and_i_choose_the_visa('Refugee status')
     and_i_click_save_and_continue
-    then_i_see_the_correct_visa_in_the_summary('Refugee Status')
+    then_i_see_the_correct_visa_in_the_summary('Refugee status')
   end
 
   scenario 'eu candidate who has the right to work' do
@@ -109,14 +109,14 @@ RSpec.describe 'Choosing visa or immigration status' do
       expect(page).to have_text('UK Ancestry visa')
       expect(page).to have_text('High Potential Individual visa')
       expect(page).to have_text('Youth Mobility Scheme')
-      expect(page).to have_text('Refugee Status')
+      expect(page).to have_text('Refugee status')
       expect(page).to have_text('Other')
 
       expect(page).to have_no_text('British National (Overseas) visa')
       expect(page).to have_no_text('India Young Professionals Scheme visa')
       expect(page).to have_no_text('Ukraine Family Scheme or Ukraine Sponsorship Scheme visa')
       expect(page).to have_no_text('India Young Professionals Scheme visa')
-      expect(page).to have_no_text('Afghan citizens resettlement scheme or Afghan Relocations and Assistance Policy')
+      expect(page).to have_no_text('Afghan Citizens Resettlement Scheme (ACRS) or Afghan Relocations and Assistance Policy (ARAP)')
     end
   end
 

--- a/spec/system/candidate_interface/entering_details/candidate_choosing_visa_or_immigration_status_non_eu_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_choosing_visa_or_immigration_status_non_eu_spec.rb
@@ -6,72 +6,78 @@ RSpec.describe 'Choosing visa or immigration status' do
     and_i_visit_the_immigration_status_edit_page
     when_i_choose_the_visa('Indefinite leave to remain in the UK')
     and_i_click_save_and_continue
-    then_i_should_see_the_correct_visa_in_the_summary('Indefinite leave to remain in the UK')
+    then_i_see_the_correct_visa_in_the_summary('Indefinite leave to remain in the UK')
 
     when_click_change_immigration_status
     and_i_choose_the_visa('Student visa')
     and_i_click_save_and_continue
-    then_i_should_see_the_correct_visa_in_the_summary('Student visa')
+    then_i_see_the_correct_visa_in_the_summary('Student visa')
 
     when_click_change_immigration_status
     and_i_choose_the_visa('Graduate visa')
     and_i_click_save_and_continue
-    then_i_should_see_the_correct_visa_in_the_summary('Graduate visa')
+    then_i_see_the_correct_visa_in_the_summary('Graduate visa')
 
     when_click_change_immigration_status
     and_i_choose_the_visa('Skilled Worker visa')
     and_i_click_save_and_continue
-    then_i_should_see_the_correct_visa_in_the_summary('Skilled Worker visa')
+    then_i_see_the_correct_visa_in_the_summary('Skilled Worker visa')
 
     when_click_change_immigration_status
     and_i_choose_the_visa('Dependent on partner’s or parent’s visa')
     and_i_click_save_and_continue
-    then_i_should_see_the_correct_visa_in_the_summary('Dependent on partner’s or parent’s visa')
+    then_i_see_the_correct_visa_in_the_summary('Dependent on partner’s or parent’s visa')
 
     when_click_change_immigration_status
     and_i_choose_the_visa('Family visa')
     and_i_click_save_and_continue
-    then_i_should_see_the_correct_visa_in_the_summary('Family visa')
+    then_i_see_the_correct_visa_in_the_summary('Family visa')
 
     when_click_change_immigration_status
     and_i_choose_the_visa('British National (Overseas) visa')
     and_i_click_save_and_continue
-    then_i_should_see_the_correct_visa_in_the_summary('British National (Overseas) visa')
+    then_i_see_the_correct_visa_in_the_summary('British National (Overseas) visa')
 
     when_click_change_immigration_status
     and_i_choose_the_visa('UK Ancestry visa')
     and_i_click_save_and_continue
-    then_i_should_see_the_correct_visa_in_the_summary('UK Ancestry visa')
+    then_i_see_the_correct_visa_in_the_summary('UK Ancestry visa')
 
     when_click_change_immigration_status
     and_i_choose_the_visa('High Potential Individual visa')
     and_i_click_save_and_continue
-    then_i_should_see_the_correct_visa_in_the_summary('High Potential Individual visa')
+    then_i_see_the_correct_visa_in_the_summary('High Potential Individual visa')
 
     when_click_change_immigration_status
     and_i_choose_the_visa('Youth Mobility Scheme')
     and_i_click_save_and_continue
-    then_i_should_see_the_correct_visa_in_the_summary('Youth Mobility Scheme')
+    then_i_see_the_correct_visa_in_the_summary('Youth Mobility Scheme')
 
     when_click_change_immigration_status
     and_i_choose_the_visa('India Young Professionals Scheme visa')
     and_i_click_save_and_continue
-    then_i_should_see_the_correct_visa_in_the_summary('India Young Professionals Scheme visa')
+    then_i_see_the_correct_visa_in_the_summary('India Young Professionals Scheme visa')
 
     when_click_change_immigration_status
     and_i_choose_the_visa('Ukraine Family Scheme or Ukraine Sponsorship Scheme visa')
     and_i_click_save_and_continue
-    then_i_should_see_the_correct_visa_in_the_summary('Ukraine Family Scheme or Ukraine Sponsorship Scheme visa')
+    then_i_see_the_correct_visa_in_the_summary('Ukraine Family Scheme or Ukraine Sponsorship Scheme visa')
 
     when_click_change_immigration_status
     and_i_choose_the_visa('Afghan citizens resettlement scheme or Afghan Relocations and Assistance Policy')
     and_i_click_save_and_continue
-    then_i_should_see_the_correct_visa_in_the_summary('Afghan citizens resettlement scheme or Afghan Relocations and Assistance Policy')
+    then_i_see_the_correct_visa_in_the_summary('Afghan citizens resettlement scheme or Afghan Relocations and Assistance Policy')
 
     when_click_change_immigration_status
     and_i_choose_the_visa('Refugee Status')
     and_i_click_save_and_continue
-    then_i_should_see_the_correct_visa_in_the_summary('Refugee Status')
+    then_i_see_the_correct_visa_in_the_summary('Refugee Status')
+  end
+
+  scenario 'eu candidate who has the right to work' do
+    given_i_am_logged_in_as_a_eu_candidate_who_has_the_right_to_work_or_study
+    and_i_visit_the_immigration_status_edit_page
+    then_i_am_presented_with_the_correct_options
   end
 
   def when_click_change_immigration_status
@@ -82,6 +88,36 @@ RSpec.describe 'Choosing visa or immigration status' do
     @candidate = create(:candidate)
     @application_form = create(:application_form, first_nationality: 'Canadian', right_to_work_or_study: 'yes', candidate: @candidate)
     login_as(@candidate)
+  end
+
+  def given_i_am_logged_in_as_a_eu_candidate_who_has_the_right_to_work_or_study
+    @candidate = create(:candidate)
+    @application_form = create(:application_form, first_nationality: 'French', right_to_work_or_study: 'yes', candidate: @candidate)
+    login_as(@candidate)
+  end
+
+  def then_i_am_presented_with_the_correct_options
+    within('.govuk-fieldset') do
+      expect(page).to have_text('EU settled status')
+      expect(page).to have_text('EU pre-settled status')
+      expect(page).to have_text('Indefinite leave to remain')
+      expect(page).to have_text('Student visa')
+      expect(page).to have_text('Graduate visa')
+      expect(page).to have_text('Skilled Worker visa')
+      expect(page).to have_text('Dependent on partner’s or parent’s visa')
+      expect(page).to have_text('Family visa')
+      expect(page).to have_text('UK Ancestry visa')
+      expect(page).to have_text('High Potential Individual visa')
+      expect(page).to have_text('Youth Mobility Scheme')
+      expect(page).to have_text('Refugee Status')
+      expect(page).to have_text('Other')
+
+      expect(page).to have_no_text('British National (Overseas) visa')
+      expect(page).to have_no_text('India Young Professionals Scheme visa')
+      expect(page).to have_no_text('Ukraine Family Scheme or Ukraine Sponsorship Scheme visa')
+      expect(page).to have_no_text('India Young Professionals Scheme visa')
+      expect(page).to have_no_text('Afghan citizens resettlement scheme or Afghan Relocations and Assistance Policy')
+    end
   end
 
   def and_i_visit_the_immigration_status_edit_page
@@ -98,7 +134,7 @@ RSpec.describe 'Choosing visa or immigration status' do
     click_link_or_button 'Save and continue'
   end
 
-  def then_i_should_see_the_correct_visa_in_the_summary(visa_summary_text)
+  def then_i_see_the_correct_visa_in_the_summary(visa_summary_text)
     within '.govuk-summary-list__row', text: 'Immigration status' do
       expect(page).to have_text(visa_summary_text)
     end

--- a/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_when_requiring_visa_2022_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_when_requiring_visa_2022_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'Entering personal details', time: CycleTimetableHelper.mid_cycle
     choose 'Yes'
     click_link_or_button t('save_and_continue')
 
-    expect(page).to have_content('What is your immigration status?')
+    expect(page).to have_content('Visa or immigration status')
     choose 'EU settled status'
     click_link_or_button t('save_and_continue')
 
@@ -92,9 +92,9 @@ RSpec.describe 'Entering personal details', time: CycleTimetableHelper.mid_cycle
   end
 
   def and_i_can_change_immigration_status
-    click_change_link('immigration status')
+    click_change_link('visa or immigration status')
 
-    expect(page).to have_content('What is your immigration status?')
+    expect(page).to have_content('Visa or immigration status')
     choose 'EU pre-settled status'
     click_link_or_button t('save_and_continue')
 

--- a/spec/system/support_interface/editing_visa_or_immigration_status_eu_spec.rb
+++ b/spec/system/support_interface/editing_visa_or_immigration_status_eu_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-RSpec.feature 'Editing visa or immigration status' do
+RSpec.feature 'Editing visa or immigration status, EU' do
   include DfESignInHelpers
 
-  scenario 'Support user edits visa or immigration status', :with_audited do
+  scenario 'Support user edits visa or immigration status' do
     given_i_am_a_support_user
     and_an_application_exists
 
@@ -20,6 +20,16 @@ RSpec.feature 'Editing visa or immigration status' do
     and_i_continue
     then_i_see_the_text_i_submitted
   end
+
+  scenario 'Support user is presented with the correct options' do
+    given_i_am_a_support_user
+    and_an_application_exists_with_the_right_to_work
+
+    when_i_visit_the_application_page
+    when_i_click_change_visa_or_immigration_status
+
+    then_i_am_presented_with_the_correct_eu_options
+  end
 end
 
 def given_i_am_a_support_user
@@ -28,6 +38,10 @@ end
 
 def and_an_application_exists
   @form = create(:completed_application_form, first_nationality: 'French', right_to_work_or_study: 'no')
+end
+
+def and_an_application_exists_with_the_right_to_work
+  @form = create(:completed_application_form, first_nationality: 'French', right_to_work_or_study: 'yes')
 end
 
 def when_i_visit_the_application_page
@@ -67,4 +81,28 @@ end
 
 def then_i_see_the_text_i_submitted
   expect(page).to have_content 'I live here forever'
+end
+
+def then_i_am_presented_with_the_correct_eu_options
+  within('.govuk-fieldset') do
+    expect(page).to have_text('EU settled status')
+    expect(page).to have_text('EU pre-settled status')
+    expect(page).to have_text('Indefinite leave to remain')
+    expect(page).to have_text('Student visa')
+    expect(page).to have_text('Graduate visa')
+    expect(page).to have_text('Skilled Worker visa')
+    expect(page).to have_text('Dependent on partner’s or parent’s visa')
+    expect(page).to have_text('Family visa')
+    expect(page).to have_text('UK Ancestry visa')
+    expect(page).to have_text('High Potential Individual visa')
+    expect(page).to have_text('Youth Mobility Scheme')
+    expect(page).to have_text('Refugee Status')
+    expect(page).to have_text('Other')
+
+    expect(page).to have_no_text('British National (Overseas) visa')
+    expect(page).to have_no_text('India Young Professionals Scheme visa')
+    expect(page).to have_no_text('Ukraine Family Scheme or Ukraine Sponsorship Scheme visa')
+    expect(page).to have_no_text('India Young Professionals Scheme visa')
+    expect(page).to have_no_text('Afghan citizens resettlement scheme or Afghan Relocations and Assistance Policy')
+  end
 end

--- a/spec/system/support_interface/editing_visa_or_immigration_status_eu_spec.rb
+++ b/spec/system/support_interface/editing_visa_or_immigration_status_eu_spec.rb
@@ -96,13 +96,13 @@ def then_i_am_presented_with_the_correct_eu_options
     expect(page).to have_text('UK Ancestry visa')
     expect(page).to have_text('High Potential Individual visa')
     expect(page).to have_text('Youth Mobility Scheme')
-    expect(page).to have_text('Refugee Status')
+    expect(page).to have_text('Refugee status')
     expect(page).to have_text('Other')
 
     expect(page).to have_no_text('British National (Overseas) visa')
     expect(page).to have_no_text('India Young Professionals Scheme visa')
     expect(page).to have_no_text('Ukraine Family Scheme or Ukraine Sponsorship Scheme visa')
     expect(page).to have_no_text('India Young Professionals Scheme visa')
-    expect(page).to have_no_text('Afghan citizens resettlement scheme or Afghan Relocations and Assistance Policy')
+    expect(page).to have_no_text('Afghan Citizens Resettlement Scheme (ACRS) or Afghan Relocations and Assistance Policy (ARAP)')
   end
 end

--- a/spec/system/support_interface/editing_visa_or_immigration_status_non_eu_spec.rb
+++ b/spec/system/support_interface/editing_visa_or_immigration_status_non_eu_spec.rb
@@ -81,16 +81,16 @@ RSpec.feature 'Editing visa or immigration status, non eu' do
     then_i_see_the_correct_visa_in_the_summary('Ukraine Family Scheme or Ukraine Sponsorship Scheme visa')
 
     when_click_change_immigration_status
-    and_i_choose_the_visa('Afghan citizens resettlement scheme or Afghan Relocations and Assistance Policy')
+    and_i_choose_the_visa('Afghan Citizens Resettlement Scheme (ACRS) or Afghan Relocations and Assistance Policy (ARAP)')
     and_i_add_an_audit_comment
     and_i_click_save_and_continue
-    then_i_see_the_correct_visa_in_the_summary('Afghan citizens resettlement scheme or Afghan Relocations and Assistance Policy')
+    then_i_see_the_correct_visa_in_the_summary('Afghan Citizens Resettlement Scheme (ACRS) or Afghan Relocations and Assistance Policy (ARAP)')
 
     when_click_change_immigration_status
-    and_i_choose_the_visa('Refugee Status')
+    and_i_choose_the_visa('Refugee status')
     and_i_add_an_audit_comment
     and_i_click_save_and_continue
-    then_i_see_the_correct_visa_in_the_summary('Refugee Status')
+    then_i_see_the_correct_visa_in_the_summary('Refugee status')
   end
 
   def given_i_am_a_support_user

--- a/spec/system/support_interface/editing_visa_or_immigration_status_non_eu_spec.rb
+++ b/spec/system/support_interface/editing_visa_or_immigration_status_non_eu_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'immigration status, non eu' do
+RSpec.feature 'Editing visa or immigration status, non eu' do
   include DfESignInHelpers
 
   scenario 'editing the immigration status of a candidate', :with_audited do
@@ -12,85 +12,85 @@ RSpec.feature 'immigration status, non eu' do
     when_i_choose_the_visa('Indefinite leave to remain in the UK')
     and_i_add_an_audit_comment
     and_i_click_save_and_continue
-    then_i_should_see_the_correct_visa_in_the_summary('Indefinite leave to remain in the UK')
+    then_i_see_the_correct_visa_in_the_summary('Indefinite leave to remain in the UK')
 
     when_click_change_immigration_status
     and_i_choose_the_visa('Student visa')
     and_i_add_an_audit_comment
     and_i_click_save_and_continue
-    then_i_should_see_the_correct_visa_in_the_summary('Student visa')
+    then_i_see_the_correct_visa_in_the_summary('Student visa')
 
     when_click_change_immigration_status
     and_i_choose_the_visa('Graduate visa')
     and_i_add_an_audit_comment
     and_i_click_save_and_continue
-    then_i_should_see_the_correct_visa_in_the_summary('Graduate visa')
+    then_i_see_the_correct_visa_in_the_summary('Graduate visa')
 
     when_click_change_immigration_status
     and_i_choose_the_visa('Skilled Worker visa')
     and_i_add_an_audit_comment
     and_i_click_save_and_continue
-    then_i_should_see_the_correct_visa_in_the_summary('Skilled Worker visa')
+    then_i_see_the_correct_visa_in_the_summary('Skilled Worker visa')
 
     when_click_change_immigration_status
     and_i_choose_the_visa('Dependent on partner’s or parent’s visa')
     and_i_add_an_audit_comment
     and_i_click_save_and_continue
-    then_i_should_see_the_correct_visa_in_the_summary('Dependent on partner’s or parent’s visa')
+    then_i_see_the_correct_visa_in_the_summary('Dependent on partner’s or parent’s visa')
 
     when_click_change_immigration_status
     and_i_choose_the_visa('Family visa')
     and_i_add_an_audit_comment
     and_i_click_save_and_continue
-    then_i_should_see_the_correct_visa_in_the_summary('Family visa')
+    then_i_see_the_correct_visa_in_the_summary('Family visa')
 
     when_click_change_immigration_status
     and_i_choose_the_visa('British National (Overseas) visa')
     and_i_add_an_audit_comment
     and_i_click_save_and_continue
-    then_i_should_see_the_correct_visa_in_the_summary('British National (Overseas) visa')
+    then_i_see_the_correct_visa_in_the_summary('British National (Overseas) visa')
 
     when_click_change_immigration_status
     and_i_choose_the_visa('UK Ancestry visa')
     and_i_add_an_audit_comment
     and_i_click_save_and_continue
-    then_i_should_see_the_correct_visa_in_the_summary('UK Ancestry visa')
+    then_i_see_the_correct_visa_in_the_summary('UK Ancestry visa')
 
     when_click_change_immigration_status
     and_i_choose_the_visa('High Potential Individual visa')
     and_i_add_an_audit_comment
     and_i_click_save_and_continue
-    then_i_should_see_the_correct_visa_in_the_summary('High Potential Individual visa')
+    then_i_see_the_correct_visa_in_the_summary('High Potential Individual visa')
 
     when_click_change_immigration_status
     and_i_choose_the_visa('Youth Mobility Scheme')
     and_i_add_an_audit_comment
     and_i_click_save_and_continue
-    then_i_should_see_the_correct_visa_in_the_summary('Youth Mobility Scheme')
+    then_i_see_the_correct_visa_in_the_summary('Youth Mobility Scheme')
 
     when_click_change_immigration_status
     and_i_choose_the_visa('India Young Professionals Scheme visa')
     and_i_add_an_audit_comment
     and_i_click_save_and_continue
-    then_i_should_see_the_correct_visa_in_the_summary('India Young Professionals Scheme visa')
+    then_i_see_the_correct_visa_in_the_summary('India Young Professionals Scheme visa')
 
     when_click_change_immigration_status
     and_i_choose_the_visa('Ukraine Family Scheme or Ukraine Sponsorship Scheme visa')
     and_i_add_an_audit_comment
     and_i_click_save_and_continue
-    then_i_should_see_the_correct_visa_in_the_summary('Ukraine Family Scheme or Ukraine Sponsorship Scheme visa')
+    then_i_see_the_correct_visa_in_the_summary('Ukraine Family Scheme or Ukraine Sponsorship Scheme visa')
 
     when_click_change_immigration_status
     and_i_choose_the_visa('Afghan citizens resettlement scheme or Afghan Relocations and Assistance Policy')
     and_i_add_an_audit_comment
     and_i_click_save_and_continue
-    then_i_should_see_the_correct_visa_in_the_summary('Afghan citizens resettlement scheme or Afghan Relocations and Assistance Policy')
+    then_i_see_the_correct_visa_in_the_summary('Afghan citizens resettlement scheme or Afghan Relocations and Assistance Policy')
 
     when_click_change_immigration_status
     and_i_choose_the_visa('Refugee Status')
     and_i_add_an_audit_comment
     and_i_click_save_and_continue
-    then_i_should_see_the_correct_visa_in_the_summary('Refugee Status')
+    then_i_see_the_correct_visa_in_the_summary('Refugee Status')
   end
 
   def given_i_am_a_support_user
@@ -121,7 +121,7 @@ RSpec.feature 'immigration status, non eu' do
     click_link_or_button 'Save and continue'
   end
 
-  def then_i_should_see_the_correct_visa_in_the_summary(visa_summary_text)
+  def then_i_see_the_correct_visa_in_the_summary(visa_summary_text)
     within '.govuk-summary-list__row', text: 'Visa or immigration status' do
       expect(page).to have_text(visa_summary_text)
     end

--- a/spec/system/support_interface/visa_or_immigration_status_spec.rb
+++ b/spec/system/support_interface/visa_or_immigration_status_spec.rb
@@ -1,24 +1,24 @@
 require 'rails_helper'
 
-RSpec.feature 'Editing immigration status' do
+RSpec.feature 'Editing visa or immigration status' do
   include DfESignInHelpers
 
-  scenario 'Support user edits immigration status', :with_audited do
+  scenario 'Support user edits visa or immigration status', :with_audited do
     given_i_am_a_support_user
     and_an_application_exists
 
     when_i_visit_the_application_page
-    i_should_not_see_the_immigration_status_column
+    i_do_not_see_the_visa_or_immigration_status_column
 
     when_i_click_the_change_link_next_right_to_work
     and_i_choose_yes
     and_i_continue
-    i_should_see_the_immigration_status_column
+    i_see_the_visa_or_immigration_status_column
 
-    when_i_click_change_immigration_status
+    when_i_click_change_visa_or_immigration_status
     and_i_choose_other_and_fill_in_the_details
     and_i_continue
-    then_i_should_see_the_text_i_submitted
+    then_i_see_the_text_i_submitted
   end
 end
 
@@ -34,16 +34,16 @@ def when_i_visit_the_application_page
   visit support_interface_application_form_path(@form)
 end
 
-def i_should_not_see_the_immigration_status_column
-  expect(page).to have_no_content 'Immigration status'
+def i_do_not_see_the_visa_or_immigration_status_column
+  expect(page).to have_no_content 'Visa or immigration status'
 end
 
-def i_should_see_the_immigration_status_column
-  expect(page).to have_content 'Immigration status'
+def i_see_the_visa_or_immigration_status_column
+  expect(page).to have_content 'Visa or immigration status'
 end
 
-def when_i_click_change_immigration_status
-  click_link_or_button 'Change immigration status'
+def when_i_click_change_visa_or_immigration_status
+  click_link_or_button 'Change visa or immigration status'
 end
 
 def when_i_click_the_change_link_next_right_to_work
@@ -65,6 +65,6 @@ def and_i_choose_other_and_fill_in_the_details
   fill_in 'support_interface_application_forms_immigration_status_form[audit_comment]', with: 'Updated as part of Zendesk ticket #12345'
 end
 
-def then_i_should_see_the_text_i_submitted
+def then_i_see_the_text_i_submitted
   expect(page).to have_content 'I live here forever'
 end


### PR DESCRIPTION
## Context

Following on from #9012 we are making a further iteration to the immigration options for EEA candidates. This will help us improve the data we collect. 

## Before

<img width="1109" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/50492247/b69eb51b-2bf8-435b-8fea-bb82c83b2a7e">


## After

<img width="621" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/50492247/9cdf0d26-2297-4906-8187-c720ddfbb4b2">



## Changes proposed in this pull request

- Update the options for EEA candidates, both on the candidate and support interfaces.
- Update the labels to be consistent with the non EEA flow. 
- Remove redundant helper methods.

## Guidance to review

On the review app go through the flow as both a EEA candidate (e.g French) and a non EEA candidate (E.G American), ensure everything looks and works as expected. 

## Link to Trello card

https://trello.com/c/ea4bs7Ho/1472-apply-update-visa-immigration-options-for-eea-candidates

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
