### PR TITLE
[1982] review and update first apply deadline email to candidates

### DIFF
--- a/app/controllers/candidate_interface/unsubscribe_from_emails_controller.rb
+++ b/app/controllers/candidate_interface/unsubscribe_from_emails_controller.rb
@@ -1,0 +1,19 @@
+module CandidateInterface
+  class UnsubscribeFromEmailsController < CandidateInterfaceController
+    skip_before_action :authenticate_candidate!, :set_user_context
+
+    def unsubscribe
+      candidate = Candidate.find_by_token_for!(:unsubscribe_link, token_param)
+      candidate.update!(unsubscribed_from_emails: true)
+
+    rescue ActiveSupport::MessageVerifier::InvalidSignature
+      render_404
+    end
+
+    private
+
+    def token_param
+      params.require(:token)
+    end
+  end
+end

--- a/app/controllers/candidate_interface/unsubscribe_from_emails_controller.rb
+++ b/app/controllers/candidate_interface/unsubscribe_from_emails_controller.rb
@@ -5,12 +5,11 @@ module CandidateInterface
     def unsubscribe
       candidate = Candidate.find_by_token_for!(:unsubscribe_link, token_param)
       candidate.update!(unsubscribed_from_emails: true)
-
     rescue ActiveSupport::MessageVerifier::InvalidSignature
       render_404
     end
 
-    private
+  private
 
     def token_param
       params.require(:token)

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -541,7 +541,12 @@ private
     realistic_job_preview_url({ id: candidate.pseudonymised_id }.merge(utm_args))
   end
 
-  helper_method :candidate_magic_link, :candidate_realistic_job_preview_link
+  def candidate_unsubscribe_link(candidate)
+    token = candidate.generate_token_for :unsubscribe_link
+    candidate_interface_unsubscribe_from_emails_url(token:)
+  end
+
+  helper_method :candidate_magic_link, :candidate_realistic_job_preview_link, :candidate_unsubscribe_link
 
   def uid
     @uid ||= EmailLogInterceptor.generate_reference

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -2,6 +2,8 @@ class Candidate < ApplicationRecord
   include Chased
   include AuthenticatedUsingMagicLinks
 
+  generates_token_for :unsubscribe_link
+
   # Only Devise's :timeoutable module is enabled to handle session expiry
   devise :timeoutable
   audited last_signed_in_at: true

--- a/app/views/candidate_interface/unsubscribe_from_emails/unsubscribe.html.erb
+++ b/app/views/candidate_interface/unsubscribe_from_emails/unsubscribe.html.erb
@@ -2,6 +2,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-m"><%=  t('unsubscribe_from_emails.heading')%></h1>
+    <h1 class="govuk-heading-m"><%= t('unsubscribe_from_emails.heading') %></h1>
   </div>
 </div>

