### PR TITLE
Do not create a recruitmentperformance report if the bigquery response is empty

### DIFF
--- a/app/lib/dfe/bigquery/test_helper.rb
+++ b/app/lib/dfe/bigquery/test_helper.rb
@@ -16,7 +16,11 @@ module DfE
         bigquery_client = instance_double(Google::Cloud::Bigquery::Project)
         allow(DfE::Bigquery).to receive(:client).and_return(bigquery_client)
 
-        allow(bigquery_client).to receive(:query).and_return(application_metrics_by_provider_results(stub_results&.first))
+        if stub_results.present?
+          allow(bigquery_client).to receive(:query).and_return(application_metrics_by_provider_results(stub_results&.first))
+        else
+          allow(bigquery_client).to receive(:query).and_return(stub_results)
+        end
       end
 
       def application_metrics_results(options = {})

--- a/app/models/publications/provider_recruitment_performance_report_generator.rb
+++ b/app/models/publications/provider_recruitment_performance_report_generator.rb
@@ -17,11 +17,16 @@ module Publications
     end
 
     def call
+      if data.empty?
+        Rails.logger.info("No recruitment performance data was received for #{provider_id}")
+        return
+      end
+
       Publications::ProviderRecruitmentPerformanceReport.create!(provider_id:, statistics: data, cycle_week:, publication_date:, generation_date:)
     end
 
     def data
-      client.provider_data.map(&:attributes)
+      @data ||= client.provider_data.map(&:attributes)
     end
   end
 end

--- a/spec/lib/dfe/bigquery/application_metrics_by_provider_spec.rb
+++ b/spec/lib/dfe/bigquery/application_metrics_by_provider_spec.rb
@@ -120,10 +120,22 @@ RSpec.describe DfE::Bigquery::ApplicationMetricsByProvider do
       expect(provider_statistics.first.number_of_candidates_who_had_an_inactive_application_this_cycle_to_date_as_proportion_of_submitted_candidates).to eq 12
       expect(provider_statistics.first.number_of_candidates_submitted_to_date).to be 100
     end
+
+    context 'when the api returns no data for the provider id' do
+      let(:bigquery_results) { [] }
+
+      before do
+        allow(client).to receive(:query).with(anything).and_return(bigquery_results)
+      end
+
+      it 'returns an empty array' do
+        expect(provider_statistics).to be_empty
+      end
+    end
   end
 
   describe '.national_data' do
-    subject(:provider_statistics) do
+    subject(:national_statistics) do
       described_class.new(cycle_week: 18).national_data
     end
 
@@ -176,32 +188,44 @@ RSpec.describe DfE::Bigquery::ApplicationMetricsByProvider do
     end
 
     it 'returns the first result' do
-      expect(provider_statistics.as_json).to eq(results.as_json)
+      expect(national_statistics.as_json).to eq(results.as_json)
     end
 
     it 'assigns the attributes for the application metrics', :aggregate_failures do
