### PR TITLE
Ignore ApplicationQualification#equivalency_details

### DIFF
--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -1,4 +1,5 @@
 class ApplicationQualification < ApplicationRecord
+  self.ignored_columns += %w[equivalency_details]
   include TouchApplicationChoices
   include TouchApplicationFormState
 

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -161,7 +161,6 @@ shared:
     - created_at
     - enic_reason
     - enic_reference
-    - equivalency_details
     - grade
     - grade_hesa_code
     - id


### PR DESCRIPTION
## Context

This column is not used in production it's nil for most records. There are only five records with any data in this field – and the data is Lorem Epsom, so test data rather than actual qualification data.

This column is not used in any form. It will be removed in a future PR.

## Changes proposed in this pull request

Ignore equivalency_details from model and dfe analytics

## Guidance to review

Do specs pass?

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
