### PR TITLE
[409] end of cycle implement a single deadline for all candidates

### DIFF
--- a/app/components/candidate_interface/carry_over_inset_text_component.rb
+++ b/app/components/candidate_interface/carry_over_inset_text_component.rb
@@ -7,7 +7,7 @@ module CandidateInterface
     end
 
     def render?
-      @application_form.unsuccessful_and_apply_2_deadline_has_passed?
+      @application_form.unsuccessful_and_apply_deadline_has_passed?
     end
 
     def application_form_academic_cycle

--- a/app/components/candidate_interface/deadline_banner_component.rb
+++ b/app/components/candidate_interface/deadline_banner_component.rb
@@ -12,8 +12,8 @@ class CandidateInterface::DeadlineBannerComponent < ViewComponent::Base
 
   def deadline
     {
-      date: CycleTimetable.date(:apply_2_deadline).to_fs(:govuk_date),
-      time: CycleTimetable.date(:apply_2_deadline).to_fs(:govuk_time),
+      date: CycleTimetable.date(:apply_deadline).to_fs(:govuk_date),
+      time: CycleTimetable.date(:apply_deadline).to_fs(:govuk_time),
     }
   end
 

--- a/app/components/candidate_interface/reopen_banner_component.rb
+++ b/app/components/candidate_interface/reopen_banner_component.rb
@@ -1,32 +1,19 @@
 class CandidateInterface::ReopenBannerComponent < ViewComponent::Base
   attr_accessor :phase, :flash_empty
 
-  def initialize(phase:, flash_empty:)
+  def initialize(flash_empty:)
     @phase = phase
     @flash_empty = flash_empty
   end
 
   def render?
-    flash_empty &&
-      (show_apply_1_reopen_banner? || show_apply_2_reopen_banner?)
+    flash_empty && show_apply_reopen_banner?
   end
 
 private
 
-  def show_apply_1_reopen_banner?
-    apply_1? && CycleTimetable.between_cycles_apply_1?
-  end
-
-  def show_apply_2_reopen_banner?
-    apply_2? && CycleTimetable.between_cycles_apply_2?
-  end
-
-  def apply_1?
-    phase == 'apply_1'
-  end
-
-  def apply_2?
-    phase == 'apply_2'
+  def show_apply_reopen_banner?
+    CycleTimetable.between_cycles?
   end
 
   def reopen_date

--- a/app/components/shared/end_of_cycle_banners_component.rb
+++ b/app/components/shared/end_of_cycle_banners_component.rb
@@ -5,15 +5,11 @@ class EndOfCycleBannersComponent < ViewComponent::Base
     [
       {
         name: 'Summer recruitment banner',
-        date: "#{banner_date(:show_summer_recruitment_banner)} to #{banner_date(:apply_1_deadline)}",
+        date: "#{banner_date(:show_summer_recruitment_banner)} to #{banner_date(:apply_deadline)}",
       },
       {
-        name: 'Apply 1 deadline banner',
-        date: "#{banner_date(:show_deadline_banner)} to #{banner_date(:apply_1_deadline)}",
-      },
-      {
-        name: 'Apply 2 deadline banner',
-        date: "#{banner_date(:show_summer_recruitment_banner)} to #{banner_date(:apply_2_deadline)}",
+        name: 'Apply deadline banner',
+        date: "#{banner_date(:show_deadline_banner)} to #{banner_date(:apply_deadline)}",
       },
     ].map do |cycle_data|
       EndOfCycleBanner.new(cycle_data)

--- a/app/components/shared/end_of_cycle_emails_component.rb
+++ b/app/components/shared/end_of_cycle_emails_component.rb
@@ -6,15 +6,9 @@ class EndOfCycleEmailsComponent < ViewComponent::Base
   def end_of_cycle_emails
     [
       {
-        link: preview_email_link('Apply 1 deadline reminder', path: 'candidate_mailer/eoc_deadline_reminder'),
-
-        date: "#{email_date(:apply_1_deadline_first_reminder)} and #{email_date(:apply_1_deadline_second_reminder)}",
-        candidates_size: apply_1_candidates,
-      },
-      {
-        link: preview_email_link('Apply 2 deadline reminder', path: 'candidate_mailer/eoc_deadline_reminder'),
-        date: "#{email_date(:apply_2_deadline_first_reminder)} and #{email_date(:apply_2_deadline_second_reminder)}",
-        candidates_size: apply_2_candidates,
+        link: preview_email_link('Apply deadline reminder', path: 'candidate_mailer/eoc_deadline_reminder'),
+        date: "#{email_date(:apply_deadline_first_reminder)} and #{email_date(:apply_deadline_second_reminder)}",
+        candidates_size: apply_candidates,
       },
       {
         link: preview_email_link('Find has opened', path: 'candidate_mailer/find_has_opened'),
@@ -36,12 +30,8 @@ class EndOfCycleEmailsComponent < ViewComponent::Base
     end
   end
 
-  def apply_1_candidates
-    GetApplicationsToSendDeadlineRemindersTo.deadline_reminder_candidates_apply_1.count
-  end
-
-  def apply_2_candidates
-    GetApplicationsToSendDeadlineRemindersTo.deadline_reminder_candidates_apply_2.count
+  def apply_candidates
+    GetApplicationsToSendDeadlineRemindersTo.deadline_reminder_query.count
   end
 
   def candidates_to_notify_about_find_and_apply

--- a/app/components/shared/end_of_cycle_timeline_component.rb
+++ b/app/components/shared/end_of_cycle_timeline_component.rb
@@ -7,7 +7,7 @@ class EndOfCycleTimelineComponent < ViewComponent::Base
   }.freeze
 
   def initialize
-    @cycle_timetable = CycleTimetable::CYCLE_DATES[CycleTimetable.current_year].merge(
+    @cycle_timetable = CYCLE_DATES[CycleTimetable.current_year].merge(
       {
         find_reopens: CycleTimetable.find_reopens,
         apply_reopens: CycleTimetable.apply_reopens,

--- a/app/controllers/candidate_interface/submitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/submitted_application_form_controller.rb
@@ -14,7 +14,7 @@ module CandidateInterface
     end
 
     def start_carry_over
-      render CycleTimetable.between_cycles_apply_2? ? :start_carry_over_between_cycles : :start_carry_over
+      render CycleTimetable.between_cycles? ? :start_carry_over_between_cycles : :start_carry_over
     end
 
     def carry_over

--- a/app/helpers/cycle_timetable_helper.rb
+++ b/app/helpers/cycle_timetable_helper.rb
@@ -13,20 +13,12 @@ module_function
     CycleTimetable.apply_opens(year) + 1.day
   end
 
-  def after_apply_1_deadline(year = CycleTimetable.current_year)
-    CycleTimetable.apply_1_deadline(year) + 1.day
+  def after_apply_deadline(year = CycleTimetable.current_year)
+    CycleTimetable.apply_deadline(year) + 1.day
   end
 
-  def before_apply_1_deadline(year = CycleTimetable.current_year)
-    CycleTimetable.apply_1_deadline(year) - 1.day
-  end
-
-  def after_apply_2_deadline(year = CycleTimetable.current_year)
-    CycleTimetable.apply_2_deadline(year) + 1.day
-  end
-
-  def before_apply_2_deadline(year = CycleTimetable.current_year)
-    CycleTimetable.apply_2_deadline(year) - 1.day
+  def before_apply_deadline(year = CycleTimetable.current_year)
+    CycleTimetable.apply_deadline(year) - 1.day
   end
 
   def after_apply_reopens(year = CycleTimetable.next_year)

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -25,7 +25,6 @@ class TestApplications
     recruitment_cycle_year:,
     states:,
     courses_to_apply_to:,
-    apply_again: false,
     carry_over: false,
     course_full: false,
     candidate: nil,
@@ -43,7 +42,6 @@ class TestApplications
         recruitment_cycle_year:,
         states:,
         courses:,
-        apply_again:,
         carry_over:,
         candidate:,
         incomplete_references:,
@@ -84,7 +82,6 @@ private
     recruitment_cycle_year:,
     states:,
     courses:,
-    apply_again: false,
     carry_over: false,
     candidate: nil,
     application_in_past: false,
@@ -92,23 +89,7 @@ private
   )
     raise CourseAndStateNumbersDoNotMatchError unless courses.count == states.count
 
-    if apply_again
-      raise OnlyOneCourseWhenApplyingAgainError unless states.one?
-
-      create_application_to_courses(
-        application_in_past: true,
-        recruitment_cycle_year:,
-        courses:,
-        states: [:rejected],
-        candidate:,
-      )
-
-      initialize_time(recruitment_cycle_year, application_in_past:)
-      candidate = candidate.presence || Candidate.last
-      first_name = candidate.current_application.first_name
-      last_name = candidate.current_application.last_name
-      previous_application_form = candidate.current_application
-    elsif carry_over
+    if carry_over
       courses_from_last_year = Course.with_course_options.distinct.in_cycle(recruitment_cycle_year - 1).sample(rand(1..3))
       create_application_to_courses(
         recruitment_cycle_year: recruitment_cycle_year - 1,
@@ -161,7 +142,6 @@ private
           created_at: time,
           updated_at: time,
           recruitment_cycle_year:,
-          phase: apply_again ? 'apply_2' : 'apply_1',
           previous_application_form:,
           references_count: 0,
         )
@@ -563,7 +543,7 @@ private
       end
     else
       earliest_date = CycleTimetable.apply_opens(recruitment_cycle_year)
-      latest_date = CycleTimetable.apply_1_deadline(recruitment_cycle_year)
+      latest_date = CycleTimetable.apply_deadline(recruitment_cycle_year)
     end
 
     @time = rand(earliest_date..latest_date)

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -278,15 +278,15 @@ class ApplicationForm < ApplicationRecord
   end
 
   def carry_over?
-    previous_recruitment_cycle? && (not_submitted_and_deadline_has_passed? || unsuccessful_and_apply_2_deadline_has_passed?)
+    previous_recruitment_cycle? && (not_submitted_and_deadline_has_passed? || unsuccessful_and_apply_deadline_has_passed?)
   end
 
   def not_submitted_and_deadline_has_passed?
-    !submitted? && ((apply_1? && CycleTimetable.apply_1_deadline_has_passed?(self)) || (apply_2? && CycleTimetable.apply_2_deadline_has_passed?(self)))
+    !submitted? && CycleTimetable.apply_deadline_has_passed?(self)
   end
 
-  def unsuccessful_and_apply_2_deadline_has_passed?
-    ended_without_success? && CycleTimetable.apply_2_deadline_has_passed?(self)
+  def unsuccessful_and_apply_deadline_has_passed?
+    ended_without_success? && CycleTimetable.apply_deadline_has_passed?(self)
   end
 
   ##########################################

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -40,7 +40,7 @@ class Candidate < ApplicationRecord
 
   def current_application
     application_form = application_forms.order(:created_at, :id).last
-    application_form || if Time.zone.now > CycleTimetable.apply_1_deadline
+    application_form || if Time.zone.now > CycleTimetable.apply_deadline
                           application_forms.create!(recruitment_cycle_year: CycleTimetable.next_year)
                         else
                           application_forms.create!

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -233,11 +233,11 @@ private
   end
 
   def date_range_query_for_recruitment_cycle_year(cycle_year)
-    start_date = CycleTimetable.apply_2_deadline(cycle_year - 1).end_of_day
+    start_date = CycleTimetable.apply_deadline(cycle_year - 1).end_of_day
 
     query = "created_at >= '#{start_date}'"
 
-    end_date = CycleTimetable.apply_2_deadline(cycle_year)
+    end_date = CycleTimetable.apply_deadline(cycle_year)
 
     if end_date
       query + " AND created_at <= '#{end_date}'"

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -40,11 +40,11 @@ module RecruitmentCycle
 
   def self.years_visible_in_support
     from_year = HostingEnvironment.production? ? current_year : next_year
-    from_year.downto(CycleTimetable::CYCLE_DATES.keys.min)
+    from_year.downto(CYCLE_DATES.keys.min)
   end
 
   def self.years_available_to_register
-    current_year.downto(CycleTimetable::CYCLE_DATES.keys.min)
+    current_year.downto(CYCLE_DATES.keys.min)
   end
 
   def self.cycle_name(year = current_year)

--- a/app/queries/get_applications_to_send_deadline_reminders_to.rb
+++ b/app/queries/get_applications_to_send_deadline_reminders_to.rb
@@ -1,24 +1,12 @@
 class GetApplicationsToSendDeadlineRemindersTo
   def self.call
-    if CycleTimetable.need_to_send_deadline_reminder? == :apply_1
-      deadline_reminder_candidates_apply_1
-    elsif CycleTimetable.need_to_send_deadline_reminder? == :apply_2
-      deadline_reminder_candidates_apply_2
-    end
+    deadline_reminder_query if CycleTimetable.need_to_send_deadline_reminder?
   end
 
-  def self.deadline_reminder_candidates_apply_1
-    deadline_reminder_query(phase: 'apply_1')
-  end
-
-  def self.deadline_reminder_candidates_apply_2
-    deadline_reminder_query(phase: 'apply_2')
-  end
-
-  def self.deadline_reminder_query(phase:)
+  def self.deadline_reminder_query
     ApplicationForm
     .joins(:candidate)
-    .where(submitted_at: nil, phase:, recruitment_cycle_year: RecruitmentCycle.current_year)
+    .where(submitted_at: nil, recruitment_cycle_year: RecruitmentCycle.current_year)
     .where.not(candidate: { unsubscribed_from_emails: true })
   end
 end

--- a/app/services/candidate_api/serializers/v1_1.rb
+++ b/app/services/candidate_api/serializers/v1_1.rb
@@ -5,7 +5,7 @@ module CandidateAPI
         Candidate
         .left_outer_joins(:application_forms)
         .where(application_forms: { recruitment_cycle_year: RecruitmentCycle.current_year })
-        .or(Candidate.where('candidates.created_at > ? ', CycleTimetable.apply_1_deadline(RecruitmentCycle.previous_year)))
+        .or(Candidate.where('candidates.created_at > ? ', CycleTimetable.apply_deadline(RecruitmentCycle.previous_year)))
         .distinct
         .includes(application_forms: :application_choices)
         .where('candidate_api_updated_at > ?', updated_since)

--- a/app/services/candidate_api/serializers/v1_2.rb
+++ b/app/services/candidate_api/serializers/v1_2.rb
@@ -22,7 +22,7 @@ module CandidateAPI
           .left_outer_joins(application_forms: { application_choices: %i[provider course interviews], application_references: [], application_qualifications: [] })
           .includes(application_forms: { application_choices: %i[provider course course_option interviews], application_qualifications: [], application_references: [] })
           .where('candidates.updated_at > :updated_since OR application_forms.updated_at > :updated_since OR application_choices.updated_at > :updated_since OR "references".updated_at > :updated_since OR application_qualifications.updated_at > :updated_since', updated_since:)
-          .where('application_forms.recruitment_cycle_year = ? OR candidates.created_at > ?', RecruitmentCycle.current_year, CycleTimetable.apply_1_deadline(RecruitmentCycle.previous_year))
+          .where('application_forms.recruitment_cycle_year = ? OR candidates.created_at > ?', RecruitmentCycle.current_year, CycleTimetable.apply_deadline(RecruitmentCycle.previous_year))
           .order(id: :asc)
           .distinct
       end

--- a/app/services/candidate_api/serializers/v1_3.rb
+++ b/app/services/candidate_api/serializers/v1_3.rb
@@ -22,7 +22,7 @@ module CandidateAPI
           .left_outer_joins(application_forms: { application_choices: %i[provider course interviews], application_references: [], application_qualifications: [] })
           .includes(application_forms: { application_choices: %i[provider course course_option interviews], application_qualifications: [], application_references: [] })
           .where('candidates.updated_at > :updated_since OR application_forms.updated_at > :updated_since OR application_choices.updated_at > :updated_since OR "references".updated_at > :updated_since OR application_qualifications.updated_at > :updated_since', updated_since:)
-          .where('application_forms.recruitment_cycle_year = ? OR candidates.created_at > ?', RecruitmentCycle.current_year, CycleTimetable.apply_1_deadline(RecruitmentCycle.previous_year))
+          .where('application_forms.recruitment_cycle_year = ? OR candidates.created_at > ?', RecruitmentCycle.current_year, CycleTimetable.apply_deadline(RecruitmentCycle.previous_year))
           .order(id: :asc)
           .distinct
       end

--- a/app/services/carry_over_application.rb
+++ b/app/services/carry_over_application.rb
@@ -8,7 +8,6 @@ class CarryOverApplication
 
     DuplicateApplication.new(
       @application_form,
-      target_phase: 'apply_1',
       recruitment_cycle_year:,
     ).duplicate
   end
@@ -26,7 +25,7 @@ private
   end
 
   def recruitment_cycle_year
-    if Time.zone.now > CycleTimetable.apply_1_deadline
+    if Time.zone.now > CycleTimetable.apply_deadline
       RecruitmentCycle.next_year
     else
       RecruitmentCycle.current_year

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -138,11 +138,13 @@ class CycleTimetable
   end
 
   def self.apply_deadline_first_reminder
-    (apply_deadline - 2.months).beginning_of_week + 1.week
+    # For 2024, date confirmed is Wednesday 17 July at 6pm
+    apply_deadline - 2.months
   end
 
   def self.apply_deadline_second_reminder
-    (apply_deadline - 1.month).beginning_of_week + 1.week
+    # For 2024, date confirmed is Saturday 17 September at 6pm
+    apply_deadline - 1.month
   end
 
   def self.between_cycles?

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -1,98 +1,5 @@
 class CycleTimetable
   # These dates are configuration for when the previous cycle ends and the next cycle starts
-  # The 2019 dates are made up so we can generate sensible test data
-  CYCLE_DATES = {
-    2019 => {
-      find_opens: Time.zone.local(2018, 10, 6, 9),
-      apply_opens: Time.zone.local(2018, 10, 13, 9),
-      apply_1_deadline: Time.zone.local(2019, 8, 24, 18),
-      apply_2_deadline: Time.zone.local(2019, 9, 18, 18),
-      reject_by_default: Time.zone.local(2019, 9, 29, 23, 59, 59),
-      find_closes: Time.zone.local(2019, 10, 3, 23, 59, 59),
-      holidays: {},
-    },
-    2020 => {
-      find_opens: Time.zone.local(2019, 10, 6, 9),
-      apply_opens: Time.zone.local(2019, 10, 13, 9),
-      show_deadline_banner: Time.zone.local(2020, 8, 1, 9),
-      show_summer_recruitment_banner: Time.zone.local(2020, 7, 1, 9),
-      apply_1_deadline: Time.zone.local(2020, 8, 24, 18),
-      apply_2_deadline: Time.zone.local(2020, 9, 18, 18),
-      reject_by_default: Time.zone.local(2021, 9, 29, 23, 59, 59),
-      find_closes: Time.zone.local(2020, 10, 3, 23, 59, 59),
-      holidays: {},
-    },
-    2021 => {
-      find_opens: Time.zone.local(2020, 10, 6, 9),
-      apply_opens: Time.zone.local(2020, 10, 13, 9),
-      show_deadline_banner: Time.zone.local(2021, 8, 1, 9),
-      show_summer_recruitment_banner: Time.zone.local(2020, 7, 1, 9),
-      apply_1_deadline: Time.zone.local(2021, 9, 7, 18),
-      apply_2_deadline: Time.zone.local(2021, 9, 21, 18),
-      reject_by_default: Time.zone.local(2021, 9, 29, 23, 59, 59),
-      find_closes: Time.zone.local(2021, 10, 4, 23, 59, 59),
-      holidays: {
-        christmas: Date.new(2020, 12, 20)..Date.new(2021, 1, 1),
-        easter: Date.new(2021, 4, 2)..Date.new(2021, 4, 16),
-      },
-    },
-    2022 => {
-      find_opens: Time.zone.local(2021, 10, 5, 9),
-      apply_opens: Time.zone.local(2021, 10, 12, 9),
-      show_deadline_banner: Time.zone.local(2022, 8, 2, 9), # 5 weeks before Apply 1 deadline
-      show_summer_recruitment_banner: Time.zone.local(2022, 7, 1), # 20 working days before reject by default date
-      apply_1_deadline: Time.zone.local(2022, 9, 6, 18), # 1st Tuesday of September
-      apply_2_deadline: Time.zone.local(2022, 9, 20, 18), # 2 weeks after Apply 1 deadline
-      reject_by_default: Time.zone.local(2022, 9, 28, 23, 59, 59), # 1 week and a day after Apply 2 deadline
-      find_closes: Time.zone.local(2022, 10, 3, 23, 59, 59), # The evening before the find opens in the new cycle
-      holidays: {
-        christmas: Date.new(2021, 12, 14)..Date.new(2022, 1, 16),
-        easter: Date.new(2022, 4, 4)..Date.new(2022, 4, 18),
-      },
-    },
-    2023 => {
-      find_opens: Time.zone.local(2022, 10, 4, 9), # First Tuesday of October
-      apply_opens: Time.zone.local(2022, 10, 11, 9), # Second Tuesday of October
-      show_deadline_banner: Time.zone.local(2023, 8, 1, 9), # 5 weeks before Apply 1 deadline
-      show_summer_recruitment_banner: Time.zone.local(2023, 7, 1), # To be defined the dates for this banner
-      apply_1_deadline: Time.zone.local(2023, 9, 5, 18), # 1st Tuesday of September
-      apply_2_deadline: Time.zone.local(2023, 9, 19, 18), # 2 weeks after Apply 1 deadline
-      reject_by_default: Time.zone.local(2023, 9, 27, 23, 59, 59), # 1 week and a day after Apply 2 deadline
-      find_closes: Time.zone.local(2023, 10, 2, 23, 59, 59), # The evening before the find opens in the new cycle
-      holidays: {
-        christmas: Date.new(2022, 12, 19)..Date.new(2023, 1, 6),
-        easter: Date.new(2023, 3, 27)..Date.new(2023, 4, 10),
-      },
-    },
-    2024 => {
-      find_opens: Time.zone.local(2023, 10, 3, 9), # First Tuesday of October
-      apply_opens: Time.zone.local(2023, 10, 10, 9), # Second Tuesday of October
-      show_summer_recruitment_banner: Time.zone.local(2024, 7, 1),
-      show_deadline_banner: Time.zone.local(2024, 7, 30, 9), # 5 weeks before Apply 1 deadline
-      apply_1_deadline: Time.zone.local(2024, 9, 3, 18), # 1st Tuesday of September
-      apply_2_deadline: Time.zone.local(2024, 9, 17, 18), # 2 weeks after Apply 1 deadline
-      reject_by_default: Time.zone.local(2024, 9, 25, 23, 59, 59), # 1 week and a day after Apply 2 deadline
-      find_closes: Time.zone.local(2024, 9, 30, 23, 59, 59), # The evening before the find opens in the new cycle
-      holidays: {
-        christmas: Date.new(2023, 12, 18)..Date.new(2024, 1, 5),
-        easter: Date.new(2024, 3, 18)..Date.new(2024, 4, 1),
-      },
-    },
-    2025 => {
-      find_opens: Time.zone.local(2024, 10, 1, 9), # First Tuesday of October
-      apply_opens: Time.zone.local(2024, 10, 8, 9), # Second Tuesday of October
-      show_summer_recruitment_banner: Time.zone.local(2025, 7, 1),
-      show_deadline_banner: Time.zone.local(2025, 7, 29, 9), # 5 weeks before Apply 1 deadline
-      apply_1_deadline: Time.zone.local(2025, 9, 2, 18), # 1st Tuesday of September
-      apply_2_deadline: Time.zone.local(2025, 9, 16, 18), # 2 weeks after Apply 1 deadline
-      reject_by_default: Time.zone.local(2025, 9, 24, 23, 59, 59), # 1 week and a day after Apply 2 deadline
-      find_closes: Time.zone.local(2025, 10, 1, 23, 59, 59), # The evening before the find opens in the new cycle
-      holidays: {
-        christmas: Date.new(2024, 12, 18)..Date.new(2025, 1, 5),
-        easter: Date.new(2025, 3, 18)..Date.new(2025, 4, 1),
-      },
-    },
-  }.freeze
 
   def self.real_next_year
     real_current_year + 1
@@ -129,10 +36,6 @@ class CycleTimetable
     current_year - 1
   end
 
-  def self.between_cycles?(phase)
-    phase == 'apply_1' ? between_cycles_apply_1? : between_cycles_apply_2?
-  end
-
   def self.current_date
     now = Time.zone.now
     now.change(year: current_year) unless current_cycle_schedule == :real
@@ -140,16 +43,12 @@ class CycleTimetable
   end
 
   def self.show_apply_deadline_banner?(application_form)
-    current_date.between?(date(:show_deadline_banner), date(:apply_2_deadline)) &&
+    current_date.between?(date(:show_deadline_banner), date(:apply_deadline)) &&
       !application_form.successful?
   end
 
-  def self.show_summer_recruitment_banner?
-    current_date.between?(date(:show_summer_recruitment_banner), date(:apply_1_deadline))
-  end
-
-  def self.between_apply_1_deadline_and_find_closes?
-    current_date.between?(CycleTimetable.apply_1_deadline, CycleTimetable.find_closes)
+  def self.between_apply_deadline_and_find_closes?
+    current_date.between?(CycleTimetable.apply_deadline, CycleTimetable.find_closes)
   end
 
   def self.between_reject_by_default_and_find_reopens?
@@ -180,19 +79,14 @@ class CycleTimetable
     end
   end
 
-  def self.apply_1_deadline(year = current_year)
-    date(:apply_1_deadline, year)
-  end
-
-  def self.apply_2_deadline(year = current_year)
-    date(:apply_2_deadline, year)
+  def self.apply_deadline(year = current_year)
+    date(:apply_deadline, year)
   end
 
   def self.next_apply_deadline
     deadlines = [
-      date(:apply_1_deadline),
-      date(:apply_2_deadline),
-      date(:apply_1_deadline, next_year),
+      date(:apply_deadline),
+      date(:apply_deadline, next_year),
     ]
     deadlines.find { |deadline| deadline > current_date }
   end
@@ -243,32 +137,18 @@ class CycleTimetable
     real_schedule_for(year).fetch(:holidays)
   end
 
-  def self.apply_1_deadline_first_reminder
-    (apply_1_deadline - 2.months).beginning_of_week + 1.week
+  def self.apply_deadline_first_reminder
+    (apply_deadline - 2.months).beginning_of_week + 1.week
   end
 
-  def self.apply_1_deadline_second_reminder
-    (apply_1_deadline - 1.month).beginning_of_week + 1.week
+  def self.apply_deadline_second_reminder
+    (apply_deadline - 1.month).beginning_of_week + 1.week
   end
 
-  def self.apply_2_deadline_first_reminder
-    (apply_2_deadline - 2.months).beginning_of_week + 1.week
-  end
-
-  def self.apply_2_deadline_second_reminder
-    (apply_2_deadline - 1.month).beginning_of_week + 1.week
-  end
-
-  def self.between_cycles_apply_1?
-    (current_date > apply_1_deadline &&
-      current_date < apply_reopens) ||
-      current_date < apply_opens
-  end
-
-  def self.between_cycles_apply_2?
-    (current_date > apply_2_deadline &&
-      current_date < apply_reopens) ||
-      current_date < apply_opens
+  def self.between_cycles?
+    (CYCLE_DATES[next_year].present? && # We need to evaluated the next year in order to compare dates.
+      current_date.between?(apply_deadline, apply_reopens)) ||
+      current_date.before?(apply_opens)
   end
 
   def self.date(name, year = current_year)
@@ -326,8 +206,7 @@ class CycleTimetable
         apply_opens: 8.days.from_now,
         show_deadline_banner: 9.days.from_now,
         show_summer_recruitment_banner: 9.days.from_now,
-        apply_1_deadline: 10.days.from_now,
-        apply_2_deadline: 11.days.from_now,
+        apply_deadline: 11.days.from_now,
         reject_by_default: 12.days.from_now,
         find_closes: 13.days.from_now,
       },
@@ -336,8 +215,7 @@ class CycleTimetable
         apply_opens: 8.days.ago,
         show_deadline_banner: 7.days.ago,
         show_summer_recruitment_banner: 7.days.ago,
-        apply_1_deadline: 6.days.ago,
-        apply_2_deadline: 5.days.ago,
+        apply_deadline: 5.days.ago,
         reject_by_default: 4.days.ago,
         find_closes: 3.days.ago,
       },
@@ -350,8 +228,7 @@ class CycleTimetable
           apply_opens: 6.days.ago,
           show_deadline_banner: 1.day.from_now,
           show_summer_recruitment_banner: 1.day.from_now,
-          apply_1_deadline: 2.days.from_now,
-          apply_2_deadline: 3.days.from_now,
+          apply_deadline: 3.days.from_now,
           reject_by_default: 4.days.from_now,
           find_closes: 5.days.from_now,
         },
