### PR TITLE
Recruitment performance generator and worker

### DIFF
--- a/app/lib/dfe/bigquery/application_metrics_by_provider.rb
+++ b/app/lib/dfe/bigquery/application_metrics_by_provider.rb
@@ -98,7 +98,8 @@ module DfE
       def result_class = self.class::Result
 
       class Result
-        attr_reader(*SELECT_COLUMNS.dup.delete_if { |s| s[/\./] }.push('provider_id'))
+        ATTRIBUTES = SELECT_COLUMNS.map { |column| column.to_s.tr('.', '_') }
+        attr_reader(*ATTRIBUTES)
 
         def initialize(attributes)
           attributes.each do |key, value|
@@ -107,6 +108,13 @@ module DfE
             if respond_to?(key)
               instance_variable_set("@#{key}", value)
             end
+          end
+        end
+
+        def attributes
+          ATTRIBUTES.each_with_object({}) do |curr, obj|
+            val = public_send(curr)
+            obj[curr.to_s] = val if val
           end
         end
       end

--- a/app/lib/dfe/bigquery/application_metrics_by_provider.rb
+++ b/app/lib/dfe/bigquery/application_metrics_by_provider.rb
@@ -113,8 +113,7 @@ module DfE
 
         def attributes
           ATTRIBUTES.each_with_object({}) do |curr, obj|
-            val = public_send(curr)
-            obj[curr.to_s] = val if val
+            obj[curr.to_s] = public_send(curr)
           end
         end
       end

--- a/app/lib/dfe/bigquery/test_helper.rb
+++ b/app/lib/dfe/bigquery/test_helper.rb
@@ -12,6 +12,17 @@ module DfE
         end
       end
 
+      def stub_bigquery_application_metrics_by_provider_request(stub_results = [])
+        bigquery_client = instance_double(Google::Cloud::Bigquery::Project)
+        allow(DfE::Bigquery).to receive(:client).and_return(bigquery_client)
+
+        if stub_results.present?
+          allow(bigquery_client).to receive(:query).and_return(stub_results)
+        else
+          allow(bigquery_client).to receive(:query).and_return(application_metrics_results)
+        end
+      end
+
       def application_metrics_results(options = {})
         [
           {
@@ -35,6 +46,37 @@ module DfE
             number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_same_date_previous_cycle: 213,
             number_of_candidates_accepted_to_date: 20,
             number_of_candidates_accepted_to_same_date_previous_cycle: 10,
+          }.merge(options.slice(:attributes)),
+        ]
+      end
+
+      def application_metrics_by_provider_results(options = {})
+        [
+          {
+            id: 1337,
+            cycle_week: 18,
+            recruitment_cycle_year: 2024,
+            nonprovider_filter: 'Level',
+            nonprovider_filter_category: 'Primary',
+            number_of_candidates_submitted_to_date: 100,
+            number_of_candidates_submitted_to_same_date_previous_cycle: 200,
+            number_of_candidates_submitted_to_date_as_proportion_of_last_cycle: 0.5,
+            number_of_candidates_with_offers_to_date: 10,
+            number_of_candidates_with_offers_to_same_date_previous_cycle: 5,
+            number_of_candidates_with_offers_to_date_as_proportion_of_last_cycle: 2.0,
+            offer_rate_to_date: 1.2,
+            offer_rate_to_same_date_previous_cycle: 1.5,
+            number_of_candidates_accepted_to_date: 1,
+            number_of_candidates_accepted_to_same_date_previous_cycle: 10,
+            number_of_candidates_accepted_to_date_as_proportion_of_last_cycle: 0.1,
+            number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_date: 12,
+            number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_same_date_previous_cycle: 12,
+            number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_date_as_proportion_of_last_cycle: 0,
+            number_of_candidates_who_had_all_applications_rejected_this_cycle_to_date: 12,
+            number_of_candidates_who_had_all_applications_rejected_this_cycle_to_same_date_previous_cycle: 12,
+            number_of_candidates_who_had_all_applications_rejected_this_cycle_to_date_as_proportion_of_last_cycle: 0,
+            number_of_candidates_who_had_an_inactive_application_this_cycle_to_date: 12,
+            number_of_candidates_who_had_an_inactive_application_this_cycle_to_date_as_proportion_of_submitted_candidates: 12,
           }.merge(options.slice(:attributes)),
         ]
       end

--- a/app/lib/dfe/bigquery/test_helper.rb
+++ b/app/lib/dfe/bigquery/test_helper.rb
@@ -16,11 +16,7 @@ module DfE
         bigquery_client = instance_double(Google::Cloud::Bigquery::Project)
         allow(DfE::Bigquery).to receive(:client).and_return(bigquery_client)
 
-        if stub_results.present?
-          allow(bigquery_client).to receive(:query).and_return(stub_results)
-        else
-          allow(bigquery_client).to receive(:query).and_return(application_metrics_results)
-        end
+        allow(bigquery_client).to receive(:query).and_return(application_metrics_by_provider_results(stub_results&.first))
       end
 
       def application_metrics_results(options = {})
@@ -64,8 +60,8 @@ module DfE
             number_of_candidates_with_offers_to_date: 10,
             number_of_candidates_with_offers_to_same_date_previous_cycle: 5,
             number_of_candidates_with_offers_to_date_as_proportion_of_last_cycle: 2.0,
-            offer_rate_to_date: 1.2,
-            offer_rate_to_same_date_previous_cycle: 1.5,
+            offer_rate_to_date: nil,
+            offer_rate_to_same_date_previous_cycle: nil,
             number_of_candidates_accepted_to_date: 1,
             number_of_candidates_accepted_to_same_date_previous_cycle: 10,
             number_of_candidates_accepted_to_date_as_proportion_of_last_cycle: 0.1,
@@ -77,7 +73,7 @@ module DfE
             number_of_candidates_who_had_all_applications_rejected_this_cycle_to_date_as_proportion_of_last_cycle: 0,
             number_of_candidates_who_had_an_inactive_application_this_cycle_to_date: 12,
             number_of_candidates_who_had_an_inactive_application_this_cycle_to_date_as_proportion_of_submitted_candidates: 12,
