### PR TITLE
Added Realistic Job Preview Links to emails with tracking

### DIFF
--- a/adr/0022-realistic-job-preview-link-tracking.md
+++ b/adr/0022-realistic-job-preview-link-tracking.md
@@ -1,0 +1,31 @@
+# 22. Realistic Job Preview Link Tracking
+
+**Date:** 18/04/2024
+
+## Status:
+
+Proposed
+
+## Context
+
+We want to encourage unsuccessful candidates to make use of an ‘RJP’ tool built by the Teacher Success team, in collaboration with a group of academics that we’ve been working with.
+
+They will then be directed to a separate service, managed by an external party, which will tell them how suitable they are to be a teacher, and give them some pointers. We will then be given access to the data from each candidate’s engagement with this tool, should they choose to click on the link.
+
+This link will be made available to candidates in emails we send when they are rejected, decline an offer, or withdraw. We need to think about where else we could signpost this links.
+
+*[RJP]: Realistic Job Preview
+
+## Proposition:
+
+We have identified a list of Candidate facing emails that we will include the content and link in.
+
+The link will have a `utm_campaign` parameter that will be used to track the candidate's engagement with the tool.
+
+The DfE's [data analytics gem](https://github.com/DFE-Digital/dfe-analytics) has a mechanism for creating a unique identifier for each user, which we can replicate to generate the `utm_campaign` parameter.
+We will refer to this identifier as a `pseudonymised_id`.
+
+## Consequences:
+
+- We will be able to track the engagement of candidates with the RJP tool.
+- We will have a one way hash of a Candidates ID to use as the `pseudonymised_id`.

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -537,7 +537,11 @@ private
     candidate_interface_authenticate_url({ token: raw_token }.merge(utm_args))
   end
 
-  helper_method :candidate_magic_link
+  def candidate_realistic_job_preview_link(candidate)
+    realistic_job_preview_url({ utm_campaign: candidate.pseudonymised_id }.merge(utm_args))
+  end
+
+  helper_method :candidate_magic_link, :candidate_realistic_job_preview_link
 
   def uid
     @uid ||= EmailLogInterceptor.generate_reference

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -75,6 +75,11 @@ class Candidate < ApplicationRecord
     last_signed_in_at.nil?
   end
 
+  def pseudonymised_id
+    # Implementation matches https://github.com/DFE-Digital/dfe-analytics/blob/80015465040513020d0c2b3a2ae45d4f05f3b547/lib/dfe/analytics.rb#L207
+    Digest::SHA2.hexdigest(id.to_s)
+  end
+
 private
 
   def downcase_email

--- a/app/views/candidate_mailer/_still_interested_content.text.erb
+++ b/app/views/candidate_mailer/_still_interested_content.text.erb
@@ -18,6 +18,6 @@ All you need to do is:
 - find a course and submit another application
 <% end %>
 
-You can also [respond to these classroom scenarios](<%= candidate_realistic_job_preview_link(@application_form.candidate) %>) to learn what it's like to be a teacher.
+[Try the realistic job preview tool](<%= candidate_realistic_job_preview_link(@application_form.candidate) %>) to get insights into life in the classroom. Respond to video scenarios and get instant feedback on your suitability for a career in teaching.
 
 [Sign in to apply again](<%= @candidate_magic_link %>).

--- a/app/views/candidate_mailer/_still_interested_content.text.erb
+++ b/app/views/candidate_mailer/_still_interested_content.text.erb
@@ -16,7 +16,8 @@ All you need to do is:
 - check your details are still correct
 - make sure you are happy with your personal statement
 - find a course and submit another application
-
 <% end %>
+
+You can also [respond to these classroom scenarios](<%= candidate_realistic_job_preview_link(@application_form.candidate) %>) to learn what it's like to be a teacher.
 
 [Sign in to apply again](<%= @candidate_magic_link %>).

