### PR TITLE
Select providers with applications submitted before the current week

### DIFF
--- a/app/queries/providers_for_recruitment_performance_report_query.rb
+++ b/app/queries/providers_for_recruitment_performance_report_query.rb
@@ -4,7 +4,7 @@ class ProvidersForRecruitmentPerformanceReportQuery
       .distinct
       .joins(courses: { course_options: :application_choices })
       .where(courses: { recruitment_cycle_year: CycleTimetable.current_year })
-      .where('application_choices.created_at < ?', Time.zone.today.beginning_of_week)
+      .where('application_choices.sent_to_provider_at < ?', Time.zone.today.beginning_of_week)
       .where.not(id: Publications::ProviderRecruitmentPerformanceReport.select('provider_id id').where(cycle_week:))
       .merge(ApplicationChoice.visible_to_provider)
   end

--- a/spec/queries/providers_for_recruitment_performance_report_query_spec.rb
+++ b/spec/queries/providers_for_recruitment_performance_report_query_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe ProvidersForRecruitmentPerformanceReportQuery do
     expect(query).to contain_exactly(application_last_week)
   end
 
-  it 'selects distinct providers when a provider has more than one appliation' do
+  it 'selects distinct providers when a provider has more than one application' do
     TestSuiteTimeMachine.travel_temporarily_to(1.week.ago) do
       application_last_week
       create(:application_choice, :awaiting_provider_decision, course_option: application_last_week.course_options.first)


### PR DESCRIPTION
## Context

Fix the query that collects the provider which should have Recruitment Performance Report produced this week.

## Changes proposed in this pull request

The query should collect providers for whom there has been an application **submitted** before the start of the current week rather than **created**.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

[Trello Ticket](https://trello.com/c/Vw1vm5XE/1649-bug-fix-on-performance-report-scheduler) 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
