### PR TITLE
Remove feature flags for generating and showing the performance report

### DIFF
--- a/app/services/data_migrations/remove_recruitment_performance_report_feature_flag.rb
+++ b/app/services/data_migrations/remove_recruitment_performance_report_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class RemoveRecruitmentPerformanceReportFeatureFlag
+    TIMESTAMP = 20240611163228
+    MANUAL_RUN = false
+
+    def change
+      Feature.where(name: %i[recruitment_performance_report recruitment_performance_report_generator]).delete_all
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveRecruitmentPerformanceReportFeatureFlag',
   'DataMigrations::MigrateDataExportDataToFile',
   'DataMigrations::RemoveCoursesNotOnPublish',
   'DataMigrations::RemoveIncidentEvictionFeatureFlag',

--- a/spec/services/data_migrations/remove_recruitment_performance_report_feature_flag_spec.rb
+++ b/spec/services/data_migrations/remove_recruitment_performance_report_feature_flag_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveRecruitmentPerformanceReportFeatureFlag do
+  context 'when the feature flags exist' do
+    before do
+      create(:feature, name: 'recruitment_performance_report_generator')
+      create(:feature, name: 'recruitment_performance_report')
+      create(:feature, name: 'some_other_feature_flag')
+    end
+
+    it 'removes the relevant feature flags' do
+      expect { described_class.new.change }.to change { Feature.count }.by(-2)
+      expect(Feature.where(name: 'recruitment_performance_report_generator')).to be_none
+      expect(Feature.where(name: 'recruitment_performance_report')).to be_none
+      expect(Feature.where(name: 'some_other_feature_flag')).to be_any
+    end
+  end
+
+  context 'when the feature flags have already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end


### PR DESCRIPTION
## Context
We used two feature flags when developing the recruitment performance report, one for generating the data and one for show the reports to users.


## Changes proposed in this pull request

This is the migration for removing the feature flags -- those use of the feature flags is removed in the first PR: https://github.com/DFE-Digital/apply-for-teacher-training/pull/9453

## Guidance to review



## Link to Trello card

[trello card](https://trello.com/c/YAxdUd1t)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
