### PR TITLE
Change Find domain links in all of our services

### DIFF
--- a/app/components/candidate_interface/course_choices_review_visa_status_component.html.erb
+++ b/app/components/candidate_interface/course_choices_review_visa_status_component.html.erb
@@ -3,7 +3,7 @@
 
   <p class="govuk-body">
     If you need a Student or Skilled Worker visa to get the right to work or study in the UK, you should
-    <%= govuk_link_to('find a course', t('find_postgraduate_teacher_training.production_url')) %> where sponsorship is available.
+    <%= govuk_link_to('find a course', t('find_teacher_training.production_url')) %> where sponsorship is available.
   </p>
 
   <p class="govuk-body">

--- a/app/controllers/candidate_interface/apply_from_find_controller.rb
+++ b/app/controllers/candidate_interface/apply_from_find_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   # The Apply from Find page is the landing page for candidates coming from the
-  # Find teacher training courses (https://www.find-postgraduate-teacher-training.service.gov.uk/)
+  # Find teacher training courses (https://find-teacher-training-courses.service.gov.uk/)
   class ApplyFromFindController < CandidateInterfaceController
     skip_before_action :authenticate_candidate!
 

--- a/app/exports/find_feedback_export.yml
+++ b/app/exports/find_feedback_export.yml
@@ -10,7 +10,7 @@ custom_columns:
     type: string
     format: link
     description: A link to the page that the candidate was on when they chose to provide feedback.
-    example: https://www.find-postgraduate-teacher-training.service.gov.uk/course/2AT/2T84
+    example: https://find-teacher-training-courses.service.gov.uk/course/2AT/2T84
   feedback:
     type: string
     description: Feedback left by the user

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,11 +23,11 @@ module ApplicationHelper
 
   def find_url
     if HostingEnvironment.sandbox_mode?
-      t('find_postgraduate_teacher_training.sandbox_url')
+      t('find_teacher_training.sandbox_url')
     elsif HostingEnvironment.qa?
-      t('find_postgraduate_teacher_training.qa_url')
+      t('find_teacher_training.qa_url')
     else
-      t('find_postgraduate_teacher_training.production_url')
+      t('find_teacher_training.production_url')
     end
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -138,9 +138,9 @@ class Course < ApplicationRecord
 
   def find_url
     url = if HostingEnvironment.sandbox_mode?
-            I18n.t('find_postgraduate_teacher_training.sandbox_url')
+            I18n.t('find_teacher_training.sandbox_url')
           else
-            I18n.t('find_postgraduate_teacher_training.production_url')
+            I18n.t('find_teacher_training.production_url')
           end
 
     "#{url}course/#{provider.code}/#{code}"

--- a/app/services/support_interface/find_feedback_export.rb
+++ b/app/services/support_interface/find_feedback_export.rb
@@ -14,7 +14,7 @@ module SupportInterface
   private
 
     def find_url(find_feedback)
-      "https://www.find-postgraduate-teacher-training.service.gov.uk#{find_feedback.path}"
+      "https://find-teacher-training-courses.service.gov.uk#{find_feedback.path}"
     end
   end
 end

--- a/app/views/candidate_interface/apply_from_find/not_found.html.erb
+++ b/app/views/candidate_interface/apply_from_find/not_found.html.erb
@@ -8,7 +8,7 @@
 
     <p class="govuk-body">
       We could not find the course you are looking for. There may be a problem with the training provider or the course.
-      <%= govuk_link_to 'Try selecting the course again or find a different course to apply to', I18n.t('find_postgraduate_teacher_training.production_url') %>.
+      <%= govuk_link_to 'Try selecting the course again or find a different course to apply to', I18n.t('find_teacher_training.production_url') %>.
     </p>
   </div>
 </div>

--- a/app/views/candidate_interface/continuous_applications_choices/index.html.erb
+++ b/app/views/candidate_interface/continuous_applications_choices/index.html.erb
@@ -10,7 +10,7 @@
       <p class="govuk-body">Applications for courses starting in September <%= RecruitmentCycle.current_year %> are closed.</p>
       <p class="govuk-body"> From <%= CycleTimetable.find_reopens.to_fs(:govuk_time_and_date) %>, you can <%= govuk_link_to(
         'find postgraduate teacher training courses',
-        t('find_postgraduate_teacher_training.production_url'),
+        t('find_teacher_training.production_url'),
       ) %> starting in September <%= RecruitmentCycle.next_year %>.</p>
 
       <p class="govuk-body">You will be able to apply to courses from <%= CycleTimetable.apply_reopens.to_fs(:govuk_time_and_date) %>.</p>