--- a/app/views/candidate_mailer/application_rejected.text.erb
+++ b/app/views/candidate_mailer/application_rejected.text.erb
@@ -7,13 +7,5 @@ Contact <%= @course.provider.name %> if you would like to talk about their feedb
 
 # You can apply again
 
-You can apply again for courses starting in the <%= "#{RecruitmentCycle.current_year} to #{RecruitmentCycle.next_year}" %> academic year.
-
-All you need to do is:
-- check that your details are still correct
-- make sure you are happy with your personal statement
-- find a course and submit another application
-
-
-[Sign in to apply again](<%= @candidate_magic_link %>).
+<%= render 'still_interested_content' %>
 

--- a/app/views/candidate_mailer/application_withdrawn_on_request.text.erb
+++ b/app/views/candidate_mailer/application_withdrawn_on_request.text.erb
@@ -2,12 +2,4 @@ Hello <%= @application_form.first_name %>,
 
 At your request, <%= @provider_name %> has withdrawn your application for <%= @course_name_and_code %>.
 
-If now’s the right time for you, you can still apply for teacher training again this year.
-
-All you need to do is:
-
-  - check that your details are still correct
-  - make sure you are happy with your personal statement
-  - find a course and submit another application
-
-[Sign in to apply again](<%= candidate_magic_link(@application_form.candidate) %>)
+<%= render 'still_interested_content' %>

--- a/app/views/candidate_mailer/declined_by_default.text.erb
+++ b/app/views/candidate_mailer/declined_by_default.text.erb
@@ -1,3 +1,5 @@
 Dear <%= @application_form.first_name %>
 
 You did not respond within <%= @declined_courses.first.decline_by_default_days %> working days so we declined your <%= 'offer'.pluralize(@declined_course_names.size) %> for <%= @declined_course_names.to_sentence %>.
+
+<%= render 'still_interested_content' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,14 @@ Rails.application.routes.draw do
     end
   end
 
+  direct :realistic_job_preview do |params|
+    uri = URI('https://platform.teachersuccess.co.uk/p/XK4rV0xN16')
+    if params.present?
+      uri.query = URI.encode_www_form(params)
+    end
+    uri.to_s
+  end
+
   namespace :integrations, path: '/integrations' do
     post '/notify/callback' => 'notify#callback'
     get '/feature-flags' => 'feature_flags#index'

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe CandidateMailer do
         I18n.t!('candidate_mailer.application_rejected.subject'),
         'intro' => 'Thank you for your application to study Mathematics at Arithmetic College',
         'rejection reasons' => 'Missing your English GCSE',
-        'realistic job preview' => 'respond to these classroom scenarios',
+        'realistic job preview' => 'Try the realistic job preview tool',
         'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
       )
     end
@@ -180,7 +180,7 @@ RSpec.describe CandidateMailer do
         'You did not respond to your offer: next steps',
         'heading' => 'Dear Fred',
         'days left to respond' => '10 working days',
-        'realistic job preview' => 'respond to these classroom scenarios',
+        'realistic job preview' => 'Try the realistic job preview tool',
         'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
       )
     end
@@ -191,7 +191,7 @@ RSpec.describe CandidateMailer do
       it_behaves_like(
         'a mail with subject and content',
         'You did not respond to your offers: next steps',
-        'realistic job preview' => 'respond to these classroom scenarios',
+        'realistic job preview' => 'Try the realistic job preview tool',
         'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
       )
     end
@@ -210,7 +210,7 @@ RSpec.describe CandidateMailer do
           'heading' => 'Dear Fred',
           'DBD_days_they_had_to_respond' => '10 working days',
           'still_interested' => 'If now’s the right time for you',
-          'realistic job preview' => 'respond to these classroom scenarios',
+          'realistic job preview' => 'Try the realistic job preview tool',
           'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
         )
       end
@@ -227,7 +227,7 @@ RSpec.describe CandidateMailer do
           'heading' => 'Dear Fred',
           'DBD_days_they_had_to_respond' => '10 working days',
           'apply_next_cycle' => 'You can apply again for courses starting in the 2022 to 2023 academic year.',