-      expect(provider_statistics.first.nonprovider_filter).to eq 'Level'
-      expect(provider_statistics.first.nonprovider_filter_category).to eq 'Primary'
-      expect(provider_statistics.first.cycle_week).to eq 18
-      expect(provider_statistics.first.recruitment_cycle_year).to eq 2024
-      expect(provider_statistics.first.number_of_candidates_submitted_to_date).to eq 100
-      expect(provider_statistics.first.number_of_candidates_submitted_to_same_date_previous_cycle).to eq 200
-      expect(provider_statistics.first.number_of_candidates_submitted_to_date_as_proportion_of_last_cycle).to eq 0.5
-      expect(provider_statistics.first.number_of_candidates_with_offers_to_date).to eq 10
-      expect(provider_statistics.first.number_of_candidates_with_offers_to_same_date_previous_cycle).to eq 5
-      expect(provider_statistics.first.number_of_candidates_with_offers_to_date_as_proportion_of_last_cycle).to eq 2
-      expect(provider_statistics.first.number_of_candidates_accepted_to_date).to eq 1
-      expect(provider_statistics.first.number_of_candidates_accepted_to_same_date_previous_cycle).to eq 10
-      expect(provider_statistics.first.number_of_candidates_accepted_to_date_as_proportion_of_last_cycle).to eq 0.1
-      expect(provider_statistics.first.number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_date).to eq 12
-      expect(provider_statistics.first.number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_same_date_previous_cycle).to eq 12
-      expect(provider_statistics.first.number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_date_as_proportion_of_last_cycle).to eq 0
-      expect(provider_statistics.first.number_of_candidates_who_had_all_applications_rejected_this_cycle_to_date).to eq 12
-      expect(provider_statistics.first.number_of_candidates_who_had_all_applications_rejected_this_cycle_to_same_date_previous_cycle).to eq 12
-      expect(provider_statistics.first.number_of_candidates_who_had_all_applications_rejected_this_cycle_to_date_as_proportion_of_last_cycle).to eq 0
-      expect(provider_statistics.first.number_of_candidates_who_had_an_inactive_application_this_cycle_to_date).to eq 12
-      expect(provider_statistics.first.number_of_candidates_who_had_an_inactive_application_this_cycle_to_date_as_proportion_of_submitted_candidates).to eq 12
-      expect(provider_statistics.first.number_of_candidates_submitted_to_date).to be 100
+      expect(national_statistics.first.nonprovider_filter).to eq 'Level'
+      expect(national_statistics.first.nonprovider_filter_category).to eq 'Primary'
+      expect(national_statistics.first.cycle_week).to eq 18
+      expect(national_statistics.first.recruitment_cycle_year).to eq 2024
+      expect(national_statistics.first.number_of_candidates_submitted_to_date).to eq 100
+      expect(national_statistics.first.number_of_candidates_submitted_to_same_date_previous_cycle).to eq 200
+      expect(national_statistics.first.number_of_candidates_submitted_to_date_as_proportion_of_last_cycle).to eq 0.5
+      expect(national_statistics.first.number_of_candidates_with_offers_to_date).to eq 10
+      expect(national_statistics.first.number_of_candidates_with_offers_to_same_date_previous_cycle).to eq 5
+      expect(national_statistics.first.number_of_candidates_with_offers_to_date_as_proportion_of_last_cycle).to eq 2
+      expect(national_statistics.first.number_of_candidates_accepted_to_date).to eq 1
+      expect(national_statistics.first.number_of_candidates_accepted_to_same_date_previous_cycle).to eq 10
+      expect(national_statistics.first.number_of_candidates_accepted_to_date_as_proportion_of_last_cycle).to eq 0.1
+      expect(national_statistics.first.number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_date).to eq 12
+      expect(national_statistics.first.number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_same_date_previous_cycle).to eq 12
+      expect(national_statistics.first.number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_date_as_proportion_of_last_cycle).to eq 0
+      expect(national_statistics.first.number_of_candidates_who_had_all_applications_rejected_this_cycle_to_date).to eq 12
+      expect(national_statistics.first.number_of_candidates_who_had_all_applications_rejected_this_cycle_to_same_date_previous_cycle).to eq 12
+      expect(national_statistics.first.number_of_candidates_who_had_all_applications_rejected_this_cycle_to_date_as_proportion_of_last_cycle).to eq 0
+      expect(national_statistics.first.number_of_candidates_who_had_an_inactive_application_this_cycle_to_date).to eq 12
+      expect(national_statistics.first.number_of_candidates_who_had_an_inactive_application_this_cycle_to_date_as_proportion_of_submitted_candidates).to eq 12
+      expect(national_statistics.first.number_of_candidates_submitted_to_date).to be 100
+    end
+
+    context 'when the api returns no data' do
+      let(:bigquery_results) { [] }
+
+      before do
+        allow(client).to receive(:query).with(anything).and_return(bigquery_results)
+      end
+
+      it 'returns an empty array' do
+        expect(national_statistics).to be_empty
+      end
     end
   end
 
@@ -213,7 +237,7 @@ RSpec.describe DfE::Bigquery::ApplicationMetricsByProvider do
         expect(result).to respond_to(:nonprovider_filter)
       end
 
-      it 'has no attr_reader for nonprovider_filter_category' do
+      it 'has attr_reader for nonprovider_filter_category' do
         expect(result).to respond_to(:nonprovider_filter_category)
       end
     end

--- a/spec/models/publications/provider_recruitment_performance_report_generator_spec.rb
+++ b/spec/models/publications/provider_recruitment_performance_report_generator_spec.rb
@@ -4,90 +4,109 @@ RSpec.describe Publications::ProviderRecruitmentPerformanceReportGenerator do
   include DfE::Bigquery::TestHelper
   subject(:generator) { described_class.new(provider_id:, cycle_week:) }
 
-  before do
-    @stubbed_response = application_metrics_by_provider_results(
-      {
-        nonprovider_filter: 'Primary',
-        nonprovider_filter_category: nil,
-        cycle_week: nil,
-        recruitment_cycle_year: nil,
-        id: provider_id,
-      },
-    )
-
-    stub_bigquery_application_metrics_by_provider_request(@stubbed_response)
-  end
-
   let(:cycle_week) { 12 }
   let(:provider_id) { create(:provider).id }
   let(:generation_date) { Time.zone.today }
-  # BigQuery returns symbols, #attributes returns strings
-  # BigQuery returns :id, for 'provider.id'
-  let(:attributes) do
-    @stubbed_response.first[:provider_id] = @stubbed_response.first.delete(:id)
-    @stubbed_response.first.stringify_keys!
-    @stubbed_response
-  end
 
-  it 'returns data' do
-    expect(generator.data).to eq(attributes)
-  end
+  describe 'when a normal response is received' do
+    before do
+      @stubbed_response = application_metrics_by_provider_results(
+        {
+          nonprovider_filter: 'Primary',
+          nonprovider_filter_category: nil,
+          cycle_week: nil,
+          recruitment_cycle_year: nil,
+          id: provider_id,
+        },
+      )
 
