### PR TITLE
Handle gracefully when client disconnects during streaming

### DIFF
--- a/app/controllers/concerns/streamable_data_export.rb
+++ b/app/controllers/concerns/streamable_data_export.rb
@@ -16,12 +16,20 @@ private
     send_stream(filename:, type: 'text/csv') do |stream|
       stream.write SafeCSV.generate_line(block.call(data.first).keys)
 
-      row_block = ->(row) { stream.write SafeCSV.generate_line(block.call(row).values) }
+      row_block = lambda do |row|
+        unless stream.closed?
+          row_values = block.call(row).values
+          stream.write SafeCSV.generate_line(row_values)
+        end
+      end
+
       if data.respond_to?(:find_each)
         data.find_each(batch_size:, &row_block)
       else
         data.each(&row_block)
       end
+    rescue ActionController::Live::ClientDisconnected, IOError
+      stream.close
     end
   end
 end


### PR DESCRIPTION
## Context

We are receiving Sentry errors relating to a CSV downloading of Manage exports.

The issue I encounter with ActionController::Live::ClientDisconnected arises when using streaming responses in Rails and the client disconnects before the response is fully streamed.

To mitigate ClientDisconnected errors, I added the check the client's connection status during the streaming process.
If the connection is closed, terminate the streaming gracefully.

## Changes proposed in this pull request

Handle the client disconnect gracefully.

## Guidance to review

1. Does the export works when you cancel the download? Does it error on sentry? Or exception in the logs?

## Link to Trello card

https://trello.com/c/IaONLeSC/1527-investigate-live-client-disconnected-error
