### PR TITLE
Reduced the number of records being queried by the Email Logs

### DIFF
--- a/app/controllers/support_interface/email_log_controller.rb
+++ b/app/controllers/support_interface/email_log_controller.rb
@@ -6,6 +6,7 @@ module SupportInterface
       @emails = Email
         .order(id: :desc)
         .includes(:application_form)
+        .where('created_at >= ?', @filter.applied_filters[:created_since])
         .page(params[:page] || 1).per(30)
 
       if @filter.applied_filters[:q].present?

--- a/app/models/support_interface/emails_filter.rb
+++ b/app/models/support_interface/emails_filter.rb
@@ -5,6 +5,8 @@ module SupportInterface
     attr_reader :applied_filters
 
     def initialize(params:)
+      params.with_defaults!(days_ago: 10)
+      params[:created_since] = params.fetch(:days_ago).to_i.days.ago.beginning_of_day
       @applied_filters = compact_params(params)
     end
 

--- a/app/views/support_interface/email_log/index.html.erb
+++ b/app/views/support_interface/email_log/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render PaginatedFilterComponent.new(filter: @filter, collection: @emails) do %>
   <table class="govuk-table">
-    <caption class="govuk-table__caption govuk-heading-m">Emails sent since <%= Email.order(:id).first&.created_at&.to_fs(:govuk_date_and_time) %></caption>
+    <caption class="govuk-table__caption govuk-heading-m">Emails sent since <%= @filter.applied_filters[:created_since].to_fs(:govuk_date_and_time) %></caption>
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Time</th>

--- a/spec/models/support_interface/emails_filter_spec.rb
+++ b/spec/models/support_interface/emails_filter_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::EmailsFilter do
+  include ActiveSupport::Testing::TimeHelpers
+
+  describe '#applied_filers' do
+    it 'adds a default of 10 for `days_ago`' do
+      emails_filter = described_class.new(params: {})
+
+      expect(emails_filter.applied_filters).to include({ days_ago: 10 })
+    end
+
+    it 'respects the given value for `days_ago`' do
+      emails_filter = described_class.new(params: { days_ago: 20 })
+
+      expect(emails_filter.applied_filters).to include({ days_ago: 20 })
+    end
+
+    it 'adds `created_since` based on `days_ago`' do
+      travel_to Time.zone.parse('2024-07-17 12:00:00') do
+        emails_filter = described_class.new(params: { days_ago: 10 })
+
+        expect(emails_filter.applied_filters).to include({ created_since: Time.zone.parse('2024-07-07 00:00:00') })
+      end
+    end
+
+    it 'adds `created_since` based on `days_ago` when `days_ago` is a string' do
+      travel_to Time.zone.parse('2024-07-17 12:00:00') do
+        emails_filter = described_class.new(params: { days_ago: '10' })
+
+        expect(emails_filter.applied_filters).to include({ created_since: Time.zone.parse('2024-07-07 00:00:00') })
+      end
+    end
+
+    it 'removes empty arrays params on initialization' do
+      emails_filter = described_class.new(params: { some_array: ['', nil], other_array: ['1', 2] })
+
+      expect(emails_filter.applied_filters).to include(some_array: [], other_array: ['1', 2])
+    end
+  end
+end

--- a/spec/models/support_interface/emails_filter_spec.rb
+++ b/spec/models/support_interface/emails_filter_spec.rb
@@ -38,4 +38,130 @@ RSpec.describe SupportInterface::EmailsFilter do
       expect(emails_filter.applied_filters).to include(some_array: [], other_array: ['1', 2])
     end
   end
+
+  describe '#filters' do
+    it 'returns an array of filters' do
+      emails_filter = described_class.new(params: {})
+
+      expect(emails_filter.filters).to be_an(Array)
+    end
+
+    it 'returns an array of filters with the correct keys' do
+      emails_filter = described_class.new(params: {})
+
+      expect(emails_filter.filters).to all(include(:type, :heading, :name))
+    end
+
+    context 'when search value is present in the params' do
+      it 'returns a search filter with the correct value' do
+        emails_filter = described_class.new(params: { q: 'search value' })
+
+        search_filter = emails_filter.filters.find { |filter| filter[:name] == 'q' }
+
+        expect(search_filter).to eq(type: :search, heading: 'Search', value: 'search value', name: 'q')
+      end
+    end
+
+    context 'when deliver_status value is present in the params' do
+      it 'returns a checkboxes filter with the correct value' do
+        emails_filter = described_class.new(params: { delivery_status: ['delivered'] })
+
+        delivery_status_filter = emails_filter.filters.find { |filter| filter[:name] == 'delivery_status' }
+
+        expect(delivery_status_filter).to eq(
+          type: :checkboxes,
+          heading: 'Delivery status',
+          name: 'delivery_status',
+          options: [
+            {
+              value: 'not_tracked',
+              label: 'Not tracked',
+              checked: false,
+            },
+            {
+              value: 'notify_error',
+              label: 'Notify error',
+              checked: false,
+            },
+            {
+              value: 'pending',
+              label: 'Pending',
+              checked: false,
+            },
+            {
+              value: 'skipped',
+              label: 'Skipped',
+              checked: false,
+            },
+            {
+              value: 'unknown',
+              label: 'Unknown',
+              checked: false,
+            },
+            {
+              value: 'delivered',
+              label: 'Delivered',
+              checked: true,
+            },
+            {
+              value: 'permanent_failure',
+              label: 'Permanent failure',
+              checked: false,
+            },
+            {
+              value: 'temporary_failure',
+              label: 'Temporary failure',
+              checked: false,
+            },
+            {
+              value: 'technical_failure',
+              label: 'Technical failure',
+              checked: false,
+            },
+          ],
+        )
+      end
+    end
+
+    context 'when mailer value is present in the params' do
+      it 'returns a checkboxes filter with the correct value' do
+        emails_filter = described_class.new(params: { mailer: ['support_mailer'] })
+
+        mailer_filter = emails_filter.filters.find { |filter| filter[:name] == 'mailer' }
+
+        expect(mailer_filter).to eq(
+          type: :checkboxes,
+          heading: 'Mailer',
+          name: 'mailer',
+          options: [
+            {
+              value: 'support_mailer',
+              label: 'Support mailer',
+              checked: true,
+            },
+            {
+              value: 'referee_mailer',
+              label: 'Referee mailer',
+              checked: false,
+            },
+            {
+              value: 'provider_mailer',
+              label: 'Provider mailer',
+              checked: false,
+            },
+            {
+              value: 'candidate_mailer',
+              label: 'Candidate mailer',
+              checked: false,
+            },
+            {
+              value: 'authentication_mailer',
+              label: 'Authentication mailer',
+              checked: false,
+            },
+          ],
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

When visiting the email logs in Production `/support/email-log/` the application times out. This is likely due to the page trying to sort every email (100's of thousands) in the database.

## Changes proposed in this pull request

- We have reduced the number of emails that we try to query, down to the past 10 days worth
- Removed a second query that was used to set the "Emails sent since xxxxxx" text.
- Added the ability to manually change the number of days using the query parameter `?days_ago=20` in the URL
- Added a `created_since` attribute to the `EmailsFilter`. This date is used to perform the query and populate the "Emails sent since xxxxxx" text.

## Guidance to review

- We have no metrics around this page showing up in Skylight. These changes are a "best guess" at a fix

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