-          }.merge(options.slice(:attributes)),
+          }.merge(options),
         ]
       end
     end

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -59,6 +59,7 @@ class ApplicationChoice < ApplicationRecord
     vendor_api_rejection_reasons: 'vendor_api_rejection_reasons', # Rejection reasons via the Vendor API.
   }, _prefix: :rejection_reasons_type
 
+  scope :visible_to_provider, -> { where(status: ApplicationStateChange.states_visible_to_provider) }
   scope :reappliable, -> { where(status: ApplicationStateChange.reapply_states) }
   scope :not_reappliable, -> { where(status: ApplicationStateChange.non_reapply_states) }
   scope :decision_pending, -> { where(status: ApplicationStateChange::DECISION_PENDING_STATUSES) }

--- a/app/models/publications/national_recruitment_performance_report_generator.rb
+++ b/app/models/publications/national_recruitment_performance_report_generator.rb
@@ -1,0 +1,25 @@
+module Publications
+  class NationalRecruitmentPerformanceReportGenerator
+    attr_reader :client,
+                :generation_date,
+                :publication_date,
+                :report_expected_time,
+                :cycle_week
+
+    def initialize(cycle_week:, generation_date: Time.zone.now, publication_date: nil)
+      @cycle_week = cycle_week
+      @generation_date = generation_date
+      @publication_date = publication_date.presence || @generation_date
+      @report_expected_time = 1.week.until(@generation_date).end_of_week
+      @client = DfE::Bigquery::ApplicationMetricsByProvider.new(cycle_week:)
+    end
+
+    def call
+      Publications::NationalRecruitmentPerformanceReport.create!(statistics: data, cycle_week:, publication_date:, generation_date:)
+    end
+
+    def data
+      client.national_data.map(&:attributes)
+    end
+  end
+end

--- a/app/models/publications/provider_recruitment_performance_report_generator.rb
+++ b/app/models/publications/provider_recruitment_performance_report_generator.rb
@@ -1,0 +1,27 @@
+module Publications
+  class ProviderRecruitmentPerformanceReportGenerator
+    attr_reader :client,
+                :provider_id,
+                :generation_date,
+                :publication_date,
+                :report_expected_time,
+                :cycle_week
+
+    def initialize(provider_id:, cycle_week:, generation_date: Time.zone.today, publication_date: nil)
+      @provider_id = provider_id
+      @generation_date = generation_date
+      @publication_date = publication_date.presence || @generation_date
+      @report_expected_time = 1.week.until(@generation_date).end_of_week
+      @cycle_week = cycle_week
+      @client = DfE::Bigquery::ApplicationMetricsByProvider.new(cycle_week:, provider_id:)
+    end
+
+    def call
+      Publications::ProviderRecruitmentPerformanceReport.create!(provider_id:, statistics: data, cycle_week:, publication_date:, generation_date:)
+    end
+
+    def data
+      client.provider_data.map(&:attributes)
+    end
+  end
+end

--- a/app/models/publications/recruitment_performance_report_scheduler.rb
+++ b/app/models/publications/recruitment_performance_report_scheduler.rb
@@ -11,7 +11,7 @@ module Publications
       return if Publications::NationalRecruitmentPerformanceReport.exists?(cycle_week:)
 
       Publications::NationalRecruitmentPerformanceReportWorker
-        .perform_async(cycle_week:)
+        .perform_async(cycle_week)
     end
 
     def schedule_provider_report

--- a/app/models/publications/recruitment_performance_report_scheduler.rb
+++ b/app/models/publications/recruitment_performance_report_scheduler.rb
@@ -20,8 +20,8 @@ module Publications
         .find_each do |provider|
         Publications::ProviderRecruitmentPerformanceReportWorker
           .perform_async(
-            provider_id: provider.id,
-            cycle_week:,
+            provider.id,
+            cycle_week,
           )
       end
     end

--- a/app/models/publications/recruitment_performance_report_scheduler.rb
+++ b/app/models/publications/recruitment_performance_report_scheduler.rb
@@ -1,0 +1,37 @@
+module Publications
+  class RecruitmentPerformanceReportScheduler
+    def call
+      schedule_national_report
+      schedule_provider_report
+    end
+
+  private
+
+    def schedule_national_report
+      Publications::NationalRecruitmentPerformanceReportWorker
+        .perform_async(cycle_week:)
+    end
+
+    def schedule_provider_report
+      provider_query.find_each do |provider|
+        Publications::ProviderRecruitmentPerformanceReportWorker
+          .perform_async(
+            provider_id: provider.id,
+            cycle_week:,
+          )
+      end
+    end
+
+    def provider_query
+      Provider
+        .joins(courses: { course_options: :application_choices })
+        .where(courses: { recruitment_cycle_year: CycleTimetable.current_year })
+        .where('application_choices.created_at < ?', Time.zone.today.beginning_of_week)
+        .merge(ApplicationChoice.visible_to_provider)
+    end
+
+    def cycle_week
+      CycleTimetable.current_cycle_week.pred
+    end
+  end
+end

--- a/app/models/publications/recruitment_performance_report_scheduler.rb
+++ b/app/models/publications/recruitment_performance_report_scheduler.rb
@@ -8,6 +8,8 @@ module Publications
   private
 
     def schedule_national_report
+      return if Publications::NationalRecruitmentPerformanceReport.exists?(cycle_week:)
+
       Publications::NationalRecruitmentPerformanceReportWorker
         .perform_async(cycle_week:)
     end
@@ -27,6 +29,7 @@ module Publications
         .joins(courses: { course_options: :application_choices })
         .where(courses: { recruitment_cycle_year: CycleTimetable.current_year })
         .where('application_choices.created_at < ?', Time.zone.today.beginning_of_week)
+        .where.not(id: Publications::ProviderRecruitmentPerformanceReport.select('provider_id id').where(cycle_week:))
         .merge(ApplicationChoice.visible_to_provider)
     end
 

--- a/app/models/publications/recruitment_performance_report_scheduler.rb
+++ b/app/models/publications/recruitment_performance_report_scheduler.rb
@@ -15,7 +15,8 @@ module Publications
     end
 
     def schedule_provider_report
