### PR TITLE
Ignore enic_reason from IGNORED_CHILD_ATTRIBUTES

### DIFF
--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -59,6 +59,7 @@ class ApplicationQualification < ApplicationRecord
 
   validates :qualification_type, length: { maximum: MAX_QUALIFICATION_TYPE_LENGTH }, allow_blank: true
   validates :non_uk_qualification_type, length: { maximum: MAX_QUALIFICATION_TYPE_LENGTH }, allow_blank: true
+  validates :enic_reason, presence: true, on: :create
 
   enum enic_reason: {
     obtained: 'obtained',

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -7,7 +7,7 @@ class DuplicateApplication
   end
 
   IGNORED_ATTRIBUTES = %w[id created_at updated_at submitted_at course_choices_completed phase support_reference english_main_language english_language_details other_language_details feedback_form_complete equality_and_diversity equality_and_diversity_completed].freeze
-  IGNORED_CHILD_ATTRIBUTES = %w[id created_at updated_at application_form_id public_id].freeze
+  IGNORED_CHILD_ATTRIBUTES = %w[id created_at updated_at application_form_id public_id enic_reason].freeze
 
   def duplicate
     attrs = original_application_form.attributes.except(

--- a/spec/factories/application_qualification.rb
+++ b/spec/factories/application_qualification.rb
@@ -23,6 +23,10 @@ FactoryBot.define do
     institution_country { international? ? Faker::Address.country_code : 'GB' }
     equivalency_details { Faker::Lorem.paragraph_by_chars(number: 200) }
 
+    trait :skip_validate do
+      to_create { |instance| instance.save(validate: false) }
+    end
+
     factory :gcse_qualification do
       level { 'gcse' }
       qualification_type { 'gcse' }

--- a/spec/forms/candidate_interface/maths_gcse_grade_form_spec.rb
+++ b/spec/forms/candidate_interface/maths_gcse_grade_form_spec.rb
@@ -121,6 +121,15 @@ RSpec.describe CandidateInterface::MathsGcseGradeForm, type: :model do
 
         expect(gcse.reload.grade).to eq('D')
       end
+
+      it 'does not raise validation error for enic_reason being nil' do
+        gcse = create(:gcse_qualification, :skip_validate, enic_reason: nil)
+        form = described_class.new(grade: 'other', other_grade: 'D', qualification_type: 'non_uk')
+
+        form.save(gcse)
+
+        expect(gcse.reload.enic_reason).to be_nil
+      end
     end
 
     describe '.build_from_qualification' do

--- a/spec/models/application_qualification_spec.rb
+++ b/spec/models/application_qualification_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe ApplicationQualification do
   end
 
   describe 'enic_reason' do
+    it { is_expected.to validate_presence_of(:enic_reason).on(:create) }
+
     it 'obtained waiting maybe, and not_needed' do
       %w[obtained waiting maybe not_needed].each do |enic_reason|
         expect { described_class.new(enic_reason:) }.not_to raise_error

--- a/spec/services/duplicate_application_spec.rb
+++ b/spec/services/duplicate_application_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe DuplicateApplication do
       create_list(:reference, 2, feedback_status: :feedback_provided, application_form: @original_application_form)
       create(:reference, feedback_status: :feedback_refused, application_form: @original_application_form)
       create(:application_choice, :rejected, application_form: @original_application_form)
+      create(:gcse_qualification, :skip_validate, enic_reason: nil, application_form: @original_application_form)
     end
   end
 
@@ -24,6 +25,10 @@ RSpec.describe DuplicateApplication do
   end
 
   let(:recruitment_cycle_year) { RecruitmentCycle.current_year }
+
+  it 'does not raise validation error for enic_reason being nil' do
+    expect(duplicate_application_form.application_qualifications.last.enic_reason).to eq 'maybe'
+  end
 
   it 'marks reference as incomplete' do
     expect(duplicate_application_form).not_to be_references_completed


### PR DESCRIPTION
## Context

When we duplicate an application it was raising a validation error for `enic_reason` being nil. This is possible as existing qualifications may have an `enic_reason` of nil (before we backfill). To fix this I have added `enic_reason` to `IGNORED_CHILD_ATTRIBUTES` and then when it hits `new_application_form.application_qualifications.create!` it will update the `enic_reason` based off the `enic_reference=(value)` method in the `ApplicationQualification` model.


[Sentry error ](https://dfe-teacher-services.sentry.io/issues/5654167119/?alert_rule_id=4434951&alert_type=issue&environment=production&notification_uuid=a95049d2-ad66-447e-9b7b-9b1b56660365&project=1765973&referrer=slack)
## Changes proposed in this pull request

Add `enic_reason` to the `IGNORED_CHILD_ATTRIBUTES` array

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
