### PR TITLE
Prevent candidate applying to closed course

### DIFF
--- a/app/components/candidate_interface/continuous_applications/application_review_and_submit_component.html.erb
+++ b/app/components/candidate_interface/continuous_applications/application_review_and_submit_component.html.erb
@@ -1,7 +1,7 @@
 <% unless application_can_submit? %>
   <% errors.each do |error| %>
     <% error.message.split(/\n+/).each_with_index do |line, index| %>
-      <% if index.zero? && (error.type.in?(%i[course_unavailable immigration_status])) %>
+      <% if index.zero? && (error.type.in?(%i[course_closed course_unavailable immigration_status])) %>
         <%= govuk_warning_text do %>
           <%= line.html_safe %>
         <% end %>
@@ -12,7 +12,7 @@
   <% end %>
 <% end %>
 
-<% if errors.map(&:type).exclude?(:course_unavailable) %>
+<% if errors.map(&:type).intersection([:course_unavailable, :course_closed]).empty? %>
 <h2 class="govuk-heading-m">Delete draft application</h2>
 <p class="govuk-body">
   You can <%= govuk_link_to('delete your draft application', candidate_interface_continuous_applications_confirm_destroy_course_choice_path(@application_choice.id), data: { action: :delete }) %> if you no longer want to apply for <%= @application_choice.current_course.name_and_code %> at <%= @application_choice.current_course.provider.name %>.

--- a/app/components/candidate_interface/continuous_applications/application_review_and_submit_component.html.erb
+++ b/app/components/candidate_interface/continuous_applications/application_review_and_submit_component.html.erb
@@ -1,9 +1,9 @@
 <% unless application_can_submit? %>
   <% errors.each do |error| %>
     <% error.message.split(/\n+/).each_with_index do |line, index| %>
-      <% if index.zero? && error.type == :immigration_status %>
+      <% if index.zero? && (error.type.in?(%i[course_unavailable immigration_status])) %>
         <%= govuk_warning_text do %>
-          <%= line %>
+          <%= line.html_safe %>
         <% end %>
       <% else %>
         <p class="govuk-body"><%= line.html_safe %></p>
@@ -12,10 +12,12 @@
   <% end %>
 <% end %>
 
+<% if errors.map(&:type).exclude?(:course_unavailable) %>
 <h2 class="govuk-heading-m">Delete draft application</h2>
 <p class="govuk-body">
   You can <%= govuk_link_to('delete your draft application', candidate_interface_continuous_applications_confirm_destroy_course_choice_path(@application_choice.id), data: { action: :delete }) %> if you no longer want to apply for <%= @application_choice.current_course.name_and_code %> at <%= @application_choice.current_course.provider.name %>.
 </p>
+<% end %>
 
 <% if application_can_submit? %>
   <h2 class="govuk-heading-m">Review and submit your application</h2>

--- a/app/controllers/candidate_interface/continuous_applications/course_choices/closed_course_selection_controller.rb
+++ b/app/controllers/candidate_interface/continuous_applications/course_choices/closed_course_selection_controller.rb
@@ -1,0 +1,28 @@
+module CandidateInterface
+  module ContinuousApplications
+    module CourseChoices
+      class ClosedCourseSelectionController < BaseController
+        before_action :set_course
+        skip_before_action :redirect_to_your_applications_if_maximum_amount_of_choices_have_been_used
+
+      private
+
+        def step_params
+          params[current_step] = {
+            provider_id: params.delete(:provider_id),
+            course_id: params.delete(:course_id),
+          }
+          params
+        end
+
+        def current_step
+          :full_course_selection
+        end
+
+        def set_course
+          @course = Course.find(params[:course_id])
+        end
+      end
+    end
+  end
+end

--- a/app/forms/candidate_interface/continuous_applications/closed_course_selection_step.rb
+++ b/app/forms/candidate_interface/continuous_applications/closed_course_selection_step.rb
@@ -1,0 +1,23 @@
+module CandidateInterface
+  module ContinuousApplications
+    class ClosedCourseSelectionStep < DfE::WizardStep
+      include Concerns::CourseSelectionStepHelper
+      attr_accessor :provider_id, :course_id
+      validates :provider_id, :course_id, presence: true
+
+      def self.permitted_params
+        %i[provider_id course_id]
+      end
+
+      def previous_step
+        :which_course_are_you_applying_to
+      end
+
+      def next_step; end
+
+      def previous_step_path_arguments
+        { provider_id: provider_id }
+      end
+    end
+  end
+end

