### PR TITLE
Manage TDA: Allow users to clearly distinguish Undergraduate vs Postgraduate courses 

### DIFF
--- a/app/components/provider_interface/application_card_component.html.erb
+++ b/app/components/provider_interface/application_card_component.html.erb
@@ -1,4 +1,9 @@
-<section id="<%= dom_id(application_choice) %>" class="app-application-card">
+<section id="<%= dom_id(application_choice) %>" class="app-application-card app-application-card__<%= course_type %>">
+  <% if undergraduate? %>
+    <p class="govuk-body-s app-application-card__course_type">
+      <%= t('provider_interface.undergraduate') %>
+    </p>
+  <% end %>
   <header class="app-application-card__header">
     <h3 class="govuk-heading-s">
       <%= govuk_link_to candidate_name, provider_interface_application_choice_path(application_choice), no_visited_state: true %>

--- a/app/components/provider_interface/application_card_component.rb
+++ b/app/components/provider_interface/application_card_component.rb
@@ -7,6 +7,9 @@ module ProviderInterface
                   :candidate_name, :course_name_and_code, :course_provider_name, :changed_at,
                   :site_name, :course_study_mode
 
+    delegate :current_course, to: :application_choice
+    delegate :course_type, :undergraduate?, to: :current_course
+
     def initialize(application_choice:)
       @accredited_provider = application_choice.current_accredited_provider
       @application_choice = application_choice

--- a/app/frontend/styles/_application-card.scss
+++ b/app/frontend/styles/_application-card.scss
@@ -86,13 +86,13 @@
   }
 
   &__course_type {
-    margin-bottom: 10px;
+    margin-bottom: govuk-spacing(2);
 
-    font-weight: 700;
+    font-weight: $govuk-font-weight-bold;
   }
 
   &__undergraduate {
-    padding: 10px;
+    padding: govuk-spacing(2);
 
     background-color: #fff6bf;
   }

--- a/app/frontend/styles/_application-card.scss
+++ b/app/frontend/styles/_application-card.scss
@@ -86,12 +86,14 @@
   }
 
   &__course_type {
-    font-weight: 700;
     margin-bottom: 10px;
+
+    font-weight: 700;
   }
 
   &__undergraduate {
-    background-color: #fff6bf;
     padding: 10px;
+
+    background-color: #fff6bf;
   }
 }

--- a/app/frontend/styles/_application-card.scss
+++ b/app/frontend/styles/_application-card.scss
@@ -84,4 +84,14 @@
       margin-top: auto;
     }
   }
+
+  &__course_type {
+    font-weight: 700;
+    margin-bottom: 10px;
+  }
+
+  &__undergraduate {
+    background-color: #fff6bf;
+    padding: 10px;
+  }
 }

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -199,6 +199,16 @@ class Course < ApplicationRecord
     @description_to_s ||= description.to_s.gsub('PGCE with QTS', 'QTS with PGCE')
   end
 
+  def undergraduate?
+    teacher_degree_apprenticeship?
+  end
+
+  def course_type
+    return I18n.t('course_types.undergraduate') if undergraduate?
+
+    I18n.t('course_types.postgraduate')
+  end
+
 private
 
   def touch_application_choices_and_forms

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,6 +78,9 @@ en:
     url: https://www.gov.uk/exoffenders-and-employment
   realistic_job_previews:
     url_apply_again: https://teacherselect.qualtrics.com/jfe/form/SV_4VHMkFk6TeonVeS
+  course_types:
+    undergraduate: undergraduate
+    postgraduate: postgraduate
   page_titles:
     continuous_applications:
       your_applications: Your applications

--- a/config/locales/provider_interface/filters.yml
+++ b/config/locales/provider_interface/filters.yml
@@ -1,8 +1,9 @@
 en:
   provider_interface:
+    undergraduate: 'Undergraduate'
     filters:
       course_type:
         heading: 'Course type'
         postgraduate: 'Postgraduate courses'
-        teacher_degree_apprenticeship: 'Teaching degree apprenticeship (TDA) courses'
+        teacher_degree_apprenticeship: 'Undergraduate courses'
 

