### PR TITLE
Remove sentry warnings around subject codes

### DIFF
--- a/app/services/provider_interface/hesa_data_export.rb
+++ b/app/services/provider_interface/hesa_data_export.rb
@@ -71,7 +71,6 @@ module ProviderInterface
     def subject_codes(application)
       hecos_subject_codes = application.course.subject_codes.compact.map do |code|
         mapping = Hesa::SubjectCode.find_by_code(code)
-        Sentry.capture_exception(MissingSubjectCodeHECOSMapping.new("Could not map Subject code: '#{code}' to HECOS code")) if mapping.nil?
 
         mapping
       end

--- a/spec/services/provider_interface/hesa_data_export_spec.rb
+++ b/spec/services/provider_interface/hesa_data_export_spec.rb
@@ -167,13 +167,8 @@ RSpec.describe ProviderInterface::HesaDataExport do
     context 'when there is an unknown subject code' do
       let(:subjects) { [create(:subject, code: 'F3'), create(:subject, code: 'X9'), create(:subject, code: 'missing-value')] }
 
-      before { allow(Sentry).to receive(:capture_exception).with(an_instance_of(described_class::MissingSubjectCodeHECOSMapping)) }
-
-      it 'captures code in Sentry error' do
-        export_row
-        expect(Sentry).to have_received(:capture_exception).with(
-          described_class::MissingSubjectCodeHECOSMapping.new("Could not map Subject code: 'missing-value' to HECOS code"),
-        )
+      it 'ignores unknown subjects' do
+        expect(export_row).to include({ 'SBJCA' => '100425 101277' })
       end
 
       it_behaves_like 'an exported HESA row'


### PR DESCRIPTION
## Context

It is already being 3 years and [many slack sentry errors,](https://dfe-teacher-services.sentry.io/issues/?alert_rule_id=853774&alert_type=issue&notification_uuid=fada980e-4b52-4c6e-9737-04f579debb1e&project=1765973&query=HECOs&referrer=issue-list&statsPeriod=90d) some trello cards being created and never prioritised. 

So removing this warning if no action is taken.

Trello cards that were archived (that I could find):
https://trello.com/c/CxMeS3DB/714-update-hesa-hecos-codes-across-cycles?search_id=2c9c4af1-c701-4a38-b0d0-0ae57aa84278
https://trello.com/c/jVDn39V7/760-sentry-investigate-missing-subject-code-hecos-mapping

## Guidance to review

1. Do you agree to silence this?


I am happy to close this if people disagrees.
