### PR TITLE
[1669] Update production database URL

### DIFF
--- a/terraform/aks/workspace_variables/production_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/production_aks.tfvars.json
@@ -58,5 +58,6 @@
         282453
       ]
     }
-  }
+  },
+  "use_terraform_db": true
 }


### PR DESCRIPTION
## Context
The database was renamed to the default name created by terraform

## Changes proposed in this pull request
Use the default connection string

## Guidance to review
Check it's the same setting as the other environments

## Link to Trello card
https://trello.com/c/HSsFc0wX