-  describe '#call' do
-    context 'when cycle_week is 12' do
-      it 'creates a new report' do
-        expect { generator.call }.to change(Publications::ProviderRecruitmentPerformanceReport, :count).by(1)
+      stub_bigquery_application_metrics_by_provider_request(@stubbed_response)
+    end
+
+    # BigQuery returns symbols, #attributes returns strings
+    # BigQuery returns :id, for 'provider.id'
+    let(:attributes) do
+      @stubbed_response.first[:provider_id] = @stubbed_response.first.delete(:id)
+      @stubbed_response.first.stringify_keys!
+      @stubbed_response
+    end
+
+    it 'returns a hash of the response data' do
+      expect(generator.data).to eq(attributes)
+    end
+
+    describe '#call' do
+      context 'when cycle_week is 12' do
+        it 'creates a new report' do
+          expect { generator.call }.to change(Publications::ProviderRecruitmentPerformanceReport, :count).by(1)
+        end
+
+        it 'stores the correct data in the model' do
+          generator.call
+          model = Publications::ProviderRecruitmentPerformanceReport.last
+
+          expect(model).to have_attributes({
+            'provider_id' => provider_id,
+            'publication_date' => Time.zone.today,
+            'generation_date' => Time.zone.today,
+            'cycle_week' => cycle_week,
+            'statistics' => attributes,
+          })
+        end
       end
 
-      it 'stores the correct data in the model' do
-        generator.call
-        model = Publications::ProviderRecruitmentPerformanceReport.last
+      context 'when cycle_week is 15' do
+        let(:cycle_week) { 15 }
 
-        expect(model).to have_attributes({
-          'provider_id' => provider_id,
-          'publication_date' => Time.zone.today,
-          'generation_date' => Time.zone.today,
-          'cycle_week' => cycle_week,
-          'statistics' => attributes,
-        })
+        it 'stores the correct data in the model' do
+          generator.call
+
+          model = Publications::ProviderRecruitmentPerformanceReport.last
+
+          expect(model).to have_attributes({
+            'provider_id' => provider_id,
+            'publication_date' => generation_date,
+            'generation_date' => generation_date,
+            'cycle_week' => 15,
+            'statistics' => attributes,
+          })
+        end
+      end
+
+      context 'when setting a future generation date' do
+        subject(:generator) { described_class.new(provider_id:, cycle_week:, generation_date:) }
+
+        let(:generation_date) { 1.week.from_now.to_date }
+
+        it 'stores the correct data in the model' do
+          generator.call
+
+          model = Publications::ProviderRecruitmentPerformanceReport.last
+
+          expect(model).to have_attributes({
+            'provider_id' => provider_id,
+            'publication_date' => generation_date,
+            'generation_date' => generation_date,
+            'cycle_week' => cycle_week,
+            'statistics' => attributes,
+          })
+        end
       end
     end
 
-    context 'when cycle_week is 15' do
-      let(:cycle_week) { 15 }
-
-      it 'stores the correct data in the model' do
-        generator.call
-
-        model = Publications::ProviderRecruitmentPerformanceReport.last
-
-        expect(model).to have_attributes({
-          'provider_id' => provider_id,
-          'publication_date' => generation_date,
-          'generation_date' => generation_date,
-          'cycle_week' => 15,
-          'statistics' => attributes,
-        })
+    describe 'when an empty response is received from Bigquery' do
+      before do
+        stub_bigquery_application_metrics_by_provider_request([])
       end
-    end
 
-    context 'when setting a future generation date' do
-      subject(:generator) { described_class.new(provider_id:, cycle_week:, generation_date:) }
+      let(:attributes) { [] }
 
-      let(:generation_date) { 1.week.from_now.to_date }
+      it 'returns an empty array from the response' do
+        expect(generator.data).to eq(attributes)
+      end
 
-      it 'stores the correct data in the model' do
-        generator.call
-
-        model = Publications::ProviderRecruitmentPerformanceReport.last
-
-        expect(model).to have_attributes({
-          'provider_id' => provider_id,
-          'publication_date' => generation_date,
-          'generation_date' => generation_date,
-          'cycle_week' => cycle_week,
-          'statistics' => attributes,
-        })
+      it 'does not create a report if the data is empty' do
+        expect { generator.call }.not_to change(Publications::ProviderRecruitmentPerformanceReport, :count)
       end
     end
   end


### PR DESCRIPTION
## Context

When Bigquery returns an empty array of data for a request we will not create a RecruitmentPerformanceReport for the empty data.

## Changes proposed in this pull request

Do not create Recruitment Performance reports with empty statistics.

## Guidance to review

Should we have more / better logging around this?

## Link to Trello card

[Trello Ticket ](https://trello.com/c/3wPCJvdd/1689-do-not-create-a-recruitmentperformance-report-if-the-bigquery-response-is-empty)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