--- a/app/views/candidate_interface/continuous_applications_choices/index.html.erb
+++ b/app/views/candidate_interface/continuous_applications_choices/index.html.erb
@@ -9,7 +9,7 @@
     <% if CycleTimetable.today_is_between_apply_deadline_and_find_reopens? %>
       <p class="govuk-body">Applications for courses starting in September <%= RecruitmentCycle.current_year %> are closed.</p>
       <p class="govuk-body"> From <%= CycleTimetable.find_reopens.to_fs(:govuk_time_and_date) %>, you can <%= govuk_link_to(
-        'find postgraduate teacher training courses',
+        'find teacher training courses',
         t('find_teacher_training.production_url'),
       ) %> starting in September <%= RecruitmentCycle.next_year %>.</p>
 

--- a/app/views/candidate_mailer/_reasons_for_rejection.text.erb
+++ b/app/views/candidate_mailer/_reasons_for_rejection.text.erb
@@ -10,7 +10,7 @@
     <% end %>
 
     <% if title == 'Qualifications' %>
-      ^ View the course requirements on [<%= t('service_name.find') %>](<%= "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{@course.provider.code}/#{@course.code}#section-entry" %>).
+      ^ View the course requirements on [<%= t('service_name.find') %>](<%= "#{t('find_teacher_training.production_url')}/course/#{@course.provider.code}/#{@course.code}#section-entry" %>).
     <% end %>
 
 <% end %>

--- a/app/views/candidate_mailer/find_has_opened.erb
+++ b/app/views/candidate_mailer/find_has_opened.erb
@@ -4,7 +4,7 @@
 
 You can now find teacher training courses starting in the <%= @academic_year %> academic year.
 
-[Find your courses](<%= I18n.t('find_postgraduate_teacher_training.production_url') %>).
+[Find your courses](<%= I18n.t('find_teacher_training.production_url') %>).
 
 You can start preparing your applications and submit them from 9am on <%= @apply_opens %>.
 

--- a/app/views/content/sandbox.html.erb
+++ b/app/views/content/sandbox.html.erb
@@ -19,7 +19,7 @@
     <h2 class="govuk-heading-l">Course data in the sandbox</h2>
     <p class="govuk-body"><strong>The live Apply service</strong> gets its course data from the <%= govuk_link_to 'Teacher training courses API', t('teacher_training_courses_api.documentation_url') %>. Training providers update those courses using <%= govuk_link_to 'Publish teacher training courses', t('publish_teacher_training_courses.production_url') %>.</p>
 
-    <p class="govuk-body"><strong>The Apply sandbox</strong> gets its course data from a sandbox version of the Teacher training courses API. As a training provider you can access <%= govuk_link_to 'a sandbox version of Publish', t('publish_teacher_training_courses.sandbox_url') %> where you will be able to create and edit courses just as you would on the live service, and see them on the <%= govuk_link_to "sandbox version of #{t('service_name.find')}", t('find_postgraduate_teacher_training.sandbox_url') %>.</p>
+    <p class="govuk-body"><strong>The Apply sandbox</strong> gets its course data from a sandbox version of the Teacher training courses API. As a training provider you can access <%= govuk_link_to 'a sandbox version of Publish', t('publish_teacher_training_courses.sandbox_url') %> where you will be able to create and edit courses just as you would on the live service, and see them on the <%= govuk_link_to "sandbox version of #{t('service_name.find')}", t('find_teacher_training.sandbox_url') %>.</p>
 
     <p class="govuk-body">To request access to the Publish sandbox, email us at <%= bat_contact_mail_to %>.</p>
 

--- a/app/views/support_interface/application_forms/application_choices/change_offered_course/change_offered_course_search.html.erb
+++ b/app/views/support_interface/application_forms/application_choices/change_offered_course/change_offered_course_search.html.erb
@@ -21,7 +21,7 @@
         Find courses by searching on
         <%= govuk_link_to(
           t('service_name.find'),
-          I18n.t('find_postgraduate_teacher_training.production_url'),
+          I18n.t('find_teacher_training.production_url'),
           target: '_blank',
           rel: 'nofollow',
         ) %>.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,10 +28,10 @@ en:
   publish_teacher_training_courses:
     production_url: https://www.publish-teacher-training-courses.service.gov.uk/
     sandbox_url: https://sandbox.publish-teacher-training-courses.service.gov.uk/
