### PR TITLE
show-deadline-banner-on-continuous-application-dashboard

### DIFF
--- a/app/views/candidate_interface/continuous_applications_choices/index.html.erb
+++ b/app/views/candidate_interface/continuous_applications_choices/index.html.erb
@@ -1,6 +1,7 @@
 <%= render ServiceInformationBanner.new(namespace: :candidate) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+    <%= render(CandidateInterface::DeadlineBannerComponent.new(application_form: current_application, flash_empty: flash.empty?)) %>
     <h1 class="govuk-heading-xl">
       <%= t('page_titles.continuous_applications.your_applications') %>
     </h1>


### PR DESCRIPTION
## Context

The deadline banner is visible on the details page, but not the continuous applications dashboard. This PR corrects that.

## Changes proposed in this pull request

Show the deadline banner on the continuous applications dashboard as well as the details page.

<img width="1101" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/44073106/2a395bb3-76cc-46fa-8d91-5d2ed93ce921">


## Guidance to review

## Link to Trello card

NA

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
