### PR TITLE
Do not set accepted_at to nil when reverting from recruited to pending

### DIFF
--- a/app/services/support_interface/revert_recruited_to_pending_conditions.rb
+++ b/app/services/support_interface/revert_recruited_to_pending_conditions.rb
@@ -11,7 +11,6 @@ module SupportInterface
       @application_choice.update!(
         status: :pending_conditions,
         recruited_at: nil,
-        accepted_at: nil,
         audit_comment: "Support request to revert recruited application to pending conditions: #{@zendesk_ticket}",
       )
     end

--- a/spec/services/support_interface/revert_recruited_to_pending_conditions_spec.rb
+++ b/spec/services/support_interface/revert_recruited_to_pending_conditions_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe SupportInterface::RevertRecruitedToPendingConditions, :with_audit
       expect(application_choice.attributes.symbolize_keys).to match(
         a_hash_including({
           recruited_at: nil,
-          accepted_at: nil,
           status: 'pending_conditions',
         }),
       )


### PR DESCRIPTION
## Context

We introduced some services last cycle to allow Support users to revert the status of application choices.

[A small mistake was made when creating the RevertRecruited to PendingConditions service.](https://github.com/DFE-Digital/apply-for-teacher-training/pull/7832)

It is not sensible to set the `accepted_at` date to nil because the application is still accepted by the candidate.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

[Trello Ticket](https://trello.com/c/pfG9Yvwl/1777-bug-acceptedat-field-reverting-to-nil-when-support-reverts-recruited)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