-  find_postgraduate_teacher_training:
-    production_url: https://www.find-postgraduate-teacher-training.service.gov.uk/
-    sandbox_url: https://sandbox.find-postgraduate-teacher-training.service.gov.uk/
-    qa_url: https://qa.find-postgraduate-teacher-training.service.gov.uk/
+  find_teacher_training:
+    production_url: https://find-teacher-training-courses.service.gov.uk/
+    sandbox_url: https://sandbox.find-teacher-training-courses.service.gov.uk/
+    qa_url: https://qa.find-teacher-training-courses.service.gov.uk/
   get_into_teaching:
     tel: 0800 389 2500
     opening_times: "Monday to Friday, 8:30am to 5:30pm (except public\u00A0holidays)"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,11 +25,11 @@ Rails.application.routes.draw do
 
   direct :find do
     if HostingEnvironment.sandbox_mode?
-      I18n.t('find_postgraduate_teacher_training.sandbox_url')
+      I18n.t('find_teacher_training.sandbox_url')
     elsif HostingEnvironment.qa?
-      I18n.t('find_postgraduate_teacher_training.qa_url')
+      I18n.t('find_teacher_training.qa_url')
     else
-      I18n.t('find_postgraduate_teacher_training.production_url')
+      I18n.t('find_teacher_training.production_url')
     end
   end
 

--- a/docs/development/developer-onboarding.md
+++ b/docs/development/developer-onboarding.md
@@ -38,7 +38,7 @@ Have a read through [Teacher Services technical documentation](https://tech-docs
 
 These are a small number of recommended Slack channels for new developers to join
 
-- Join `#apply-dev-notifications` for GitHub notifications from the [Apply postgraduate teacher training](https://github.com/DFE-Digital/apply-for-teacher-training) and [Find/Publish for teacher training](https://github.com/DFE-Digital/publish-teacher-training) codebases
+- Join `#apply-dev-notifications` for GitHub notifications from the [Apply teacher training](https://github.com/DFE-Digital/apply-for-teacher-training) and [Find/Publish for teacher training](https://github.com/DFE-Digital/publish-teacher-training) codebases
 
 - `#civil_servant_devs` is a channel for civil servant developers. Join if you would like to be part of ongoing developer discussion, meet ups and technical talks.
 This is a private channel, so ask a permanent developer within Teacher Services to invite you.

--- a/spec/components/candidate_interface/grouped_provider_courses_component_spec.rb
+++ b/spec/components/candidate_interface/grouped_provider_courses_component_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe CandidateInterface::GroupedProviderCoursesComponent do
       expect(result.css('h2').text).to include('South East')
       expect(result.css('h2').text).to include('North West')
       expect(result.css('h2').text).to include('No region')
-      expect(result.css('a').to_html).to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{course.provider.code}/#{course.code}")
+      expect(result.css('a').to_html).to include("https://find-teacher-training-courses.service.gov.uk/course/#{course.provider.code}/#{course.code}")
     end
   end
 
@@ -37,7 +37,7 @@ RSpec.describe CandidateInterface::GroupedProviderCoursesComponent do
     it 'does not include a link to find' do
       travel_temporarily_to(CycleTimetable.find_closes.end_of_day + 1.hour) do
         result = render_inline(described_class.new)
-        expect(result.css('a').to_html).not_to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{course.provider.code}/#{course.code}")
+        expect(result.css('a').to_html).not_to include("https://find-teacher-training-courses.service.gov.uk/course/#{course.provider.code}/#{course.code}")
       end
     end
   end

--- a/spec/components/candidate_interface/rejection_reasons/reasons_for_rejection_component_spec.rb
+++ b/spec/components/candidate_interface/rejection_reasons/reasons_for_rejection_component_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe CandidateInterface::RejectionReasons::ReasonsForRejectionComponen
       expect(html).to include('No English GCSE grade 4 (C) or above, or valid equivalent')
       expect(html).to include('No Science GCSE grade 4 (C) or above, or valid equivalent (for primary applicants)')
       expect(html).to include('No degree')
-      expect(html).not_to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course_option.course.code}#section-entry")
+      expect(html).not_to include("https://find-teacher-training-courses.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course_option.course.code}#section-entry")
 
       expect(result.css('.govuk-body.app-rejection__label').text).to include('Performance at interview:')
       expect(html).to include('There was no need to do all those pressups')
@@ -76,7 +76,7 @@ RSpec.describe CandidateInterface::RejectionReasons::ReasonsForRejectionComponen
       expect(html).to include('No English GCSE grade 4 (C) or above, or valid equivalent')
       expect(html).to include('No Science GCSE grade 4 (C) or above, or valid equivalent (for primary applicants)')
       expect(html).to include('No degree')
-      expect(html).to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course.code}#section-entry")
+      expect(html).to include("https://find-teacher-training-courses.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course.code}#section-entry")
     end
 
     context 'when future applications question is not given' do

--- a/spec/components/shared/rejection_reasons/reasons_for_rejection_component_spec.rb
+++ b/spec/components/shared/rejection_reasons/reasons_for_rejection_component_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe RejectionReasons::ReasonsForRejectionComponent do
       expect(html).to include('No English GCSE grade 4 (C) or above, or valid equivalent')
       expect(html).to include('No Science GCSE grade 4 (C) or above, or valid equivalent (for primary applicants)')
       expect(html).to include('No degree')
-      expect(html).not_to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course_option.course.code}#section-entry")
+      expect(html).not_to include("https://find-teacher-training-courses.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course_option.course.code}#section-entry")
 
       expect(result.css('h3.govuk-heading-s').text).to include('Performance at interview')
       expect(html).to include('There was no need to do all those pressups')
