### PR TITLE
[1530] Update enic guidance

### DIFF
--- a/app/views/candidate_interface/degrees/degree/new_enic.html.erb
+++ b/app/views/candidate_interface/degrees/degree/new_enic.html.erb
@@ -34,7 +34,14 @@
         <% end %>
       <% end %>
       <%= f.govuk_radio_button :have_enic_reference, 'No', label: { text: 'No' } do %>
-        <p class="govuk-body">Ask your training provider if they need a <%= t('service_name.enic.short_name') %> statement of comparability. <%= govuk_link_to_with_utm_params 'Chat online', t('get_into_teaching.url_online_chat'), utm_campaign(params), current_application.phase %> to get a free statement (it usually costs £49.50 plus VAT) or call <%= t('service_name.get_into_teaching') %> on <%= t('get_into_teaching.tel') %>.</p>
+        <p class="govuk-body">
+          You should <%= govuk_link_to('apply for a statement of comparability from UK ENIC (opens in new tab)',
+                                                            t('service_name.enic.statement_of_comparability_url'),
+                                                            target: '_blank',
+                                                            rel: 'noopener') %>.
+        </p>
+
+        <p class="govuk-body">Applications with a statement are 28% more likely to be successful.</p>
       <% end %>
     <% end %>
     <%= f.govuk_submit t('save_and_continue') %>

--- a/app/views/candidate_interface/gcse/enic/_form.html.erb
+++ b/app/views/candidate_interface/gcse/enic/_form.html.erb
@@ -16,7 +16,14 @@
     <% end %>
   <% end %>
   <%= f.govuk_radio_button :have_enic_reference, 'No', label: { text: 'No' } do %>
-    <p class="govuk-body">Ask your training provider if they need a <%= t('service_name.enic.short_name') %> statement of comparability. You can get a free statement (this usually costs £49.50 plus VAT) by calling <%= t('service_name.get_into_teaching') %> on <%= t('get_into_teaching.tel') %>. Or <%= govuk_link_to_with_utm_params 'chat to an adviser using the online chat service', t('get_into_teaching.url_online_chat'), utm_campaign(params), current_application.phase %>.</p>
+    <p class="govuk-body">
+          You should <%= govuk_link_to('apply for a statement of comparability from UK ENIC (opens in new tab)',
+                                                            t('service_name.enic.statement_of_comparability_url'),
+                                                            target: '_blank',
+                                                            rel: 'noopener') %>.
+        </p>
+
+        <p class="govuk-body">Applications with a statement are 28% more likely to be successful.</p>
   <% end %>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,7 @@ en:
       short_name_with_naric: UK ENIC or NARIC
       full_name: UK ENIC (the UK agency that recognises international qualifications and skills)
       url: https://www.enic.org.uk
+      statement_of_comparability_url: https://www.enic.org.uk/Qualifications/SOC/Default.aspx
   govuk:
     url: https://www.gov.uk
     terms_conditions_url: https://www.gov.uk/help/terms-conditions


### PR DESCRIPTION
## Context

DfE is removing funding for free Statements of Comparability. We are updating our guidance to reflect this.

## Before

<img width="722" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/50492247/a6ac3e24-5ff9-4f61-afec-21449d94475b">


## After

<img width="673" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/50492247/5c9f9798-5f5d-4d33-9098-2836ccab3cb4">


## Guidance to review

Select no to "Do you have a statement of comparability from UK ENIC" using the review app linked below, with JS and without JS. 

https://apply-review-9293.test.teacherservices.cloud/candidate/application/degrees/enic

## Link to Trello card

https://trello.com/c/U9NZcLjV/1530-enic-remove-reference-to-free-statement-of-comparability-from-dfe

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
