### PR TITLE
Add a note about ENIC to the rejection reason on Apply

### DIFF
--- a/app/components/candidate_interface/rejection_reasons/rejection_reasons_component.html.erb
+++ b/app/components/candidate_interface/rejection_reasons/rejection_reasons_component.html.erb
@@ -21,7 +21,9 @@
         <p><%= I18n.t("rejection_reasons.#{reason.id}.description") %></p>
       <% end %>
     <% end %>
-    <% if render_link_to_find?(reason) %>
+    <% if render_rejection_link_to_enic?(reason) %>
+      <p><%= render_link_for_rejection_due_to_non_uk_qualification_and_no_enic %></p>
+    <% elsif render_link_to_find?(reason) %>
       <p><%= link_to_find_when_rejected_on_qualifications %></p>
     <% end %>
   </div>

--- a/app/components/candidate_interface/rejection_reasons/rejection_reasons_component.rb
+++ b/app/components/candidate_interface/rejection_reasons/rejection_reasons_component.rb
@@ -19,12 +19,34 @@ module CandidateInterface
         "View the course requirements on #{link}.".html_safe
       end
 
+      def render_link_for_rejection_due_to_non_uk_qualification_and_no_enic
+        link = govuk_link_to('Apply for a statement of comparability from UK ENIC', I18n.t('service_name.enic.statement_of_comparability_url'))
+
+        "If you decide to apply again, think about including a statement of comparability from UK ENIC.
+        It shows training providers how your qualifications compare to UK ones. <br><br>#{link}<br><br>
+        Applications with a statement from UK ENIC are around 28% more likely to receive an offer.".html_safe
+      end
+
       def reasons
         ::RejectionReasons.new(application_choice.structured_rejection_reasons)
       end
 
       def render_link_to_find?(reason)
         reason.id == 'qualifications' && @render_link_to_find_when_rejected_on_qualifications
+      end
+
+      def render_rejection_link_to_enic?(reason)
+        return false unless reason.id == 'qualifications' && reason.selected_reasons
+
+        reason.selected_reasons.any? do |nested_reason|
+          nested_reason.id == 'unverified_qualifications' && application_form.missing_enic_reference_for_non_uk_qualifications?
+        end
+      end
+
+    private
+
+      def application_form
+        @application_form ||= ApplicationForm.find(application_choice.application_form_id)
       end
     end
   end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -206,6 +206,12 @@ class ApplicationForm < ApplicationRecord
     application_choices.touch_all
   end
 
+  def missing_enic_reference_for_non_uk_qualifications?
+    @missing_enic_reference_for_non_uk_qualifications ||= application_qualifications
+                                                            .where.not(institution_country: 'GB')
+                                                            .exists?(enic_reference: nil)
+  end
+
   def submitted?
     submitted_at.present?
   end

--- a/spec/components/candidate_interface/rejections_component_spec.rb
+++ b/spec/components/candidate_interface/rejections_component_spec.rb
@@ -27,13 +27,13 @@ RSpec.describe CandidateInterface::RejectionsComponent do
 
       result = render_inline(described_class.new(application_choice:, render_link_to_find_when_rejected_on_qualifications: true))
       expect(result.text).to include('View the course requirements on')
-      expect(result.css('.govuk-link')[0][:href]).to eq("#{course.find_url}#section-entry")
-      expect(result.css('.govuk-link')[0].text).to eq('Find postgraduate teacher training courses')
+      expect(result).to have_link('Find postgraduate teacher training courses', href: "#{course.find_url}#section-entry")
     end
   end
 
   describe "when the rejection reason type is 'rejection_reasons'" do
-    let(:application_choice) { build_stubbed(:application_choice, :with_structured_rejection_reasons) }
+    let(:application_form) { create(:application_form, :minimum_info) }
+    let(:application_choice) { build_stubbed(:application_choice, :with_structured_rejection_reasons, application_form: application_form) }
 
     it 'renders using RejectionReasonsComponent' do
       result = render_inline(described_class.new(application_choice:))
