### PR TITLE
Allow candidates to submit when they have free slot & conditions not met

### DIFF
--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -16,7 +16,7 @@ class ApplicationStateChange
   REAPPLY_STATUSES = %i[rejected cancelled withdrawn declined offer_withdrawn].freeze
 
   TERMINAL_STATES = UNSUCCESSFUL_STATES + %i[recruited].freeze
-  IN_PROGRESS_STATES = DECISION_PENDING_STATUSES + ACCEPTED_STATES + %i[offer].freeze
+  IN_PROGRESS_STATES = DECISION_PENDING_STATUSES + ACCEPTED_STATES + %i[offer].freeze - %i[conditions_not_met]
 
   attr_reader :application_choice
 

--- a/spec/services/candidate_interface/continuous_applications/application_choice_submission_spec.rb
+++ b/spec/services/candidate_interface/continuous_applications/application_choice_submission_spec.rb
@@ -297,6 +297,16 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationChoiceSubm
         end
       end
 
+      context 'when candidate has conditions not met and can submit further applications' do
+        let(:application_form) { create(:completed_application_form) }
+        let(:application_choice) { create(:application_choice, :unsubmitted, application_form:) }
+
+        it 'is valid' do
+          create_list(:application_choice, 4, :conditions_not_met, application_form:)
+          expect(application_choice_submission).to be_valid
+        end
+      end
+
       context 'when candidate can not submit further applications' do
         let(:application_form) { create(:completed_application_form, submitted_application_choices_count: 4) }
         let(:application_choice) { create(:application_choice, :unsubmitted, application_form:) }

--- a/spec/system/candidate_interface/continuous_applications/submitting/candidate_tries_to_submit_after_exceeding_the_maximum_amount_of_choices_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/submitting/candidate_tries_to_submit_after_exceeding_the_maximum_amount_of_choices_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate submits an application up to 4 choices' do
+  include CandidateHelper
+
+  before { given_courses_exist }
+
+  scenario 'when candidate has a conditions not met and only one free slot' do
+    given_i_am_signed_in
+    and_i_have_a_conditions_not_met_application_and_one_free_slot_to_submit
+    when_i_visit_my_applications
+    then_i_can_see_i_have_one_choice_left
+    given_i_have_a_draft_application
+    when_i_submit_a_new_application
+    then_i_can_see_my_application_has_been_successfully_submitted
+    and_i_am_unable_to_add_any_further_choices
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_have_a_conditions_not_met_application_and_one_free_slot_to_submit
+    current_candidate.current_application.destroy!
+    application_form = create(:application_form, :completed, candidate: current_candidate)
+    create(:application_choice, :awaiting_provider_decision, application_form:)
+    create(:application_choice, :awaiting_provider_decision, application_form:)
+    create(:application_choice, :awaiting_provider_decision, application_form:)
+    create(:application_choice, :conditions_not_met, application_form:)
+  end
+
+  def given_i_have_a_draft_application
+    @application_choice = create(:application_choice, :unsubmitted, application_form: current_candidate.current_application)
+  end
+
+  def when_i_submit_a_new_application
+    when_i_visit_my_applications
+    when_i_click_to_view_my_application
+    when_i_click_to_review_my_application
+    when_i_click_to_submit_my_application
+  end
+
+  def then_i_can_see_my_application_has_been_successfully_submitted
+    expect(page).to have_content 'Application submitted'
+  end
+
+  def then_i_can_see_i_have_one_choice_left
+    expect(page).to have_content 'You can add 1 more application'
+  end
+
+  def and_i_am_unable_to_add_any_further_choices
+    expect(page).to have_content 'You cannot add any more applications.'
+  end
+end


### PR DESCRIPTION
## Context

We have a support ticket where the candidate stated that can only add up to 3 applications (although the content says 4).

After an investigation I conclude the reason is that we are counting conditions not met as an unavailable slot for submission - meaning if the user has 4 conditions not met applications, the candidate can never apply ever - which is a bug because conditions not met is an unsuccessful state and not an in progress state.

## Changes proposed in this pull request

Conditions not met should not be in the criteria for add more choices and should only be counted towards the max submission application.

## Guidance to review

1. Does it work on the review app when you have conditions not met and it excluding from the slot availables for submission?

## Documentations to refer to

[docs/states.md](https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/docs/states.md)

## Link to Trello card

https://trello.com/c/JPqXmRKL/1541-bug-candidates-cant-submit-applications-when-they-have-x-conditionsnotmet-applications
