### PR TITLE
Added missing `unique: true` on vendors index

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -838,7 +838,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_09_134457) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["name"], name: "index_vendors_on_name"
+    t.index ["name"], name: "index_vendors_on_name", unique: true
   end
 
   add_foreign_key "application_choices", "application_forms", on_delete: :cascade


### PR DESCRIPTION
## Context

In #9262 we added a unique index to the vendors table `index_vendors_on_name`.
The index was added to the `schema.rb` file missing the `unique: true` argument.
This should unblock #9261 

## Changes proposed in this pull request

N/A

## Guidance to review

N/A

## Link to Trello card

https://trello.com/c/jMnBxRIb

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
