### PR TITLE
Improve the course sync between apply and ttapi

### DIFF
--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -15,12 +15,12 @@ module TeacherTrainingPublicAPI
       @incremental_sync = incremental_sync
       @updates = {}
 
-      scope = TeacherTrainingPublicAPI::Course.where(
+      provider_courses_from_api = TeacherTrainingPublicAPI::Course.where(
         year: recruitment_cycle_year,
         provider_code: @provider.code,
       ).paginate(per_page: 500)
 
-      scope.each do |course_from_api|
+      provider_courses_from_api.each do |course_from_api|
         ActiveRecord::Base.transaction do
           create_or_update_course(course_from_api, recruitment_cycle_year, @incremental_sync, suppress_sync_update_errors)
         end

--- a/app/services/teacher_training_public_api/sync_courses.rb
+++ b/app/services/teacher_training_public_api/sync_courses.rb
@@ -7,6 +7,8 @@ module TeacherTrainingPublicAPI
     include Sidekiq::Worker
     sidekiq_options retry: 3, queue: :low_priority
 
+    API_COURSE_DRAFT_STATES = %w[rolled_over draft].freeze
+
     def perform(provider_id, recruitment_cycle_year, incremental_sync = true, suppress_sync_update_errors = false, run_in_background: true)
       @provider = ::Provider.find(provider_id)
       @run_in_background = run_in_background
@@ -32,6 +34,8 @@ module TeacherTrainingPublicAPI
   private
 
     def create_or_update_course(course_from_api, recruitment_cycle_year, incremental_sync, suppress_sync_update_errors)
+      return if course_from_api.state.in?(API_COURSE_DRAFT_STATES)
+
       course = provider.courses.find_or_initialize_by(
         uuid: course_from_api.uuid,
         recruitment_cycle_year:,

--- a/spec/services/teacher_training_public_api/sync_all_providers_and_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_all_providers_and_courses_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncAllProvidersAndCourses, :sidekiq do
       end
     end
 
-    context 'when intremental sync is off' do
+    context 'when incremental sync is off' do
       before do
         allow(Sentry).to receive(:capture_exception)
         stub_teacher_training_api_providers_with_multiple_pages

--- a/spec/services/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_courses_spec.rb
@@ -9,17 +9,15 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, :sidekiq do
       described_class.new.perform(provider.id,
                                   RecruitmentCycle.current_year)
     end
-
-    let(:specified_attributes) { [{ accredited_body_code: nil }] }
+    let(:stubbed_attributes) { [{ accredited_body_code: nil, state: stubbed_api_course_state }] }
 
     before do
-      stub_teacher_training_api_courses(provider_code: provider.code, specified_attributes:)
+      stub_teacher_training_api_courses(provider_code: provider.code, specified_attributes: stubbed_attributes)
       allow(TeacherTrainingPublicAPI::SyncSites).to receive(:perform_async).and_return(true)
     end
 
     context 'when courses are published' do
-      let(:api_course_state) { 'published' }
-      let(:specified_attributes) { [{ accredited_body_code: nil, state: api_course_state }] }
+      let(:stubbed_api_course_state) { 'published' }
 
       it 'creates the courses' do
         expect { perform_job }.to change(provider.courses, :count)
@@ -27,8 +25,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, :sidekiq do
     end
 
     context 'when the API courses are withdrawn' do
-      let(:api_course_state) { 'withdrawn' }
-      let(:specified_attributes) { [{ accredited_body_code: nil, state: api_course_state }] }
+      let(:stubbed_api_course_state) { 'withdrawn' }
 
       it 'creates the courses' do
         expect { perform_job }.to change(provider.courses, :count)
@@ -37,9 +34,9 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, :sidekiq do
       context 'when the course is published' do
         let(:uuid) { SecureRandom.uuid }
         let!(:course) { create(:course, provider: provider, withdrawn: false, uuid: uuid) }
-        let(:specified_attributes) {
+        let(:stubbed_attributes) {
           [
-            { accredited_body_code: nil, state: api_course_state, uuid: uuid },
+            { accredited_body_code: nil, state: stubbed_api_course_state, uuid: uuid },
           ]
         }
 
@@ -51,8 +48,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, :sidekiq do
     end
 
     context 'when the API courses are rolled_over' do
-      let(:api_course_state) { 'rolled_over' }
-      let(:specified_attributes) { [{ accredited_body_code: nil, state: api_course_state }] }
+      let(:stubbed_api_course_state) { 'rolled_over' }
 
       it 'does not create the courses' do
         expect { perform_job }.not_to change(Course, :count)
@@ -60,8 +56,7 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, :sidekiq do
     end
 
     context 'when the API courses are draft' do
-      let(:api_course_state) { 'draft' }
-      let(:specified_attributes) { [{ accredited_body_code: nil, state: api_course_state }] }
+      let(:stubbed_api_course_state) { 'draft' }
 
       it 'does not create the courses' do
         expect { perform_job }.not_to change(Course, :count)

--- a/spec/services/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_courses_spec.rb
@@ -16,22 +16,22 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, :sidekiq do
       allow(TeacherTrainingPublicAPI::SyncSites).to receive(:perform_async).and_return(true)
     end
 
-    context 'when courses are published' do
+    context 'when the API course has a published state' do
       let(:stubbed_api_course_state) { 'published' }
 
-      it 'creates the courses' do
+      it 'creates the course' do
         expect { perform_job }.to change(provider.courses, :count)
       end
     end
 
-    context 'when the API courses are withdrawn' do
+    context 'when the API course has a withdrawn state' do
       let(:stubbed_api_course_state) { 'withdrawn' }
 
-      it 'creates the courses' do
+      it 'creates the course' do
         expect { perform_job }.to change(provider.courses, :count)
       end
 
-      context 'when the course is published' do
+      context 'when the Course exists and has not been withdrawn' do
         let(:uuid) { SecureRandom.uuid }
         let!(:course) { create(:course, provider: provider, withdrawn: false, uuid: uuid) }
         let(:stubbed_attributes) {
@@ -40,25 +40,25 @@ RSpec.describe TeacherTrainingPublicAPI::SyncCourses, :sidekiq do
           ]
         }
 
-        it 'updates the course to withdrawn' do
+        it 'updates the Course to withdrawn' do
           expect { perform_job }.not_to change(Course, :count)
           expect(course.reload.withdrawn).to be_truthy
         end
       end
     end
 
-    context 'when the API courses are rolled_over' do
+    context 'when the API course has a rolled_over state' do
       let(:stubbed_api_course_state) { 'rolled_over' }
 
-      it 'does not create the courses' do
+      it 'does not create the course' do
         expect { perform_job }.not_to change(Course, :count)
       end
     end
 
-    context 'when the API courses are draft' do
+    context 'when the API course has a draft state' do
       let(:stubbed_api_course_state) { 'draft' }
 
-      it 'does not create the courses' do
+      it 'does not create the course' do
         expect { perform_job }.not_to change(Course, :count)
       end
     end

--- a/spec/services/teacher_training_public_api/sync_courses_spec.rb
+++ b/spec/services/teacher_training_public_api/sync_courses_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe TeacherTrainingPublicAPI::SyncCourses, :sidekiq do
+  include TeacherTrainingPublicAPIHelper
+
+  describe 'syncing courses' do
+    let!(:provider) { create(:provider) }
+    let(:perform_job) do
+      described_class.new.perform(provider.id,
+                                  RecruitmentCycle.current_year)
+    end
+
+    before do
+      stub_teacher_training_api_courses(provider_code: provider.code, specified_attributes: [{ accredited_body_code: nil }])
+      allow(TeacherTrainingPublicAPI::SyncSites).to receive(:perform_async).and_return(true)
+    end
+
+    it 'creates courses' do
+      expect { perform_job }.to change(provider.courses, :count)
+    end
+  end
+end

--- a/spec/system/teacher_training_public_api/sync_is_called_with_the_new_course_attribute_spec.rb
+++ b/spec/system/teacher_training_public_api/sync_is_called_with_the_new_course_attribute_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'Sync sites' do
 
   it 'a site has no vacancies and is not set to vacancies by the sync' do
     given_there_is_a_provider_and_has_two_courses_on_apply
-    and_that_the_courses_exists_on_the_ttapi
+    and_that_both_courses_exists_on_the_ttapi
 
     when_sync_provider_is_called_with_an_open_course
     then_the_site_has_vacancies
@@ -23,7 +23,7 @@ RSpec.feature 'Sync sites' do
     @second_course = create(:course, code: 'ABC2', provider: @provider, name: 'Secondary')
   end
 
-  def and_that_the_courses_exists_on_the_ttapi
+  def and_that_both_courses_exists_on_the_ttapi
     stub_teacher_training_api_course_with_site(provider_code: 'ABC',
                                                course_code: 'ABC1',
                                                site_code: 'A',


### PR DESCRIPTION
## Context

The current `SyncCourses` job does not filter out `rolled_over` or `draft` courses which Apply should not sync. These courses are not ready for Candidates to apply to.

## Changes proposed in this pull request

- Added a spec for the `TeacherTrainingPublicAPI::SyncCourses`
- Added logic to `TeacherTrainingPublicAPI::SyncCourses` skipping "draft" and "rolled_over" courses from TTAPI

## Guidance to review

🤔

## Link to Trello card

https://trello.com/c/cxgbES4O

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
