### PR TITLE
Always get the latest report ordered by cycle week

### DIFF
--- a/app/controllers/provider_interface/reports/recruitment_performance_reports_controller.rb
+++ b/app/controllers/provider_interface/reports/recruitment_performance_reports_controller.rb
@@ -3,7 +3,7 @@ module ProviderInterface
     class RecruitmentPerformanceReportsController < ProviderInterfaceController
       def show
         @provider = current_user.providers.find(provider_id)
-        @provider_report = Publications::ProviderRecruitmentPerformanceReport.where(provider: @provider).last
+        @provider_report = Publications::ProviderRecruitmentPerformanceReport.where(provider: @provider).order(:cycle_week).last
         @provider_data = @provider_report&.statistics
         @national_data = national_report&.statistics
       end


### PR DESCRIPTION
## Context

Last week we had to backfill some data for the recruitment performance report. Because the controller was just looking for the `last` report, we would have been showing providers the backfilled data rather than the latest data. 

## Changes proposed in this pull request

Orders the reports by cycle week because calling `last`

## Guidance to review


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
