### PR TITLE
Create ENIC_REASON backfill migration

### DIFF
--- a/app/services/data_migrations/backfill_enic_reason.rb
+++ b/app/services/data_migrations/backfill_enic_reason.rb
@@ -1,0 +1,20 @@
+module DataMigrations
+  class BackfillEnicReason
+    TIMESTAMP = 20240729111251
+    MANUAL_RUN = false
+
+    def change
+      ApplicationQualification.where(enic_reason: nil).where.not(enic_reference: nil).in_batches do |batch|
+        batch.update_all(enic_reason: 'obtained')
+      end
+
+      ApplicationQualification.where(enic_reason: nil, enic_reference: nil, qualification_type: 'non_uk').in_batches do |batch|
+        batch.update_all(enic_reason: 'maybe')
+      end
+
+      ApplicationQualification.where(enic_reason: nil, enic_reference: nil).in_batches do |batch|
+        batch.update_all(enic_reason: 'not_needed')
+      end
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,6 +1,7 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
   'DataMigrations::BackfillWeek42PerformanceReportData',
+  'DataMigrations::BackfillEnicReason',
   'DataMigrations::RemoveRecruitmentPerformanceReportFeatureFlag',
   'DataMigrations::MigrateDataExportDataToFile',
   'DataMigrations::RemoveCoursesNotOnPublish',

--- a/spec/services/data_migrations/backfill_enic_reason_spec.rb
+++ b/spec/services/data_migrations/backfill_enic_reason_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillEnicReason do
+  context 'when backfilling an applications qualifications enic_reason' do
+    it 'backfills the enic_reason to obtained if enic_reference present' do
+      application_qualification = create(:application_qualification, enic_reason: nil, enic_reference: '1234')
+      described_class.new.change
+      expect(application_qualification.enic_reason).to eq('obtained')
+    end
+
+    it 'backfills the enic_reason to maybe for a non_uk qualification if enic_reference nil' do
+      application_qualification = create(:application_qualification, enic_reason: nil, enic_reference: nil, qualification_type: 'non_uk')
+      described_class.new.change
+      expect(application_qualification.enic_reason).to eq('maybe')
+    end
+
+    it 'backfills the enic_reason to not_needed if no enic_reference' do
+      application_qualification = create(:application_qualification)
+      described_class.new.change
+      expect(application_qualification.enic_reason).to eq('not_needed')
+    end
+  end
+end


### PR DESCRIPTION
## Context

Now we have the new `enic_reason` field we need to update all pre exisiting `ApplicationQualifications` to ensure they have an `enic_reason`.

PR for adding validation: https://github.com/DFE-Digital/apply-for-teacher-training/pull/9628

## Changes proposed in this pull request

Create a backfill migration to update the new field. This will also fix the sentry errors we had before reverting the PR where we removed the validation on the `enic_reason`.

## Guidance to review


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
