### PR TITLE
RecruitmentReportScheduler accepts explicit cycle_week argument

### DIFF
--- a/app/models/publications/recruitment_performance_report_scheduler.rb
+++ b/app/models/publications/recruitment_performance_report_scheduler.rb
@@ -1,11 +1,17 @@
 module Publications
   class RecruitmentPerformanceReportScheduler
+    def initialize(cycle_week: CycleTimetable.current_cycle_week.pred)
+      @cycle_week = cycle_week
+    end
+
     def call
       schedule_national_report
       schedule_provider_report
     end
 
   private
+
+    attr_accessor :cycle_week
 
     def schedule_national_report
       return if Publications::NationalRecruitmentPerformanceReport.exists?(cycle_week:)
@@ -24,10 +30,6 @@ module Publications
             cycle_week,
           )
       end
-    end
-
-    def cycle_week
-      CycleTimetable.current_cycle_week.pred
     end
   end
 end

--- a/spec/models/publications/recruitment_performance_report_scheduler_spec.rb
+++ b/spec/models/publications/recruitment_performance_report_scheduler_spec.rb
@@ -4,19 +4,29 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
   let(:provider_worker) { Publications::ProviderRecruitmentPerformanceReportWorker }
   let(:national_worker) { Publications::NationalRecruitmentPerformanceReportWorker }
   let(:provider) { create(:provider) }
-  let(:previous_cycle_week) { CycleTimetable.current_cycle_week.pred }
+  let(:cycle_week) { CycleTimetable.current_cycle_week.pred }
 
   context 'provider report is generated for appropriate providers' do
     before do
       allow(provider_worker).to receive(:perform_async)
       provider
-      allow(ProvidersForRecruitmentPerformanceReportQuery).to receive(:call).with(cycle_week: previous_cycle_week).and_return(Provider)
+      allow(ProvidersForRecruitmentPerformanceReportQuery).to receive(:call).with(cycle_week:).and_return(Provider)
     end
 
     it 'creates a report for a provider who received an application last week' do
       described_class.new.call
 
-      expect(provider_worker).to have_received(:perform_async).with(provider.id, previous_cycle_week)
+      expect(provider_worker).to have_received(:perform_async).with(provider.id, cycle_week)
+    end
+
+    context 'explicit cycle_week is passed' do
+      let(:cycle_week) { 2 }
+
+      it 'creates a report for a provider who received an application before cycle_week' do
+        described_class.new(cycle_week:).call
+
+        expect(provider_worker).to have_received(:perform_async).with(provider.id, cycle_week)
+      end
     end
   end
 
@@ -28,19 +38,29 @@ RSpec.describe Publications::RecruitmentPerformanceReportScheduler do
     it 'creates a National report' do
       described_class.new.call
 
-      expect(national_worker).to have_received(:perform_async).with(previous_cycle_week)
+      expect(national_worker).to have_received(:perform_async).with(cycle_week)
     end
 
     it 'does not create a National report worker when a report already exists' do
       Publications::NationalRecruitmentPerformanceReport.create!(
         statistics: {},
         publication_date: Time.zone.today,
-        cycle_week: previous_cycle_week,
+        cycle_week:,
       )
 
       described_class.new.call
 
-      expect(national_worker).not_to have_received(:perform_async).with(previous_cycle_week)
+      expect(national_worker).not_to have_received(:perform_async).with(cycle_week)
+    end
+
+    context 'explicit cycle_week is passed' do
+      let(:cycle_week) { 2 }
+
+      it 'creates a national report for the cycle_week value' do
+        described_class.new(cycle_week:).call
+
+        expect(national_worker).to have_received(:perform_async).with(cycle_week)
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

Add default param to the Recruitment Performance Report Scheduler to allow us to run the report scheduler for arbitrary `cycle_week`s.

## Changes proposed in this pull request

Give us more control to run the RecruitmentPerformanceReportScheduler from the console

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

[Trello Ticket](https://trello.com/c/mDr3YiHM/1690-pass-optional-cycleweek-to-report-scheduler)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
