### PR TITLE
Update API documentation to reflect continuous applications

### DIFF
--- a/app/components/shared/state_explanation_component.html.erb
+++ b/app/components/shared/state_explanation_component.html.erb
@@ -10,8 +10,8 @@
         <dd><code><%= govuk_link_to state_name.inspect, api_docs_reference_path(anchor: 'applicationattributes-object') %></code></dd>
         <% if ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER.include?(state_name.to_sym) %>
           <dt>Appears to candidate as</dd>
-          <% component = CandidateInterface::ApplicationStatusTagComponent.new(application_choice: Struct.new(:status).new(state_name)) %>
-          <dd><%= govuk_tag(text: t("candidate_application_states.#{state_name}"), colour: component.colour) %></dd>
+          <% component = CandidateInterface::ContinuousApplications::ApplicationStatusTagComponent.new(application_choice: Struct.new(:status).new(state_name)) %>
+          <dd><%= govuk_tag(text: t("continuous_applications.candidate_application_states.#{state_name}"), colour: component.colour) %></dd>
           <dt>Appears to provider as</dd>
           <% component = ProviderInterface::ApplicationStatusTagComponent.new(application_choice: Struct.new(:status).new(state_name)) %>
           <dd><%= govuk_tag(text: t("provider_application_states.#{state_name}"), colour: component.colour) %></dd>

--- a/app/views/api_docs/vendor_api_docs/reference/reference.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/reference.html.erb
@@ -75,8 +75,8 @@
   We have a production environment and a sandbox environment.
   When version <%= version %> is initially launched for testing, it will only be accessible
   within the sandbox environment. Use the version value as specified in the following URL:
-  <%= govuk_link_to "https://sandbox.apply-for-teacher-training.service.gov.uk/api/#{version}",
-  "https://sandbox.apply-for-teacher-training.service.gov.uk/api/#{version}" %>.
+  <%= govuk_link_to "https://sandbox.apply-for-teacher-training.service.gov.uk/api/v#{version}",
+  "https://sandbox.apply-for-teacher-training.service.gov.uk/api/v#{version}" %>.
   Only after testing is complete, the production environment will automatically upgrade
   to the latest minor version without the need to update the URL.
 </p>


### PR DESCRIPTION
## Context

From slack thread: https://ukgovernmentdfe.slack.com/archives/C05D5S8C6PJ/p1711123087598109

I've spotted a few non-urgent things, I'm not sure if it's just Friday-brain...

API reference doesn't list "inactive" status in the [ApplicationAttibures object](https://www.apply-for-teacher-training.service.gov.uk/api-docs/v1.4/reference#applicationattributes-object)(?)
...yet the [Lifecycle doc](https://www.apply-for-teacher-training.service.gov.uk/api-docs/lifecycle) does.
On the lifecycle doc, when we say a status "Appears to candidate as" and "Appears to provider as" I assume we're describing how we render those statuses in our services? If so:

"'inactive' appears as Inactive' is incorrect? (awaiting decision)
"'interviewing' appears as Awaiting decision' is incorrect? (interviewing)
Some of the tags are a different colour shade to what's now in Apply - e.g. Offer declined and Unsuccessful

## Changes proposed in this pull request

Fix API wrong documentation

## Link to Trello card

https://trello.com/c/6y8iTU6y/1493-tech-debt-update-api-docs-to-reflect-latest-changes