@@ -76,7 +76,7 @@ RSpec.describe RejectionReasons::ReasonsForRejectionComponent do
       expect(html).to include('No English GCSE grade 4 (C) or above, or valid equivalent')
       expect(html).to include('No Science GCSE grade 4 (C) or above, or valid equivalent (for primary applicants)')
       expect(html).to include('No degree')
-      expect(html).to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course.code}#section-entry")
+      expect(html).to include("https://find-teacher-training-courses.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course.code}#section-entry")
     end
 
     context 'when future applications question is not given' do

--- a/spec/components/shared/rejection_reasons/rejection_reasons_component_spec.rb
+++ b/spec/components/shared/rejection_reasons/rejection_reasons_component_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe RejectionReasons::RejectionReasonsComponent do
 
       expect(result.css('.govuk-link').size).to eq(1)
       link_element = result.css('.govuk-summary-list__value').first.css('.govuk-link').first
-      expect(link_element[:href]).to eq("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{course.provider.code}/#{course.code}#section-entry")
+      expect(link_element[:href]).to eq("https://find-teacher-training-courses.service.gov.uk/course/#{course.provider.code}/#{course.code}#section-entry")
       expect(link_element.text).to eq(t('service_name.find'))
     end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -4,21 +4,21 @@ RSpec.describe ApplicationHelper do
   describe '#find_url' do
     context 'when sandbox', :sandbox do
       it 'returns sandbox url' do
-        expect(helper.find_url).to eq(I18n.t('find_postgraduate_teacher_training.sandbox_url'))
+        expect(helper.find_url).to eq(I18n.t('find_teacher_training.sandbox_url'))
       end
     end
 
     context 'when qa' do
       it 'returns qa url' do
         ClimateControl.modify HOSTING_ENVIRONMENT_NAME: 'qa' do
-          expect(helper.find_url).to eq(I18n.t('find_postgraduate_teacher_training.qa_url'))
+          expect(helper.find_url).to eq(I18n.t('find_teacher_training.qa_url'))
         end
       end
     end
 
     context 'when other environments' do
       it 'returns production url' do
-        expect(helper.find_url).to eq(I18n.t('find_postgraduate_teacher_training.production_url'))
+        expect(helper.find_url).to eq(I18n.t('find_teacher_training.production_url'))
       end
     end
   end

--- a/spec/services/support_interface/find_feedback_export_spec.rb
+++ b/spec/services/support_interface/find_feedback_export_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe SupportInterface::FindFeedbackExport do
       expect(described_class.new.data_for_export).to contain_exactly(
         {
           feedback_provided_at: feedback2.created_at,
-          find_url: 'https://www.find-postgraduate-teacher-training.service.gov.uk/course/L24/2CCR',
+          find_url: 'https://find-teacher-training-courses.service.gov.uk/course/L24/2CCR',
           email: feedback2.email_address,
           feedback: feedback2.feedback,
         },
         {
           feedback_provided_at: feedback1.created_at,
-          find_url: 'https://www.find-postgraduate-teacher-training.service.gov.uk/results',
+          find_url: 'https://find-teacher-training-courses.service.gov.uk/results',
           email: feedback1.email_address,
           feedback: feedback1.feedback,
         },

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_not_signed_in_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_not_signed_in_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'An existing candidate arriving from Find with a course and provider code (with course selection page)' do
+RSpec.describe 'An existing candidate arriving from Find with a course and provider code (with course selection page)' do
   include CourseOptionHelpers
   include SignInHelper
   include CandidateHelper
@@ -191,7 +191,7 @@ RSpec.feature 'An existing candidate arriving from Find with a course and provid
   def and_i_see_a_link_to_the_course_on_find
     expect(page).to have_link(
       "#{@course.provider.name} #{@course.name_and_code}",
-      href: "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{@course.provider.code}/#{@course.code}",
+      href: "https://find-teacher-training-courses.service.gov.uk/course/#{@course.provider.code}/#{@course.code}",
     )
   end
 


### PR DESCRIPTION
### Context

The Find domain has change.

We should point to the new domain.

### Guidance to review

1. All links pointing to find are updated to use the new domain?