### PR TITLE
[1717] Report data to seeds

### DIFF
--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -30,6 +30,16 @@ task setup_local_dev_data: %i[environment copy_feature_flags_from_production syn
 
   puts 'Finding duplicate applications'
   UpdateDuplicateMatchesWorker.new.perform
+
+  puts 'Creating recruitment performance reports'
+  cycle_week = CycleTimetable.current_cycle_week.pred
+
+  Publications::NationalRecruitmentPerformanceReportWorker.new.perform(cycle_week)
+  Provider.pluck(:id).first(16).each do |provider_id|
+    # Limiting the number of reports generated to 16 -- that's the number of providers we currently create here
+    # But if that changes, we don't want to accidentally hit BigQuery hundreds of times.
+    Publications::ProviderRecruitmentPerformanceReportWorker.new.perform(provider_id, cycle_week)
+  end
 end
 
 desc 'Sync some pilot-enabled providers'


### PR DESCRIPTION
## Context

We have finished the recruitment performance report work. This ticket just adds some reports to the seeds so we have realistic data in our review apps and local development

## Changes proposed in this pull request

Fetch report data when running the rake task `setup_local_dev_data`. This is run from `bin/setup` and when the review apps are created, so that there is data in the seeds and local development environment.

 <img width="755" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/44073106/116680d9-bc0f-401f-8908-2233609b97c4"> |

## Guidance to review

- I'm currently creating reports for all 16 providers in the seeds. Could limit it to just a few providers so the seeds run faster, but it might not be as realistic.
- Run `bin/rails db:drop` and then `bin/setup`. After it is complete, check on the rails console that there are 16 `ProviderRecruitmentPerformanceReport` s and 1 `NationalRecruitmentPerformanceReport`
- In the review app, impersonate a provider user and view reports. 

## Link to Trello card

https://trello.com/c/J71IwctP

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
