### PR TITLE
Drop the data ignored column from the DataExport model

### DIFF
--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -1,6 +1,4 @@
 class DataExport < ApplicationRecord
-  self.ignored_columns += %w[data]
-
   EXPORT_TYPES = {
     active_provider_user_permissions: {
       name: 'Active provider user permissions',


### PR DESCRIPTION
## Context

Now that we've dropped the database column, we can safely remove the ignored column from our model.

This is the final step, step 3, to drop the data column entirely.

Step 1 - Ignore the `data` column in our model
Step 2 - Migration to remove the column
Step 3 - Remove the `ignore_columns` call

## Changes proposed in this pull request

- Remove `self.ignored_columns += %w[data]` from the `DataExport` model.

## Guidance to review

Refer to https://github.com/DFE-Digital/apply-for-teacher-training/pull/9486 for Step 2.