### PR TITLE
Backfilling week 42 data on performance reports

### DIFF
--- a/app/services/data_migrations/backfill_week42_performance_report_data.rb
+++ b/app/services/data_migrations/backfill_week42_performance_report_data.rb
@@ -1,0 +1,13 @@
+module DataMigrations
+  class BackfillWeek42PerformanceReportData
+    TIMESTAMP = 20240731130619
+    MANUAL_RUN = false
+
+    def change
+      Publications::NationalRecruitmentPerformanceReport.where(cycle_week: 42).destroy_all
+      Publications::ProviderRecruitmentPerformanceReport.where(cycle_week: 42).destroy_all
+
+      Publications::RecruitmentPerformanceReportScheduler.new(cycle_week: 42).call
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillWeek42PerformanceReportData',
   'DataMigrations::RemoveRecruitmentPerformanceReportFeatureFlag',
   'DataMigrations::MigrateDataExportDataToFile',
   'DataMigrations::RemoveCoursesNotOnPublish',

--- a/spec/services/data_migrations/backfill_week42_performance_report_data_spec.rb
+++ b/spec/services/data_migrations/backfill_week42_performance_report_data_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillWeek42PerformanceReportData do
+  it 'destroys existing week 42 data' do
+    national_report_week_43 = create(:national_recruitment_performance_report, cycle_week: 43)
+    national_report_week_42 = create(:national_recruitment_performance_report, cycle_week: 42)
+
+    provider_report_week_43 = create(:provider_recruitment_performance_report, cycle_week: 43)
+    provider_report_week_42 = create(:provider_recruitment_performance_report, cycle_week: 42)
+
+    described_class.new.change
+
+    expect(national_report_week_43.reload.present?).to be true
+    expect(provider_report_week_43.reload.present?).to be true
+
+    expect { national_report_week_42.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    expect { provider_report_week_42.reload }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+
+  describe 'creates new data' do
+    let(:provider_worker) { Publications::ProviderRecruitmentPerformanceReportWorker }
+    let(:national_worker) { Publications::NationalRecruitmentPerformanceReportWorker }
+    let(:provider) { create(:provider) }
+
+    before do
+      allow(national_worker).to receive(:perform_async)
+      allow(provider_worker).to receive(:perform_async)
+      provider
+      allow(ProvidersForRecruitmentPerformanceReportQuery).to receive(:call).with(cycle_week: 42).and_return(Provider)
+    end
+
+    it 'enqueues jobs for creating new data for week 42' do
+      described_class.new.change
+
+      expect(provider_worker).to have_received(:perform_async).with(provider.id, 42)
+      expect(national_worker).to have_received(:perform_async).with(42)
+    end
+  end
+end


### PR DESCRIPTION
## Context

Last week (week 42), there was an error in the Dataform pipelines and execution of downstream queries were blocked to prevent potentially inaccurate data and/or security issues until the bug was fixed. As a result, the recruitment performance data reports (both national and provider) are full of nil data in our database

The data for week 42 has been generated correctly now on BigData so we can replace the nil data with the correct week 42 data.

There won't be any disruption to users because the week 42 data is no longer visible to them -- we are onto week 43 data now and that was generated according to plan. 

## Changes proposed in this pull request

This PR replaces the existing week 42 data with the accurate week 42 data that was generated after our initial data fetch occurred on Monday morning.

## Guidance to review

You can test it locally if you have redis and sidekiq running. You can create some dummy week 42 data. Then run the migration. Your data should be replaced with new week 42 data. 

## Link to Trello card

https://trello.com/c/O8oL8sny

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
