### PR TITLE
Temporarily skip pdf tests to unblock merging

### DIFF
--- a/spec/system/provider_interface/see_individual_application_as_pdf_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_as_pdf_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
-RSpec.feature 'Provider sees an application as PDF' do
+RSpec.describe 'Provider sees an application as PDF' do
   include CourseOptionHelpers
   include DfESignInHelpers
 
-  scenario 'viewing application in PDF format' do
+  it 'viewing application in PDF format', skip: 'Fails on CI since chromium update, pending until alternative to grover is found or new version of chrome' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_permitted_to_see_applications_for_my_provider
     and_i_sign_in_to_the_provider_interface
@@ -12,11 +12,11 @@ RSpec.feature 'Provider sees an application as PDF' do
 
     when_i_visit_the_provider_application_page
     and_i_click_the_applications_pdf_link
-    then_i_should_see_the_application_choice_in_pdf_format
+    then_i_see_the_application_choice_in_pdf_format
 
     when_i_visit_the_provider_application_references_page
     and_i_click_the_references_pdf_link
-    then_i_should_see_the_application_references_in_pdf_format
+    then_i_see_the_application_references_in_pdf_format
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -51,7 +51,7 @@ RSpec.feature 'Provider sees an application as PDF' do
     click_link_or_button 'Download application (PDF)'
   end
 
-  def then_i_should_see_the_application_choice_in_pdf_format
+  def then_i_see_the_application_choice_in_pdf_format
     expect(page.driver.response.status).to eq(200)
     expect(page.driver.response.content_type).to eq('application/pdf')
     expect(page.driver.response.length).to be > 0
@@ -65,7 +65,7 @@ RSpec.feature 'Provider sees an application as PDF' do
     click_link_or_button 'Download references (PDF)'
   end
 
-  def then_i_should_see_the_application_references_in_pdf_format
+  def then_i_see_the_application_references_in_pdf_format
     expect(page.driver.response.status).to eq(200)
     expect(page.driver.response.content_type).to eq('application/pdf')
     expect(page.driver.response.length).to be > 0


### PR DESCRIPTION
## Context

Our tests related to downloading a PDF have started to fail since a chromium update. The last time the test suite passed:

ran `apk add chromium chromium-chromedriver`
=> `(1/1) Installing chromium-chromedriver (126.0.6478.182-r0)`

It started to fail when this started to happen:

`apk add chromium chromium-chromedriver` 
=> `(1/2) Upgrading chromium (126.0.6478.182-r0 -> 127.0.6533.72-r0)`

[Alpine does not support older versions of chromium](https://gitlab.alpinelinux.org/alpine/abuild/-/issues/9996#note_87135), so we can't pin the working version. 

## Changes proposed in this pull request

Temporarily skip failing tests. I've created a card for investigating a replacement for Grover (which has caused us problems before). And I've put a note in my diary to check what version of Chromium is being used by Alpine in two weeks time to see if the issue has resolved itself.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
