### PR TITLE
[604] Update queries so that unsubmitted works as intended

### DIFF
--- a/app/queries/get_applications_to_send_deadline_reminders_to.rb
+++ b/app/queries/get_applications_to_send_deadline_reminders_to.rb
@@ -5,7 +5,7 @@ class GetApplicationsToSendDeadlineRemindersTo
 
   def self.deadline_reminder_query
     ApplicationForm
-    .includes(:candidate)
+    .joins(:candidate)
     .current_cycle
     .unsubmitted
     .where.not(candidate: { unsubscribed_from_emails: true })

--- a/app/queries/get_applications_to_send_deadline_reminders_to.rb
+++ b/app/queries/get_applications_to_send_deadline_reminders_to.rb
@@ -5,8 +5,11 @@ class GetApplicationsToSendDeadlineRemindersTo
 
   def self.deadline_reminder_query
     ApplicationForm
-    .joins(:candidate)
-    .where(submitted_at: nil, recruitment_cycle_year: RecruitmentCycle.current_year)
+    .includes(:candidate)
+    .current_cycle
+    .unsubmitted
     .where.not(candidate: { unsubscribed_from_emails: true })
+    .where.not(candidate: { submission_blocked: true })
+    .where.not(candidate: { account_locked: true })
   end
 end

--- a/app/queries/get_incomplete_course_choice_applications_ready_to_nudge.rb
+++ b/app/queries/get_incomplete_course_choice_applications_ready_to_nudge.rb
@@ -8,7 +8,7 @@ class GetIncompleteCourseChoiceApplicationsReadyToNudge
 
   def call
     ApplicationForm
-      .includes(:candidate)
+      .joins(:candidate)
       .where.not('candidate.submission_blocked': true)
       .where.not('candidate.account_locked': true)
       .where.not('candidate.unsubscribed_from_emails': true)

--- a/app/queries/get_incomplete_course_choice_applications_ready_to_nudge.rb
+++ b/app/queries/get_incomplete_course_choice_applications_ready_to_nudge.rb
@@ -8,7 +8,10 @@ class GetIncompleteCourseChoiceApplicationsReadyToNudge
 
   def call
     ApplicationForm
-      .unsubmitted
+      .includes(:candidate)
+      .where.not('candidate.submission_blocked': true)
+      .where.not('candidate.account_locked': true)
+      .where.not('candidate.unsubscribed_from_emails': true)
       .inactive_since(7.days.ago)
       .with_completion(COMPLETION_ATTRS)
       .current_cycle

--- a/app/queries/get_incomplete_personal_statement_applications_ready_to_nudge.rb
+++ b/app/queries/get_incomplete_personal_statement_applications_ready_to_nudge.rb
@@ -10,10 +10,13 @@ class GetIncompletePersonalStatementApplicationsReadyToNudge
 
   def call
     ApplicationForm
-      .unsubmitted
       .inactive_since(7.days.ago)
       .with_completion(COMPLETION_ATTRS)
       .current_cycle
+      .includes(:candidate)
+      .where.not('candidate.submission_blocked': true)
+      .where.not('candidate.account_locked': true)
+      .where.not('candidate.unsubscribed_from_emails': true)
       .where(INCOMPLETION_ATTRS.map { |attr| "#{attr} = false" }.join(' AND '))
       .has_not_received_email(MAILER, MAIL_TEMPLATE)
       .includes(:application_choices).where('application_choices.status': 'unsubmitted')

--- a/app/queries/get_incomplete_personal_statement_applications_ready_to_nudge.rb
+++ b/app/queries/get_incomplete_personal_statement_applications_ready_to_nudge.rb
@@ -13,12 +13,12 @@ class GetIncompletePersonalStatementApplicationsReadyToNudge
       .inactive_since(7.days.ago)
       .with_completion(COMPLETION_ATTRS)
       .current_cycle
