### PR TITLE
Every ProviderUser receives Apply / Find open email notification

### DIFF
--- a/app/models/chaser_sent.rb
+++ b/app/models/chaser_sent.rb
@@ -1,6 +1,10 @@
 class ChaserSent < ApplicationRecord
   belongs_to :chased, polymorphic: true
 
+  scope :since_service_opened, lambda { |service|
+    where('created_at >= ?', CycleTimetable.send("#{service}_opens"))
+  }
+
   enum chaser_type: {
     ######################################
     ####     Service availability     ####

--- a/app/queries/get_providers_to_notify_about_find_and_apply.rb
+++ b/app/queries/get_providers_to_notify_about_find_and_apply.rb
@@ -3,12 +3,12 @@ class GetProvidersToNotifyAboutFindAndApply
     Provider
       .joins('INNER JOIN provider_users_providers ON providers.id = provider_users_providers.provider_id')
       .joins('INNER JOIN provider_users ON provider_users.id = provider_users_providers.provider_user_id')
-      .where.not(Arel.sql(providers_whose_users_have_been_chased))
+      .where.not(Arel.sql(providers_whose_users_have_been_chased_this_year))
       .order('providers.name')
       .distinct
   end
 
-  def self.providers_whose_users_have_been_chased
+  def self.providers_whose_users_have_been_chased_this_year
     <<-SQL.squish
       EXISTS(
         SELECT 1
@@ -16,6 +16,7 @@ class GetProvidersToNotifyAboutFindAndApply
         WHERE chased_type = 'Provider'
         AND chased_id = providers.id
         AND chaser_type = 'find_service_open_organisation_notification'
+        AND created_at > '#{CycleTimetable.find_opens.to_fs(:db)}'
       )
     SQL
   end

--- a/app/workers/start_of_cycle_notification_worker.rb
+++ b/app/workers/start_of_cycle_notification_worker.rb
@@ -9,7 +9,7 @@ class StartOfCycleNotificationWorker
 
     providers_scope.limit(fetch_limit).each do |provider|
       provider.provider_users.each do |provider_user|
-        if !ChaserSent.where('created_at > ?', CycleTimetable.send("#{service}_opens")).exists?(chased: provider_user, chaser_type: service_open_email)
+        if !ChaserSent.since_service_opened(service).exists?(chased: provider_user, chaser_type: service_open_email)
           ProviderMailer.send(service_open_email, provider_user).deliver_later
           ChaserSent.create!(chased: provider_user, chaser_type: service_open_email)
         end

--- a/app/workers/start_of_cycle_notification_worker.rb
+++ b/app/workers/start_of_cycle_notification_worker.rb
@@ -9,7 +9,7 @@ class StartOfCycleNotificationWorker
 
     providers_scope.limit(fetch_limit).each do |provider|
       provider.provider_users.each do |provider_user|
-        unless ChaserSent.where('created_at < ?', 11.months.ago).exists?(chased: provider_user, chaser_type: service_open_email)
+        if !ChaserSent.where('created_at > ?', CycleTimetable.send("#{service}_opens")).exists?(chased: provider_user, chaser_type: service_open_email)
           ProviderMailer.send(service_open_email, provider_user).deliver_later
           ChaserSent.create!(chased: provider_user, chaser_type: service_open_email)
         end

--- a/app/workers/start_of_cycle_notification_worker.rb
+++ b/app/workers/start_of_cycle_notification_worker.rb
@@ -9,7 +9,7 @@ class StartOfCycleNotificationWorker
 
     providers_scope.limit(fetch_limit).each do |provider|
       provider.provider_users.each do |provider_user|
-        unless ChaserSent.exists?(chased: provider_user, chaser_type: service_open_email)
+        unless ChaserSent.where('created_at < ?', 11.months.ago).exists?(chased: provider_user, chaser_type: service_open_email)
           ProviderMailer.send(service_open_email, provider_user).deliver_later
           ChaserSent.create!(chased: provider_user, chaser_type: service_open_email)
         end

--- a/spec/models/chaser_sent_spec.rb
+++ b/spec/models/chaser_sent_spec.rb
@@ -2,4 +2,34 @@ require 'rails_helper'
 
 RSpec.describe ChaserSent do
   it { is_expected.to belong_to(:chased) }
+
+  describe '.since_service_opened' do
+    context 'find' do
+      it 'returns records created this cycle' do
+        this_year = nil # needed for block scoping
+        travel_temporarily_to(CycleTimetable.find_opens(CycleTimetable.previous_year)) do
+          create(:chaser_sent)
+        end
+        travel_temporarily_to(CycleTimetable.find_opens(CycleTimetable.current_year)) do
+          this_year = create(:chaser_sent)
+        end
+
+        expect(described_class.since_service_opened(:find)).to contain_exactly(this_year)
+      end
+    end
+
+    context 'apply' do
+      it 'returns records created this cycle' do
+        this_year = nil # needed for block scoping
+        travel_temporarily_to(CycleTimetable.apply_opens(CycleTimetable.previous_year)) do
+          create(:chaser_sent)
+        end
+        travel_temporarily_to(CycleTimetable.apply_opens(CycleTimetable.current_year)) do
+          this_year = create(:chaser_sent)
+        end
+
+        expect(described_class.since_service_opened(:apply)).to contain_exactly(this_year)
+      end
+    end
+  end
 end

--- a/spec/workers/start_of_cycle_notification_worker_spec.rb
+++ b/spec/workers/start_of_cycle_notification_worker_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe StartOfCycleNotificationWorker do
     let(:provider_users_who_need_to_set_up_permissions) do
       create_list(:provider_user, 2, providers: providers_needing_set_up)
     end
-    let(:provider_with_chaser_sent) { create(:provider) }
 
     let(:other_providers) { %w[CCC DDD].map { |name| create(:provider, name:) } }
     let(:other_provider_users) { create_list(:provider_user, 2, providers: other_providers) }
@@ -91,6 +90,7 @@ RSpec.describe StartOfCycleNotificationWorker do
       end
 
       it 'ignores providers with chasers sent' do
+        provider_with_chaser_sent = create(:provider)
         create(:chaser_sent, chased: provider_with_chaser_sent, chaser_type: "#{service}_service_open_organisation_notification")
 
         expect { described_class.new.perform(service) }.not_to change(ChaserSent.where(chased: provider_with_chaser_sent), :count)

--- a/spec/workers/start_of_cycle_notification_worker_spec.rb
+++ b/spec/workers/start_of_cycle_notification_worker_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe StartOfCycleNotificationWorker do
   describe '#perform' do
     let(:mailer_delivery) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
-    let(:providers_needing_set_up) { %w[AAA BBB].map { |name| create(:provider, name:) } }
+    let(:providers_needing_set_up) { %w[AAA BBB].map { |name| create(:provider, :no_users, name:) } }
     let(:provider_users_who_need_to_set_up_permissions) do
       create_list(:provider_user, 2, providers: providers_needing_set_up)
     end

--- a/spec/workers/start_of_cycle_notification_worker_spec.rb
+++ b/spec/workers/start_of_cycle_notification_worker_spec.rb
@@ -130,17 +130,15 @@ RSpec.describe StartOfCycleNotificationWorker do
         end
       end
 
-      context 'when a provider user received an email last year' do
-        it 'they also receive one the following year' do
-          allow(CycleTimetable).to receive(:service_opens_today?).and_return(true)
-
-          TestSuiteTimeMachine.travel_permanently_to(CycleTimetable.find_opens(2022).change(hour: 16))
-          described_class.new.perform(service)
-
+      context 'when a provider user received an email last cycle' do
+        it 'they receive another email this cycle' do
           TestSuiteTimeMachine.travel_permanently_to(CycleTimetable.find_opens(2023).change(hour: 16))
           described_class.new.perform(service)
 
-          expect(ProviderMailer).to have_received(:find_service_is_now_open).with(other_provider_users.first).twice
+          TestSuiteTimeMachine.travel_permanently_to(CycleTimetable.find_opens(2024).change(hour: 16))
+          described_class.new.perform(service)
+
+          expect(ProviderMailer).to have_received(:find_service_is_now_open).with(other_provider_user).twice
         end
       end
     end


### PR DESCRIPTION
## Context

Our system should send an email notification to every ProviderUser at the start of the cycle notifying them that the Find Service is open. Also, notify each ProviderUser who is associate with a Provider which has relationships that have not been setup yet.

A bug was found which limited this email to be sent only one in the life of a ProviderUser instead of each cycle.

The bug is in two queries. 

1. Query to fetch the Providers that need organisation permission setup
2. Query to test if the present ProviderUser has had a chaser sent to them about the cycle opening.

we need to scope these queries to the current cycle.

## Changes proposed in this pull request

  The worker used to check if the ProviderUser had EVER got the email
  but now we check that the email hasn't been sent in the current cycle.

  That means it will send the email once for each relevant  ProviderUser every cycle.


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

[Trello Ticket](https://trello.com/c/zCiKeTjZ/1019-bug-startofcyclenotificationworker-only-ever-sends-email-to-any-provideruser-once-and-not-per-cycle)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
