### PR TITLE
Testing old zendesk chat for accesibility

### DIFF
--- a/app/views/shared/_zendesk_snippet.html.erb
+++ b/app/views/shared/_zendesk_snippet.html.erb
@@ -4,6 +4,6 @@
   <script
     id="ze-snippet"
     nonce="<%= request.content_security_policy_nonce %>"
-    src=https://static.zdassets.com/ekr/snippet.js?key=904d04ae-8027-4ebb-ad39-d0e9f68d6ab1>
+    src=https://static.zdassets.com/ekr/snippet.js?key=f67490d3-7167-4d1c-83cf-3c9d486d85e1>
   </script>
 <% end %>


### PR DESCRIPTION
This sends messages to a new test channel setup in zendesk to not send messages to the live support team.