--- a/spec/components/provider_interface/application_card_component_spec.rb
+++ b/spec/components/provider_interface/application_card_component_spec.rb
@@ -146,8 +146,48 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
       end
     end
 
+    context 'when undergraduate' do
+      let(:course_option) do
+        course_option_for_provider(
+          provider: current_provider,
+          course: create(
+            :course,
+            :teacher_degree_apprenticeship,
+            name: 'Alchemy',
+            provider: current_provider,
+            accredited_provider:,
+          ),
+          site: create(
+            :site,
+            code: 'L123',
+            name: 'Skywalker Training',
+            provider: current_provider,
+          ),
+          study_mode: 'part_time',
+        )
+      end
+
+      it 'renders undergraduate content' do
+        expect(result.text.gsub(/\r?\n/, ' ').squeeze(' ').strip).to match(
+          /^Undergraduate Jim James/,
+        )
+        expect(result).to have_css(
+          'section.app-application-card.app-application-card__undergraduate',
+        )
+      end
+    end
+
     it 'renders the application number' do
       expect(card).to include(application_choice.id.to_fs)
+    end
+
+    it 'does not render undergraduate content' do
+      expect(result.text.gsub(/\r?\n/, ' ').squeeze(' ').strip).to match(
+        /^Jim James/,
+      )
+      expect(result).to have_css(
+        'section.app-application-card.app-application-card__postgraduate',
+      )
     end
   end
 

--- a/spec/components/provider_interface/application_card_component_spec.rb
+++ b/spec/components/provider_interface/application_card_component_spec.rb
@@ -168,9 +168,7 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
       end
 
       it 'renders undergraduate content' do
-        expect(result.text.gsub(/\r?\n/, ' ').squeeze(' ').strip).to match(
-          /^Undergraduate Jim James/,
-        )
+        expect(result).to have_text('Undergraduate Jim James', normalize_ws: true)
         expect(result).to have_css(
           'section.app-application-card.app-application-card__undergraduate',
         )

--- a/spec/components/provider_interface/application_card_component_spec.rb
+++ b/spec/components/provider_interface/application_card_component_spec.rb
@@ -22,12 +22,7 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
   let(:course_option) do
     course_option_for_provider(
       provider: current_provider,
-      course: create(
-        :course,
-        name: 'Alchemy',
-        provider: current_provider,
-        accredited_provider:,
-      ),
+      course:,
       site: create(
         :site,
         code: 'L123',
@@ -35,6 +30,15 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
         provider: current_provider,
       ),
       study_mode: 'part_time',
+    )
+  end
+
+  let(:course) do
+    create(
+      :course,
+      name: 'Alchemy',
+      provider: current_provider,
+      accredited_provider:,
     )
   end
 
@@ -147,23 +151,13 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
     end
 
     context 'when undergraduate' do