-      ProvidersForRecruitmentPerformanceReportQuery.call(cycle_week:)
+      ProvidersForRecruitmentPerformanceReportQuery
+        .call(cycle_week:)
         .find_each do |provider|
         Publications::ProviderRecruitmentPerformanceReportWorker
           .perform_async(

--- a/app/queries/providers_for_recruitment_performance_report_query.rb
+++ b/app/queries/providers_for_recruitment_performance_report_query.rb
@@ -1,0 +1,11 @@
+class ProvidersForRecruitmentPerformanceReportQuery
+  def self.call(cycle_week:)
+    Provider
+      .distinct
+      .joins(courses: { course_options: :application_choices })
+      .where(courses: { recruitment_cycle_year: CycleTimetable.current_year })
+      .where('application_choices.created_at < ?', Time.zone.today.beginning_of_week)
+      .where.not(id: Publications::ProviderRecruitmentPerformanceReport.select('provider_id id').where(cycle_week:))
+      .merge(ApplicationChoice.visible_to_provider)
+  end
+end

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -288,9 +288,8 @@ class CycleTimetable
   end
 
   def self.current_cycle_week(time = Time.zone.now)
-    first_week_start = CycleTimetable.find_opens(current_year(time)).beginning_of_week
-    weeks = (time - first_week_start).seconds.in_weeks.floor.succ
-    weeks <= 52 ? weeks : weeks % 52
+    weeks = (time.to_date - find_opens(current_year(time)).beginning_of_week.to_date).to_i / 7
+    (weeks % 52).succ
   end
 
   def self.current_cycle_schedule

--- a/app/services/recruitment_performance_report_timetable.rb
+++ b/app/services/recruitment_performance_report_timetable.rb
@@ -3,7 +3,7 @@ module RecruitmentPerformanceReportTimetable
   LAST_CYCLE_WEEK_REPORT = 51
 
   def self.report_season?
-    CycleTimetable.current_cycle_week.between?(FIRST_CYCLE_WEEK_REPORT, LAST_CYCLE_WEEK_REPORT)
+    CycleTimetable.current_cycle_week.between?(FIRST_CYCLE_WEEK_REPORT, LAST_CYCLE_WEEK_REPORT) && FeatureFlag.active?(:recruitment_performance_report_generator)
   end
 
   # Generation and Publication date are the same (today) for now until we

--- a/app/services/recruitment_performance_report_timetable.rb
+++ b/app/services/recruitment_performance_report_timetable.rb
@@ -1,0 +1,19 @@
+module RecruitmentPerformanceReportTimetable
+  FIRST_CYCLE_WEEK_REPORT = 27
+  LAST_CYCLE_WEEK_REPORT = 51
+
+  def self.report_season?
+    CycleTimetable.current_cycle_week.between?(FIRST_CYCLE_WEEK_REPORT, LAST_CYCLE_WEEK_REPORT)
+  end
+
+  # Generation and Publication date are the same (today) for now until we
+  # decide otherwise
+
+  def self.current_generation_date
+    Time.zone.today
+  end
+
+  def self.current_publication_date
+    Time.zone.today
+  end
+end

--- a/app/workers/publications/national_recruitment_performance_report_worker.rb
+++ b/app/workers/publications/national_recruitment_performance_report_worker.rb
@@ -1,0 +1,25 @@
+module Publications
+  class NationalRecruitmentPerformanceReportWorker
+    include Sidekiq::Worker
+
+    sidekiq_options retry: 3, queue: :default
+
+    def perform(cycle_week: CycleTimetable.current_cycle_week.pred)
+      Publications::NationalRecruitmentPerformanceReportGenerator.new(
+        cycle_week:,
+        generation_date:,
+        publication_date:,
+      ).call
+    end
+
+  private
+
+    def generation_date
+      RecruitmentPerformanceReportTimetable.current_generation_date
+    end
+
+    def publication_date
+      RecruitmentPerformanceReportTimetable.current_publication_date
+    end
+  end
+end

--- a/app/workers/publications/national_recruitment_performance_report_worker.rb
+++ b/app/workers/publications/national_recruitment_performance_report_worker.rb
@@ -4,7 +4,7 @@ module Publications
 
     sidekiq_options retry: 3, queue: :default
 
-    def perform(cycle_week: CycleTimetable.current_cycle_week.pred)
+    def perform(cycle_week)
       Publications::NationalRecruitmentPerformanceReportGenerator.new(
         cycle_week:,
         generation_date:,

--- a/app/workers/publications/provider_recruitment_performance_report_worker.rb
+++ b/app/workers/publications/provider_recruitment_performance_report_worker.rb
@@ -1,0 +1,26 @@
+module Publications
+  class ProviderRecruitmentPerformanceReportWorker
+    include Sidekiq::Worker
+
+    sidekiq_options retry: 3, queue: :default
+
+    def perform(cycle_week:, provider_id:)
+      ProviderRecruitmentPerformanceReportGenerator.new(
+        provider_id:,
+        cycle_week:,
+        generation_date:,
+        publication_date:,
+      ).call
+    end
+
+  private
+
+    def generation_date
+      RecruitmentPerformanceReportTimetable.current_generation_date
+    end
+
+    def publication_date
+      RecruitmentPerformanceReportTimetable.current_publication_date
+    end
+  end
+end

--- a/app/workers/publications/provider_recruitment_performance_report_worker.rb
+++ b/app/workers/publications/provider_recruitment_performance_report_worker.rb
@@ -4,7 +4,7 @@ module Publications
 
     sidekiq_options retry: 3, queue: :default
 
-    def perform(cycle_week:, provider_id:)
+    def perform(provider_id, cycle_week)
       ProviderRecruitmentPerformanceReportGenerator.new(
         provider_id:,
         cycle_week:,

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -65,4 +65,6 @@ class Clock
 
   every(7.days, 'ApplicationsBySubjectRouteAndDegreeGradeExport', at: 'Sunday 23:55') { SupportInterface::ApplicationsBySubjectRouteAndDegreeGradeExport.run_weekly }
   every(7.days, 'ApplicationsByDemographicDomicileAndDegreeClassExport', at: 'Sunday 23:57') { SupportInterface::ApplicationsByDemographicDomicileAndDegreeClassExport.run_weekly }
+
+  every(7.days, 'Schedule Recruitment Performance reports', at: 'Monday 05:30', if: ->(_period) { RecruitmentPerformanceReportTimetable.report_season? }) { Publications::RecruitmentPerformanceReportScheduler.new.call }
 end

--- a/spec/lib/dfe/bigquery/application_metrics_by_provider_spec.rb
+++ b/spec/lib/dfe/bigquery/application_metrics_by_provider_spec.rb
@@ -204,4 +204,24 @@ RSpec.describe DfE::Bigquery::ApplicationMetricsByProvider do
       expect(provider_statistics.first.number_of_candidates_submitted_to_date).to be 100
     end
   end
+
+  describe described_class::Result do
+    let(:result) { described_class.new({ provider_id: 123, nonprovider_filter: 'Primary' }) }
+
+    describe 'attr_readers' do
+      it 'has attr_reader for nonprovider_filter' do
+        expect(result).to respond_to(:nonprovider_filter)
+      end
+
+      it 'has no attr_reader for nonprovider_filter_category' do
+        expect(result).to respond_to(:nonprovider_filter_category)
+      end
+    end
+
+    describe '#attributes' do
+      it 'returns the correct #attributes' do
+        expect(result.attributes).to eq({ 'provider_id' => 123, 'nonprovider_filter' => 'Primary' })
+      end
+    end
+  end
 end

--- a/spec/lib/dfe/bigquery/application_metrics_by_provider_spec.rb
+++ b/spec/lib/dfe/bigquery/application_metrics_by_provider_spec.rb
@@ -220,7 +220,11 @@ RSpec.describe DfE::Bigquery::ApplicationMetricsByProvider do
 
     describe '#attributes' do
       it 'returns the correct #attributes' do
-        expect(result.attributes).to eq({ 'provider_id' => 123, 'nonprovider_filter' => 'Primary' })
+        expect(result.attributes).to include({
+          'provider_id' => 123,
+          'nonprovider_filter' => 'Primary',
+          'number_of_candidates_submitted_to_same_date_previous_cycle' => nil,
+        })
       end
     end
   end

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -23,6 +23,27 @@ RSpec.describe ApplicationChoice do
     end
   end
 
+  describe '.visible_to_provider' do
+    it 'returns nothing when there are no records with status in visible_to_provider' do
+      (ApplicationStateChange.valid_states - ApplicationStateChange.states_visible_to_provider).each do |status|
+        create(:application_choice, status:)
+      end
+
+      expect(described_class.visible_to_provider).to be_empty
+    end
+
+    it 'scopes to visible_to_provider choices' do
+      (ApplicationStateChange.valid_states - ApplicationStateChange.states_visible_to_provider).each do |state|
+        create(:application_choice, status: state)
+      end
+      visible_to_provider = ApplicationStateChange.states_visible_to_provider.map do |state|
+        create(:application_choice, status: state)
+      end
+
+      expect(described_class.visible_to_provider.pluck(:status)).to match_array(visible_to_provider.map(&:status))
+    end
+  end
+
   describe '.not_reappliable' do
     it 'returns nothing when there are no records with status in non_reapply_states' do
       (ApplicationStateChange.valid_states - ApplicationStateChange.non_reapply_states).each do |status|

--- a/spec/models/publications/national_recruitment_performance_report_generator_spec.rb
+++ b/spec/models/publications/national_recruitment_performance_report_generator_spec.rb
@@ -5,15 +5,44 @@ RSpec.describe Publications::NationalRecruitmentPerformanceReportGenerator do
   subject(:generator) { described_class.new(cycle_week:) }
 
   before do
-    @attributes = [{ 'nonprovider_filter' => 'Primary' }]
-    stub_bigquery_application_metrics_by_provider_request(@attributes)
+    @stubbed_response = [
+      {
+        nonprovider_filter: 'Primary',
+        nonprovider_filter_category: nil,
+        cycle_week: nil,
+        recruitment_cycle_year: nil,
+        provider_id: nil,
+        number_of_candidates_submitted_to_date: nil,
+        number_of_candidates_submitted_to_same_date_previous_cycle: nil,
+        number_of_candidates_submitted_to_date_as_proportion_of_last_cycle: nil,
+        number_of_candidates_with_offers_to_date: nil,
+        number_of_candidates_with_offers_to_same_date_previous_cycle: nil,
+        number_of_candidates_with_offers_to_date_as_proportion_of_last_cycle: nil,
+        offer_rate_to_date: nil,
+        offer_rate_to_same_date_previous_cycle: nil,
+        number_of_candidates_accepted_to_date: nil,
+        number_of_candidates_accepted_to_same_date_previous_cycle: nil,
+        number_of_candidates_accepted_to_date_as_proportion_of_last_cycle: nil,
+        number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_date: nil,
+        number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_same_date_previous_cycle: nil,
+        number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_date_as_proportion_of_last_cycle: nil,
+        number_of_candidates_who_had_all_applications_rejected_this_cycle_to_date: nil,
+        number_of_candidates_who_had_all_applications_rejected_this_cycle_to_same_date_previous_cycle: nil,
+        number_of_candidates_who_had_all_applications_rejected_this_cycle_to_date_as_proportion_of_last_cycle: nil,
+        number_of_candidates_who_had_an_inactive_application_this_cycle_to_date: nil,
+        number_of_candidates_who_had_an_inactive_application_this_cycle_to_date_as_proportion_of_submitted_candidates: nil,
+      },
+    ]
+    stub_bigquery_application_metrics_by_provider_request(@stubbed_response)
   end
 
   let(:cycle_week) { 12 }
   let(:generation_date) { Time.zone.today }
+  # BigQuery returns symbols, #attributes returns strings
+  let(:attributes) { @stubbed_response.map(&:stringify_keys!) }
 
   it 'returns data' do
-    expect(generator.data).to eq(@attributes)
+    expect(generator.data).to eq(attributes)
   end
 
   describe '#call' do
@@ -31,7 +60,7 @@ RSpec.describe Publications::NationalRecruitmentPerformanceReportGenerator do
           'publication_date' => Time.zone.today,
           'generation_date' => Time.zone.today,
           'cycle_week' => cycle_week,
-          'statistics' => @attributes,
+          'statistics' => attributes,
         })
       end
     end
@@ -48,7 +77,7 @@ RSpec.describe Publications::NationalRecruitmentPerformanceReportGenerator do
           'publication_date' => generation_date,
           'generation_date' => generation_date,
           'cycle_week' => 15,
-          'statistics' => @attributes,
+          'statistics' => attributes,
         })
       end
     end
