### PR TITLE
Update tracking param for Realistic Job Preview links

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -538,7 +538,7 @@ private
   end
 
   def candidate_realistic_job_preview_link(candidate)
-    realistic_job_preview_url({ utm_campaign: candidate.pseudonymised_id }.merge(utm_args))
+    realistic_job_preview_url({ id: candidate.pseudonymised_id }.merge(utm_args))
   end
 
   helper_method :candidate_magic_link, :candidate_realistic_job_preview_link

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe CandidateMailer do
         'intro' => 'Thank you for your application to study Mathematics at Arithmetic College',
         'rejection reasons' => 'Missing your English GCSE',
         'realistic job preview' => 'Try the realistic job preview tool',
-        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
+        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
       )
     end
   end
@@ -181,7 +181,7 @@ RSpec.describe CandidateMailer do
         'heading' => 'Dear Fred',
         'days left to respond' => '10 working days',
         'realistic job preview' => 'Try the realistic job preview tool',
-        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
+        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
       )
     end
 
@@ -192,7 +192,7 @@ RSpec.describe CandidateMailer do
         'a mail with subject and content',
         'You did not respond to your offers: next steps',
         'realistic job preview' => 'Try the realistic job preview tool',
-        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
+        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
       )
     end
 
@@ -211,7 +211,7 @@ RSpec.describe CandidateMailer do
           'DBD_days_they_had_to_respond' => '10 working days',
           'still_interested' => 'If now’s the right time for you',
           'realistic job preview' => 'Try the realistic job preview tool',
-          'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
+          'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
         )
       end
 
@@ -228,7 +228,7 @@ RSpec.describe CandidateMailer do
           'DBD_days_they_had_to_respond' => '10 working days',
           'apply_next_cycle' => 'You can apply again for courses starting in the 2022 to 2023 academic year.',
           'realistic job preview' => 'Try the realistic job preview tool',
-          'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
+          'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
         )
       end
     end
@@ -247,7 +247,7 @@ RSpec.describe CandidateMailer do
         'DBD_days_they_had_to_respond' => '10 working days',
         'still_interested' => 'If now’s the right time for you',
         'realistic job preview' => 'Try the realistic job preview tool',
-        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
+        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
       )
     end
 
@@ -260,7 +260,7 @@ RSpec.describe CandidateMailer do
         'heading' => 'Dear Fred',
         'days left to respond' => '10 working days',
         'realistic job preview' => 'Try the realistic job preview tool',
-        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
+        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
       )
     end
 
@@ -273,7 +273,7 @@ RSpec.describe CandidateMailer do
         'heading' => 'Dear Fred',
         'days left to respond' => '10 working days',
         'realistic job preview' => 'Try the realistic job preview tool',
-        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
+        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
       )
     end
   end
@@ -299,7 +299,7 @@ RSpec.describe CandidateMailer do
         'heading' => 'Hello Fred',
         'application_withdrawn' => 'You have withdrawn your application',
         'realistic job preview' => 'Try the realistic job preview tool',
-        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
+        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
       )
     end
 
@@ -336,7 +336,7 @@ RSpec.describe CandidateMailer do
       'greeting' => 'Hello Fred',
       'content' => 'declined your offer to study',
       'realistic job preview' => 'Try the realistic job preview tool',
-      'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
+      'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
     )
   end
 
@@ -388,7 +388,7 @@ RSpec.describe CandidateMailer do
       'offer details' => 'Arachnid College has withdrawn their offer for you to study Mathematics (M101)',
       'withdrawal reason' => 'You lied to us about secretly being Spiderman',
       'realistic job preview' => 'Try the realistic job preview tool',
-      'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
+      'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
     )
   end
 
@@ -836,7 +836,7 @@ RSpec.describe CandidateMailer do
         'details' => 'has withdrawn your application for',
         'content' => 'If now’s the right time for you, you can still apply for teacher training again this year.',
         'realistic job preview' => 'Try the realistic job preview tool',
-        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?utm_campaign=\w{64}&utm_source/,
+        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
       )
     end
   end


### PR DESCRIPTION
## Context

This data is collected by a 3rd party and required the `id` parameter for tracking

## Changes proposed in this pull request

Changed `utm_campaign` parameter to `id` when the links are provided in the candidate mailers

## Guidance to review

- View mailer previews
- Check link to RJP have an `id` param

## Link to Trello card

https://trello.com/c/6N7mqj9H

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
