### PR TITLE
Bug: exception raised due to error message not being parsed correctly

### DIFF
--- a/app/controllers/provider_interface/courses_controller.rb
+++ b/app/controllers/provider_interface/courses_controller.rb
@@ -26,7 +26,7 @@ module ProviderInterface
         @wizard.clear_state!
         track_validation_error(@wizard)
 
-        flash[:warning] = t('.failure')
+        flash[:warning] = t('.failure.title')
       end
       redirect_to provider_interface_application_choice_path(@application_choice)
     end

--- a/spec/support/capybara_rspec_monkey_patch.rb
+++ b/spec/support/capybara_rspec_monkey_patch.rb
@@ -9,6 +9,14 @@ module CapybaraRSpecMonkeyPatch
     end
   end
 
+  def find_field(locator, **options)
+    if self.class.metadata.keys.intersect?(%i[js js_browser])
+      super(locator, **options.merge(visible: false))
+    else
+      super
+    end
+  end
+
   def select(value = nil, from: nil, **options)
     if has_css?('.autocomplete__wrapper input') && self.class.metadata.keys.intersect?(%i[js js_browser])
 

--- a/spec/system/provider_interface/change_course/change_course_error_messages_spec.rb
+++ b/spec/system/provider_interface/change_course/change_course_error_messages_spec.rb
@@ -1,0 +1,137 @@
+require 'rails_helper'
+
+RSpec.describe 'Provider changes a course with error' do
+  include DfESignInHelpers
+  include ProviderUserPermissionsHelper
+
+  scenario 'Display update errors' do
+    given_i_am_a_provider_user
+    and_i_am_permitted_to_make_decisions_for_my_provider
+    and_i_sign_in_to_the_provider_interface
+    and_the_provider_user_can_offer_multiple_provider_courses
+
+    when_i_visit_the_provider_interface
+    and_i_click_the_application_choice
+    and_i_click_on_change_the_training_provider
+    then_i_see_a_list_of_training_providers_to_select_from
+
+    when_i_select_a_different_provider
+    and_i_click_continue
+    then_i_see_a_list_of_courses_to_select_from
+
+    when_i_select_a_different_course
+    and_i_click_continue
+    then_the_review_page_is_loaded
+
+    when_the_update_action_cannot_be_done
+    and_i_click_update_course
+    then_i_see_the_error_message
+  end
+
+  def given_i_am_a_provider_user
+    @provider_user = create(:provider_user, :with_dfe_sign_in, :with_set_up_interviews)
+    user_exists_in_dfe_sign_in(email_address: @provider_user.email_address)
+  end
+
+  def and_i_am_permitted_to_make_decisions_for_my_provider
+    permit_make_decisions!
+  end
+
+  def and_i_sign_in_to_the_provider_interface
+    provider_signs_in_using_dfe_sign_in
+  end
+
+  def and_the_provider_user_can_offer_multiple_provider_courses
+    @target_provider = create(:provider)
+
+    @source_provider = @provider_user.providers.first
+    @ratifying_provider = create(:provider)
+
+    @course = build(:course, :full_time, provider: @source_provider, accredited_provider: @ratifying_provider)
+    @course_option = build(:course_option, course: @course)
+
+    @application_form = build(:application_form, :minimum_info)
+
+    @application_choice = create(:application_choice, :awaiting_provider_decision,
+                                 application_form: @application_form,
+                                 course_option: @course_option)
+
+    @target_course = create(:course, :open, study_mode: :full_time, provider: @target_provider, accredited_provider: @ratifying_provider)
+
+    @one_mode_and_location_course = create(:course, :open, study_mode: :full_time, provider: @target_provider, accredited_provider: @ratifying_provider)
+    @one_mode_and_location_course_option = create(:course_option, :full_time, site: create(:site, provider: @one_mode_and_location_course.provider), course: @one_mode_and_location_course)
+
+    @target_course_option = create(:course_option, :part_time, course: @target_course)
+
+    # Give the ProviderUser permission on the courses belonging to their provider
+    create(:provider_permissions, provider: @target_provider, provider_user: @provider_user, make_decisions: true, set_up_interviews: true)
+
+    # Allow the ProviderUser to move courses from one provider to another
+    create(
+      :provider_relationship_permissions,
+      training_provider: @source_provider,
+      ratifying_provider: @ratifying_provider,
+      ratifying_provider_can_make_decisions: true,
+    )
+
+    create(
+      :provider_relationship_permissions,
+      training_provider: @target_provider,
+      ratifying_provider: @ratifying_provider,
+      ratifying_provider_can_make_decisions: true,
+    )
+  end
+
+  def when_i_visit_the_provider_interface
+    visit provider_interface_applications_path
+  end
+
+  def and_i_click_the_application_choice
+    click_link_or_button @application_choice.application_form.full_name
+  end
+
+  def and_i_click_on_change_the_training_provider
+    within(all('.govuk-summary-list__row').find { |e| e.text.include?('Training provider') }) do
+      click_link_or_button 'Change'
+    end
+  end
+
+  def then_i_see_a_list_of_training_providers_to_select_from
+    expect(page).to have_content "Update course - #{@application_form.full_name}"
+    expect(page).to have_content 'Training provider'
+  end
+
+  def when_i_select_a_different_provider
+    choose @target_provider.name_and_code
+  end
+
+  def and_i_click_continue
+    click_link_or_button t('continue')
+  end
+
+  def then_i_see_a_list_of_courses_to_select_from
+    expect(page).to have_content "Update course - #{@application_form.full_name}"
+    expect(page).to have_content 'Course'
+  end
+
+  def when_i_select_a_different_course
+    choose @target_course.name_and_code
+  end
+
+  def then_the_review_page_is_loaded
+    expect(page).to have_content "Update course - #{@application_form.full_name}"
+    expect(page).to have_content 'Check details and update course'
+  end
+
+  def and_i_click_update_course
+    click_link_or_button 'Update course'
+  end
+
+  def when_the_update_action_cannot_be_done
+    allow_any_instance_of(ProviderInterface::CourseWizard).to receive(:valid?).with(:save).and_return(false) # rubocop:disable RSpec::AnyInstance
+  end
+
+  def then_i_see_the_error_message
+    expect(page).to have_content('The course could not be changed')
+  end
+end


### PR DESCRIPTION
## Context

We added error messages explaining why in certain cases that when a Provider tries to move a Candidate to another course there is a specific error message we can surface.

We forgot to update the error message I18n translation in another part of the application.

## Changes proposed in this pull request

Update the I18n call to translations for an error message in the ProviderInterface.

This fixes this [Sentry error](https://dfe-teacher-services.sentry.io/issues/5619333495/?environment=production&project=1765973&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=8)

## Guidance to review

![image](https://github.com/user-attachments/assets/14607281-5182-4328-a1fc-f7f994ab9b50)

**It is not really possible to reproduce this error. It's caused by a bug in the CourseWizard where some values stored in redis are not present when the update action is hit.**

**Normally, validation should prevent the user from reaching the point where one of the study_mode / course / provider are not present**



## Link to Trello card

[Trello Ticket](https://trello.com/c/F29Nqwkx/2067-bug-exception-raised-due-to-error-message-not-being-parsed-correctly)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
