### PR TITLE
Ignore the uk_residency_status column on ApplicationForm

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -1,6 +1,8 @@
 # The Application Form is filled in and submitted by the Candidate. Candidates
 # can initially apply to 3 different courses, represented by an Application Choice.
 class ApplicationForm < ApplicationRecord
+  self.ignored_columns += %w[uk_residency_status]
+
   audited
   has_associated_audits
   geocoded_by :address_formatted_for_geocoding, params: { region: 'uk' }

--- a/app/services/delete_application.rb
+++ b/app/services/delete_application.rb
@@ -21,7 +21,6 @@ class DeleteApplication
     country
     postcode
     disability_disclosure
-    uk_residency_status
     work_history_explanation
     becoming_a_teacher
     interview_preferences

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -125,7 +125,6 @@ shared:
     - support_reference
     - third_nationality
     - training_with_a_disability_completed
-    - uk_residency_status
     - updated_at
     - volunteering_completed
     - volunteering_experience


### PR DESCRIPTION
## Context

The `uk_residency_status` column on `ApplicationForm` is `null` on every database record. We should drop it.

## Changes proposed in this pull request

- Add `uk_residency_status` column to `ApplicationForm`'s ignored columns.

## Guidance to review

- The `uk_residency_status` field on `ApplicationForm` is removed.
- All flows should work without change.

## Link to Trello card

https://trello.com/c/lJOnVQl5/461-remove-ukresidencystatus-in-application-form

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
