### PR TITLE
Change Find service name as we're accepting undergraduate courses

### DIFF
--- a/app/components/candidate_interface/rejection_reasons/reasons_for_rejection_component.rb
+++ b/app/components/candidate_interface/rejection_reasons/reasons_for_rejection_component.rb
@@ -15,7 +15,7 @@ module CandidateInterface
 
     def link_to_find_when_rejected_on_qualifications
       link = govuk_link_to(
-        'Find postgraduate teacher training courses',
+        t('service_name.find'),
         "#{@application_choice.course.find_url}#section-entry",
       )
 

--- a/app/components/candidate_interface/rejection_reasons/rejection_reasons_component.rb
+++ b/app/components/candidate_interface/rejection_reasons/rejection_reasons_component.rb
@@ -12,7 +12,7 @@ module CandidateInterface
 
       def link_to_find_when_rejected_on_qualifications
         link = govuk_link_to(
-          'Find postgraduate teacher training courses',
+          t('service_name.find'),
           "#{@application_choice.course.find_url}#section-entry",
         )
 

--- a/app/components/shared/rejection_reasons/reasons_for_rejection_component.rb
+++ b/app/components/shared/rejection_reasons/reasons_for_rejection_component.rb
@@ -14,7 +14,7 @@ class RejectionReasons::ReasonsForRejectionComponent < ViewComponent::Base
 
   def link_to_find_when_rejected_on_qualifications
     link = govuk_link_to(
-      'Find postgraduate teacher training courses',
+      t('service_name.find'),
       "#{@application_choice.course.find_url}#section-entry",
     )
 

--- a/app/components/shared/rejection_reasons/rejection_reasons_component.rb
+++ b/app/components/shared/rejection_reasons/rejection_reasons_component.rb
@@ -15,7 +15,7 @@ class RejectionReasons::RejectionReasonsComponent < ViewComponent::Base
 
   def link_to_find_when_rejected_on_qualifications
     link = govuk_link_to(
-      'Find postgraduate teacher training courses',
+      t('service_name.find'),
       "#{@application_choice.course.find_url}#section-entry",
     )
 

--- a/app/controllers/candidate_interface/apply_from_find_controller.rb
+++ b/app/controllers/candidate_interface/apply_from_find_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   # The Apply from Find page is the landing page for candidates coming from the
-  # Find postgraduate teacher training (https://www.find-postgraduate-teacher-training.service.gov.uk/)
+  # Find teacher training courses (https://www.find-postgraduate-teacher-training.service.gov.uk/)
   class ApplyFromFindController < CandidateInterfaceController
     skip_before_action :authenticate_candidate!
 

--- a/app/views/candidate_mailer/_reasons_for_rejection.text.erb
+++ b/app/views/candidate_mailer/_reasons_for_rejection.text.erb
@@ -10,7 +10,7 @@
     <% end %>
 
     <% if title == 'Qualifications' %>
-        ^ View the course requirements on [Find postgraduate teacher training courses](<%= "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{@course.provider.code}/#{@course.code}#section-entry" %>).
+        ^ View the course requirements on [t('service_name.find')](<%= "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{@course.provider.code}/#{@course.code}#section-entry" %>).
     <% end %>
 
 <% end %>

--- a/app/views/candidate_mailer/_reasons_for_rejection.text.erb
+++ b/app/views/candidate_mailer/_reasons_for_rejection.text.erb
@@ -10,7 +10,7 @@
     <% end %>
 
     <% if title == 'Qualifications' %>
-        ^ View the course requirements on [t('service_name.find')](<%= "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{@course.provider.code}/#{@course.code}#section-entry" %>).
+      ^ View the course requirements on [<%= t('service_name.find') %>](<%= "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{@course.provider.code}/#{@course.code}#section-entry" %>).
     <% end %>
 
 <% end %>

