### PR TITLE
[1842] Update end-of-cycle banner content and conditions for rendering

### DIFF
--- a/app/components/candidate_interface/deadline_banner_component.html.erb
+++ b/app/components/candidate_interface/deadline_banner_component.html.erb
@@ -1,4 +1,4 @@
 <%= govuk_notification_banner(title_text: t('notification_banner.important')) do |notification_banner| %>
-  <% notification_banner.with_heading(text: "The deadline for applying to courses starting in the #{academic_year} academic year is #{deadline[:time]} on #{deadline[:date]}") %>
-  <p class="govuk-body">Courses may fill up before then. Check course availability with your provider.</p>
+  <% notification_banner.with_heading(text: t('heading', academic_year:, deadline_time: deadline[:time], deadline_date: deadline[:date])) %>
+  <p class="govuk-body"><%= t('text') %></p>
 <% end %>

--- a/app/components/candidate_interface/deadline_banner_component.rb
+++ b/app/components/candidate_interface/deadline_banner_component.rb
@@ -7,15 +7,14 @@ class CandidateInterface::DeadlineBannerComponent < ViewComponent::Base
   end
 
   def render?
-    flash_empty && render_deadline_banner?
+    flash_empty && CycleTimetable.show_apply_deadline_banner?(@application_form)
   end
 
   def deadline
-    if CycleTimetable.show_apply_2_deadline_banner?(@application_form)
-      apply_2_deadline
-    else
-      apply_1_deadline
-    end
+    {
+      date: CycleTimetable.date(:apply_2_deadline).to_fs(:govuk_date),
+      time: CycleTimetable.date(:apply_2_deadline).to_fs(:govuk_time),
+    }
   end
 
   def academic_year
@@ -23,24 +22,6 @@ class CandidateInterface::DeadlineBannerComponent < ViewComponent::Base
   end
 
 private
-
-  def render_deadline_banner?
-    CycleTimetable.show_apply_1_deadline_banner?(@application_form) || CycleTimetable.show_apply_2_deadline_banner?(@application_form)
-  end
-
-  def apply_1_deadline
-    {
-      date: CycleTimetable.date(:apply_1_deadline).to_fs(:govuk_date),
-      time: CycleTimetable.date(:apply_1_deadline).to_fs(:govuk_time),
-    }
-  end
-
-  def apply_2_deadline
-    {
-      date: CycleTimetable.date(:apply_2_deadline).to_fs(:govuk_date),
-      time: CycleTimetable.date(:apply_2_deadline).to_fs(:govuk_time),
-    }
-  end
 
   def application_form_recruitment_cycle_year
     @application_form.recruitment_cycle_year

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -139,9 +139,8 @@ class CycleTimetable
     now
   end
 
-  def self.show_apply_1_deadline_banner?(application_form)
-    current_date.between?(date(:show_deadline_banner), date(:apply_1_deadline)) &&
-      application_form.phase == 'apply_1' &&
+  def self.show_apply_deadline_banner?(application_form)
+    current_date.between?(date(:show_deadline_banner), date(:apply_2_deadline)) &&
       !application_form.successful?
   end
 
@@ -155,11 +154,6 @@ class CycleTimetable
 
   def self.between_reject_by_default_and_find_reopens?
     current_date.between?(CycleTimetable.reject_by_default, CycleTimetable.find_reopens)
-  end
-
-  def self.show_apply_2_deadline_banner?(application_form)
-    current_date.between?(date(:show_deadline_banner), date(:apply_2_deadline)) &&
-      (application_form.phase == 'apply_2' || (application_form.phase == 'apply_1' && application_form.ended_without_success?))
   end
 
   def self.show_non_working_days_banner?

--- a/config/locales/candidate_interface/deadline_banner_component.yml
+++ b/config/locales/candidate_interface/deadline_banner_component.yml
@@ -1,0 +1,3 @@
+en:
+  heading: The deadline for applying to courses starting in %{academic_year} is %{deadline_time} on %{deadline_date}
+  text: Courses may fill up before then. Check course availability with the provider.

--- a/spec/components/candidate_interface/deadline_banner_component_spec.rb
+++ b/spec/components/candidate_interface/deadline_banner_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CandidateInterface::DeadlineBannerComponent, type: :component do
 
     it 'does not render when flash is not empty' do
       allow(flash).to receive(:empty?).and_return(false)
-      allow(CycleTimetable).to receive_messages(show_apply_1_deadline_banner?: true, show_apply_2_deadline_banner?: true)
+      allow(CycleTimetable).to receive_messages(show_apply_deadline_banner?: true)
 
       result = render_inline(described_class.new(application_form:, flash_empty: flash.empty?))
 
@@ -16,32 +16,21 @@ RSpec.describe CandidateInterface::DeadlineBannerComponent, type: :component do
 
     it 'does not render when a deadline banner should not be shown' do
       allow(flash).to receive(:empty?).and_return(true)
-      allow(CycleTimetable).to receive_messages(show_apply_1_deadline_banner?: false, show_apply_2_deadline_banner?: false)
+      allow(CycleTimetable).to receive_messages(show_apply_deadline_banner?: false)
 
       result = render_inline(described_class.new(application_form:, flash_empty: flash.empty?))
 
       expect(result.text).to eq('')
     end
 
-    it 'renders the Apply 1 banner when the right conditions are met' do
+    it 'renders the banner when the right conditions are met' do
       allow(flash).to receive(:empty?).and_return(true)
