### PR TITLE
Add presence validation for enic_reason

### DIFF
--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -59,6 +59,7 @@ class ApplicationQualification < ApplicationRecord
 
   validates :qualification_type, length: { maximum: MAX_QUALIFICATION_TYPE_LENGTH }, allow_blank: true
   validates :non_uk_qualification_type, length: { maximum: MAX_QUALIFICATION_TYPE_LENGTH }, allow_blank: true
+  validates :enic_reason, presence: true, on: :create
 
   enum enic_reason: {
     obtained: 'obtained',

--- a/spec/factories/application_qualification.rb
+++ b/spec/factories/application_qualification.rb
@@ -23,6 +23,10 @@ FactoryBot.define do
     institution_country { international? ? Faker::Address.country_code : 'GB' }
     equivalency_details { Faker::Lorem.paragraph_by_chars(number: 200) }
 
+    trait :skip_validate do
+      to_create { |instance| instance.save(validate: false) }
+    end
+
     factory :gcse_qualification do
       level { 'gcse' }
       qualification_type { 'gcse' }

--- a/spec/forms/candidate_interface/maths_gcse_grade_form_spec.rb
+++ b/spec/forms/candidate_interface/maths_gcse_grade_form_spec.rb
@@ -121,6 +121,15 @@ RSpec.describe CandidateInterface::MathsGcseGradeForm, type: :model do
 
         expect(gcse.reload.grade).to eq('D')
       end
+
+      it 'does not raise validation error for enic_reason being nil' do
+        gcse = create(:gcse_qualification, :skip_validate, enic_reason: nil)
+        form = described_class.new(grade: 'other', other_grade: 'D', qualification_type: 'non_uk')
+
+        form.save(gcse)
+
+        expect(gcse.reload.enic_reason).to be_nil
+      end
     end
 
     describe '.build_from_qualification' do

--- a/spec/models/application_qualification_spec.rb
+++ b/spec/models/application_qualification_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe ApplicationQualification do
   end
 
   describe 'enic_reason' do
+    it { is_expected.to validate_presence_of(:enic_reason).on(:create) }
+
     it 'obtained waiting maybe, and not_needed' do
       %w[obtained waiting maybe not_needed].each do |enic_reason|
         expect { described_class.new(enic_reason:) }.not_to raise_error


### PR DESCRIPTION
## Context

Enforce presence validation for `enic_reason` on `ApplicationQualifications` ONLY on create

## Changes proposed in this pull request

Add `validates :enic_reason, presence: true, on: :create` to the `ApplicationQualification` model

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
