### PR TITLE
Add teacher degree apprenticeship filter to Manage

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -58,6 +58,7 @@ class Course < ApplicationRecord
     scitt_programme: 'SC',
     scitt_salaried_programme: 'SSC',
     pg_teaching_apprenticeship: 'TA',
+    teacher_degree_apprenticeship: 'TDA',
   }
 
   enum degree_grade: {

--- a/app/models/provider_interface/provider_applications_filter.rb
+++ b/app/models/provider_interface/provider_applications_filter.rb
@@ -2,6 +2,9 @@ module ProviderInterface
   class ProviderApplicationsFilter
     include FilterParamsHelper
 
+    POSTGRADUATE_COURSES_PARAM_NAME = 'postgraduate_courses'.freeze
+    TEACHER_DEGREE_APPRENTICESHIP_PARAM_NAME = 'teacher_degree_apprenticeship_courses'.freeze
+
     attr_accessor :available_filters, :filter_selections, :provider_user
     attr_reader :applied_filters
 
@@ -104,23 +107,20 @@ module ProviderInterface
     def course_type_filter
       return unless FeatureFlag.active?(:teacher_degree_apprenticeship)
 
-      postgraduate_courses_param_name = 'postgraduate_courses'
-      teacher_degree_apprenticeship_param_name = 'teacher_degree_apprenticeship_courses'
-
       {
         type: :checkboxes,
-        heading: 'Course type',
+        heading: I18n.t('provider_interface.filters.course_type.heading'),
         name: 'course_type',
         options: [
           {
-            value: postgraduate_courses_param_name,
-            label: 'Postgraduate courses',
-            checked: applied_filters[:course_type]&.include?(postgraduate_courses_param_name),
+            value: POSTGRADUATE_COURSES_PARAM_NAME,
+            label: I18n.t('provider_interface.filters.course_type.option_one'),
+            checked: applied_filters[:course_type]&.include?(POSTGRADUATE_COURSES_PARAM_NAME),
           },
           {
-            value: teacher_degree_apprenticeship_param_name,
-            label: 'Teaching degree apprenticeship (TDA) courses',
-            checked: applied_filters[:course_type]&.include?(teacher_degree_apprenticeship_param_name),
+            value: TEACHER_DEGREE_APPRENTICESHIP_PARAM_NAME,
+            label: I18n.t('provider_interface.filters.course_type.option_two'),
+            checked: applied_filters[:course_type]&.include?(TEACHER_DEGREE_APPRENTICESHIP_PARAM_NAME),
           },
         ],
       }

--- a/app/models/provider_interface/provider_applications_filter.rb
+++ b/app/models/provider_interface/provider_applications_filter.rb
@@ -2,8 +2,8 @@ module ProviderInterface
   class ProviderApplicationsFilter
     include FilterParamsHelper
 
-    POSTGRADUATE_COURSES_PARAM_NAME = 'postgraduate_courses'.freeze
-    TEACHER_DEGREE_APPRENTICESHIP_PARAM_NAME = 'teacher_degree_apprenticeship_courses'.freeze
+    POSTGRADUATE_PARAM_NAME = 'postgraduate'.freeze
+    TEACHER_DEGREE_APPRENTICESHIP_PARAM_NAME = 'teacher_degree_apprenticeship'.freeze
 
     attr_accessor :available_filters, :filter_selections, :provider_user
     attr_reader :applied_filters
@@ -113,13 +113,13 @@ module ProviderInterface
         name: 'course_type',
         options: [
           {
-            value: POSTGRADUATE_COURSES_PARAM_NAME,
-            label: I18n.t('provider_interface.filters.course_type.option_one'),
-            checked: applied_filters[:course_type]&.include?(POSTGRADUATE_COURSES_PARAM_NAME),
+            value: POSTGRADUATE_PARAM_NAME,
+            label: I18n.t('provider_interface.filters.course_type.postgraduate'),
+            checked: applied_filters[:course_type]&.include?(POSTGRADUATE_PARAM_NAME),
           },
           {
             value: TEACHER_DEGREE_APPRENTICESHIP_PARAM_NAME,
-            label: I18n.t('provider_interface.filters.course_type.option_two'),
+            label: I18n.t('provider_interface.filters.course_type.teacher_degree_apprenticeship'),
             checked: applied_filters[:course_type]&.include?(TEACHER_DEGREE_APPRENTICESHIP_PARAM_NAME),
           },
         ],

--- a/app/models/provider_interface/provider_applications_filter.rb
+++ b/app/models/provider_interface/provider_applications_filter.rb
@@ -20,7 +20,7 @@ module ProviderInterface
     end
 
     def filters
-      ([] << search_filter << recruitment_cycle_filter << status_filter << provider_filter << accredited_provider_filter << subject_filter << study_modes_filter).concat(provider_locations_filters).compact
+      ([] << search_filter << recruitment_cycle_filter << status_filter << provider_filter << accredited_provider_filter << subject_filter << study_modes_filter << course_type_filter).concat(provider_locations_filters).compact
     end
 
     def filtered?
@@ -44,7 +44,7 @@ module ProviderInterface
   private
 
     def parse_params(params)
-      compact_params(params.permit(:remove, :candidate_name, recruitment_cycle_year: [], provider: [], status: [], accredited_provider: [], provider_location: [], subject: [], study_mode: []).to_h)
+      compact_params(params.permit(:remove, :candidate_name, recruitment_cycle_year: [], provider: [], status: [], accredited_provider: [], provider_location: [], subject: [], study_mode: [], course_type: []).to_h)
     end
 
     def save_filter_state!
@@ -98,6 +98,31 @@ module ProviderInterface
         heading: 'Status',
         name: 'status',
         options: status_options,
+      }
+    end
+
+    def course_type_filter
+      return unless FeatureFlag.active?(:teacher_degree_apprenticeship)
+
+      postgraduate_courses_param_name = 'postgraduate_courses'
+      teacher_degree_apprenticeship_param_name = 'teacher_degree_apprenticeship_courses'
+
+      {
+        type: :checkboxes,
+        heading: 'Course type',
+        name: 'course_type',
+        options: [
+          {
+            value: postgraduate_courses_param_name,
+            label: 'Postgraduate courses',
+            checked: applied_filters[:course_type]&.include?(postgraduate_courses_param_name),
+          },
+          {
+            value: teacher_degree_apprenticeship_param_name,
+            label: 'Teaching degree apprenticeship (TDA) courses',
+            checked: applied_filters[:course_type]&.include?(teacher_degree_apprenticeship_param_name),
+          },
+        ],
       }
     end
 

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -95,7 +95,7 @@ class FilterApplicationChoicesForProviders
     def course_type(application_choices, course_type_filter)
       return application_choices if course_type_filter.blank? || all_course_types?(course_type_filter)
 