-          'realistic job preview' => 'respond to these classroom scenarios',
+          'realistic job preview' => 'Try the realistic job preview tool',
           'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
         )
       end
@@ -246,7 +246,7 @@ RSpec.describe CandidateMailer do
         'heading' => 'Dear Fred',
         'DBD_days_they_had_to_respond' => '10 working days',
         'still_interested' => 'If now’s the right time for you',
-        'realistic job preview' => 'respond to these classroom scenarios',
+        'realistic job preview' => 'Try the realistic job preview tool',
         'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
       )
     end
@@ -259,7 +259,7 @@ RSpec.describe CandidateMailer do
         'Application withdrawn automatically',
         'heading' => 'Dear Fred',
         'days left to respond' => '10 working days',
-        'realistic job preview' => 'respond to these classroom scenarios',
+        'realistic job preview' => 'Try the realistic job preview tool',
         'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
       )
     end
@@ -272,7 +272,7 @@ RSpec.describe CandidateMailer do
         'Applications withdrawn automatically',
         'heading' => 'Dear Fred',
         'days left to respond' => '10 working days',
-        'realistic job preview' => 'respond to these classroom scenarios',
+        'realistic job preview' => 'Try the realistic job preview tool',
         'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
       )
     end
@@ -298,7 +298,7 @@ RSpec.describe CandidateMailer do
         'You have withdrawn your application',
         'heading' => 'Hello Fred',
         'application_withdrawn' => 'You have withdrawn your application',
-        'realistic job preview' => 'respond to these classroom scenarios',
+        'realistic job preview' => 'Try the realistic job preview tool',
         'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
       )
     end
@@ -335,7 +335,7 @@ RSpec.describe CandidateMailer do
       'You have declined an offer: next steps',
       'greeting' => 'Hello Fred',
       'content' => 'declined your offer to study',
-      'realistic job preview' => 'respond to these classroom scenarios',
+      'realistic job preview' => 'Try the realistic job preview tool',
       'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
     )
   end
@@ -387,7 +387,7 @@ RSpec.describe CandidateMailer do
       'greeting' => 'Dear Fred',
       'offer details' => 'Arachnid College has withdrawn their offer for you to study Mathematics (M101)',
       'withdrawal reason' => 'You lied to us about secretly being Spiderman',
-      'realistic job preview' => 'respond to these classroom scenarios',
+      'realistic job preview' => 'Try the realistic job preview tool',
       'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
     )
   end
@@ -835,7 +835,7 @@ RSpec.describe CandidateMailer do
         'greeting' => 'Hello Fred',
         'details' => 'has withdrawn your application for',
         'content' => 'If now’s the right time for you, you can still apply for teacher training again this year.',
-        'realistic job preview' => 'respond to these classroom scenarios',
+        'realistic job preview' => 'Try the realistic job preview tool',
         'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
       )
     end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -93,6 +93,7 @@ RSpec.describe CandidateMailer do
         'intro' => 'Thank you for your application to study Mathematics at Arithmetic College',
         'rejection reasons' => 'Missing your English GCSE',
         'realistic job preview' => 'respond to these classroom scenarios',
+        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
       )
     end
   end
@@ -180,6 +181,7 @@ RSpec.describe CandidateMailer do
         'heading' => 'Dear Fred',
         'days left to respond' => '10 working days',
         'realistic job preview' => 'respond to these classroom scenarios',
+        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
       )
     end
 
@@ -190,6 +192,7 @@ RSpec.describe CandidateMailer do
         'a mail with subject and content',
         'You did not respond to your offers: next steps',
         'realistic job preview' => 'respond to these classroom scenarios',
+        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
       )
     end
 
@@ -208,6 +211,7 @@ RSpec.describe CandidateMailer do
           'DBD_days_they_had_to_respond' => '10 working days',
           'still_interested' => 'If now’s the right time for you',
           'realistic job preview' => 'respond to these classroom scenarios',