@@ -67,7 +96,7 @@ RSpec.describe Publications::NationalRecruitmentPerformanceReportGenerator do
           'publication_date' => generation_date,
           'generation_date' => generation_date,
           'cycle_week' => cycle_week,
-          'statistics' => @attributes,
+          'statistics' => attributes,
         })
       end
     end

--- a/spec/models/publications/national_recruitment_performance_report_generator_spec.rb
+++ b/spec/models/publications/national_recruitment_performance_report_generator_spec.rb
@@ -5,41 +5,26 @@ RSpec.describe Publications::NationalRecruitmentPerformanceReportGenerator do
   subject(:generator) { described_class.new(cycle_week:) }
 
   before do
-    @stubbed_response = [
+    @stubbed_response = application_metrics_by_provider_results(
       {
         nonprovider_filter: 'Primary',
         nonprovider_filter_category: nil,
-        cycle_week: nil,
-        recruitment_cycle_year: nil,
-        provider_id: nil,
-        number_of_candidates_submitted_to_date: nil,
-        number_of_candidates_submitted_to_same_date_previous_cycle: nil,
-        number_of_candidates_submitted_to_date_as_proportion_of_last_cycle: nil,
-        number_of_candidates_with_offers_to_date: nil,
-        number_of_candidates_with_offers_to_same_date_previous_cycle: nil,
-        number_of_candidates_with_offers_to_date_as_proportion_of_last_cycle: nil,
-        offer_rate_to_date: nil,
-        offer_rate_to_same_date_previous_cycle: nil,
-        number_of_candidates_accepted_to_date: nil,
-        number_of_candidates_accepted_to_same_date_previous_cycle: nil,
-        number_of_candidates_accepted_to_date_as_proportion_of_last_cycle: nil,
-        number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_date: nil,
-        number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_same_date_previous_cycle: nil,
-        number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_date_as_proportion_of_last_cycle: nil,
-        number_of_candidates_who_had_all_applications_rejected_this_cycle_to_date: nil,
-        number_of_candidates_who_had_all_applications_rejected_this_cycle_to_same_date_previous_cycle: nil,
-        number_of_candidates_who_had_all_applications_rejected_this_cycle_to_date_as_proportion_of_last_cycle: nil,
-        number_of_candidates_who_had_an_inactive_application_this_cycle_to_date: nil,
-        number_of_candidates_who_had_an_inactive_application_this_cycle_to_date_as_proportion_of_submitted_candidates: nil,
+        cycle_week:,
+        id: nil,
       },
-    ]
+    )
     stub_bigquery_application_metrics_by_provider_request(@stubbed_response)
   end
 
   let(:cycle_week) { 12 }
   let(:generation_date) { Time.zone.today }
   # BigQuery returns symbols, #attributes returns strings