-      allow(CycleTimetable).to receive_messages(show_apply_1_deadline_banner?: true, show_apply_2_deadline_banner?: false)
+      allow(CycleTimetable).to receive_messages(show_apply_deadline_banner?: true)
 
       result = render_inline(described_class.new(application_form:, flash_empty: flash.empty?))
 
       expect(result.text).to include(
-        "The deadline for applying to courses starting in the #{academic_year} academic year is #{deadline_time(:apply_1_deadline)} on #{deadline_date(:apply_1_deadline)}",
-      )
-    end
-
-    it 'renders the Apply 2 banner when the right conditions are met' do
-      allow(flash).to receive(:empty?).and_return(true)
-      allow(CycleTimetable).to receive_messages(show_apply_1_deadline_banner?: false, show_apply_2_deadline_banner?: true)
-
-      result = render_inline(described_class.new(application_form:, flash_empty: flash.empty?))
-
-      expect(result.text).to include(
-        "The deadline for applying to courses starting in the #{academic_year} academic year is #{deadline_time(:apply_2_deadline)} on #{deadline_date(:apply_2_deadline)}",
+        "The deadline for applying to courses starting in #{academic_year} is #{deadline_time(:apply_2_deadline)} on #{deadline_date(:apply_2_deadline)}",
       )
     end
   end

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -55,20 +55,21 @@ RSpec.describe CycleTimetable do
     end
   end
 
-  describe '.show_apply_1_deadline_banner?' do
-    it 'returns true before the configured date and it is an unsuccessful apply_1 application' do
-      application_form = build(:application_form, phase: 'apply_1')
+  describe '.show_apply_deadline_banner?' do
+    it 'returns true before the deadline and the choices have not ben successful' do
+      application_choices = [build(:application_choice, :withdrawn)]
+      application_form = build(:application_form, application_choices:)
 
       travel_temporarily_to(one_hour_before_apply1_deadline) do
-        expect(described_class.show_apply_1_deadline_banner?(application_form)).to be true
+        expect(described_class.show_apply_deadline_banner?(application_form)).to be true
       end
     end
 
-    it 'returns false if it is a apply_2 application' do
-      application_form = build(:application_form, phase: 'apply_2')
+    it 'returns true if there are no application choices' do
+      application_form = build(:application_form)
 
       travel_temporarily_to(one_hour_before_apply1_deadline) do
-        expect(described_class.show_apply_1_deadline_banner?(application_form)).to be false
+        expect(described_class.show_apply_deadline_banner?(application_form)).to be true
       end
     end
 
@@ -77,15 +78,15 @@ RSpec.describe CycleTimetable do
       application_form = build(:application_form, phase: 'apply_1', application_choices: [application_choice])
 
       travel_temporarily_to(one_hour_before_apply1_deadline) do
-        expect(described_class.show_apply_1_deadline_banner?(application_form)).to be false
+        expect(described_class.show_apply_deadline_banner?(application_form)).to be false
       end
     end
 
     it 'returns false after the configured date' do
       application_form = build(:application_form, phase: 'apply_1')
 
-      travel_temporarily_to(one_hour_after_apply1_deadline) do
-        expect(described_class.show_apply_1_deadline_banner?(application_form)).to be false
+      travel_temporarily_to(one_hour_after_apply2_deadline) do
+        expect(described_class.show_apply_deadline_banner?(application_form)).to be false
       end
     end
   end
@@ -113,33 +114,6 @@ RSpec.describe CycleTimetable do
     it 'returns false after apply 1 closes' do
       travel_temporarily_to(described_class.apply_1_deadline(2022) + 1.hour) do
         expect(described_class.show_summer_recruitment_banner?).to be false
-      end
-    end
-  end
-
-  describe '.show_apply_2_deadline_banner?' do
-    it 'returns true before the configured date and it is a phase 2 application' do
-      application_form = build(:application_form, phase: 'apply_2')
-
-      travel_temporarily_to(one_hour_before_apply2_deadline) do
-        expect(described_class.show_apply_2_deadline_banner?(application_form)).to be true
-      end
-    end
-
-    it 'returns false if it is a successful apply_1 application' do
-      application_choice = build(:application_choice, :offered)
-      application_form = build(:application_form, phase: 'apply_1', application_choices: [application_choice])
-
-      travel_temporarily_to(one_hour_before_apply2_deadline) do
-        expect(described_class.show_apply_2_deadline_banner?(application_form)).to be false
-      end
-    end
-
-    it 'returns false after the configured date' do
-      unsuccessful_application_form = build(:application_form, phase: 'apply_2', application_choices: [build(:application_choice, :rejected)])
-
-      travel_temporarily_to(one_hour_after_apply2_deadline) do
-        expect(described_class.show_apply_2_deadline_banner?(unsuccessful_application_form)).to be false
       end
     end
   end


### PR DESCRIPTION
## Context

The End-of-cycle gets underway on the 1 July. The first thing is that candidates with unsuccessful applications will see this banner on their application dashboard and candidate details page. 

## Changes proposed in this pull request

We are very soon going to do away with the `apply_1` and `apply_2` distinctions. But because of the time sensitivity with this ticket,  we have had to work within the existing structure, using the `apply_2` deadline as the `apply_deadline`. 

I have deleted all the 'phase' related queries as phase is now irrelevant.

| Before | After |
| ------ | ----- |
|  <img width="737" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/44073106/9181f5b2-dbcc-4f9b-a78a-afae3882d3ee"> | <img width="658" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/44073106/0b632336-ec43-4c31-9a42-087e242fa51a"> |

## Guidance to review

The preview is at `/view_components/candidate_interface/summer_recruitment_banner_component/twenty_twenty_four`

locally

## Link to Trello card

https://trello.com/c/OHHgoRn8

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
