### PR TITLE
Ignore ApplicationQualification#equivalency_details

### DIFF
--- a/app/decorators/application_choice_export_decorator.rb
+++ b/app/decorators/application_choice_export_decorator.rb
@@ -68,7 +68,7 @@ class ApplicationChoiceExportDecorator < SimpleDelegator
       comparable_uk_qualification = I18n.t("application_qualification.comparable_uk_degree.#{comparable_uk_qualification}") if comparable_uk_qualification
     end
 
-    [enic_reference, comparable_uk_qualification, first_degree.equivalency_details]
+    [enic_reference, comparable_uk_qualification]
       .compact
       .map(&:strip)
       .join(' - ')

--- a/app/decorators/degree_export_decorator.rb
+++ b/app/decorators/degree_export_decorator.rb
@@ -26,10 +26,6 @@ class DegreeExportDecorator
     pad_attribute(:institution_hesa_code, 4)
   end
 
-  def equivalency_details
-    pad_attribute(:equivalency_details, 2)
-  end
-
   def start_year
     year_to_iso8601(fetch_attribute(:start_year))
   end

--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -1,4 +1,5 @@
 class ApplicationQualification < ApplicationRecord
+  self.ignored_columns += %w[equivalency_details]
   include TouchApplicationChoices
   include TouchApplicationFormState
 
@@ -174,7 +175,6 @@ class ApplicationQualification < ApplicationRecord
     details = [
       ("Enic: #{enic_reference}" if enic_reference),
       comparable_uk_qualification || comparable_uk_degree,
-      equivalency_details,
     ].compact.join(' - ')
 
     details.strip if details.present?

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -161,7 +161,6 @@ shared:
     - created_at
     - enic_reason
     - enic_reference
-    - equivalency_details
     - grade
     - grade_hesa_code
     - id

--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -178,7 +178,6 @@ Create the same qualification locally, turn the relevant fields into JSON, paste
 
 If you are asked to add an ENIC number to a qualification, you should first make sure that what you are being asked to do is reflected on the ENIC statement. If you are in doubt refer it back to support or to policy.
 
-`equivalency_details` is a field on the `ApplicationQualification` model, but it is not used. Do not add any data to this field. There is a card on trello to remove it from the database.
 For all international qualifications, you'll have to include an `institution_country`: https://github.com/DFE-Digital/apply-for-teacher-training/blob/78c9421d8582f63cfdec564b5c0677bfd787552c/config/initializers/countries_and_territories.rb
 
 ***Degrees***
@@ -203,7 +202,6 @@ ApplicationQualification.find(QUALIFICATION_ID).update!(
   qualification_type: 'non_uk',
   non_uk_qualification_type: nil, # not to be confused with the comparable_uk_degree. This can should be blank for degrees
   award_year: AWARD_YEAR,
-  equivalency_details: nil,
   )
 ````
 

--- a/spec/decorators/application_choice_export_decorator_spec.rb
+++ b/spec/decorators/application_choice_export_decorator_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe ApplicationChoiceExportDecorator do
 
       summary = described_class.new(application_choice).formatted_equivalency_details
 
-      expect(summary).to match(/^ENIC: \d+ - Bachelor's degree \(ordinary\) - /)
+      expect(summary).to match(/^ENIC: \d+ - Bachelor's degree \(ordinary\)/)
     end
   end
 end

--- a/spec/decorators/degree_export_decorator_spec.rb
+++ b/spec/decorators/degree_export_decorator_spec.rb
@@ -95,24 +95,6 @@ RSpec.describe DegreeExportDecorator do
     end
   end
 
-  describe '#equivalency_details' do
-    context 'when degree is present' do
-      before { allow(degree).to receive(:equivalency_details).and_return('Some details') }
-
-      it 'returns the equivalency details padded to 2 digits' do
-        expect(decorator.equivalency_details).to eq('Some details')
-      end
-    end
-
-    context 'when degree is nil' do
-      let(:degree) { nil }
-
-      it 'returns "no degree"' do
-        expect(decorator.equivalency_details).to eq('no degree')
-      end
-    end
-  end
-
   describe '#start_year' do
     context 'when degree is present' do
       before { allow(degree).to receive(:start_year).and_return(2020) }

--- a/spec/factories/application_qualification.rb
+++ b/spec/factories/application_qualification.rb
@@ -21,7 +21,6 @@ FactoryBot.define do
     award_year { Faker::Date.between(from: 10.years.ago, to: 1.year.ago).year }
     institution_name { Faker::University.name }
     institution_country { international? ? Faker::Address.country_code : 'GB' }
-    equivalency_details { Faker::Lorem.paragraph_by_chars(number: 200) }
 
     factory :gcse_qualification do
       level { 'gcse' }

--- a/spec/models/application_qualification_spec.rb
+++ b/spec/models/application_qualification_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe ApplicationQualification do
       'award_year',
       'institution_name',
       'institution_country',
-      'equivalency_details',
     )
   end
 
@@ -262,24 +261,13 @@ RSpec.describe ApplicationQualification do
         institution_country: 'US',
         enic_reference: '0123456789',
         comparable_uk_degree: 'bachelor_honours_degree',
-        equivalency_details: 'equivalent to a UK BSc',
       )
 
