### PR TITLE
Add indexes to fields commonly used in queries to build emails

### DIFF
--- a/db/migrate/20240711122121_add_indexes_to_email_related_filters.rb
+++ b/db/migrate/20240711122121_add_indexes_to_email_related_filters.rb
@@ -1,0 +1,9 @@
+class AddIndexesToEmailRelatedFilters < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :candidates, :submission_blocked, algorithm: :concurrently
+    add_index :candidates, :account_locked, algorithm: :concurrently
+    add_index :candidates, :unsubscribed_from_emails, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -400,9 +400,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_08_120414) do
     t.boolean "submission_blocked", default: false, null: false
     t.boolean "account_locked", default: false, null: false
     t.string "account_recovery_status", default: "not_started", null: false
+    t.index ["account_locked"], name: "index_candidates_on_account_locked"
     t.index ["email_address"], name: "index_candidates_on_email_address", unique: true
     t.index ["fraud_match_id"], name: "index_candidates_on_fraud_match_id"
     t.index ["magic_link_token"], name: "index_candidates_on_magic_link_token", unique: true
+    t.index ["submission_blocked"], name: "index_candidates_on_submission_blocked"
+    t.index ["unsubscribed_from_emails"], name: "index_candidates_on_unsubscribed_from_emails"
   end
 
   create_table "chasers_sent", force: :cascade do |t|


### PR DESCRIPTION
## Context

When I looked at the email queries earlier, it was clear could potentially send nudges to candidates who couldn't do anything with them (users whose accounts were blocked or locked for some reason). So we added those filters. 

This PR just adds indexes to those fields to help speed up queries. 

## Changes proposed in this pull request

This PR just adds indexes to those fields to help speed up queries. 

## Guidance to review

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
