### PR TITLE
Remove unused method from candidate model

### DIFF
--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -57,10 +57,6 @@ class Candidate < ApplicationRecord
     application_forms.max_by(&:updated_at)
   end
 
-  def encrypted_id
-    Encryptor.encrypt(id)
-  end
-
   def public_id
     "C#{id}"
   end

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -196,16 +196,6 @@ RSpec.describe Candidate do
     end
   end
 
-  describe '#encrypted_id' do
-    let(:candidate) { create(:candidate) }
-
-    it 'invokes Encryptor to encrypt id' do
-      allow(Encryptor).to receive(:encrypt).with(candidate.id).and_return 'encrypted id value'
-
-      expect(candidate.encrypted_id).to eq 'encrypted id value'
-    end
-  end
-
   describe '#in_apply_2?' do
     subject(:candidate) { build(:candidate) }
 

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_using_legacy_email_link_with_u_param_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_using_legacy_email_link_with_u_param_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate account' do
+RSpec.describe 'Candidate account' do
   include CandidateHelper
   include SignInHelper
 
@@ -39,7 +39,8 @@ RSpec.feature 'Candidate account' do
   end
 
   def and_i_try_to_use_a_legacy_email_link
-    visit "/candidate/sign-in/confirm?token=missing_token&u=#{current_candidate.encrypted_id}"
+    token = Encryptor.encrypt(current_candidate.id)
+    visit "/candidate/sign-in/confirm?token=missing_token&u=#{token}"
   end
 
   def then_i_am_prompted_to_get_a_new_magic_link


### PR DESCRIPTION
## Context

I came across the method when setting up the unsubscribe link -- it's not used anywhere but in a spec, so just cleaning it up. It appears to have been used in a now defunct magic-link generator.  

## Changes proposed in this pull request

Remove the `encrypted_id` method from the candidate method.

## Guidance to review

Just let me know if I've misunderstood the relevance of this method.

## Link to Trello card

NA

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