-      .includes(:candidate)
+      .joins(:candidate)
       .where.not('candidate.submission_blocked': true)
       .where.not('candidate.account_locked': true)
       .where.not('candidate.unsubscribed_from_emails': true)
       .where(INCOMPLETION_ATTRS.map { |attr| "#{attr} = false" }.join(' AND '))
       .has_not_received_email(MAILER, MAIL_TEMPLATE)
-      .includes(:application_choices).where('application_choices.status': 'unsubmitted')
+      .joins(:application_choices).where('application_choices.status': 'unsubmitted')
   end
 end

--- a/app/queries/get_incomplete_reference_applications_ready_to_nudge.rb
+++ b/app/queries/get_incomplete_reference_applications_ready_to_nudge.rb
@@ -10,7 +10,7 @@ class GetIncompleteReferenceApplicationsReadyToNudge
     uk_and_irish = uk_and_irish_names.map { |name| ActiveRecord::Base.connection.quote(name) }.join(',')
 
     ApplicationForm
-      .includes(:candidate)
+      .joins(:candidate)
       .where.not('candidate.submission_blocked': true)
       .where.not('candidate.account_locked': true)
       .where.not('candidate.unsubscribed_from_emails': true)

--- a/app/queries/get_unsubmitted_applications_ready_to_nudge.rb
+++ b/app/queries/get_unsubmitted_applications_ready_to_nudge.rb
@@ -15,11 +15,11 @@ class GetUnsubmittedApplicationsReadyToNudge
       .with_completion(COMMON_COMPLETION_ATTRS)
       .current_cycle
       .has_not_received_email(MAILER, MAIL_TEMPLATE)
-      .includes(:candidate)
+      .joins(:candidate)
       .where.not('candidate.submission_blocked': true)
       .where.not('candidate.account_locked': true)
       .where.not('candidate.unsubscribed_from_emails': true)