-      if course_type_filter.include?('teacher_degree_apprenticeship_courses')
+      if course_type_filter.include?(ProviderInterface::ProviderApplicationsFilter::TEACHER_DEGREE_APPRENTICESHIP_PARAM_NAME)
         application_choices.joins(:current_course).where(current_course: { program_type: 'TDA' })
       else
         application_choices.joins(:current_course).where.not(current_course: { program_type: 'TDA' })
@@ -103,7 +103,7 @@ class FilterApplicationChoicesForProviders
     end
 
     def all_course_types?(course_type_filter)
-      course_type_filter.compact_blank.sort == %w[postgraduate_courses teacher_degree_apprenticeship_courses]
+      course_type_filter.compact_blank.sort == [ProviderInterface::ProviderApplicationsFilter::POSTGRADUATE_PARAM_NAME, ProviderInterface::ProviderApplicationsFilter::TEACHER_DEGREE_APPRENTICESHIP_PARAM_NAME]
     end
 
     def create_filter_query(application_choices, filters)

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -92,6 +92,20 @@ class FilterApplicationChoicesForProviders
       application_choices.where(candidate: { hide_in_reporting: })
     end
 
+    def course_type(application_choices, course_type_filter)
+      return application_choices if course_type_filter.blank? || all_course_types?(course_type_filter)
+
+      if course_type_filter.include?('teacher_degree_apprenticeship_courses')
+        application_choices.joins(:current_course).where(current_course: { program_type: 'TDA' })
+      else
+        application_choices.joins(:current_course).where.not(current_course: { program_type: 'TDA' })
+      end
+    end
+
+    def all_course_types?(course_type_filter)
+      course_type_filter.compact_blank.sort == %w[postgraduate_courses teacher_degree_apprenticeship_courses]
+    end
+
     def create_filter_query(application_choices, filters)
       filtered_application_choices = search(application_choices, filters[:candidate_name])
       filtered_application_choices = recruitment_cycle_year(filtered_application_choices, filters[:recruitment_cycle_year])
