### PR TITLE
Bugfix for `equality_and_diversity` HESA codes

### DIFF
--- a/app/lib/hesa/ethnicity.rb
+++ b/app/lib/hesa/ethnicity.rb
@@ -24,7 +24,7 @@ module Hesa
         'Irish' => HesaEthnicityValues::WHITE_IRISH,
         'Roma' => HesaEthnicityValues::WHITE_ROMA,
         'Irish Traveller or Gypsy' => HesaEthnicityValues::GYPSY_OR_TRAVELLER,
-        'Another White background' => HesaEthnicityValues::WHITE,
+        'Another White background' => HesaEthnicityValues::OTHER_WHITE,
         'Prefer not to say' => HesaEthnicityValues::INFORMATION_REFUSED,
         'Bangladeshi' => HesaEthnicityValues::BANGLADESHI,
         'Chinese' => HesaEthnicityValues::CHINESE,

--- a/spec/forms/candidate_interface/equality_and_diversity/ethnic_background_form_spec.rb
+++ b/spec/forms/candidate_interface/equality_and_diversity/ethnic_background_form_spec.rb
@@ -119,6 +119,22 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm, t
         )
       end
     end
+
+    context 'regression other white ethnicity' do
+      let(:application_form) { build(:application_form, equality_and_diversity: { 'ethnic_group' => 'White' }) }
+
+      it 'updates the application form with the white ethnic background value if other background is not provided' do
+        form = described_class.new(ethnic_background: 'Another White background', other_background: nil)
+
+        form.save(application_form)
+
+        expect(application_form.equality_and_diversity).to eq(
+          'ethnic_group' => 'White',
+          'ethnic_background' => 'Another White background',
+          'hesa_ethnicity' => '179',
+        )
+      end
+    end
   end
 
   describe 'validations' do


### PR DESCRIPTION
## Context

HESA Ethnicity code are not being set correctly for 'Another White background' in `ApplicationForm#equality_and_diversity`.

When a candidate chooses "White" for Ethnic group.
Then they choose "Another White background" for Ethnic background, the wrong values are being saved to the `ApplicationForm`.


## Changes proposed in this pull request

Map the 'Another White background' value to '179' `OTHER_WHITE` ethnicity.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

[Trello Ticket](https://trello.com/c/EonWpMIa/1746-bug-chosing-other-white-in-equality-and-diversity-section-should-have-hesa-code-179-not-160)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
