### PR TITLE
Make it easier to switch between js driver

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -145,7 +145,7 @@ jobs:
         tests: [rubocop, erblint, brakeman, yarn_lint]
         include:
           - tests: rubocop
-            command: bundle exec rubocop --format clang --parallel --except RSpec/NoShouldInSpecs
+            command: bundle exec rubocop --format clang --parallel --except RSpec/NoShouldInSpecs --except RSpec/RSpecDescribeSystemSpecs
           - tests: erblint
             command: bundle exec rake erblint
           - tests: brakeman

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -145,7 +145,7 @@ jobs:
         tests: [rubocop, erblint, brakeman, yarn_lint]
         include:
           - tests: rubocop
-            command: bundle exec rubocop --format clang --parallel --except RSpec/NoShouldInSpecs --except RSpec/UseDescribeSystemSpecs
+            command: bundle exec rubocop --format clang --parallel --except RSpec/NoShouldInSpecs,RSpec/UseDescribeSystemSpecs
           - tests: erblint
             command: bundle exec rake erblint
           - tests: brakeman

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -145,7 +145,7 @@ jobs:
         tests: [rubocop, erblint, brakeman, yarn_lint]
         include:
           - tests: rubocop
-            command: bundle exec rubocop --format clang --parallel --except RSpec/NoShouldInSpecs --except RSpec/RSpecDescribeSystemSpecs
+            command: bundle exec rubocop --format clang --parallel --except RSpec/NoShouldInSpecs --except RSpec/UseDescribeSystemSpecs
           - tests: erblint
             command: bundle exec rake erblint
           - tests: brakeman

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ require:
   - rubocop-capybara
   - rubocop-factory_bot
   - ./lib/rubocop/cop/rspec/no_should_in_specs.rb
+  - ./lib/rubocop/cop/rspec/rspec_describe_in_system_specs.rb
   - ./lib/rubocop/cop/application_api_controller.rb
   - ./lib/rubocop/cop/govuk/govuk_button_to.rb
   - ./lib/rubocop/cop/govuk/govuk_link_to.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ require:
   - rubocop-capybara
   - rubocop-factory_bot
   - ./lib/rubocop/cop/rspec/no_should_in_specs.rb
-  - ./lib/rubocop/cop/rspec/rspec_describe_in_system_specs.rb
+  - ./lib/rubocop/cop/rspec/use_describe_in_system_specs.rb
   - ./lib/rubocop/cop/application_api_controller.rb
   - ./lib/rubocop/cop/govuk/govuk_button_to.rb
   - ./lib/rubocop/cop/govuk/govuk_link_to.rb

--- a/lib/rubocop/cop/rspec/rspec_describe_in_system_specs.rb
+++ b/lib/rubocop/cop/rspec/rspec_describe_in_system_specs.rb
@@ -1,0 +1,28 @@
+module RuboCop
+  module Cop
+    module RSpec
+      class RSpecDescribeSystemSpecs < Base
+        extend AutoCorrector
+        include RangeHelp
+
+        def_node_matcher :rspec_describe_system_specs?, <<~PATTERN
+          $(send (const nil? :RSpec) :feature ...)
+        PATTERN
+
+        MSG = 'Change RSpec.feature to RSpec.describe'.freeze
+
+        def on_send(node)
+          expr = rspec_describe_system_specs?(node)
+          return unless expr
+
+          range = node.receiver.source_range
+          range = range.resize(range.size + node.method_name.length + 1)
+
+          add_offense(range) do |corrector|
+            corrector.replace(expr, expr.source.sub('feature', 'describe'))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/rspec/use_describe_in_system_specs.rb
+++ b/lib/rubocop/cop/rspec/use_describe_in_system_specs.rb
@@ -1,7 +1,7 @@
 module RuboCop
   module Cop
     module RSpec