@@ -101,6 +115,7 @@ class FilterApplicationChoicesForProviders
       filtered_application_choices = course_subject(filtered_application_choices, filters[:subject])
       filtered_application_choices = study_mode(filtered_application_choices, filters[:study_mode])
       filtered_application_choices = hide_in_reporting(filtered_application_choices, filters[:hide_in_reporting])
+      filtered_application_choices = course_type(filtered_application_choices, filters[:course_type])
       provider_location(filtered_application_choices, filters[:provider_location])
     end
   end

--- a/config/locales/provider_interface/filters.yml
+++ b/config/locales/provider_interface/filters.yml
@@ -1,0 +1,8 @@
+en:
+  provider_interface:
+    filters:
+      course_type:
+        heading: 'Course type'
+        option_one: 'Postgraduate courses'
+        option_two: 'Teaching degree apprenticeship (TDA) courses'
+

--- a/config/locales/provider_interface/filters.yml
+++ b/config/locales/provider_interface/filters.yml
@@ -3,6 +3,6 @@ en:
     filters:
       course_type:
         heading: 'Course type'
-        option_one: 'Postgraduate courses'
-        option_two: 'Teaching degree apprenticeship (TDA) courses'
+        postgraduate: 'Postgraduate courses'
+        teacher_degree_apprenticeship: 'Teaching degree apprenticeship (TDA) courses'
 

--- a/spec/factories/course.rb
+++ b/spec/factories/course.rb
@@ -69,6 +69,15 @@ FactoryBot.define do
       uuid { SecureRandom.uuid }
     end
 
+    trait :teacher_degree_apprenticeship do
+      apprenticeship
+      full_time
+      description { 'Teacher degree apprenticeship with QTS full time teaching apprenticeship' }
+
+      qualifications { %w[qts undergraduate_degree] }
+      program_type { 'teacher_degree_apprenticeship' }
+    end
+
     trait :previous_year do
       recruitment_cycle_year { RecruitmentCycle.previous_year }
     end

--- a/spec/models/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/models/provider_interface/provider_applications_filter_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
     StateStores::RedisStore.new(key: "#{described_class::STATE_STORE_KEY}_#{provider_user.id}")
   end
 
+  before do
+    FeatureFlag.deactivate(:teacher_degree_apprenticeship)
+  end
+
   describe '#filters' do
     let(:headings) { filter.filters.map { |f| f[:heading] } }
     let(:params) { ActionController::Parameters.new }
@@ -65,6 +69,23 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
 
           expect(filter.filters.size).to eq(expected_number_of_filters)
           expect(headings).not_to include('Provider')
+        end
+      end
+
+      context 'when teacher degree apprenticeship feature flag active' do
+        let(:filter) do
+          described_class.new(params:,
+                              provider_user:,
+                              state_store:)
+        end
+
+        before do
+          FeatureFlag.activate(:teacher_degree_apprenticeship)
+        end
+
+        it 'does include the course type filter' do
+          expect(filter.filters.size).to be(7)
+          expect(headings).to include('Course type')
         end
       end
     end

--- a/spec/system/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/system/provider_interface/provider_applications_filter_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'Providers should be able to filter applications' do
     and_i_am_permitted_to_see_applications_from_multiple_providers
     and_my_organisation_has_courses_with_applications
     and_i_sign_in_to_the_provider_interface
+    and_teacher_degree_apprenticeship_feature_flag_is_inactive
 
     when_i_visit_the_provider_page
 
@@ -145,6 +146,10 @@ RSpec.describe 'Providers should be able to filter applications' do
 
   def and_teacher_degree_apprenticeship_feature_flag_is_active
     FeatureFlag.activate(:teacher_degree_apprenticeship)
+  end
+
+  def and_teacher_degree_apprenticeship_feature_flag_is_inactive
+    FeatureFlag.deactivate(:teacher_degree_apprenticeship)
   end
 
   def and_my_organisation_has_courses_with_applications_without_accredited_providers

