### PR TITLE
Add enic_reason enum to ApplicationQualification model and double write

### DIFF
--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -59,13 +59,14 @@ class ApplicationQualification < ApplicationRecord
 
   validates :qualification_type, length: { maximum: MAX_QUALIFICATION_TYPE_LENGTH }, allow_blank: true
   validates :non_uk_qualification_type, length: { maximum: MAX_QUALIFICATION_TYPE_LENGTH }, allow_blank: true
+  validates :enic_reason, presence: true
 
   enum enic_reason: {
-    obtained: 'obtained',     # I have obtained a statement of comparibility
-    waiting: 'waiting',       # I am waiting for a statement of comparibility to arrive
-    maybe: 'maybe',           # I might obtain a statement of comparibility (in the future)
-    not_needed: 'not_needed', # I don't need a statement of comparibility
-  }, _prefix: :enic_reason
+    obtained: 'obtained',
+    waiting: 'waiting',
+    maybe: 'maybe',
+    not_needed: 'not_needed',
+  }, _prefix: :enic_reason, _default: :not_needed
 
   enum level: {
     degree: 'degree',

--- a/spec/models/application_qualification_spec.rb
+++ b/spec/models/application_qualification_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe ApplicationQualification do
   end
 
   describe 'enic_reason' do
-    it 'yes waiting future, and no' do
+    it 'obtained waiting maybe, and not_needed' do
       %w[obtained waiting maybe not_needed].each do |enic_reason|
         expect { described_class.new(enic_reason:) }.not_to raise_error
       end
@@ -41,6 +41,25 @@ RSpec.describe ApplicationQualification do
     it 'raises an error when level is invalid' do
       expect { described_class.new(enic_reason: 'invalid_reason') }
         .to raise_error ArgumentError, "'invalid_reason' is not a valid enic_reason"
+    end
+  end
+
+  describe '#enic_reference=' do
+    context 'when value is present' do
+      it 'sets enic_reason to :obtained' do
+        qualification = build_stubbed(:application_qualification, enic_reference: '12345')
+        expect(qualification.enic_reason).to eq('obtained')
+      end
+    end
+
+    context 'when value is not present' do
+      it 'sets enic_reason to :maybe' do
+        qualification = build_stubbed(:application_qualification, enic_reference: nil)
+        expect(qualification.enic_reason).to eq('maybe')
+
+        qualification.enic_reference = ''
+        expect(qualification.enic_reason).to eq('maybe')
+      end
     end
   end
 

--- a/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Entering their other qualifications', :mid_cycle do
+RSpec.describe 'Entering their other qualifications', :mid_cycle do
   include CandidateHelper
 
   scenario 'Candidate submits their other qualifications' do
@@ -38,14 +38,14 @@ RSpec.feature 'Entering their other qualifications', :mid_cycle do
     and_i_choose_not_to_add_additional_qualifications
     and_click_save_and_continue
     then_i_see_the_other_qualification_review_page
-    and_i_should_see_my_qualifications
+    and_i_see_my_qualifications
     and_my_other_uk_qualification_has_the_correct_format
 
     when_i_select_add_another_qualification
     and_choose_as_level
     then_the_form_is_empty
     and_i_visit_the_other_qualification_review_page
-    then_i_should_not_see_an_incomplete_as_level_qualification
+    then_i_will_not_see_an_incomplete_as_level_qualification
 
     when_i_click_on_delete_my_first_qualification
     and_i_confirm_that_i_want_to_delete_my_additional_qualification
@@ -73,7 +73,7 @@ RSpec.feature 'Entering their other qualifications', :mid_cycle do
 
     when_i_mark_this_section_as_incomplete
     and_i_click_on_continue
-    then_i_should_see_the_form
+    then_i_see_the_form
     and_the_section_is_not_completed
 
     when_i_click_on_other_qualifications
@@ -82,7 +82,7 @@ RSpec.feature 'Entering their other qualifications', :mid_cycle do
     when_i_mark_this_section_as_completed
     and_i_have_an_incomplete_qualification
     and_i_click_on_continue
-    then_i_should_be_told_i_cannot_submit_incomplete_qualifications
+    then_i_will_be_told_i_cannot_submit_incomplete_qualifications
 
     when_i_delete_my_incomplete_qualification
     and_i_confirm_that_i_want_to_delete_my_additional_qualification
@@ -202,7 +202,7 @@ RSpec.feature 'Entering their other qualifications', :mid_cycle do
     expect(page).to have_current_path(candidate_interface_review_other_qualifications_path)
   end
 
-  def and_i_should_see_my_qualifications
+  def and_i_see_my_qualifications
     expect(page).to have_content('A level Believing in the Heart of the Cards')
     expect(page).to have_content('A level Oh')
     expect(page).to have_content('Access Course History, English and Psychology')
@@ -223,7 +223,7 @@ RSpec.feature 'Entering their other qualifications', :mid_cycle do
     fill_in t('application_form.other_qualification.subject.label'), with: 'Winning at life'
   end
 
-  def then_i_should_see_the_review_page_with_a_flash_warning
+  def then_i_see_the_review_page_with_a_flash_warning
     expect(page).to have_content "To update one of your qualifications use the 'Change' links below"
     expect(page).to have_content 'Access Course, History, English and Psychology'
   end
@@ -247,7 +247,7 @@ RSpec.feature 'Entering their other qualifications', :mid_cycle do
     visit candidate_interface_review_other_qualifications_path
   end
 
-  def then_i_should_not_see_an_incomplete_as_level_qualification
+  def then_i_will_not_see_an_incomplete_as_level_qualification
     expect(page).to have_no_content('AS level')
     expect(all('.govuk-summary-list__value').last.text).not_to eq 'Not entered'
   end
@@ -345,7 +345,7 @@ RSpec.feature 'Entering their other qualifications', :mid_cycle do
     expect(page).to have_content t('activemodel.errors.models.candidate_interface/section_complete_form.attributes.completed.blank')
   end
 
-  def then_i_should_be_told_i_cannot_submit_incomplete_qualifications
+  def then_i_will_be_told_i_cannot_submit_incomplete_qualifications
     expect(page).to have_content('You must fill in all your qualifications to complete this section')
   end
 
@@ -355,7 +355,7 @@ RSpec.feature 'Entering their other qualifications', :mid_cycle do
     end
   end
 
-  def then_i_should_see_the_form
+  def then_i_see_the_form
     expect(page).to have_content(t('page_titles.application_form'))
   end
 


### PR DESCRIPTION
## Context

Related PR: https://github.com/DFE-Digital/apply-for-teacher-training/pull/9586

Now we have added the `enic_reason` field to the ApplicationQualification model, this PR adds an ENUM for the `enic_reason` for a nicer way to store this data.

In addition to deal with new qualifications that are created, we have added a double write to keep the `enic_reason` up to date, before we backfill.

Blog post around this approach: https://dcyoung.dev/shorts/make-an-existing-relationship-polymorphic

`_prefix` now allows us to do `application_qualification.enic_reason_yes?` 

Doc: https://api.rubyonrails.org/v5.1/classes/ActiveRecord/Enum.html

## Changes proposed in this pull request

- Add enum to the ApplicationQualification model
For reference 
```
  enum enic_reason: {
    obtained: 'obtained',     # I have obtained a statement of comparibility
    waiting: 'waiting',       # I am waiting for a statement of comparibility to arrive
    maybe: 'maybe',           # I might obtain a statement of comparibility (in the future)
    not_needed: 'not_needed', # I don't need a statement of comparibility
  }, _prefix: :enic_reason
```

## Link to Trello card

https://trello.com/c/mipxt6uk/1382-implement-content-flow-improvements-for-surfacing-enic

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