--- a/app/views/content/sandbox.html.erb
+++ b/app/views/content/sandbox.html.erb
@@ -19,7 +19,7 @@
     <h2 class="govuk-heading-l">Course data in the sandbox</h2>
     <p class="govuk-body"><strong>The live Apply service</strong> gets its course data from the <%= govuk_link_to 'Teacher training courses API', t('teacher_training_courses_api.documentation_url') %>. Training providers update those courses using <%= govuk_link_to 'Publish teacher training courses', t('publish_teacher_training_courses.production_url') %>.</p>
 
-    <p class="govuk-body"><strong>The Apply sandbox</strong> gets its course data from a sandbox version of the Teacher training courses API. As a training provider you can access <%= govuk_link_to 'a sandbox version of Publish', t('publish_teacher_training_courses.sandbox_url') %> where you will be able to create and edit courses just as you would on the live service, and see them on the <%= govuk_link_to 'sandbox version of Find postgraduate teacher training', t('find_postgraduate_teacher_training.sandbox_url') %>.</p>
+    <p class="govuk-body"><strong>The Apply sandbox</strong> gets its course data from a sandbox version of the Teacher training courses API. As a training provider you can access <%= govuk_link_to 'a sandbox version of Publish', t('publish_teacher_training_courses.sandbox_url') %> where you will be able to create and edit courses just as you would on the live service, and see them on the <%= govuk_link_to "sandbox version of #{t('service_name.find')}", t('find_postgraduate_teacher_training.sandbox_url') %>.</p>
 
     <p class="govuk-body">To request access to the Publish sandbox, email us at <%= bat_contact_mail_to %>.</p>
 

--- a/app/views/content/service_privacy_notice.md
+++ b/app/views/content/service_privacy_notice.md
@@ -133,7 +133,7 @@ We may contact you to ask if you would like to participate in user research. Thi
 ### Getting insight to make government policy better
 We will analyse your data to help us inform government policy around teacher recruitment and retention.
 
-If you use other digital services for which the data controller is also the Department for Education (for example, Find postgraduate teacher training, or Get Into Teaching), we may use your IP address to understand how you are using these services. This allows us to ensure that public funds are being spent effectively.
+If you use other digital services for which the data controller is also the Department for Education (for example, Find teacher training courses, or Get Into Teaching), we may use your IP address to understand how you are using these services. This allows us to ensure that public funds are being spent effectively.
 
 ### How long we keep your data
 

--- a/app/views/content/service_privacy_notice_candidate.html.erb
+++ b/app/views/content/service_privacy_notice_candidate.html.erb
@@ -179,7 +179,7 @@
 
     <p class="govuk-body">If you use other digital services for which the data controller
     is also the Department for Education (for example,
-    Find postgraduate teacher training, or Get Into Teaching),
+    <%= t('service_name.find') %>, or Get Into Teaching),
     we may use your IP address to understand how you are using these services.
     This allows us to ensure that public funds are being spent effectively.</p>
 

--- a/app/views/support_interface/application_forms/application_choices/change_offered_course/change_offered_course_search.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/change_offered_course/change_offered_course_search.html.erb
@@ -20,7 +20,7 @@
       <p class="govuk-body">
         Find courses by searching on
         <%= govuk_link_to(
-          'Find postgraduate teacher training',
+          t('service_name.find'),
           I18n.t('find_postgraduate_teacher_training.production_url'),
           target: '_blank',
           rel: 'nofollow',

--- a/config/locales/candidate_interface/apply_from_find.yml
+++ b/config/locales/candidate_interface/apply_from_find.yml
@@ -1,4 +1,4 @@
 en:
   apply_from_find:
-    find_button: Find postgraduate teacher training
+    find_button: Find teacher training courses
     heading_not_found: We could not find the course you are looking for

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,7 @@ en:
     support: Support for Apply
     api: Apply for teacher training API
     get_into_teaching: Get Into Teaching
+    find: Find teacher training courses
     enic:
       short_name: UK ENIC
       short_name_with_naric: UK ENIC or NARIC

--- a/spec/components/candidate_interface/rejection_reasons/rejection_reasons_component_spec.rb
+++ b/spec/components/candidate_interface/rejection_reasons/rejection_reasons_component_spec.rb
@@ -83,12 +83,12 @@ RSpec.describe CandidateInterface::RejectionReasons::RejectionReasonsComponent d
       )
 
       expect(result.css('.app-rejection__label').first.text).to eq('Qualifications:')
