### PR TITLE
Make MigrateDataExportDataToFile a manual migration

### DIFF
--- a/app/services/data_migrations/migrate_data_export_data_to_file.rb
+++ b/app/services/data_migrations/migrate_data_export_data_to_file.rb
@@ -1,7 +1,7 @@
 module DataMigrations
   class MigrateDataExportDataToFile
     TIMESTAMP = 20240528140244
-    MANUAL_RUN = false
+    MANUAL_RUN = true
 
     def change
       DataExport.find_each do |data_export|


### PR DESCRIPTION
## Context

This data migration is currently blocking production deployments as the pod runs out of memory.

## Changes proposed in this pull request

- Change the `MigrateDataExportDataToFile` data migration to be manually run.

## Guidance to review

\-