-  let(:attributes) { @stubbed_response.map(&:stringify_keys!) }
+  # BigQuery returns :id, for 'provider.id'
+  let(:attributes) do
+    @stubbed_response.first[:provider_id] = @stubbed_response.first.delete(:id)
+    @stubbed_response.first.stringify_keys!
+    @stubbed_response
+  end
 
   it 'returns data' do
     expect(generator.data).to eq(attributes)

--- a/spec/models/publications/national_recruitment_performance_report_generator_spec.rb
+++ b/spec/models/publications/national_recruitment_performance_report_generator_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.describe Publications::NationalRecruitmentPerformanceReportGenerator do
+  include DfE::Bigquery::TestHelper
+  subject(:generator) { described_class.new(cycle_week:) }
+
+  before do
+    @attributes = [{ 'nonprovider_filter' => 'Primary' }]
+    stub_bigquery_application_metrics_by_provider_request(@attributes)
+  end
+
+  let(:cycle_week) { 12 }
+  let(:generation_date) { Time.zone.today }
+
+  it 'returns data' do
+    expect(generator.data).to eq(@attributes)
+  end
+
+  describe '#call' do
+    context 'when cycle_week is 12' do
+      it 'creates a new report' do
+        expect { generator.call }.to change(Publications::NationalRecruitmentPerformanceReport, :count).by(1)
+      end
+
+      it 'stores the correct data in the model' do
+        generator.call
+
+        model = Publications::NationalRecruitmentPerformanceReport.last
+
+        expect(model).to have_attributes({
+          'publication_date' => Time.zone.today,
+          'generation_date' => Time.zone.today,
+          'cycle_week' => cycle_week,
+          'statistics' => @attributes,
+        })
+      end
+    end
+
+    context 'when cycle_week is 15' do
+      let(:cycle_week) { 15 }
+
+      it 'stores the correct data in the model' do
+        generator.call
+
+        model = Publications::NationalRecruitmentPerformanceReport.last
+
+        expect(model).to have_attributes({
+          'publication_date' => generation_date,
+          'generation_date' => generation_date,
+          'cycle_week' => 15,
+          'statistics' => @attributes,
+        })
+      end
+    end
+
+    context 'when setting a future generation date' do
+      subject(:generator) { described_class.new(cycle_week:, generation_date:) }
+
+      let(:generation_date) { 1.week.from_now.to_date }
+
+      it 'stores the correct data in the model' do
+        generator.call
+
+        model = Publications::NationalRecruitmentPerformanceReport.last
+
+        expect(model).to have_attributes({
+          'publication_date' => generation_date,
+          'generation_date' => generation_date,
+          'cycle_week' => cycle_week,
+          'statistics' => @attributes,
+        })
+      end
+    end
+  end
+end

