### PR TITLE
[1654] Add infra team statuscake contact group

### DIFF
--- a/terraform/aks/workspace_variables/production_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/production_aks.tfvars.json
@@ -36,7 +36,8 @@
       "website_url": "https://www.apply-for-teacher-training.service.gov.uk/integrations/monitoring/all",
       "check_rate": 30,
       "contact_group": [
-        204421
+        204421,
+        282453
       ]
     },
     "apply-production-check": {
@@ -44,7 +45,8 @@
       "website_url": "https://www.apply-for-teacher-training.service.gov.uk/check",
       "check_rate": 30,
       "contact_group": [
-        204421
+        204421,
+        282453
       ]
     },
     "apply-ingress-production": {
@@ -52,7 +54,8 @@
       "website_url": "https://apply-production.teacherservices.cloud/check",
       "check_rate": 30,
       "contact_group": [
-        204421
+        204421,
+        282453
       ]
     }
   }


### PR DESCRIPTION
## Context
There is only 1 statuscake contact group "Slack-Apply-Tech" with outdated contact details

## Changes proposed in this pull request
Add standard infra team contact group so contact details are updated in one place only
Add devs contact details to Slack-Apply-Tech separately

## Guidance to review
Check contact groups in statuscake

## Link to Trello card
https://trello.com/c/Z6eliKhq

