### PR TITLE
Extract cycle week method

### DIFF
--- a/app/models/publications/itt_monthly_report_generator.rb
+++ b/app/models/publications/itt_monthly_report_generator.rb
@@ -27,7 +27,6 @@ module Publications
     def initialize(generation_date: Time.zone.now, publication_date: nil, model: MonthlyStatistics::MonthlyStatisticsReport)
       @generation_date = generation_date.to_time
       @publication_date = publication_date.presence || 1.week.after(@generation_date)
-      @first_cycle_week = CycleTimetable.find_opens.beginning_of_week
       @report_expected_time = @generation_date.beginning_of_week(:sunday)
       @cycle_week = CycleTimetable.current_cycle_week(@report_expected_time)
       @client = DfE::Bigquery::ApplicationMetrics.new(cycle_week:)
@@ -72,7 +71,7 @@ module Publications
     alias statistics to_h
 
     def period
-      "From #{first_cycle_week.to_fs(:govuk_date)} to #{report_expected_time.to_fs(:govuk_date)}"
+      "From #{CycleTimetable.find_opens.beginning_of_week.to_fs(:govuk_date)} to #{report_expected_time.to_fs(:govuk_date)}"
     end
   end
 end

--- a/app/models/publications/itt_monthly_report_generator.rb
+++ b/app/models/publications/itt_monthly_report_generator.rb
@@ -16,13 +16,13 @@ module Publications
       candidate_area_and_subject
     ].freeze
 
-    attr_reader :client
-    attr_accessor :generation_date,
-                  :publication_date,
-                  :month,
-                  :report_expected_time,
-                  :cycle_week,
-                  :model
+    attr_reader :client,
+                :generation_date,
+                :publication_date,
+                :month,
+                :report_expected_time,
+                :cycle_week,
+                :model
 
     def initialize(generation_date: Time.zone.now, publication_date: nil, model: MonthlyStatistics::MonthlyStatisticsReport)
       @generation_date = generation_date.to_time

--- a/app/models/publications/itt_monthly_report_generator.rb
+++ b/app/models/publications/itt_monthly_report_generator.rb
@@ -20,7 +20,6 @@ module Publications
     attr_accessor :generation_date,
                   :publication_date,
                   :month,
-                  :first_cycle_week,
                   :report_expected_time,
                   :cycle_week,
                   :model
@@ -30,7 +29,7 @@ module Publications
       @publication_date = publication_date.presence || 1.week.after(@generation_date)
       @first_cycle_week = CycleTimetable.find_opens.beginning_of_week
       @report_expected_time = @generation_date.beginning_of_week(:sunday)
-      @cycle_week = (@report_expected_time - first_cycle_week).seconds.in_weeks.round
+      @cycle_week = CycleTimetable.current_cycle_week(@report_expected_time)
       @client = DfE::Bigquery::ApplicationMetrics.new(cycle_week:)
       @month = @generation_date.strftime('%Y-%m')
       @model = model

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -284,6 +284,12 @@ class CycleTimetable
     schedule.fetch(name)
   end
 
+  def self.current_cycle_week(time = Time.zone.now)
+    first_week_start = CycleTimetable.find_opens.beginning_of_week
+    weeks = (time - first_week_start).seconds.in_weeks.floor.succ
+    weeks <= 52 ? weeks : weeks % 52
+  end
+
   def self.current_cycle_schedule
     # Make sure this setting only has effect on non-production environments
     return :real if HostingEnvironment.production?

--- a/app/views/support_interface/settings/cycles.html.erb
+++ b/app/views/support_interface/settings/cycles.html.erb
@@ -27,6 +27,7 @@
   'Current cycle year' => RecruitmentCycle.current_year,
   'Next cycle year' => RecruitmentCycle.next_year,
   'Years visible to providers' => RecruitmentCycle.years_visible_to_providers.to_sentence,
+  'Current cycle week' => CycleTimetable.current_cycle_week,
 }) %>
 
 <h2 class="govuk-heading-m">Deadlines</h2>

--- a/spec/models/publications/itt_monthly_report_generator_spec.rb
+++ b/spec/models/publications/itt_monthly_report_generator_spec.rb
@@ -108,24 +108,6 @@ RSpec.describe Publications::ITTMonthlyReportGenerator do
     end
   end
 
-  describe '#first_cycle_week' do
-    context 'when we are on 2023 recruitment cycle' do
-      it 'returns first monday week of beginning of the cycle' do
-        travel_temporarily_to(Time.zone.local(2023, 9, 1)) do
-          expect(described_class.new.first_cycle_week).to eq(Time.zone.local(2022, 10, 3))
-        end
-      end
-    end
-
-    context 'when we are on 2024 recruitment cycle' do
-      it 'returns first monday week of beginning of the cycle' do
-        travel_temporarily_to(Time.zone.local(2023, 11, 15)) do
-          expect(described_class.new.first_cycle_week).to eq(Time.zone.local(2023, 10, 2))
-        end
-      end
-    end
-  end
-
   describe '#report_expected_time' do
     it 'returns the last Sunday of the expected generation time' do
       generation_date = Time.zone.local(2023, 11, 8)

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -646,4 +646,49 @@ RSpec.describe CycleTimetable do
       end
     end
   end
+
+  describe '.current_cycle_week' do
+    # The week before find opens
+    let(:date) { Time.zone.local(2023, 10, 1) }
+
+    context 'the last week of the previous cycle' do
+      it 'returns 52' do
+        travel_temporarily_to(date) do
+          expect(described_class.current_cycle_week).to be 52
+        end
+      end
+    end
+
+    context 'when first apply cycle week' do
+      it 'returns 1' do
+        travel_temporarily_to(date + 1.week) do
+          expect(described_class.current_cycle_week).to be 1
+        end
+      end
+    end
+
+    context 'when mid cycle' do
+      it 'returns the week number' do
+        travel_temporarily_to(date + 5.weeks) do
+          expect(described_class.current_cycle_week).to be 5
+        end
+      end
+    end
+
+    context 'when last cycle week' do
+      it 'returns 52' do
+        travel_temporarily_to(date + 52.weeks) do
+          expect(described_class.current_cycle_week).to be 52
+        end
+      end
+    end
+
+    context 'the first week of the next cycle' do
+      it 'returns 1' do
+        travel_temporarily_to(date + 53.weeks) do
+          expect(described_class.current_cycle_week).to be 1
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

Extract the calculation of the `cycle_week` from the ITT Monthly Report to a place it can be shared.jk

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

[Trello Ticket](https://trello.com/c/z2YQfOMt/1574-extract-cycleweek-method-from-applicationmetrics-in-to-cycletimetable)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
