### PR TITLE
[1780] Fix rendering where the section after an empty state was outside main tag  

### DIFF
--- a/app/components/provider_interface/recruitment_performance_report/deferrals_table_component.html.erb
+++ b/app/components/provider_interface/recruitment_performance_report/deferrals_table_component.html.erb
@@ -6,10 +6,10 @@
     <p class="govuk-body"><%= t('deferrals_table_component.description_one', provider_name:) %></p>
     <p class="govuk-body"><%= t('deferrals_table_component.description_two') %></p>
 
+    <div class="recruitment-performance-report-table__wrapper">
     <% if deferral_rows.empty? %>
       <p class="govuk-body"><%= t('shared.empty_state') %></p>
     <% else %>
-    <div class="recruitment-performance-report-table__wrapper">
       <%= govuk_table do |table| %>
         <%= table.with_caption(text: t('deferrals_table_component.caption'),
                                html_attributes: { class: 'govuk-visually-hidden' }) %>

--- a/app/components/provider_interface/recruitment_performance_report/proportion_with_inactive_applications_table_component.html.erb
+++ b/app/components/provider_interface/recruitment_performance_report/proportion_with_inactive_applications_table_component.html.erb
@@ -9,11 +9,11 @@
     <p class="govuk-body"><%= t('proportion_with_inactive_applications_table_component.description_two') %></p>
     <p class="govuk-body"><%= t('proportion_with_inactive_applications_table_component.description_three') %></p>
 
+    <div class="recruitment-performance-report-table__wrapper">
     <% if subject_rows.empty? %>
       <p class="govuk-body"><%= t('shared.empty_state') %></p>
     <% else %>
 
-    <div class="recruitment-performance-report-table__wrapper">
       <%= govuk_table do |table| %>
         <%= table.with_caption(text: t('proportion_with_inactive_applications_table_component.caption'),
                                html_attributes: { class: 'govuk-visually-hidden' }) %>

--- a/app/components/provider_interface/recruitment_performance_report/subject_table_component.html.erb
+++ b/app/components/provider_interface/recruitment_performance_report/subject_table_component.html.erb
@@ -5,47 +5,47 @@
     <% end %>
     <%= content %>
 
+    <div class="recruitment-performance-report-table__wrapper">
     <% if subject_rows.empty? %>
       <p class="govuk-body"><%= t('shared.empty_state') %></p>
     <% else %>
-      <div class="recruitment-performance-report-table__wrapper">
-        <%= govuk_table do |table| %>
-          <%= table.with_caption(text: t("subject_table_component.#{table_caption}"),
-                                 html_attributes: { class: 'govuk-visually-hidden' }) %>
+      <%= govuk_table do |table| %>
+        <%= table.with_caption(text: t("subject_table_component.#{table_caption}"),
+                               html_attributes: { class: 'govuk-visually-hidden' }) %>
 
-          <%= table.with_colgroup do |colgroup| %>
-            <%= colgroup.with_col(span: 1) %>
-            <%= colgroup.with_col(span: colspan) %>
-            <%= colgroup.with_col(span: colspan) %>
+        <%= table.with_colgroup do |colgroup| %>
+          <%= colgroup.with_col(span: 1) %>
+          <%= colgroup.with_col(span: colspan) %>
+          <%= colgroup.with_col(span: colspan) %>
+        <% end %>
+
+        <%= table.with_head do |head| %>
+          <%= head.with_row do |row| %>
+            <%= row.with_cell(scope: false,
+                              html_attributes: { class: 'recruitment-performance-report-table__heading--no-border' }) %>
+            <%= row.with_cell(text: provider_name, colspan:, scope: 'colgroup',
+                              html_attributes: { class: 'recruitment-performance-report-table__heading' }) %>
+            <%= row.with_cell(text: t('shared.all_providers'), colspan:, scope: 'colgroup',
+                              html_attributes: { class: 'recruitment-performance-report-table__heading' }) %>
           <% end %>
 
-          <%= table.with_head do |head| %>
-            <%= head.with_row do |row| %>
-              <%= row.with_cell(scope: false,
-                                html_attributes: { class: 'recruitment-performance-report-table__heading--no-border' }) %>
-              <%= row.with_cell(text: provider_name, colspan:, scope: 'colgroup',
-                                html_attributes: { class: 'recruitment-performance-report-table__heading' }) %>
-              <%= row.with_cell(text: t('shared.all_providers'), colspan:, scope: 'colgroup',
-                                html_attributes: { class: 'recruitment-performance-report-table__heading' }) %>
-            <% end %>
-
-            <%= head.with_row do |row| %>
-              <%= row.with_cell(text: t('shared.subject'), **subheading_html_attributes) %>
-              <% columns.each do |column| %>
-                <%= row.with_cell(text: t("subject_table_component.#{column}"),
-                                  numeric: true,
-                                  **subheading_html_attributes(column)) %>
-              <% end %>
+          <%= head.with_row do |row| %>
+            <%= row.with_cell(text: t('shared.subject'), **subheading_html_attributes) %>
+            <% columns.each do |column| %>
+              <%= row.with_cell(text: t("subject_table_component.#{column}"),
+                                numeric: true,
+                                **subheading_html_attributes(column)) %>
             <% end %>
           <% end %>
+        <% end %>
 
-          <% table.with_body do |body| %>
-            <% subject_rows.each do |subject_row| %>
-              <% body.with_row do |row| %>
-                <%= row.with_cell(header: true, text: subject_row.title, **level_html_attributes(subject_row)) %>
-                <%= columns.each do |column| %>
-                  <%= row.with_cell(text: format_number(subject_row, column), numeric: true,
-                                    **numeric_html_attributes(column)) %>
+        <% table.with_body do |body| %>
+          <% subject_rows.each do |subject_row| %>
+            <% body.with_row do |row| %>
+              <%= row.with_cell(header: true, text: subject_row.title, **level_html_attributes(subject_row)) %>
+              <%= columns.each do |column| %>
+                <%= row.with_cell(text: format_number(subject_row, column), numeric: true,
+                                  **numeric_html_attributes(column)) %>
                 <% end %>
               <% end %>
             <% end %>


### PR DESCRIPTION
## Context

Identified a formatting bug which occurs after tables without data.

## Changes proposed in this pull request

Move div to to include empty state. 

| Before | After|
| ------ | ----- |
| <img width="1313" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/44073106/5633e78d-3262-4e9e-90db-a99ebc0c1305"> | <img width="1054" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/44073106/a3249562-b9b1-4c33-a1aa-3a65768ba83e"> |

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/BQkte1pB

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
