### PR TITLE
Include a content in degree section when viewing a TDA course

### DIFF
--- a/app/components/shared/qualifications_component.html.erb
+++ b/app/components/shared/qualifications_component.html.erb
@@ -1,12 +1,18 @@
 <section class="app-section">
   <h2 class="govuk-heading-m govuk-!-font-size-27" id="qualifications">Qualifications</h2>
 
-  <%= render DegreeQualificationCardsComponent.new(
-    application_form.application_qualifications.degrees,
-    application_choice_state: application_choice_state,
-    show_hesa_codes: show_hesa_codes,
-    editable: editable?,
-  ) %>
+  <% if render_degrees? %>
+    <%= render DegreeQualificationCardsComponent.new(
+      application_form.application_qualifications.degrees,
+      application_choice_state: application_choice_state,
+      show_hesa_codes: show_hesa_codes,
+      editable: editable?,
+    ) %>
+  <% else %>
+    <h3 class="govuk-heading-m" id="degrees">Degree</h3>
+
+    <p class="govuk-body">A degree is not required for a teacher degree apprenticeship (TDA).</p>
+  <% end %>
   <%= render GcseQualificationCardsComponent.new(application_form, editable: editable?) %>
   <%= render QualificationsTableComponent.new(qualifications: application_form.application_qualifications.other, header: 'A levels and other qualifications', subheader: 'Details of A levels and other qualifications', editable: editable?) %>
   <%= render EflQualificationCardComponent.new(application_form) %>

--- a/app/components/shared/qualifications_component.rb
+++ b/app/components/shared/qualifications_component.rb
@@ -6,13 +6,27 @@ class QualificationsComponent < ViewComponent::Base
 
   alias show_hesa_codes? show_hesa_codes
 
-  def initialize(application_form:, application_choice_state: nil, show_hesa_codes: false)
+  def initialize(application_form:, application_choice: nil, show_hesa_codes: false)
     @application_form = application_form
-    @application_choice_state = application_choice_state
+    @application_choice = application_choice
+    @application_choice_state = application_choice&.status
     @show_hesa_codes = show_hesa_codes
   end
 
   def editable?
     application_form.editable? && current_namespace == 'support_interface'
+  end
+
+  def render_degrees?
+    support_interface? ||
+      (provider_interface? && @application_choice.present? && !@application_choice.teacher_degree_apprenticeship?)
+  end
+
+  def support_interface?
+    current_namespace == 'support_interface'
+  end
+
+  def provider_interface?
+    current_namespace == 'provider_interface'
   end
 end

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -274,6 +274,8 @@ class ApplicationChoice < ApplicationRecord
     days_since_calculation(offered_at)
   end
 
+  delegate :teacher_degree_apprenticeship?, to: :current_course
+
 private
 
   def days_since_calculation(date_field)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -58,6 +58,7 @@ class Course < ApplicationRecord
     scitt_programme: 'SC',
     scitt_salaried_programme: 'SSC',
     pg_teaching_apprenticeship: 'TA',
