### PR TITLE
Run Mailer Previews monkey patch after full initialization

### DIFF
--- a/config/initializers/mailer_previews.rb
+++ b/config/initializers/mailer_previews.rb
@@ -1,4 +1,4 @@
-ActiveSupport.on_load(:action_controller, run_once: true) do
+Rails.application.config.after_initialize do
   Rails::MailersController.class_eval do
     include Rails.application.routes.url_helpers
 


### PR DESCRIPTION
## Context

We allow support users in QA environments to view previews of emails. The code that loads these emails sometimes tries to create records in the database. This is not great for the QA environment. 

In the past developers found a way to wrap the preview in a transaction so the creating of records for previews would be rolledback. For some reason the loading of that code has triggered failures while building and loading the application.

The load hook tries to load application code before the application code has been loaded.

The way to solve this is to only run the rollback monkey patch after the application has been fully loaded. There is not reason why this shouldn't be done as far as I can see.

## Changes proposed in this pull request

  Application initialization was failing with missing constant errors
  when the monkey patch of Rails::MailersController was happening after
  action_controller was loaded. This is because the block tried to load
  applciation classes that had not been loaded by the standard
  initialization process.

  We now delay this monkey patch until after_initialization when all
  application code is loaded.


## Guidance to review

I don't know why this has suddenly started happening on some dependabot PRs.

## Link to Trello card

Trello card not required.
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
