### PR TITLE
Don't reset the course option id when store course is blank

### DIFF
--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -324,7 +324,7 @@ module ProviderInterface
     end
 
     def sanitize_attrs(attrs)
-      if !last_saved_state.empty? && attrs[:course_id].present? && last_saved_state['course_id'] != attrs[:course_id]
+      if !last_saved_state.empty? && attrs[:course_id].present? && last_saved_state['course_id'].present? && last_saved_state['course_id'] != attrs[:course_id]
         attrs.merge!(study_mode: nil, course_option_id: nil)
       end
       attrs

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -209,6 +209,25 @@ RSpec.describe ProviderInterface::OfferWizard do
           expect(wizard.provider_id).to eq(10)
         end
       end
+
+      context 'when stored values does not contain a course' do
+        let(:wizard) do
+          described_class.new(store, { course_id: course_id })
+        end
+        let(:stored_data) { { course_option_id: 3, study_mode: :full_time, provider_id: 10 }.to_json }
+        let(:course_id) { 5 }
+
+        before do
+          allow(store).to receive(:read).and_return(stored_data)
+        end
+
+        it 'does not reset the study mode and course_option_id' do
+          expect(wizard.study_mode).to eq 'full_time'
+          expect(wizard.course_option_id).to be 3
+          expect(wizard.course_id).to eq(course_id)
+          expect(wizard.provider_id).to eq(10)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Context

We are getting Sentry errors:

https://dfe-teacher-services.sentry.io/issues/4278332369/?alert_rule_id=853774&alert_type=issue&notification_uuid=fd00558c-7e56-484a-8581-a476039a0c45&project=1765973&referrer=slack

We need to investigate the root cause and fix.

## Changes proposed in this pull request

If Redis expired and the user comes back to take a decision the course is blank stored in redis (the first time), which makes the attribute course option id to be nil and store in Redis, then when the user goes to review an offer, the page errors.

So, let's not reset the course option id if course stored in Redis is blank.

## Guidance to review

In case you want to understand more about the bug, steps to reproduce the bug locally in main branch (not in this branch!):

1. Click make a decision in Manage for any application
2. Chooses make an offer
3. Expire Redis (remember offer wizard is using the redis wizards)
4. Return to make a decision (step 1)
5. Chooses make an offer
6. Click continue
7. Error happens