--- a/spec/models/publications/provider_recruitment_performance_report_generator_spec.rb
+++ b/spec/models/publications/provider_recruitment_performance_report_generator_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe Publications::ProviderRecruitmentPerformanceReportGenerator do
+  include DfE::Bigquery::TestHelper
+  subject(:generator) { described_class.new(provider_id:, cycle_week:) }
+
+  before do
+    @attributes = [{ 'provider_id' => provider_id, 'nonprovider_filter' => 'Primary' }]
+    stub_bigquery_application_metrics_by_provider_request(@attributes)
+  end
+
+  let(:cycle_week) { 12 }
+  let(:provider_id) { create(:provider).id }
+  let(:generation_date) { Time.zone.today }
+
+  it 'returns data' do
+    expect(generator.data).to eq(@attributes)
+  end
+
+  describe '#call' do
+    context 'when cycle_week is 12' do
+      it 'creates a new report' do
+        expect { generator.call }.to change(Publications::ProviderRecruitmentPerformanceReport, :count).by(1)
+      end
+
+      it 'stores the correct data in the model' do
+        generator.call
+        model = Publications::ProviderRecruitmentPerformanceReport.last
+
+        expect(model).to have_attributes({
+          'provider_id' => provider_id,
+          'publication_date' => Time.zone.today,
+          'generation_date' => Time.zone.today,
+          'cycle_week' => cycle_week,
+          'statistics' => @attributes,
+        })
+      end
+    end
+
+    context 'when cycle_week is 15' do
+      let(:cycle_week) { 15 }
+
+      it 'stores the correct data in the model' do
+        generator.call
+
+        model = Publications::ProviderRecruitmentPerformanceReport.last
+
+        expect(model).to have_attributes({
+          'provider_id' => provider_id,
+          'publication_date' => generation_date,
+          'generation_date' => generation_date,
+          'cycle_week' => 15,
+          'statistics' => @attributes,
+        })
+      end
+    end
+
+    context 'when setting a future generation date' do
+      subject(:generator) { described_class.new(provider_id:, cycle_week:, generation_date:) }
+
+      let(:generation_date) { 1.week.from_now.to_date }
+
+      it 'stores the correct data in the model' do
+        generator.call
+
+        model = Publications::ProviderRecruitmentPerformanceReport.last
+
+        expect(model).to have_attributes({
+          'provider_id' => provider_id,
+          'publication_date' => generation_date,
+          'generation_date' => generation_date,
+          'cycle_week' => cycle_week,
+          'statistics' => @attributes,
+        })
+      end
+    end
+  end
+end

--- a/spec/models/publications/recruitment_performance_report_scheduler_spec.rb
+++ b/spec/models/publications/recruitment_performance_report_scheduler_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
     it 'creates a report for a provider who received an application last week' do
       described_class.new.call
 
-      expect(provider_worker).to have_received(:perform_async).with(provider_id: provider.id, cycle_week: previous_cycle_week)
+      expect(provider_worker).to have_received(:perform_async).with(provider.id, previous_cycle_week)
     end
   end
 

--- a/spec/models/publications/recruitment_performance_report_scheduler_spec.rb
+++ b/spec/models/publications/recruitment_performance_report_scheduler_spec.rb
@@ -3,78 +3,20 @@ require 'rails_helper'
 RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
   let(:provider_worker) { Publications::ProviderRecruitmentPerformanceReportWorker }
   let(:national_worker) { Publications::NationalRecruitmentPerformanceReportWorker }
-  let(:provider_without_applications) { create(:course_option, :open).provider }
-  let(:provider_with_application) { create(:application_choice, :awaiting_provider_decision).provider }
-  let(:provider_with_unsubmitted_application) { create(:application_choice, :unsubmitted).provider }
+  let(:provider) { create(:provider) }
   let(:previous_cycle_week) { CycleTimetable.current_cycle_week.pred }
 
   context 'provider report is generated for appropriate providers' do
     before do
       allow(provider_worker).to receive(:perform_async)
+      provider
+      allow(ProvidersForRecruitmentPerformanceReportQuery).to receive(:call).with(cycle_week: previous_cycle_week).and_return(Provider)
     end
 
     it 'creates a report for a provider who received an application last week' do
-      TestSuiteTimeMachine.travel_permanently_to(Time.zone.local(2024, 4, 21, 18, 0))
-      provider_with_application
-
-      advance_time_to(1.day.from_now)
-
-      described_class.new.call
-      expect(provider_worker).to have_received(:perform_async).with(provider_id: provider_with_application.id, cycle_week: previous_cycle_week)
-    end
-
-    it 'does not create a report worker for a provider without any applications in the current cycle' do
-      TestSuiteTimeMachine.travel_permanently_to(Time.zone.local(2024, 4, 21, 18, 0))
-      # Create provider that has no applications but has an open course
-      provider_without_applications
-
-      advance_time_to(1.day.from_now)
-
-      described_class.new.call
-      expect(provider_worker).not_to have_received(:perform_async)
-    end
-
-    it 'does not create a report worker for a provider without a submitted application' do
-      TestSuiteTimeMachine.travel_permanently_to(Time.zone.local(2024, 4, 21, 18, 0))
-      # Create provider that has no applications but has an open course
-      provider_with_unsubmitted_application
-
-      advance_time_to(1.day.from_now)
-
-      described_class.new.call
-      expect(provider_worker).not_to have_received(:perform_async)
-    end
-
-    it 'does not create a report worker for a provider without an application in the current week' do
-      TestSuiteTimeMachine.travel_permanently_to(Time.zone.local(2024, 4, 21, 18, 0))
-      # Create provider that has an application this week
-      provider_with_application
-
-      described_class.new.call
-      expect(provider_worker).not_to have_received(:perform_async).with(provider_id: provider_with_application.id)
-    end
-
-    it 'does not create a new Provider report worker when an existing report exists' do
-      TestSuiteTimeMachine.travel_permanently_to(Time.zone.local(2024, 4, 21, 18, 0))
-      provider_with_application
-
-      advance_time_to(1.day.from_now)
-
-      Publications::ProviderRecruitmentPerformanceReport.create!(
-        provider: provider_with_application,
-        statistics: {},
-        publication_date: Time.zone.today,
-        cycle_week: previous_cycle_week,
-      )
-
       described_class.new.call
 
