### PR TITLE
Fix flaky spec

### DIFF
--- a/spec/system/support_interface/revert_withdrawal/duplicate_application_choice_when_reverting_withdrawal_spec.rb
+++ b/spec/system/support_interface/revert_withdrawal/duplicate_application_choice_when_reverting_withdrawal_spec.rb
@@ -55,9 +55,7 @@ RSpec.describe 'Revert a withdrawn application choice' do
   end
 
   def then_i_see_the_withdrawn_course_choice
-    within(all('.app-summary-card__body')[0]) do
-      expect(page).to have_content('Withdrawn')
-    end
+    expect(page).to have_content('Withdrawn').once
   end
 
   def when_i_click_on_the_revert_withdrawal_link


### PR DESCRIPTION
## Context
We have a flaky spec. i think it fails occasionally because the withdrawn application isn't always the first one shown in the list.  

![image](https://github.com/user-attachments/assets/44bff2dd-cec7-4bb2-ba44-03142339cf65)

## Changes proposed in this pull request

Just look for the text on the page rather than in a specific css.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