--- a/spec/system/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/system/provider_interface/provider_applications_filter_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Providers should be able to filter applications' do
+RSpec.describe 'Providers should be able to filter applications' do
   include CourseOptionHelpers
   include DfESignInHelpers
 
@@ -26,27 +26,29 @@ RSpec.feature 'Providers should be able to filter applications' do
 
     then_i_expect_to_see_the_filter_dialogue
 
-    then_i_location_filters_should_not_be_visible
+    then_location_filters_are_not_visible
 
     then_i_can_see_applications_from_the_previous_year_too
 
+    and_teacher_degree_apprenticeship_filter_is_not_visible
+
     when_i_filter_for_rejected_applications
-    then_only_rejected_applications_should_be_visible
-    and_a_rejected_tag_should_be_visible
-    and_the_rejected_tickbox_should_still_be_checked
+    then_only_rejected_applications_are_visible
+    and_a_rejected_tag_is_visible
+    and_the_rejected_tickbox_is_checked
 
     when_i_filter_for_applications_that_i_do_not_have
-    then_i_should_see_the_no_filter_results_error_message
+    then_i_see_the_no_filter_results_error_message
     then_i_expect_to_see_the_filter_dialogue
 
     when_i_filter_for_rejected_and_offered_applications
-    then_only_rejected_and_offered_applications_should_be_visible
+    then_only_rejected_and_offered_applications_are_visible
 
     when_i_clear_the_filters
     then_i_expect_all_applications_to_be_visible
 
     when_i_filter_by_providers
-    then_location_filters_should_be_visible
+    then_location_filters_are_visible
     then_i_only_see_applications_for_a_given_provider
     then_i_expect_the_relevant_provider_tags_to_be_visible
 
@@ -61,11 +63,11 @@ RSpec.feature 'Providers should be able to filter applications' do
     when_i_click_to_remove_an_accredited_provider_tag
 
     when_i_filter_by_providers
-    then_i_should_see_locations_that_belong_to_all_of_the_selected_providers_that_have_more_than_one_site
+    then_i_see_locations_that_belong_to_all_of_the_selected_providers_that_have_more_than_one_site
 
     when_i_clear_the_filters
     when_i_filter_by_a_specific_provider
-    then_i_should_only_see_locations_that_belong_to_that_provider
+    then_i_only_see_locations_that_belong_to_that_provider
 
     when_i_filter_by_provider_location
     then_i_only_see_applications_for_that_provider_location
@@ -116,8 +118,33 @@ RSpec.feature 'Providers should be able to filter applications' do
     and_i_click_the_sign_out_button
   end
 
+  scenario 'when teacher degree apprenticeship is active' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_teacher_degree_apprenticeship_feature_flag_is_active
+    and_i_am_permitted_to_see_applications_from_multiple_providers
+    and_my_organisation_has_courses_with_applications_without_accredited_providers
+    and_my_organisation_has_courses_that_awards_a_degree
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_visit_the_provider_page
+    then_teacher_degree_apprenticeship_filter_is_visible
+
+    when_i_filter_by_postgraduate_courses
+    then_i_only_see_postgraduate_applications
+
+    when_i_filter_by_teacher_degree_apprenticeship_courses
+    then_i_only_see_teacher_degree_apprenticeship_applications
+
+    when_i_check_both_course_types_filter
+    then_i_see_postgraduate_and_teacher_degree_apprenticeship_applications
+  end
+
   def and_i_click_the_sign_out_button
     click_link_or_button 'Sign out'
+  end
+
+  def and_teacher_degree_apprenticeship_feature_flag_is_active
+    FeatureFlag.activate(:teacher_degree_apprenticeship)
   end
 
   def and_my_organisation_has_courses_with_applications_without_accredited_providers
@@ -136,26 +163,62 @@ RSpec.feature 'Providers should be able to filter applications' do
            build(:application_form, first_name: 'Greg', last_name: 'Taft'), updated_at: 4.days.ago)
   end
 
