### PR TITLE
Fix bug where grade was being stored as nil instead of N/A or Unknown

### DIFF
--- a/app/components/candidate_interface/degree_review_component.rb
+++ b/app/components/candidate_interface/degree_review_component.rb
@@ -232,7 +232,7 @@ module CandidateInterface
     end
 
     def grade_row(degree)
-      return nil if doctorate?(degree)
+      return nil if doctorate?(degree) && !degree.international?
 
       {
         key: degree.completed? ? t('application_form.degree.grade.review_label') : t('application_form.degree.grade.review_label_predicted'),

--- a/app/forms/candidate_interface/degree_wizard.rb
+++ b/app/forms/candidate_interface/degree_wizard.rb
@@ -485,6 +485,8 @@ module CandidateInterface
     end
 
     def map_value_for_no_submitted_international_grade(grade)
+      return grade if grade.in? [NOT_APPLICABLE, UNKNOWN]
+
       self.grade = {
         NO => NOT_APPLICABLE,
         I_DO_NOT_KNOW => UNKNOWN,

--- a/spec/forms/candidate_interface/degree_wizard_spec.rb
+++ b/spec/forms/candidate_interface/degree_wizard_spec.rb
@@ -557,6 +557,46 @@ RSpec.describe CandidateInterface::DegreeWizard do
       end
     end
 
+    context 'international with where no grade is awarded' do
+      let(:wizard_attrs) do
+        {
+          application_form_id: 1,
+          uk_or_non_uk: 'non_uk',
+          subject: 'History',
+          international_type: 'Doctor of Philosophy',
+          university: 'Purdue University',
+          country: 'USA',
+          grade: 'No',
+          completed: 'Yes',
+          start_year: '2000',
+          award_year: '2004',
+        }
+      end
+
+      let(:wizard) { described_class.new(store, wizard_attrs) }
+
+      it 'persists the correct attributes' do
+        expect(wizard.attributes_for_persistence).to eq(
+          {
+            application_form_id: 1,
+            international: true,
+            level: 'degree',
+            qualification_type: 'Doctor of Philosophy',
+            institution_name: 'Purdue University',
+            institution_country: 'USA',
+            subject: 'History',
+            degree_subject_uuid: Hesa::Subject.find_by_name('History').id,
+            predicted_grade: false,
+            grade: 'N/A',
+            start_year: '2000',
+            award_year: '2004',
+            enic_reference: nil,
+            comparable_uk_degree: nil,
+          },
+        )
+      end
+    end
+
     context 'international' do
       let(:wizard_attrs) do
         {

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degree_without_a_grade_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degree_without_a_grade_spec.rb
@@ -1,0 +1,163 @@
+require 'rails_helper'
+
+RSpec.describe 'Entering an international doctorate degree' do
+  include CandidateHelper
+
+  scenario 'Candidate enters their degree' do
+    given_i_am_signed_in
+    when_i_view_the_degree_section
+
+    and_i_click_add_degree
+    and_i_select_another_country
+    and_i_fill_in_the_subject
+    and_i_fill_in_the_type_of_degree
+    and_i_fill_in_the_university
+    and_i_choose_whether_degree_is_completed
+    and_i_select_no_grade_was_given
+    and_i_fill_in_the_start_year
+    when_i_fill_in_the_award_year
+    and_i_check_no_for_enic_statement
+
+    then_i_can_check_my_international_degree
+
+    when_i_change_my_degree_grade_to_not_known
+    then_i_can_check_the_grade_has_changed
+
+    when_i_mark_this_section_as_completed
+    and_i_click_on_continue
+    then_i_see_the_form
+    and_that_the_section_is_completed
+    when_i_click_on_degree
+    then_i_can_check_my_answers
+  end
+
+private
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def when_i_view_the_degree_section
+    visit candidate_interface_continuous_applications_details_path
+    when_i_click_on_degree
+  end
+
+  def when_i_click_on_degree
+    click_link_or_button 'Degree'
+  end
+
+  def and_i_click_add_degree
+    click_link_or_button 'Add a degree'
+  end
+
+  def and_i_select_another_country
+    choose 'Another country'
+    select 'France'
+    and_i_click_on_save_and_continue
+  end
+
+  def and_i_click_on_save_and_continue
+    click_link_or_button t('save_and_continue')
+  end
+
+  def and_i_click_on_continue
+    click_on 'Continue'
+  end
+
+  def when_i_fill_in_the_type
+    choose 'Doctor of Philosophy'
+  end
+
+  def then_i_can_see_the_subject_page
+    expect(page).to have_content 'What subject is your degree?'
+  end
+
+  def and_i_fill_in_the_subject
+    select 'History', from: 'What subject is your degree?'
+    and_i_click_on_save_and_continue
+  end
+
+  def and_i_fill_in_the_type_of_degree
+    fill_in 'candidate_interface_degree_wizard[international_type]', with: 'Doctorate of Philosophy'
+    and_i_click_on_save_and_continue
+  end
+
+  def and_i_fill_in_the_university
+    fill_in 'candidate_interface_degree_wizard[university]', with: 'Purdue University'
+    and_i_click_on_save_and_continue
+  end
+
+  def and_i_choose_whether_degree_is_completed
+    choose 'Yes'
+    and_i_click_on_save_and_continue
+  end
+
+  def and_i_select_no_grade_was_given
+    choose 'No'
+    and_i_click_on_save_and_continue
+  end
+
+  def and_i_fill_in_the_start_year
+    fill_in t('page_titles.what_year_did_you_start_your_degree'), with: '2006'
+    and_i_click_on_save_and_continue
+  end
+
+  def when_i_fill_in_the_award_year
+    fill_in t('page_titles.what_year_did_you_graduate'), with: '2009'
+    and_i_click_on_save_and_continue
+  end
+
+  def and_i_check_no_for_enic_statement
+    choose 'No'
+    and_i_click_on_save_and_continue
+  end
+
+  def when_i_mark_this_section_as_completed
+    choose t('application_form.completed_radio')
+  end
+
+  def then_i_see_the_form
+    expect(page).to have_content(t('page_titles.application_form'))
+  end
+
+  def and_that_the_section_is_completed
+    expect(page).to have_css('#degree-badge-id', text: 'Completed')
+  end
+
+  def then_i_can_check_my_international_degree
+    expect(page).to have_current_path candidate_interface_degree_review_path
+    expect(page).to have_content 'History'
+    within '[data-qa="degree-grade"]' do
+      expect(page).to have_content 'Grade'
+      expect(page).to have_content 'N/A'
+    end
+  end
+
+  def when_i_change_my_degree_grade_to_not_known
+    within '[data-qa="degree-grade"]' do
+      click_on 'Change'
+    end
+    choose 'I do not know'
+    and_i_click_on_save_and_continue
+  end
+
+  def then_i_can_check_the_grade_has_changed
+    expect(page).to have_current_path candidate_interface_degree_review_path
+    expect(page).to have_content 'History'
+    within '[data-qa="degree-grade"]' do
+      expect(page).to have_content 'Grade'
+      expect(page).to have_content 'Unknown'
+    end
+  end
+
+  def then_i_can_check_my_answers
+    expect(page).to have_content 'France'
+    within '[data-qa="degree-type"]' do
+      expect(page).to have_content 'Doctor'
+    end
+    expect(page).to have_content 'Purdue University'
+    expect(page).to have_content 'Doctorate of Philosophy, History,'
+    expect(page).to have_content '2006'
+    expect(page).to have_content '2009'
+  end
+end


### PR DESCRIPTION
## Context

Support tickets have appeared a number of times from candidates who cannot “Complete” the Degrees section of the Application Form.

This occurred when people selected "No" when answering the question 'Did your degree give a grade?'. Instead of storing 'N/A' as intended, 'nil' was being persisted. 

Candidates could not 'complete' this section without a grade value
AND we hid that row from people with Doctoral degrees, so they couldn't fix the problem or see why they couldn't complete the section.

There was no test coverage for any of this

## Changes proposed in this pull request

- Fixed the bug -- the method that assigned grades gets called twice during create. The first time worked fine, but the second time (after the correct grade was assigned), it failed. This was fine for other degree types because it could be edited. But candidates with a PhD were unable to edit the field.
- Allowed candidates with international doctoral degrees to edit the grade row
- Added some tests

| Before | After |
| ------ | ------ |
| ![image](https://github.com/user-attachments/assets/11c1774a-f88e-49a9-8872-0e9c2dbd956a) | ![image](https://github.com/user-attachments/assets/c7d57d7b-2847-4ef5-86b0-68e471c2b96d) | 

## Guidance to review

This can be tested in the review app by creating / editing degrees without degrees (no or I do not know).

## Link to Trello card

https://trello.com/c/cEMVRlft

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
