### PR TITLE
FeatureFlag to toggle the Recruitment Performance Report generation

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -35,6 +35,7 @@ class FeatureFlag
     [:continuous_applications, 'The new continuous applications flow', 'James Glenn'],
     [:teacher_degree_apprenticeship, 'The degree apprenticeship program', 'Tomas Destefi'],
     [:recruitment_performance_report, 'The new and improved mid-cycle report', 'Lori Bailey'],
+    [:recruitment_performance_report_generator, 'Toggle the Recruitment Performance Report generation', 'Iain McNulty'],
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day


### PR DESCRIPTION
## Context

FeatureFlag will allow support users and admins to disable the Recruitment Performance Report generation if it becomes necessary to do so.

## Changes proposed in this pull request

Add FeatureFlag to control the generation of Recruitment Performance Reports

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

[Trello Ticket](https://trello.com/c/YOESX2QD/1635-featureflag-for-recruitmentperformance-generator)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
