### PR TITLE
Rollout workload identity federation to all environments 

### DIFF
--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -49,4 +49,9 @@ DfE::Analytics.configure do |config|
   # to all events we send to BigQuery.
   #
   config.environment = HostingEnvironment.environment_name
+
+  # Whether to use azure workload identity federation for authentication
+  # instead of the BigQuery API JSON Key. Note that this also will also
+  # use a new version of the BigQuery streaming APIs.
+  config.azure_federated_auth = true
 end

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -23,11 +23,6 @@ DfE::Analytics.configure do |config|
   #
   config.bigquery_dataset = ENV['BIG_QUERY_DATASET']
 
-  # Service account JSON key for the BigQuery API. See
-  # https://cloud.google.com/bigquery/docs/authentication/service-account-file
-  #
-  config.bigquery_api_json_key = ENV['BIG_QUERY_API_JSON_KEY']
-
   # Enables the EntityTableCheckJob
   config.entity_table_checks_enabled = true
 

--- a/terraform/aks/application.tf
+++ b/terraform/aks/application.tf
@@ -60,6 +60,7 @@ module "main_worker" {
   kubernetes_secret_name     = module.application_configuration.kubernetes_secret_name
   command                    = ["bundle", "exec", "sidekiq", "-c", "5", "-C", "config/sidekiq-main.yml"]
   probe_command              = ["pgrep", "-f", "sidekiq"]
+  enable_gcp_wif             = true
 }
 
 module "secondary_worker" {
@@ -79,6 +80,7 @@ module "secondary_worker" {
   kubernetes_secret_name     = module.application_configuration.kubernetes_secret_name
   command                    = ["bundle", "exec", "sidekiq", "-c", "5", "-C", "config/sidekiq-secondary.yml"]
   probe_command              = ["pgrep", "-f", "sidekiq"]
+  enable_gcp_wif             = true
 }
 
 module "clock_worker" {


### PR DESCRIPTION
## Context

This is part of a wider BigQuery Assurance piece to to harden the security around BigQuery.

It allows the use of OAuth mechanism for authentication to BigQuery rather than relying on plain text JSON API Keys.

## Changes proposed in this pull request

Enable Azure workload identity federation within DfE Analytics.

Set GOOGLE_CLOUD_CREDENTIALS secret in the key vault for each environment. 

## Guidance to review

See [Dfe Analytics GEM](https://github.com/DFE-Digital/dfe-analytics) for further details.

This change involves the following steps
- Set GOOGLE_CLOUD_CREDENTIALS by downloading from GCP. This should be done for each environment.
- Enable WIF in the Azure Infrastructure
- Enable WIF in the App. We can remove references to the the JSON API Key at the same time
- Enable WIF in the Review App and test sending of data to BIgQuery. This can be disabled after testing
- Release to production

## Link to Trello card

The Data Insights ticket is [here](https://trello.com/c/IDG7vXFy).

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
