### PR TITLE
Vendor API v1.5

### DIFF
--- a/app/controllers/api_docs/vendor_api_docs/reference_controller.rb
+++ b/app/controllers/api_docs/vendor_api_docs/reference_controller.rb
@@ -42,6 +42,8 @@ module APIDocs
           api_docs_spec_1_3_url
         when '1.4'
           api_docs_spec_1_4_url
+        when '1.5'
+          api_docs_spec_1_5_url
         end
       end
       helper_method :spec_url_for_current_version

--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -63,6 +63,7 @@ module VendorAPI
     ],
     '1.5pre' => [
       Changes::V15::AddApplicationSentToProviderDatetime,
+      Changes::V15::AddReferenceFeedbackProvidedAtDatetime,
     ],
   }.freeze
 end

--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -29,6 +29,7 @@ module VendorAPI
       Changes::ExperimentalClearTestData,
       Changes::ExperimentalGenerateTestData,
       Changes::ReferenceStatus,
+      Changes::RefactoredReferenceOnApplication,
     ],
     '1.1' => [
       Changes::DeferOffer,

--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -6,8 +6,8 @@ module VendorAPI
   VERSION_1_2 = '1.2'.freeze
   VERSION_1_3 = '1.3'.freeze
   VERSION_1_4 = '1.4'.freeze
-  VERSION_1_5 = '1.5'.freeze
-  VERSION = VERSION_1_5
+  VERSION_1_5 = '1.5pre'.freeze
+  VERSION = VERSION_1_4
 
   VERSIONS = {
     '1.0' => [

--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -59,6 +59,8 @@ module VendorAPI
     '1.4' => [
       Changes::V14::AddGcseCompletingQualificationData,
     ],
-    '1.5pre' => [],
+    '1.5pre' => [
+      Changes::V15::AddApplicationSentToProviderDatetime,
+    ],
   }.freeze
 end

--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -56,6 +56,7 @@ module VendorAPI
       Changes::WorkHistory::MarkDescriptionAsOptional,
       Changes::MarkPhaseAsDeprecated,
       Changes::RemoveReferencesWhenApplicationIsUnsuccessful,
+      Changes::V13::AddReferenceReceivedToReference,
     ],
     '1.4' => [
       Changes::V14::AddGcseCompletingQualificationData,

--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -6,7 +6,8 @@ module VendorAPI
   VERSION_1_2 = '1.2'.freeze
   VERSION_1_3 = '1.3'.freeze
   VERSION_1_4 = '1.4'.freeze
-  VERSION = VERSION_1_4
+  VERSION_1_5 = '1.5'.freeze
+  VERSION = VERSION_1_5
 
   VERSIONS = {
     '1.0' => [
@@ -58,5 +59,6 @@ module VendorAPI
     '1.4' => [
       Changes::V14::AddGcseCompletingQualificationData,
     ],
+    '1.5pre' => [],
   }.freeze
 end

--- a/app/lib/vendor_api/changes/refactored_reference_on_application.rb
+++ b/app/lib/vendor_api/changes/refactored_reference_on_application.rb
@@ -1,0 +1,9 @@
+module VendorAPI
+  module Changes
+    class RefactoredReferenceOnApplication < VersionChange
+      description 'Refactored Reference object on Application'
+
+      resource ReferencePresenter
+    end
+  end
+end

--- a/app/lib/vendor_api/changes/v13/add_reference_received_to_reference.rb
+++ b/app/lib/vendor_api/changes/v13/add_reference_received_to_reference.rb
@@ -1,0 +1,11 @@
+module VendorAPI
+  module Changes
+    module V13
+      class AddReferenceReceivedToReference < VersionChange
+        description 'Include reference received in Reference json responses.'
+
+        resource ReferencePresenter, [ReferencePresenter::ReferenceReceived]
+      end
+    end
+  end
+end

--- a/app/lib/vendor_api/changes/v15/add_application_sent_to_provider_datetime.rb
+++ b/app/lib/vendor_api/changes/v15/add_application_sent_to_provider_datetime.rb
@@ -1,0 +1,11 @@
+module VendorAPI
+  module Changes
+    module V15
+      class AddApplicationSentToProviderDatetime < VersionChange
+        description 'Add the date and time that the application was sent to the provider.'
+
+        resource ApplicationPresenter, [ApplicationPresenter::AddSentToProviderDatetime]
+      end
+    end
+  end
+end

--- a/app/lib/vendor_api/changes/v15/add_reference_feedback_provided_at_datetime.rb
+++ b/app/lib/vendor_api/changes/v15/add_reference_feedback_provided_at_datetime.rb
@@ -1,0 +1,11 @@
+module VendorAPI
+  module Changes
+    module V15
+      class AddReferenceFeedbackProvidedAtDatetime < VersionChange
+        description 'Add the date and time that feedback was provided for the Reference.'
+
+        resource ReferencePresenter, [ReferencePresenter::FeedbackProvidedAt]
+      end
+    end
+  end
+end

--- a/app/presenters/vendor_api/application_presenter.rb
+++ b/app/presenters/vendor_api/application_presenter.rb
@@ -97,6 +97,10 @@ module VendorAPI
         application_accepted?
     end
 
+    def version_1_3_or_above?
+      Gem::Version.new(active_version) >= Gem::Version.new('1.3')
+    end
+
     def safeguarding_issues_details_url
       application_form.has_safeguarding_issues_to_declare? ? provider_interface_application_choice_url(application_choice, anchor: 'criminal-convictions-and-professional-misconduct') : nil
     end

--- a/app/presenters/vendor_api/application_presenter.rb
+++ b/app/presenters/vendor_api/application_presenter.rb
@@ -97,14 +97,6 @@ module VendorAPI
         application_accepted?
     end
 
-    def version_1_3_or_above?
-      Gem::Version.new(active_version) >= Gem::Version.new('1.3')
-    end
-
-    def reference_received?(reference)
-      reference.feedback_provided? && application_accepted?
-    end
-
     def safeguarding_issues_details_url
       application_form.has_safeguarding_issues_to_declare? ? provider_interface_application_choice_url(application_choice, anchor: 'criminal-convictions-and-professional-misconduct') : nil
     end
@@ -114,19 +106,7 @@ module VendorAPI
     end
 
     def reference_to_hash(reference)
-      received = reference_received?(reference)
-
-      {
-        id: reference.id,
-        name: reference.name,
-        email: reference.email_address,
-        relationship: reference.relationship,
-        reference: (reference.feedback if received),
-        referee_type: reference.referee_type,
-        safeguarding_concerns: (reference.has_safeguarding_concerns_to_declare? if received),
-      }.tap do |hash|
-        hash[:reference_received] = received if version_1_3_or_above?
-      end
+      VendorAPI::ReferencePresenter.new(active_version, reference, application_accepted: application_accepted?).schema
     end
 
     def domicile

--- a/app/presenters/vendor_api/application_presenter/add_sent_to_provider_datetime.rb
+++ b/app/presenters/vendor_api/application_presenter/add_sent_to_provider_datetime.rb
@@ -1,0 +1,9 @@
+module VendorAPI::ApplicationPresenter::AddSentToProviderDatetime
+  def schema
+    super.deep_merge!({
+      attributes: {
+        sent_to_provider_at: application_choice.sent_to_provider_at.iso8601,
+      },
+    })
+  end
+end

--- a/app/presenters/vendor_api/base.rb
+++ b/app/presenters/vendor_api/base.rb
@@ -55,10 +55,6 @@ module VendorAPI
     def cache_key(model, api_version, suffixes = {})
       CacheKey.generate("#{api_version}_#{model.cache_key_with_version}#{suffixes.hash}")
     end
-
-    def version_1_3_or_above?
-      Gem::Version.new(active_version) >= Gem::Version.new('1.3')
-    end
   end
 end
 

--- a/app/presenters/vendor_api/base.rb
+++ b/app/presenters/vendor_api/base.rb
@@ -55,6 +55,10 @@ module VendorAPI
     def cache_key(model, api_version, suffixes = {})
       CacheKey.generate("#{api_version}_#{model.cache_key_with_version}#{suffixes.hash}")
     end
+
+    def version_1_3_or_above?
+      Gem::Version.new(active_version) >= Gem::Version.new('1.3')
+    end
   end
 end
 

--- a/app/presenters/vendor_api/reference_presenter.rb
+++ b/app/presenters/vendor_api/reference_presenter.rb
@@ -1,0 +1,38 @@
+module VendorAPI
+  class ReferencePresenter < Base
+    attr_reader :reference
+
+    def initialize(version, reference, application_accepted: false)
+      super(version)
+      @reference = reference
+      @application_accepted = application_accepted
+    end
+
+    def as_json
+      schema.to_json
+    end
+
+    def schema
+      {
+        id: reference.id,
+        name: reference.name,
+        email: reference.email_address,
+        relationship: reference.relationship,
+        reference: (reference.feedback if reference_received?),
+        referee_type: reference.referee_type,
+        safeguarding_concerns: (reference.has_safeguarding_concerns_to_declare? if reference_received?),
+      }.tap do |hash|
+        hash[:reference_received] = reference_received? if version_1_3_or_above?
+      end
+    end
+
+  private
+
+    attr_reader :application_accepted
+    alias application_accepted? application_accepted
+
+    def reference_received?
+      reference.feedback_provided? && application_accepted?
+    end
+  end
+end

--- a/app/presenters/vendor_api/reference_presenter.rb
+++ b/app/presenters/vendor_api/reference_presenter.rb
@@ -21,9 +21,7 @@ module VendorAPI
         reference: (reference.feedback if reference_received?),
         referee_type: reference.referee_type,
         safeguarding_concerns: (reference.has_safeguarding_concerns_to_declare? if reference_received?),
-      }.tap do |hash|
-        hash[:reference_received] = reference_received? if version_1_3_or_above?
-      end
+      }
     end
 
   private

--- a/app/presenters/vendor_api/reference_presenter/feedback_provided_at.rb
+++ b/app/presenters/vendor_api/reference_presenter/feedback_provided_at.rb
@@ -1,0 +1,7 @@
+module VendorAPI::ReferencePresenter::FeedbackProvidedAt
+  def schema
+    super.deep_merge!({
+      feedback_provided_at: (reference.feedback_provided_at&.iso8601 if reference_received?),
+    })
+  end
+end

--- a/app/presenters/vendor_api/reference_presenter/reference_received.rb
+++ b/app/presenters/vendor_api/reference_presenter/reference_received.rb
@@ -1,0 +1,7 @@
+module VendorAPI::ReferencePresenter::ReferenceReceived
+  def schema
+    super.deep_merge!({
+      reference_received: reference_received?,
+    })
+  end
+end

--- a/app/views/api_docs/vendor_api_docs/pages/release_notes.md
+++ b/app/views/api_docs/vendor_api_docs/pages/release_notes.md
@@ -1,3 +1,9 @@
+## v1.5pre — 10th July 2024
+
+Minor Version Upgrade:
+
+Release API version `v1.5` to production. Please refer to the [API Reference](/api-docs/v1.5/reference) for details.
+
 ## v1.4 — 15th January 2024
 
 Minor Version Upgrade:

--- a/app/views/api_docs/vendor_api_docs/reference/_v1_5_changes.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/_v1_5_changes.html.erb
@@ -1,0 +1,17 @@
+<h2 class="govuk-heading-l" id="important">Version 1.5 changes</h2>
+
+<p class="govuk-heading-s">Added the timestamp when the Application was sent to the Provider</p>
+
+<p class="govuk-body">
+  The following fields have been added to the <%= govuk_link_to 'application attributes', '#applicationattributes-object' %> object:
+</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li><code>sent_to_provider_at</code> (string)</li>
+</ul>
+
+<p class="govuk-body">
+  The following fields have been marked as deprecated in the <%= govuk_link_to 'application attributes', '#applicationattributes-object' %> object:
+</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li><code>submitted_at</code> (string) use <code>sent_to_provider_at</code> instead</li>
+</ul>

--- a/app/views/api_docs/vendor_api_docs/reference/_v1_5_changes.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/_v1_5_changes.html.erb
@@ -15,3 +15,12 @@
 <ul class="govuk-list govuk-list--bullet">
   <li><code>submitted_at</code> (string) use <code>sent_to_provider_at</code> instead</li>
 </ul>
+
+<p class="govuk-heading-s">Added the timestamp when the Reference Feedback was provided</p>
+
+<p class="govuk-body">
+  The following fields have been added to the <%= govuk_link_to 'reference attributes', '#reference-object' %> object:
+</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li><code>feedback_provided_at</code> (string)</li>
+</ul>

--- a/config/routes/api/docs.rb
+++ b/config/routes/api/docs.rb
@@ -20,6 +20,7 @@ namespace :api_docs, path: nil do
     get '/spec-1.2.yml' => 'openapi#spec_1_2', as: :spec_1_2
     get '/spec-1.3.yml' => 'openapi#spec_1_3', as: :spec_1_3
     get '/spec-1.4.yml' => 'openapi#spec_1_4', as: :spec_1_4
+    get '/spec-1.5.yml' => 'openapi#spec_1_5', as: :spec_1_5
   end
 
   namespace :data_api_docs, path: '/data-api' do

--- a/config/vendor_api/draft.yml
+++ b/config/vendor_api/draft.yml
@@ -19,7 +19,6 @@ components:
   schemas:
     ApplicationAttributes:
       type: object
-      additionalProperties: false
       properties:
         sent_to_provider_at:
           type: string
@@ -34,3 +33,13 @@ components:
           deprecated: true
       required:
         - sent_to_provider_at
+    Reference:
+      type: object
+      properties:
+        feedback_provided_at:
+          type: string
+          format: date-time
+          description: The date and time the reference was provided
+          example: "2024-07-10T13:00:00+01:00"
+      required:
+        - feedback_provided_at

--- a/config/vendor_api/draft.yml
+++ b/config/vendor_api/draft.yml
@@ -29,7 +29,7 @@ components:
           type: string
           format: date-time
           description: The date and time the Candidate first submitted in this cycle. See `sent_to_provider_at` for the date and time this specific Application was submitted.
-          example: 2019-06-13T10:44:31Z
+          example: "2019-06-13T10:44:31Z"
           deprecated: true
       required:
         - sent_to_provider_at

--- a/config/vendor_api/draft.yml
+++ b/config/vendor_api/draft.yml
@@ -1,7 +1,7 @@
 ---
 openapi: 3.0.0
 info:
-  version: v1.5pre
+  version: v1.5
   title: Apply API
   contact:
     name: DfE

--- a/config/vendor_api/v1.3.yml
+++ b/config/vendor_api/v1.3.yml
@@ -33,6 +33,11 @@ components:
           nullable: true
         safeguarding_concerns:
           nullable: true
+        reference_received:
+          nullable: true
+          type: boolean
+          description: 'Has the reference been received?'
+          example: true
     Month:
       type: object
       additionalProperties: false

--- a/config/vendor_api/v1.5.yml
+++ b/config/vendor_api/v1.5.yml
@@ -34,3 +34,13 @@ components:
           deprecated: true
       required:
         - sent_to_provider_at
+    Reference:
+      type: object
+      properties:
+        feedback_provided_at:
+          type: string
+          format: date-time
+          description: The date and time the reference was provided
+          example: "2024-07-10T13:00:00+01:00"
+      required:
+        - feedback_provided_at

--- a/config/vendor_api/v1.5.yml
+++ b/config/vendor_api/v1.5.yml
@@ -30,7 +30,7 @@ components:
           type: string
           format: date-time
           description: The date and time the Candidate first submitted in this cycle. See `sent_to_provider_at` for the date and time this specific Application was submitted.
-          example: 2019-06-13T10:44:31Z
+          example: "2019-06-13T10:44:31Z"
           deprecated: true
       required:
         - sent_to_provider_at

--- a/config/vendor_api/v1.5.yml
+++ b/config/vendor_api/v1.5.yml
@@ -12,9 +12,9 @@ info:
     Experimental endpoints prefixed with `/test-data` may change or be removed.
 servers:
   - description: Sandbox (test environment for vendors)
-    url: https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.5
+    url: https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.5pre
   - description: Production
-    url: https://www.apply-for-teacher-training.service.gov.uk/api/v1.5
+    url: https://www.apply-for-teacher-training.service.gov.uk/api/v1.5pre
 components:
   schemas:
     ApplicationAttributes:

--- a/config/vendor_api/v1.5.yml
+++ b/config/vendor_api/v1.5.yml
@@ -1,7 +1,7 @@
 ---
 openapi: 3.0.0
 info:
-  version: v1.5pre
+  version: v1.5
   title: Apply API
   contact:
     name: DfE

--- a/spec/presenters/vendor_api/v1.0/reference_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.0/reference_presenter_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe 'ReferencePresenter' do
+  subject(:reference_json) { reference_presenter.new(version, reference, application_accepted: application_accepted).as_json }
+
+  let(:reference_presenter) { VendorAPI::ReferencePresenter }
+  let(:version) { '1.0' }
+
+  let(:reference) {
+    create(:reference,
+           reference_status,
+           name: 'Some Name',
+           email_address: 'someone@email.address',
+           relationship: 'Some Relationship',
+           referee_type: 'academic',
+           feedback: 'Some Feedback',
+           safeguarding_concerns_status: 'has_safeguarding_concerns_to_declare')
+  }
+
+  context 'when the reference has been received and the application has been accepted' do
+    let(:reference_status) { :feedback_provided }
+    let(:application_accepted) { true }
+
+    it 'includes the all details including `feedback` and `safeguarding_concerns_status`' do
+      expected_json = {
+        id: reference.id,
+        name: 'Some Name',
+        email: 'someone@email.address',
+        relationship: 'Some Relationship',
+        reference: 'Some Feedback',
+        referee_type: 'academic',
+        safeguarding_concerns: true,
+      }.to_json
+
+      expect(reference_json).to eq(expected_json)
+    end
+  end
+
+  context 'when the reference has not been received' do
+    let(:reference_status) { :not_requested_yet }
+    let(:application_accepted) { true }
+
+    it 'does not include `feedback` or `safeguarding_concerns_status`' do
+      expected_json = {
+        id: reference.id,
+        name: 'Some Name',
+        email: 'someone@email.address',
+        relationship: 'Some Relationship',
+        reference: nil,
+        referee_type: 'academic',
+        safeguarding_concerns: nil,
+      }.to_json
+
+      expect(reference_json).to eq(expected_json)
+    end
+  end
+
+  context 'when the application has not been accepted' do
+    let(:reference_status) { :feedback_provided }
+    let(:application_accepted) { false }
+
+    it 'does not include `feedback` or `safeguarding_concerns_status`' do
+      expected_json = {
+        id: reference.id,
+        name: 'Some Name',
+        email: 'someone@email.address',
+        relationship: 'Some Relationship',
+        reference: nil,
+        referee_type: 'academic',
+        safeguarding_concerns: nil,
+      }.to_json
+
+      expect(reference_json).to eq(expected_json)
+    end
+  end
+end

--- a/spec/presenters/vendor_api/v1.3/reference_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.3/reference_presenter_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe 'ReferencePresenter' do
+  subject(:reference_schema) { reference_presenter.new(version, reference, application_accepted: application_accepted).schema }
+
+  let(:reference_presenter) { VendorAPI::ReferencePresenter }
+  let(:version) { '1.3' }
+
+  context 'when the reference has not been provided and the application has not been accepted' do
+    let(:reference) { create(:reference, :feedback_requested) }
+    let(:application_accepted) { false }
+
+    it 'includes the reference received attribute as false' do
+      expect(reference_schema).to have_key(:reference_received)
+      expect(reference_schema[:reference_received]).to be(false)
+    end
+  end
+
+  context 'when the reference has been provided and the application has not been accepted' do
+    let(:reference) { create(:reference, :feedback_provided) }
+    let(:application_accepted) { false }
+
+    it 'includes the reference received attribute as true' do
+      expect(reference_schema).to have_key(:reference_received)
+      expect(reference_schema[:reference_received]).to be(false)
+    end
+  end
+
+  context 'when the reference has not been provided and the application has been accepted' do
+    let(:reference) { create(:reference, :feedback_requested) }
+    let(:application_accepted) { true }
+
+    it 'includes the reference received attribute as false' do
+      expect(reference_schema).to have_key(:reference_received)
+      expect(reference_schema[:reference_received]).to be(false)
+    end
+  end
+
+  context 'when the reference has been provided and the application has been accepted' do
+    let(:reference) { create(:reference, :feedback_provided) }
+    let(:application_accepted) { true }
+
+    it 'includes the reference received attribute as true' do
+      expect(reference_schema).to have_key(:reference_received)
+      expect(reference_schema[:reference_received]).to be(true)
+    end
+  end
+end

--- a/spec/presenters/vendor_api/v1.5/application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.5/application_presenter_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe 'ApplicationPresenter' do
+  let(:version) { '1.5' }
+  let(:application_json) { VendorAPI::ApplicationPresenter.new(version, application_choice).as_json }
+
+  subject(:sent_to_provider_at) { application_json.dig(:attributes, :sent_to_provider_at) }
+
+  describe 'sent_to_provider_at' do
+    let(:application_choice) {
+      create(:application_choice,
+             application_form: create(:application_form, :submitted),
+             sent_to_provider_at: DateTime.new(2024, 7, 10, 12, 0))
+    }
+
+    it 'returns the date and time the application was sent to the provider' do
+      expect(sent_to_provider_at).to eq('2024-07-10T13:00:00+01:00')
+    end
+  end
+end

--- a/spec/presenters/vendor_api/v1.5/reference_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.5/reference_presenter_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe 'ReferencePresenter' do
+  subject(:reference_schema) { reference_presenter.new(version, reference, application_accepted: application_accepted).schema }
+
+  let(:reference_presenter) { VendorAPI::ReferencePresenter }
+  let(:version) { '1.5' }
+
+  context 'when the reference has been provided and the application has been accepted' do
+    let(:reference) { create(:reference, :feedback_provided, feedback_provided_at: Time.zone.local(2024, 7, 10, 12, 0)) }
+    let(:application_accepted) { true }
+
+    it 'includes the feedback provided at attribute as a timestamp' do
+      expect(reference_schema).to have_key(:feedback_provided_at)
+      expect(reference_schema[:feedback_provided_at]).to eq('2024-07-10T12:00:00+01:00')
+    end
+  end
+
+  context 'when the reference has not been provided and the application has not been accepted' do
+    let(:reference) { create(:reference, :feedback_requested, feedback_provided_at: Time.zone.local(2024, 7, 10, 12, 0)) }
+    let(:application_accepted) { false }
+
+    it 'includes the feedback provided at attribute as nil' do
+      expect(reference_schema).to have_key(:feedback_provided_at)
+      expect(reference_schema[:feedback_provided_at]).to be_nil
+    end
+  end
+
+  context 'when the reference has been provided and the application has not been accepted' do
+    let(:reference) { create(:reference, :feedback_provided, feedback_provided_at: Time.zone.local(2024, 7, 10, 12, 0)) }
+    let(:application_accepted) { false }
+
+    it 'includes the feedback provided at attribute as nil' do
+      expect(reference_schema).to have_key(:feedback_provided_at)
+      expect(reference_schema[:feedback_provided_at]).to be_nil
+    end
+  end
+
+  context 'when the reference has not been provided and the application has been accepted' do
+    let(:reference) { create(:reference, :feedback_requested, feedback_provided_at: Time.zone.local(2024, 7, 10, 12, 0)) }
+    let(:application_accepted) { true }
+
+    it 'includes the feedback provided at attribute as nil' do
+      expect(reference_schema).to have_key(:feedback_provided_at)
+      expect(reference_schema[:feedback_provided_at]).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Context

We have a couple of requests to add additional data to our APIs

## Changes proposed in this pull request

- Added a v1.5 Vendor APi
  - Currently set as v1.5pre - this enables the version in Sandbox but not Production
- Added `sent_to_provider_at` timestamp to Applications
- Marked `submitted_at` timestamp on Applications as deprecated in favour of `sent_to_provider_at`
- Added `feedback_provided_at` timestamp to References
- Refactored Reference data to a presenter
  - Removed the need for a version conditional as the module is only included above v1.3 - see commit for more detail

## Guidance to review

- Check `/api-docs/v1.5/reference` for changes
- Check `/api-docs/v1.5/reference#important` for wording - might need a Content Designer
- Check api data matches schema

## Link to Trello card

- Closes: https://trello.com/c/VWCpIk9a
- Closes: https://trello.com/c/OWWfPcge

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