-      class RSpecDescribeSystemSpecs < Base
+      class UseDescribeSystemSpecs < Base
         extend AutoCorrector
         include RangeHelp
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     ]
   },
   "lint-staged": {
-    "*_spec.rb": "bundle exec rubocop -P --only RSpec/NoShouldInSpecs RSpec/UseDescribeSystemSpecs"
+    "*_spec.rb": "bundle exec rubocop -P --only RSpec/NoShouldInSpecs,RSpec/UseDescribeSystemSpecs"
   },
   "standard": {
     "env": [

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     ]
   },
   "lint-staged": {
-    "*_spec.rb": "bundle exec rubocop -P --only RSpec/NoShouldInSpecs RSpec/RSpecDescribeSystemSpecs"
+    "*_spec.rb": "bundle exec rubocop -P --only RSpec/NoShouldInSpecs RSpec/UseDescribeSystemSpecs"
   },
   "standard": {
     "env": [

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     ]
   },
   "lint-staged": {
-    "*_spec.rb": "bundle exec rubocop -P --only RSpec/NoShouldInSpecs"
+    "*_spec.rb": "bundle exec rubocop -P --only RSpec/NoShouldInSpecs RSpec/RSpecDescribeSystemSpecs"
   },
   "standard": {
     "env": [

--- a/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
+++ b/spec/components/candidate_interface/continuous_applications/application_review_component_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe CandidateInterface::ContinuousApplications::ApplicationReviewComp
     end
 
     it 'shows the personal statement' do
-      expect(result).to have_content("Personal statement\n  #{personal_statement}")
+      expect(result).to have_content("Personal statement #{personal_statement}")
     end
 
     it 'does not show the interview row' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -89,6 +89,7 @@ RSpec.configure do |config|
 
   config.include ViewComponent::TestHelpers, type: :component
   config.include Capybara::RSpecMatchers, type: :component
+  config.include CapybaraRSpecMonkeyPatch, type: :system
 
   config.extend FactorySpecHelpers
 

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -5,27 +5,33 @@ if ENV['TEST_ENV_NUMBER']
   Capybara.server_port = 9887 + ENV['TEST_ENV_NUMBER'].to_i
 end
 
-Capybara.register_driver :chrome_headless do |app|
-  options = Selenium::WebDriver::Chrome::Options.new
+options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|
+  opts.add_argument('--no-sandbox')
+  opts.add_argument('--disable-dev-shm-usage')
+  opts.add_argument('--disable-gpu')
+  opts.add_argument('--window-size=1400,1400')
+end
 
-  options.add_argument('--headless') unless ENV['HEADLESS'] == 'false'
-  options.add_argument('--no-sandbox')
-  options.add_argument('--disable-dev-shm-usage')
-  options.add_argument('--disable-gpu')
-  options.add_argument('--window-size=1400,1400')
-
+Capybara.register_driver :chrome do |app|
   Capybara::Selenium::Driver.new(app, browser: :chrome, options:)
 end
 
-Capybara.javascript_driver = :chrome_headless
+Capybara.register_driver :chrome_headless do |app|
+  options.add_argument('--headless')
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options:)
+end
 
 RSpec.configure do |config|
   config.before(:each, type: :system) do
-    if self.class.metadata[:js] == true
-      driven_by(:chrome_headless)
-    else
-      driven_by(:rack_test)
-    end
+    driven_by(:rack_test)
+  end
+
+  config.before(:each, :js, type: :system) do
+    driven_by(:chrome_headless)
+  end
+
+  config.before(:each, :js_browser, type: :system) do
+    driven_by(:chrome)
   end
 
   config.before(:each, :smoke) do

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -4,6 +4,7 @@ require 'capybara/rspec'
 if ENV['TEST_ENV_NUMBER']
   Capybara.server_port = 9887 + ENV['TEST_ENV_NUMBER'].to_i
 end
+Capybara.default_normalize_ws = true
 
 options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|
   opts.add_argument('--no-sandbox')

--- a/spec/support/capybara_rspec_monkey_patch.rb
+++ b/spec/support/capybara_rspec_monkey_patch.rb
@@ -1,0 +1,39 @@
+# Modify methods called by Capybara::RSpec so they work with :js specs and
+# with rack_test
+module CapybaraRSpecMonkeyPatch
+  def check(locator = nil, **options)
+    if self.class.metadata.keys.intersect?(%i[js js_browser])
+      super(locator, **options.merge(visible: false))
+    else
+      super
+    end
+  end
+
+  def select(value = nil, from: nil, **options)
+    if has_css?('.autocomplete__wrapper input') && self.class.metadata.keys.intersect?(%i[js js_browser])
+
+      input = find('.autocomplete__wrapper input')
+      input.fill_in(with: value)
+      input.send_keys(:down)
+      page.send_keys(:enter)
+    else
+      super
+    end
+  end
+
+  def uncheck(locator = nil, **options)
+    if self.class.metadata.keys.intersect?(%i[js js_browser])
+      super(locator, **options.merge(visible: false))
+    else
+      super
+    end
+  end
+
+  def choose(locator = nil, **options)
+    if self.class.metadata.keys.intersect?(%i[js js_browser])
+      super(locator, **options.merge(visible: false))
+    else
+      super
+    end
+  end
+end

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_signs_up_for_an_adviser_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_signs_up_for_an_adviser_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate signs up for an adviser', :js do
+RSpec.describe 'Candidate signs up for an adviser', :js do
   include_context 'get into teaching api stubbed endpoints'
 
   include CandidateHelper
@@ -17,19 +17,19 @@ RSpec.feature 'Candidate signs up for an adviser', :js do
     and_i_visit_the_application_form_page
 
     when_i_click_on_the_adviser_cta
-    then_i_should_be_on_the_adviser_sign_up_page
+    then_i_am_on_the_adviser_sign_up_page
 
     when_i_click_the_sign_up_button
-    then_i_should_see_validation_errors_for_preferred_teaching_subject
-    and_the_validation_error_should_be_tracked
+    then_i_see_validation_errors_for_preferred_teaching_subject
+    and_the_validation_error_is_tracked
 
     when_i_select_a_preferred_teaching_subject(preferred_teaching_subject.value)
     when_i_click_the_sign_up_button
-    then_i_should_be_redirected_to_the_application_form_page
-    and_i_should_see_the_success_message
+    then_i_am_redirected_to_the_application_form_page
+    and_i_see_the_success_message
     and_the_adviser_cta_be_replaced_with_the_waiting_to_be_assigned_message
-    and_an_adviser_sign_up_job_should_be_enqueued
-    and_the_sign_up_should_be_tracked
+    and_an_adviser_sign_up_job_is_enqueued
+    and_the_sign_up_is_tracked
   end
 
   def given_i_am_signed_in
@@ -78,7 +78,7 @@ RSpec.feature 'Candidate signs up for an adviser', :js do
     find("a[href='#{new_candidate_interface_adviser_sign_up_path}']", match: :first).click
   end
 
-  def then_i_should_be_on_the_adviser_sign_up_page
+  def then_i_am_on_the_adviser_sign_up_page
     expect(page).to have_current_path(new_candidate_interface_adviser_sign_up_path)
   end
 
@@ -86,13 +86,13 @@ RSpec.feature 'Candidate signs up for an adviser', :js do
     click_link_or_button t('application_form.adviser_sign_up.submit_text')
   end
 
-  def then_i_should_see_validation_errors_for_preferred_teaching_subject
+  def then_i_see_validation_errors_for_preferred_teaching_subject
     expect(page).to have_content(
       t('activemodel.errors.models.adviser/sign_up.attributes.preferred_teaching_subject_id.inclusion'),
     )
   end
 
-  def and_the_validation_error_should_be_tracked
+  def and_the_validation_error_is_tracked
     last_error = ValidationError.last
     expect(last_error).to have_attributes({
       form_object: Adviser::SignUp.name,
@@ -104,15 +104,15 @@ RSpec.feature 'Candidate signs up for an adviser', :js do
     find('label', text: subject).click
   end
 
-  def then_i_should_be_redirected_to_the_application_form_page
+  def then_i_am_redirected_to_the_application_form_page
     expect(page).to have_current_path(candidate_interface_continuous_applications_details_path)
   end
 
-  def and_i_should_see_the_success_message
+  def and_i_see_the_success_message
     expect(page).to have_content(t('application_form.adviser_sign_up.flash.success'))
   end
 
-  def and_an_adviser_sign_up_job_should_be_enqueued
+  def and_an_adviser_sign_up_job_is_enqueued
     expect(AdviserSignUpWorker).to have_received(:perform_async)
       .with(@application_form.id, preferred_teaching_subject.id).once
   end
@@ -122,7 +122,7 @@ RSpec.feature 'Candidate signs up for an adviser', :js do
     expect(page).to have_text(t('application_form.adviser_sign_up.call_to_action.waiting_to_be_assigned.text'))
   end
 
-  def and_the_sign_up_should_be_tracked
+  def and_the_sign_up_is_tracked
     expect(:candidate_signed_up_for_adviser).to have_been_enqueued_as_analytics_events
   end
 end

--- a/spec/system/candidate_interface/continuous_applications/adviser_sign_up/candidate_signs_up_for_an_adviser_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/adviser_sign_up/candidate_signs_up_for_an_adviser_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate signs up for an adviser', :js do
+RSpec.describe 'Candidate signs up for an adviser', :js do
   include_context 'get into teaching api stubbed endpoints'
 
   include CandidateHelper
@@ -17,19 +17,19 @@ RSpec.feature 'Candidate signs up for an adviser', :js do
     and_i_visit_your_details_page
 
     when_i_click_on_the_adviser_cta
-    then_i_should_be_on_the_adviser_sign_up_page
+    then_i_am_on_the_adviser_sign_up_page
 
     when_i_click_the_sign_up_button
-    then_i_should_see_validation_errors_for_preferred_teaching_subject
-    and_the_validation_error_should_be_tracked
+    then_i_see_validation_errors_for_preferred_teaching_subject
+    and_the_validation_error_is_tracked
 
     when_i_select_a_preferred_teaching_subject(preferred_teaching_subject.value)
     when_i_click_the_sign_up_button
-    then_i_should_be_redirected_to_your_details_page
-    and_i_should_see_the_success_message
+    then_i_am_redirected_to_your_details_page
+    and_i_see_the_success_message
     and_the_adviser_cta_be_replaced_with_the_waiting_to_be_assigned_message
-    and_an_adviser_sign_up_job_should_be_enqueued
-    and_the_sign_up_should_be_tracked
+    and_an_adviser_sign_up_job_is_enqueued
+    and_the_sign_up_is_tracked
   end
 
   def given_i_am_signed_in
@@ -78,7 +78,7 @@ RSpec.feature 'Candidate signs up for an adviser', :js do
     click_link_or_button t('application_form.adviser_sign_up.call_to_action.available.button_text')
   end
 
-  def then_i_should_be_on_the_adviser_sign_up_page
+  def then_i_am_on_the_adviser_sign_up_page
     expect(page).to have_current_path(new_candidate_interface_adviser_sign_up_path)
   end
 
@@ -86,13 +86,13 @@ RSpec.feature 'Candidate signs up for an adviser', :js do
     click_link_or_button t('application_form.adviser_sign_up.submit_text')
   end
 
-  def then_i_should_see_validation_errors_for_preferred_teaching_subject
+  def then_i_see_validation_errors_for_preferred_teaching_subject
     expect(page).to have_content(
       t('activemodel.errors.models.adviser/sign_up.attributes.preferred_teaching_subject_id.inclusion'),
     )
   end
 
-  def and_the_validation_error_should_be_tracked
+  def and_the_validation_error_is_tracked
     last_error = ValidationError.last
     expect(last_error).to have_attributes({
       form_object: Adviser::SignUp.name,
@@ -104,15 +104,15 @@ RSpec.feature 'Candidate signs up for an adviser', :js do
     find('label', text: subject).click
   end
 
-  def then_i_should_be_redirected_to_your_details_page
+  def then_i_am_redirected_to_your_details_page
     expect(page).to have_current_path(candidate_interface_continuous_applications_details_path)
   end
 
-  def and_i_should_see_the_success_message
+  def and_i_see_the_success_message
     expect(page).to have_content(t('application_form.adviser_sign_up.flash.success'))
   end
 
-  def and_an_adviser_sign_up_job_should_be_enqueued
+  def and_an_adviser_sign_up_job_is_enqueued
     expect(AdviserSignUpWorker).to have_received(:perform_async)
       .with(@application_form.id, preferred_teaching_subject.id).once
   end
@@ -122,7 +122,7 @@ RSpec.feature 'Candidate signs up for an adviser', :js do
     expect(page).to have_text(t('application_form.adviser_sign_up.call_to_action.waiting_to_be_assigned.text'))
   end
 
-  def and_the_sign_up_should_be_tracked
+  def and_the_sign_up_is_tracked
     expect(:candidate_signed_up_for_adviser).to have_been_enqueued_as_analytics_events
   end
 end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_edits_course_choices_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_edits_course_choices_spec.rb
@@ -234,7 +234,7 @@ RSpec.feature 'Candidate edits course choices' do
   end
 
   def and_i_see_the_updated_full_time_or_part_time_section_for_the_second_choice
-    expect(page).to have_content("Full time or part time\nPart time")
+    expect(page).to have_content('Full time or part time Part time')
   end
 
   def when_i_click_to_change_full_time_or_part_time_of_the_third_course_choice
@@ -242,7 +242,7 @@ RSpec.feature 'Candidate edits course choices' do
   end
 
   def and_i_see_the_updated_full_time_or_part_time_section_for_the_third_choice
-    expect(page).to have_content("Full time or part time\nPart time")
+    expect(page).to have_content('Full time or part time Part time')
   end
 
   def when_i_click_to_continue_my_second_course_choice

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_without_pass_grade_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_without_pass_grade_spec.rb
@@ -68,7 +68,7 @@ RSpec.feature 'Candidate entering GCSE details but without a pass grade' do
     expect(page).to have_content 'Maths GCSE or equivalent'
 
     expect(page).to have_content 'GCSE'
-    expect(page).to have_content "Grade\nD"
+    expect(page).to have_content 'Grade D'
     expect(page).to have_content 'Hard work and dedication'
     expect(page).to have_content '1990'
   end
@@ -116,7 +116,7 @@ RSpec.feature 'Candidate entering GCSE details but without a pass grade' do
   end
 
   def then_i_see_the_review_page_with_new_details
-    expect(page).to have_content "Grade\nB"
+    expect(page).to have_content 'Grade B'
   end
 
   def and_the_not_completed_explanation_has_been_reset

--- a/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_when_requiring_visa_2022_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_when_requiring_visa_2022_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'Entering personal details', time: CycleTimetableHelper.mid_cycle
     expect(page).to have_content('Name')
     expect(page).to have_content('Lando Calrissian')
     expect(page).to have_content('Pakistani')
-    expect(page).to have_content("Do you have the right to work or study in the UK?\nNo")
+    expect(page).to have_content('Do you have the right to work or study in the UK? No')
   end
 
   def and_i_can_change_state_that_i_have_permanent_residence
@@ -64,8 +64,8 @@ RSpec.describe 'Entering personal details', time: CycleTimetableHelper.mid_cycle
     expect(page).to have_content('Name')
     expect(page).to have_content('Lando Calrissian')
     expect(page).to have_content('Pakistani')
-    expect(page).to have_content("Do you have the right to work or study in the UK?\nYes")
-    expect(page).to have_content("Immigration status\nI have permanent residence")
+    expect(page).to have_content('Do you have the right to work or study in the UK? Yes')
+    expect(page).to have_content('Immigration status I have permanent residence')
   end
 
   def and_i_can_change_nationality_to_an_eu_country_with_settled_status
@@ -86,9 +86,9 @@ RSpec.describe 'Entering personal details', time: CycleTimetableHelper.mid_cycle
     click_link_or_button t('save_and_continue')
 
     expect(page).to have_current_path candidate_interface_personal_details_show_path
-    expect(page).to have_content("Nationality\nFrench")
-    expect(page).to have_content("Do you have the right to work or study in the UK?\nYes")
-    expect(page).to have_content("Immigration status\nEU settled status")
+    expect(page).to have_content('Nationality French')
+    expect(page).to have_content('Do you have the right to work or study in the UK? Yes')
+    expect(page).to have_content('Immigration status EU settled status')
   end
 
   def and_i_can_change_immigration_status
@@ -99,7 +99,7 @@ RSpec.describe 'Entering personal details', time: CycleTimetableHelper.mid_cycle
     click_link_or_button t('save_and_continue')
 
     expect(page).to have_current_path candidate_interface_personal_details_show_path
-    expect(page).to have_content("Immigration status\nEU pre-settled status")
+    expect(page).to have_content('Immigration status EU pre-settled status')
   end
 
   def and_i_can_mark_the_section_complete

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_adding_unknown_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_adding_unknown_degrees_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Adding an unknown degree', :js do
+RSpec.describe 'Adding an unknown degree', :js do
   include CandidateHelper
 
   scenario 'Candidate enters their degree' do
@@ -61,7 +61,7 @@ RSpec.feature 'Adding an unknown degree', :js do
     # Mark section as complete
     when_i_mark_this_section_as_completed
     and_i_click_on_continue
-    then_i_should_see_the_form
+    then_i_see_the_form
     and_that_the_section_is_completed
     when_i_click_on_degree
     then_i_can_check_my_answers
@@ -71,7 +71,7 @@ RSpec.feature 'Adding an unknown degree', :js do
   scenario 'Candidate enters a custom degree subject that has an incorrect auto-suggestion' do
     given_i_am_at_the_degree_subject_page
     when_i_fill_in_the_subject_with_a_custom_subject_that_has_an_incorrect_auto_suggestion
-    then_the_custom_subject_should_have_remained_filled_in
+    then_the_custom_subject_remains_filled_in
   end
 
   def given_i_am_at_the_degree_subject_page
@@ -98,7 +98,7 @@ RSpec.feature 'Adding an unknown degree', :js do
     find_by_id('main-content').click
   end
 
-  def then_the_custom_subject_should_have_remained_filled_in
+  def then_the_custom_subject_remains_filled_in
     expect(@input.value).to eq('History of Art and History')
   end
 
@@ -227,7 +227,7 @@ RSpec.feature 'Adding an unknown degree', :js do
     when_i_click_on_continue
   end
 
-  def then_i_should_see_the_form
+  def then_i_see_the_form
     expect(page).to have_content(t('page_titles.application_form'))
   end
 

--- a/spec/system/candidate_interface/references/candidate_request_references_continuous_applications_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_request_references_continuous_applications_spec.rb
@@ -157,7 +157,7 @@ RSpec.feature 'New References', :with_audited do
   end
 
   def then_i_see_the_email_error_validation_message
-    expect(page).to have_content("There is a problem\nEnter their email address")
+    expect(page).to have_content('There is a problem Enter their email address')
   end
 
   def and_i_be_on_add_relationship_page

--- a/spec/system/candidate_interface/signup_and_signin/candidate_views_guidance_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_views_guidance_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature 'Candidate visits the sign-in page and views guidance' do
     expect(page).to have_content('The application process for courses starting in September 2024')
     expect(page).to have_content('3 October 2023 at 9am')
     expect(page).to have_content('Start finding postgraduate teacher training courses')
-    expect(page).to have_content("10 October 2023 at 9am\nStart applying to courses.")
+    expect(page).to have_content('10 October 2023 at 9am Start applying to courses.')
     expect(page).to have_content('17 September 2024 at 6pmThe last day to submit any applications.')
     expect(page).to have_content('25 September 2024 at 11:59pm')
     expect(page).to have_content('The last day for training providers to make a decision on all applications for courses starting in September 2024')

--- a/spec/system/inactive_application_spec.rb
+++ b/spec/system/inactive_application_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Process Stale applications', :sidekiq do
+RSpec.describe 'Process Stale applications', :sidekiq do
   include CourseOptionHelpers
 
   scenario 'An application is marked as inactive', :with_audited do
@@ -8,7 +8,7 @@ RSpec.feature 'Process Stale applications', :sidekiq do
     and_there_is_a_candidate
     and_an_application_is_ready_to_be_marked_as_inactive
     when_we_process_stale_applications
-    then_the_application_should_be_inactive
+    then_the_application_is_inactive
   end
 
   def given_there_is_a_provider_user_for_the_provider_course
@@ -42,7 +42,7 @@ RSpec.feature 'Process Stale applications', :sidekiq do
     end
   end
 
-  def then_the_application_should_be_inactive
+  def then_the_application_is_inactive
     expect(@application_choice.reload.status).to eq('inactive')
   end
 end

--- a/spec/system/provider_interface/change_existing_offer_ske_standard_flow_spec.rb
+++ b/spec/system/provider_interface/change_existing_offer_ske_standard_flow_spec.rb
@@ -287,16 +287,16 @@ RSpec.feature 'Provider changes an existing offer' do
 
   def and_the_ske_conditions_be_displayed
     expect(page).to have_content('Subject knowledge enhancement course')
-    expect(page).to have_content("Subject\n#{@ske_subject.name}")
-    expect(page).to have_content("Length\n8 weeks")
-    expect(page).to have_content("Reason\nTheir degree subject was not #{@ske_subject.name}")
+    expect(page).to have_content("Subject #{@ske_subject.name}")
+    expect(page).to have_content('Length 8 weeks')
+    expect(page).to have_content("Reason Their degree subject was not #{@ske_subject.name}")
   end
 
   def and_the_modified_ske_conditions_be_displayed
     expect(page).to have_content('Subject knowledge enhancement course')
-    expect(page).to have_content("Subject\n#{@ske_subject.name}")
-    expect(page).to have_content("Length\n12 weeks")
-    expect(page).to have_content("Reason\nTheir degree subject was not #{@ske_subject.name}")
+    expect(page).to have_content("Subject #{@ske_subject.name}")
+    expect(page).to have_content('Length 12 weeks')
+    expect(page).to have_content("Reason Their degree subject was not #{@ske_subject.name}")
   end
 
   def and_the_ske_conditions_not_be_displayed

--- a/spec/system/provider_interface/edit_user_permissions_spec.rb
+++ b/spec/system/provider_interface/edit_user_permissions_spec.rb
@@ -89,12 +89,12 @@ RSpec.feature 'User permissions' do
 
   def then_i_see_the_check_page
     expect(page).to have_content('Check and save user permissions')
-    expect(page).to have_css('.govuk-summary-list__row', text: "Manage users\nNo")
-    expect(page).to have_css('.govuk-summary-list__row', text: "Manage organisation permissions\nNo")
-    expect(page).to have_css('.govuk-summary-list__row', text: "Manage interviews\nYes")
-    expect(page).to have_css('.govuk-summary-list__row', text: "Make offers and reject applications\nYes")
-    expect(page).to have_css('.govuk-summary-list__row', text: "View criminal convictions and professional misconduct\nYes")
-    expect(page).to have_css('.govuk-summary-list__row', text: "View sex, disability and ethnicity information\nNo")
+    expect(page).to have_css('.govuk-summary-list__row', text: 'Manage users No')
+    expect(page).to have_css('.govuk-summary-list__row', text: 'Manage organisation permissions No')
+    expect(page).to have_css('.govuk-summary-list__row', text: 'Manage interviews Yes')
+    expect(page).to have_css('.govuk-summary-list__row', text: 'Make offers and reject applications Yes')
+    expect(page).to have_css('.govuk-summary-list__row', text: 'View criminal convictions and professional misconduct Yes')
+    expect(page).to have_css('.govuk-summary-list__row', text: 'View sex, disability and ethnicity information No')
   end
 
   def when_i_click_change
@@ -112,12 +112,12 @@ RSpec.feature 'User permissions' do
   end
 
   def and_i_see_the_modified_permissions
-    expect(page).to have_css('.govuk-summary-list__row', text: "Manage users\nYes")
-    expect(page).to have_css('.govuk-summary-list__row', text: "Manage organisation permissions\nNo")
-    expect(page).to have_css('.govuk-summary-list__row', text: "Manage interviews\nNo")
-    expect(page).to have_css('.govuk-summary-list__row', text: "Make offers and reject applications\nYes")
-    expect(page).to have_css('.govuk-summary-list__row', text: "View criminal convictions and professional misconduct\nYes")
-    expect(page).to have_css('.govuk-summary-list__row', text: "View sex, disability and ethnicity information\nYes")
+    expect(page).to have_css('.govuk-summary-list__row', text: 'Manage users Yes')
+    expect(page).to have_css('.govuk-summary-list__row', text: 'Manage organisation permissions No')
+    expect(page).to have_css('.govuk-summary-list__row', text: 'Manage interviews No')
+    expect(page).to have_css('.govuk-summary-list__row', text: 'Make offers and reject applications Yes')
+    expect(page).to have_css('.govuk-summary-list__row', text: 'View criminal convictions and professional misconduct Yes')
+    expect(page).to have_css('.govuk-summary-list__row', text: 'View sex, disability and ethnicity information Yes')
   end
 
   def when_i_submit_the_modified_permissions

--- a/spec/system/provider_interface/invite_user_spec.rb
+++ b/spec/system/provider_interface/invite_user_spec.rb
@@ -117,19 +117,19 @@ RSpec.feature 'Provider user invitation' do
 
   def and_i_see_the_specified_personal_details
     expect(page).to have_css('h2', text: 'Personal details')
-    expect(page).to have_css('.govuk-summary-list__row', text: "First name\nJohnathy")
-    expect(page).to have_css('.govuk-summary-list__row', text: "Last name\nSmithinson")
-    expect(page).to have_css('.govuk-summary-list__row', text: "Email address\njohn.smith@example.com")
+    expect(page).to have_css('.govuk-summary-list__row', text: 'First name Johnathy')
+    expect(page).to have_css('.govuk-summary-list__row', text: 'Last name Smithinson')
+    expect(page).to have_css('.govuk-summary-list__row', text: 'Email address john.smith@example.com')
   end
 
   def and_i_see_the_selected_permissions
     expect(page).to have_css('h2', text: 'User permissions')
-    expect(page).to have_css('.govuk-summary-list__row', text: "Manage users\nYes")
-    expect(page).to have_css('.govuk-summary-list__row', text: "Manage organisation permissions\nNo")
-    expect(page).to have_css('.govuk-summary-list__row', text: "Manage interviews\nNo")
-    expect(page).to have_css('.govuk-summary-list__row', text: "Make offers and reject applications\nNo")
-    expect(page).to have_css('.govuk-summary-list__row', text: "View criminal convictions and professional misconduct\nNo")
-    expect(page).to have_css('.govuk-summary-list__row', text: "View sex, disability and ethnicity information\nYes")
+    expect(page).to have_css('.govuk-summary-list__row', text: 'Manage users Yes')
+    expect(page).to have_css('.govuk-summary-list__row', text: 'Manage organisation permissions No')
+    expect(page).to have_css('.govuk-summary-list__row', text: 'Manage interviews No')
+    expect(page).to have_css('.govuk-summary-list__row', text: 'Make offers and reject applications No')
+    expect(page).to have_css('.govuk-summary-list__row', text: 'View criminal convictions and professional misconduct No')
+    expect(page).to have_css('.govuk-summary-list__row', text: 'View sex, disability and ethnicity information Yes')
   end
 
   def when_i_click_to_change_the_first_name
@@ -141,7 +141,7 @@ RSpec.feature 'Provider user invitation' do
   end
 
   def and_i_see_the_first_name_has_been_updated
-    expect(page).to have_css('.govuk-summary-list__row', text: "First name\nJack")
+    expect(page).to have_css('.govuk-summary-list__row', text: 'First name Jack')
   end
 
   def when_i_commit_the_changes

--- a/spec/system/provider_interface/make_offer_ske_language_flow_spec.rb
+++ b/spec/system/provider_interface/make_offer_ske_language_flow_spec.rb
@@ -47,33 +47,33 @@ RSpec.feature 'Provider makes an offer with SKE enabled on language flow' do
 
     then_the_ske_language_flow_is_loaded
     when_i_dont_select_any_ske_answer
-    then_i_should_see_a_error_message_to_select_language
+    then_i_see_a_error_message_to_select_language
 
     and_i_select_language_and_the_no_option
     and_i_click_continue
-    then_i_should_see_a_error_message_to_select_one_or_the_other_language
+    then_i_see_a_error_message_to_select_one_or_the_other_language
 
     when_i_select_three_languages
     and_i_click_continue
-    then_i_should_see_an_error_message_to_select_no_more_than_2_languages
+    then_i_see_an_error_message_to_select_no_more_than_2_languages
 
     when_i_select_two_languages
     and_i_click_continue
     then_the_ske_reason_page_is_loaded
 
     when_i_dont_give_a_ske_reason
-    then_i_should_see_a_error_message_to_give_a_reason_for_ske_for_all_languages
+    then_i_see_a_error_message_to_give_a_reason_for_ske_for_all_languages
 
     when_i_add_a_ske_reason_for_all_languages
     and_i_click_continue
     then_the_ske_length_page_is_loaded
 
     when_i_dont_answer_ske_length
-    then_i_should_see_a_error_message_to_give_a_ske_course_length_for_all_languages
+    then_i_see_a_error_message_to_give_a_ske_course_length_for_all_languages
 
     when_i_select_both_ske_courses_over_8_weeks
     and_i_click_continue
-    then_i_should_see_a_error_message_to_select_at_least_one_8_week_course
+    then_i_see_a_error_message_to_select_at_least_one_8_week_course
 
     when_i_answer_the_ske_length
     and_i_click_continue
@@ -86,7 +86,7 @@ RSpec.feature 'Provider makes an offer with SKE enabled on language flow' do
     and_i_click_continue
     then_the_review_page_is_loaded
     and_i_can_confirm_my_answers
-    and_the_ske_conditions_should_be_displayed
+    and_the_ske_conditions_is_displayed
 
     when_i_click_change_course
     then_i_am_taken_to_the_change_course_page
@@ -142,7 +142,7 @@ RSpec.feature 'Provider makes an offer with SKE enabled on language flow' do
     click_link_or_button 'Continue'
   end
 
-  def then_i_should_see_a_error_message_to_select_language
+  def then_i_see_a_error_message_to_select_language
     expect(page).to have_content('There is a problem')
     expect(page).to have_content('Select whether you require the candidate to do a course')
   end
@@ -152,7 +152,7 @@ RSpec.feature 'Provider makes an offer with SKE enabled on language flow' do
     check 'No, a SKE course is not required'
   end
 
-  def then_i_should_see_a_error_message_to_select_one_or_the_other_language
+  def then_i_see_a_error_message_to_select_one_or_the_other_language
     expect(page).to have_content('Select a language, or select ‘No, a SKE course is not required’')
   end
 
@@ -166,7 +166,7 @@ RSpec.feature 'Provider makes an offer with SKE enabled on language flow' do
     check 'German'
   end
 
-  def then_i_should_see_an_error_message_to_select_no_more_than_2_languages
+  def then_i_see_an_error_message_to_select_no_more_than_2_languages
     expect(page).to have_content('Select no more than 2 languages')
   end
 
@@ -201,12 +201,12 @@ RSpec.feature 'Provider makes an offer with SKE enabled on language flow' do
     click_link_or_button 'Continue'
   end
 
-  def then_i_should_see_a_error_message_to_give_a_reason_for_ske_for_all_languages
+  def then_i_see_a_error_message_to_give_a_reason_for_ske_for_all_languages
     expect(page).to have_content('There is a problem')
     expect(page).to have_content('Select why the candidate needs to take a course')
   end
 
-  def then_i_should_see_a_error_message_to_give_a_reason_for_ske
+  def then_i_see_a_error_message_to_give_a_reason_for_ske
     expect(page).to have_content('There is a problem')
     expect(page).to have_content('Select why the candidate needs to take a course')
   end
@@ -229,17 +229,17 @@ RSpec.feature 'Provider makes an offer with SKE enabled on language flow' do
     form_groups.last.choose('12 weeks')
   end
 
-  def then_i_should_see_a_error_message_to_give_a_ske_course_length_for_all_languages
+  def then_i_see_a_error_message_to_give_a_ske_course_length_for_all_languages
     expect(page).to have_content('There is a problem')
     expect(page).to have_content('Select how long the course must be')
   end
 
-  def then_i_should_see_a_error_message_to_give_a_ske_course_length
+  def then_i_see_a_error_message_to_give_a_ske_course_length
     expect(page).to have_content('There is a problem')
     expect(page).to have_content('Select how long the course must be')
   end
 
-  def then_i_should_see_a_error_message_to_select_at_least_one_8_week_course
+  def then_i_see_a_error_message_to_select_at_least_one_8_week_course
     expect(page).to have_content('There is a problem')
     expect(page).to have_content('Select one language course that’s 8 weeks, the other course can be between 8 and 28 weeks')
   end
@@ -253,12 +253,12 @@ RSpec.feature 'Provider makes an offer with SKE enabled on language flow' do
     page.all('.govuk-form-group')
   end
 
-  def and_the_ske_conditions_should_be_displayed
+  def and_the_ske_conditions_is_displayed
     %w[French Spanish].each do |language|
       expect(page).to have_content('Subject knowledge enhancement course')
-      expect(page).to have_content("Subject\n#{language}")
-      expect(page).to have_content("Length\n12 weeks")
-      expect(page).to have_content("Reason\nTheir degree subject was not #{language}")
+      expect(page).to have_content("Subject #{language}")
+      expect(page).to have_content('Length 12 weeks')
+      expect(page).to have_content("Reason Their degree subject was not #{language}")
     end
   end
 

--- a/spec/system/provider_interface/provider_changes_conditions_on_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_changes_conditions_on_an_offer_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Change offer conditions' do
+RSpec.describe 'Change offer conditions' do
   include CourseOptionHelpers
   include DfESignInHelpers
   include ProviderUserPermissionsHelper
@@ -21,10 +21,10 @@ RSpec.feature 'Change offer conditions' do
     then_i_expect_to_see_the_updated_conditions
 
     when_i_click_on_add_or_change_conditions
-    then_i_should_not_see_the_removed_condition
+    then_i_does_not_see_the_removed_condition
 
     when_i_send_the_new_offer
-    then_the_candidate_should_have_the_new_conditions
+    then_the_candidate_has_the_new_conditions
   end
 
   scenario 'Provider user changes the conditions on an offer with javascript off', js: false do
@@ -43,10 +43,10 @@ RSpec.feature 'Change offer conditions' do
     then_i_expect_to_see_the_updated_conditions
 
     when_i_click_on_add_or_change_conditions
-    then_i_should_not_see_the_removed_condition
+    then_i_does_not_see_the_removed_condition
 
     when_i_send_the_new_offer
-    then_the_candidate_should_have_the_new_conditions
+    then_the_candidate_has_the_new_conditions
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -118,7 +118,7 @@ RSpec.feature 'Change offer conditions' do
     expect(page).to have_no_content 'and another'
   end
 
-  def then_i_should_not_see_the_removed_condition
+  def then_i_does_not_see_the_removed_condition
     expect(page).to have_content 'Conditions of offer'
     expect(page).to have_content @condition.text
     expect(page).to have_content 'condition'
@@ -130,7 +130,7 @@ RSpec.feature 'Change offer conditions' do
     click_link_or_button 'Send new offer'
   end
 
-  def then_the_candidate_should_have_the_new_conditions
+  def then_the_candidate_has_the_new_conditions
     conditions = @application_choice.reload.offer.non_structured_conditions_text
     expect(conditions).to contain_exactly(@condition.text, 'condition')
   end

--- a/spec/system/provider_interface/provider_edits_organisation_permissions_spec.rb
+++ b/spec/system/provider_interface/provider_edits_organisation_permissions_spec.rb
@@ -98,7 +98,7 @@ RSpec.feature 'Provider edits organisation permissions' do
   end
 
   def and_my_organisation_is_listed_as_able_to_make_decisions
-    expect(page).to have_content("Make offers and reject applications\n#{@ratifying_provider.name}\n#{@training_provider.name}")
+    expect(page).to have_content("Make offers and reject applications #{@ratifying_provider.name} #{@training_provider.name}")
   end
 
   def and_my_organisation_is_able_to_make_decisions

--- a/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
+++ b/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'A Provider viewing an individual application', :with_audited do
     then_i_see_an_error_message
 
     and_i_go_back
-    then_i_should_be_on_the_application_page
+    then_i_am_on_the_application_page
 
     and_i_click_set_up_an_interview
     and_i_fill_out_the_interview_form(days_in_future: 1, time: '10pm')
@@ -53,7 +53,7 @@ RSpec.describe 'A Provider viewing an individual application', :with_audited do
     then_i_see_a_validation_error
 
     and_i_go_back
-    then_i_should_be_on_the_application_interviews_page
+    then_i_am_on_the_application_interviews_page
 
     when_i_click_to_cancel_an_interview
     and_i_enter_a_valid_cancellation_reason
@@ -127,11 +127,11 @@ RSpec.describe 'A Provider viewing an individual application', :with_audited do
     expect(page).to have_content 'There is a problem'
   end
 
-  def then_i_should_be_on_the_application_page
+  def then_i_am_on_the_application_page
     expect(page).to have_current_path(provider_interface_application_choice_path(application_choice))
   end
 
-  def then_i_should_be_on_the_application_interviews_page
+  def then_i_am_on_the_application_interviews_page
     expect(page).to have_current_path(provider_interface_application_choice_interviews_path(application_choice))
   end
 
@@ -182,10 +182,10 @@ RSpec.describe 'A Provider viewing an individual application', :with_audited do
 
   def and_i_confirm_the_interview_details
     expect(page).to have_content('Check and send new interview details')
-    expect(page).to have_content("Date\n#{2.days.from_now.to_fs(:govuk_date)}")
-    expect(page).to have_content("Start time\n10am")
-    expect(page).to have_content("Address or online meeting details\nZoom meeting")
-    expect(page).to have_content("Additional details\nBusiness casual")
+    expect(page).to have_content("Date #{2.days.from_now.to_fs(:govuk_date)}")
+    expect(page).to have_content('Start time 10am')
+    expect(page).to have_content('Address or online meeting details Zoom meeting')
+    expect(page).to have_content('Additional details Business casual')
 
     click_link_or_button 'Change', match: :first
 
@@ -193,7 +193,7 @@ RSpec.describe 'A Provider viewing an individual application', :with_audited do
 
     click_link_or_button 'Continue'
 
-    expect(page).to have_content("Additional details\nBusiness casual, first impressions are important")
+    expect(page).to have_content('Additional details Business casual, first impressions are important')
 
     click_link_or_button 'Send new interview details'
   end
@@ -201,8 +201,8 @@ RSpec.describe 'A Provider viewing an individual application', :with_audited do
   def then_i_can_see_the_interview_was_updated
     expect(page).to have_content('Interview changed')
     expect(page).to have_content("#{2.days.from_now.to_fs(:govuk_date)} at 10am")
-    expect(page).to have_content("Address or online meeting details\nZoom meeting")
-    expect(page).to have_content("Additional details\nBusiness casual, first impressions are important")
+    expect(page).to have_content('Address or online meeting details Zoom meeting')
+    expect(page).to have_content('Additional details Business casual, first impressions are important')
   end
 
   def when_i_click_to_cancel_an_interview

--- a/spec/system/provider_interface/provider_removes_conditions_from_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_removes_conditions_from_an_offer_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Remove offer conditions' do
+RSpec.describe 'Remove offer conditions' do
   include CourseOptionHelpers
   include DfESignInHelpers
   include ProviderUserPermissionsHelper
@@ -18,10 +18,10 @@ RSpec.feature 'Remove offer conditions' do
     then_i_expect_to_see_the_updated_conditions
 
     when_i_click_on_add_or_change_conditions
-    then_i_should_not_see_the_removed_condition
+    then_i_do_not_see_the_removed_condition
 
     when_i_send_the_new_offer
-    then_the_candidate_should_have_the_new_conditions
+    then_the_candidate_has_the_new_conditions
   end
 
   scenario 'Provider user removes the conditions from an offer with javascript off', js: false do
@@ -37,10 +37,10 @@ RSpec.feature 'Remove offer conditions' do
     then_i_expect_to_see_the_updated_conditions
 
     when_i_click_on_add_or_change_conditions
-    then_i_should_not_see_the_removed_condition
+    then_i_do_not_see_the_removed_condition
 
     when_i_send_the_new_offer
-    then_the_candidate_should_have_the_new_conditions
+    then_the_candidate_has_the_new_conditions
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -100,7 +100,7 @@ RSpec.feature 'Remove offer conditions' do
     expect(page).to have_no_content @conditions.third.text
   end
 
-  def then_i_should_not_see_the_removed_condition
+  def then_i_do_not_see_the_removed_condition
     expect(page).to have_content 'Conditions of offer'
     expect(page).to have_no_content @conditions.first.text
     expect(page).to have_no_content @conditions.second.text
@@ -112,7 +112,7 @@ RSpec.feature 'Remove offer conditions' do
     click_link_or_button 'Send new offer'
   end
 
-  def then_the_candidate_should_have_the_new_conditions
+  def then_the_candidate_has_the_new_conditions
     conditions = @application_choice.reload.offer.conditions
     expect(conditions).to be_empty
   end

--- a/spec/system/provider_interface/provider_uses_webchat_spec.rb
+++ b/spec/system/provider_interface/provider_uses_webchat_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Provider uses webchat' do
+RSpec.describe 'Provider uses webchat' do
   include DfESignInHelpers
 
   scenario 'controlling the widget via a link in the footer', :js do
@@ -10,14 +10,14 @@ RSpec.feature 'Provider uses webchat' do
     when_i_visit_the_provider_interface
     and_there_is_no_support_agent_online
 
-    then_i_should_see_a_placeholder_in_the_footer
+    then_i_see_a_placeholder_in_the_footer
 
     when_a_support_agent_comes_online
-    then_i_should_see_a_link_in_the_footer
+    then_i_see_a_link_in_the_footer
     and_when_i_click_the_link_i_see_a_popup
 
     when_the_support_agent_goes_offline
-    then_i_should_be_informed_chat_is_unavailable
+    then_i_am_informed_chat_is_unavailable
   end
 
   def given_i_am_a_provider_user
@@ -39,7 +39,7 @@ RSpec.feature 'Provider uses webchat' do
 
   def and_there_is_no_support_agent_online; end
 
-  def then_i_should_see_a_placeholder_in_the_footer
+  def then_i_see_a_placeholder_in_the_footer
     expect(page).to have_content('You cannot use online chat')
   end
 
@@ -47,7 +47,7 @@ RSpec.feature 'Provider uses webchat' do
     page.evaluate_script('setZendeskStatus("online")')
   end
 
-  def then_i_should_see_a_link_in_the_footer
+  def then_i_see_a_link_in_the_footer
     expect(page).to have_content('Speak to an adviser now')
   end
 
@@ -61,7 +61,7 @@ RSpec.feature 'Provider uses webchat' do
     page.evaluate_script('setZendeskStatus("offline")')
   end
 
-  def then_i_should_be_informed_chat_is_unavailable
+  def then_i_am_informed_chat_is_unavailable
     expect(page).to have_content('Available Monday to Friday')
   end
 end

--- a/spec/system/provider_interface/view_organisation_users_spec.rb
+++ b/spec/system/provider_interface/view_organisation_users_spec.rb
@@ -94,12 +94,12 @@ RSpec.feature 'Organisation users' do
 
   def and_i_can_see_their_user_permissions
     expect(page).to have_css('h2', text: 'User permissions')
-    expect(page).to have_css('.govuk-summary-list__row', text: "Manage users\nNo")
-    expect(page).to have_css('.govuk-summary-list__row', text: "Manage organisation permissions\nNo")
-    expect(page).to have_css('.govuk-summary-list__row', text: "Manage interviews\nNo")
-    expect(page).to have_css('.govuk-summary-list__row', text: "Make offers and reject applications\nNo")
-    expect(page).to have_css('.govuk-summary-list__row', text: "View criminal convictions and professional misconduct\nNo")
-    expect(page).to have_css('.govuk-summary-list__row', text: "View sex, disability and ethnicity information\nNo")
+    expect(page).to have_css('.govuk-summary-list__row', text: 'Manage users No')
+    expect(page).to have_css('.govuk-summary-list__row', text: 'Manage organisation permissions No')
+    expect(page).to have_css('.govuk-summary-list__row', text: 'Manage interviews No')
+    expect(page).to have_css('.govuk-summary-list__row', text: 'Make offers and reject applications No')
+    expect(page).to have_css('.govuk-summary-list__row', text: 'View criminal convictions and professional misconduct No')
+    expect(page).to have_css('.govuk-summary-list__row', text: 'View sex, disability and ethnicity information No')
   end
 
   def and_i_can_see_change_links

--- a/spec/system/support_interface/change_offer_conditions_spec.rb
+++ b/spec/system/support_interface/change_offer_conditions_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Add course to submitted application' do
     and_i_visit_the_support_page
 
     when_i_click_on_the_application
-    then_i_should_see_the_current_conditions
+    then_i_see_the_current_conditions
 
     when_i_click_on_change_conditions
     then_i_see_the_condition_edit_form_with_a_warning
@@ -62,8 +62,8 @@ RSpec.feature 'Add course to submitted application' do
     click_link_or_button 'Candy Dayte'
   end
 
-  def then_i_should_see_the_current_conditions
-    expect(page).to have_content("Conditions\nBe cool")
+  def then_i_see_the_current_conditions
+    expect(page).to have_content('Conditions Be cool')
   end
 
   def when_i_click_on_change_conditions
@@ -122,8 +122,6 @@ RSpec.feature 'Add course to submitted application' do
   def then_i_see_that_the_candidate_has_been_recruited_and_conditions_have_been_removed
     expect(page).to have_current_path(support_interface_application_form_path(@application_choice.application_form_id))
     expect(page).to have_content('Recruited')
-    expect(page.all('.govuk-summary-list__row').map(&:text)).to include(
-      "Conditions\nNo conditions added\nChange conditions",
-    )
+    expect(page).to have_css('.govuk-summary-list__row', text: 'Conditions No conditions added Change conditions')
   end
 end

--- a/spec/system/support_interface/change_offer_language_ske_conditions_spec.rb
+++ b/spec/system/support_interface/change_offer_language_ske_conditions_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Add course to submitted application' do
     and_i_visit_the_support_page
 
     when_i_click_on_the_application
-    then_i_should_see_the_current_conditions
+    then_i_see_the_current_conditions
 
     when_i_click_on_change_conditions
     then_i_see_the_condition_edit_form_with_a_warning
@@ -68,8 +68,8 @@ RSpec.feature 'Add course to submitted application' do
     click_link_or_button 'Candy Dayte'
   end
 
-  def then_i_should_see_the_current_conditions
-    expect(page).to have_content("Conditions\nBe cool")
+  def then_i_see_the_current_conditions
+    expect(page).to have_content('Conditions Be cool')
   end
 
   def when_i_click_on_change_conditions
@@ -99,8 +99,8 @@ RSpec.feature 'Add course to submitted application' do
 
   def then_i_see_the_new_ske_conditions
     expect(page).to have_content('Subject knowledge enhancement course')
-    expect(page).to have_content("Length\n8 weeks")
-    expect(page).to have_content("Reason\nTheir degree subject was not German")
+    expect(page).to have_content('Length 8 weeks')
+    expect(page).to have_content('Reason Their degree subject was not German')
   end
 
   def and_i_change_the_length_of_the_ske_condition
@@ -120,8 +120,8 @@ RSpec.feature 'Add course to submitted application' do
 
   def then_i_see_the_updated_ske_condition
     expect(page).to have_content('Subject knowledge enhancement course')
-    expect(page).to have_content("Length\n16 weeks")
-    expect(page).to have_content("Reason\nTheir degree subject was not German")
+    expect(page).to have_content('Length 16 weeks')
+    expect(page).to have_content('Reason Their degree subject was not German')
   end
 
   def and_i_delete_the_ske_condition

--- a/spec/system/support_interface/change_offer_ske_conditions_spec.rb
+++ b/spec/system/support_interface/change_offer_ske_conditions_spec.rb
@@ -72,7 +72,7 @@ RSpec.feature 'Add course to submitted application' do
   end
 
   def then_i_see_the_current_conditions
-    expect(page).to have_content("Conditions\nBe cool")
+    expect(page).to have_content('Conditions Be cool')
   end
 
   def when_i_click_on_change_conditions
@@ -107,8 +107,8 @@ RSpec.feature 'Add course to submitted application' do
 
   def then_i_see_the_new_ske_condition
     expect(page).to have_content('Subject knowledge enhancement course')
-    expect(page).to have_content("Length\n8 weeks")
-    expect(page).to have_content("Reason\nTheir degree subject was not Chemistry")
+    expect(page).to have_content('Length 8 weeks')
+    expect(page).to have_content('Reason Their degree subject was not Chemistry')
   end
 
   def and_i_change_the_length_of_the_ske_condition
@@ -121,8 +121,8 @@ RSpec.feature 'Add course to submitted application' do
 
   def then_i_see_the_updated_ske_condition
     expect(page).to have_content('Subject knowledge enhancement course')
-    expect(page).to have_content("Length\n20 weeks")
-    expect(page).to have_content("Reason\nTheir degree subject was not Chemistry")
+    expect(page).to have_content('Length 20 weeks')
+    expect(page).to have_content('Reason Their degree subject was not Chemistry')
   end
 
   def and_i_delete_the_ske_condition

--- a/spec/system/support_interface/cycle_switching_spec.rb
+++ b/spec/system/support_interface/cycle_switching_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature 'Cycle switching' do
 
   def then_i_see_the_cycle_information
     expect(page).to have_title 'Recruitment cycles'
-    expect(page).to have_content("Find closes on\n#{CycleTimetable.find_closes.to_fs(:govuk_date)}")
+    expect(page).to have_content("Find closes on #{CycleTimetable.find_closes.to_fs(:govuk_date)}")
   end
 
   def when_i_click_to_choose_a_new_schedule
@@ -32,6 +32,6 @@ RSpec.feature 'Cycle switching' do
   end
 
   def then_the_schedule_is_updated
-    expect(page).to have_content("Apply 1 deadline\n#{CycleTimetable.apply_1_deadline.to_fs(:govuk_date)}")
+    expect(page).to have_content("Apply 1 deadline #{CycleTimetable.apply_1_deadline.to_fs(:govuk_date)}")
   end
 end

--- a/spec/system/support_interface/validation_errors_vendor_api_spec.rb
+++ b/spec/system/support_interface/validation_errors_vendor_api_spec.rb
@@ -9,13 +9,13 @@ RSpec.feature 'Validation errors Vendor API' do
     and_vendor_api_requests_for_applications_have_been_made
 
     when_i_navigate_to_the_validation_errors_page
-    then_i_should_see_a_list_of_error_groups
+    then_i_see_a_list_of_error_groups
 
     when_i_click_on_a_group
-    then_i_should_see_a_list_of_individual_errors
+    then_i_see_a_list_of_individual_errors
 
     when_i_click_on_link_in_breadcrumb_trail
-    then_i_should_be_back_on_index_page
+    then_i_am_back_on_index_page
   end
 
   def given_i_am_a_support_user
@@ -41,7 +41,7 @@ RSpec.feature 'Validation errors Vendor API' do
     click_link_or_button 'Vendor API validation errors'
   end
 
-  def then_i_should_see_a_list_of_error_groups
+  def then_i_see_a_list_of_error_groups
     expect(page).to have_content('/api/v1/applications: ParameterInvalid')
     expect(page).to have_content('2')
   end
@@ -50,10 +50,10 @@ RSpec.feature 'Validation errors Vendor API' do
     click_link_or_button('ParameterInvalid')
   end
 
-  def then_i_should_see_a_list_of_individual_errors
+  def then_i_see_a_list_of_individual_errors
     expect(page).to have_content('Showing errors on the ParameterInvalid field in /api/v1/applications by all providers')
-    expect(page).to have_content("Query string:\n\"since=2019-01-012222\"")
-    expect(page).to have_content("Request body:\n{ \"since\": \"2019-01-012222\" }")
+    expect(page).to have_content('Query string: "since=2019-01-012222"')
+    expect(page).to have_content('Request body: { "since": "2019-01-012222" }')
     expect(page).to have_content('/api/v1/applications: ParameterInvalid')
     expect(page).to have_content('Parameter is invalid (should be ISO8601): since')
   end
@@ -62,7 +62,7 @@ RSpec.feature 'Validation errors Vendor API' do
     click_link_or_button 'Vendor API'
   end
 
-  def then_i_should_be_back_on_index_page
+  def then_i_am_back_on_index_page
     expect(page).to have_current_path(support_interface_validation_errors_vendor_api_path)
   end
 end

--- a/spec/system/temporarily_editable_sections_spec.rb
+++ b/spec/system/temporarily_editable_sections_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Unlocking non editable sections temporarily via support' do
+RSpec.describe 'Unlocking non editable sections temporarily via support' do
   include DfESignInHelpers
   include CandidateHelper
 
@@ -122,13 +122,13 @@ RSpec.feature 'Unlocking non editable sections temporarily via support' do
   def then_candidate_can_edit_degrees
     click_link_or_button 'Your details'
     click_link_or_button 'Degree'
+
     expect(page).to have_content('Change country for Bachelor of Science, Rocket, School of Awesomeness, 2020')
     click_link_or_button 'Change country for Bachelor of Science, Rocket, School of Awesomeness, 2020'
     choose 'Another country'
     select 'Brazil', from: 'Country or territory'
     and_i_click_save_and_continue
     expect(page).to have_current_path(candidate_interface_degree_subject_path)
-    expect(page).to have_content('Brazil')
   end
 
   def and_candidate_can_edit_english_gcse
@@ -160,8 +160,9 @@ RSpec.feature 'Unlocking non editable sections temporarily via support' do
     and_i_click_save_and_continue
 
     expect(page).to have_content('Change qualification for GCSE, english')
-    expect(page).to have_content('GradeC (English Single award)')
-    expect(page).to have_content("Year awarded\n2022")
+    expect(page).to have_content('Grade')
+    expect(page).to have_content('C (English Single award)')
+    expect(page).to have_content('Year awarded 2022')
   end
 
   def when_the_editable_time_is_expired
@@ -175,7 +176,7 @@ RSpec.feature 'Unlocking non editable sections temporarily via support' do
     click_link_or_button 'Degree'
     expect(page).to have_no_content('Change')
     visit candidate_interface_degree_country_path
-    and_i_should_be_redirected_to_your_details_page
+    and_i_am_redirected_to_your_details_page
   end
 
   def and_candidate_can_not_edit_english_gcse
@@ -183,20 +184,20 @@ RSpec.feature 'Unlocking non editable sections temporarily via support' do
     click_link_or_button 'English GCSE or equivalent'
     expect(page).to have_no_content('Change')
     visit candidate_interface_edit_gcse_english_grade_path
-    and_i_should_be_redirected_to_your_details_page
+    and_i_am_redirected_to_your_details_page
   end
 
   def and_i_click_save_and_continue
     click_link_or_button 'Save and continue'
   end
 
-  def and_i_should_be_redirected_to_your_details_page
+  def and_i_am_redirected_to_your_details_page
     expect(page).to have_current_path candidate_interface_continuous_applications_details_path
   end
 
   def and_candidate_can_not_delete_degrees
     expect(page).to have_no_content('Delete')
     visit candidate_interface_confirm_degree_destroy_path(@degree)
-    and_i_should_be_redirected_to_your_details_page
+    and_i_am_redirected_to_your_details_page
   end
 end


### PR DESCRIPTION
## Context

System tests run features within the application from end-to-end.

While we write them to be easy to read and understand, it is often invaluable to see the features executed in the browser.

Right now, we need to run the test with the environment variable `HEADLESS=false`

This is not convenient, and we would be much better served by just being able to change the metadata on the example and run the test.

The other blocker for conveniently running features in the browser is the use of the autocomplete libarary and the govuk-components. The normal methods used to interact with these elements when javascript is enabled v disabled mean we can’t run any test involving these elements without updating the test.

Introduce monkey patching to allow these methods to work when javascript is enable or disabled.

## Changes proposed in this pull request

### Overriding `Capybara::Node::Actions` 

https://rubydoc.info/github/teamcapybara/capybara/master/Capybara/Node/Actions

**Add CapybaraRSpecMonkeyPatch**
  This allows system specs to interact successfully with the application
  when javascript is enabled or disabled

**Register Selenium driver for chrome (browser)**
  We now have three options in the metadata for a system spec
  - js: false (or absent :js) => rack_test
  - :js => :chrome_headless
  - :js_browser => :chrome

**Update failing tests**
 - Introduce _Capybara.default_normalize_ws_ to normailze the whitespace
   when running `has_content` or `text` like Capybara methods. This
   replaces \n with a space so they are comparable with and without
   javascript
 - Change _RSpec.feature_ to _RSpec.describe_ for all existing :js tests.
   When a spec has _RSpec.feature_, the metadata is automatically set to
   _type: :feature_. In order for the correct driver to be loaded we need
   those to be _type: :system_.
 - The whole test suite should be changed from _RSpec.feature_ to
   _RSpec.describe_ but that means 300 file changes


 - Added RuboCop to autocorrect RSpec.feature to RSpec.describe in system tests.
## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

[Trello Ticket](https://trello.com/c/HVJGQlVt/1696-make-it-easier-to-run-system-tests-in-the-browser)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
