### PR TITLE
1711 remaining clean up for recruitment performance report part 1

### DIFF
--- a/app/controllers/provider_interface/reports/recruitment_performance_reports_controller.rb
+++ b/app/controllers/provider_interface/reports/recruitment_performance_reports_controller.rb
@@ -1,8 +1,6 @@
 module ProviderInterface
   module Reports
     class RecruitmentPerformanceReportsController < ProviderInterfaceController
-      before_action :redirect_if_feature_inactive
-
       def show
         @provider = current_user.providers.find(provider_id)
         @provider_report = Publications::ProviderRecruitmentPerformanceReport.where(provider: @provider).last
@@ -23,12 +21,6 @@ module ProviderInterface
 
       def provider_id
         params.permit(:provider_id)[:provider_id]
-      end
-
-      def redirect_if_feature_inactive
-        if FeatureFlag.inactive? :recruitment_performance_report
-          redirect_to provider_interface_reports_path
-        end
       end
     end
   end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -34,7 +34,6 @@ class FeatureFlag
     [:structured_reference_condition, 'Structured reference condition that can be added as a condition to an offer', 'Tomas Destefi'],
     [:continuous_applications, 'The new continuous applications flow', 'James Glenn'],
     [:teacher_degree_apprenticeship, 'The degree apprenticeship program', 'Tomas Destefi'],
-    [:recruitment_performance_report, 'The new and improved mid-cycle report', 'Lori Bailey'],
     [:recruitment_performance_report_generator, 'Toggle the Recruitment Performance Report generation', 'Iain McNulty'],
   ].freeze
 

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -34,7 +34,6 @@ class FeatureFlag
     [:structured_reference_condition, 'Structured reference condition that can be added as a condition to an offer', 'Tomas Destefi'],
     [:continuous_applications, 'The new continuous applications flow', 'James Glenn'],
     [:teacher_degree_apprenticeship, 'The degree apprenticeship program', 'Tomas Destefi'],
-    [:recruitment_performance_report_generator, 'Toggle the Recruitment Performance Report generation', 'Iain McNulty'],
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day

--- a/app/services/recruitment_performance_report_timetable.rb
+++ b/app/services/recruitment_performance_report_timetable.rb
@@ -3,7 +3,7 @@ module RecruitmentPerformanceReportTimetable
   LAST_CYCLE_WEEK_REPORT = 51
 
   def self.report_season?
-    CycleTimetable.current_cycle_week.between?(FIRST_CYCLE_WEEK_REPORT, LAST_CYCLE_WEEK_REPORT) && FeatureFlag.active?(:recruitment_performance_report_generator)
+    CycleTimetable.current_cycle_week.between?(FIRST_CYCLE_WEEK_REPORT, LAST_CYCLE_WEEK_REPORT)
   end
 
   # Generation and Publication date are the same (today) for now until we

--- a/app/views/provider_interface/reports/index.html.erb
+++ b/app/views/provider_interface/reports/index.html.erb
@@ -6,40 +6,20 @@
       <%= t('page_titles.provider.reports') %>
     </h1>
 
-    <% if FeatureFlag.active?(:recruitment_performance_report) %>
-      <% if @performance_reports %>
-        <h2 class="govuk-heading-m">
-          <%= t('.performance_report_heading') %>
-        </h2>
-      <% end %>
-
-      <% @providers.select { _1.performance_reports.any? }.each do |provider| %>
-        <% if @providers.many? %>
-          <h3 class="govuk-heading-s"><%= provider.name %></h3>
-        <% end %>
-        <% report = provider.performance_reports.last %>
-        <ul class="govuk-list govuk-list--spaced">
-          <li><%= govuk_link_to("Weekly report for week ending #{report.reporting_end_date.to_fs(:govuk_date)}", provider_interface_reports_provider_recruitment_performance_report_path(provider.id)) %></li>
-        </ul>
-      <% end %>
-    <% else %>
-      <% if @providers.any? { mid_cycle_report_present_for?(_1) } %>
+    <% if @performance_reports %>
       <h2 class="govuk-heading-m">
-        Mid-cycle recruitment performance report
+        <%= t('.performance_report_heading') %>
       </h2>
-      <% end %>
+    <% end %>
 
-      <% @providers.select { mid_cycle_report_present_for?(_1) }.each do |provider| %>
+    <% @providers.select { _1.performance_reports.any? }.each do |provider| %>
+      <% if @providers.many? %>
         <h3 class="govuk-heading-s"><%= provider.name %></h3>
-
-        <ul class="govuk-list govuk-list--spaced">
-          <li>
-            <% if mid_cycle_report_present_for?(provider) %>
-              <%= govuk_link_to mid_cycle_report_label_for(provider), provider_interface_reports_provider_mid_cycle_report_path(provider_id: provider) %>
-            <% end %>
-          </li>
-        </ul>
       <% end %>
+      <% report = provider.performance_reports.last %>
+      <ul class="govuk-list govuk-list--spaced">
+        <li><%= govuk_link_to("Weekly report for week ending #{report.reporting_end_date.to_fs(:govuk_date)}", provider_interface_reports_provider_recruitment_performance_report_path(provider.id)) %></li>
+      </ul>
     <% end %>
 
     <h2 class="govuk-heading-m"><%= t('.application_data_heading') %></h2>

