### PR TITLE
Add deprecation notice to `/reject` endpoint in documentation

### DIFF
--- a/config/vendor_api/v1.0.yml
+++ b/config/vendor_api/v1.0.yml
@@ -225,11 +225,9 @@ paths:
     post:
       tags:
       - Application management
-      summary: Reject application
+      summary: Reject application (DEPRECATED)
       description: |
-        Reject the candidate’s application with a reason.
-
-        This will transition the application to the [rejected state](/api-docs/lifecycle#rejected).
+        This endpoint has been deprecated. Please use `/reject-by-codes`
       parameters:
       - "$ref": "#/components/parameters/application_id"
       requestBody:


### PR DESCRIPTION
## Context
We want to ensure new Vendors do not use the /reject endpoint as we want all Vendors to use /reject-by-codes

## Changes proposed in this pull request
Update documentation to add deprecation notice to `/reject` endpoint

## Guidance to review
Visit: https://apply-review-9473.test.teacherservices.cloud/api-docs/v1.4/reference#post-applications-application_id-reject

## Link to Trello card

https://trello.com/c/hMzmUHKe/1637-add-deprecation-notice-to-reject-endpoint-in-documentation
