### PR TITLE
Only select the Data Export ID to enqueue the migration jobs

### DIFF
--- a/app/services/data_migrations/migrate_data_export_data_to_file.rb
+++ b/app/services/data_migrations/migrate_data_export_data_to_file.rb
@@ -4,7 +4,7 @@ module DataMigrations
     MANUAL_RUN = true
 
     def change
-      BatchDelivery.new(relation: DataExport.all, stagger_over: 4.hours, batch_size: 10).each do |next_batch_time, data_exports|
+      BatchDelivery.new(relation: DataExport.select(:id), stagger_over: 4.hours, batch_size: 10).each do |next_batch_time, data_exports|
         data_exports.each do |data_export|
           DataExportFileMigrationWorker.perform_at(next_batch_time, data_export.id)
         end


### PR DESCRIPTION
## Context

As we instantiate active record objects when we loop through queueing objects, we run out of memory as we instantiate each active record object _with_ the `data` fields.

## Changes proposed in this pull request

Only select `id` for the enqueue loop.

## Guidance to review

\-