### PR TITLE
Fix flaky equality and diversity factory spec

### DIFF
--- a/spec/services/sample_applications_factory_spec.rb
+++ b/spec/services/sample_applications_factory_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe SampleApplicationsFactory do
 
     it 'assigns the correct hesa code for sex' do
       if equality_and_diversity['sex'] == 'Prefer not to say'
-        expect(equality_and_diversity['hesa_sex']).to be_nil
+        expect(equality_and_diversity['hesa_sex']).to be '96'
       else
         expect(equality_and_diversity['hesa_sex']).to eq(
           Hesa::Sex.find(equality_and_diversity['sex'], RecruitmentCycle.current_year)['hesa_code'],


### PR DESCRIPTION
## Context

Test was failing whenever 'sex' was 'Prefer not to say'. In the past, this would have returned nil, but now it returns '96' for the hesa_sex.

## Changes proposed in this pull request

expect the correct value in the factory spec

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