--- a/spec/support_specs/clockwork_spec.rb
+++ b/spec/support_specs/clockwork_spec.rb
@@ -65,7 +65,6 @@ RSpec.describe Clockwork, :clockwork do
   context 'when the performance report is in season' do
     before do
       allow(RecruitmentPerformanceReportTimetable).to receive(:report_season?).and_return(true)
-      allow(FeatureFlag).to receive(:active?).with(:recruitment_performance_report_generator).and_return(true)
     end
 
     it 'runs the report scheduler every Monday' do
@@ -86,28 +85,6 @@ RSpec.describe Clockwork, :clockwork do
   context 'when the performance report is out season' do
     before do
       allow(CycleTimetable).to receive(:current_cycle_week).and_return(2)
-      allow(FeatureFlag).to receive(:active?).with(:recruitment_performance_report_generator).and_return(true)
-    end
-
-    it 'does not run the report scheduler every Monday' do
-      start_time = Time.zone.now.beginning_of_week.change(hour: 5)
-      end_time = Time.zone.now.beginning_of_week.change(hour: 6)
-
-      Clockwork::Test.run(
-        start_time:,
-        end_time:,
-        tick_speed: 1.minute,
-        file: './config/clock.rb',
-      )
-
-      expect(Clockwork::Test.manager.send(:history).jobs).not_to include('Schedule Recruitment Performance reports')
-    end
-  end
-
-  context 'when recruitment_performance_report_generator FeatureFlag is not active' do
-    before do
-      allow(CycleTimetable).to receive(:current_cycle_week).and_return(27)
-      allow(FeatureFlag).to receive(:active?).with(:recruitment_performance_report_generator).and_return(false)
     end
 
     it 'does not run the report scheduler every Monday' do

--- a/spec/system/provider_interface/reports/index_provider_user_two_providers_with_performance_report_spec.rb
+++ b/spec/system/provider_interface/reports/index_provider_user_two_providers_with_performance_report_spec.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
 
-RSpec.feature 'Provider with two providers reports index' do
+RSpec.describe 'Provider with two providers reports index' do
   include DfESignInHelpers
-  before { FeatureFlag.activate(:recruitment_performance_report) }
 
   scenario 'when provider user has multiple provider with performance report' do
     given_a_provider_user_with_two_providers_exists

--- a/spec/system/provider_interface/reports/view_provider_recruitment_performance_report_spec.rb
+++ b/spec/system/provider_interface/reports/view_provider_recruitment_performance_report_spec.rb
@@ -1,40 +1,23 @@
 require 'rails_helper'
 
-RSpec.feature 'Visit provider recruitment performance report page' do
+RSpec.describe 'Visit provider recruitment performance report page' do
   include DfESignInHelpers
 
-  describe 'Feature flag is active' do
-    before { FeatureFlag.activate(:recruitment_performance_report) }
-
-    scenario 'provider report has been generated' do
-      given_a_provider_and_provider_user_exists
-      and_a_provider_recruitment_performance_report_has_been_generated
-      and_national_recruitment_performance_report_has_been_generated
-      and_i_am_signed_in_as_provider_user
-      and_i_visit_the_provider_recruitment_report_page
-      then_i_see_the_report
-      and_i_can_navigate_to_report_sections
-    end
-
-    scenario 'provider report has not been generated' do
-      given_a_provider_and_provider_user_exists
-      and_i_am_signed_in_as_provider_user
-      and_i_visit_the_provider_recruitment_report_page
-      then_i_see_no_report_message
-    end
+  scenario 'provider report has been generated' do
+    given_a_provider_and_provider_user_exists
+    and_a_provider_recruitment_performance_report_has_been_generated
+    and_national_recruitment_performance_report_has_been_generated
+    and_i_am_signed_in_as_provider_user
+    and_i_visit_the_provider_recruitment_report_page
+    then_i_see_the_report
+    and_i_can_navigate_to_report_sections
   end
 
-  describe 'Feature flag is inactive' do
-    before { FeatureFlag.deactivate(:recruitment_performance_report) }
-
-    scenario 'trying to view the report' do
-      given_a_provider_and_provider_user_exists
-      and_a_provider_recruitment_performance_report_has_been_generated
-      and_national_recruitment_performance_report_has_been_generated
-      and_i_am_signed_in_as_provider_user
-      and_i_visit_the_provider_recruitment_report_page
-      then_i_am_redirected_to_reports_page
-    end
+  scenario 'provider report has not been generated' do
+    given_a_provider_and_provider_user_exists
+    and_i_am_signed_in_as_provider_user
+    and_i_visit_the_provider_recruitment_report_page
+    then_i_see_no_report_message
   end
 
 private


### PR DESCRIPTION
## Context

We used two feature flags when developing the recruitment performance report, one for generating the data and one for show the reports to users. 

## Changes proposed in this pull request

This PR removes the use of those feature flags. A [second PR](https://github.com/DFE-Digital/apply-for-teacher-training/pull/9454) has a data migration for removing the feature flags

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

[trello card](https://trello.com/c/YAxdUd1t)

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