@@ -52,8 +52,22 @@ RSpec.describe CandidateInterface::RejectionsComponent do
 
       result = render_inline(described_class.new(application_choice:, render_link_to_find_when_rejected_on_qualifications: true))
       expect(result.text).to include('View the course requirements on')
-      expect(result.css('.govuk-link')[0][:href]).to eq("#{course.find_url}#section-entry")
-      expect(result.css('.govuk-link')[0].text).to eq('Find postgraduate teacher training courses')
+      expect(result).to have_link('Find postgraduate teacher training courses', href: "#{course.find_url}#section-entry")
+    end
+  end
+
+  describe 'when the rejection reason type is the non_uk qualification does not have an ENIC reference' do
+    let(:application_form) { create(:application_form, :minimum_info) }
+    let(:application_choice) { build_stubbed(:application_choice, :with_structured_rejection_reasons, application_form: application_form) }
+    let!(:application_qualification) { create(:degree_qualification, enic_reference: nil, institution_country: 'FR', application_form: application_form) }
+
+    it 'renders a link to Apply for a statement of comparability with no enic_reference, a non uk qualification and could not verify qualifications rejection reason' do
+      course = build_stubbed(:course)
+      allow(application_choice).to receive_messages(course: course)
+
+      result = render_inline(described_class.new(application_choice:, render_link_to_find_when_rejected_on_qualifications: true))
+      expect(result.text).to include('If you decide to apply again, think about including a statement of comparability from UK ENIC')
+      expect(page).to have_link('Apply for a statement of comparability from UK ENIC', href: 'https://www.enic.org.uk/Qualifications/SOC/Default.aspx')
     end
   end
 
@@ -76,8 +90,7 @@ RSpec.describe CandidateInterface::RejectionsComponent do
 
       result = render_inline(described_class.new(application_choice:, render_link_to_find_when_rejected_on_qualifications: true))
       expect(result.text).to include('View the course requirements on')
-      expect(result.css('.govuk-link')[0][:href]).to eq("#{course.find_url}#section-entry")
-      expect(result.css('.govuk-link')[0].text).to eq('Find postgraduate teacher training courses')
+      expect(result).to have_link('Find postgraduate teacher training courses', href: "#{course.find_url}#section-entry")
     end
   end
 end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -315,6 +315,22 @@ RSpec.describe ApplicationForm do
     end
   end
 
+  describe '#missing_enic_reference_for_non_uk_qualifications?' do
+    it 'returns false if there are no application_qualifications which are non_uk and have no enic_reference' do
+      application_form = create(:application_form)
+      create(:degree_qualification, enic_reference: '12345', institution_country: 'GB', application_form: application_form)
+
+      expect(application_form.missing_enic_reference_for_non_uk_qualifications?).to be(false)
+    end
+
+    it 'returns true if there are application_qualifications which are non_uk and have no enic_reference' do
+      application_form = create(:application_form)
+      create(:degree_qualification, enic_reference: nil, institution_country: 'FR', application_form: application_form)
+
+      expect(application_form.missing_enic_reference_for_non_uk_qualifications?).to be(true)
+    end
+  end
+
   describe '#previous_application_form' do
     it 'refers to the previous application' do
       previous_application_form = create(:application_form)


### PR DESCRIPTION
## Context

Add content to the rejection screen in Apply in the following circumstance:

- Candidate has selected at least 1 qualification is from overseas
- Candidate has not entered a UK ENIC number
- Provider has selected the rejection reason: ‘could not verify qualifications’

## Changes proposed in this pull request

If the candidates rejection reason satisfies the above we render different content

## Guidance to review

- Submit an application which fulfils the above criteria
- Reject the application as a provider and select `could not verify qualifications` as the reason

## Link to Trello card

https://trello.com/c/GCxNmtK8/1523-add-a-note-about-enic-to-the-rejection-reason-on-apply

<img width="737" alt="Screenshot 2024-07-14 at 16 17 20" src="https://github.com/user-attachments/assets/23cd1e30-9b9d-44ea-bf12-e5431407e691">