--- a/app/forms/candidate_interface/continuous_applications/course_review_step.rb
+++ b/app/forms/candidate_interface/continuous_applications/course_review_step.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   module ContinuousApplications
     class CourseReviewStep < DfE::WizardStep
+      def next_step; end
     end
   end
 end

--- a/app/forms/candidate_interface/continuous_applications/course_selection_wizard.rb
+++ b/app/forms/candidate_interface/continuous_applications/course_selection_wizard.rb
@@ -13,6 +13,7 @@ module CandidateInterface
           { duplicate_course_selection: DuplicateCourseSelectionStep },
           { reached_reapplication_limit: ReachedReapplicationLimitStep },
           { full_course_selection: FullCourseSelectionStep },
+          { closed_course_selection: ClosedCourseSelectionStep },
           { course_study_mode: CourseStudyModeStep },
           { course_site: CourseSiteStep },
           { find_course_selection: FindCourseSelectionStep },

--- a/app/forms/candidate_interface/continuous_applications/which_course_are_you_applying_to_step.rb
+++ b/app/forms/candidate_interface/continuous_applications/which_course_are_you_applying_to_step.rb
@@ -38,6 +38,8 @@ module CandidateInterface
           :reached_reapplication_limit
         elsif duplicate_course?
           :duplicate_course_selection
+        elsif course.application_status_closed?
+          :closed_course_selection
         elsif !course.available?
           :full_course_selection
         elsif multiple_study_modes?
@@ -48,7 +50,7 @@ module CandidateInterface
       end
 
       def next_edit_step_path(next_step_klass)
-        classes_without_edit = [DuplicateCourseSelectionStep, FullCourseSelectionStep]
+        classes_without_edit = [DuplicateCourseSelectionStep, FullCourseSelectionStep, ClosedCourseSelectionStep]
         return next_step_path(next_step_klass) if classes_without_edit.include?(next_step_klass)
 
         super
@@ -57,7 +59,7 @@ module CandidateInterface
       def next_step_path_arguments
         if completed?
           default_path_arguments
-        elsif duplicate_course? || reapplication_limit_reached? || !course.available? || multiple_study_modes?
+        elsif duplicate_course? || reapplication_limit_reached? || !course.available? || course.application_status_closed? || multiple_study_modes?
           { provider_id:, course_id: }
         elsif multiple_sites?
           { provider_id:, course_id:, study_mode: }
@@ -85,7 +87,7 @@ module CandidateInterface
     private
 
       def valid_course_choice
-        @valid_course_choice ||= !duplicate_course? && !reapplication_limit_reached? && course.available?
+        @valid_course_choice ||= !duplicate_course? && !reapplication_limit_reached? && course.available? && course.application_status_open?
       end
 
       def duplicate_course?

--- a/app/forms/candidate_interface/continuous_applications/which_course_are_you_applying_to_step.rb
+++ b/app/forms/candidate_interface/continuous_applications/which_course_are_you_applying_to_step.rb
@@ -50,8 +50,7 @@ module CandidateInterface
       end
 
       def next_edit_step_path(next_step_klass)
-        classes_without_edit = [DuplicateCourseSelectionStep, FullCourseSelectionStep, ClosedCourseSelectionStep]
-        return next_step_path(next_step_klass) if classes_without_edit.include?(next_step_klass)
+        return next_step_path(next_step_klass) unless next_step_klass.new.next_step
 
         super
       end

--- a/app/validators/candidate_interface/continuous_applications/course_selection_validator.rb
+++ b/app/validators/candidate_interface/continuous_applications/course_selection_validator.rb
@@ -1,7 +1,5 @@
 module CandidateInterface
   module ContinuousApplications
-    # Validates that the course choice is not duplicated
-    # Conditional exists to remove the course that is being edited from the checks for duplication
     class CourseSelectionValidator < ActiveModel::Validator
       ALLOWED_REAPPLICATION_LIMIT = 2
 