@@ -364,36 +241,20 @@ class CycleTimetable
           apply_opens: 6.days.ago,
           show_deadline_banner: 1.day.ago,
           show_summer_recruitment_banner: 1.day.ago,
-          apply_1_deadline: 1.day.from_now,
-          apply_2_deadline: 2.days.from_now,
+          apply_deadline: 2.days.from_now,
           reject_by_default: 3.days.from_now,
           find_closes: 4.days.from_now,
         },
         next_year => next_and_previous[next_year],
         previous_year => next_and_previous[previous_year],
       },
-      today_is_after_apply_1_deadline_passed: {
-        current_year => {
-          find_opens: 7.days.ago,
-          apply_opens: 6.days.ago,
-          show_deadline_banner: 3.days.ago,
-          show_summer_recruitment_banner: 3.days.ago,
-          apply_1_deadline: 1.day.ago,
-          apply_2_deadline: 2.days.from_now,
-          reject_by_default: 3.days.from_now,
-          find_closes: 4.days.from_now,
-        },
-        next_year => next_and_previous[next_year],
-        previous_year => next_and_previous[previous_year],
-      },
-      today_is_after_apply_2_deadline_passed: {
+      today_is_after_apply_deadline_passed: {
         current_year => {
           find_opens: 7.days.ago,
           apply_opens: 6.days.ago,
           show_deadline_banner: 4.days.ago,
           show_summer_recruitment_banner: 4.days.ago,
-          apply_1_deadline: 3.days.ago,
-          apply_2_deadline: 1.day.ago,
+          apply_deadline: 3.days.ago,
           reject_by_default: 1.day.from_now,
           find_closes: 2.days.from_now,
         },
@@ -406,8 +267,7 @@ class CycleTimetable
           apply_opens: 6.days.ago,
           show_deadline_banner: 5.days.ago,
           show_summer_recruitment_banner: 5.days.ago,
-          apply_1_deadline: 4.days.ago,
-          apply_2_deadline: 3.days.ago,
+          apply_deadline: 3.days.ago,
           reject_by_default: 2.days.ago,
           find_closes: 1.day.ago,
         },
@@ -420,8 +280,7 @@ class CycleTimetable
           apply_opens: 3.days.from_now,
           show_deadline_banner: 4.days.from_now,
           show_summer_recruitment_banner: 5.days.from_now,
-          apply_1_deadline: 6.days.from_now,
-          apply_2_deadline: 7.days.from_now,
+          apply_deadline: 7.days.from_now,
           reject_by_default: 8.days.from_now,
           find_closes: 9.days.from_now,
         },
@@ -434,8 +293,7 @@ class CycleTimetable
           apply_opens: 6.days.ago,
           show_deadline_banner: 1.day.ago,
           show_summer_recruitment_banner: 1.day.ago,
-          apply_1_deadline: 1.day.from_now,
-          apply_2_deadline: 2.days.from_now,
+          apply_deadline: 2.days.from_now,
           reject_by_default: 3.days.from_now,
           find_closes: 4.days.from_now,
         },
@@ -467,8 +325,8 @@ class CycleTimetable
     false
   end
 
-  def self.today_is_between_apply_1_deadline_and_find_reopens?
-    current_date.between?(apply_1_deadline, find_reopens)
+  def self.today_is_between_apply_deadline_and_find_reopens?
+    current_date.between?(apply_deadline, find_reopens)
   end
 
   def self.before_apply_reopens?
@@ -479,27 +337,18 @@ class CycleTimetable
     year == CYCLE_DATES.keys.last
   end
 
-  def self.currently_mid_cycle?(application_form)
-    (application_form.apply_1? && !current_date.between?(apply_1_deadline, find_reopens)) ||
-      (application_form.apply_2? && !current_date.between?(apply_2_deadline, find_reopens))
+  def self.currently_mid_cycle?(_application_form)
+    !current_date.between?(apply_deadline, find_reopens)
   end
 
-  def self.apply_1_deadline_has_passed?(application_form)
+  def self.apply_deadline_has_passed?(application_form)
     recruitment_cycle_year = application_form.recruitment_cycle_year
 
-    current_date > apply_1_deadline(recruitment_cycle_year)
-  end
-
-  def self.apply_2_deadline_has_passed?(application_form)
-    recruitment_cycle_year = application_form.recruitment_cycle_year
-
-    current_date > apply_2_deadline(recruitment_cycle_year)
+    current_date > apply_deadline(recruitment_cycle_year)
   end
 
   def self.need_to_send_deadline_reminder?
-    return :apply_1 if current_date.to_date == apply_1_deadline_first_reminder.to_date || current_date.to_date == apply_1_deadline_second_reminder.to_date
-
-    :apply_2 if current_date.to_date == apply_2_deadline_first_reminder.to_date || current_date.to_date == apply_2_deadline_second_reminder.to_date
+    current_date.to_date == apply_deadline_first_reminder.to_date || current_date.to_date == apply_deadline_second_reminder.to_date
   end
 
   def self.send_find_has_opened_email?

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -148,9 +148,9 @@ class CycleTimetable
   end
 
   def self.between_cycles?
-    (CYCLE_DATES[next_year].present? && # We need to evaluated the next year in order to compare dates.
-      current_date.between?(apply_deadline, apply_reopens)) ||
-      current_date.before?(apply_opens)
+    current_date.before?(apply_opens) || # In the current cycle, when find is open, but apply is not
+      (CYCLE_DATES[next_year].present? && # We need to evaluated the next year to compare these dates
+      current_date.between?(apply_deadline, apply_reopens)) # The current cycle deadline has passed, but apply has not reopened for the next cycle
   end
 
   def self.date(name, year = current_year)

--- a/app/services/data_migrations/update_decline_by_default_at_from_current_cycle.rb
+++ b/app/services/data_migrations/update_decline_by_default_at_from_current_cycle.rb
@@ -6,7 +6,7 @@ module DataMigrations
     def change
       records.each do |application_choice|
         application_choice.update_columns(
-          decline_by_default_at: CycleTimetable.date(:apply_1_deadline),
+          decline_by_default_at: CycleTimetable.apply_deadline,
           decline_by_default_days: nil,
         )
       end
@@ -15,8 +15,8 @@ module DataMigrations
     def records
       ApplicationChoice
       .joins(:application_form)
-      .where('decline_by_default_at >= ?', CycleTimetable.date(:find_opens))
-      .where('decline_by_default_at < ?', CycleTimetable.date(:apply_1_deadline))
+      .where('decline_by_default_at >= ?', CycleTimetable.find_opens)
+      .where('decline_by_default_at < ?', CycleTimetable.apply_deadline)
       .where('application_forms.recruitment_cycle_year': 2024)
       .where.not(declined_by_default: true)
     end

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -1,9 +1,8 @@
 class DuplicateApplication
-  attr_reader :original_application_form, :target_phase
+  attr_reader :original_application_form
 
-  def initialize(original_application_form, target_phase:, recruitment_cycle_year: RecruitmentCycle.current_year)
+  def initialize(original_application_form, recruitment_cycle_year: RecruitmentCycle.current_year)
     @original_application_form = original_application_form
-    @target_phase = target_phase
     @recruitment_cycle_year = recruitment_cycle_year
   end
 
@@ -15,7 +14,6 @@ class DuplicateApplication
     attrs = original_application_form.attributes.except(
       *IGNORED_ATTRIBUTES,
     ).merge(
-      phase: target_phase,
       previous_application_form_id: original_application_form.id,
       recruitment_cycle_year: @recruitment_cycle_year,
       work_history_status: original_application_form.work_history_status || 'can_complete',

--- a/app/services/get_referees_to_chase.rb
+++ b/app/services/get_referees_to_chase.rb
@@ -15,17 +15,9 @@ class GetRefereesToChase
         application_forms: {
           recruitment_cycle_year: RecruitmentCycle.current_year,
           application_choices: { status: APPLICATION_STATUSES },
-        }.merge(only_chase_apply_again_references),
+        },
       )
       .where('requested_at < ?', chase_referee_by)
       .where.not(id: rejected_chased_ids)
-  end
-
-  def only_chase_apply_again_references
-    if CycleTimetable.between_apply_1_deadline_and_find_closes?
-      { phase: 'apply_2' }
-    else
-      {}
-    end
   end
 end

--- a/app/views/candidate_interface/continuous_applications_choices/index.html.erb
+++ b/app/views/candidate_interface/continuous_applications_choices/index.html.erb
@@ -5,7 +5,7 @@
       <%= t('page_titles.continuous_applications.your_applications') %>
     </h1>
 