+  def and_my_organisation_has_courses_that_awards_a_degree
+    course_option_one = course_option_for_provider(provider: current_provider,
+                                                   site:,
+                                                   course: build(:course,
+                                                                 :teacher_degree_apprenticeship,
+                                                                 name: 'Alchemy',
+                                                                 provider: current_provider))
+
+    course_option_two = course_option_for_provider(provider: second_provider, course: build(:course, :teacher_degree_apprenticeship, name: 'Science', provider: second_provider))
+
+    course_option_three = course_option_for_provider(provider: second_provider, course: build(:course, :teacher_degree_apprenticeship, name: 'Biology', provider: second_provider))
+
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_one, status: 'withdrawn', application_form:
+           build(:application_form, first_name: 'Andres', last_name: 'Bartell'), updated_at: 5.days.ago)
+
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_two, status: 'offer', application_form:
+           build(:application_form, first_name: 'Quinton', last_name: 'Marks'), updated_at: 4.days.ago)
+
+    create(:application_choice, :awaiting_provider_decision, current_course_option: course_option_three, status: 'offer', application_form:
+           build(:application_form, first_name: 'Leland', last_name: 'Harris'), updated_at: 4.days.ago)
+  end
+
+  def and_teacher_degree_apprenticeship_filter_is_not_visible
+    expect(page).to have_content('Filter')
+    expect(page).to have_no_content('Course type')
+    expect(page).to have_no_content('Postgraduate courses')
+    expect(page).to have_no_content('Teaching degree apprenticeship (TDA) courses')
+  end
+
+  def then_teacher_degree_apprenticeship_filter_is_visible
+    expect(page).to have_content('Filter')
+    expect(page).to have_content('Course type')
+    expect(page).to have_content('Postgraduate courses')
+    expect(page).to have_content('Teaching degree apprenticeship (TDA) courses')
+  end
+
   def then_i_do_not_expect_to_see_the_accredited_providers_filter_heading
     expect(page).to have_content('Filter')
     expect(page).to have_no_content('Accredited provider')
   end
 
-  def then_i_should_see_locations_that_belong_to_all_of_the_selected_providers_that_have_more_than_one_site
+  def then_i_see_locations_that_belong_to_all_of_the_selected_providers_that_have_more_than_one_site
     expect(page).to have_content('Locations for Hoth Teacher Training')
     expect(page).to have_content('Locations for Caladan University')
     expect(page).to have_no_content('Locations for University of Arrakis')
   end
 
-  def then_i_should_only_see_locations_that_belong_to_that_provider
+  def then_i_only_see_locations_that_belong_to_that_provider
     expect(page).to have_no_content('Locations for Caladan University')
   end
 
-  def then_location_filters_should_be_visible
+  def then_location_filters_are_visible
     expect(page).to have_content('Locations for')
   end
 
-  def then_i_location_filters_should_not_be_visible
+  def then_location_filters_are_not_visible
     expect(page).to have_no_content('Locations for')
   end
 
@@ -167,7 +230,48 @@ RSpec.feature 'Providers should be able to filter applications' do
 
   def when_i_filter_by_provider_location
     find_by_id("provider_location-#{site.provider_id}_#{site.name}_#{site.code}").set(true)
-    click_link_or_button('Apply filters')
+    and_i_apply_the_filters
+  end
+
+  def when_i_filter_by_postgraduate_courses
+    check 'Postgraduate courses'
+    and_i_apply_the_filters
+  end
+
+  def then_i_only_see_postgraduate_applications
+    expect(page).to have_content('Jim James')
+    expect(page).to have_content('Greg Taft')
+    expect(page).to have_no_content('Andres Bartell')
+    expect(page).to have_no_content('Quinton Marks')
+    expect(page).to have_no_content('Leland Harris')
+  end
+
+  def when_i_filter_by_teacher_degree_apprenticeship_courses
+    uncheck 'Postgraduate courses'
+    check 'Teaching degree apprenticeship (TDA) courses'
+    and_i_apply_the_filters
+  end
+
+  def then_i_only_see_teacher_degree_apprenticeship_applications
+    expect(page).to have_content('Andres Bartell')
+    expect(page).to have_content('Quinton Marks')
+    expect(page).to have_content('Leland Harris')
+    expect(page).to have_no_content('Jim James')
+    expect(page).to have_no_content('Greg Taft')
+  end
+
+  def when_i_check_both_course_types_filter
+    check 'Postgraduate courses'
+    check 'Teaching degree apprenticeship (TDA) courses'
+    and_i_apply_the_filters
+  end
+
+  def then_i_see_postgraduate_and_teacher_degree_apprenticeship_applications
+    expect(page).to have_content('Andres Bartell')
+    expect(page).to have_content('Quinton Marks')
+    expect(page).to have_content('Leland Harris')
+    expect(page).to have_content('Jim James')
+    expect(page).to have_content('Greg Taft')
   end
 
   def and_i_expect_the_relevant_provider_location_tags_to_be_visible