+          'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
         )
       end
 
@@ -224,6 +228,7 @@ RSpec.describe CandidateMailer do
           'DBD_days_they_had_to_respond' => '10 working days',
           'apply_next_cycle' => 'You can apply again for courses starting in the 2022 to 2023 academic year.',
           'realistic job preview' => 'respond to these classroom scenarios',
+          'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
         )
       end
     end
@@ -242,6 +247,7 @@ RSpec.describe CandidateMailer do
         'DBD_days_they_had_to_respond' => '10 working days',
         'still_interested' => 'If now’s the right time for you',
         'realistic job preview' => 'respond to these classroom scenarios',
+        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
       )
     end
 
@@ -254,6 +260,7 @@ RSpec.describe CandidateMailer do
         'heading' => 'Dear Fred',
         'days left to respond' => '10 working days',
         'realistic job preview' => 'respond to these classroom scenarios',
+        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
       )
     end
 
@@ -266,6 +273,7 @@ RSpec.describe CandidateMailer do
         'heading' => 'Dear Fred',
         'days left to respond' => '10 working days',
         'realistic job preview' => 'respond to these classroom scenarios',
+        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
       )
     end
   end
@@ -291,6 +299,7 @@ RSpec.describe CandidateMailer do
         'heading' => 'Hello Fred',
         'application_withdrawn' => 'You have withdrawn your application',
         'realistic job preview' => 'respond to these classroom scenarios',
+        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
       )
     end
 
@@ -327,6 +336,7 @@ RSpec.describe CandidateMailer do
       'greeting' => 'Hello Fred',
       'content' => 'declined your offer to study',
       'realistic job preview' => 'respond to these classroom scenarios',
+      'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
     )
   end
 
@@ -378,6 +388,7 @@ RSpec.describe CandidateMailer do
       'offer details' => 'Arachnid College has withdrawn their offer for you to study Mathematics (M101)',
       'withdrawal reason' => 'You lied to us about secretly being Spiderman',
       'realistic job preview' => 'respond to these classroom scenarios',
+      'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
     )
   end
 
@@ -825,6 +836,7 @@ RSpec.describe CandidateMailer do
         'details' => 'has withdrawn your application for',
         'content' => 'If now’s the right time for you, you can still apply for teacher training again this year.',
         'realistic job preview' => 'respond to these classroom scenarios',
+        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
       )
     end
   end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -92,6 +92,7 @@ RSpec.describe CandidateMailer do
         I18n.t!('candidate_mailer.application_rejected.subject'),
         'intro' => 'Thank you for your application to study Mathematics at Arithmetic College',
         'rejection reasons' => 'Missing your English GCSE',
+        'realistic job preview' => 'respond to these classroom scenarios',
       )
     end
   end
@@ -178,13 +179,18 @@ RSpec.describe CandidateMailer do
         'You did not respond to your offer: next steps',
         'heading' => 'Dear Fred',
         'days left to respond' => '10 working days',
+        'realistic job preview' => 'respond to these classroom scenarios',
       )
     end
 
     context 'when a candidate has 2 or 3 offers that were declined' do
       let(:application_choices) { [dbd_application, dbd_application] }
 
-      it_behaves_like 'a mail with subject and content', 'You did not respond to your offers: next steps', {}
+      it_behaves_like(
+        'a mail with subject and content',
+        'You did not respond to your offers: next steps',
+        'realistic job preview' => 'respond to these classroom scenarios',
+      )
     end
 
     context 'when a candidate has 1 offer that was declined by default and a rejection' do
@@ -201,6 +207,7 @@ RSpec.describe CandidateMailer do
           'heading' => 'Dear Fred',
           'DBD_days_they_had_to_respond' => '10 working days',
           'still_interested' => 'If now’s the right time for you',
+          'realistic job preview' => 'respond to these classroom scenarios',
         )
       end
 
