### PR TITLE
1598 update service information banner content to support scheduled downtime

### DIFF
--- a/config/locales/service_information_banner.yml
+++ b/config/locales/service_information_banner.yml
@@ -3,10 +3,10 @@ en:
     provider:
       sandbox_header: The sandbox will be unavailable on Tuesday 25 May from 8am to 9am
       sandbox_body: This will affect both the web service and the API. You may lose work if you are using the sandbox when it becomes unavailable.
-      header: The Manage service will be unavailable on Wednesday 19 April from 8pm to 10:30pm
+      header: The Manage service will be unavailable on Thursday 16 May from 8am to 9am
       body: This will affect both the web service and the API. You may lose work if you are using Manage when it becomes unavailable.
     candidate:
       sandbox_header: The sandbox will be unavailable on Tuesday 25 May from 8am to 9am
       sandbox_body: You may lose work if you are using the sandbox when it becomes unavailable.
-      header: This service will be unavailable on Wednesday 19 April from 8pm to 10:30pm
+      header: The service will be unavailable on Thursday 16 May from 8am to 9am
       body: You may lose work if you are using this service when it becomes unavailable.


### PR DESCRIPTION
## Context

Add content to the service infromation banner to warn candidates and providers of planned maintenance on Thrusday 16 May 2024

## Changes proposed in this pull request

#### Candidate interface
![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/a01354c7-b38a-4bc3-9d29-dc680f2dea1f)

#### Provider Interface

![image](https://github.com/DFE-Digital/apply-for-teacher-training/assets/135042929/7ea4d261-8f26-450f-b43a-b67be43019d1)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

[Trello Ticket](https://trello.com/c/iPgVJxFM/1598-update-service-information-banner-content-to-support-scheduled-downtime)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
