### PR TITLE
Remove Enic reason validation

### DIFF
--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -59,7 +59,6 @@ class ApplicationQualification < ApplicationRecord
 
   validates :qualification_type, length: { maximum: MAX_QUALIFICATION_TYPE_LENGTH }, allow_blank: true
   validates :non_uk_qualification_type, length: { maximum: MAX_QUALIFICATION_TYPE_LENGTH }, allow_blank: true
-  validates :enic_reason, presence: true
 
   enum enic_reason: {
     obtained: 'obtained',


### PR DESCRIPTION
## Context

After merging in the https://github.com/DFE-Digital/apply-for-teacher-training/pull/9588 we noticed a sentry errors where its failing on the validation of `enic_reason`. This PR removes this validation

## Changes proposed in this pull request

This PR removes this validation

Sentry error: https://dfe-teacher-services.sentry.io/issues/5654117824/?environment=production&project=1765973&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=7d&stream_index=0

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