-      expect(result.css('.app-rejection').first.css('p').last.text).to include('View the course requirements on Find postgraduate teacher training courses')
+      expect(result.css('.app-rejection').first.css('p').last.text).to include("View the course requirements on #{t('service_name.find')}")
 
       expect(result.css('.govuk-link').size).to eq(1)
       link_element = result.css('.app-rejection').first.css('.govuk-link').first
       expect(link_element[:href]).to eq("#{course.find_url}#section-entry")
-      expect(link_element.text).to eq('Find postgraduate teacher training courses')
+      expect(link_element.text).to eq(t('service_name.find'))
     end
   end
 end

--- a/spec/components/candidate_interface/rejections_component_spec.rb
+++ b/spec/components/candidate_interface/rejections_component_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe CandidateInterface::RejectionsComponent do
 
       result = render_inline(described_class.new(application_choice:, render_link_to_find_when_rejected_on_qualifications: true))
       expect(result.text).to include('View the course requirements on')
-      expect(result).to have_link('Find postgraduate teacher training courses', href: "#{course.find_url}#section-entry")
+      expect(result).to have_link(t('service_name.find'), href: "#{course.find_url}#section-entry")
     end
   end
 
@@ -52,7 +52,7 @@ RSpec.describe CandidateInterface::RejectionsComponent do
 
       result = render_inline(described_class.new(application_choice:, render_link_to_find_when_rejected_on_qualifications: true))
       expect(result.text).to include('View the course requirements on')
-      expect(result).to have_link('Find postgraduate teacher training courses', href: "#{course.find_url}#section-entry")
+      expect(result).to have_link(t('service_name.find'), href: "#{course.find_url}#section-entry")
     end
   end
 
@@ -90,7 +90,7 @@ RSpec.describe CandidateInterface::RejectionsComponent do
 
       result = render_inline(described_class.new(application_choice:, render_link_to_find_when_rejected_on_qualifications: true))
       expect(result.text).to include('View the course requirements on')
-      expect(result).to have_link('Find postgraduate teacher training courses', href: "#{course.find_url}#section-entry")
+      expect(result).to have_link(t('service_name.find'), href: "#{course.find_url}#section-entry")
     end
   end
 end

--- a/spec/components/shared/rejection_reasons/rejection_reasons_component_spec.rb
+++ b/spec/components/shared/rejection_reasons/rejection_reasons_component_spec.rb
@@ -80,12 +80,12 @@ RSpec.describe RejectionReasons::RejectionReasonsComponent do
       )
 
       expect(result.css('.govuk-summary-list__key').first.text).to eq('Qualifications')
-      expect(result.css('.govuk-summary-list__value').first.text).to include('View the course requirements on Find postgraduate teacher training courses')
+      expect(result.css('.govuk-summary-list__value').first.text).to include("View the course requirements on #{t('service_name.find')}")
 
       expect(result.css('.govuk-link').size).to eq(1)
       link_element = result.css('.govuk-summary-list__value').first.css('.govuk-link').first
       expect(link_element[:href]).to eq("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{course.provider.code}/#{course.code}#section-entry")
-      expect(link_element.text).to eq('Find postgraduate teacher training courses')
+      expect(link_element.text).to eq(t('service_name.find'))
     end
 
     it 'renders change links' do


### PR DESCRIPTION
### Context

We need to update the new service name for Find in Apply, so that we can enable Teacher Degree Apprenticeship (TDA) courses.

The new service name is:

Find teacher training courses

### Guidance to review

1. Check each page changed on this PR on the review app and the service name should match with the above.
2. Is there any other place mentioning postgraduate that we should change?

### What this PR does not do?

It doesn't change the links. This will be done in a future card/PR.
