### PR TITLE
Move SCSS from Webpack to CSS Bundling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ ministerial-report-applications*.txt
 .cftoken
 
 maintenance_page/manifests/maintenance/deployment_maintenance.yml
+
+/app/assets/builds/*
+!/app/assets/builds/.keep

--- a/Gemfile
+++ b/Gemfile
@@ -194,3 +194,5 @@ group :development, :test do
   gem 'pry'
   gem 'rspec-rails', require: false
 end
+
+gem 'cssbundling-rails', '~> 1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,6 +222,8 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
+    cssbundling-rails (1.4.0)
+      railties (>= 6.0.0)
     csv (3.3.0)
     date (3.3.4)
     db-query-matchers (0.12.0)
@@ -874,6 +876,7 @@ DEPENDENCIES
   clockwork
   clockwork-test
   colorize
+  cssbundling-rails (~> 1.4)
   db-query-matchers
   deepsort
   devise

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -2,4 +2,5 @@ web: SERVICE_TYPE=web bundle exec puma -C config/puma.rb
 worker: SERVICE_TYPE=worker bundle exec sidekiq -c 5 -C config/sidekiq-main.yml
 worker_secondary: SERVICE_TYPE=worker bundle exec sidekiq -c 5 -C config/sidekiq-secondary.yml
 clock: SERVICE_TYPE=clock bundle exec clockwork config/clock.rb
+css: yarn build:css --watch
 caddy: caddy run -c Caddyfile.dev

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,1 +1,2 @@
 // This is just here for Blazer.
+//= link_tree ../builds

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -4,3 +4,4 @@
 // govuk-frontend assets
 //= link_directory ../../../node_modules/govuk-frontend/dist/govuk/assets/images
 //= link_directory ../../../node_modules/govuk-frontend/dist/govuk/assets/fonts
+//= link_directory ../../../node_modules/@ministryofjustice/frontend/moj/assets/images

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,6 @@
 // This is just here for Blazer.
 //= link_tree ../builds
+
+// govuk-frontend assets
+//= link_directory ../../../node_modules/govuk-frontend/dist/govuk/assets/images
+//= link_directory ../../../node_modules/govuk-frontend/dist/govuk/assets/fonts

--- a/app/frontend/packs/application-api-docs.js
+++ b/app/frontend/packs/application-api-docs.js
@@ -1,5 +1,4 @@
 import { initAll as govUKFrontendInitAll } from 'govuk-frontend'
-import '../styles/application-api-docs.scss'
 
 require.context('govuk-frontend/dist/govuk/assets')
 

--- a/app/frontend/packs/application-candidate.js
+++ b/app/frontend/packs/application-candidate.js
@@ -5,8 +5,6 @@ import { initAutosuggest } from './autosuggests/init-autosuggest'
 import { candidateAutocompleteInputs } from './autocompletes/candidate/candidate-autocomplete-inputs'
 import { candidateAutosuggestInputs } from './autosuggests/candidate/candidate-autosuggest-inputs'
 import nationalitiesComponent from './nationalities-component'
-import 'accessible-autocomplete/dist/accessible-autocomplete.min.css'
-import '../styles/application-candidate.scss'
 import cookieBanners from './cookies/cookie-banners'
 import showMoreShowLess from './components/show-more-show-less'
 

--- a/app/frontend/packs/application-provider.js
+++ b/app/frontend/packs/application-provider.js
@@ -3,7 +3,6 @@ import initWarnOnUnsavedChanges from './warn-on-unsaved-changes'
 import initAddFurtherConditions from './further_conditions'
 import filter from './components/paginated_filter'
 import checkboxSearchFilter from './components/checkbox_search_filter'
-import '../styles/application-provider.scss'
 import cookieBanners from './cookies/cookie-banners'
 
 require.context('govuk-frontend/dist/govuk/assets')

--- a/app/frontend/packs/application-publications.js
+++ b/app/frontend/packs/application-publications.js
@@ -1,8 +1,6 @@
 import { initAll as govUKFrontendInitAll } from 'govuk-frontend'
 import SortableTable from './sortable-table'
 
-import '../styles/application-publications.scss'
-
 require.context('govuk-frontend/dist/govuk/assets')
 govUKFrontendInitAll()
 

--- a/app/frontend/packs/application-support.js
+++ b/app/frontend/packs/application-support.js
@@ -1,7 +1,5 @@
 import { initAll as govUKFrontendInitAll } from 'govuk-frontend'
 import filter from './components/paginated_filter'
-import 'accessible-autocomplete/dist/accessible-autocomplete.min.css'
-import '../styles/application-support.scss'
 import { initAutocomplete } from './autocompletes/init-autocomplete'
 import { supportAutocompleteInputs } from './autocompletes/support/support-autocomplete-inputs'
 import sortByFilter from './sort-by-filter'

--- a/app/frontend/packs/application.js
+++ b/app/frontend/packs/application.js
@@ -1,5 +1,4 @@
 import { initAll as govUKFrontendInitAll } from 'govuk-frontend'
-import '../styles/application.scss'
 
 require.context('govuk-frontend/dist/govuk/assets')
 

--- a/app/frontend/styles/api_docs/_all.scss
+++ b/app/frontend/styles/api_docs/_all.scss
@@ -1,10 +1,10 @@
 // API Docs components
-@import "~@ministryofjustice/frontend/moj/settings/assets";
-@import "~@ministryofjustice/frontend/moj/settings/measurements";
-@import "~@ministryofjustice/frontend/moj/helpers/all";
-@import "~@ministryofjustice/frontend/moj/objects/width-container";
-@import "~@ministryofjustice/frontend/moj/components/filter/filter";
-@import "~@ministryofjustice/frontend/moj/components/sub-navigation/sub-navigation";
-@import "~@ministryofjustice/frontend/moj/components/primary-navigation/primary-navigation";
-@import "~@ministryofjustice/frontend/moj/utilities/all";
-@import "styles/syntax-highlighting";
+@import "@ministryofjustice/frontend/moj/settings/assets";
+@import "@ministryofjustice/frontend/moj/settings/measurements";
+@import "@ministryofjustice/frontend/moj/helpers/all";
+@import "@ministryofjustice/frontend/moj/objects/width-container";
+@import "@ministryofjustice/frontend/moj/components/filter/filter";
+@import "@ministryofjustice/frontend/moj/components/sub-navigation/sub-navigation";
+@import "@ministryofjustice/frontend/moj/components/primary-navigation/primary-navigation";
+@import "@ministryofjustice/frontend/moj/utilities/all";
+@import "../syntax-highlighting";

--- a/app/frontend/styles/application-candidate.scss
+++ b/app/frontend/styles/application-candidate.scss
@@ -3,3 +3,4 @@
 @import "components/tabs";
 @import "components/show_more_show_less";
 @import "dfe-autocomplete/src/dfe-autocomplete";
+@import 'accessible-autocomplete/dist/accessible-autocomplete.min';

--- a/app/frontend/styles/application-support.scss
+++ b/app/frontend/styles/application-support.scss
@@ -3,6 +3,7 @@
 @import "components/paginated_filter";
 @import "components/checkbox_search_filter";
 @import "dfe-autocomplete/src/dfe-autocomplete";
+@import 'accessible-autocomplete/dist/accessible-autocomplete.min';
 
 .app-data-set-documentation--datatype {
   margin: 0;

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -22,7 +22,7 @@ $govuk-breakpoints: (
   wide: 1300px,
 );
 
-$moj-images-path: "~@ministryofjustice/frontend/moj/assets/images/";
+$moj-images-path: "@ministryofjustice/frontend/moj/assets/images/";
 
 // Enable new link styles (currently opt-in).
 // TODO: remove this when this becomes the default.

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -1,18 +1,10 @@
-@function frontend-font-url($filename) {
-  @return url("~assets/fonts/" + $filename);
-}
-
-@function frontend-image-url($filename) {
-  @return url("~assets/images/" + $filename);
-}
-
+$govuk-fonts-path: "";
+$govuk-images-path: "";
 // app colours that don't appear in govuk-frontend
 // but are used throughout DfE
 // e.g. https://github.com/search?q=org%3ADFE-Digital+EBF2F6&type=code
 $app-grey: #ebf2f6;
 
-$govuk-font-url-function: frontend-font-url;
-$govuk-image-url-function: frontend-image-url;
 
 $govuk-breakpoints: (
   mobile: 320px,

--- a/app/frontend/styles/components/_paginated_filter.scss
+++ b/app/frontend/styles/components/_paginated_filter.scss
@@ -1,11 +1,11 @@
-@import "~@ministryofjustice/frontend/moj/settings/assets";
-@import "~@ministryofjustice/frontend/moj/settings/measurements";
-@import "~@ministryofjustice/frontend/moj/helpers/all";
-@import "~@ministryofjustice/frontend/moj/objects/width-container";
-@import "~@ministryofjustice/frontend/moj/components/pagination/pagination";
-@import "~@ministryofjustice/frontend/moj/objects/filter-layout";
-@import "~@ministryofjustice/frontend/moj/objects/scrollable-pane";
-@import "~@ministryofjustice/frontend/moj/components/filter/filter";
+@import "@ministryofjustice/frontend/moj/settings/assets";
+@import "@ministryofjustice/frontend/moj/settings/measurements";
+@import "@ministryofjustice/frontend/moj/helpers/all";
+@import "@ministryofjustice/frontend/moj/objects/width-container";
+@import "@ministryofjustice/frontend/moj/components/pagination/pagination";
+@import "@ministryofjustice/frontend/moj/objects/filter-layout";
+@import "@ministryofjustice/frontend/moj/objects/scrollable-pane";
+@import "@ministryofjustice/frontend/moj/components/filter/filter";
 
 .moj-filter-layout__content {
   overflow-x: hidden;

--- a/app/frontend/styles/provider/_all.scss
+++ b/app/frontend/styles/provider/_all.scss
@@ -1,9 +1,9 @@
 // Provider components
-@import "~@ministryofjustice/frontend/moj/settings/assets";
-@import "~@ministryofjustice/frontend/moj/settings/measurements";
-@import "~@ministryofjustice/frontend/moj/helpers/all";
-@import "~@ministryofjustice/frontend/moj/objects/width-container";
-@import "~@ministryofjustice/frontend/moj/utilities/all";
+@import "@ministryofjustice/frontend/moj/settings/assets";
+@import "@ministryofjustice/frontend/moj/settings/measurements";
+@import "@ministryofjustice/frontend/moj/helpers/all";
+@import "@ministryofjustice/frontend/moj/objects/width-container";
+@import "@ministryofjustice/frontend/moj/utilities/all";
 @import "action-bar";
 @import "button";
 @import "count";

--- a/app/frontend/styles/support/_all.scss
+++ b/app/frontend/styles/support/_all.scss
@@ -1,13 +1,13 @@
 // Support components
-@import "~@ministryofjustice/frontend/moj/settings/assets";
-@import "~@ministryofjustice/frontend/moj/settings/measurements";
-@import "~@ministryofjustice/frontend/moj/helpers/all";
-@import "~@ministryofjustice/frontend/moj/objects/width-container";
-@import "~@ministryofjustice/frontend/moj/components/filter/filter";
-@import "~@ministryofjustice/frontend/moj/components/sub-navigation/sub-navigation";
-@import "~@ministryofjustice/frontend/moj/components/primary-navigation/primary-navigation";
-@import "~@ministryofjustice/frontend/moj/utilities/all";
-@import "styles/syntax-highlighting";
+@import "@ministryofjustice/frontend/moj/settings/assets";
+@import "@ministryofjustice/frontend/moj/settings/measurements";
+@import "@ministryofjustice/frontend/moj/helpers/all";
+@import "@ministryofjustice/frontend/moj/objects/width-container";
+@import "@ministryofjustice/frontend/moj/components/filter/filter";
+@import "@ministryofjustice/frontend/moj/components/sub-navigation/sub-navigation";
+@import "@ministryofjustice/frontend/moj/components/primary-navigation/primary-navigation";
+@import "@ministryofjustice/frontend/moj/utilities/all";
+@import "../syntax-highlighting";
 @import "app-count";
 @import "button";
 @import "checkboxes-scroll";

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -22,17 +22,17 @@
 
     <% case try(:current_namespace) %>
     <% when 'candidate_interface' %>
-      <%= stylesheet_pack_tag 'application-candidate', media: 'all' %>
+      <%= stylesheet_link_tag 'application-candidate', media: 'all' %>
     <% when 'support_interface' %>
-      <%= stylesheet_pack_tag 'application-support', media: 'all' %>
+      <%= stylesheet_link_tag 'application-support', media: 'all' %>
     <% when 'provider_interface' %>
-      <%= stylesheet_pack_tag 'application-provider', media: 'all' %>
+      <%= stylesheet_link_tag 'application-provider', media: 'all' %>
     <% when 'publications' %>
-      <%= stylesheet_pack_tag 'application-publications', media: 'all' %>
+      <%= stylesheet_link_tag 'application-publications', media: 'all' %>
     <% when /api_docs/ %>
-      <%= stylesheet_pack_tag 'application-api-docs', media: 'all' %>
+      <%= stylesheet_link_tag 'application-api-docs', media: 'all' %>
     <% else %>
-      <%= stylesheet_pack_tag 'application', media: 'all' %>
+      <%= stylesheet_link_tag 'application', media: 'all' %>
     <% end %>
   </head>
 

--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -15,7 +15,7 @@
     <link rel="apple-touch-icon" href="<%= asset_pack_path('media/images/govuk-icon-180.png') %>">
 
     <meta property="og:image" content="<%= asset_pack_path('media/images/govuk-opengraph-image.png') %>">
-    <%= stylesheet_pack_tag 'application', media: 'all' %>
+    <%= stylesheet_link_tag 'application', media: 'all' %>
   </head>
 
   <body class="govuk-template__body">

--- a/app/views/layouts/previews/provider.html.erb
+++ b/app/views/layouts/previews/provider.html.erb
@@ -1,5 +1,5 @@
 <% content_for :before_content do %>
-  <%= stylesheet_pack_tag 'application-provider', media: 'all' %>
+  <%= stylesheet_link_tag 'application-provider', media: 'all' %>
 <% end %>
 
 <%= render template: 'layouts/application' %>

--- a/docs/development/frontend.md
+++ b/docs/development/frontend.md
@@ -106,7 +106,11 @@ Spec files should be saved alongside the corresponding JavaScript file.
 
 ## Asset pipeline
 
-We use the Rails webpack wrapper [Webpacker](https://github.com/rails/webpacker) to compile CSS, images, fonts and JavaScript.
+We use [cssbundling-rails](https://guides.rubyonrails.org/asset_pipeline.html#cssbundling-rails) with [Dart Sass](https://sass-lang.com/) to compile SCSS into CSS.
+
+We use the Rails asset pipeline [Sprockets](https://guides.rubyonrails.org/asset_pipeline.html) to fingerprint and concatenate CSS, images and fonts
+
+We use the Rails webpack wrapper [Webpacker](https://github.com/rails/webpacker) to compile JavaScript.
 
 ## Debugging Webpacker
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "govuk-frontend": "^5.4.0",
     "jquery": "^3.7.1",
     "postcss": "^8.4.39",
-    "puppeteer": "^22.13.1"
+    "puppeteer": "^22.13.1",
+    "sass": "^1.75.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",
@@ -30,7 +31,8 @@
   "scripts": {
     "lint": "standard 'app/frontend/packs'",
     "test": "jest",
-    "prepare": "husky"
+    "prepare": "husky",
+    "build:css": "sass ./app/frontend/styles/application.scss:./app/assets/builds/application.css ./app/frontend/styles/application-api-docs.scss:./app/assets/builds/application-api-docs.css ./app/frontend/styles/application-candidate.scss:./app/assets/builds/application-candidate.css ./app/frontend/styles/application-provider.scss:./app/assets/builds/application-provider.css ./app/frontend/styles/application-publications.scss:./app/assets/builds/application-publications.css ./app/frontend/styles/application-support.scss:./app/assets/builds/application-support.css --no-source-map --load-path=node_modules"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/spec/components/previews/publications/data_table_component/default.html.erb
+++ b/spec/components/previews/publications/data_table_component/default.html.erb
@@ -1,4 +1,4 @@
-<%= stylesheet_pack_tag 'application-publications' %>
+<%= stylesheet_link_tag 'application-publications' %>
 <div>
   <%= render Publications::DataTableComponent.new(caption: 'Applications by Age', title: local_assigns[:age_title], data: local_assigns[:age_data]) %>
 </div>

--- a/spec/components/previews/publications/status_totals/default.html.erb
+++ b/spec/components/previews/publications/status_totals/default.html.erb
@@ -1,4 +1,4 @@
-<%= stylesheet_pack_tag 'application-publications' %>
+<%= stylesheet_link_tag 'application-publications' %>
 
 <div class="govuk-grid-row">
   <%= render Publications::StatusTotalsComponent.new(

--- a/yarn.lock
+++ b/yarn.lock
@@ -8318,6 +8318,15 @@ sass@^1.38.0:
     immutable "^4.0.0"
     source-map-js ">=0.6.2 <2.0.0"
 
+sass@^1.75.0:
+  version "1.75.0"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.75.0.tgz#91bbe87fb02dfcc34e052ddd6ab80f60d392be6c"
+  integrity sha512-ShMYi3WkrDWxExyxSZPst4/okE9ts46xZmJDSawJQrnte7M1V9fScVB+uNXOVKRBt0PggHOwoZcn8mYX4trnBw==
+  dependencies:
+    chokidar ">=3.0.0 <4.0.0"
+    immutable "^4.0.0"
+    source-map-js ">=0.6.2 <2.0.0"
+
 sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"


### PR DESCRIPTION
## Context

As part of an attempt to simplify our stack, we aim to remove the dependancy on webpack (no longer supported in Rails) to compile assets.

## Changes proposed in this pull request

This Pull Request moves SCSS/CSS compiling away from webpack and uses the standard Rails [`css-bundling`](https://github.com/rails/cssbundling-rails) gem which compiles SCSS using [dart-sass](https://sass-lang.com/dart-sass/) under the hood

## Guidance to review

**Review locally**
- `bundle install`
- `yarn install`
- `rails assets:clobber` to make sure no assets are hanging around
- `bin/dev` to spin up the `css` process for building and watching SCSS files
- Check all pages load without missing styles or images

**Review in review app**
- visit https://apply-review-9303.test.teacherservices.cloud/
- Check all pages load without missing styles or images

**Review code**
- Step by step commit messages

## Link to Trello card


## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