+    teacher_degree_apprenticeship: 'TDA',
   }
 
   enum degree_grade: {

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -73,7 +73,7 @@
 
 <%= render WorkHistoryAndUnpaidExperienceComponent.new(application_form: @application_choice.application_form) %>
 
-<%= render QualificationsComponent.new(application_form: @application_choice.application_form, application_choice_state: @application_choice.status) %>
+<%= render QualificationsComponent.new(application_form: @application_choice.application_form, application_choice: @application_choice) %>
 
 <%= render LanguageSkillsComponent.new(application_form: @application_choice.application_form) %>
 

--- a/spec/components/shared/qualifications_component_spec.rb
+++ b/spec/components/shared/qualifications_component_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe QualificationsComponent, type: :component do
+  let(:application_form) { instance_double(ApplicationForm, editable?: true) }
+  let(:application_choice) { instance_double(ApplicationChoice, status: 'accepted', teacher_degree_apprenticeship?: false) }
+  let(:show_hesa_codes) { false }
+  let(:component) { described_class.new(application_form: application_form, application_choice: application_choice, show_hesa_codes: show_hesa_codes) }
+
+  describe '#editable?' do
+    context 'when the form is editable and in support interface' do
+      before do
+        allow(component).to receive(:current_namespace).and_return('support_interface')
+      end
+
+      it 'returns true' do
+        expect(component).to be_editable
+      end
+    end
+
+    context 'when the form is not editable' do
+      let(:application_form) { instance_double(ApplicationForm, editable?: false) }
+
+      it 'returns false' do
+        expect(component).not_to be_editable
+      end
+    end
+
+    context 'when not in support interface' do
+      before do
+        allow(component).to receive(:current_namespace).and_return('provider_interface')
+      end
+
+      it 'returns false' do
+        expect(component).not_to be_editable
+      end
+    end
+  end
+
+  describe '#render_degrees?' do
+    context 'when in support interface' do
+      before do
+        allow(component).to receive(:current_namespace).and_return('support_interface')
+      end
+
+      it 'returns true' do
+        expect(component.render_degrees?).to be true
+      end
+    end
+
+    context 'when in provider interface and application_choice is present and not a teacher degree apprenticeship' do
+      before do
+        allow(component).to receive(:current_namespace).and_return('provider_interface')
+      end
+
+      it 'returns true' do
+        expect(component.render_degrees?).to be true
+      end
+    end
+
+    context 'when in provider interface and application_choice is nil' do
+      let(:application_choice) { nil }
+
+      before do
+        allow(component).to receive(:current_namespace).and_return('provider_interface')
+      end
+
+      it 'returns false' do
+        expect(component.render_degrees?).to be false
+      end
+    end
+
+    context 'when in provider interface and application_choice is a teacher degree apprenticeship' do
+      let(:application_choice) { instance_double(ApplicationChoice, status: 'accepted', teacher_degree_apprenticeship?: true) }
+
+      before do
+        allow(component).to receive(:current_namespace).and_return('provider_interface')
+      end
+
+      it 'returns false' do
+        expect(component.render_degrees?).to be false
+      end
+    end
+  end
+end

--- a/spec/factories/course.rb
+++ b/spec/factories/course.rb
@@ -69,6 +69,15 @@ FactoryBot.define do
       uuid { SecureRandom.uuid }
     end
 
+    trait :teacher_degree_apprenticeship do
+      apprenticeship
+      full_time
+      description { 'Teacher degree apprenticeship with QTS full time teaching apprenticeship' }
+
+      qualifications { %w[qts undergraduate_degree] }
+      program_type { 'teacher_degree_apprenticeship' }
+    end
+
     trait :previous_year do
       recruitment_cycle_year { RecruitmentCycle.previous_year }
     end

--- a/spec/system/provider_interface/provider_views_a_teacher_degree_apprenticeship_application_spec.rb
+++ b/spec/system/provider_interface/provider_views_a_teacher_degree_apprenticeship_application_spec.rb
@@ -1,0 +1,122 @@
+require 'rails_helper'
+
+RSpec.describe 'A Provider user views a teacher degree apprenticeship application' do
+  include DfESignInHelpers
+
+  let(:provider_user) { create(:provider_user, :with_dfe_sign_in) }
+  let(:provider) { provider_user.providers.first }
+
+  before do
+    FeatureFlag.activate(:teacher_degree_apprenticeship)
+  end
+
+  scenario 'does not see degrees when application is teacher degree apprenticeship without degrees' do
+    given_i_am_a_provider_user
+    and_i_sign_in_to_the_provider_interface
+    and_i_have_submitted_applications
+
+    when_i_visit_the_provider_interface
+    and_i_visit_a_teacher_degree_apprenticeship_application
+
+    then_i_see_a_message_on_the_degree_section
+    and_i_do_not_see_the_degrees_of_the_candidate
+  end
+
+  scenario 'does not see degrees when application is teacher degree apprenticeship with degrees' do
+    given_i_am_a_provider_user
+    and_i_sign_in_to_the_provider_interface
+    and_i_have_submitted_applications
+    and_the_application_has_degrees
+
+    when_i_visit_the_provider_interface
+    and_i_visit_a_teacher_degree_apprenticeship_application
+
+    then_i_see_a_message_on_the_degree_section
+    and_i_do_not_see_the_degrees_of_the_candidate
+  end
+
+  scenario 'does see the degrees section when the application is postgraduate' do
+    given_i_am_a_provider_user
+    and_i_sign_in_to_the_provider_interface
+    and_i_have_submitted_applications
+
+    when_i_visit_the_provider_interface
+    and_i_visit_a_postgraduate_application
+
+    then_i_dont_see_a_message_on_the_degree_section
+    and_i_see_the_degrees_of_the_candidate
+  end
+
+  def given_i_am_a_provider_user
+    user_exists_in_dfe_sign_in(email_address: provider_user.email_address)
+  end
+
+  def and_i_sign_in_to_the_provider_interface
+    provider_signs_in_using_dfe_sign_in
+  end
+
+  def when_i_visit_the_provider_interface
+    visit provider_interface_applications_path
+  end
+
+  def and_i_have_submitted_applications
+    @teacher_degree_apprenticeship_application_form = create(:application_form)
+    @postgraduate_application_form = create(:application_form, :with_bachelor_degree)
+    teacher_degree_apprenticeship_course = create(:course, :teacher_degree_apprenticeship, :open, provider:)
+    postgraduate_course = create(:course, :open, provider:)
+
+    @teacher_degree_apprenticeship_application = create(
+      :application_choice,
+      :awaiting_provider_decision,
+      course_option: create(:course_option, course: teacher_degree_apprenticeship_course),
+      application_form: @teacher_degree_apprenticeship_application_form,
+    )
+
+    @postgraduate_application = create(
+      :application_choice,
+      :awaiting_provider_decision,
+      course_option: create(:course_option, course: postgraduate_course),
+      application_form: @postgraduate_application_form,
+    )
+  end
+
+  def and_the_application_has_degrees
+    create(:degree_qualification, :bachelor, application_form: @teacher_degree_apprenticeship_application_form)
+  end
+
+  def and_i_visit_a_teacher_degree_apprenticeship_application
+    visit provider_interface_application_choice_path(@teacher_degree_apprenticeship_application)
+  end
+
+  def and_i_visit_a_postgraduate_application
+    visit provider_interface_application_choice_path(@postgraduate_application)
+  end
+
+  def and_teacher_degree_apprenticeship_feature_flag_is_inactive
+    FeatureFlag.deactivate(:teacher_degree_apprenticeship)
+  end
+
+  def then_i_see_a_message_on_the_degree_section
+    expect(page).to have_content('A degree is not required for a teacher degree apprenticeship (TDA)')
+  end
+
+  def then_i_dont_see_a_message_on_the_degree_section
+    expect(page).to have_no_content('A degree is not required for a teacher degree apprenticeship (TDA)')
+  end
+
+  def and_i_see_the_degrees_of_the_candidate
+    expect(@postgraduate_application_form.application_qualifications.degrees.count).to be 1
+
+    @postgraduate_application_form.application_qualifications.degrees.each do |degree|
+      expect(page).to have_content(degree.subject)
+      expect(page).to have_content(degree.institution_name)
+    end
+  end
+
+  def and_i_do_not_see_the_degrees_of_the_candidate
+    @teacher_degree_apprenticeship_application_form.application_qualifications.degrees.each do |degree|
+      expect(page).to have_no_content(degree.subject)
+      expect(page).to have_no_content(degree.institution_name)
+    end
+  end
+end


### PR DESCRIPTION

## Context

Always display a “Degree” heading even when no degree is entered, and include the following body copy under the heading when viewing TDA applications:

`A degree is not required for a teacher degree apprenticeship (TDA).`

Otherwise show the normal degree section.


Additional change: Add more coverage to the qualifications component by adding the missing test file.

## Guidance to review

If you wanna to take a look on the review app:

1. Enable the TDA feature flag
2. Create a TDA course (program_type "teacher_degree_apprenticeship")
3. Apply for the TDA course
4. See in Manage

## Link to Trello card

https://trello.com/c/QnKvueiI/1729-add-degree-content-when-application-is-from-a-tda-course?filter=label:Squad%20B,label:Squad%20Unassigned