-      expect(provider_worker).not_to(
-        have_received(:perform_async).with(
-          cycle_week: previous_cycle_week,
-          provider_id: provider_with_application.id,
-        ),
-      )
+      expect(provider_worker).to have_received(:perform_async).with(provider_id: provider.id, cycle_week: previous_cycle_week)
     end
   end
 
@@ -85,6 +27,7 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
 
     it 'creates a National report' do
       described_class.new.call
+
       expect(national_worker).to have_received(:perform_async).with(cycle_week: previous_cycle_week)
     end
 

--- a/spec/models/publications/recruitment_performance_report_scheduler_spec.rb
+++ b/spec/models/publications/recruitment_performance_report_scheduler_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
+  let(:provider_worker) { Publications::ProviderRecruitmentPerformanceReportWorker }
+  let(:national_worker) { Publications::NationalRecruitmentPerformanceReportWorker }
+  let(:provider_without_applications) { create(:course_option, :open).provider }
+  let(:provider_with_application) { create(:application_choice, :awaiting_provider_decision).provider }
+  let(:provider_with_unsubmitted_application) { create(:application_choice, :unsubmitted).provider }
+  let(:previous_cycle_week) { CycleTimetable.current_cycle_week.pred }
+
+  context 'provider report is generated for appropriate providers' do
+    before do
+      allow(provider_worker).to receive(:perform_async)
+    end
+
+    it 'creates a report for a provider who received an application last week' do
+      TestSuiteTimeMachine.travel_permanently_to(Time.zone.local(2024, 4, 21, 18, 0))
+      provider_with_application
+
+      advance_time_to(1.day.from_now)
+
+      described_class.new.call
+      expect(provider_worker).to have_received(:perform_async).with(provider_id: provider_with_application.id, cycle_week: previous_cycle_week)
+    end
+
+    it 'does not create a report worker for a provider without any applications in the current cycle' do
+      TestSuiteTimeMachine.travel_permanently_to(Time.zone.local(2024, 4, 21, 18, 0))
+      # Create provider that has no applications but has an open course
+      provider_without_applications
+
+      advance_time_to(1.day.from_now)
+
+      described_class.new.call
+      expect(provider_worker).not_to have_received(:perform_async)
+    end
+
+    it 'does not create a report worker for a provider without a submitted application' do
+      TestSuiteTimeMachine.travel_permanently_to(Time.zone.local(2024, 4, 21, 18, 0))
+      # Create provider that has no applications but has an open course
+      provider_with_unsubmitted_application
+
+      advance_time_to(1.day.from_now)
+
+      described_class.new.call
+      expect(provider_worker).not_to have_received(:perform_async)
+    end
+
+    it 'does not create a report worker for a provider without an application in the current week' do
+      TestSuiteTimeMachine.travel_permanently_to(Time.zone.local(2024, 4, 21, 18, 0))
+      # Create provider that has an application this week
+      provider_with_application
+
+      described_class.new.call
+      expect(provider_worker).not_to have_received(:perform_async).with(provider_id: provider_with_application.id)
+    end
+  end
+
+  context 'national report is generated' do
+    before do
+      allow(national_worker).to receive(:perform_async)
+    end
+
+    it 'creates a National report' do
+      described_class.new.call
+      expect(national_worker).to have_received(:perform_async).with(cycle_week: previous_cycle_week)
+    end
+  end
+end

--- a/spec/models/publications/recruitment_performance_report_scheduler_spec.rb
+++ b/spec/models/publications/recruitment_performance_report_scheduler_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
     it 'creates a National report' do
       described_class.new.call
 
-      expect(national_worker).to have_received(:perform_async).with(cycle_week: previous_cycle_week)
+      expect(national_worker).to have_received(:perform_async).with(previous_cycle_week)
     end
 
     it 'does not create a National report worker when a report already exists' do
@@ -40,7 +40,7 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
 
       described_class.new.call
 
-      expect(national_worker).not_to have_received(:perform_async).with(cycle_week: previous_cycle_week)
+      expect(national_worker).not_to have_received(:perform_async).with(previous_cycle_week)
     end
   end
 end

--- a/spec/queries/providers_for_recruitment_performance_report_query_spec.rb
+++ b/spec/queries/providers_for_recruitment_performance_report_query_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe ProvidersForRecruitmentPerformanceReportQuery do
+  subject(:query) { described_class.call(cycle_week: CycleTimetable.current_cycle_week.pred) }
+
+  let(:application_choice_offer_from_last_cycle) { create(:application_choice, :awaiting_provider_decision).provider }
+  let(:application_this_week) { create(:application_choice, :awaiting_provider_decision).provider }
+  let(:application_last_week) { create(:application_choice, :awaiting_provider_decision).provider }
+  let(:application_last_week_unsubmitted) { create(:application_choice, :unsubmitted).provider }
+  let(:application_with_existing_report) do
+    create(:application_choice, :awaiting_provider_decision).provider.tap do |provider|
+      Publications::ProviderRecruitmentPerformanceReport.create(cycle_week: CycleTimetable.current_cycle_week, provider_id: provider.id, publication_date: Time.zone.today)
+    end
+  end
+
+  it 'selects providers only with submitted applications this cycle before the current week' do
+    TestSuiteTimeMachine.travel_temporarily_to(1.year.ago) do
+      application_choice_offer_from_last_cycle
+    end
+    TestSuiteTimeMachine.travel_temporarily_to(1.week.ago) do
+      application_last_week
+      application_with_existing_report
+      application_last_week_unsubmitted
+    end
+
+    application_this_week
+    expect(query).to contain_exactly(application_last_week)
+  end
+
+  it 'selects distinct providers when a provider has more than one appliation' do
+    TestSuiteTimeMachine.travel_temporarily_to(1.week.ago) do
+      application_last_week
+      create(:application_choice, :awaiting_provider_decision, course_option: application_last_week.course_options.first)
+    end
+
+    expect(query).to contain_exactly(application_last_week)
+  end
+end

--- a/spec/support_specs/clockwork_spec.rb
+++ b/spec/support_specs/clockwork_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe Clockwork, :clockwork do
   context 'when the performance report is in season' do
     before do
       allow(RecruitmentPerformanceReportTimetable).to receive(:report_season?).and_return(true)
