### PR TITLE
reinstate cancel unsubmitted applications worker with additional specs

### DIFF
--- a/app/helpers/cycle_timetable_helper.rb
+++ b/app/helpers/cycle_timetable_helper.rb
@@ -17,6 +17,10 @@ module_function
     CycleTimetable.apply_deadline(year) + 1.day
   end
 
+  def cancel_application_deadline(year = CycleTimetable.current_year)
+    CycleTimetable.apply_deadline(year)
+  end
+
   def before_apply_deadline(year = CycleTimetable.current_year)
     CycleTimetable.apply_deadline(year) - 1.day
   end

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -95,6 +95,10 @@ class CycleTimetable
     date(:reject_by_default, year)
   end
 
+  def self.cancel_unsubmitted_applications?
+    current_date.to_date == apply_deadline.to_date
+  end
+
   def self.find_closes(year = current_year)
     date(:find_closes, year)
   end

--- a/app/workers/cancel_unsubmitted_applications_worker.rb
+++ b/app/workers/cancel_unsubmitted_applications_worker.rb
@@ -10,7 +10,7 @@ class CancelUnsubmittedApplicationsWorker
 private
 
   def unsubmitted_applications_from_earlier_cycle
-    return [] unless CycleTimetable.between_cycles?
+    return [] unless CycleTimetable.cancel_unsubmitted_applications?
 
     ApplicationForm
       .where(submitted_at: nil)

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -47,7 +47,7 @@ class Clock
   every(1.day, 'SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesWorker', at: '10:00') { SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesWorker.perform_async }
   every(1.day, 'DfE::Analytics::EntityTableCheckJob', at: '00:30') { DfE::Analytics::EntityTableCheckJob.perform_later }
 
-  # every(1.day, 'CancelUnsubmittedApplicationsWorker', at: '11:00') { CancelUnsubmittedApplicationsWorker.perform_async }
+  every(1.day, 'CancelUnsubmittedApplicationsWorker', at: '19:00') { CancelUnsubmittedApplicationsWorker.perform_async }
 
   # Daily jobs - mon-thurs only
   every(1.day, 'SendStatsSummaryToSlack', at: '17:00', if: ->(period) { period.wday.between?(1, 4) }) { SendStatsSummaryToSlack.new.perform }

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -642,4 +642,40 @@ RSpec.describe CycleTimetable do
       end
     end
   end
+
+  describe '#cancel_unsubmitted_applicaions?' do
+    before { TestSuiteTimeMachine.travel_permanently_to(date) }
+
+    context 'mid-cycle' do
+      let(:date) { mid_cycle }
+
+      it 'returns false' do
+        expect(described_class.cancel_unsubmitted_applications?).to be false
+      end
+    end
+
+    context 'on reject by default date' do
+      let(:date) { described_class.reject_by_default }
+
+      it 'returns false' do
+        expect(described_class.cancel_unsubmitted_applications?).to be false
+      end
+    end
+
+    context 'on cancel date' do
+      let(:date) { cancel_application_deadline }
+
+      it 'returns false' do
+        expect(described_class.cancel_unsubmitted_applications?).to be true
+      end
+    end
+
+    context 'after find reopens' do
+      let(:date) { after_apply_reopens }
+
+      it 'returns false' do
+        expect(described_class.cancel_unsubmitted_applications?).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

This code was commented out because last year it sent the email to a bunch of people it shouldn't have. The problem was caused by the between_cycles? method on the CycleTimetable class. 

This method has been corrected with a previous PR that removed the apply_1 and apply_2 deadline. The job will now run as expected.

## Changes proposed in this pull request

- Reinstated the job in clock
- Added lots of tests to reassure ourselves that it would only run between the apply deadline and the new cycle starting.

## Guidance to review

Run the `CancelUnsubmittedApplicationsWorker` job in review app with different cycle dates. 

## Link to Trello card

https://trello.com/c/8IeQ6qYI

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
