### PR TITLE
Add secondary database and secondary models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@ DB_USERNAME=
 DB_PASSWORD=
 DB_HOSTNAME=localhost
 DB_PORT=5432
+SECONDARY_DATABASE_URL=postgresql://@localhost:5432
 REDIS_URL=redis://localhost:6379/0
 TEACHER_TRAINING_API_BASE_URL=https://qa.api.publish-teacher-training-courses.service.gov.uk/api/public/v1
 GOVUK_NOTIFY_API_KEY=test-key

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -242,8 +242,9 @@ jobs:
         DB_HOSTNAME: postgres
         DB_USERNAME: postgres
         DB_PASSWORD: postgres
-        REDIS_URL: redis://redis:6379/0
         DB_PORT: 5432
+        SECONDARY_DATABASE_URL: postgres://postgres:postgres@postgres:5432
+        REDIS_URL: redis://redis:6379/0
     steps:
       - name: Setup Parallel Database
         run: bundle exec rake parallel:setup

--- a/.github/workflows/pull_request_checks.yml
+++ b/.github/workflows/pull_request_checks.yml
@@ -21,6 +21,13 @@ jobs:
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
+    env:
+      DB_HOSTNAME: localhost
+      DB_USERNAME: postgres
+      DB_PASSWORD: password
+      DB_PORT: 5432
+      SECONDARY_DATABASE_URL: postgresql://postgres:password@localhost:5432
+
     steps:
       # Check-out current branch
       - name: Checkout PR branch
@@ -41,20 +48,10 @@ jobs:
       # Set up development database
       - name: Setup development database
         run: bundle exec rails db:setup
-        env:
-          DB_HOSTNAME: localhost
-          DB_USERNAME: postgres
-          DB_PASSWORD: password
-          DB_PORT: 5432
 
       # Get all enums in changed models
       - name: Check for changed enums
         run: bundle exec ruby .github/scripts/enums_in_models.rb >enums_after.log
-        env:
-          DB_HOSTNAME: localhost
-          DB_USERNAME: postgres
-          DB_PASSWORD: password
-          DB_PORT: 5432
 
       # Keep a copy of the detection script
       - name: Preserve the detection script
@@ -69,11 +66,6 @@ jobs:
         run: |
           bundle install
           bundle exec ruby /tmp/enums_in_models.rb enums_after.log >enums_before.log
-        env:
-          DB_HOSTNAME: localhost
-          DB_USERNAME: postgres
-          DB_PASSWORD: password
-          DB_PORT: 5432
 
       # Diff definitions before and after
       - name: Check for changed enums

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,7 @@ AllCops:
   Exclude:
     - 'bin/*'
     - 'db/schema.rb'
+    - 'db/secondary_schema.rb'
     - 'node_modules/**/*'
     - 'config/application.rb'
     - 'config/puma.rb'

--- a/app/models/secondary/application_record.rb
+++ b/app/models/secondary/application_record.rb
@@ -1,0 +1,5 @@
+class Secondary::ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+
+  connects_to database: { reading: :secondary, writing: :secondary }
+end

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,4 +1,4 @@
-default: &default
+primary: &primary
   adapter: postgresql
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: <%= ENV['DB_USERNAME'] %>
@@ -11,16 +11,40 @@ default: &default
   keepalives_interval: 10
   keepalives_count: 3
 
+secondary: &secondary
+  adapter: postgresql
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  url: <%= ENV["SECONDARY_DATABASE_URL"] %>
+  migrations_paths: db/secondary_migrate
+  keepalives: 1
+  keepalives_idle: 60
+  keepalives_interval: 10
+  keepalives_count: 3
+
 development:
-  <<: *default
-  database: <%= ENV.fetch('DB_DATABASE', 'bat_apply_development') %>
+  primary:
+    <<: *primary
+    database: <%= ENV.fetch('DB_DATABASE', 'bat_apply_development') %>
+  secondary:
+    <<: *secondary
+    database: <%= ENV.fetch('SECONDARY_DB_DATABASE', 'bat_apply_secondary_development') %>
 
 test:
-  <<: *default
-  database: bat_apply_test<%= ENV['TEST_ENV_NUMBER'] %>
-  variables:
-    idle_in_transaction_session_timeout: 0
+  primary:
+    <<: *primary
+    database: bat_apply_test<%= ENV['TEST_ENV_NUMBER'] %>
+    variables:
+      idle_in_transaction_session_timeout: 0
+  secondary:
+    <<: *secondary
+    database: bat_apply_secondary_test<%= ENV['TEST_ENV_NUMBER'] %>
+    variables:
+      idle_in_transaction_session_timeout: 0
 
 production:
-  <<: *default
-  sslmode: <%= ENV.fetch("DB_SSLMODE") { "require" } %>
+  primary:
+    <<: *primary
+    sslmode: <%= ENV.fetch("DB_SSLMODE") { "require" } %>
+  secondary:
+    <<: *secondary
+    sslmode: <%= ENV.fetch("SECONDARY_DB_SSLMODE") { "require" } %>

--- a/db/secondary_schema.rb
+++ b/db/secondary_schema.rb
@@ -1,0 +1,17 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.1].define(version: 0) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,15 @@ services:
     ports:
       - 5432:5432
 
+  secondary-db:
+    image: postgres:14-alpine
+    volumes:
+      - secondary_db_data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=developmentpassword
+    ports:
+      - 5433:5432
+
   redis:
     image: redis:alpine
     ports:
@@ -15,3 +24,4 @@ services:
 
 volumes:
   db_data:
+  secondary_db_data:


### PR DESCRIPTION
## Context

We want to add an additional secondary database to save non-critical data, such as audit logs and email logs.

## Changes proposed in this pull request

- [x] Add a secondary database to local setup.
- [x] Add a `Secondary::ApplicationRecord` that subclasses inherit from to connect to the secondary db.
- [ ] Add secondary database to deployments. cc: @DFE-Digital/teacher-services-infrastructure 

## Guidance to review

### Metal

Set the following env vars to point the secondary database to the same postgres instance, but different database.

```properties
SECONDARY_DATABASE_URL=postgres://username:password@localhost:5432
```

### Docker

The `docker-compose.yml` file has been setup to spin up 2 databases and expose them on separate ports, `5432` (Postgres default - primary db) and `5433` (secondary db).

```properties
SECONDARY_DATABASE_URL=postgres://username:password@localhost:5433
```
