### PR TITLE
Added `other_uk_qualification_type` to Vendor API

### DIFF
--- a/app/presenters/concerns/qualification_api_data.rb
+++ b/app/presenters/concerns/qualification_api_data.rb
@@ -66,6 +66,10 @@ module QualificationAPIData
     false
   end
 
+  def exclude_completing_qualification?
+    !include_completing_qualification?
+  end
+
   def qualifications_of_level(level)
     application_form.application_qualifications.select do |qualification|
       qualification.level == level
@@ -151,18 +155,20 @@ module QualificationAPIData
 private
 
   def completing_qualification(qualification)
-    return {} unless include_completing_qualification?
+    return {} if exclude_completing_qualification?
 
-    if qualification.gcse?
-      return {
-        currently_completing_qualification: qualification[:currently_completing_qualification],
-        missing_explanation: qualification[:missing_explanation],
-        other_uk_qualification_type: qualification[:other_uk_qualification_type],
-      }
-    end
+    return completing_gcse(qualification) if qualification.gcse?
 
     {
       other_uk_qualification_type: qualification[:other_uk_qualification_type],
+    }
+  end
+
+  def completing_gcse(gcse_qualification)
+    {
+      currently_completing_qualification: gcse_qualification[:currently_completing_qualification],
+      missing_explanation: gcse_qualification[:missing_explanation],
+      other_uk_qualification_type: gcse_qualification[:other_uk_qualification_type],
     }
   end
 end

--- a/app/presenters/concerns/qualification_api_data.rb
+++ b/app/presenters/concerns/qualification_api_data.rb
@@ -151,11 +151,17 @@ module QualificationAPIData
 private
 
   def completing_qualification(qualification)
-    return {} unless include_completing_qualification? && qualification.gcse?
+    return {} unless include_completing_qualification?
+
+    if qualification.gcse?
+      return {
+        currently_completing_qualification: qualification[:currently_completing_qualification],
+        missing_explanation: qualification[:missing_explanation],
+        other_uk_qualification_type: qualification[:other_uk_qualification_type],
+      }
+    end
 
     {
-      currently_completing_qualification: qualification[:currently_completing_qualification],
-      missing_explanation: qualification[:missing_explanation],
       other_uk_qualification_type: qualification[:other_uk_qualification_type],
     }
   end

--- a/spec/presenters/vendor_api/v1.4/application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.4/application_presenter_spec.rb
@@ -8,10 +8,28 @@ RSpec.describe 'ApplicationPresenter' do
   let(:application_form) { create(:application_form, :submitted) }
   let(:application_choice) { create(:application_choice, application_form:) }
 
-  describe '#GCSEs' do
-    subject(:gcse) { attributes[:qualifications][:gcses].first }
+  describe 'qualifications' do
+    context 'when the application has a other_uk_qualification_type qualification' do
+      subject(:other_qualification) { attributes[:qualifications][:other_qualifications].first }
 
-    context 'when the application has a missing_and_currently_completing qualification' do
+      before do
+        create(
+          :other_qualification,
+          other_uk_qualification_type: 'Equivalency test',
+          application_form: application_form,
+        )
+      end
+
+      it 'returns the correct other_uk_qualification_type field' do
+        expect(other_qualification[:other_uk_qualification_type]).to eq 'Equivalency test'
+        expect(other_qualification).not_to have_key(:currently_completing_qualification)
+        expect(other_qualification).not_to have_key(:missing_explanation)
+      end
+    end
+
+    context 'when the application has a missing_and_currently_completing GCSE' do
+      subject(:gcse) { attributes[:qualifications][:gcses].first }
+
       before do
         create(
           :gcse_qualification,


### PR DESCRIPTION
## Context

This attribute was only shown for GCSEs however the data is relevant to all Qualifications

## Changes proposed in this pull request

Added `other_uk_qualification_type` to Vendor API

## Link to Trello card

https://trello.com/c/1rAVdEiq

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
