### PR TITLE
Use correct base url for api end points in the documentation

### DIFF
--- a/app/views/api_docs/vendor_api_docs/pages/home.md
+++ b/app/views/api_docs/vendor_api_docs/pages/home.md
@@ -124,9 +124,9 @@ This means that if you use the major version URL, you do not need to update stud
 
 For example, after version `1.1` is released you can use:
 
-- <https://apply-for-teacher-training.service.gov.uk/api/v1.0> for version `1.0`
-- <https://apply-for-teacher-training.service.gov.uk/api/v1.1> for version `1.1`
-- <https://apply-for-teacher-training.service.gov.uk/api/v1> for version `1.1` - but if version `1.2` is released then this URL will give you version `1.2` instead
+- <https://www.apply-for-teacher-training.service.gov.uk/api/v1.0> for version `1.0`
+- <https://www.apply-for-teacher-training.service.gov.uk/api/v1.1> for version `1.1`
+- <https://www.apply-for-teacher-training.service.gov.uk/api/v1> for version `1.1` - but if version `1.2` is released then this URL will give you version `1.2` instead
 
 ## How applications are updated
 


### PR DESCRIPTION
## Context

Our public API docs refer to the wrong host name for our API endpoint. 

## Changes proposed in this pull request

change `https://apply...` to `https://www.apply...`

## Guidance to review

Are there any areas where this information needs to be updated? 

## Link to Trello card

NA

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