@@ -262,7 +366,7 @@ RSpec.feature 'Providers should be able to filter applications' do
     click_link_or_button('Apply filters')
   end
 
-  def then_only_rejected_applications_should_be_visible
+  def then_only_rejected_applications_are_visible
     expect(page).to have_css('.app-application-cards', text: 'Rejected')
     expect(page).to have_no_css('.app-application-cards', text: 'Offer')
     expect(page).to have_no_css('.app-application-cards', text: 'Application withdrawn')
@@ -270,7 +374,7 @@ RSpec.feature 'Providers should be able to filter applications' do
     expect(page).to have_no_css('.app-application-cards', text: 'Offer withdrawn')
   end
 
-  def and_the_rejected_tickbox_should_still_be_checked
+  def and_the_rejected_tickbox_is_checked
     rejected_checkbox = find_by_id('status-rejected')
     expect(rejected_checkbox.checked?).to be(true)
   end
@@ -281,7 +385,7 @@ RSpec.feature 'Providers should be able to filter applications' do
     click_link_or_button('Apply filters')
   end
 
-  def then_i_should_see_the_no_filter_results_error_message
+  def then_i_see_the_no_filter_results_error_message
     expect(page).to have_content('There are no results for the selected filter.')
   end
 
@@ -292,7 +396,7 @@ RSpec.feature 'Providers should be able to filter applications' do
     click_link_or_button('Apply filters')
   end
 
-  def then_only_rejected_and_offered_applications_should_be_visible
+  def then_only_rejected_and_offered_applications_are_visible
     expect(page).to have_css('.app-application-cards', text: 'Rejected')
     expect(page).to have_css('.app-application-cards', text: 'Offer')
     expect(page).to have_no_css('.app-application-cards', text: 'Application withdrawn')
@@ -361,7 +465,7 @@ RSpec.feature 'Providers should be able to filter applications' do
     expect(page).to have_css('.app-application-cards', text: 'Caladan University')
   end
 
-  def and_a_rejected_tag_should_be_visible
+  def and_a_rejected_tag_is_visible
     expect(page).to have_css('.moj-filter-tags', text: 'Rejected')
   end
 
@@ -373,5 +477,9 @@ RSpec.feature 'Providers should be able to filter applications' do
     expect(page).to have_content('Adam Jones')
     expect(page).to have_content('Tom Jones')
     expect(page).to have_content('Jim James')
+  end
+
+  def and_i_apply_the_filters
+    click_link_or_button('Apply filters')
   end
 end

--- a/spec/system/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/system/provider_interface/provider_applications_filter_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe 'Providers should be able to filter applications' do
     and_i_click_the_sign_out_button
   end
 
-  scenario 'when teacher degree apprenticeship is active' do
+  scenario 'when the teacher degree apprenticeship feature flag is active' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_teacher_degree_apprenticeship_feature_flag_is_active
     and_i_am_permitted_to_see_applications_from_multiple_providers


### PR DESCRIPTION
## Context

We need to make changes to Manage to allow providers to view applications with the a new type “Teacher degree apprenticeship (TDA) with QTS”.

## Changes proposed in this pull request

<img width="315" alt="Screenshot 2024-05-28 at 16 17 36" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/27509/00a38dfc-ba33-4cab-a28f-4e56f31636d9">


* Added a new filter for TDA courses (when apply the filters when user select)

```
Course type

[ ] Postgraduate courses
[ ] Teaching degree apprenticeship (TDA) courses
```

## Guidance to review

If you want to test:

1. Enable the feature flag in the review app
2. Create a TDA course (see spec/factories/course trait TDA)
3. Apply for a TDA course
4. Then filter for TDA and non TDA applications in Manage

## Trello card 

https://trello.com/c/HIsIqv1q/1728-add-filters-to-manage-for-tda