--- a/app/views/candidate_interface/unsubscribe_from_emails/unsubscribe.html.erb
+++ b/app/views/candidate_interface/unsubscribe_from_emails/unsubscribe.html.erb
@@ -1,0 +1,7 @@
+<% content_for :title, t('unsubscribe_from_emails.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-m"><%=  t('unsubscribe_from_emails.heading')%></h1>
+  </div>
+</div>

--- a/app/views/candidate_mailer/eoc_deadline_reminder.erb
+++ b/app/views/candidate_mailer/eoc_deadline_reminder.erb
@@ -2,7 +2,7 @@
 Dear <%= @application_form.first_name %>
 <% end %>
 
-[Submit your application](<%= candidate_magic_link(@application_form.candidate) %>) as soon as you can to get on a course starting in the <%= RecruitmentCycle.current_year %> to <%= RecruitmentCycle.next_year %> academic year.
+[Submit your application for teacher training](<%= candidate_magic_link(@application_form.candidate) %>) as soon as you can to get on a course starting in the <%= RecruitmentCycle.current_year %> to <%= RecruitmentCycle.next_year %> academic year.
 
 <%=  "The deadline to submit your application is #{CycleTimetable.date(:apply_deadline).to_fs(:govuk_time)} on #{CycleTimetable.apply_deadline.to_fs(:govuk_date)} but courses may fill up before then." %>
 
@@ -10,6 +10,8 @@ Courses fill up quickly at this time of year.
 
 # Get help
 
-A teacher training adviser can help you write a strong application:
+If you have questions about your application, you can [get in touch with us on the phone or through live chat](<%= email_link_with_utm_params I18n.t('get_into_teaching.url_online_chat'), 'eoc_deadline_reminder', @application_form.phase %>).
 
-[Get a teacher training adviser](<%= email_link_with_utm_params I18n.t('get_into_teaching.url_get_an_adviser_start'), 'eoc_deadline_reminder', @application_form.phase %>)
+You can also [get a teacher training adviser](<%= email_link_with_utm_params I18n.t('get_into_teaching.url_get_an_adviser_start'), 'eoc_deadline_reminder', @application_form.phase %>) for free, one-to-one support to help you write a strong application.
+
+[Unsubscribe from these messages](<%= candidate_unsubscribe_link(@application_form.candidate) %>) to stop receiving deadline reminders. You will still receive updates about your application.

--- a/app/workers/send_eoc_deadline_reminder_email_to_candidates_worker.rb
+++ b/app/workers/send_eoc_deadline_reminder_email_to_candidates_worker.rb
@@ -6,7 +6,7 @@ class SendEocDeadlineReminderEmailToCandidatesWorker
   def perform
     return unless CycleTimetable.need_to_send_deadline_reminder?
 
-    GroupedRelationBatchDelivery.new(
+    BatchDelivery.new(
       relation: GetApplicationsToSendDeadlineRemindersTo.call,
       batch_size: BATCH_SIZE,
     ).each do |batch_time, records|

--- a/config/locales/candidate_interface/unsubscribe_from_emails.yml
+++ b/config/locales/candidate_interface/unsubscribe_from_emails.yml
@@ -1,0 +1,4 @@
+en:
+  unsubscribe_from_emails:
+    page_title: Unsubscribe from emails
+    heading: You have unsubscribed from emails

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -22,6 +22,7 @@ namespace :candidate_interface, path: '/candidate' do
   get '/terms-of-use', to: 'content#terms_candidate', as: :terms
   get '/guidance-for-using-ai', to: 'content#guidance_for_using_ai'
   post '/feedback-survey' => 'rejection_feedback_survey#new', as: :rejection_feedback_survey
+  get '/unsubscribe-from-emails/:token' => 'unsubscribe_from_emails#unsubscribe', as: :unsubscribe_from_emails
 
   resources :cookie_preferences, only: 'create', path: 'cookie-preferences'
   post '/cookie-preferences-hide-confirmation', to: 'cookie_preferences#hide_confirmation', as: :cookie_preferences_hide_confirmation

--- a/spec/system/candidate_interface/candidate_unsubscribe_from_emails_spec.rb
+++ b/spec/system/candidate_interface/candidate_unsubscribe_from_emails_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Candidate clicks unsubscribe link' do
     then_i_see_a_404
   end
 
-  private
+private
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
@@ -48,16 +48,15 @@ RSpec.describe 'Candidate clicks unsubscribe link' do
   end
 
   def and_i_see_unsubscribe_confirmation
-    expect(page).to have_content "You have unsubscribed from emails"
+    expect(page).to have_content 'You have unsubscribed from emails'
   end
 
-
   def and_i_am_on_application_details_page
-    expect(current_path).to eq candidate_interface_continuous_applications_details_path
+    expect(page).to have_current_path candidate_interface_continuous_applications_details_path, ignore_query: true
   end
 
   def and_i_am_on_the_sign_in_page
-    expect(current_path).to eq candidate_interface_sign_in_path
+    expect(page).to have_current_path candidate_interface_sign_in_path, ignore_query: true
   end
 
   def then_i_see_a_404

--- a/spec/system/candidate_interface/candidate_unsubscribe_from_emails_spec.rb
+++ b/spec/system/candidate_interface/candidate_unsubscribe_from_emails_spec.rb
@@ -23,6 +23,17 @@ RSpec.describe 'Candidate clicks unsubscribe link' do
     then_i_see_a_404
   end
 
+  scenario 'Candidate has multiple tokens generated' do
+    given_i_am_signed_in
+    and_multiple_tokens_have_been_generated
+    when_i_click_on_a_link_with_any_of_the_tokens
+    then_i_am_unsubscribed
+    and_i_see_unsubscribe_confirmation
+
+    given_i_click_on_another_link
+    then_i_see_unsubscribe_confirmation
+  end
+
 private
 
   def given_i_am_signed_in
@@ -32,6 +43,16 @@ private
   def given_i_am_not_signed_in
     current_candidate
   end
+
+  def and_multiple_tokens_have_been_generated
+    @tokens = (1..2).map { current_candidate.generate_token_for :unsubscribe_link }
+  end
+
+  def when_i_click_on_a_link_with_any_of_the_tokens
+    token = @tokens.sample
+    visit candidate_interface_unsubscribe_from_emails_path(token:)
+  end
+  alias_method :given_i_click_on_another_link, :when_i_click_on_a_link_with_any_of_the_tokens
 
   def and_i_visit_the_unsubscribe_link_with_valid_token
     token = current_candidate.generate_token_for :unsubscribe_link
@@ -50,7 +71,7 @@ private
   def and_i_see_unsubscribe_confirmation
     expect(page).to have_content 'You have unsubscribed from emails'
   end
-
+  alias_method :then_i_see_unsubscribe_confirmation, :and_i_see_unsubscribe_confirmation
   def and_i_am_on_application_details_page
     expect(page).to have_current_path candidate_interface_continuous_applications_details_path, ignore_query: true
   end

--- a/spec/system/candidate_interface/candidate_unsubscribe_from_emails_spec.rb
+++ b/spec/system/candidate_interface/candidate_unsubscribe_from_emails_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidate clicks unsubscribe link' do
+  include CandidateHelper
+
+  scenario 'Candidate is logged in and clicks on valid link' do
+    given_i_am_signed_in
+    and_i_visit_the_unsubscribe_link_with_valid_token
+    then_i_am_unsubscribed
+    and_i_see_unsubscribe_confirmation
+  end
+
+  scenario 'Candidate is not logged in and clicks on valid link' do
+    given_i_am_not_signed_in
+    and_i_visit_the_unsubscribe_link_with_valid_token
+    then_i_am_unsubscribed
+    and_i_see_unsubscribe_confirmation
+  end
+
+  scenario 'Candidate visits link with invalid token' do
+    given_i_am_signed_in
+    and_i_visit_a_bad_unsubscribe_link
+    then_i_see_a_404
+  end
+
+  private
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def given_i_am_not_signed_in
+    current_candidate
+  end
+
+  def and_i_visit_the_unsubscribe_link_with_valid_token
+    token = current_candidate.generate_token_for :unsubscribe_link
+    visit candidate_interface_unsubscribe_from_emails_path(token:)
+  end
+
+  def and_i_visit_a_bad_unsubscribe_link
+    token = 'something-useless'
+    visit candidate_interface_unsubscribe_from_emails_path(token:)
+  end
+
+  def then_i_am_unsubscribed
+    expect(current_candidate.reload.unsubscribed_from_emails).to be true
+  end
+
+  def and_i_see_unsubscribe_confirmation
+    expect(page).to have_content "You have unsubscribed from emails"
+  end
+
+
+  def and_i_am_on_application_details_page
+    expect(current_path).to eq candidate_interface_continuous_applications_details_path
+  end
+
+  def and_i_am_on_the_sign_in_page
+    expect(current_path).to eq candidate_interface_sign_in_path
+  end
+
+  def then_i_see_a_404
+    expect(page).to have_content 'Page not found'
+  end
+end


### PR DESCRIPTION
## Context

Our first email to candidates who have not submitted an application goes out on 17 July. In the process of reviewing this content, we realised we didn't have an unsubscribe link, which should be in included on non-transactional messages.

## Changes proposed in this pull request

- Updated the text for the eoc deadline reminder
- Added an unsubscribe controller, route and basic confirmation page
<img width="1086" alt="image" src="https://github.com/DFE-Digital/apply-for-teacher-training/assets/44073106/4141b872-6918-4c36-a936-0910d94389aa">

## Guidance to review

- [Preview of the email](https://apply-review-9534.test.teacherservices.cloud/rails/mailers/candidate_mailer/eoc_deadline_reminder) (the unsubscribe link won't work here because the candidate isn't persisted in the database for the preview)
- Test the unsubscribe link on the rails console by: 

1.   Generate an unsubscribe link for a candidate (make sure they have `unsubscribed_from_emails` set to `false` with `candidate_interface_unsubscribe_from_emails_url(token: candidate.generate_token_for :unsubscribe_link`)
2. Copy and paste the link into the browser
3. You should see an unsubscribed page
4. Reload the candidate -- `unsubscribed_from_emails` should now be set to `true`

## Link to Trello card

https://trello.com/c/pP7LLy1O

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
