### PR TITLE
[1669] Remove database rename feature flag

### DIFF
--- a/terraform/aks/application.tf
+++ b/terraform/aks/application.tf
@@ -10,8 +10,8 @@ module "application_configuration" {
   config_variables = local.app_env_values
 
   secret_variables = {
-    DATABASE_URL        = local.database_url
-    BLAZER_DATABASE_URL = local.database_url
+    DATABASE_URL        = module.postgres.url
+    BLAZER_DATABASE_URL = module.postgres.url
     REDIS_URL           = module.redis-queue.url
     REDIS_CACHE_URL     = module.redis-cache.url
   }

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -70,12 +70,6 @@ variable "alert_window_size" {
   description = "The period of time that is used to monitor alert activity e.g PT1M, PT5M, PT15M, PT30M, PT1H, PT6H or PT12H"
 }
 
-# Remove when all environments are migrated to the terraform DB
-variable "use_terraform_db" {
-  description = "Connect app to the database created by terraform"
-  default     = false
-}
-
 variable "send_traffic_to_maintenance_page" {
   default     = false
   description = "During a maintenance operation, keep sending traffic to the maintenance page instead of resetting the ingress"
@@ -102,7 +96,4 @@ locals {
   app_resource_group_name = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-rg"
 
   webapp_startup_command = var.webapp_startup_command == null ? null : ["/bin/sh", "-c", var.webapp_startup_command]
-
-  legacy_database_url = "postgres://${module.postgres.username}:${module.postgres.password}@${module.postgres.host}:${module.postgres.port}/apply-postgres-${var.app_environment}"
-  database_url        = var.use_terraform_db ? module.postgres.url : local.legacy_database_url
 }

--- a/terraform/aks/workspace_variables/production_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/production_aks.tfvars.json
@@ -58,6 +58,5 @@
         282453
       ]
     }
-  },
-  "use_terraform_db": true
+  }
 }

--- a/terraform/aks/workspace_variables/qa_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/qa_aks.tfvars.json
@@ -43,6 +43,5 @@
         204421
       ]
     }
-  },
-  "use_terraform_db": true
+  }
 }

--- a/terraform/aks/workspace_variables/review_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/review_aks.tfvars.json
@@ -7,6 +7,5 @@
   "namespace": "bat-qa",
   "deploy_azure_backing_services": false,
   "db_sslmode": "prefer",
-  "webapp_startup_command": "bundle exec rails db:prepare && bundle exec rails server -b 0.0.0.0",
-  "use_terraform_db": true
+  "webapp_startup_command": "bundle exec rails db:prepare && bundle exec rails server -b 0.0.0.0"
 }

--- a/terraform/aks/workspace_variables/sandbox_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/sandbox_aks.tfvars.json
@@ -50,6 +50,5 @@
         204421
       ]
     }
-  },
-  "use_terraform_db": true
+  }
 }

--- a/terraform/aks/workspace_variables/staging_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/staging_aks.tfvars.json
@@ -40,6 +40,5 @@
         204421
       ]
     }
-  },
-  "use_terraform_db": true
+  }
 }


### PR DESCRIPTION
## Context
All environments have been renamed so we can clean up

## Changes proposed in this pull request
Remove the variable and conditions

## Guidance to review
- Check review app connects to its database
- Run deploy-plan in each environment, it should show no change to secrets

I already did:
```shell
% make production deploy-plan CONFIRM_PRODUCTION=yes. IMAGE_TAG=e36d0f68c01541cdd329c472e979e473964e2a92
{
  "environmentName": "AzureCloud",
...

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```

## Link to Trello card
https://trello.com/c/HSsFc0wX