-      expect(degree.composite_equivalency_details).to eq('Enic: 0123456789 - bachelor_honours_degree - equivalent to a UK BSc')
-    end
-
-    it 'returns a sentence describing equivalency details for a GCSE level qualification' do
-      gcse = build_stubbed(
-        :gcse_qualification,
-        qualification_type: 'scottish_national_5',
-        equivalency_details: 'equivalent to a GCSE',
-      )
-
-      expect(gcse.composite_equivalency_details).to eq('equivalent to a GCSE')
+      expect(degree.composite_equivalency_details).to eq('Enic: 0123456789 - bachelor_honours_degree')
     end
 
     it 'returns nil if there is no data to show' do
-      gcse = build_stubbed(:gcse_qualification, equivalency_details: nil)
+      gcse = build_stubbed(:gcse_qualification)
 
       expect(gcse.composite_equivalency_details).to be_nil
     end

--- a/spec/presenters/concerns/qualification_api_data_spec.rb
+++ b/spec/presenters/concerns/qualification_api_data_spec.rb
@@ -42,30 +42,6 @@ RSpec.describe QualificationAPIData do
       end
     end
 
-    context 'equivalency_details' do
-      context 'default' do
-        let!(:qualification) { create(:other_qualification, :non_uk, application_form: application_choice.application_form) }
-
-        it "renders the qualification's equivalency_details" do
-          expect(presenter.qualifications[:other_qualifications][0][:equivalency_details]).to eq(qualification.equivalency_details)
-        end
-      end
-
-      context 'with ENIC information' do
-        let!(:qualification) { create(:gcse_qualification, :non_uk, application_form: application_choice.application_form) }
-
-        it 'renders the correct information' do
-          composite_equivalency_details = [
-            "Enic: #{qualification.enic_reference}",
-            qualification.comparable_uk_qualification,
-            qualification.equivalency_details,
-          ].join(' - ')
-
-          expect(presenter.qualifications[:gcses][0][:equivalency_details]).to eq(composite_equivalency_details)
-        end
-      end
-    end
-
     context 'non_uk_qualification_type' do
       let!(:qualification) { create(:gcse_qualification, :non_uk, application_form: application_choice.application_form) }
 

--- a/spec/presenters/register_api/single_application_presenter_spec.rb
+++ b/spec/presenters/register_api/single_application_presenter_spec.rb
@@ -621,22 +621,6 @@ RSpec.describe RegisterAPI::SingleApplicationPresenter do
       expect(qualification_hash).to have_key(:hesa_degstdt)
     end
 
-    it 'contains equivalency_details' do
-      qualification = create(
-        :other_qualification,
-        :non_uk,
-        application_form: application_choice.application_form,
-      )
-
-      equivalency_details = presenter.as_json.dig(
-        :attributes,
-        :qualifications,
-        :other_qualifications,
-      ).first[:equivalency_details]
-
-      expect(equivalency_details).to eq(qualification.equivalency_details)
-    end
-
     it 'adds ENIC information, if present, to equivalency_details' do
       qualification = create(
         :gcse_qualification,
@@ -653,7 +637,6 @@ RSpec.describe RegisterAPI::SingleApplicationPresenter do
       composite_equivalency_details = [
         "Enic: #{qualification.enic_reference}",
         qualification.comparable_uk_qualification,
-        qualification.equivalency_details,
       ].join(' - ')
 
       expect(equivalency_details).to eq(composite_equivalency_details)


### PR DESCRIPTION
## Context

This column is not used in production it's nil for most records. There are only five records with any data in this field – and the data is Lorem Epsom, so test data rather than actual qualification data.

This column is not used in any form.

## Changes proposed in this pull request

Remove the equivalency_details column use

## Guidance to review

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
