### PR TITLE
Make sure candidates dont see an error when GIT API returns an error

### DIFF
--- a/app/services/adviser/candidate_matchback.rb
+++ b/app/services/adviser/candidate_matchback.rb
@@ -8,11 +8,12 @@ class Adviser::CandidateMatchback
   def matchback
     @matchback ||= begin
       api = GetIntoTeachingApiClient::TeacherTrainingAdviserApi.new
-      Adviser::APIModelDecorator.new(api.matchback_candidate(existing_candidate_request))
-    rescue GetIntoTeachingApiClient::ApiError => e
+      response = api.matchback_candidate(existing_candidate_request)
+      Adviser::APIModelDecorator.new(response)
+    rescue StandardError => e
       #  A 404 not found is returned when the matchback is unsuccessful,
       # indicating that the candidate does not exist in the GiT API.
-      raise unless e.code == 404
+      raise unless e.respond_to?(:code) && e.code == 404
 
       nil
     end

--- a/app/services/adviser/sign_up_availability.rb
+++ b/app/services/adviser/sign_up_availability.rb
@@ -38,7 +38,8 @@ private
     return false unless feature_active?
 
     refresh_adviser_status_from_git_api
-  rescue GetIntoTeachingApiClient::ApiError => e
+  rescue StandardError => e
+    Sentry.capture_message('GIT API has returned an error. This error is only logged into Sentry and the candidate is not seeing an error page. But the teacher training advisor feature was not active for this request due to this error. It is recommend to contact the GIT team on #twd_git_bat')
     Sentry.capture_exception(e)
 
     false

--- a/spec/services/adviser/candidate_matchback_spec.rb
+++ b/spec/services/adviser/candidate_matchback_spec.rb
@@ -35,8 +35,14 @@ RSpec.describe Adviser::CandidateMatchback do
       expect(candidate_matchback.matchback).to be_nil
     end
 
-    it 're-raises when the API responds with any other error' do
+    it 're-raises when the API responds with error' do
       error = GetIntoTeachingApiClient::ApiError.new(code: 500)
+      allow(api_double).to receive(:matchback_candidate).with(existing_candidate_request).and_raise(error)
+      expect { candidate_matchback.matchback }.to raise_error(error)
+    end
+
+    it 're-raises when the API responds with any other error' do
+      error = Faraday::Error.new('Some error')
       allow(api_double).to receive(:matchback_candidate).with(existing_candidate_request).and_raise(error)
       expect { candidate_matchback.matchback }.to raise_error(error)
     end

--- a/spec/services/adviser/sign_up_availability_spec.rb
+++ b/spec/services/adviser/sign_up_availability_spec.rb
@@ -35,9 +35,29 @@ RSpec.describe Adviser::SignUpAvailability do
 
       it 'captures the exception' do
         allow(Sentry).to receive(:capture_exception)
+        allow(Sentry).to receive(:capture_message)
 
         precheck_method_under_test
 
+        expect(Sentry).to have_received(:capture_message)
+        expect(Sentry).to have_received(:capture_exception).with(error)
+      end
+    end
+
+    context 'when the candidate cannot be retrieved because other errors' do
+      let(:error) { Faraday::Error.new('Some error') }
+
+      before { allow(candidate_matchback_double).to receive(:matchback).and_raise(error) }
+
+      it { expect(precheck_method_under_test).to be(false) }
+
+      it 'captures the exception' do
+        allow(Sentry).to receive(:capture_exception)
+        allow(Sentry).to receive(:capture_message)
+
+        precheck_method_under_test
+
+        expect(Sentry).to have_received(:capture_message)
         expect(Sentry).to have_received(:capture_exception).with(error)
       end
     end


### PR DESCRIPTION
## Context

Any error raised by the GIT API should not raise a 500 error page to the user.

This is very difficult to debug and understand. 

Sometimes Faraday returns an error.

And sometimes it return the API error.

Both can be seen [here](https://dfe-teacher-services.sentry.io/issues/4480875739/?project=1765973&query=&referrer=issue-stream&statsPeriod=90d&stream_index=0)

The API error should be ignored but it wasn't, so I am doing an improvement to understand more the scenarios of the error (this is not the final solution - but an improvement to understand why the rescue is not rescuing the error that it supposes to rescue). 

So then we could report back to the GIT team.

## Changes proposed in this pull request

Rescue all Standard error and send to sentry but ignores from the candidate request. (The candidate should not see any error, only the teacher training advisor feature should just be disable if there is any error)

## How to test in the review app?

* To be confirmed - I will need to talk with GiT team about this as I pickup the credentials from QA. I need to talk with them and I'll add here.
