### PR TITLE
Template Error when disabilities are nil

### DIFF
--- a/app/components/provider_interface/diversity_information_component.rb
+++ b/app/components/provider_interface/diversity_information_component.rb
@@ -40,11 +40,12 @@ module ProviderInterface
     end
 
     def disability_value
-      disabilities = equality_and_diversity['disabilities'].map do |disability|
+      disabilities = Array(equality_and_diversity.fetch('disabilities', []))
+      disability_list_items = disabilities.map do |disability|
         "<li>#{disability} </li>"
       end
 
-      "<ul class=\"govuk-list\">#{disabilities.join}</ul>"
+      "<ul class=\"govuk-list\">#{disability_list_items.join}</ul>"
     end
 
     def application_in_correct_state?

--- a/app/components/provider_interface/diversity_information_component.rb
+++ b/app/components/provider_interface/diversity_information_component.rb
@@ -40,7 +40,7 @@ module ProviderInterface
     end
 
     def disability_value
-      disabilities = Array(equality_and_diversity.fetch('disabilities', []))
+      disabilities = Array(equality_and_diversity['disabilities'])
       disability_list_items = disabilities.map do |disability|
         "<li>#{disability} </li>"
       end

--- a/spec/components/provider_interface/diversity_information_component_spec.rb
+++ b/spec/components/provider_interface/diversity_information_component_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe ProviderInterface::DiversityInformationComponent do
           expect(result.text).to include('Chinese')
         end
 
-        it 'does not dispay Ethnic background if they are not declared' do
+        it 'does not display Ethnic background if they are not declared' do
           prefer_not_to_say_diversity_info = { 'sex' => 'Prefer not to say',
                                                'disabilities' => ['I do not have any of these disabilities or health conditions'],
                                                'ethnic_group' => 'Prefer not to say',
@@ -118,6 +118,26 @@ RSpec.describe ProviderInterface::DiversityInformationComponent do
 
           result = render_inline(described_class.new(application_choice:, current_provider_user: provider_user))
           expect(result.text).to include('Prefer not to say')
+        end
+
+        it 'displays nothing for disabilities when they are nil' do
+          nil_disabilities_diversity_info = { 'sex' => 'female',
+                                              'disabilities' => nil,
+                                              'ethnic_group' => 'Asian or Asian British',
+                                              'ethnic_background' => 'Chinese' }
+
+          application_form = build_stubbed(
+            :application_form,
+            equality_and_diversity: nil_disabilities_diversity_info,
+          )
+          application_choice = build(:application_choice,
+                                     application_form:,
+                                     course:,
+                                     current_course: course,
+                                     status: 'pending_conditions')
+
+          result = render_inline(described_class.new(application_choice:, current_provider_user: provider_user))
+          expect(result.text).to include('Disabilities and health conditions')
         end
       end
 


### PR DESCRIPTION
## Context

We received a [Sentry Error](https://dfe-teacher-services.sentry.io/issues/5102297223/?alert_rule_id=4434951&alert_type=issue&environment=production&notification_uuid=686dc6d7-1b5d-4468-8171-0d15717a76d5&project=1765973) highlighting this bug.

The underlying issue is that the section should not have been valid without any values. This will be addressed in a following [Trello task](https://trello.com/c/GpWF10Dy/1544-does-validate-disabilities-values-when-marking-the-ed-section-complete)

## Changes proposed in this pull request

N/A

## Guidance to review

N/A

## Link to Trello card

https://trello.com/c/vKD8u8eX

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
