### PR TITLE
Stop detecting API Sync invariant in review environment

### DIFF
--- a/app/workers/detect_invariants_hourly_check.rb
+++ b/app/workers/detect_invariants_hourly_check.rb
@@ -5,7 +5,7 @@ class DetectInvariantsHourlyCheck
   SIDEKIQ_LATENCY_THRESHOLD = 120
 
   def perform
-    detect_course_sync_not_succeeded_for_an_hour
+    detect_course_sync_not_succeeded_for_an_hour unless HostingEnvironment.review?
     detect_high_sidekiq_retries_queue_length
     detect_high_sidekiq_latency
     detect_unauthorised_application_form_edits

--- a/spec/workers/detect_invariants_hourly_check_spec.rb
+++ b/spec/workers/detect_invariants_hourly_check_spec.rb
@@ -138,5 +138,29 @@ RSpec.describe DetectInvariantsHourlyCheck do
 
       expect(Sentry).not_to have_received(:capture_exception)
     end
+
+    context 'when HostingEnvironment is review' do
+      it 'doesn’t check API sync on review apps' do
+        allow(HostingEnvironment).to receive(:review?).and_return(true)
+        allow(TeacherTrainingPublicAPI::SyncCheck).to receive(:check)
+
+        described_class.new.perform
+
+        expect(TeacherTrainingPublicAPI::SyncCheck).not_to have_received(:check)
+        expect(Sentry).not_to have_received(:capture_exception)
+      end
+    end
+
+    context 'when HostingEnvironment is not review' do
+      it 'check API sync on not on review apps' do
+        allow(HostingEnvironment).to receive(:review?).and_return(false)
+        allow(TeacherTrainingPublicAPI::SyncCheck).to receive(:check)
+
+        described_class.new.perform
+
+        expect(TeacherTrainingPublicAPI::SyncCheck).to have_received(:check)
+        expect(Sentry).to have_received(:capture_exception)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

2.8k Setnry errors happen every 30 days

## Changes proposed in this pull request

Stop checking the invariant on review apps

https://dfe-teacher-services.sentry.io/issues/5477413208/?environment=review&project=1765973&referrer=issue-stream&statsPeriod=14d&stream_index=1

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

[Trello Ticket](https://trello.com/c/rYLF6YNk/1874-sentry-error-because-ttapi-does-not-sync-in-review-apps)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
