### PR TITLE
604 part 3 reinstate queries with changes

### DIFF
--- a/app/queries/get_applications_to_send_deadline_reminders_to.rb
+++ b/app/queries/get_applications_to_send_deadline_reminders_to.rb
@@ -8,8 +8,7 @@ class GetApplicationsToSendDeadlineRemindersTo
     .joins(:candidate)
     .current_cycle
     .unsubmitted
-    .where.not(candidate: { unsubscribed_from_emails: true })
-    .where.not(candidate: { submission_blocked: true })
-    .where.not(candidate: { account_locked: true })
+    # Filter out candidates who should not be receiving emails about their accounts
+    .where(candidates: { submission_blocked: false, account_locked: false, unsubscribed_from_emails: false })
   end
 end

--- a/app/queries/get_incomplete_personal_statement_applications_ready_to_nudge.rb
+++ b/app/queries/get_incomplete_personal_statement_applications_ready_to_nudge.rb
@@ -1,4 +1,8 @@
 class GetIncompletePersonalStatementApplicationsReadyToNudge
+  # The purpose of this nudge is to contact candidates who have
+  # - completed the references section of the application form
+  # - has made application choices
+  # - but have NOT completed the personal statement
   MAILER = 'candidate_mailer'.freeze
   MAIL_TEMPLATE = 'nudge_unsubmitted_with_incomplete_personal_statement'.freeze
   COMPLETION_ATTRS = %w[
@@ -10,15 +14,19 @@ class GetIncompletePersonalStatementApplicationsReadyToNudge
 
   def call
     ApplicationForm
+      # Only candidates with unsubmitted application_choices
+      .joins(:application_choices).where('application_choices.status': 'unsubmitted')
+      # Filter out candidates who should not receive emails about their accounts
+      .joins(:candidate).where(candidates: { submission_blocked: false, account_locked: false, unsubscribed_from_emails: false })
+      # Only include candidates who have not submitted ANY applications. unsubmitted == NEVER submitted.
+      # Candidates can't submit an application choice without a personal statement, so this is just here to be explicit, it won't practically change anything.
+      .unsubmitted
       .inactive_since(7.days.ago)
-      .with_completion(COMPLETION_ATTRS)
       .current_cycle
-      .joins(:candidate)
-      .where.not('candidate.submission_blocked': true)
-      .where.not('candidate.account_locked': true)
-      .where.not('candidate.unsubscribed_from_emails': true)
+      # They have completed their references
+      .with_completion(COMPLETION_ATTRS)
+      # But have not completed their personal statements
       .where(INCOMPLETION_ATTRS.map { |attr| "#{attr} = false" }.join(' AND '))
       .has_not_received_email(MAILER, MAIL_TEMPLATE)
-      .joins(:application_choices).where('application_choices.status': 'unsubmitted')
   end
 end

--- a/app/queries/get_incomplete_reference_applications_ready_to_nudge.rb
+++ b/app/queries/get_incomplete_reference_applications_ready_to_nudge.rb
@@ -1,4 +1,10 @@
 class GetIncompleteReferenceApplicationsReadyToNudge
+  # The purpose of this nudge is to contact candidates who have:
+  # - completed their application forms except for the references section
+  # - have made application choices
+  # - but NOT submitted anything
+  # NOTE: Candidates cannot submit an application choice without having completed the references section
+  # We are explicitly asking for `unsubmitted` applications to be explicit, but it is not strictly necessary.
   COMMON_COMPLETION_ATTRS_WITHOUT_REFERENCES = GetUnsubmittedApplicationsReadyToNudge::COMMON_COMPLETION_ATTRS.filter do |attr|
     attr != 'references_completed'
   end
@@ -17,6 +23,8 @@ class GetIncompleteReferenceApplicationsReadyToNudge
       .joins('LEFT OUTER JOIN course_options ON course_options.id = ac_primary.course_option_id')
       .joins("LEFT OUTER JOIN courses courses_primary ON courses_primary.id = course_options.course_id AND LOWER(courses_primary.level) = 'primary'")
       .current_cycle
+      # `unsubmitted` is not strictly neccesary because no forms can be submitted with a choice if the references are incomplete
+      .unsubmitted
       # Only applications forms with at least one unsubmitted application choice (inflight)
       .where('application_choices.status': 'unsubmitted')
       # Filter out candidates who should not be receiving emails about their accounts

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -42,7 +42,7 @@ class Clock
   every(1.day, 'SendNewCycleStartedEmailToCandidatesWorker', at: '10:00') { SendNewCycleHasStartedEmailToCandidatesWorker.new.perform }
 
   every(1.day, 'TriggerFullSyncIfFindClosed', at: '00:05') { TeacherTrainingPublicAPI::TriggerFullSyncIfFindClosed.call }
-  # every(1.day, 'NudgeCandidatesWorker', at: '10:00') { NudgeCandidatesWorker.perform_async }
+  every(1.day, 'NudgeCandidatesWorker', at: '10:00') { NudgeCandidatesWorker.perform_async }
   every(1.day, 'SendApplyToAnotherCourseWhenInactiveEmailToCandidatesWorker', at: '10:00') { SendApplyToAnotherCourseWhenInactiveEmailToCandidatesWorker.perform_async }
   every(1.day, 'SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesWorker', at: '10:00') { SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesWorker.perform_async }
   every(1.day, 'DfE::Analytics::EntityTableCheckJob', at: '00:30') { DfE::Analytics::EntityTableCheckJob.perform_later }

--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -116,6 +116,10 @@ FactoryBot.define do
       references_completed { true }
     end
 
+    trait :unsubmitted do
+      submitted_at { nil }
+    end
+
     trait :with_feedback_completed do
       feedback_satisfaction_level { ApplicationForm.feedback_satisfaction_levels.values.sample }
       feedback_suggestions { Faker::Lorem.paragraph_by_chars(number: 200) }

--- a/spec/queries/get_incomplete_personal_statement_applications_ready_to_nudge_spec.rb
+++ b/spec/queries/get_incomplete_personal_statement_applications_ready_to_nudge_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe GetIncompletePersonalStatementApplicationsReadyToNudge do
     application_form = create(
       :completed_application_form,
       :with_completed_references,
-      submitted_at: 10.days.ago,
+      :unsubmitted,
       becoming_a_teacher_completed: false,
     )
     create(:application_choice, :unsubmitted, application_form:)
@@ -21,8 +21,8 @@ RSpec.describe GetIncompletePersonalStatementApplicationsReadyToNudge do
     application_form = create(
       :completed_application_form,
       :with_completed_references,
+      :unsubmitted,
       candidate:,
-      submitted_at: 10.days.ago,
       becoming_a_teacher_completed: false,
     )
 
@@ -36,8 +36,8 @@ RSpec.describe GetIncompletePersonalStatementApplicationsReadyToNudge do
     application_form = create(
       :completed_application_form,
       :with_completed_references,
+      :unsubmitted,
       candidate:,
-      submitted_at: 10.days.ago,
       becoming_a_teacher_completed: false,
     )
     application_form.update_columns(updated_at: 10.days.ago)
@@ -50,8 +50,8 @@ RSpec.describe GetIncompletePersonalStatementApplicationsReadyToNudge do
     application_form = create(
       :completed_application_form,
       :with_completed_references,
+      :unsubmitted,
       candidate:,
-      submitted_at: 10.days.ago,
       becoming_a_teacher_completed: false,
     )
     application_form.update_columns(updated_at: 10.days.ago)
@@ -62,7 +62,7 @@ RSpec.describe GetIncompletePersonalStatementApplicationsReadyToNudge do
   it 'omits unsubmitted applications that have not completed references' do
     application_form = create(
       :completed_application_form,
-      submitted_at: 10.days.ago,
+      :unsubmitted,
       becoming_a_teacher_completed: true,
       references_completed: false,
     )
@@ -78,7 +78,7 @@ RSpec.describe GetIncompletePersonalStatementApplicationsReadyToNudge do
     application_form = create(
       :completed_application_form,
       :with_completed_references,
-      submitted_at: 10.days.ago,
+      :unsubmitted,
       becoming_a_teacher_completed: true,
     )
     create(:application_choice, application_form:)
@@ -93,7 +93,7 @@ RSpec.describe GetIncompletePersonalStatementApplicationsReadyToNudge do
     application_form = create(
       :completed_application_form,
       :with_completed_references,
-      submitted_at: 10.days.ago,
+      :unsubmitted,
       becoming_a_teacher_completed: false,
     )
     create(:application_choice, application_form:)
@@ -108,7 +108,7 @@ RSpec.describe GetIncompletePersonalStatementApplicationsReadyToNudge do
     application_form = create(
       :completed_application_form,
       :with_completed_references,
-      submitted_at: 10.days.ago,
+      :unsubmitted,
       becoming_a_teacher_completed: false,
     )
     application_form.update_columns(
@@ -122,7 +122,7 @@ RSpec.describe GetIncompletePersonalStatementApplicationsReadyToNudge do
     application_form = create(
       :completed_application_form,
       :with_completed_references,
-      submitted_at: 10.days.ago,
+      :unsubmitted,
       becoming_a_teacher_completed: false,
     )
     create(:application_choice, application_form:)

--- a/spec/queries/get_incomplete_reference_applications_ready_to_nudge_spec.rb
+++ b/spec/queries/get_incomplete_reference_applications_ready_to_nudge_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
   it 'includes forms with unsubmitted application choices that have not completed their references' do
     application_form = create(
       :completed_application_form,
-      submitted_at: 10.days.ago,
+      :unsubmitted,
       references_completed: false,
     )
     create(:application_choice, :unsubmitted, application_form:)
@@ -18,7 +18,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
   it 'returns unsubmitted applications that are complete, with references, but the candidate has not marked as references complete' do
     application_form = create(
       :completed_application_form,
-      submitted_at: 10.days.ago,
+      :unsubmitted,
       references_count: 2,
       references_completed: false,
     )
@@ -34,7 +34,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
     candidate = create(:candidate, account_locked: true)
     application_form = create(
       :completed_application_form,
-      submitted_at: 10.days.ago,
+      :unsubmitted,
       references_count: 0,
       candidate:,
     )
@@ -48,7 +48,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
     candidate = create(:candidate, submission_blocked: true)
     application_form = create(
       :completed_application_form,
-      submitted_at: 10.days.ago,
+      :unsubmitted,
       references_count: 0,
       candidate:,
     )
@@ -62,7 +62,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
     candidate = create(:candidate, unsubscribed_from_emails: true)
     application_form = create(
       :completed_application_form,
-      submitted_at: 10.days.ago,
+      :unsubmitted,
       references_count: 0,
       candidate:,
     )
@@ -75,7 +75,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
   it 'omits submitted applications' do
     application_form = create(
       :completed_application_form,
-      submitted_at: 10.days.ago,
+      :unsubmitted,
       references_count: 0,
     )
     create(:application_choice, status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER.sample, application_form:)
@@ -87,7 +87,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
   it 'omits applications that have not completed everything except for references' do
     application_form = create(
       :completed_application_form,
-      submitted_at: nil,
+      :unsubmitted,
       references_count: 0,
     )
     create(:application_choice, application_form:)
@@ -102,7 +102,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
   it 'omits applications that have been edited in the past week' do
     application_form = create(
       :completed_application_form,
-      submitted_at: nil,
+      :unsubmitted,
       references_count: 0,
     )
     create(:application_choice, application_form:)
@@ -116,7 +116,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
   it 'includes uk applications that have not completed EFL section' do
     application_form = create(
       :completed_application_form,
-      submitted_at: nil,
+      :unsubmitted,
       first_nationality: 'British',
       efl_completed: false,
       references_completed: false,
@@ -132,7 +132,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
   it 'omits international applications that have not completed EFL section' do
     application_form = create(
       :completed_application_form,
-      submitted_at: nil,
+      :unsubmitted,
       first_nationality: 'French',
       efl_completed: false,
       references_count: 0,
@@ -148,7 +148,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
   it 'omits primary course applications that have not completed GCSE Science section' do
     application_form = create(
       :completed_application_form,
-      submitted_at: nil,
+      :unsubmitted,
       science_gcse_completed: false,
       references_count: 0,
     )
@@ -172,7 +172,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
   it 'includes primary course applications that have completed GCSE Science section' do
     application_form = create(
       :completed_application_form,
-      submitted_at: nil,
+      :unsubmitted,
       science_gcse_completed: true,
       references_completed: false,
     )
@@ -196,7 +196,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
   it 'omits applications that were started in a previous cycle' do
     application_form = create(
       :completed_application_form,
-      submitted_at: nil,
+      :unsubmitted,
       recruitment_cycle_year: RecruitmentCycle.previous_year,
       references_count: 0,
     )
@@ -229,6 +229,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
   it 'includes applications that have received other emails' do
     application_form = create(
       :completed_application_form,
+      :unsubmitted,
       references_completed: false,
     )
     create(:application_choice, :unsubmitted, application_form:)
@@ -246,7 +247,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
   it 'omits applications without application choices' do
     application_form = create(
       :completed_application_form,
-      submitted_at: nil,
+      :unsubmitted,
       references_count: 0,
     )
     application_form.update_columns(
@@ -259,7 +260,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
   it 'omits applications from before the current recruitment cycle' do
     application_form1 = create(
       :completed_application_form,
-      submitted_at: nil,
+      :unsubmitted,
       references_completed: false,
       recruitment_cycle_year: RecruitmentCycle.previous_year,
     )
@@ -268,7 +269,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
     )
     application_form2 = create(
       :completed_application_form,
-      submitted_at: nil,
+      :unsubmitted,
       references_completed: false,
     )
     create(:application_choice, application_form: application_form2)
@@ -282,7 +283,7 @@ RSpec.describe GetIncompleteReferenceApplicationsReadyToNudge do
   it 'does not send duplicate emails' do
     application_form = create(
       :completed_application_form,
-      submitted_at: 10.days.ago,
+      :unsubmitted,
       references_completed: false,
     )
     create(:application_choice, :unsubmitted, application_form:)

--- a/spec/queries/get_unsubmitted_applications_ready_to_nudge_spec.rb
+++ b/spec/queries/get_unsubmitted_applications_ready_to_nudge_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe GetUnsubmittedApplicationsReadyToNudge do
     application_form = create(
       :completed_application_form,
       :with_completed_references,
-      submitted_at: 10.days.ago,
+      :unsubmitted,
     )
     create(:application_choice, :unsubmitted, application_form:)
     application_form.update_columns(updated_at: 10.days.ago)
@@ -18,8 +18,8 @@ RSpec.describe GetUnsubmittedApplicationsReadyToNudge do
     application_form = create(
       :completed_application_form,
       :with_completed_references,
+      :unsubmitted,
       candidate:,
-      submitted_at: 10.days.ago,
     )
     create(:application_choice, :unsubmitted, application_form:)
     application_form.update_columns(updated_at: 10.days.ago)
@@ -32,8 +32,8 @@ RSpec.describe GetUnsubmittedApplicationsReadyToNudge do
     application_form = create(
       :completed_application_form,
       :with_completed_references,
+      :unsubmitted,
       candidate:,
-      submitted_at: 10.days.ago,
     )
     create(:application_choice, :unsubmitted, application_form:)
     application_form.update_columns(updated_at: 10.days.ago)
@@ -46,8 +46,8 @@ RSpec.describe GetUnsubmittedApplicationsReadyToNudge do
     application_form = create(
       :completed_application_form,
       :with_completed_references,
+      :unsubmitted,
       candidate:,
-      submitted_at: 10.days.ago,
     )
     create(:application_choice, :unsubmitted, application_form:)
     application_form.update_columns(updated_at: 10.days.ago)
@@ -59,7 +59,7 @@ RSpec.describe GetUnsubmittedApplicationsReadyToNudge do
     application_form = create(
       :completed_application_form,
       :with_completed_references,
-      submitted_at: 10.days.ago,
+      :unsubmitted,
     )
     create(:application_choice, status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER.sample, application_form:)
     application_form.update_columns(updated_at: 10.days.ago)
@@ -71,7 +71,7 @@ RSpec.describe GetUnsubmittedApplicationsReadyToNudge do
     application_form = create(
       :completed_application_form,
       :with_completed_references,
-      submitted_at: 10.days.ago,
+      :unsubmitted,
     )
     create(:application_choice, :unsubmitted, application_form:)
     application_form.update_columns(
@@ -86,7 +86,7 @@ RSpec.describe GetUnsubmittedApplicationsReadyToNudge do
     application_form = create(
       :completed_application_form,
       :with_completed_references,
-      submitted_at: 10.days.ago,
+      :unsubmitted,
     )
     create(:application_choice, :unsubmitted, application_form:)
     application_form.update_columns(
@@ -100,7 +100,7 @@ RSpec.describe GetUnsubmittedApplicationsReadyToNudge do
     application_form = create(
       :completed_application_form,
       :with_completed_references,
-      submitted_at: nil,
+      :unsubmitted,
       first_nationality: 'British',
       efl_completed: false,
     )
@@ -116,7 +116,7 @@ RSpec.describe GetUnsubmittedApplicationsReadyToNudge do
     application_form = create(
       :completed_application_form,
       :with_completed_references,
-      submitted_at: nil,
+      :unsubmitted,
       first_nationality: 'French',
       efl_completed: false,
     )
@@ -132,7 +132,7 @@ RSpec.describe GetUnsubmittedApplicationsReadyToNudge do
     application_form = create(
       :completed_application_form,
       :with_completed_references,
-      submitted_at: nil,
+      :unsubmitted,
       science_gcse_completed: false,
     )
     create(
@@ -158,7 +158,7 @@ RSpec.describe GetUnsubmittedApplicationsReadyToNudge do
     application_form = create(
       :completed_application_form,
       :with_completed_references,
-      submitted_at: nil,
+      :unsubmitted,
       science_gcse_completed: true,
     )
     create(
@@ -184,7 +184,7 @@ RSpec.describe GetUnsubmittedApplicationsReadyToNudge do
     application_form = create(
       :completed_application_form,
       :with_completed_references,
-      submitted_at: nil,
+      :unsubmitted,
       recruitment_cycle_year: RecruitmentCycle.previous_year,
     )
     application_form.update_columns(
@@ -198,7 +198,7 @@ RSpec.describe GetUnsubmittedApplicationsReadyToNudge do
     application_form = create(
       :completed_application_form,
       :with_completed_references,
-      submitted_at: nil,
+      :unsubmitted,
     )
     application_form.update_columns(updated_at: 10.days.ago)
     create(
@@ -215,12 +215,27 @@ RSpec.describe GetUnsubmittedApplicationsReadyToNudge do
     application_form = create(
       :completed_application_form,
       :with_completed_references,
-      submitted_at: nil,
+      :unsubmitted,
       first_nationality: 'British',
       efl_completed: false,
     )
     application_form.update_columns(updated_at: 10.days.ago)
 
     expect(described_class.new.call).to eq([])
+  end
+
+  it 'does not send duplicate emails' do
+    application_form = create(
+      :completed_application_form,
+      :with_completed_references,
+      :unsubmitted,
+    )
+    create(:application_choice, :unsubmitted, application_form:)
+    create(:application_choice, :unsubmitted, application_form:)
+
+    application_form.update_columns(
+      updated_at: 10.days.ago,
+    )
+    expect(described_class.new.call).to eq([application_form])
   end
 end


### PR DESCRIPTION
## Context

We need to be very explicit about what each nudge is attempting to do, so we can avoid confusion and avoid sending emails to people who shouldn't receive them when there are changes.

## Changes proposed in this pull request

Mostly this is added comments to ensure each nudge is very clearly explained.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

This is a follow on from [this card](https://trello.com/c/njdwKzXF/604-ca-clock-workers-assess-impact-of-submittedat-on-workers)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
