### PR TITLE
Ignore columns before dropping them

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,4 +1,6 @@
 class Course < ApplicationRecord
+  self.ignored_columns += %w[open_on_apply opened_on_apply_at]
+
   belongs_to :provider
   has_many :course_options
   has_many :application_choices, through: :course_options

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -235,8 +235,6 @@ shared:
     - id
     - level
     - name
-    - open_on_apply
-    - opened_on_apply_at
     - program_type
     - provider_id
     - qualifications


### PR DESCRIPTION
## Context

We are dropping `open_on_apply` and `opened_on_apply_at` columns from the Database. As recommended, we will instruct ActiveRecord to ignore the columns before we drop them.

## Changes proposed in this pull request

Instruct ActiveRecord to ignore columns prepared for deletion so they aren't cached.

## Guidance to review

[Strong Migrations recommendations](https://github.com/ankane/strong_migrations?tab=readme-ov-file#removing-a-column)
## Link to Trello card

[Trello Ticket](https://trello.com/c/qh90rptL/1521-drop-openonapply-and-openedonapplyat-columns-from-course-model)
