### PR TITLE
Add a BigQuery maintenance window

### DIFF
--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -49,4 +49,8 @@ DfE::Analytics.configure do |config|
   # to all events we send to BigQuery.
   #
   config.environment = HostingEnvironment.environment_name
+
+  # Schedule a maintenance window during which no events are streamed to BigQuery
+  # in the format of '22-01-2024 19:30..22-01-2024 20:30' (UTC).
+  config.bigquery_maintenance_window = '05-06-2024 18:15..05-06-2024 18:30'
 end


### PR DESCRIPTION
## Context

This allows the Data Insights team to perform some maintenance on live streamed tables in BigQuery.

Any events to be sent to BigQuery are queued up in Redis and sent after the maintenance window is over.

Requires dfe_analytics GEM Versions >= 1.12.7

## Changes proposed in this pull request

Proposed time: 05-06-2024 18:15 - 18:30 UTC

Please note that UTC is 1 hour behind of BST.

Link to trello card: https://trello.com/c/OLgfjgl9

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