-      let(:course_option) do
-        course_option_for_provider(
+      let(:course) do
+        create(
+          :course,
+          :teacher_degree_apprenticeship,
+          name: 'Alchemy',
           provider: current_provider,
-          course: create(
-            :course,
-            :teacher_degree_apprenticeship,
-            name: 'Alchemy',
-            provider: current_provider,
-            accredited_provider:,
-          ),
-          site: create(
-            :site,
-            code: 'L123',
-            name: 'Skywalker Training',
-            provider: current_provider,
-          ),
-          study_mode: 'part_time',
+          accredited_provider:,
         )
       end
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -310,4 +310,36 @@ RSpec.describe Course do
       expect(course.ske_graduation_cutoff_date).to eq(Date.new(2018, 1, 1))
     end
   end
+
+  describe '#undergraduate?' do
+    context 'when the course is undergraduate' do
+      it 'returns true' do
+        course = build(:course, :teacher_degree_apprenticeship)
+        expect(course.undergraduate?).to be true
+      end
+    end
+
+    context 'when the course is not undergraduate' do
+      it 'returns false' do
+        course = build(:course, program_type: 'scitt_programme')
+        expect(course.undergraduate?).to be false
+      end
+    end
+  end
+
+  describe '#course_type' do
+    context 'when the course is undergraduate' do
+      it 'returns the translated undergraduate course type' do
+        course = build(:course, :teacher_degree_apprenticeship)
+        expect(course.course_type).to eq('undergraduate')
+      end
+    end
+
+    context 'when the course is not undergraduate' do
+      it 'returns the translated postgraduate course type' do
+        course = build(:course, program_type: 'scitt_programme')
+        expect(course.course_type).to eq('postgraduate')
+      end
+    end
+  end
 end

--- a/spec/system/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/system/provider_interface/provider_applications_filter_spec.rb
@@ -194,14 +194,14 @@ RSpec.describe 'Providers should be able to filter applications' do
     expect(page).to have_content('Filter')
     expect(page).to have_no_content('Course type')
     expect(page).to have_no_content('Postgraduate courses')
-    expect(page).to have_no_content('Teaching degree apprenticeship (TDA) courses')
+    expect(page).to have_no_content('Undergraduate courses')
   end
 
   def then_teacher_degree_apprenticeship_filter_is_visible
     expect(page).to have_content('Filter')
     expect(page).to have_content('Course type')
     expect(page).to have_content('Postgraduate courses')
-    expect(page).to have_content('Teaching degree apprenticeship (TDA) courses')
+    expect(page).to have_content('Undergraduate courses')
   end
 
   def then_i_do_not_expect_to_see_the_accredited_providers_filter_heading
@@ -253,7 +253,7 @@ RSpec.describe 'Providers should be able to filter applications' do
 
   def when_i_filter_by_teacher_degree_apprenticeship_courses
     uncheck 'Postgraduate courses'
-    check 'Teaching degree apprenticeship (TDA) courses'
+    check 'Undergraduate courses'
     and_i_apply_the_filters
   end
 
@@ -267,14 +267,14 @@ RSpec.describe 'Providers should be able to filter applications' do
 
   def when_i_check_both_course_types_filter
     check 'Postgraduate courses'
-    check 'Teaching degree apprenticeship (TDA) courses'
+    check 'Undergraduate courses'
     and_i_apply_the_filters
   end
 
   def then_i_see_postgraduate_and_teacher_degree_apprenticeship_applications
     expect(page).to have_content('Andres Bartell')
-    expect(page).to have_content('Quinton Marks')
-    expect(page).to have_content('Leland Harris')
+    expect(page).to have_content('Undergraduate Quinton Marks')
+    expect(page).to have_content('Undergraduate Leland Harris')
     expect(page).to have_content('Jim James')
     expect(page).to have_content('Greg Taft')
   end


### PR DESCRIPTION
## Context

Currently there is no way of knowing which courses are postgraduate and which courses are undergraduate (TDA) in the list of applications in Manage.

[User research](https://educationgovuk-my.sharepoint.com.mcas.ms/personal/clair-marie_george_education_gov_uk/_layouts/15/stream.aspx?id=%2Fpersonal%2Fclair%2Dmarie%5Fgeorge%5Feducation%5Fgov%5Fuk%2FDocuments%2FRecordings%2FTDA%5F%20Publish%20User%20Research%20Playback%2D20240612%5F150218%2DMeeting%20Recording%2Emp4&referrer=StreamWebApp%2EWeb&referrerScenario=AddressBarCopied%2Eview%2E43782611%2D34ca%2D4d95%2Daa8c%2Da7abe850c899&ga=1) mentions providers would prefer TDA applications in a separate list, however we have agreed to do the simplest solution now to enable TDA, and to revisit Manage more holistically in the future.

## Changes proposed in this pull request

![apply-review-9154 test teacherservices cloud_provider_applications_commit=Apply+filters recruitment_cycle_year_5B_5D= status_5B_5D= subject_5B_5D= study_mode_5B_5D= course_type_5B_5D= provider_location_5B_5D=](https://github.com/user-attachments/assets/124d299d-5a12-42c6-8de7-8afb71d16209)

## Guidance to review

1. Does it work?

## Link to Trello card

https://trello.com/c/Du78wvX9/1840-manage-tda-allow-users-to-clearly-distinguish-undergraduate-vs-postgraduate-courses-in-applications-list