-      .includes(:application_choices).where('application_choices.status': 'unsubmitted')
+      .joins(:application_choices).where('application_choices.status': 'unsubmitted')
       .and(ApplicationForm
         .where(science_gcse_completed: true)
         .or(

--- a/app/queries/get_unsubmitted_applications_ready_to_nudge.rb
+++ b/app/queries/get_unsubmitted_applications_ready_to_nudge.rb
@@ -11,11 +11,14 @@ class GetUnsubmittedApplicationsReadyToNudge
     uk_and_irish = uk_and_irish_names.map { |name| ActiveRecord::Base.connection.quote(name) }.join(',')
 
     ApplicationForm
-      .unsubmitted
       .inactive_since(7.days.ago)
       .with_completion(COMMON_COMPLETION_ATTRS)
       .current_cycle
       .has_not_received_email(MAILER, MAIL_TEMPLATE)
+      .includes(:candidate)
+      .where.not('candidate.submission_blocked': true)
+      .where.not('candidate.account_locked': true)
+      .where.not('candidate.unsubscribed_from_emails': true)
       .includes(:application_choices).where('application_choices.status': 'unsubmitted')
       .and(ApplicationForm
         .where(science_gcse_completed: true)

--- a/app/queries/get_unsuccessful_and_unsubmitted_candidates.rb
+++ b/app/queries/get_unsuccessful_and_unsubmitted_candidates.rb
@@ -1,20 +1,27 @@
 class GetUnsuccessfulAndUnsubmittedCandidates
   def self.call
+    previous_recruitment_year = RecruitmentCycle.previous_year
+    # Candidates who didn't have successful applications last year
     Candidate
       .left_outer_joins(:application_forms)
       .where.not(candidates: { unsubscribed_from_emails: true })
       .where.not(candidates: { submission_blocked: true })
       .where.not(candidates: { account_locked: true })
       .where(
-        '(application_forms.recruitment_cycle_year = 2023 AND NOT EXISTS (:successful))',
+        '(application_forms.recruitment_cycle_year = (:previous_recruitment_year) AND NOT EXISTS (:successful))',
+        previous_recruitment_year:,
         successful: ApplicationChoice
             .select(1)
-            .where(status: %w[recruited pending_conditions offer offer_deferred])
+            .where(status: ApplicationStateChange::SUCCESSFUL_STATES)
             .where('application_choices.application_form_id = application_forms.id'),
       )
       .or(
+        # Candidates who have started working on applications this year, but not submitted.
         Candidate
-          .where(application_forms: { recruitment_cycle_year: 2024 })
+          .where(application_forms: {
+            recruitment_cycle_year: RecruitmentCycle.current_year,
+            submitted_at: nil,
+          })
           .where.not(candidates: { unsubscribed_from_emails: true })
           .where.not(candidates: { submission_blocked: true })
           .where.not(candidates: { account_locked: true }),

--- a/app/workers/cancel_unsubmitted_applications_worker.rb
+++ b/app/workers/cancel_unsubmitted_applications_worker.rb
@@ -13,8 +13,7 @@ private
     return [] unless CycleTimetable.cancel_unsubmitted_applications?
 
     ApplicationForm
-      .where(submitted_at: nil)
-      .where(recruitment_cycle_year: RecruitmentCycle.current_year)
+      .current_cycle
       .where.not(application_forms: { candidate_id: Candidate.where(hide_in_reporting: true).select(:id) })
       .where(application_forms: { id: ApplicationChoice.unsubmitted.select(:application_form_id) })
       .includes(:application_choices)

--- a/app/workers/cancel_unsubmitted_applications_worker.rb
+++ b/app/workers/cancel_unsubmitted_applications_worker.rb
@@ -15,8 +15,7 @@ private
     ApplicationForm
       .current_cycle
       .where.not(application_forms: { candidate_id: Candidate.where(hide_in_reporting: true).select(:id) })
-      .where(application_forms: { id: ApplicationChoice.unsubmitted.select(:application_form_id) })
-      .includes(:application_choices)
+      .includes(:application_choices).where('application_choices.status': 'unsubmitted')
       .distinct
   end
 end

--- a/spec/queries/get_unsuccessful_and_unsubmitted_candidates_spec.rb
+++ b/spec/queries/get_unsuccessful_and_unsubmitted_candidates_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe GetUnsuccessfulAndUnsubmittedCandidates do
         candidate: rejected_application_form_from_previous_cycle.candidate,
       )
 
-      application_form_current_year = create(:application_form, :minimum_info, recruitment_cycle_year: RecruitmentCycle.current_year)
+      application_form_current_year = create(:application_form, :minimum_info, submitted_at: nil, recruitment_cycle_year: RecruitmentCycle.current_year)
 
       application_form_previous_year = create(:application_form, submitted_at: 1.year.ago, recruitment_cycle_year: RecruitmentCycle.previous_year)
 

--- a/spec/services/sample_applications_factory_spec.rb
+++ b/spec/services/sample_applications_factory_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe SampleApplicationsFactory do
 
     it 'assigns the correct hesa code for sex' do
       if equality_and_diversity['sex'] == 'Prefer not to say'
-        expect(equality_and_diversity['hesa_sex']).to be '96'
+        expect(equality_and_diversity['hesa_sex']).to eq '96'
       else
         expect(equality_and_diversity['hesa_sex']).to eq(
           Hesa::Sex.find(equality_and_diversity['sex'], RecruitmentCycle.current_year)['hesa_code'],


### PR DESCRIPTION
## Context
The way `submitted_at` is updated has changed in the 2024 recruitment cycle. In the 2023 cycle it meant  all the application choices on the application form had been submitted. But in 2024, it just means that at least one of the choices has been submitted.

I've gone through all the identified workers and made a judgment about whether or not they should be updated to ensure we send messages / cancel applications for the right group of people.

Changes for each individual worker are listed below. Where the worker is related to end of cycle, that's noted.

## CancelUnsubmittedApplicationsWorker (end of cycle related)

### Changes
- Removes the filtering for unsubmitted.

### Why?
If submitted_at is nil, then ALL the application_choices are unsubmitted now. but we want to cancel all the unsubmitted choices.

## SendEocDeadlineReminderEmailToCandidatesWorker (end of cycle related)

### Changes
We want to add two additional filters
```ruby
  .where.not(candidates: { submission_blocked: true })
  .where.not(candidates: { account_locked: true })
```

### Why
- So that we don't send messages to people who can't actually submit an application.
- No change related to `submitted_at`. We've written the email with the audience described in mind.

## SendNewCycleHasStartedEmailToCandidatesWorker (end of cycle related)

### Changes
- Removes specific years. (2023 and 2024)
- Add 'unsubmitted' to the query. 

### Why
1. We no longer need to be specific about year of the cycle. We can use 'current' and 'previous' instead
2. The original query didn't actually look at unsubmitted. It assumed that the applications were unsubmitted because the query is done on the day apply opens. But for completeness, I've added it. (we don't want to send messages to someone who submitted as soon as apply opened) 

## SendStatsSummaryToSlack

### Changes
No changes required

### Why
Does not use the `submitted_at` in the queries. We are not looking at unsubmitted choices either. Just choices that are in specific states. 
We are counting application choices. Eg 'submitted applications' is counting the number of choices that have been submitted. There can be multiple choices per application_form.
So the status of the application_form is moot.

## SendWeeklyStatsSummaryToSlack

### Changes
No changes required

### Why
Does not use the `submitted_at` in the queries. We are not looking at unsubmitted choices either. Just choices that are in specific states.
We are counting application choices. Eg 'submitted applications' is counting the number of choices that have been submitted. There can be multiple choices per application_form.
So the submitted_at field on the application_form is moot.

## SupportInterface::ApplicationsBySubjectRouteAndDegreeGradeExport

### Changes 
No changes required

### Why
We have been generating the data to this specification (`where.not submitted_at: nil`) for the entire cycle, so to change the data now would make it incomparable to previous reports.

## SupportInterface::ApplicationsByDemographicDomicileAndDegreeClassExport
### Changes
No changes required

### Why
We have been generating the data to this specification (`where.not submitted_at: nil`) for the entire cycle, so to change the data now would make it incomparable to previous reports.

## NudgeCandidatesWorker

### GetUnsubmittedApplicationsReadyToNudge

#### Changes
- Replace `.unsubmitted` with unsubmitted application choices
- Add filters to ensure we are only sending message to people who should receive them (not blocked or locked)

#### Why
- Using 'unsubmitted' changes the intended behaviour significantly. We want to nudge people with inflight applications.
- We should only nudge people who can action things and who have subscribed to emails 

### GetIncompleteCourseChoiceApplicationsReadyToNudge

#### Changes
- Add filters to ensure we are only sending message to people who should receive them
- Remove unsubmitted

#### Why
Since the application has no application choices, the form is probably unsubmitted (nothing to submit), but what we really care about is that there are no application choices. 
We should only nudge people who can action things and who have subscribed to emails

### GetIncompletePersonalStatementApplicationsReadyToNudge

#### Changes
Remove `.unsubmitted` with unsubmitted application choices
Add filters to ensure we are only sending message to people who should receive them

#### Why
Using 'unsubmitted' changes the intended behaviour significantly. We want to nudge people with inflight applications.
We should only nudge people who can action things and who have subscribed to emails

### GetIncompleteReferenceApplicationsReadyToNudge
#### Changes
- Remove unsubmitted -- it's moot because they could not have submitted anything if they do not have application choices
- Add filters to ensure we are only sending message to people who should receive them

#### Why
Using 'unsubmitted' changes the intended behaviour significantly. We want to nudge people with inflight applications.
We should only nudge people who can action things and who have subscribed to emails

## Guidance to review


## Link to Trello card

[Trello ticket](https://trello.com/c/njdwKzXF)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
