### PR TITLE
Don't log email subjects

### DIFF
--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -10,3 +10,5 @@ shared:
     - dfe_sign_in_uid
   validation_errors:
     - user_id
+  emails:
+    - subject

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -20,5 +20,6 @@ SANITIZED_REQUEST_PARAMS = %i[
   password
   phone_number
   postcode
+  subject
 ].freeze
 Rails.application.config.filter_parameters += SANITIZED_REQUEST_PARAMS

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -25,7 +25,7 @@ class CustomLogFormatter < SemanticLogger::Formatters::Raw
     end
 
     if hash['payload'].present?
-      hash['payload'].reject! { |key, _| SANITIZED_REQUEST_PARAMS.include?(key.to_sym) }
+      hash['payload'].reject! { |key, _| SANITIZED_REQUEST_PARAMS.map(&:to_s).include?(key) }
     end
 
     # Remove post parameters if it's a PUT, POST, or PATCH request

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -24,6 +24,10 @@ class CustomLogFormatter < SemanticLogger::Formatters::Raw
       hash['ctx'] = ctx
     end
 
+    if hash['payload'].present?
+      hash['payload'].reject! { |key, _| SANITIZED_REQUEST_PARAMS.include?(key.to_sym) }
+    end
+
     # Remove post parameters if it's a PUT, POST, or PATCH request
     if method_is_post_or_put_or_patch? && hash.dig(:payload, :params).present?
       hash[:payload][:params].clear


### PR DESCRIPTION
## Context

DfE Analytics gem creates records when Emails are created. The data stored by the Analytics gem includes the Subject field of the email. These subject fields often include the Candidate’s full name.

This has been noticed as these records also generate a log entry on the application, which also contain the PII.

There may be other instances of PII appearing in the application logs, when Audit records are created for example.

When:

* MailDeliveryJob enqueues the job in Sidekiq
* When DfE::Analytics sends the new email to Bigquery

## Changes

Make sure those are not logged.

## Review

1. Is it working?

## Trello

https://trello.com/c/lSivlx8Z/1737-remove-pii-from-logs?filter=label:Squad%20B,label:Squad%20Unassigned