@@ -216,6 +223,7 @@ RSpec.describe CandidateMailer do
           'heading' => 'Dear Fred',
           'DBD_days_they_had_to_respond' => '10 working days',
           'apply_next_cycle' => 'You can apply again for courses starting in the 2022 to 2023 academic year.',
+          'realistic job preview' => 'respond to these classroom scenarios',
         )
       end
     end
@@ -233,6 +241,7 @@ RSpec.describe CandidateMailer do
         'heading' => 'Dear Fred',
         'DBD_days_they_had_to_respond' => '10 working days',
         'still_interested' => 'If now’s the right time for you',
+        'realistic job preview' => 'respond to these classroom scenarios',
       )
     end
 
@@ -244,6 +253,7 @@ RSpec.describe CandidateMailer do
         'Application withdrawn automatically',
         'heading' => 'Dear Fred',
         'days left to respond' => '10 working days',
+        'realistic job preview' => 'respond to these classroom scenarios',
       )
     end
 
@@ -255,6 +265,7 @@ RSpec.describe CandidateMailer do
         'Applications withdrawn automatically',
         'heading' => 'Dear Fred',
         'days left to respond' => '10 working days',
+        'realistic job preview' => 'respond to these classroom scenarios',
       )
     end
   end
@@ -279,6 +290,7 @@ RSpec.describe CandidateMailer do
         'You have withdrawn your application',
         'heading' => 'Hello Fred',
         'application_withdrawn' => 'You have withdrawn your application',
+        'realistic job preview' => 'respond to these classroom scenarios',
       )
     end
 
@@ -314,6 +326,7 @@ RSpec.describe CandidateMailer do
       'You have declined an offer: next steps',
       'greeting' => 'Hello Fred',
       'content' => 'declined your offer to study',
+      'realistic job preview' => 'respond to these classroom scenarios',
     )
   end
 
@@ -364,6 +377,7 @@ RSpec.describe CandidateMailer do
       'greeting' => 'Dear Fred',
       'offer details' => 'Arachnid College has withdrawn their offer for you to study Mathematics (M101)',
       'withdrawal reason' => 'You lied to us about secretly being Spiderman',
+      'realistic job preview' => 'respond to these classroom scenarios',
     )
   end
 
@@ -810,6 +824,7 @@ RSpec.describe CandidateMailer do
         'greeting' => 'Hello Fred',
         'details' => 'has withdrawn your application for',
         'content' => 'If now’s the right time for you, you can still apply for teacher training again this year.',
+        'realistic job preview' => 'respond to these classroom scenarios',
       )
     end
   end

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -261,4 +261,11 @@ RSpec.describe Candidate do
       end
     end
   end
+
+  describe '#pseudonymised_id' do
+    it 'returns the pseudonymised id based on the candidate id' do
+      candidate = build_stubbed(:candidate, id: 0)
+      expect(candidate.pseudonymised_id).to eq '5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9'
+    end
+  end
 end


### PR DESCRIPTION
## Context

We want to add links to candidate emails pointing them to use the Realistic Job Preview service. As part of this implementation we want to track Candidate interactions between both services.

## Changes proposed in this pull request

Introduction of a new ADR for review

We have added a `#pseudonymised_id` to the Candidate model to generate a trackable ID based on the Candidate ID

We have added a `direct` route to the RJP url with the ability to add custom query parameters to the url.

We have added content to the following emails adding the RJP links.
- [x] application_rejected
- [x] application_rejected_all_applications_rejected
- [x] application_withdrawn_on_request
- [x] decline_last_application_choice
- [x] declined_by_default
- [x] declined_by_default_with_rejections
- [x] declined_by_default_without_rejections
- [x] withdraw_last_application_choice
- [x] offer_withdrawn

## Guidance to review

Email previews can be viewed at http://localhost:3000/support/docs/mailers or https://apply-review-9295.test.teacherservices.cloud/support/docs/mailers

## Link to Trello card

https://trello.com/c/csDRylWV

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