+      allow(FeatureFlag).to receive(:active?).with(:recruitment_performance_report_generator).and_return(true)
     end
 
     it 'runs the report scheduler every Monday' do
@@ -84,7 +85,29 @@ RSpec.describe Clockwork, :clockwork do
 
   context 'when the performance report is out season' do
     before do
-      allow(RecruitmentPerformanceReportTimetable).to receive(:report_season?).and_return(nil)
+      allow(CycleTimetable).to receive(:current_cycle_week).and_return(2)
+      allow(FeatureFlag).to receive(:active?).with(:recruitment_performance_report_generator).and_return(true)
+    end
+
+    it 'does not run the report scheduler every Monday' do
+      start_time = Time.zone.now.beginning_of_week.change(hour: 5)
+      end_time = Time.zone.now.beginning_of_week.change(hour: 6)
+
+      Clockwork::Test.run(
+        start_time:,
+        end_time:,
+        tick_speed: 1.minute,
+        file: './config/clock.rb',
+      )
+
+      expect(Clockwork::Test.manager.send(:history).jobs).not_to include('Schedule Recruitment Performance reports')
+    end
+  end
+
+  context 'when recruitment_performance_report_generator FeatureFlag is not active' do
+    before do
+      allow(CycleTimetable).to receive(:current_cycle_week).and_return(27)
+      allow(FeatureFlag).to receive(:active?).with(:recruitment_performance_report_generator).and_return(false)
     end
 
     it 'does not run the report scheduler every Monday' do

--- a/spec/workers/publications/national_recruitment_performance_report_worker_spec.rb
+++ b/spec/workers/publications/national_recruitment_performance_report_worker_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Publications::NationalRecruitmentPerformanceReportWorker do
+  before do
+    @instance = instance_double(Publications::NationalRecruitmentPerformanceReportGenerator, call: nil)
+    allow(Publications::NationalRecruitmentPerformanceReportGenerator).to receive(:new).and_return(@instance)
+  end
+
+  let(:cycle_week) { CycleTimetable.current_cycle_week.pred }
+  let(:generation_date) { RecruitmentPerformanceReportTimetable.current_generation_date }
+  let(:publication_date) { RecruitmentPerformanceReportTimetable.current_generation_date }
+
+  describe '#perform' do
+    it 'calls the National Report Generator' do
+      described_class.new.perform
+
+      expect(@instance).to have_received(:call)
+      expect(Publications::NationalRecruitmentPerformanceReportGenerator).to have_received(:new).with(cycle_week:, generation_date:, publication_date:)
+    end
+  end
+end

--- a/spec/workers/publications/national_recruitment_performance_report_worker_spec.rb
+++ b/spec/workers/publications/national_recruitment_performance_report_worker_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Publications::NationalRecruitmentPerformanceReportWorker do
 
   describe '#perform' do
     it 'calls the National Report Generator' do
-      described_class.new.perform
+      described_class.new.perform(cycle_week)
 
       expect(@instance).to have_received(:call)
       expect(Publications::NationalRecruitmentPerformanceReportGenerator).to have_received(:new).with(cycle_week:, generation_date:, publication_date:)

--- a/spec/workers/publications/provider_recruitment_performance_report_worker_spec.rb
+++ b/spec/workers/publications/provider_recruitment_performance_report_worker_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Publications::ProviderRecruitmentPerformanceReportWorker do
 
   describe '#perform' do
     it 'calls the Provider Report Generator' do
-      described_class.new.perform(cycle_week:, provider_id:)
+      described_class.new.perform(provider_id, cycle_week)
 
       expect(@instance).to have_received(:call)
       expect(Publications::ProviderRecruitmentPerformanceReportGenerator).to have_received(:new).with(cycle_week:, generation_date:, publication_date:, provider_id:)

--- a/spec/workers/publications/provider_recruitment_performance_report_worker_spec.rb
+++ b/spec/workers/publications/provider_recruitment_performance_report_worker_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe Publications::ProviderRecruitmentPerformanceReportWorker do
+  before do
+    @instance = instance_double(Publications::ProviderRecruitmentPerformanceReportGenerator, call: nil)
+    allow(Publications::ProviderRecruitmentPerformanceReportGenerator).to receive(:new).and_return(@instance)
+  end
+
+  let(:cycle_week) { CycleTimetable.current_cycle_week.pred }
+  let(:generation_date) { RecruitmentPerformanceReportTimetable.current_generation_date }
+  let(:publication_date) { RecruitmentPerformanceReportTimetable.current_generation_date }
+  let(:provider_id) { create(:provider).id }
+
+  describe '#perform' do
+    it 'calls the Provider Report Generator' do
+      described_class.new.perform(cycle_week:, provider_id:)
+
+      expect(@instance).to have_received(:call)
+      expect(Publications::ProviderRecruitmentPerformanceReportGenerator).to have_received(:new).with(cycle_week:, generation_date:, publication_date:, provider_id:)
+    end
+  end
+end


### PR DESCRIPTION
## Context

This PR implements the plumbing required to fetch Recruitment Performance data from Bigquery and store it in the apply database.

### Diagram

![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/9deec9ce-fca2-43c7-8ec5-37aa58c8e928)



## Changes proposed in this pull request

 - [x] Only get providers that have not had a report generated already
 - [ ] Throttle / stagger the jobs for generating reports
 - [x] Check Bigquery request limiting
 - [x] Get an estimate of how many queries will be sent to BQ each week

### BigQuery quota 
[BigQuery quotas](https://cloud.google.com/bigquery/quotas)

### Queries per week estimate:

Running the query that is used to fetch the provider for whom we should generate a report, we see there are **780** valid providers.
We will make 1 BigQuery request for each of these Providers and that will return all the data we require.

### Throttle / stagger the jobs for generating reports
We could make these queries in batches of 50, 100, 250 or what ever, but I have not tried to optimise for this in this PR. We should test the performance before deciding how to optimise.




## Guidance to review

 - Are there any more edge cases that should be considered?
 - Are the tests written clearly enough?
 - Do we need a FeatureFlag for this? - These jobs will start being enqueued as soon as we merge this otherwise

## Link to Trello card

[Trello Ticket](https://trello.com/c/b9ucaiYB/1609-performance-report-importer-and-worker)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