--- a/app/validators/course_unavailable_validator.rb
+++ b/app/validators/course_unavailable_validator.rb
@@ -11,11 +11,19 @@ class CourseUnavailableValidator < ActiveModel::EachValidator
               course.exposed_in_find? &&
               course.application_status_open?
 
-    record.errors.add(
-      attribute,
-      :course_unavailable,
-      link_to_remove: link_to_remove(application_choice),
-    )
+    if course.application_status_closed?
+      record.errors.add(
+        attribute,
+        :course_closed,
+        link_to_remove: link_to_remove(application_choice),
+      )
+    else
+      record.errors.add(
+        attribute,
+        :course_unavailable,
+        link_to_remove: link_to_remove(application_choice),
+      )
+    end
   end
 
 private

--- a/app/validators/course_unavailable_validator.rb
+++ b/app/validators/course_unavailable_validator.rb
@@ -8,7 +8,8 @@ class CourseUnavailableValidator < ActiveModel::EachValidator
 
     return if !course.full? &&
               application_choice.course_option.site_still_valid? &&
-              course.exposed_in_find?
+              course.exposed_in_find? &&
+              course.application_status_open?
 
     record.errors.add(
       attribute,

--- a/app/views/candidate_interface/continuous_applications/course_choices/closed_course_selection/new.html.erb
+++ b/app/views/candidate_interface/continuous_applications/course_choices/closed_course_selection/new.html.erb
@@ -1,0 +1,20 @@
+<% content_for :title, t('page_titles.full_course') %>
+<% content_for(:before_content, govuk_back_link_to(@wizard.previous_step_path)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.closed_course', course_name: @course.name_and_code) %>
+    </h1>
+
+    <% if @course.provider.course_options.available.any? %>
+      <p class="govuk-body">You can:</p>
+      <ul class="govuk-list govuk-list--bullet govuk-!-padding-bottom-8">
+        <li>apply to a <%= govuk_link_to 'different course', candidate_interface_continuous_applications_which_course_are_you_applying_to_path(provider_id: @course.provider.id) %> offered by <%= @course.provider.name %></li>
+        <li>apply to a <%= govuk_link_to 'different training provider', candidate_interface_continuous_applications_provider_selection_path %></li>
+      </ul>
+    <% else %>
+      <p class="govuk-body">You can apply to a <%= govuk_link_to 'different training provider', candidate_interface_continuous_applications_provider_selection_path %>.</p>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/candidate_interface/submit_application.yml
+++ b/config/locales/candidate_interface/submit_application.yml
@@ -15,6 +15,10 @@ en:
                 You cannot submit this application as the course is no longer available.
 
                 %{link_to_remove} and search for other courses.
+              course_closed: |-
+                You cannot submit this application because the course has closed.
+
+                %{link_to_remove} and search for other courses.
               incomplete_details: |-
                 You cannot submit this application until you %{link_to_details}.
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -171,6 +171,7 @@ en:
     courses: Courses
     course_choices: Course choices
     full_course: Unfortunately, you cannot apply to %{course_name} because it is now full
+    closed_course: Unfortunately, you cannot apply to %{course_name} because it is now closed
     destroy_course_choice: Are you sure you want to delete this choice?
     continuous_applications_destroy_course_choice: Are you sure you want to delete this draft application?
     do_you_know: Do you know which course you want to apply to?

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -353,6 +353,7 @@ namespace :candidate_interface, path: '/candidate' do
       get '/provider/:provider_id/courses/:course_id/reached-reapplication-limit' => 'continuous_applications/course_choices/reached_reapplication_limit#new', as: :continuous_applications_reached_reapplication_limit
       get '/provider/:provider_id/courses/:course_id/duplicate' => 'continuous_applications/course_choices/duplicate_course_selection#new', as: :continuous_applications_duplicate_course_selection
       get '/provider/:provider_id/courses/:course_id/full' => 'continuous_applications/course_choices/full_course_selection#new', as: :continuous_applications_full_course_selection
+      get '/provider/:provider_id/courses/:course_id/closed' => 'continuous_applications/course_choices/closed_course_selection#new', as: :continuous_applications_closed_course_selection
 
       get '/provider/:provider_id/courses/:course_id' => 'continuous_applications/course_choices/course_study_mode#new', as: :continuous_applications_course_study_mode
       post '/provider/:provider_id/courses/:course_id' => 'continuous_applications/course_choices/course_study_mode#create'

--- a/spec/forms/candidate_interface/continuous_applications/which_course_are_you_applying_to_step_spec.rb
+++ b/spec/forms/candidate_interface/continuous_applications/which_course_are_you_applying_to_step_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe CandidateInterface::ContinuousApplications::WhichCourseAreYouAppl
   let(:course) do
     create(
       :course,
+      :open,
       :with_both_study_modes,
       provider:,
       name: 'Software Engineering',
@@ -111,6 +112,7 @@ RSpec.describe CandidateInterface::ContinuousApplications::WhichCourseAreYouAppl
     let(:course) do
       create(
         :course,
+        :open,
         :with_both_study_modes,
         provider:,
         name: 'Software Engineering',

--- a/spec/services/candidate_interface/continuous_applications/course_selection_store_spec.rb
+++ b/spec/services/candidate_interface/continuous_applications/course_selection_store_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe CandidateInterface::ContinuousApplications::CourseSelectionStore 
     let(:course) do
       create(
         :course,
+        :open,
         :with_both_study_modes,
         provider:,
         name: 'Software Engineering',
@@ -111,6 +112,7 @@ RSpec.describe CandidateInterface::ContinuousApplications::CourseSelectionStore 
     let(:course) do
       create(
         :course,
+        :open,
         :with_both_study_modes,
         provider:,
         name: 'Software Engineering',

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -839,11 +839,10 @@ module CandidateHelper
   end
   alias then_i_am_on_the_review_and_submit_page then_i_should_be_on_the_review_and_submit_page
 
-  def then_i_should_see_that_the_course_is_full
+  def then_i_see_that_the_course_is_unavailable
     expect(page).to have_content('You cannot submit this application as the course is no longer available.')
     expect(page).to have_content('Remove this application and search for other courses.')
   end
-  alias then_i_see_that_the_course_is_full then_i_should_see_that_the_course_is_full
 
   def and_i_click_continue
     click_link_or_button t('continue')

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_spec.rb
@@ -162,11 +162,6 @@ RSpec.feature 'Selecting a course' do
     when_i_visit_my_applications
   end
 
-  def then_i_see_that_the_course_is_unavailable
-    expect(page).to have_content('You cannot submit this application as the course is no longer available.')
-    expect(page).to have_content('Remove this application and search for other courses.')
-  end
-
   def and_i_can_change_the_course
     click_link_or_button 'Change'
     expect(page).to have_content('Which course are you applying to?')

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature 'Selecting a course' do
     when_the_course_is_full
     when_i_visit_the_course_choices_page
     when_i_click_to_view_my_application
-    then_i_see_that_the_course_is_full
+    then_i_see_that_the_course_is_unavailable
     and_i_can_change_the_course
 
     given_the_provider_has_over_twenty_courses
@@ -162,7 +162,7 @@ RSpec.feature 'Selecting a course' do
     when_i_visit_my_applications
   end
 
-  def then_i_see_that_the_course_is_full
+  def then_i_see_that_the_course_is_unavailable
     expect(page).to have_content('You cannot submit this application as the course is no longer available.')
     expect(page).to have_content('Remove this application and search for other courses.')
   end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_that_is_closed_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_that_is_closed_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.feature 'Selecting a course' do
+  include CandidateHelper
+
+  it 'Candidate selects a course that is closed' do
+    given_i_am_signed_in
+    and_the_course_has_been_closed
+
+    when_i_visit_the_site
+    and_i_click_on_course_choices
+    and_i_choose_that_i_know_where_i_want_to_apply
+    and_i_choose_a_provider
+    then_i_see_a_course_and_its_description
+
+    and_i_choose_a_course_that_has_been_closed
+    then_i_be_on_the_application_choice_closed_page
+    and_i_see_that_i_can_apply_to_a_different_provider
+
+    when_the_provider_adds_more_vacancies
+    then_i_see_that_i_can_apply_to_another_course
+
+    when_i_click_back
+    then_i_be_on_the_course_choice_page
+  end
+
+  def given_i_am_signed_in
+    @candidate = create(:candidate)
+    create_and_sign_in_candidate(candidate: @candidate)
+  end
+
+  def and_the_course_has_been_closed
+    @provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
+    @course = create(:course, :open, application_status: 'closed', name: 'Primary', code: '2XT2', provider: @provider)
+  end
+
+  def when_i_visit_the_site
+    visit candidate_interface_continuous_applications_details_path
+  end
+
+  def and_i_click_on_course_choices
+    click_link_or_button 'Your application'
+    click_link_or_button 'Add application'
+  end
+
+  def and_i_choose_that_i_know_where_i_want_to_apply
+    choose 'Yes, I know where I want to apply'
+    click_link_or_button t('continue')
+  end
+
+  def and_i_choose_a_provider
+    select 'Gorse SCITT (1N1)'
+    click_link_or_button t('continue')
+  end
+
+  def then_i_see_a_course_and_its_description
+    expect(page).to have_content(@course.name_and_code)
+    expect(page).to have_content(@course.description_to_s)
+  end
+
+  def and_i_choose_a_course_that_has_been_closed
+    choose 'Primary (2XT2)'
+    click_link_or_button t('continue')
+  end
+
+  def then_i_be_on_the_application_choice_closed_page
+    expect(page).to have_content('Unfortunately, you cannot apply to Primary (2XT2) because it is now closed')
+  end
+
+  def and_i_see_that_i_can_apply_to_a_different_provider
+    expect(page).to have_no_content('apply to a different course offered by Gorse SCITT')
+    expect(page).to have_content('You can apply to a different training provider.')
+  end
+
+  def when_the_provider_adds_more_vacancies
+    create(:course, :open, :with_course_options, provider: @provider)
+  end
+
+  def then_i_see_that_i_can_apply_to_another_course
+    visit current_path
+
+    expect(page).to have_content('apply to a different course offered by Gorse SCITT')
+    expect(page).to have_content('apply to a different training provider')
+  end
+
+  def when_i_click_back
+    click_link_or_button 'Back'
+  end
+
+  def then_i_be_on_the_course_choice_page
+    expect(page.current_url).to end_with(candidate_interface_continuous_applications_which_course_are_you_applying_to_path(provider_id: @provider.id))
+  end
+end

--- a/spec/system/candidate_interface/continuous_applications/submitting/candidate_tries_to_submit_an_application_for_course_unavailable_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/submitting/candidate_tries_to_submit_an_application_for_course_unavailable_spec.rb
@@ -12,9 +12,9 @@ RSpec.feature 'Candidate tries to submit an application choice when the course i
     and_my_course_choice_becomes_closed
     when_i_visit_my_applications
     and_i_click_to_view_my_application
-    then_i_see_that_the_course_is_unavailable
+    then_i_see_that_the_course_is_closed
     when_i_visit_the_review_page_directly
-    then_i_see_the_course_unavailable_error_message
+    then_i_see_the_course_closed_error_message
     and_i_do_not_see_notice_to_delete_draft
     when_i_click_to_remove_the_application
     and_i_confirm_to_remove_the_application
@@ -75,6 +75,12 @@ RSpec.feature 'Candidate tries to submit an application choice when the course i
     expect(page).to have_no_content('Delete draft application')
   end
 
+  def then_i_see_the_course_closed_error_message
+    within('.govuk-warning-text') do
+      expect(page).to have_content('You cannot submit this application because the course has closed.')
+    end
+  end
+
   def then_i_see_the_course_unavailable_error_message
     within('.govuk-warning-text') do
       expect(page).to have_content('You cannot submit this application as the course is no longer available.')
@@ -99,5 +105,10 @@ RSpec.feature 'Candidate tries to submit an application choice when the course i
 
   def then_my_application_choice_is_removed
     expect(@application_form.reload.application_choices.count).to be_zero
+  end
+
+  def then_i_see_that_the_course_is_closed
+    expect(page).to have_content('You cannot submit this application because the course has closed.')
+    expect(page).to have_content('Remove this application and search for other courses.')
   end
 end

--- a/spec/system/candidate_interface/continuous_applications/submitting/candidate_tries_to_submit_an_application_for_course_unavailable_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/submitting/candidate_tries_to_submit_an_application_for_course_unavailable_spec.rb
@@ -15,6 +15,7 @@ RSpec.feature 'Candidate tries to submit an application choice when the course i
     then_i_see_that_the_course_is_unavailable
     when_i_visit_the_review_page_directly
     then_i_see_the_course_unavailable_error_message
+    and_i_do_not_see_notice_to_delete_draft
     when_i_click_to_remove_the_application
     and_i_confirm_to_remove_the_application
     then_my_application_choice_is_removed
@@ -27,6 +28,7 @@ RSpec.feature 'Candidate tries to submit an application choice when the course i
     then_i_see_that_the_course_is_unavailable
     when_i_visit_the_review_page_directly
     then_i_see_the_course_unavailable_error_message
+    and_i_do_not_see_notice_to_delete_draft
     when_i_click_to_remove_the_application
     and_i_confirm_to_remove_the_application
     then_my_application_choice_is_removed
@@ -37,6 +39,7 @@ RSpec.feature 'Candidate tries to submit an application choice when the course i
     when_i_visit_my_applications
     and_i_click_to_view_my_application
     then_i_see_the_course_unavailable_error_message
+    and_i_do_not_see_notice_to_delete_draft
     when_i_click_to_remove_the_application
     and_i_confirm_to_remove_the_application
     then_my_application_choice_is_removed
@@ -46,6 +49,7 @@ RSpec.feature 'Candidate tries to submit an application choice when the course i
     and_my_course_choice_is_not_exposed_in_find_anymore
     when_i_continue_my_draft_application
     then_i_see_the_course_unavailable_error_message
+    and_i_do_not_see_notice_to_delete_draft
     when_i_click_to_remove_the_application
     and_i_confirm_to_remove_the_application
     then_my_application_choice_is_removed
@@ -67,8 +71,14 @@ RSpec.feature 'Candidate tries to submit an application choice when the course i
     @application_choice.current_course.update(exposed_in_find: false)
   end
 
+  def and_i_do_not_see_notice_to_delete_draft
+    expect(page).to have_no_content('Delete draft application')
+  end
+
   def then_i_see_the_course_unavailable_error_message
-    expect(page).to have_content('You cannot submit this application as the course is no longer available.')
+    within('.govuk-warning-text') do
+      expect(page).to have_content('You cannot submit this application as the course is no longer available.')
+    end
   end
 
   def then_i_not_see_the_continue_application_link

--- a/spec/system/candidate_interface/continuous_applications/submitting/candidate_tries_to_submit_an_application_for_course_unavailable_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/submitting/candidate_tries_to_submit_an_application_for_course_unavailable_spec.rb
@@ -8,35 +8,51 @@ RSpec.feature 'Candidate tries to submit an application choice when the course i
     and_i_have_one_application_in_draft
   end
 
+  scenario 'Course becomes closed' do
+    and_my_course_choice_becomes_closed
+    when_i_visit_my_applications
+    and_i_click_to_view_my_application
+    then_i_see_that_the_course_is_unavailable
+    when_i_visit_the_review_page_directly
+    then_i_see_the_course_unavailable_error_message
+    when_i_click_to_remove_the_application
+    and_i_confirm_to_remove_the_application
+    then_my_application_choice_is_removed
+  end
+
   scenario 'Course becomes full' do
     and_my_course_choice_becomes_full
     when_i_visit_my_applications
     and_i_click_to_view_my_application
-    then_i_should_see_that_the_course_is_full
+    then_i_see_that_the_course_is_unavailable
     when_i_visit_the_review_page_directly
-    then_i_should_see_the_course_unavailable_error_message
+    then_i_see_the_course_unavailable_error_message
     when_i_click_to_remove_the_application
     and_i_confirm_to_remove_the_application
-    then_my_application_choice_should_be_removed
+    then_my_application_choice_is_removed
   end
 
   scenario 'Invalid course location' do
     and_my_course_location_is_not_valid_anymore
     when_i_visit_my_applications
     and_i_click_to_view_my_application
-    then_i_should_see_the_course_unavailable_error_message
+    then_i_see_the_course_unavailable_error_message
     when_i_click_to_remove_the_application
     and_i_confirm_to_remove_the_application
-    then_my_application_choice_should_be_removed
+    then_my_application_choice_is_removed
   end
 
   scenario 'Course not exposed in find' do
     and_my_course_choice_is_not_exposed_in_find_anymore
     when_i_continue_my_draft_application
-    then_i_should_see_the_course_unavailable_error_message
+    then_i_see_the_course_unavailable_error_message
     when_i_click_to_remove_the_application
     and_i_confirm_to_remove_the_application
-    then_my_application_choice_should_be_removed
+    then_my_application_choice_is_removed
+  end
+
+  def and_my_course_choice_becomes_closed
+    @application_choice.current_course.update(application_status: 'closed')
   end
 
   def and_my_course_choice_becomes_full
@@ -51,11 +67,11 @@ RSpec.feature 'Candidate tries to submit an application choice when the course i
     @application_choice.current_course.update(exposed_in_find: false)
   end
 
-  def then_i_should_see_the_course_unavailable_error_message
+  def then_i_see_the_course_unavailable_error_message
     expect(page).to have_content('You cannot submit this application as the course is no longer available.')
   end
 
-  def then_i_should_not_see_the_continue_application_link
+  def then_i_not_see_the_continue_application_link
     expect(page).to have_no_content('Continue application')
   end
 
@@ -71,7 +87,7 @@ RSpec.feature 'Candidate tries to submit an application choice when the course i
     click_link_or_button 'Yes I’m sure - delete this application'
   end
 
-  def then_my_application_choice_should_be_removed
+  def then_my_application_choice_is_removed
     expect(@application_form.reload.application_choices.count).to be_zero
   end
 end

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_details_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_details_section_spec.rb
@@ -7,65 +7,65 @@ RSpec.feature 'Candidate is redirected correctly' do
     given_i_am_signed_in
     when_i_have_completed_my_application
     and_i_review_my_application
-    then_i_should_see_all_sections_are_complete
+    then_i_see_all_sections_are_complete
 
     # name
     click_link_or_button 'Personal information'
     when_i_click_change_name
-    then_i_should_see_the_personal_details_form
+    then_i_see_the_personal_details_form
 
     when_i_click_back
-    then_i_should_be_redirected_to_the_personal_information_review_page
+    then_i_redirected_to_the_personal_information_review_page
 
     when_i_update_my_name
-    then_i_should_be_redirected_to_the_personal_information_review_page
-    and_i_should_see_my_updated_name
+    then_i_redirected_to_the_personal_information_review_page
+    and_i_see_my_updated_name
 
     # date of birth
     when_i_click_change_date_of_birth
-    then_i_should_see_the_personal_details_form
+    then_i_see_the_personal_details_form
 
     when_i_click_back
-    then_i_should_be_redirected_to_the_personal_information_review_page
+    then_i_redirected_to_the_personal_information_review_page
 
     when_i_update_my_date_of_birth
-    then_i_should_be_redirected_to_the_personal_information_review_page
-    and_i_should_see_my_updated_date_of_birth
+    then_i_redirected_to_the_personal_information_review_page
+    and_i_see_my_updated_date_of_birth
 
     # nationality
     when_i_click_change_nationality
-    then_i_should_see_the_nationality_form
+    then_i_see_the_nationality_form
 
     when_i_click_back
-    then_i_should_be_redirected_to_the_personal_information_review_page
+    then_i_redirected_to_the_personal_information_review_page
 
     when_i_update_my_nationality
-    then_i_should_be_redirected_to_the_personal_information_review_page
-    and_i_should_see_my_updated_nationality
+    then_i_redirected_to_the_personal_information_review_page
+    and_i_see_my_updated_nationality
 
     # phone number
     when_i_click_back
     click_link_or_button 'Contact information'
     when_i_click_change_phone_number
-    then_i_should_see_the_phone_number_form
+    then_i_see_the_phone_number_form
 
     when_i_click_back
-    then_i_should_be_redirected_to_the_contact_information_review_page
+    then_i_redirected_to_the_contact_information_review_page
 
     when_i_update_my_phone_number
-    then_i_should_be_redirected_to_the_contact_information_review_page
-    and_i_should_see_my_updated_phone_number
+    then_i_redirected_to_the_contact_information_review_page
+    and_i_see_my_updated_phone_number
 
     # address
     when_i_click_change_address
-    then_i_should_see_the_address_type_form
+    then_i_see_the_address_type_form
 
     when_i_click_back
-    then_i_should_be_redirected_to_the_contact_information_review_page
+    then_i_redirected_to_the_contact_information_review_page
 
     when_i_update_my_address
-    then_i_should_be_redirected_to_the_contact_information_review_page
-    and_i_should_see_my_updated_address
+    then_i_redirected_to_the_contact_information_review_page
+    and_i_see_my_updated_address
   end
 
   def given_i_am_signed_in
@@ -80,7 +80,7 @@ RSpec.feature 'Candidate is redirected correctly' do
     and_i_visit_the_application_form_page
   end
 
-  def then_i_should_see_all_sections_are_complete
+  def then_i_see_all_sections_are_complete
     application_form_sections.each do |section|
       expect(page).to have_no_css "[data-qa='incomplete-#{section}']"
     end
@@ -120,19 +120,19 @@ RSpec.feature 'Candidate is redirected correctly' do
     end
   end
 
-  def then_i_should_see_the_personal_details_form
+  def then_i_see_the_personal_details_form
     expect(page).to have_current_path(candidate_interface_edit_name_and_dob_path)
   end
 
-  def then_i_should_see_the_nationality_form
+  def then_i_see_the_nationality_form
     expect(page).to have_current_path(candidate_interface_edit_nationalities_path)
   end
 
-  def then_i_should_see_the_phone_number_form
+  def then_i_see_the_phone_number_form
     expect(page).to have_current_path(candidate_interface_edit_phone_number_path)
   end
 
-  def then_i_should_see_the_address_type_form
+  def then_i_see_the_address_type_form
     expect(page).to have_current_path(candidate_interface_edit_address_type_path)
   end
 
@@ -140,11 +140,11 @@ RSpec.feature 'Candidate is redirected correctly' do
     click_link_or_button 'Back'
   end
 
-  def then_i_should_be_redirected_to_the_personal_information_review_page
+  def then_i_redirected_to_the_personal_information_review_page
     expect(page).to have_current_path(candidate_interface_personal_details_show_path)
   end
 
-  def then_i_should_be_redirected_to_the_contact_information_review_page
+  def then_i_redirected_to_the_contact_information_review_page
     expect(page).to have_current_path(candidate_interface_contact_information_review_path)
   end
 
@@ -182,31 +182,31 @@ RSpec.feature 'Candidate is redirected correctly' do
     click_link_or_button 'Save and continue'
   end
 
-  def and_i_should_see_my_updated_name
+  def and_i_see_my_updated_name
     within('[data-qa="personal-details-name"]') do
       expect(page).to have_content('Ruddeger')
     end
   end
 
-  def and_i_should_see_my_updated_date_of_birth
+  def and_i_see_my_updated_date_of_birth
     within('[data-qa="personal-details-dob"]') do
       expect(page).to have_content('2')
     end
   end
 
-  def and_i_should_see_my_updated_nationality
+  def and_i_see_my_updated_nationality
     within('[data-qa="personal-details-nationality"]') do
       expect(page).to have_content('Irish')
     end
   end
 
-  def and_i_should_see_my_updated_phone_number
+  def and_i_see_my_updated_phone_number
     within('[data-qa="contact-details-phone-number"]') do
       expect(page).to have_content('0736519012')
     end
   end
 
-  def and_i_should_see_my_updated_address
+  def and_i_see_my_updated_address
     within('[data-qa="contact-details-address"]') do
       expect(page).to have_content('Auckland')
     end


### PR DESCRIPTION
## Context

We are moving away from managing course application availablility from the vacancies of the CourseOptions and toward managing the course availability through the course open/closed.

We need to stop candidates applying to courses that are closed.

We have begin syncing `application_status` on the Course. Here we enforce the Candidat application submission based on the courses `application_status`

## Changes proposed in this pull request

 1. Prevent candidate from adding a closed course to their application choice
 2. Prevent candidate from submitting an application with a closed course

## Guidance to review

Other test scenarios to propose?


## Screenshots

|Adding closed course to application|Submitting application with closed course|
|---|---|
|![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/6a6d8a85-d72c-40f9-91ec-7a7318d8d79f)|![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/7a2471fe-6ab4-4514-b811-463a0b8aa6cb)|


## Link to Trello card

[Trello Ticket](https://trello.com/c/5PtBd3gV/1516-implement-applicationstatus-in-places-where-appropriate)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