-    <% if CycleTimetable.today_is_between_apply_1_deadline_and_find_reopens? %>
+    <% if CycleTimetable.today_is_between_apply_deadline_and_find_reopens? %>
       <p class="govuk-body">Applications for courses starting in September <%= RecruitmentCycle.current_year %> are closed.</p>
       <p class="govuk-body"> From <%= CycleTimetable.find_reopens.to_fs(:govuk_time_and_date) %>, you can <%= govuk_link_to(
         'find postgraduate teacher training courses',

--- a/app/views/candidate_interface/guidance/index.html.erb
+++ b/app/views/candidate_interface/guidance/index.html.erb
@@ -46,10 +46,10 @@
                 row.with_cell(text: 'The time training providers have to make a decision about your application is reduced from 40 working days to 20 working days.')
               end
               body.with_row do |row|
-                row.with_cell(text: CycleTimetable.apply_1_deadline.to_fs(:govuk_date_and_time))
+                row.with_cell(text: CycleTimetable.apply_deadline.to_fs(:govuk_date_and_time))
                 row.with_cell do
-                  "<p class='govuk-body'>If you have not already applied for teacher training, you will not be able to apply after #{CycleTimetable.apply_1_deadline.to_fs(:govuk_date)}.</p>
-                   <p class='govuk-body govuk-!-margin-bottom-0'>If you have already applied, but your applications were unsuccessful, you can continue to apply for courses until #{CycleTimetable.apply_2_deadline.to_fs(:govuk_date_and_time)}.</p>".html_safe
+                  "<p class='govuk-body'>If you have not already applied for teacher training, you will not be able to apply after #{CycleTimetable.apply_deadline.to_fs(:govuk_date)}.</p>
+                   <p class='govuk-body govuk-!-margin-bottom-0'>If you have already applied, but your applications were unsuccessful, you can continue to apply for courses until #{CycleTimetable.apply_deadline.to_fs(:govuk_date_and_time)}.</p>".html_safe
                 end
               end
               body.with_row do |row|
@@ -92,7 +92,7 @@
                 end
               end
               body.with_row do |row|
-                row.with_cell(text: CycleTimetable.apply_2_deadline.to_fs(:govuk_date_and_time))
+                row.with_cell(text: CycleTimetable.apply_deadline.to_fs(:govuk_date_and_time))
                 row.with_cell(text: 'The last day to submit any applications.')
               end
               body.with_row do |row|

--- a/app/views/candidate_interface/shared/_details.html.erb
+++ b/app/views/candidate_interface/shared/_details.html.erb
@@ -2,7 +2,7 @@
 
 <%= render CandidateInterface::CarryOverInsetTextComponent.new(application_form: @application_form_presenter.application_form) %>
 <%= render CandidateInterface::DeadlineBannerComponent.new(application_form: @application_form_presenter.application_form, flash_empty: flash.empty?) %>
-<%= render CandidateInterface::ReopenBannerComponent.new(phase: @application_form_presenter.phase, flash_empty: flash.empty?) %>
+<%= render CandidateInterface::ReopenBannerComponent.new(flash_empty: flash.empty?) %>
 
 <%= render ServiceInformationBanner.new(namespace: :candidate) %>
 

--- a/app/views/candidate_mailer/_still_interested_content.text.erb
+++ b/app/views/candidate_mailer/_still_interested_content.text.erb
@@ -1,4 +1,4 @@
-<% if CycleTimetable.between_cycles_apply_2? %>
+<% if CycleTimetable.between_cycles? %>
 
 You can apply again for courses starting in the <%= "#{RecruitmentCycle.next_year} to #{RecruitmentCycle.next_year + 1}" %> academic year.
 

--- a/app/views/candidate_mailer/eoc_deadline_reminder.erb
+++ b/app/views/candidate_mailer/eoc_deadline_reminder.erb
@@ -4,11 +4,7 @@ Dear <%= @application_form.first_name %>
 
 [Submit your application](<%= candidate_magic_link(@application_form.candidate) %>) as soon as you can to get on a course starting in the <%= RecruitmentCycle.current_year %> to <%= RecruitmentCycle.next_year %> academic year.
 
-<% apply_1_copy =  "The deadline to submit your application is #{CycleTimetable.date(:apply_1_deadline).to_fs(:govuk_time)} on #{CycleTimetable.apply_1_deadline.to_fs(:govuk_date)} but courses may fill up before then." %>
-<% apply_2_copy =  "The deadline to submit your application is #{CycleTimetable.date(:apply_2_deadline).to_fs(:govuk_time)} on #{CycleTimetable.apply_2_deadline.to_fs(:govuk_date)} but courses may fill up before then." %>
-
-<%= apply_1_copy if @application_form.phase == 'apply_1' %>
-<%= apply_2_copy if @application_form.phase == 'apply_2' %>
+<%=  "The deadline to submit your application is #{CycleTimetable.date(:apply_deadline).to_fs(:govuk_time)} on #{CycleTimetable.apply_deadline.to_fs(:govuk_date)} but courses may fill up before then." %>
 
 Courses fill up quickly at this time of year.
 

--- a/app/views/content/dates_and_deadlines.md
+++ b/app/views/content/dates_and_deadlines.md
@@ -3,15 +3,15 @@
 | --- | --- |
 | <%= CycleTimetable.find_opens.to_fs(:govuk_date_and_time) %> | Candidates can find courses for the <%= RecruitmentCycle.cycle_name(RecruitmentCycle.current_year) %> recruitment cycle on GOV.UK. |
 | <%= CycleTimetable.apply_opens.to_fs(:govuk_date_and_time) %> | Start of <%= RecruitmentCycle.cycle_name(RecruitmentCycle.current_year) %> recruitment cycle. Candidates can apply for courses. |
-| <%= CycleTimetable.apply_2_deadline.to_fs(:govuk_date_and_time) %> | The last day for all candidates to apply for courses. |
+| <%= CycleTimetable.apply_deadline.to_fs(:govuk_date_and_time) %> | The last day for all candidates to apply for courses. |
 | <%= CycleTimetable.reject_by_default.to_fs(:govuk_date_and_time) %> | End of <%= RecruitmentCycle.cycle_name(RecruitmentCycle.current_year) %> recruitment cycle. Applications awaiting decisions are automatically rejected. |
 
 
 ### <%= RecruitmentCycle.cycle_name(RecruitmentCycle.next_year) %> recruitment cycle
 
-| **Date and time** | **What happens** |
-| --- | --- |
-| <%= CycleTimetable.find_opens(CycleTimetable.next_year).to_fs(:govuk_date_and_time) %> | Candidates can find courses for the <%= RecruitmentCycle.cycle_name(RecruitmentCycle.next_year) %> recruitment cycle on GOV.UK. |
-| <%= CycleTimetable.apply_opens(CycleTimetable.next_year).to_fs(:govuk_date_and_time) %> | Start of the <%= RecruitmentCycle.cycle_name(RecruitmentCycle.next_year) %> recruitment cycle. Candidates can apply for courses. |
-| <%= CycleTimetable.apply_2_deadline(CycleTimetable.next_year).to_fs(:govuk_date_and_time) %> | The last day for all candidates to apply for courses. |
+| **Date and time**                                                                             | **What happens** |
+|-----------------------------------------------------------------------------------------------| --- |
+| <%= CycleTimetable.find_opens(CycleTimetable.next_year).to_fs(:govuk_date_and_time) %>        | Candidates can find courses for the <%= RecruitmentCycle.cycle_name(RecruitmentCycle.next_year) %> recruitment cycle on GOV.UK. |
+| <%= CycleTimetable.apply_opens(CycleTimetable.next_year).to_fs(:govuk_date_and_time) %>       | Start of the <%= RecruitmentCycle.cycle_name(RecruitmentCycle.next_year) %> recruitment cycle. Candidates can apply for courses. |
+| <%= CycleTimetable.apply_deadline(CycleTimetable.next_year).to_fs(:govuk_date_and_time) %>    | The last day for all candidates to apply for courses. |
 | <%= CycleTimetable.reject_by_default(CycleTimetable.next_year).to_fs(:govuk_date_and_time) %> | End of <%= RecruitmentCycle.cycle_name(RecruitmentCycle.next_year) %> recruitment cycle. Applications awaiting decisions are automatically rejected. |

--- a/app/views/provider_interface/reports/hesa_exports/index.html.erb
+++ b/app/views/provider_interface/reports/hesa_exports/index.html.erb
@@ -26,7 +26,7 @@
       <%= RecruitmentCycle.cycle_name(RecruitmentCycle.previous_year) %>
     </h2>
     <p class="govuk-body">
-      <%= t('provider_interface.reports.hesa.previous_cycle.info', start_date: CycleTimetable.apply_opens(RecruitmentCycle.previous_year).to_fs(:govuk_date), end_date: CycleTimetable.apply_2_deadline(RecruitmentCycle.previous_year).to_fs(:govuk_date)) %>
+      <%= t('provider_interface.reports.hesa.previous_cycle.info', start_date: CycleTimetable.apply_opens(RecruitmentCycle.previous_year).to_fs(:govuk_date), end_date: CycleTimetable.apply_deadline(RecruitmentCycle.previous_year).to_fs(:govuk_date)) %>
     </p>
     <p class="govuk-body">
       <%= govuk_link_to t('provider_interface.reports.hesa.download_link', cycle_name: RecruitmentCycle.cycle_name(RecruitmentCycle.previous_year)),

--- a/app/views/support_interface/settings/cycles.html.erb
+++ b/app/views/support_interface/settings/cycles.html.erb
@@ -35,8 +35,7 @@
 <p class="govuk-body">(Today is <%= CycleTimetable.current_date.to_date.to_fs(:govuk_date) %>)</p>
 
 <%= render SummaryListComponent.new(rows: {
-  'Apply 1 deadline' => CycleTimetable.apply_1_deadline.to_fs(:govuk_date_and_time),
-  'Apply 2 deadline' => CycleTimetable.apply_2_deadline.to_fs(:govuk_date_and_time),
+  'Apply deadline' => CycleTimetable.apply_deadline.to_fs(:govuk_date_and_time),
   'Find closes on' => CycleTimetable.find_closes.to_fs(:govuk_date_and_time),
   'Find reopens on' => CycleTimetable.find_reopens.to_fs(:govuk_date_and_time),
   'Apply reopens on' => CycleTimetable.apply_reopens.to_fs(:govuk_date_and_time),

--- a/app/views/support_interface/tasks/confirm_cancel_applications_at_end_of_cycle.html.erb
+++ b/app/views/support_interface/tasks/confirm_cancel_applications_at_end_of_cycle.html.erb
@@ -8,7 +8,7 @@
       <h1 class="govuk-heading-l">Are you sure you want to cancel all unsubmitted applications?</h1>
 
       <p class="govuk-body">This task finds any unsubmitted applications from the most recently closed recruitment cycle and moves them to the <code>application_not_sent</code> status.</p>
-      <p class="govuk-body">This should be run shortly after the Apply 2 deadline closes at midnight on <%= CycleTimetable.date(:apply_2_deadline).to_fs(:govuk_date) %>.</p>
+      <p class="govuk-body">This should be run shortly after the apply deadline closes at midnight on <%= CycleTimetable.date(:apply_deadline).to_fs(:govuk_date) %>.</p>
 
       <%= f.govuk_submit 'Yes, I’m sure – cancel all unsubmitted applications', warning: true %>
 

--- a/app/views/support_interface/tasks/index.html.erb
+++ b/app/views/support_interface/tasks/index.html.erb
@@ -18,7 +18,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-m">End-of-cycle: Cancel unsubmitted applications</h2>
       <p class="govuk-body">This task finds any unsubmitted applications from the most recently closed recruitment cycle and moves them to the <code>application_not_sent</code> status.</p>
-      <p class="govuk-body">It should be run shortly after the Apply 2 deadline closes at midnight on <%= CycleTimetable.date(:apply_2_deadline).to_fs(:govuk_date) %>.</p>
+      <p class="govuk-body">It should be run shortly after the Apply 2 deadline closes at midnight on <%= CycleTimetable.date(:apply_deadline).to_fs(:govuk_date) %>.</p>
     </div>
     <div class="govuk-grid-column-one-third">
       <%= govuk_button_link_to 'Cancel applications', support_interface_confirm_cancel_applications_at_end_of_cycle_path, warning: true %>

--- a/app/workers/cancel_unsubmitted_applications_worker.rb
+++ b/app/workers/cancel_unsubmitted_applications_worker.rb
@@ -10,7 +10,7 @@ class CancelUnsubmittedApplicationsWorker
 private
 
   def unsubmitted_applications_from_earlier_cycle
-    return [] unless CycleTimetable.between_cycles_apply_2?
+    return [] unless CycleTimetable.between_cycles?
 
     ApplicationForm
       .where(submitted_at: nil)

--- a/app/workers/generate_test_applications.rb
+++ b/app/workers/generate_test_applications.rb
@@ -92,10 +92,10 @@ class GenerateTestApplications
       end
 
       create(recruitment_cycle_year: current_cycle, states: %i[unsubmitted], course_full: true, courses_to_apply_to: current_cycle_courses)
-      create(recruitment_cycle_year: current_cycle, states: %i[awaiting_provider_decision], apply_again: true, courses_to_apply_to: current_cycle_courses)
+      create(recruitment_cycle_year: current_cycle, states: %i[awaiting_provider_decision], courses_to_apply_to: current_cycle_courses)
       create(recruitment_cycle_year: current_cycle, states: %i[awaiting_provider_decision], carry_over: true, courses_to_apply_to: current_cycle_courses)
       create(recruitment_cycle_year: current_cycle, states: %i[offer rejected], carry_over: true, courses_to_apply_to: current_cycle_courses)
-      create(recruitment_cycle_year: current_cycle, states: %i[offer], apply_again: true, courses_to_apply_to: current_cycle_courses)
+      create(recruitment_cycle_year: current_cycle, states: %i[offer], courses_to_apply_to: current_cycle_courses)
     end
 
     StateChangeNotifier.disable_notifications do
@@ -109,7 +109,6 @@ private
     recruitment_cycle_year:,
     states:,
     courses_to_apply_to:,
-    apply_again: false,
     carry_over: false,
     course_full: false
   )
@@ -120,7 +119,6 @@ private
 
     ApplicationForm.with_unsafe_application_choice_touches do
       factory.create_application(
-        apply_again:,
         carry_over:,
         states:,
         recruitment_cycle_year:,

--- a/config/initializers/cycle_timetables.rb
+++ b/config/initializers/cycle_timetables.rb
@@ -1,0 +1,99 @@
+CURRENT_CYCLE_DATES = {
+  # Previous cycle
+  2023 => {
+    find_opens: Time.zone.local(2022, 10, 4, 9), # First Tuesday of October
+    apply_opens: Time.zone.local(2022, 10, 11, 9), # Second Tuesday of October
+    show_deadline_banner: Time.zone.local(2023, 8, 1, 9), # 5 weeks before Apply 1 deadline
+    show_summer_recruitment_banner: Time.zone.local(2023, 7, 1), # To be defined the dates for this banner
+    apply_1_deadline: Time.zone.local(2023, 9, 5, 18), # 1st Tuesday of September
+    apply_2_deadline: Time.zone.local(2023, 9, 19, 18), # 2 weeks after Apply 1 deadline
+    apply_deadline: Time.zone.local(2023, 9, 19, 18), # Adding an 'apply_deadline' for backward compatibility.
+    reject_by_default: Time.zone.local(2023, 9, 27, 23, 59, 59), # 1 week and a day after Apply 2 deadline
+    find_closes: Time.zone.local(2023, 10, 2, 23, 59, 59), # The evening before the find opens in the new cycle
+    holidays: {
+      christmas: Date.new(2022, 12, 19)..Date.new(2023, 1, 6),
+      easter: Date.new(2023, 3, 27)..Date.new(2023, 4, 10),
+    },
+  },
+  # Current cycle
+  2024 => {
+    find_opens: Time.zone.local(2023, 10, 3, 9), # First Tuesday of October
+    apply_opens: Time.zone.local(2023, 10, 10, 9), # Second Tuesday of October
+    show_summer_recruitment_banner: Time.zone.local(2024, 7, 1), # 12 weeks before deadline
+    show_deadline_banner: Time.zone.local(2024, 7, 1, 9), # 12 weeks before deadline
+    apply_deadline: Time.zone.local(2024, 9, 17, 18),
+    reject_by_default: Time.zone.local(2024, 9, 25, 23, 59, 59), # 1 week and a day after apply deadline
+    find_closes: Time.zone.local(2024, 9, 30, 23, 59, 59), # The evening before the find opens in the new cycle
+    holidays: {
+      christmas: Date.new(2023, 12, 18)..Date.new(2024, 1, 5),
+      easter: Date.new(2024, 3, 18)..Date.new(2024, 4, 1),
+    },
+  },
+  # Next cycle
+  2025 => {
+    find_opens: Time.zone.local(2024, 10, 1, 9), # First Tuesday of October
+    apply_opens: Time.zone.local(2024, 10, 8, 9), # Second Tuesday of October
+    show_summer_recruitment_banner: Time.zone.local(2025, 7, 1), # 12 weeks before apply deadline
+    show_deadline_banner: Time.zone.local(2025, 7, 1, 9), # 12 weeks before Apply deadline
+    apply_deadline: Time.zone.local(2025, 9, 16, 18),
+    reject_by_default: Time.zone.local(2025, 9, 24, 23, 59, 59), # 1 week and a day after apply deadline
+    find_closes: Time.zone.local(2025, 10, 1, 23, 59, 59), # The evening before the find opens in the new cycle
+    holidays: {
+      christmas: Date.new(2024, 12, 18)..Date.new(2025, 1, 5),
+      easter: Date.new(2025, 3, 18)..Date.new(2025, 4, 1),
+    },
+  },
+}.freeze
+
+OLDER_CYCLE_DATES = {
+  2019 => {
+    find_opens: Time.zone.local(2018, 10, 6, 9),
+    apply_opens: Time.zone.local(2018, 10, 13, 9),
+    apply_1_deadline: Time.zone.local(2019, 8, 24, 18),
+    apply_2_deadline: Time.zone.local(2019, 9, 18, 18),
+    reject_by_default: Time.zone.local(2019, 9, 29, 23, 59, 59),
+    find_closes: Time.zone.local(2019, 10, 3, 23, 59, 59),
+    holidays: {},
+  },
+  2020 => {
+    find_opens: Time.zone.local(2019, 10, 6, 9),
+    apply_opens: Time.zone.local(2019, 10, 13, 9),
+    show_deadline_banner: Time.zone.local(2020, 8, 1, 9),
+    show_summer_recruitment_banner: Time.zone.local(2020, 7, 1, 9),
+    apply_1_deadline: Time.zone.local(2020, 8, 24, 18),
+    apply_2_deadline: Time.zone.local(2020, 9, 18, 18),
+    reject_by_default: Time.zone.local(2021, 9, 29, 23, 59, 59),
+    find_closes: Time.zone.local(2020, 10, 3, 23, 59, 59),
+    holidays: {},
+  },
+  2021 => {
+    find_opens: Time.zone.local(2020, 10, 6, 9),
+    apply_opens: Time.zone.local(2020, 10, 13, 9),
+    show_deadline_banner: Time.zone.local(2021, 8, 1, 9),
+    show_summer_recruitment_banner: Time.zone.local(2020, 7, 1, 9),
+    apply_1_deadline: Time.zone.local(2021, 9, 7, 18),
+    apply_2_deadline: Time.zone.local(2021, 9, 21, 18),
+    reject_by_default: Time.zone.local(2021, 9, 29, 23, 59, 59),
+    find_closes: Time.zone.local(2021, 10, 4, 23, 59, 59),
+    holidays: {
+      christmas: Date.new(2020, 12, 20)..Date.new(2021, 1, 1),
+      easter: Date.new(2021, 4, 2)..Date.new(2021, 4, 16),
+    },
+  },
+  2022 => {
+    find_opens: Time.zone.local(2021, 10, 5, 9),
+    apply_opens: Time.zone.local(2021, 10, 12, 9),
+    show_deadline_banner: Time.zone.local(2022, 8, 2, 9), # 5 weeks before Apply 1 deadline
+    show_summer_recruitment_banner: Time.zone.local(2022, 7, 1), # 20 working days before reject by default date
+    apply_1_deadline: Time.zone.local(2022, 9, 6, 18), # 1st Tuesday of September
+    apply_2_deadline: Time.zone.local(2022, 9, 20, 18), # 2 weeks after Apply 1 deadline
+    reject_by_default: Time.zone.local(2022, 9, 28, 23, 59, 59), # 1 week and a day after Apply 2 deadline
+    find_closes: Time.zone.local(2022, 10, 3, 23, 59, 59), # The evening before the find opens in the new cycle
+    holidays: {
+      christmas: Date.new(2021, 12, 14)..Date.new(2022, 1, 16),
+      easter: Date.new(2022, 4, 4)..Date.new(2022, 4, 18),
+    },
+  },
+}.freeze
+
+CYCLE_DATES = OLDER_CYCLE_DATES.merge(CURRENT_CYCLE_DATES)

--- a/config/initializers/cycle_timetables.rb
+++ b/config/initializers/cycle_timetables.rb
@@ -51,6 +51,7 @@ OLDER_CYCLE_DATES = {
     apply_opens: Time.zone.local(2018, 10, 13, 9),
     apply_1_deadline: Time.zone.local(2019, 8, 24, 18),
     apply_2_deadline: Time.zone.local(2019, 9, 18, 18),
+    apply_deadline: Time.zone.local(2019, 9, 18, 18),
     reject_by_default: Time.zone.local(2019, 9, 29, 23, 59, 59),
     find_closes: Time.zone.local(2019, 10, 3, 23, 59, 59),
     holidays: {},
@@ -62,6 +63,7 @@ OLDER_CYCLE_DATES = {
     show_summer_recruitment_banner: Time.zone.local(2020, 7, 1, 9),
     apply_1_deadline: Time.zone.local(2020, 8, 24, 18),
     apply_2_deadline: Time.zone.local(2020, 9, 18, 18),
+    apply_deadline: Time.zone.local(2020, 9, 18, 18), # Adding an 'apply_deadline' for backward compatibility.
     reject_by_default: Time.zone.local(2021, 9, 29, 23, 59, 59),
     find_closes: Time.zone.local(2020, 10, 3, 23, 59, 59),
     holidays: {},
@@ -73,6 +75,7 @@ OLDER_CYCLE_DATES = {
     show_summer_recruitment_banner: Time.zone.local(2020, 7, 1, 9),
     apply_1_deadline: Time.zone.local(2021, 9, 7, 18),
     apply_2_deadline: Time.zone.local(2021, 9, 21, 18),
+    apply_deadline: Time.zone.local(2021, 9, 21, 18), # Adding an 'apply_deadline' for backward compatibility.
     reject_by_default: Time.zone.local(2021, 9, 29, 23, 59, 59),
     find_closes: Time.zone.local(2021, 10, 4, 23, 59, 59),
     holidays: {
@@ -87,6 +90,7 @@ OLDER_CYCLE_DATES = {
     show_summer_recruitment_banner: Time.zone.local(2022, 7, 1), # 20 working days before reject by default date
     apply_1_deadline: Time.zone.local(2022, 9, 6, 18), # 1st Tuesday of September
     apply_2_deadline: Time.zone.local(2022, 9, 20, 18), # 2 weeks after Apply 1 deadline
+    apply_deadline: Time.zone.local(2022, 9, 20, 18), # Addling an 'apply_deadline' for backward compatibility
     reject_by_default: Time.zone.local(2022, 9, 28, 23, 59, 59), # 1 week and a day after Apply 2 deadline
     find_closes: Time.zone.local(2022, 10, 3, 23, 59, 59), # The evening before the find opens in the new cycle
     holidays: {

--- a/config/locales/support_interface/cycle_timeline.yml
+++ b/config/locales/support_interface/cycle_timeline.yml
@@ -1,12 +1,14 @@
 en:
   cycle_timeline:
-    find_opens: 'Candidates can browse and add courses (current cycle)'
-    apply_opens: 'Candidates can now submit their applications (current cycle)'
-    show_deadline_banner: 'Candidates are alerted of the upcoming deadlines'
-    show_summer_recruitment_banner: 'Providers are alerted that applications will be automatically rejected if they don‘t make a decision within 20 working days'
-    apply_1_deadline: 'Candidates who have an Apply 1 application can no longer continue with it but can start preparing it for the new cycle'
-    apply_2_deadline: 'Candidates who have an Apply 2 application can no longer continue with it but can start preparing it for the new cycle'
-    reject_by_default: 'All applications are automatically rejected'
-    find_closes: 'Candidates can no longer browse or add courses'
-    find_reopens: 'Candidates can browse and add courses from the new cycle'
-    apply_reopens: 'Candidates can now submit their applications for the new cycle'
+    find_opens: Candidates can browse and add courses (current cycle)
+    apply_opens: Candidates can now submit their applications (current cycle)
+    show_deadline_banner: Candidates are alerted of the upcoming deadlines
+    show_summer_recruitment_banner: Providers are alerted that applications will be automatically rejected if they don‘t make a decision within 20 working days
+    # Apply 1 and apply 2 deadlines kept for backward compatibility when showing previous schedules
+    apply_1_deadline: Candidates who have an Apply 1 application can no longer continue with it but can start preparing it for the new cycle
+    apply_2_deadline: Candidates who have an Apply 2 application can no longer continue with it but can start preparing it for the new cycle
+    apply_deadline: Candidates with an application can no longer continue with it but can start preparing it for the new cycle
+    reject_by_default: All applications are automatically rejected
+    find_closes: Candidates can no longer browse or add courses
+    find_reopens: Candidates can browse and add courses from the new cycle
+    apply_reopens: Candidates can now submit their applications for the new cycle

--- a/config/locales/support_interface/cycle_timeline.yml
+++ b/config/locales/support_interface/cycle_timeline.yml
@@ -4,9 +4,6 @@ en:
     apply_opens: Candidates can now submit their applications (current cycle)
     show_deadline_banner: Candidates are alerted of the upcoming deadlines
     show_summer_recruitment_banner: Providers are alerted that applications will be automatically rejected if they don‘t make a decision within 20 working days
-    # Apply 1 and apply 2 deadlines kept for backward compatibility when showing previous schedules
-    apply_1_deadline: Candidates who have an Apply 1 application can no longer continue with it but can start preparing it for the new cycle
-    apply_2_deadline: Candidates who have an Apply 2 application can no longer continue with it but can start preparing it for the new cycle
     apply_deadline: Candidates with an application can no longer continue with it but can start preparing it for the new cycle
     reject_by_default: All applications are automatically rejected
     find_closes: Candidates can no longer browse or add courses

--- a/config/locales/support_interface/cycles.yml
+++ b/config/locales/support_interface/cycles.yml
@@ -9,15 +9,12 @@ en:
     today_is_mid_cycle:
       name: Mid cycle and deadlines should be displayed
       description: Candidates can see upcoming application deadlines
-    today_is_after_apply_1_deadline_passed:
-      name: Apply 1 deadline has passed
-      description: Candidates can no longer submit their initial application
+    today_is_after_apply_deadline_passed:
+      name: Apply deadline has passed
+      description: Candidates can no longer submit applications
     today_is_after_full_course_deadline_passed:
       name: Full course deadline has passed
       description: Candidates can no longer apply to unavailable courses
-    today_is_after_apply_2_deadline_passed:
-      name: Apply 2 deadline has passed
-      description: Candidates can no longer submit any subsequent applications
     today_is_after_find_closes:
       name: Find has closed
       description: Candidates can no longer browse courses on Find

--- a/spec/components/candidate_interface/application_dashboard_component_spec.rb
+++ b/spec/components/candidate_interface/application_dashboard_component_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe CandidateInterface::ApplicationDashboardComponent do
     end
   end
 
-  context 'when it is after the apply1 deadline', time: (CycleTimetable.apply_1_deadline + 1.day) do
+  context 'when it is after the apply1 deadline', time: (CycleTimetable.apply_deadline + 1.day) do
     context 'the application has ended without success' do
       it 'renders the deadline banner' do
         application_form = create_application_form_with_course_choices(
@@ -60,7 +60,7 @@ RSpec.describe CandidateInterface::ApplicationDashboardComponent do
           statuses: %w[recruited],
         )
         render_result = render_inline(described_class.new(application_form:))
-        expect(render_result.text).not_to include("The deadline for applying to courses starting in the #{CycleTimetable.cycle_year_range} academic year is 6pm on #{CycleTimetable.apply_2_deadline.to_fs(:govuk_date)}")
+        expect(render_result.text).not_to include("The deadline for applying to courses starting in the #{CycleTimetable.cycle_year_range} academic year is 6pm on #{CycleTimetable.apply_deadline.to_fs(:govuk_date)}")
       end
     end
   end

--- a/spec/components/candidate_interface/carry_over_inset_text_component_spec.rb
+++ b/spec/components/candidate_interface/carry_over_inset_text_component_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::CarryOverInsetTextComponent do
-  context 'application is unsuccessful and apply 2 deadline has passed' do
+  context 'application is unsuccessful and apply deadline has passed' do
     context 'after the new recruitment cycle begins' do
       before do
-        TestSuiteTimeMachine.travel_permanently_to(CycleTimetable.apply_reopens(2022))
+        TestSuiteTimeMachine.travel_permanently_to(CycleTimetable.apply_reopens(2024))
       end
 
       it 'renders the correct academic years' do
@@ -14,14 +14,14 @@ RSpec.describe CandidateInterface::CarryOverInsetTextComponent do
                                  application_choices: [application_choice])
         result = render_inline(described_class.new(application_form:))
 
-        expect(result.text).to include('You submitted your application for courses starting in the 2021 to 2022 academic year, which have now closed.')
-        expect(result.text).to include('You can apply for courses starting in the 2022 to 2023 academic year instead.')
+        expect(result.text).to include('You submitted your application for courses starting in the 2023 to 2024 academic year, which have now closed.')
+        expect(result.text).to include('You can apply for courses starting in the 2024 to 2025 academic year instead.')
       end
     end
 
-    context 'after the apply_2 deadline but before apply reopens' do
+    context 'after the apply deadline but before apply reopens' do
       before do
-        TestSuiteTimeMachine.travel_permanently_to(CycleTimetable.apply_2_deadline(2021))
+        TestSuiteTimeMachine.travel_permanently_to(CycleTimetable.apply_deadline(2023))
       end
 
       it 'renders the correct academic years' do
@@ -30,11 +30,11 @@ RSpec.describe CandidateInterface::CarryOverInsetTextComponent do
                                  recruitment_cycle_year: RecruitmentCycle.current_year,
                                  application_choices: [application_choice])
 
-        advance_time_to(after_apply_2_deadline(2021))
+        advance_time_to(after_apply_deadline(2023))
         result = render_inline(described_class.new(application_form:))
 
-        expect(result.text).to include('You submitted your application for courses starting in the 2021 to 2022 academic year, which have now closed.')
-        expect(result.text).to include('You can apply for courses starting in the 2022 to 2023 academic year instead.')
+        expect(result.text).to include('You submitted your application for courses starting in the 2023 to 2024 academic year, which have now closed.')
+        expect(result.text).to include('You can apply for courses starting in the 2024 to 2025 academic year instead.')
         expect(result.css('.govuk-button').first.text).to eq('Apply again')
       end
     end

--- a/spec/components/candidate_interface/carry_over_interstitial_component_spec.rb
+++ b/spec/components/candidate_interface/carry_over_interstitial_component_spec.rb
@@ -8,23 +8,23 @@ RSpec.describe CandidateInterface::CarryOverInterstitialComponent do
     expect(result.text).to include('Continue your application')
   end
 
-  context 'after the new recruitment cycle begins', time: CycleTimetable.apply_reopens(2022) do
+  context 'after the new recruitment cycle begins', time: CycleTimetable.apply_reopens(2024) do
     it 'renders the correct academic years' do
-      application_form = build(:completed_application_form, recruitment_cycle_year: 2021)
+      application_form = build(:completed_application_form, recruitment_cycle_year: 2023)
       result = render_inline(described_class.new(application_form:))
 
-      expect(result.text).to include('You started an application for courses starting in the 2021 to 2022 academic year, which have now closed.')
-      expect(result.text).to include('Continue your application to apply for courses starting in the 2022 to 2023 academic year instead.')
+      expect(result.text).to include('You started an application for courses starting in the 2023 to 2024 academic year, which have now closed.')
+      expect(result.text).to include('Continue your application to apply for courses starting in the 2024 to 2025 academic year instead.')
     end
   end
 
-  context 'after the apply_1 deadline but before apply reopens', time: CycleTimetable.apply_1_deadline(2021) do
+  context 'after the apply_1 deadline but before apply reopens', time: CycleTimetable.apply_deadline(2023) do
     it 'renders the correct academic years' do
       application_form = build(:completed_application_form, recruitment_cycle_year: RecruitmentCycle.current_year)
       result = render_inline(described_class.new(application_form:))
 
-      expect(result.text).to include('You started an application for courses starting in the 2021 to 2022 academic year, which have now closed.')
-      expect(result.text).to include('Continue your application to apply for courses starting in the 2022 to 2023 academic year instead.')
+      expect(result.text).to include('You started an application for courses starting in the 2023 to 2024 academic year, which have now closed.')
+      expect(result.text).to include('Continue your application to apply for courses starting in the 2024 to 2025 academic year instead.')
     end
   end
 end

--- a/spec/components/candidate_interface/deadline_banner_component_spec.rb
+++ b/spec/components/candidate_interface/deadline_banner_component_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe CandidateInterface::DeadlineBannerComponent, type: :component do
       result = render_inline(described_class.new(application_form:, flash_empty: flash.empty?))
 
       expect(result.text).to include(
-        "The deadline for applying to courses starting in #{academic_year} is #{deadline_time(:apply_2_deadline)} on #{deadline_date(:apply_2_deadline)}",
+        "The deadline for applying to courses starting in #{academic_year} is #{deadline_time(:apply_deadline)} on #{deadline_date(:apply_deadline)}",
       )
     end
   end

--- a/spec/components/candidate_interface/reopen_banner_component_spec.rb
+++ b/spec/components/candidate_interface/reopen_banner_component_spec.rb
@@ -2,42 +2,29 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::ReopenBannerComponent do
   describe '#render' do
-    let(:application_form) { build(:application_form) }
     let(:flash) { double }
 
-    def configure_conditions_for_rendering_banner(phase)
-      application_form.phase = phase
+    def configure_conditions_for_rendering_banner
       FeatureFlag.activate(:deadline_notices)
       allow(flash).to receive(:empty?).and_return true
-      allow(CycleTimetable).to receive_messages(between_cycles_apply_1?: true, between_cycles_apply_2?: true, current_year: 2021, apply_opens: Time.zone.local(2020, 10, 13, 9), apply_reopens: Time.zone.local(2021, 10, 12, 9))
-      allow(CycleTimetable).to receive(:cycle_year_range).with(2021).and_return('2021 to 2022')
-      allow(CycleTimetable).to receive(:cycle_year_range).with(2022).and_return('2022 to 2023')
+      allow(CycleTimetable).to receive_messages(between_cycles?: true, current_year: 2023, apply_opens: Time.zone.local(2023, 9, 13, 9), apply_reopens: Time.zone.local(2023, 10, 12, 9))
+      allow(CycleTimetable).to receive(:cycle_year_range).with(2023).and_return('2023 to 2024')
+      allow(CycleTimetable).to receive(:cycle_year_range).with(2024).and_return('2024 to 2023')
     end
 
     context 'before find reopens' do
       before do
-        TestSuiteTimeMachine.travel_permanently_to(CycleTimetable.apply_2_deadline + 1.day)
+        TestSuiteTimeMachine.travel_permanently_to(CycleTimetable.apply_deadline + 1.day)
       end
 
-      it 'renders the banner for an Apply 1 app with the correct details' do
-        configure_conditions_for_rendering_banner('apply_1')
+      it 'renders the banner for an app with the correct details' do
+        configure_conditions_for_rendering_banner
 
         render_inline(
-          described_class.new(phase: application_form.phase, flash_empty: flash.empty?),
+          described_class.new(flash_empty: flash.empty?),
         ) do |result|
-          expect(result.text).to include('Applications for courses starting in the 2021 to 2022 academic year are closed')
-          expect(result.text).to include('Submit your application from 9am on 12 October 2021 for courses starting in the 2022 to 2023 academic year.')
-        end
-      end
-
-      it 'renders the banner for an Apply 2 app' do
-        configure_conditions_for_rendering_banner('apply_2')
-
-        render_inline(
-          described_class.new(phase: application_form.phase, flash_empty: flash.empty?),
-        ) do |result|
-          expect(result.text).to include('Applications for courses starting in the 2021 to 2022 academic year are closed')
-          expect(result.text).to include('Submit your application from 9am on 12 October 2021 for courses starting in the 2022 to 2023 academic year.')
+          expect(result.text).to include('Applications for courses starting in the 2023 to 2024 academic year are closed')
+          expect(result.text).to include('Submit your application from 9am on 12 October 2023 for courses starting in the 2024 to 2023 academic year.')
         end
       end
     end
@@ -48,47 +35,31 @@ RSpec.describe CandidateInterface::ReopenBannerComponent do
       end
 
       it 'renders the banner for an Apply 1 app with the correct details' do
-        configure_conditions_for_rendering_banner('apply_1')
+        configure_conditions_for_rendering_banner
 
         render_inline(
-          described_class.new(phase: application_form.phase, flash_empty: flash.empty?),
+          described_class.new(flash_empty: flash.empty?),
         ) do |result|
-          expect(result.text).to include('Applications for courses starting in the 2021 to 2022 academic year are closed')
-          expect(result.text).to include('Submit your application from 9am on 12 October 2021 for courses starting in the 2022 to 2023 academic year.')
-        end
-      end
-
-      it 'renders the banner for an Apply 2 app' do
-        configure_conditions_for_rendering_banner('apply_2')
-
-        render_inline(
-          described_class.new(phase: application_form.phase, flash_empty: flash.empty?),
-        ) do |result|
-          expect(result.text).to include('Applications for courses starting in the 2021 to 2022 academic year are closed')
-          expect(result.text).to include('Submit your application from 9am on 12 October 2021 for courses starting in the 2022 to 2023 academic year.')
+          expect(result.text).to include('Applications for courses starting in the 2023 to 2024 academic year are closed')
+          expect(result.text).to include('Submit your application from 9am on 12 October 2023 for courses starting in the 2024 to 2023 academic year.')
         end
       end
     end
 
     it 'does not render when we are not between cycles' do
-      configure_conditions_for_rendering_banner('apply_1')
-      allow(CycleTimetable).to receive(:between_cycles_apply_1?).and_return(false)
+      configure_conditions_for_rendering_banner
+      allow(CycleTimetable).to receive(:between_cycles?).and_return(false)
 
-      result = render_inline(
-        described_class.new(
-          phase: application_form.phase,
-          flash_empty: flash.empty?,
-        ),
-      )
+      result = render_inline(described_class.new(flash_empty: flash.empty?))
 
       expect(result.text).not_to include('Applications for courses starting this academic year have now closed')
     end
 
     it 'renders nothing if the flash contains something' do
-      configure_conditions_for_rendering_banner('apply_1')
+      configure_conditions_for_rendering_banner
       allow(flash).to receive(:empty?).and_return false
 
-      result = render_inline(described_class.new(phase: application_form.phase, flash_empty: flash.empty?))
+      result = render_inline(described_class.new(flash_empty: flash.empty?))
 
       expect(result.text).to be_blank
     end

--- a/spec/components/previews/candidate_interface/carry_over_alert_preview.rb
+++ b/spec/components/previews/candidate_interface/carry_over_alert_preview.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   class CarryOverAlertPreview < ViewComponent::Preview
     def twenty_twenty_four
-      application_form = ApplicationForm.new(recruitment_cycle_year: 2024, phase: 'apply_1')
+      application_form = ApplicationForm.new(recruitment_cycle_year: 2024)
 
       render CandidateInterface::CarryOverAlertComponent.new(application_form:)
     end

--- a/spec/components/previews/candidate_interface/reopen_banner_alert_preview.rb
+++ b/spec/components/previews/candidate_interface/reopen_banner_alert_preview.rb
@@ -2,7 +2,6 @@ module CandidateInterface
   class ReopenBannerAlertPreview < ViewComponent::Preview
     def twenty_twenty_four
       render CandidateInterface::ReopenBannerComponentPreviewComponent.new(
-        phase: 'apply_1',
         flash_empty: true,
       )
     end

--- a/spec/components/shared/end_of_cycle_emails_component_spec.rb
+++ b/spec/components/shared/end_of_cycle_emails_component_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe EndOfCycleEmailsComponent do
       result = render_inline(described_class.new)
 
       expect(result.css('.govuk-table__body a').map(&:text)).to eq([
-        'Apply 1 deadline reminder',
-        'Apply 2 deadline reminder',
+        'Apply deadline reminder',
         'Find has opened',
         'Apply has opened',
         'Find is now open (providers)',
@@ -22,8 +21,7 @@ RSpec.describe EndOfCycleEmailsComponent do
 
       expect(result.css('.govuk-table__body a').map(&:text)).to eq([])
       expect(result.css('.govuk-table__body th').map(&:text)).to eq([
-        'Apply 1 deadline reminder',
-        'Apply 2 deadline reminder',
+        'Apply deadline reminder',
         'Find has opened',
         'Apply has opened',
         'Find is now open (providers)',

--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -406,8 +406,8 @@ FactoryBot.define do
 
     trait :apply_again do
       completed
-      created_at { CycleTimetableHelper.before_apply_2_deadline }
-      updated_at { CycleTimetableHelper.before_apply_2_deadline }
+      created_at { CycleTimetableHelper.before_apply_deadline }
+      updated_at { CycleTimetableHelper.before_apply_deadline }
       recruitment_cycle_year { CycleTimetable.current_year }
       phase { 'apply_2' }
 

--- a/spec/factory_specs/application_form_factory_spec.rb
+++ b/spec/factory_specs/application_form_factory_spec.rb
@@ -346,8 +346,8 @@ RSpec.describe 'ApplicationForm factory' do
     it_behaves_like 'trait :completed', phase: 'apply_2'
 
     field :recruitment_cycle_year, value: RecruitmentCycle.current_year
-    field :created_at, value: CycleTimetableHelper.before_apply_2_deadline
-    field :updated_at, value: CycleTimetableHelper.before_apply_2_deadline
+    field :created_at, value: CycleTimetableHelper.before_apply_deadline
+    field :updated_at, value: CycleTimetableHelper.before_apply_deadline
 
     it 'associates a previous application form in the current year' do
       expect(record.previous_application_form).to be_present

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe CandidateMailer do
 
       context 'when it is before the apply_2_deadline' do
         before do
-          allow(CycleTimetable).to receive(:between_cycles_apply_2?).and_return(false)
+          allow(CycleTimetable).to receive(:between_cycles?).and_return(false)
         end
 
         it_behaves_like(
@@ -217,7 +217,7 @@ RSpec.describe CandidateMailer do
 
       context 'when it is after the apply_2_deadline' do
         before do
-          allow(CycleTimetable).to receive_messages(between_cycles_apply_2?: true, apply_opens: Date.new(2021, 10, 13))
+          allow(CycleTimetable).to receive_messages(between_cycles?: true, apply_opens: Date.new(2021, 10, 13))
           allow(RecruitmentCycle).to receive(:next_year).and_return(2022)
         end
 
@@ -237,7 +237,7 @@ RSpec.describe CandidateMailer do
       let(:application_choices) { [dbd_application, dbd_application, build_stubbed(:application_choice, status: 'rejected')] }
 
       before do
-        allow(CycleTimetable).to receive(:between_cycles_apply_2?).and_return(false)
+        allow(CycleTimetable).to receive(:between_cycles?).and_return(false)
       end
 
       it_behaves_like(
@@ -713,29 +713,16 @@ RSpec.describe CandidateMailer do
   end
 
   describe '.deadline_reminder' do
-    context 'when a candidate is in Apply 1' do
+    context 'when a candidate has provided a first name' do
       let(:email) { mailer.eoc_deadline_reminder(application_form) }
-      let(:application_form) { build_stubbed(:application_form, phase: 'apply_1', first_name: 'Fred') }
+      let(:application_form) { build_stubbed(:application_form, first_name: 'Fred') }
 
       it_behaves_like(
         'a mail with subject and content',
         'Submit your teacher training application before courses fill up',
         'heading' => 'Dear Fred',
         'cycle_details' => "as soon as you can to get on a course starting in the #{RecruitmentCycle.current_year} to #{RecruitmentCycle.next_year} academic year.",
-        'details' => "The deadline to submit your application is 6pm on #{CycleTimetable.apply_1_deadline.to_fs(:govuk_date)}",
-      )
-    end
-
-    context 'when a candidate is in Apply 2' do
-      let(:email) { mailer.eoc_deadline_reminder(application_form) }
-      let(:application_form) { build_stubbed(:application_form, phase: 'apply_2', first_name: 'Fred') }
-
-      it_behaves_like(
-        'a mail with subject and content',
-        'Submit your teacher training application before courses fill up',
-        'heading' => 'Dear Fred',
-        'cycle_details' => "as soon as you can to get on a course starting in the #{RecruitmentCycle.current_year} to #{RecruitmentCycle.next_year} academic year.",
-        'details' => "The deadline to submit your application is 6pm on #{CycleTimetable.apply_2_deadline.to_fs(:govuk_date)}",
+        'details' => "The deadline to submit your application is 6pm on #{CycleTimetable.apply_deadline.to_fs(:govuk_date)}",
       )
     end
 

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -326,30 +326,8 @@ RSpec.describe ApplicationForm do
   end
 
   describe '#number_of_slots_left' do
-    it 'returns the number of choices that an candidate can make in the first instance' do
+    it 'returns the number of choices that a candidate can make in Apply' do
       application_form = create(:application_form)
-
-      expect(application_form.reload.number_of_slots_left).to eq(4)
-
-      create(:application_choice, application_form:)
-
-      expect(application_form.reload.number_of_slots_left).to eq(3)
-
-      create(:application_choice, application_form:)
-
-      expect(application_form.reload.number_of_slots_left).to eq(2)
-
-      create(:application_choice, application_form:)
-
-      expect(application_form.reload.number_of_slots_left).to eq(1)
-
-      create(:application_choice, application_form:)
-
-      expect(application_form.reload.number_of_slots_left).to eq(0)
-    end
-
-    it 'returns the number of choices that a candidate can make in Apply 2' do
-      application_form = create(:application_form, phase: 'apply_2')
 
       expect(application_form.reload.number_of_slots_left).to eq(4)
 
@@ -775,7 +753,7 @@ RSpec.describe ApplicationForm do
     end
   end
 
-  describe '#not_submitted_and_apply_1_deadline_has_passed?' do
+  describe '#not_submitted_and_apply_deadline_has_passed?' do
     context 'application has been submitted' do
       it 'returns false' do
         travel_temporarily_to(mid_cycle) do
@@ -786,30 +764,10 @@ RSpec.describe ApplicationForm do
       end
     end
 
-    context 'phase 1 application has not been submitted and apply 1 deadline has passed' do
+    context 'application has not been submitted and apply deadline has passed' do
       it 'returns true' do
-        travel_temporarily_to(after_apply_1_deadline) do
-          application_form = build(:application_form, phase: 'apply_1')
-
-          expect(application_form.not_submitted_and_deadline_has_passed?).to be(true)
-        end
-      end
-    end
-
-    context 'phase 2 application has not been submitted and apply 1 deadline has passed' do
-      it 'returns false' do
-        travel_temporarily_to(after_apply_1_deadline) do
-          application_form = build(:application_form, phase: 'apply_2')
-
-          expect(application_form.not_submitted_and_deadline_has_passed?).to be(false)
-        end
-      end
-    end
-
-    context 'phase 2 application has not been submitted and apply 2 deadline has passed' do
-      it 'returns true' do
-        travel_temporarily_to(after_apply_2_deadline) do
-          application_form = build(:application_form, phase: 'apply_2')
+        travel_temporarily_to(after_apply_deadline) do
+          application_form = build(:application_form)
 
           expect(application_form.not_submitted_and_deadline_has_passed?).to be(true)
         end
@@ -817,36 +775,36 @@ RSpec.describe ApplicationForm do
     end
   end
 
-  describe '#unsucessful_and_apply_2_deadline_has_passed?' do
+  describe '#unsucessful_and_apply_deadline_has_passed?' do
     context 'application ended with success' do
       it 'returns false' do
-        travel_temporarily_to(CycleTimetable.apply_2_deadline) do
+        travel_temporarily_to(CycleTimetable.apply_deadline) do
           application_choice = build(:application_choice, :offered)
-          application_form = build(:application_form, phase: 'apply_2', application_choices: [application_choice])
+          application_form = build(:application_form, application_choices: [application_choice])
 
-          expect(application_form.unsuccessful_and_apply_2_deadline_has_passed?).to be(false)
+          expect(application_form.unsuccessful_and_apply_deadline_has_passed?).to be(false)
         end
       end
     end
 
-    context 'phase 2 application ended without success and apply 2 deadline has passed' do
+    context 'application ended without success and apply deadline has passed' do
       it 'returns true' do
-        travel_temporarily_to(after_apply_2_deadline) do
+        travel_temporarily_to(after_apply_deadline) do
           application_choice = build(:application_choice, :rejected)
-          application_form = build(:application_form, phase: 'apply_2', application_choices: [application_choice])
+          application_form = build(:application_form, application_choices: [application_choice])
 
-          expect(application_form.unsuccessful_and_apply_2_deadline_has_passed?).to be(true)
+          expect(application_form.unsuccessful_and_apply_deadline_has_passed?).to be(true)
         end
       end
     end
 
-    context 'phase 2 application ended without success and apply 2 deadline has not passed' do
+    context 'application ended without success and apply deadline has not passed' do
       it 'returns false' do
-        travel_temporarily_to(after_apply_1_deadline) do
+        travel_temporarily_to(before_apply_deadline) do
           application_choice = build(:application_choice, :rejected)
-          application_form = build(:application_form, phase: 'apply_2', application_choices: [application_choice])
+          application_form = build(:application_form, application_choices: [application_choice])
 
-          expect(application_form.unsuccessful_and_apply_2_deadline_has_passed?).to be(false)
+          expect(application_form.unsuccessful_and_apply_deadline_has_passed?).to be(false)
         end
       end
     end

--- a/spec/models/candidate_interface/rejection_reasons_history_spec.rb
+++ b/spec/models/candidate_interface/rejection_reasons_history_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe CandidateInterface::RejectionReasonsHistory do
   private
 
     def apply_again!(application_form)
-      DuplicateApplication.new(application_form, target_phase: :apply_2).duplicate
+      DuplicateApplication.new(application_form).duplicate
     end
   end
 end

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -126,9 +126,9 @@ RSpec.describe Candidate do
       end
     end
 
-    context 'after the apply1 deadline' do
+    context 'after the apply deadline' do
       around do |example|
-        travel_temporarily_to(CycleTimetable.apply_1_deadline + 1.day) do
+        travel_temporarily_to(CycleTimetable.apply_deadline + 1.day) do
           example.run
         end
       end

--- a/spec/models/performance_statistics_spec.rb
+++ b/spec/models/performance_statistics_spec.rb
@@ -115,22 +115,22 @@ RSpec.describe PerformanceStatistics do
 
   describe '#candidate_count' do
     it 'returns the total number of candidates that were created during a given cycle' do
-      travel_temporarily_to(CycleTimetable.find_opens(2020) + 1.day) do
+      travel_temporarily_to(CycleTimetable.find_opens(2023) + 1.day) do
         create_list(:candidate, 2)
       end
-      travel_temporarily_to(CycleTimetable.apply_2_deadline(2020) + 1.day) do
+      travel_temporarily_to(CycleTimetable.apply_deadline(2023) + 1.day) do
         create_list(:candidate, 3)
       end
 
-      expect(described_class.new(2020).candidate_count).to eq(2)
-      expect(described_class.new(2021).candidate_count).to eq(3)
+      expect(described_class.new(2023).candidate_count).to eq(2)
+      expect(described_class.new(2024).candidate_count).to eq(3)
     end
 
     it 'returns the total number of candidates that exist when no cycle is given' do
-      travel_temporarily_to(2020, 1, 5) do
+      travel_temporarily_to(2023, 1, 5) do
         create_list(:candidate, 2)
       end
-      travel_temporarily_to(2020, 12, 25) do
+      travel_temporarily_to(2023, 12, 25) do
         create_list(:candidate, 3)
       end
 
@@ -138,12 +138,12 @@ RSpec.describe PerformanceStatistics do
     end
 
     it 'does not take into account any application forms that a candidate may have' do
-      travel_temporarily_to(2020, 1, 5) do
-        create(:application_form, recruitment_cycle_year: 2021)
+      travel_temporarily_to(2023, 1, 5) do
+        create(:application_form, recruitment_cycle_year: 2024)
       end
 
-      expect(described_class.new(2020).candidate_count).to eq(1)
-      expect(described_class.new(2021).candidate_count).to eq(0)
+      expect(described_class.new(2023).candidate_count).to eq(1)
+      expect(described_class.new(2024).candidate_count).to eq(0)
     end
   end
 

--- a/spec/requests/candidate_interface/continuous_applications_choose_course_spec.rb
+++ b/spec/requests/candidate_interface/continuous_applications_choose_course_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'continuous applications redirects' do
 
   context 'when cycle is over' do
     it 'redirects the user when trying to add a course from find' do
-      TestSuiteTimeMachine.travel_permanently_to(after_apply_1_deadline + 1.day)
+      TestSuiteTimeMachine.travel_permanently_to(after_apply_deadline + 1.day)
       provider = create(:provider, code: '8N5', name: 'Snape University')
       course = create(:course, name: 'Potions', provider:)
 

--- a/spec/services/carry_over_application_spec.rb
+++ b/spec/services/carry_over_application_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe CarryOverApplication do
   end
 
   before do
-    TestSuiteTimeMachine.travel_permanently_to(after_apply_2_deadline)
+    TestSuiteTimeMachine.travel_permanently_to(after_apply_deadline)
   end
 
   let(:application_form) { create(:completed_application_form, references_count: 0) }
@@ -49,7 +49,7 @@ RSpec.describe CarryOverApplication do
       original_application_form.save(touch: false)
     end
 
-    it_behaves_like 'duplicates application form', 'apply_1', CycleTimetable.current_year
+    it_behaves_like 'duplicates application form', CycleTimetable.current_year
   end
 
   context 'when original application is from multiple cycles ago' do
@@ -59,14 +59,14 @@ RSpec.describe CarryOverApplication do
       original_application_form.save(touch: false)
     end
 
-    it_behaves_like 'duplicates application form', 'apply_1', CycleTimetable.current_year
+    it_behaves_like 'duplicates application form', CycleTimetable.current_year
   end
 
-  context 'when original application is from the current recruitment cycle but that cycle has now closed', time: after_apply_2_deadline do
-    it_behaves_like 'duplicates application form', 'apply_1', CycleTimetable.next_year
+  context 'when original application is from the current recruitment cycle but that cycle has now closed', time: after_apply_deadline do
+    it_behaves_like 'duplicates application form', CycleTimetable.next_year
   end
 
-  context 'when application form has unstructured work history', time: (CycleTimetable.apply_1_deadline + 1.day) do
+  context 'when application form has unstructured work history', time: (CycleTimetable.apply_deadline + 1.day) do
     it 'carries over history' do
       described_class.new(original_application_form).call
       carried_over_application_form = ApplicationForm.last

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -3,13 +3,12 @@ require 'rails_helper'
 RSpec.describe CycleTimetable do
   let(:this_year) { Time.zone.now.year }
   let(:next_year) { this_year + 1 }
+  let(:last_year) { this_year - 1 }
   let(:next_next_year) { this_year + 2 }
-  let(:one_hour_before_apply1_deadline) { described_class.apply_1_deadline(this_year) - 1.hour }
-  let(:one_hour_after_apply1_deadline) { described_class.apply_1_deadline(this_year) + 1.hour  }
-  let(:one_hour_before_apply2_deadline) { described_class.apply_2_deadline(this_year) - 1.hour }
-  let(:one_hour_after_apply2_deadline) { described_class.apply_2_deadline(this_year) + 1.hour  }
+  let(:one_hour_before_apply_deadline) { described_class.apply_deadline(this_year) - 1.hour }
+  let(:one_hour_after_apply_deadline) { described_class.apply_deadline(this_year) + 1.hour  }
   let(:one_hour_after_this_year_cycle_opens) { described_class.apply_opens(this_year) + 1.hour }
-  let(:one_hour_after_next_year_cycle_opens) { described_class.apply_opens(next_year) + 1.hour }
+  let(:one_hour_after_near_year_apply_opens) { described_class.apply_opens(next_year) + 1.hour }
   let(:one_hour_before_find_closes) { described_class.find_closes(this_year) - 1.hour }
   let(:one_hour_after_find_closes) { described_class.find_closes(this_year) + 1.hour }
   let(:one_hour_after_find_opens) { described_class.find_opens(this_year) + 1.hour }
@@ -25,7 +24,7 @@ RSpec.describe CycleTimetable do
     end
 
     it 'is next_year if we are in the middle of the next_year cycle' do
-      travel_temporarily_to(one_hour_after_next_year_cycle_opens) do
+      travel_temporarily_to(one_hour_after_near_year_apply_opens) do
         expect(described_class.current_year).to eq(next_year)
       end
     end
@@ -36,8 +35,11 @@ RSpec.describe CycleTimetable do
       end
     end
 
-    it 'returns 2022 for current_year(CycleTimetable.find_opens(2023))' do
-      expect(described_class.current_year(described_class.find_opens(2023))).to eq(2022)
+    it 'returns last_year for current_year(CycleTimetable.find_opens(this_year))' do
+      # What this test shows that right at the moment find_opens, #current_year returns the year before.
+      # Like we haven't quite started the cycle yet.
+      # This doesn't make sense to have the first date that defines a cycle not be included in the cycle.
+      expect(described_class.current_year(described_class.find_opens(this_year))).to eq(last_year)
     end
   end
 
@@ -49,18 +51,18 @@ RSpec.describe CycleTimetable do
     end
 
     it 'is next_next_year if we are in the middle of the next_year cycle' do
-      travel_temporarily_to(one_hour_after_next_year_cycle_opens) do
+      travel_temporarily_to(one_hour_after_near_year_apply_opens) do
         expect(described_class.next_year).to eq(next_next_year)
       end
     end
   end
 
   describe '.show_apply_deadline_banner?' do
-    it 'returns true before the deadline and the choices have not ben successful' do
+    it 'returns true before the deadline and the choices have not been successful' do
       application_choices = [build(:application_choice, :withdrawn)]
       application_form = build(:application_form, application_choices:)
 
-      travel_temporarily_to(one_hour_before_apply1_deadline) do
+      travel_temporarily_to(one_hour_before_apply_deadline) do
         expect(described_class.show_apply_deadline_banner?(application_form)).to be true
       end
     end
@@ -68,7 +70,7 @@ RSpec.describe CycleTimetable do
     it 'returns true if there are no application choices' do
       application_form = build(:application_form)
 
-      travel_temporarily_to(one_hour_before_apply1_deadline) do
+      travel_temporarily_to(one_hour_before_apply_deadline) do
         expect(described_class.show_apply_deadline_banner?(application_form)).to be true
       end
     end
@@ -77,43 +79,16 @@ RSpec.describe CycleTimetable do
       application_choice = build(:application_choice, :offered)
       application_form = build(:application_form, phase: 'apply_1', application_choices: [application_choice])
 
-      travel_temporarily_to(one_hour_before_apply1_deadline) do
+      travel_temporarily_to(one_hour_before_apply_deadline) do
         expect(described_class.show_apply_deadline_banner?(application_form)).to be false
       end
     end
 
     it 'returns false after the configured date' do
-      application_form = build(:application_form, phase: 'apply_1')
+      application_form = build(:application_form)
 
-      travel_temporarily_to(one_hour_after_apply2_deadline) do
+      travel_temporarily_to(one_hour_after_apply_deadline) do
         expect(described_class.show_apply_deadline_banner?(application_form)).to be false
-      end
-    end
-  end
-
-  describe '.show_summer_recruitment_banner?' do
-    let(:one_hour_before_show_summer_recruitment_banner) do
-      described_class.date(:show_summer_recruitment_banner) - 1.hour
-    end
-    let(:one_hour_after_show_summer_recruitment_banner) do
-      described_class.date(:show_summer_recruitment_banner) + 1.hour
-    end
-
-    it 'returns false before the configured date' do
-      travel_temporarily_to(one_hour_before_show_summer_recruitment_banner) do
-        expect(described_class.show_summer_recruitment_banner?).to be false
-      end
-    end
-
-    it 'returns true between configure date and apply 1 closes' do
-      travel_temporarily_to(one_hour_after_show_summer_recruitment_banner) do
-        expect(described_class.show_summer_recruitment_banner?).to be true
-      end
-    end
-
-    it 'returns false after apply 1 closes' do
-      travel_temporarily_to(described_class.apply_1_deadline(2022) + 1.hour) do
-        expect(described_class.show_summer_recruitment_banner?).to be false
       end
     end
   end
@@ -123,7 +98,7 @@ RSpec.describe CycleTimetable do
       let(:one_hour_after_christmas_period) { described_class.holidays[:christmas].last.end_of_day + 1.hour }
 
       it 'returns false if before the 20 day period' do
-        travel_temporarily_to(one_hour_after_next_year_cycle_opens) do
+        travel_temporarily_to(one_hour_after_near_year_apply_opens) do
           expect(described_class.show_non_working_days_banner?).to be false
         end
       end
@@ -166,74 +141,48 @@ RSpec.describe CycleTimetable do
     end
   end
 
-  describe '.between_cycles_apply_1?' do
-    it 'returns false before the configured date' do
-      travel_temporarily_to(one_hour_before_apply1_deadline) do
-        expect(described_class.between_cycles_apply_1?).to be false
+  describe '.between_cycles?' do
+    it 'returns false before if apply deadline has not passed' do
+      travel_temporarily_to(one_hour_before_apply_deadline) do
+        expect(described_class.between_cycles?).to be false
       end
     end
 
-    it 'returns true after the configured date' do
-      travel_temporarily_to(one_hour_after_apply1_deadline) do
-        expect(described_class.between_cycles_apply_1?).to be true
+    it 'returns true after apply deadline has passed but find is still open' do
+      travel_temporarily_to(one_hour_after_apply_deadline) do
+        expect(described_class.between_cycles?).to be true
       end
     end
 
     it 'returns true between find and apply reopening' do
       travel_temporarily_to(one_hour_after_find_opens) do
-        expect(described_class.between_cycles_apply_2?).to be true
+        expect(described_class.between_cycles?).to be true
       end
     end
 
     it 'returns false after the new cycle opens' do
-      travel_temporarily_to(one_hour_after_next_year_cycle_opens) do
-        expect(described_class.between_cycles_apply_1?).to be false
+      travel_temporarily_to(one_hour_after_near_year_apply_opens) do
+        expect(described_class.between_cycles?).to be false
       end
     end
   end
 
-  describe '.between_apply_1_deadline_and_find_closes?' do
+  describe '.between_apply_deadline_and_find_closes?' do
     it 'returns false before the configured date' do
-      travel_temporarily_to(one_hour_before_apply1_deadline) do
-        expect(described_class.between_apply_1_deadline_and_find_closes?).to be false
+      travel_temporarily_to(one_hour_before_apply_deadline) do
+        expect(described_class.between_apply_deadline_and_find_closes?).to be false
       end
     end
 
     it 'returns true during the configured date' do
-      travel_temporarily_to(one_hour_after_apply1_deadline) do
-        expect(described_class.between_apply_1_deadline_and_find_closes?).to be true
+      travel_temporarily_to(one_hour_after_apply_deadline) do
+        expect(described_class.between_apply_deadline_and_find_closes?).to be true
       end
     end
 
     it 'returns false after the configured date' do
       travel_temporarily_to(one_hour_after_find_reopens) do
-        expect(described_class.between_apply_1_deadline_and_find_closes?).to be false
-      end
-    end
-  end
-
-  describe '.between_cycles_apply_2?' do
-    it 'returns false before the configured date' do
-      travel_temporarily_to(one_hour_before_apply2_deadline) do
-        expect(described_class.between_cycles_apply_2?).to be false
-      end
-    end
-
-    it 'returns true after the configured date' do
-      travel_temporarily_to(one_hour_after_apply2_deadline) do
-        expect(described_class.between_cycles_apply_2?).to be true
-      end
-    end
-
-    it 'returns true between find and apply reopening' do
-      travel_temporarily_to(one_hour_after_find_opens) do
-        expect(described_class.between_cycles_apply_2?).to be true
-      end
-    end
-
-    it 'returns false after the new cycle opens' do
-      travel_temporarily_to(one_hour_after_next_year_cycle_opens) do
-        expect(described_class.between_cycles_apply_2?).to be false
+        expect(described_class.between_apply_deadline_and_find_closes?).to be false
       end
     end
   end
@@ -292,7 +241,7 @@ RSpec.describe CycleTimetable do
 
       context 'when the date is after the apply1 submission deadline' do
         it 'returns false' do
-          travel_temporarily_to(one_hour_after_apply1_deadline) do
+          travel_temporarily_to(one_hour_after_apply_deadline) do
             expect(execute_service).to be false
           end
         end
@@ -300,7 +249,7 @@ RSpec.describe CycleTimetable do
 
       context 'when the date is before the apply1 submission deadline' do
         it 'returns true' do
-          travel_temporarily_to(one_hour_before_apply1_deadline) do
+          travel_temporarily_to(one_hour_before_apply_deadline) do
             expect(execute_service).to be true
           end
         end
@@ -312,7 +261,7 @@ RSpec.describe CycleTimetable do
 
       context 'when the date is after the apply again submission deadline' do
         it 'returns false' do
-          travel_temporarily_to(one_hour_after_apply2_deadline) do
+          travel_temporarily_to(one_hour_after_apply_deadline) do
             expect(execute_service).to be false
           end
         end
@@ -320,7 +269,7 @@ RSpec.describe CycleTimetable do
 
       context 'when the date is before the apply again submission deadline' do
         it 'returns true' do
-          travel_temporarily_to(one_hour_before_apply2_deadline) do
+          travel_temporarily_to(one_hour_before_apply_deadline) do
             expect(execute_service).to be true
           end
         end
@@ -352,97 +301,51 @@ RSpec.describe CycleTimetable do
 
   describe '.need_to_send_deadline_reminder?' do
     it 'does not return for a non deadline date' do
-      travel_temporarily_to(described_class.apply_1_deadline_first_reminder - 1.day) do
-        expect(described_class.need_to_send_deadline_reminder?).to be_nil
+      travel_temporarily_to(described_class.apply_deadline_first_reminder - 1.day) do
+        expect(described_class.need_to_send_deadline_reminder?).to be false
       end
     end
 
-    it 'returns apply_1 when it is the first apply 1 deadline' do
-      travel_temporarily_to(described_class.apply_1_deadline_first_reminder) do
-        expect(described_class.need_to_send_deadline_reminder?).to be :apply_1
-      end
-    end
-
-    it 'returns apply_1 when it is the second apply 1 deadline' do
-      travel_temporarily_to(described_class.apply_1_deadline_second_reminder) do
-        expect(described_class.need_to_send_deadline_reminder?).to be :apply_1
-      end
-    end
-
-    it 'returns apply_2 when it is the first apply 2 deadline' do
-      travel_temporarily_to(described_class.apply_2_deadline_first_reminder) do
-        expect(described_class.need_to_send_deadline_reminder?).to be :apply_2
-      end
-    end
-
-    it 'returns apply_2 when it is the second apply 2 deadline' do
-      travel_temporarily_to(described_class.apply_2_deadline_second_reminder) do
-        expect(described_class.need_to_send_deadline_reminder?).to be :apply_2
+    it 'returns true when it is the apply deadline' do
+      travel_temporarily_to(described_class.apply_deadline_first_reminder) do
+        expect(described_class.need_to_send_deadline_reminder?).to be true
       end
     end
   end
 
   describe '.next_apply_deadline' do
-    context 'after cycle start and before apply 1 deadline' do
-      it 'returns apply_1_deadline' do
-        travel_temporarily_to(one_hour_before_apply1_deadline) do
-          expect(described_class.next_apply_deadline).to eq(described_class.apply_1_deadline)
+    context 'after cycle start and before apply deadline' do
+      it 'returns apply_deadline' do
+        travel_temporarily_to(one_hour_before_apply_deadline) do
+          expect(described_class.next_apply_deadline).to eq(described_class.apply_deadline)
         end
       end
     end
 
-    context 'after apply 1 deadline and before apply 2 deadline' do
-      it 'returns apply_2_deadline' do
-        travel_temporarily_to(one_hour_after_apply1_deadline) do
-          expect(described_class.next_apply_deadline).to eq(described_class.apply_2_deadline)
-        end
-      end
-    end
-
-    context 'after apply 2 deadline' do
-      it 'returns apply_1_deadline for next cycle' do
-        travel_temporarily_to(one_hour_after_apply2_deadline) do
-          expect(described_class.next_apply_deadline).to eq(CycleTimetable::CYCLE_DATES[described_class.next_year][:apply_1_deadline])
+    context 'after apply deadline' do
+      it 'returns apply_deadline for next year' do
+        travel_temporarily_to(one_hour_after_apply_deadline) do
+          expect(described_class.next_apply_deadline).to eq(described_class.apply_deadline(next_year))
         end
       end
     end
   end
 
-  describe 'apply_1_deadline_has_passed?' do
-    context 'it is before the apply 1 deadline' do
+  describe 'apply_deadline_has_passed?' do
+    context 'it is before the apply deadline' do
       it 'returns false' do
         travel_temporarily_to(described_class.apply_opens) do
           application_form = build(:application_form)
-          expect(described_class.apply_1_deadline_has_passed?(application_form)).to be(false)
+          expect(described_class.apply_deadline_has_passed?(application_form)).to be(false)
         end
       end
     end
 
-    context 'it is after the apply 1 deadline' do
-      it 'returns true' do
-        travel_temporarily_to(described_class.apply_2_deadline) do
-          application_form = build(:application_form)
-          expect(described_class.apply_1_deadline_has_passed?(application_form)).to be(true)
-        end
-      end
-    end
-  end
-
-  describe 'apply_2_deadline_has_passed?' do
-    context 'it is before the apply 2 deadline' do
-      it 'returns false' do
-        travel_temporarily_to(described_class.apply_opens) do
-          application_form = build(:application_form)
-          expect(described_class.apply_1_deadline_has_passed?(application_form)).to be(false)
-        end
-      end
-    end
-
-    context 'it is after the apply 1 deadline' do
+    context 'it is after the apply deadline' do
       it 'returns true' do
         travel_temporarily_to(described_class.find_closes) do
           application_form = build(:application_form)
-          expect(described_class.apply_1_deadline_has_passed?(application_form)).to be(true)
+          expect(described_class.apply_deadline_has_passed?(application_form)).to be(true)
         end
       end
     end
@@ -464,12 +367,12 @@ RSpec.describe CycleTimetable do
   end
 
   describe 'cycle switcher' do
-    it 'correctly sets can_add_course_choice? and can_submit? between cycles', time: mid_cycle(2023) do
+    it 'correctly sets can_add_course_choice? and can_submit? between cycles', time: mid_cycle do
       SiteSetting.set(name: 'cycle_schedule', value: :today_is_mid_cycle)
 
-      application_form = create(:application_form, phase: 'apply_1')
+      application_form = create(:application_form)
 
-      SiteSetting.set(name: 'cycle_schedule', value: :today_is_after_apply_1_deadline_passed)
+      SiteSetting.set(name: 'cycle_schedule', value: :today_is_after_apply_deadline_passed)
 
       new_application = CarryOverApplication.new(application_form).call
 
@@ -489,7 +392,7 @@ RSpec.describe CycleTimetable do
       SiteSetting.set(name: 'cycle_schedule', value: nil)
     end
 
-    context 'when cycle_schedule is set to today_is_after_find_opens', time: mid_cycle(2023) do
+    context 'when cycle_schedule is set to today_is_after_find_opens', time: mid_cycle do
       it 'changes the CycleTimetable.current_year to the next year' do
         current_year = described_class.current_year
         next_year = described_class.next_year
@@ -500,7 +403,7 @@ RSpec.describe CycleTimetable do
       end
     end
 
-    context 'when cycle_schedule is set to today_is_after_apply_opens', time: mid_cycle(2023) do
+    context 'when cycle_schedule is set to today_is_after_apply_opens', time: mid_cycle do
       it 'changes the CycleTimetable.current_year to the next year' do
         current_year = described_class.current_year
         next_year = described_class.next_year

--- a/spec/services/data_migrations/update_decline_by_default_at_from_current_cycle_spec.rb
+++ b/spec/services/data_migrations/update_decline_by_default_at_from_current_cycle_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe DataMigrations::UpdateDeclineByDefaultAtFromCurrentCycle do
     end
 
     context 'when application has a decline_by_default_at set to apply deadline' do
-      let!(:decline_by_default_at) { CycleTimetable.apply_1_deadline(recruitment_cycle_year) }
+      let!(:decline_by_default_at) { CycleTimetable.apply_deadline(recruitment_cycle_year) }
 
       it 'does not update records' do
         expect { described_class.new.change }.not_to(change { application_choice.reload.decline_by_default_at })
@@ -47,13 +47,13 @@ RSpec.describe DataMigrations::UpdateDeclineByDefaultAtFromCurrentCycle do
     end
 
     context 'when application has a decline_by_default_at set to before apply deadline' do
-      let!(:decline_by_default_at) { CycleTimetable.apply_1_deadline(recruitment_cycle_year) - 1.day }
+      let!(:decline_by_default_at) { CycleTimetable.apply_deadline(recruitment_cycle_year) - 1.day }
 
       it 'updates the records' do
         expect { described_class.new.change }.to(
           change { application_choice.reload.decline_by_default_at }
-            .from(CycleTimetable.apply_1_deadline(recruitment_cycle_year) - 1.day)
-            .to(CycleTimetable.apply_1_deadline(recruitment_cycle_year)),
+            .from(CycleTimetable.apply_deadline(recruitment_cycle_year) - 1.day)
+            .to(CycleTimetable.apply_deadline(recruitment_cycle_year)),
         )
       end
     end

--- a/spec/services/duplicate_application_shared_examples.rb
+++ b/spec/services/duplicate_application_shared_examples.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.shared_examples 'duplicates application form' do |expected_phase, expected_cycle|
+RSpec.shared_examples 'duplicates application form' do |expected_cycle|
   def duplicate_application_form
     return @duplicate_application_form if @duplicate_application_form
 
@@ -25,10 +25,6 @@ RSpec.shared_examples 'duplicates application form' do |expected_phase, expected
   it 'resets the state to unsubmitted' do
     expect(duplicate_application_form.submitted_at).to be_nil
     expect(duplicate_application_form.course_choices_completed).to be_nil
-  end
-
-  it "sets the phase to `#{expected_phase}`" do
-    expect(duplicate_application_form.phase).to eq expected_phase
   end
 
   it "sets the recruitment_cycle_year to `#{expected_cycle}`" do

--- a/spec/services/duplicate_application_spec.rb
+++ b/spec/services/duplicate_application_spec.rb
@@ -21,10 +21,9 @@ RSpec.describe DuplicateApplication do
   end
 
   subject(:duplicate_application_form) do
-    described_class.new(@original_application_form, target_phase:).duplicate
+    described_class.new(@original_application_form).duplicate
   end
 
-  let(:target_phase) { 'apply_1' }
   let(:recruitment_cycle_year) { RecruitmentCycle.current_year }
 
   it 'marks reference as incomplete' do

--- a/spec/services/get_referees_to_chase_spec.rb
+++ b/spec/services/get_referees_to_chase_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe GetRefereesToChase do
   describe '#call' do
-    context 'when application is not pending conditions recruited or offer deferred', time: (CycleTimetable.find_reopens(2023) + 10.days) do
+    context 'when application is not pending conditions recruited or offer deferred', time: (CycleTimetable.find_reopens(2024) + 10.days) do
       it 'does not return references to chase' do
-        application_form = create(:application_form, :minimum_info, recruitment_cycle_year: 2023)
+        application_form = create(:application_form, :minimum_info, recruitment_cycle_year: 2024)
         create(:reference, :feedback_requested, application_form:, requested_at: 8.days.ago)
         create(:application_choice, :awaiting_provider_decision, application_form:)
         create(:application_choice, :withdrawn, application_form:)
@@ -18,14 +18,14 @@ RSpec.describe GetRefereesToChase do
       end
     end
 
-    context 'when application is recruited or offer deferred', time: mid_cycle(2023) do
+    context 'when application is recruited or offer deferred', time: mid_cycle(2024) do
       it 'returns references to chase' do
-        application_form = create(:application_form, :minimum_info, recruitment_cycle_year: 2023)
+        application_form = create(:application_form, :minimum_info, recruitment_cycle_year: 2024)
         reference = create(:reference, :feedback_requested, application_form:, requested_at: 8.days.ago)
         create(:application_choice, :recruited, application_form:)
         create(:application_choice, :withdrawn, application_form:)
 
-        second_application_form = create(:application_form, :minimum_info, recruitment_cycle_year: 2023)
+        second_application_form = create(:application_form, :minimum_info, recruitment_cycle_year: 2024)
         second_application_form_reference = create(:reference, :feedback_requested, application_form: second_application_form, requested_at: 8.days.ago)
         create(:application_choice, :offer_deferred, application_form: second_application_form)
         create(:application_choice, :withdrawn, application_form: second_application_form)
@@ -38,18 +38,18 @@ RSpec.describe GetRefereesToChase do
       end
     end
 
-    context 'when between apply 1 deadline and find has opened', time: (CycleTimetable.apply_1_deadline(2022) + 1.day) do
+    context 'when between apply 1 deadline and find has opened', time: (CycleTimetable.apply_deadline(2023) + 1.day) do
       it 'returns requested references for candidates on apply 2 only for the current cycle' do
-        application_form = create(:application_form, :minimum_info, recruitment_cycle_year: 2022)
-        create(:reference, :feedback_requested, application_form: application_form, requested_at: CycleTimetable.apply_1_deadline - 7.days)
+        application_form = create(:application_form, :minimum_info, recruitment_cycle_year: 2023)
+        create(:reference, :feedback_requested, application_form: application_form, requested_at: CycleTimetable.apply_deadline - 7.days)
 
-        application_form_apply_again = create(:application_form, :minimum_info, recruitment_cycle_year: 2022, phase: 'apply_2')
+        application_form_apply_again = create(:application_form, :minimum_info, recruitment_cycle_year: 2023)
         create(:application_choice, :accepted, application_form: application_form_apply_again)
         first_reference_apply_again = create(:reference, :feedback_requested, application_form: application_form_apply_again, requested_at: 8.days.ago)
         second_reference_apply_again = create(:reference, :feedback_requested, application_form: application_form_apply_again, requested_at: 8.days.ago)
 
-        application_form_next_cycle =  create(:application_form, :minimum_info, recruitment_cycle_year: 2023)
-        create(:reference, :feedback_requested, application_form: application_form_next_cycle, requested_at: CycleTimetable.apply_1_deadline - 7.days)
+        application_form_next_cycle =  create(:application_form, :minimum_info, recruitment_cycle_year: 2024)
+        create(:reference, :feedback_requested, application_form: application_form_next_cycle, requested_at: CycleTimetable.apply_deadline - 7.days)
 
         references = described_class.new(
           chase_referee_by: 7.days.before(Time.zone.now),
@@ -60,18 +60,18 @@ RSpec.describe GetRefereesToChase do
       end
     end
 
-    context 'when between apply has opened and the apply 1 deadline', time: (CycleTimetable.find_reopens(2023) + 7.days) do
+    context 'when between apply has opened and the apply 1 deadline', time: (CycleTimetable.find_reopens(2024) + 7.days) do
       it 'returns requested references in last days of current recruitment cycle' do
-        old_application_form = create(:application_form, :minimum_info, recruitment_cycle_year: 2022, phase: 'apply_1')
-        create(:reference, :feedback_requested, application_form: old_application_form, requested_at: CycleTimetable.find_reopens(2023) - 7.days)
+        old_application_form = create(:application_form, :minimum_info, recruitment_cycle_year: 2023)
+        create(:reference, :feedback_requested, application_form: old_application_form, requested_at: CycleTimetable.find_reopens(2024) - 7.days)
 
-        old_application_form_apply_again = create(:application_form, :minimum_info, recruitment_cycle_year: 2022, phase: 'apply_2')
+        old_application_form_apply_again = create(:application_form, :minimum_info, recruitment_cycle_year: 2023)
         create(:application_choice, :accepted, application_form: old_application_form_apply_again)
-        create(:reference, :feedback_requested, application_form: old_application_form_apply_again, requested_at: CycleTimetable.find_reopens(2023) - 7.days)
+        create(:reference, :feedback_requested, application_form: old_application_form_apply_again, requested_at: CycleTimetable.find_reopens(2024) - 7.days)
 
-        application_form = create(:application_form, :minimum_info, recruitment_cycle_year: 2023)
+        application_form = create(:application_form, :minimum_info, recruitment_cycle_year: 2024)
         create(:application_choice, :accepted, application_form:)
-        reference = create(:reference, :feedback_requested, application_form: application_form, requested_at: CycleTimetable.find_reopens(2023))
+        reference = create(:reference, :feedback_requested, application_form: application_form, requested_at: CycleTimetable.find_reopens(2024))
 
         references = described_class.new(
           chase_referee_by: 7.days.before(1.second.from_now),

--- a/spec/services/sample_applications_factory_spec.rb
+++ b/spec/services/sample_applications_factory_spec.rb
@@ -203,10 +203,10 @@ RSpec.describe SampleApplicationsFactory do
       previous_form = new_form.previous_application_form
 
       expect(previous_form).not_to be_nil
-      expect(previous_form.created_at).to be_between(CycleTimetable.apply_opens, CycleTimetable.apply_1_deadline)
+      expect(previous_form.created_at).to be_between(CycleTimetable.apply_opens, CycleTimetable.apply_deadline)
       expect(previous_form.phase).to eq('apply_1')
       expect(new_form).not_to be_nil
-      expect(new_form.created_at).to be_between(CycleTimetable.apply_1_deadline, CycleTimetable.apply_2_deadline)
+      expect(new_form.created_at).to be_between(CycleTimetable.apply_opens, CycleTimetable.apply_deadline)
       expect(new_form.phase).to eq('apply_2')
     end
   end

--- a/spec/services/support_interface/application_references_export_spec.rb
+++ b/spec/services/support_interface/application_references_export_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe SupportInterface::ApplicationReferencesExport, :bullet do
 
       application_form_two = DuplicateApplication.new(
         application_form_one,
-        target_phase: 'apply_2',
       ).duplicate
 
       new_reference1 = create(:reference, feedback_status: 'feedback_refused', referee_type: 'academic', application_form: application_form_two)

--- a/spec/services/support_interface/ministerial_report_applications_export_spec.rb
+++ b/spec/services/support_interface/ministerial_report_applications_export_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe SupportInterface::MinisterialReportApplicationsExport do
          [:classics,                 0, 0, 0, 0, 0, 0],
          [:computing,                0, 0, 0, 0, 0, 0],
          [:design_and_technology,    0, 0, 0, 0, 0, 0],
-         [:drama,                    1, 0, 0, 0, 1, 0],
+         [:drama,                    2, 0, 0, 0, 2, 0],
          [:english,                  1, 0, 0, 0, 0, 1],
          [:further_education,        1, 0, 0, 0, 1, 0],
          [:geography,                0, 0, 0, 0, 0, 0],
@@ -42,8 +42,8 @@ RSpec.describe SupportInterface::MinisterialReportApplicationsExport do
          [:stem,                     7, 1, 1, 0, 4, 2],
          [:ebacc,                    12, 2, 2, 0, 5, 5],
          [:primary,                  7, 3, 2, 0, 0, 0],
-         [:secondary,                18, 6, 5, 1, 6, 6],
-         [:total,                    25, 9, 7, 1, 6, 6]]
+         [:secondary,                19, 6, 5, 1, 7, 6],
+         [:total,                    26, 9, 7, 1, 7, 6]]
       end
     end
   end

--- a/spec/services/support_interface/ministerial_report_candidates_export_spec.rb
+++ b/spec/services/support_interface/ministerial_report_candidates_export_spec.rb
@@ -23,30 +23,30 @@ RSpec.describe SupportInterface::MinisterialReportCandidatesExport do
         application_withdrawn
       ]) do
         [[:art_and_design,           1, 1, 0, 1, 0, 0],
-         [:biology,                  2, 1, 1, 0, 1, 0],
+         [:biology,                  3, 1, 1, 0, 1, 1],
          [:business_studies,         1, 1, 1, 0, 0, 0],
          [:chemistry,                1, 0, 0, 0, 1, 0],
          [:classics,                 0, 0, 0, 0, 0, 0],
          [:computing,                0, 0, 0, 0, 0, 0],
          [:design_and_technology,    0, 0, 0, 0, 0, 0],
-         [:drama,                    0, 0, 0, 0, 0, 0],
+         [:drama,                    2, 0, 0, 0, 2, 0],
          [:english,                  1, 0, 0, 0, 0, 1],
-         [:further_education,        1, 1, 1, 0, 0, 0],
+         [:further_education,        1, 0, 0, 0, 1, 0],
          [:geography,                0, 0, 0, 0, 0, 0],
          [:history,                  0, 0, 0, 0, 0, 0],
          [:mathematics,              1, 0, 0, 0, 1, 0],
-         [:modern_foreign_languages, 1, 0, 0, 0, 1, 0],
+         [:modern_foreign_languages, 2, 1, 1, 0, 1, 0],
          [:music,                    0, 0, 0, 0, 0, 0],
          [:other,                    2, 1, 1, 0, 0, 1],
          [:physical_education,       0, 0, 0, 0, 0, 0],
-         [:physics,                  0, 0, 0, 0, 0, 0],
+         [:physics,                  1, 0, 0, 0, 0, 1],
          [:religious_education,      0, 0, 0, 0, 0, 0],
-         [:stem,                     4, 1, 1, 0, 3, 0],
-         [:ebacc,                    6, 1, 1, 0, 4, 1],
+         [:stem,                     6, 1, 1, 0, 3, 2],
+         [:ebacc,                    9, 2, 2, 0, 4, 3],
          [:primary,                  4, 3, 2, 0, 0, 0],
-         [:secondary,                10, 4, 3, 1, 4, 2],
+         [:secondary,                15, 5, 4, 1, 6, 4],
          [:split,                    1, 1, 1, 0, 0, 0],
-         [:total,                    15, 8, 6, 1, 4, 2]]
+         [:total,                    20, 9, 7, 1, 6, 4]]
       end
     end
 

--- a/spec/services/support_interface/offer_conditions_export_spec.rb
+++ b/spec/services/support_interface/offer_conditions_export_spec.rb
@@ -43,10 +43,10 @@ RSpec.describe SupportInterface::OfferConditionsExport do
     it 'returns phase information for each offer' do
       unsuccessful_application_choices = [create(:application_choice, :declined),
                                           create(:application_choice, :withdrawn)]
-      apply_1_form = create(:completed_application_form,
-                            application_choices: unsuccessful_application_choices)
-      apply_2_form = DuplicateApplication.new(apply_1_form, target_phase: 'apply_2').duplicate
-      create(:application_choice, :offered, application_form: apply_2_form)
+      original_apply_form = create(:completed_application_form,
+                                   application_choices: unsuccessful_application_choices)
+      duplicate_apply_form = DuplicateApplication.new(original_apply_form).duplicate
+      create(:application_choice, :offered, application_form: duplicate_apply_form)
 
       phases = described_class.new.offers.map { |o| o[:phase] }
       expect(phases).to eq(%w[apply_1 apply_2])

--- a/spec/services/support_interface/offer_conditions_export_spec.rb
+++ b/spec/services/support_interface/offer_conditions_export_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe SupportInterface::OfferConditionsExport do
       create(:application_choice, :offered, application_form: duplicate_apply_form)
 
       phases = described_class.new.offers.map { |o| o[:phase] }
-      expect(phases).to eq(%w[apply_1 apply_2])
+      expect(phases).to eq(%w[apply_1 apply_1])
     end
 
     it 'contains qualification information' do

--- a/spec/support/shared_examples/a_candidate_api_endpoint.rb
+++ b/spec/support/shared_examples/a_candidate_api_endpoint.rb
@@ -55,7 +55,7 @@ RSpec.shared_examples 'a candidate API endpoint' do |path, _date_param, api_vers
   end
 
   it 'does not return candidates without application forms which signed up during the previous recruitment_cycle' do
-    create(:candidate, created_at: CycleTimetable.apply_1_deadline(RecruitmentCycle.previous_year))
+    create(:candidate, created_at: CycleTimetable.apply_deadline(RecruitmentCycle.previous_year))
 
     get_api_request "#{path}?updated_since=#{CGI.escape(2.years.ago.iso8601)}", token: candidate_api_token
 
@@ -64,7 +64,7 @@ RSpec.shared_examples 'a candidate API endpoint' do |path, _date_param, api_vers
   end
 
   it 'does not return candidates who only have application forms in the previous cycle' do
-    candidate = create(:candidate, created_at: CycleTimetable.apply_1_deadline(RecruitmentCycle.previous_year))
+    candidate = create(:candidate, created_at: CycleTimetable.apply_deadline(RecruitmentCycle.previous_year))
     create(:completed_application_form, recruitment_cycle_year: RecruitmentCycle.previous_year, candidate:)
 
     get_api_request "#{path}?updated_since=#{CGI.escape(2.years.ago.iso8601)}", token: candidate_api_token

--- a/spec/support/statistics_test_helper.rb
+++ b/spec/support/statistics_test_helper.rb
@@ -17,7 +17,7 @@ module StatisticsTestHelper
         candidate = create_and_advance(:candidate, **candidate_attrs(entry))
         form = create_and_advance(:application_form, :minimum_info, :with_equality_and_diversity_data, candidate:, **form_attrs(entry))
       elsif entry.fetch(:phase) == 'apply_2'
-        form = DuplicateApplication.new(form, target_phase: 'apply_2').duplicate
+        form = DuplicateApplication.new(form).duplicate
         form.update(submitted_at: Time.zone.now) unless entry.fetch(:status) == 'unsubmitted'
       end
 

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-RSpec.feature 'Carry over unsubmitted application' do
+RSpec.describe 'Carry over unsubmitted application' do
   include CandidateHelper
 
   scenario 'Candidate carries over their application to the new cycle' do
     given_i_am_signed_in
     and_i_have_an_unsubmitted_application_with_references
 
-    when_the_apply1_deadline_passes
+    when_the_apply_deadline_passes
     and_i_sign_in_again
     and_i_visit_the_application_dashboard
     and_i_have_to_carry_my_application_over
@@ -18,7 +18,7 @@ RSpec.feature 'Carry over unsubmitted application' do
     then_i_see_the_new_states_of_my_references
 
     when_i_visit_the_application_complete_page
-    then_i_should_be_on_your_details_page
+    then_i_am_on_your_details_page
   end
 
   def given_i_am_signed_in
@@ -27,7 +27,7 @@ RSpec.feature 'Carry over unsubmitted application' do
   end
 
   def and_i_have_an_unsubmitted_application_with_references
-    @application_form = create(:completed_application_form, recruitment_cycle_year: 2023, submitted_at: nil, candidate: @candidate)
+    @application_form = create(:completed_application_form, recruitment_cycle_year: 2024, submitted_at: nil, candidate: @candidate)
 
     @pending_reference = create(:reference, :feedback_requested, application_form: @application_form)
     @declined_reference = create(:reference, :feedback_refused, application_form: @application_form)
@@ -35,8 +35,8 @@ RSpec.feature 'Carry over unsubmitted application' do
     @selected_reference = create(:selected_reference, application_form: @application_form)
   end
 
-  def when_the_apply1_deadline_passes
-    advance_time_to(after_apply_1_deadline)
+  def when_the_apply_deadline_passes
+    advance_time_to(after_apply_deadline)
   end
 
   def and_i_sign_in_again

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Candidate can carry over unsuccessful application to a new recruitment cycle after the apply 2 deadline' do
+RSpec.describe 'Candidate can carry over unsuccessful application to a new recruitment cycle after the apply deadline' do
   include CandidateHelper
 
   before do
@@ -11,7 +11,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
     given_i_am_signed_in
     and_i_have_an_application_with_a_rejection
 
-    when_the_apply2_deadline_passes
+    when_the_apply_deadline_passes
     and_i_visit_my_application_complete_page
     then_i_see_the_carry_over_inset_text
 
@@ -24,7 +24,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   scenario 'Candidate can see the add another job button in the new cycle' do
     given_i_am_signed_in
     and_i_have_an_application_with_a_rejection
-    and_the_apply2_deadline_passes
+    and_the_apply_deadline_passes
     and_i_visit_my_application_complete_page
     and_i_carry_over_my_application
     and_the_next_cycle_opens
@@ -54,8 +54,8 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
     @application_form.application_work_experiences << [job]
   end
 
-  def when_the_apply2_deadline_passes
-    advance_time_to(after_apply_2_deadline)
+  def when_the_apply_deadline_passes
+    advance_time_to(after_apply_deadline)
   end
 
   def and_i_visit_my_application_complete_page
@@ -81,6 +81,6 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
     click_link_or_button 'Apply again'
   end
 
-  alias_method :and_the_apply2_deadline_passes, :when_the_apply2_deadline_passes
+  alias_method :and_the_apply_deadline_passes, :when_the_apply_deadline_passes
   alias_method :and_the_next_cycle_opens, :when_the_next_cycle_opens
 end

--- a/spec/system/candidate_interface/continuous_applications/carry_over/candidate_carries_over_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/carry_over/candidate_carries_over_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Carry over', :sidekiq do
 
   scenario 'candidate carries over unsubmitted application after apply 1 deadline' do
     given_i_have_unsubmitted_application
-    and_today_is_after_apply_1_deadline
+    and_today_is_after_apply_deadline
 
     when_i_sign_in
     then_i_should_be_asked_to_carry_over
@@ -134,18 +134,14 @@ private
     ProcessStaleApplicationsWorker.perform_async
   end
 
-  def given_today_is_one_day_before_apply_1_deadline
-    TestSuiteTimeMachine.travel_permanently_to(after_apply_1_deadline - 1.day)
+  def and_today_is_after_apply_deadline
+    TestSuiteTimeMachine.travel_permanently_to(after_apply_deadline)
   end
 
-  def and_today_is_after_apply_1_deadline
-    TestSuiteTimeMachine.travel_permanently_to(after_apply_1_deadline)
+  def and_today_is_after_apply_deadline
+    TestSuiteTimeMachine.travel_permanently_to(after_apply_deadline)
   end
-
-  def and_today_is_after_apply_2_deadline
-    TestSuiteTimeMachine.travel_permanently_to(after_apply_2_deadline)
-  end
-  alias_method :given_today_is_after_apply_2_deadline, :and_today_is_after_apply_2_deadline
+  alias_method :given_today_is_after_apply_deadline, :and_today_is_after_apply_deadline
 
   def given_today_is_after_rejected_by_default_date
     TestSuiteTimeMachine.travel_permanently_to(after_reject_by_default)

--- a/spec/system/candidate_interface/continuous_applications/carry_over/candidate_carries_over_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/carry_over/candidate_carries_over_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Carry over', :sidekiq do
+RSpec.describe 'Carry over', :sidekiq do
   include CandidateHelper
 
   before do
@@ -12,20 +12,20 @@ RSpec.feature 'Carry over', :sidekiq do
     and_today_is_after_apply_deadline
 
     when_i_sign_in
-    then_i_should_be_asked_to_carry_over
+    then_i_am_asked_to_carry_over
 
     when_i_carry_over
-    then_i_should_be_redirected_to_continuous_application_details_page
+    then_i_am_redirected_to_continuous_application_details_page
 
     when_i_go_to_your_applications_tab
-    then_i_should_not_see_the_add_course_button
-    and_i_should_not_see_previous_applications_heading
+    then_i_do_not_see_the_add_course_button
+    and_i_do_not_see_previous_applications_heading
 
     when_i_visit_add_course_url
-    then_i_should_be_redirect_to_your_applications_tab
+    then_i_am_redirect_to_your_applications_tab
 
     when_i_visit_the_old_complete_page
-    then_i_should_be_redirected_to_continuous_application_details_page
+    then_i_am_redirected_to_continuous_application_details_page
   end
 
   scenario 'candidate carries over unsubmitted application after find opens deadline' do
@@ -33,19 +33,19 @@ RSpec.feature 'Carry over', :sidekiq do
     and_today_is_after_find_reopens
 
     when_i_sign_in
-    then_i_should_be_asked_to_carry_over
+    then_i_am_asked_to_carry_over
 
     when_i_carry_over
-    then_i_should_be_redirected_to_continuous_application_details_page
+    then_i_am_redirected_to_continuous_application_details_page
 
     when_i_go_to_your_applications_tab
-    then_i_should_not_see_the_add_course_button
+    then_i_do_not_see_the_add_course_button
 
     when_i_visit_add_course_url
-    then_i_should_be_redirect_to_your_applications_tab
+    then_i_am_redirect_to_your_applications_tab
 
     when_i_visit_the_old_complete_page
-    then_i_should_be_redirected_to_continuous_application_details_page
+    then_i_am_redirected_to_continuous_application_details_page
   end
 
   scenario 'candidate carries over submitted application after find opens deadline' do
@@ -53,19 +53,19 @@ RSpec.feature 'Carry over', :sidekiq do
     and_today_is_after_find_reopens
 
     when_i_sign_in
-    then_i_should_be_asked_to_carry_over_as_apply_again
+    then_i_am_asked_to_carry_over_as_apply_again
 
     when_i_click_apply_again
-    then_i_should_be_redirected_to_continuous_application_details_page
+    then_i_am_redirected_to_continuous_application_details_page
 
     when_i_go_to_your_applications_tab
-    then_i_should_not_see_the_add_course_button
+    then_i_do_not_see_the_add_course_button
 
     when_i_visit_add_course_url
-    then_i_should_be_redirect_to_your_applications_tab
+    then_i_am_redirect_to_your_applications_tab
 
     when_i_visit_the_old_complete_page
-    then_i_should_be_redirected_to_continuous_application_details_page
+    then_i_am_redirected_to_continuous_application_details_page
   end
 
 private
@@ -111,7 +111,7 @@ private
   end
 
   def and_i_have_applied_again_in_2023
-    DuplicateApplication.new(@application_form, target_phase: 'apply_2').duplicate
+    DuplicateApplication.new(@application_form).duplicate
   end
 
   def given_i_have_submitted_application
@@ -157,12 +157,12 @@ private
   end
   alias_method :and_i_sign_in, :when_i_sign_in
 
-  def then_i_should_be_asked_to_carry_over
+  def then_i_am_asked_to_carry_over
     expect(page).to have_current_path candidate_interface_start_carry_over_path
   end
 
-  def then_i_should_be_asked_to_carry_over_as_apply_again
-    then_i_should_be_asked_to_apply_again
+  def then_i_am_asked_to_carry_over_as_apply_again
+    then_i_am_asked_to_apply_again
     expect(carry_over_apply_again_form[:action]).to eq(candidate_interface_carry_over_path)
   end
 
@@ -170,8 +170,8 @@ private
     page.all('button').find { |button| button.text == 'Apply again' }.first(:xpath, './/..')
   end
 
-  def then_i_should_be_asked_to_apply_again
-    then_i_should_be_redirected_to_complete_page
+  def then_i_am_asked_to_apply_again
+    then_i_am_redirected_to_complete_page
     expect(page).to have_content('Apply again')
   end
 
@@ -192,7 +192,7 @@ private
     end
   end
 
-  def then_i_should_be_redirected_to_complete_page
+  def then_i_am_redirected_to_complete_page
     expect(page).to have_current_path(candidate_interface_application_complete_path)
   end
 
@@ -200,7 +200,7 @@ private
     click_link_or_button 'Continue'
   end
 
-  def then_i_should_be_redirected_to_continuous_application_details_page
+  def then_i_am_redirected_to_continuous_application_details_page
     expect(page).to have_current_path candidate_interface_continuous_applications_details_path
     then_i_see_a_copy_of_my_application
   end
@@ -209,12 +209,12 @@ private
     click_link_or_button 'Your application'
   end
 
-  def then_i_should_not_see_the_add_course_button
+  def then_i_do_not_see_the_add_course_button
     expect(page).to have_no_content('Add application')
     expect(page).to have_content("Applications for courses starting in September #{RecruitmentCycle.current_year} are closed.")
   end
 
-  def and_i_should_not_see_previous_applications_heading
+  def and_i_do_not_see_previous_applications_heading
     expect(page).to have_no_content('Previous applications')
   end
 
@@ -226,7 +226,7 @@ private
     visit candidate_interface_continuous_applications_do_you_know_the_course_path
   end
 
-  def then_i_should_be_redirect_to_your_applications_tab
+  def then_i_am_redirect_to_your_applications_tab
     expect(page).to have_current_path candidate_interface_continuous_applications_choices_path
   end
 
@@ -239,7 +239,7 @@ private
 
     click_link_or_button 'Personal information'
     expect(page).to have_content(date_of_birth.to_fs(:govuk_date))
-    and_my_application_should_be_on_the_new_cycle
+    and_my_application_is_on_the_new_cycle
   end
 
   def and_i_sign_in_again
@@ -248,7 +248,7 @@ private
     visit candidate_interface_continuous_applications_details_path
   end
 
-  def and_my_application_should_be_on_the_new_cycle
+  def and_my_application_is_on_the_new_cycle
     expect(current_candidate.current_application.reload.recruitment_cycle_year).to be(2024)
   end
 

--- a/spec/system/candidate_interface/references/candidate_request_references_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_request_references_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'New References', :with_audited, time: CycleTimetableHelper.after_apply_1_deadline do
+RSpec.describe 'New References', :with_audited, time: CycleTimetableHelper.after_apply_deadline do
   include CandidateHelper
 
   scenario 'Candidate request their references on the post offer dashboard' do

--- a/spec/system/candidate_interface/references/candidate_views_their_references_on_the_post_offer_dashboard_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_views_their_references_on_the_post_offer_dashboard_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Post-offer references', :with_audited, time: CycleTimetableHelper.after_apply_1_deadline do
+RSpec.describe 'Post-offer references', :with_audited, time: CycleTimetableHelper.after_apply_deadline do
   include CandidateHelper
 
   scenario 'Candidate views their references on the post offer dashboard' do

--- a/spec/system/provider_interface/export_applications_in_hesa_format_spec.rb
+++ b/spec/system/provider_interface/export_applications_in_hesa_format_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Export applications in HESA format' do
+RSpec.describe 'Export applications in HESA format' do
   include CourseOptionHelpers
   include DfESignInHelpers
 
@@ -55,7 +55,7 @@ RSpec.feature 'Export applications in HESA format' do
 
   def then_i_can_see_links_to_the_report_for_the_current_and_previous_cycles
     expect(page).to have_content("The data will include all candidates who have accepted an offer since #{CycleTimetable.apply_opens(RecruitmentCycle.current_year).to_fs(:govuk_date)}")
-    expect(page).to have_content("The data will include all candidates who have accepted an offer from #{CycleTimetable.apply_opens(RecruitmentCycle.previous_year).to_fs(:govuk_date)} to #{CycleTimetable.apply_2_deadline(RecruitmentCycle.previous_year).to_fs(:govuk_date)}.")
+    expect(page).to have_content("The data will include all candidates who have accepted an offer from #{CycleTimetable.apply_opens(RecruitmentCycle.previous_year).to_fs(:govuk_date)} to #{CycleTimetable.apply_deadline(RecruitmentCycle.previous_year).to_fs(:govuk_date)}.")
   end
 
   def and_i_can_download_application_data_as_csv_for_the_current_recruitment_cycle

--- a/spec/system/referee_interface/referee_refuses_to_give_a_reference_from_previous_cycle_spec.rb
+++ b/spec/system/referee_interface/referee_refuses_to_give_a_reference_from_previous_cycle_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
-RSpec.feature 'Refusing to give a reference' do
+RSpec.describe 'Refusing to give a reference' do
   include CandidateHelper
 
   before do
-    TestSuiteTimeMachine.travel_permanently_to(CycleTimetable.apply_1_deadline(2024))
+    TestSuiteTimeMachine.travel_permanently_to(CycleTimetable.apply_deadline(2024))
   end
 
   scenario 'Referee refuses to give a reference' do
@@ -19,7 +19,7 @@ RSpec.feature 'Refusing to give a reference' do
     and_i_confirm_that_i_wont_give_a_reference
     and_a_slack_notification_is_sent
     then_an_email_is_sent_to_the_candidate
-    then_i_should_see_the_thank_you_page
+    then_i_see_the_thank_you_page
   end
 
   def given_i_am_a_referee_of_an_application_from_old_cycle
@@ -68,7 +68,7 @@ RSpec.feature 'Refusing to give a reference' do
     expect(current_email.subject).to have_content('Terri Tudor is unable to give you a reference')
   end
 
-  def then_i_should_see_the_thank_you_page
+  def then_i_see_the_thank_you_page
     expect(page).to have_content('Thank you')
   end
 

--- a/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
+++ b/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
-RSpec.feature 'Refusing to give a reference' do
+RSpec.describe 'Refusing to give a reference' do
   include CandidateHelper
 
   before do
-    TestSuiteTimeMachine.travel_permanently_to(CycleTimetable.apply_1_deadline(2021))
+    TestSuiteTimeMachine.travel_permanently_to(CycleTimetable.apply_deadline(2021))
   end
 
   scenario 'Referee refuses to give a reference' do
@@ -19,7 +19,7 @@ RSpec.feature 'Refusing to give a reference' do
     and_i_confirm_that_i_wont_give_a_reference
     and_a_slack_notification_is_sent
     then_an_email_is_sent_to_the_candidate
-    then_i_should_see_the_thank_you_page
+    then_i_see_the_thank_you_page
   end
 
   def given_i_am_a_referee_of_an_application
@@ -68,7 +68,7 @@ RSpec.feature 'Refusing to give a reference' do
     expect(current_email.subject).to have_content('Terri Tudor is unable to give you a reference')
   end
 
-  def then_i_should_see_the_thank_you_page
+  def then_i_see_the_thank_you_page
     expect(page).to have_content('Thank you')
   end
 

--- a/spec/system/support_interface/cancel_previous_cycle_unsubmitted_at_eoc_task_spec.rb
+++ b/spec/system/support_interface/cancel_previous_cycle_unsubmitted_at_eoc_task_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Cancel previous cycle unsubmitted applications support task', :sidekiq, time: CycleTimetableHelper.after_apply_2_deadline do
+RSpec.describe 'Cancel previous cycle unsubmitted applications support task', :sidekiq, time: CycleTimetableHelper.after_apply_deadline do
   include DfESignInHelpers
 
   scenario 'Support user performs the cancel previous cycle unsubmitted applications at EoC task' do

--- a/spec/system/support_interface/cycle_switching_spec.rb
+++ b/spec/system/support_interface/cycle_switching_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Cycle switching' do
+RSpec.describe 'Cycle switching' do
   include DfESignInHelpers
 
   scenario 'Support user switches cycle schedule' do
@@ -27,11 +27,11 @@ RSpec.feature 'Cycle switching' do
   end
 
   def when_i_click_to_choose_a_new_schedule
-    choose 'Apply 1 deadline has passed'
+    choose 'Apply deadline has passed'
     click_link_or_button 'Update point in recruitment cycle'
   end
 
   def then_the_schedule_is_updated
-    expect(page).to have_content("Apply 1 deadline #{CycleTimetable.apply_1_deadline.to_fs(:govuk_date)}")
+    expect(page).to have_content("Apply deadline #{CycleTimetable.apply_deadline.to_fs(:govuk_date)}")
   end
 end

--- a/spec/system/support_interface/service_performance_spec.rb
+++ b/spec/system/support_interface/service_performance_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
-RSpec.feature 'Service performance' do
+RSpec.describe 'Service performance' do
   include DfESignInHelpers
 
   before do
-    TestSuiteTimeMachine.travel_permanently_to(CycleTimetable.apply_1_deadline(2021))
+    TestSuiteTimeMachine.travel_permanently_to(CycleTimetable.apply_deadline(2021))
   end
 
   scenario 'View service statistics' do
@@ -13,8 +13,8 @@ RSpec.feature 'Service performance' do
 
     when_i_visit_the_performance_dashboard_in_support
 
-    then_i_should_see_the_total_count_of_candidates
-    and_i_should_see_the_total_count_of_application_forms
+    then_i_see_the_total_count_of_candidates
+    and_i_see_the_total_count_of_application_forms
 
     when_there_are_candidates_that_have_never_signed_in
     and_i_visit_the_performance_dashboard_in_support
@@ -50,11 +50,11 @@ RSpec.feature 'Service performance' do
 
   alias_method :and_i_visit_the_performance_dashboard_in_support, :when_i_visit_the_performance_dashboard_in_support
 
-  def then_i_should_see_the_total_count_of_candidates
+  def then_i_see_the_total_count_of_candidates
     expect(page).to have_content '3 unique candidates'
   end
 
-  def and_i_should_see_the_total_count_of_application_forms
+  def and_i_see_the_total_count_of_application_forms
     expect(page).to have_content '3 application forms'
   end
 

--- a/spec/workers/cancel_unsubmitted_applications_worker_spec.rb
+++ b/spec/workers/cancel_unsubmitted_applications_worker_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe CancelUnsubmittedApplicationsWorker do
-  describe '#perform', time: after_apply_2_deadline do
+  describe '#perform', time: after_apply_deadline do
     let(:unsubmitted_application_from_this_year) do
       create(:application_form,
              submitted_at: nil,

--- a/spec/workers/generate_test_applications_spec.rb
+++ b/spec/workers/generate_test_applications_spec.rb
@@ -44,9 +44,6 @@ RSpec.describe GenerateTestApplications do
 
     # there is at least one successful carried over application
     expect(ApplicationForm.joins(:application_choices).where('application_choices.status': 'offer', phase: 'apply_1').where.not(previous_application_form_id: nil)).not_to be_empty
-
-    # there is at least one successful apply again application
-    expect(ApplicationForm.joins(:application_choices).where('application_choices.status': 'offer', phase: 'apply_2').where.not(previous_application_form_id: nil)).not_to be_empty
   end
 
   it 'generates test applications for the next cycle', :sidekiq do

--- a/spec/workers/send_eoc_deadline_reminder_email_to_candidates_batch_worker_spec.rb
+++ b/spec/workers/send_eoc_deadline_reminder_email_to_candidates_batch_worker_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe SendEocDeadlineReminderEmailToCandidatesBatchWorker, :sidekiq do
       create(
         :application_form,
         candidate:,
-        phase: 'apply_1',
         application_choices: [create(:application_choice, :application_not_sent)],
         recruitment_cycle_year: RecruitmentCycle.current_year,
       )
@@ -27,7 +26,7 @@ RSpec.describe SendEocDeadlineReminderEmailToCandidatesBatchWorker, :sidekiq do
     end
 
     it 'does nothing if the email was already sent' do
-      allow(CycleTimetable).to receive(:apply_1_deadline).and_return(1.day.ago)
+      allow(CycleTimetable).to receive(:apply_deadline).and_return(1.day.ago)
 
       candidate.current_application.chasers_sent.create(
         chaser_type: :eoc_deadline_reminder,

--- a/spec/workers/send_eoc_deadline_reminder_email_to_candidates_worker_spec.rb
+++ b/spec/workers/send_eoc_deadline_reminder_email_to_candidates_worker_spec.rb
@@ -2,232 +2,111 @@ require 'rails_helper'
 
 RSpec.describe SendEocDeadlineReminderEmailToCandidatesWorker, :sidekiq do
   describe '#perform' do
-    context 'when the candidate is in Apply 1' do
-      it 'returns an application when the deadline is 2 months away' do
-        travel_temporarily_to(CycleTimetable.apply_1_deadline_first_reminder) do
-          candidate = create(:candidate)
+    it 'returns an application when the deadline is 2 months away' do
+      travel_temporarily_to(CycleTimetable.apply_deadline_first_reminder) do
+        candidate = create(:candidate)
 
-          create(
-            :application_form,
-            candidate:,
-            phase: 'apply_1',
-            application_choices: [create(:application_choice, :application_not_sent)],
-            recruitment_cycle_year: RecruitmentCycle.current_year,
-          )
-
-          described_class.new.perform
-
-          email_for_candidate = email_for_candidate(candidate)
-
-          expect(email_for_candidate).to be_present
-        end
-      end
-
-      it 'does not return an application where the candidate is unsubscribed' do
-        allow(CycleTimetable).to receive(:need_to_send_deadline_reminder?).and_return(:apply_1)
-
-        unsubscribed_candidate = create(:candidate, unsubscribed_from_emails: true)
-        create(:application_form, candidate: unsubscribed_candidate)
+        create(
+          :application_form,
+          candidate:,
+          application_choices: [create(:application_choice, :application_not_sent)],
+          recruitment_cycle_year: RecruitmentCycle.current_year,
+        )
 
         described_class.new.perform
 
-        email_for_candidate = email_for_candidate(unsubscribed_candidate)
+        email_for_candidate = email_for_candidate(candidate)
 
-        expect(email_for_candidate).not_to be_present
-      end
-
-      it 'returns an application when the deadline is 1 month away' do
-        travel_temporarily_to(CycleTimetable.apply_1_deadline_second_reminder) do
-          candidate = create(:candidate)
-
-          create(
-            :application_form,
-            candidate:,
-            phase: 'apply_1',
-            application_choices: [create(:application_choice, :application_not_sent)],
-            recruitment_cycle_year: RecruitmentCycle.current_year,
-          )
-
-          described_class.new.perform
-
-          email_for_candidate = email_for_candidate(candidate)
-
-          expect(email_for_candidate).to be_present
-        end
-      end
-
-      it 'does not return an application when the deadline is 3 months away' do
-        travel_temporarily_to(CycleTimetable.apply_1_deadline_first_reminder - 1.month) do
-          candidate = create(:candidate)
-
-          create(
-            :application_form,
-            candidate:,
-            phase: 'apply_1',
-            application_choices: [create(:application_choice, :application_not_sent)],
-            recruitment_cycle_year: RecruitmentCycle.current_year,
-          )
-
-          described_class.new.perform
-
-          email_for_candidate = email_for_candidate(candidate)
-
-          expect(email_for_candidate).not_to be_present
-        end
-      end
-
-      it 'does not return an application when the deadline has passed' do
-        travel_temporarily_to(CycleTimetable.apply_1_deadline + 1.day) do
-          candidate = create(:candidate)
-
-          create(
-            :application_form,
-            candidate:,
-            phase: 'apply_1',
-            application_choices: [create(:application_choice, :application_not_sent)],
-            recruitment_cycle_year: RecruitmentCycle.current_year,
-          )
-
-          described_class.new.perform
-
-          email_for_candidate = email_for_candidate(candidate)
-
-          expect(email_for_candidate).not_to be_present
-        end
-      end
-
-      it 'does not return an application form from the previous cycle' do
-        travel_temporarily_to(CycleTimetable.apply_1_deadline_first_reminder) do
-          candidate = create(:candidate)
-
-          create(
-            :application_form,
-            candidate:,
-            phase: 'apply_1',
-            application_choices: [create(:application_choice, :application_not_sent)],
-            recruitment_cycle_year: RecruitmentCycle.previous_year,
-          )
-
-          described_class.new.perform
-
-          email_for_candidate = email_for_candidate(candidate)
-
-          expect(email_for_candidate).not_to be_present
-        end
+        expect(email_for_candidate).to be_present
       end
     end
 
-    context 'when the candidate is in Apply 2' do
-      it 'returns an application when the deadline is 2 months away' do
-        travel_temporarily_to(CycleTimetable.apply_2_deadline_first_reminder) do
-          candidate = create(:candidate)
+    it 'does not return an application where the candidate is unsubscribed' do
+      allow(CycleTimetable).to receive(:need_to_send_deadline_reminder?).and_return(true)
 
-          create(
-            :application_form,
-            candidate:,
-            phase: 'apply_2',
-            application_choices: [create(:application_choice, :application_not_sent)],
-            recruitment_cycle_year: RecruitmentCycle.current_year,
-          )
+      unsubscribed_candidate = create(:candidate, unsubscribed_from_emails: true)
+      create(:application_form, candidate: unsubscribed_candidate)
 
-          described_class.new.perform
+      described_class.new.perform
 
-          email_for_candidate = email_for_candidate(candidate)
+      email_for_candidate = email_for_candidate(unsubscribed_candidate)
 
-          expect(email_for_candidate).to be_present
-        end
-      end
+      expect(email_for_candidate).not_to be_present
+    end
 
-      it 'does not return an application where the candidate is unsubscribed' do
-        allow(CycleTimetable).to receive(:need_to_send_deadline_reminder?).and_return(:apply_2)
+    it 'returns an application when the deadline is 1 month away' do
+      travel_temporarily_to(CycleTimetable.apply_deadline_second_reminder) do
+        candidate = create(:candidate)
 
-        unsubscribed_candidate = create(:candidate, unsubscribed_from_emails: true)
-        create(:application_form, candidate: unsubscribed_candidate)
+        create(
+          :application_form,
+          candidate:,
+          application_choices: [create(:application_choice, :application_not_sent)],
+          recruitment_cycle_year: RecruitmentCycle.current_year,
+        )
 
         described_class.new.perform
 
-        email_for_candidate = email_for_candidate(unsubscribed_candidate)
+        email_for_candidate = email_for_candidate(candidate)
+
+        expect(email_for_candidate).to be_present
+      end
+    end
+
+    it 'does not return an application when the deadline is 3 months away' do
+      travel_temporarily_to(CycleTimetable.apply_deadline_first_reminder - 1.month) do
+        candidate = create(:candidate)
+
+        create(
+          :application_form,
+          candidate:,
+          application_choices: [create(:application_choice, :application_not_sent)],
+          recruitment_cycle_year: RecruitmentCycle.current_year,
+        )
+
+        described_class.new.perform
+
+        email_for_candidate = email_for_candidate(candidate)
 
         expect(email_for_candidate).not_to be_present
       end
+    end
 
-      it 'returns an application when the deadline is 1 month away' do
-        travel_temporarily_to(CycleTimetable.apply_2_deadline_second_reminder) do
-          candidate = create(:candidate)
+    it 'does not return an application when the deadline has passed' do
+      travel_temporarily_to(CycleTimetable.apply_deadline + 1.day) do
+        candidate = create(:candidate)
 
-          create(
-            :application_form,
-            candidate:,
-            phase: 'apply_2',
-            application_choices: [create(:application_choice, :application_not_sent)],
-            recruitment_cycle_year: RecruitmentCycle.current_year,
-          )
+        create(
+          :application_form,
+          candidate:,
+          application_choices: [create(:application_choice, :application_not_sent)],
+          recruitment_cycle_year: RecruitmentCycle.current_year,
+        )
 
-          described_class.new.perform
+        described_class.new.perform
 
-          email_for_candidate = email_for_candidate(candidate)
+        email_for_candidate = email_for_candidate(candidate)
 
-          expect(email_for_candidate).to be_present
-        end
+        expect(email_for_candidate).not_to be_present
       end
+    end
 
-      it 'does not return an application when the deadline is 3 months away' do
-        travel_temporarily_to(CycleTimetable.apply_2_deadline_first_reminder - 1.month) do
-          candidate = create(:candidate)
+    it 'does not return an application form from the previous cycle' do
+      travel_temporarily_to(CycleTimetable.apply_deadline_first_reminder) do
+        candidate = create(:candidate)
 
-          create(
-            :application_form,
-            candidate:,
-            phase: 'apply_2',
-            application_choices: [create(:application_choice, :application_not_sent)],
-            recruitment_cycle_year: RecruitmentCycle.current_year,
-          )
+        create(
+          :application_form,
+          candidate:,
+          application_choices: [create(:application_choice, :application_not_sent)],
+          recruitment_cycle_year: RecruitmentCycle.previous_year,
+        )
 
-          described_class.new.perform
+        described_class.new.perform
 
-          email_for_candidate = email_for_candidate(candidate)
+        email_for_candidate = email_for_candidate(candidate)
 
-          expect(email_for_candidate).not_to be_present
-        end
-      end
-
-      it 'does not return an application when the deadline has passed' do
-        travel_temporarily_to(CycleTimetable.apply_2_deadline + 1.day) do
-          candidate = create(:candidate)
-
-          create(
-            :application_form,
-            candidate:,
-            phase: 'apply_2',
-            application_choices: [create(:application_choice, :application_not_sent)],
-            recruitment_cycle_year: RecruitmentCycle.current_year,
-          )
-
-          described_class.new.perform
-
-          email_for_candidate = email_for_candidate(candidate)
-
-          expect(email_for_candidate).not_to be_present
-        end
-      end
-
-      it 'does not return an application form from the previous cycle' do
-        travel_temporarily_to(CycleTimetable.apply_2_deadline_first_reminder) do
-          candidate = create(:candidate)
-
-          create(
-            :application_form,
-            candidate:,
-            phase: 'apply_2',
-            recruitment_cycle_year: RecruitmentCycle.previous_year,
-          )
-
-          described_class.new.perform
-
-          email_for_candidate = email_for_candidate(candidate)
-
-          expect(email_for_candidate).not_to be_present
-        end
+        expect(email_for_candidate).not_to be_present
       end
     end
   end


### PR DESCRIPTION
## Context
This card to remove the 'apply_2' deadline was created in July last year during the continuous application work. Now that we have started doing the end of cycle work again this year, it is apparent that this apply_1 and apply_2 logic creates confusion and should be removed before we move forward.

## Changes proposed in this pull request
Broadly, the PR just:
- adds an apply_deadline to the cycle definitions
- replaces methods in the `CycleTimeable` service to remove the distinction between the two deadlines.

For backward compatibility, I have retained the apply_1 and apply_2 deadlines on those cycles where it was relevant. 

What IS NOT in this PR (tickets to be written for the following):
- Completely remove the apply_again concept (apply_again is defined throughout the code base as apply_2 applications with submitted statuses. There are no apply_2 applications now, so this is irrelevant, but too big for this pr
- Remove the phase column from the application. This is 'apply_1' for all applications so just extra noise that we should remove. But too big for this ticket. 
- Change the way we store / maintain cycle deadlines. We need to decide how far back we want to keep this data and if we are keeping ad infinitum, we should start storing it in the database rather just a constant in the codebase.

## Guidance to review
I've got the test suite passing and I've done lots of manual testing locally. Would appreciate other people to do lots of clicking and see if I've broken anything. 

It's a big PR, so best to review commit by commit. 

## Link to Trello card

https://trello.com/c/FPph5syu

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
