### PR TITLE
Handled `sent_to_provider_at` being nil

### DIFF
--- a/app/presenters/vendor_api/application_presenter/add_sent_to_provider_datetime.rb
+++ b/app/presenters/vendor_api/application_presenter/add_sent_to_provider_datetime.rb
@@ -2,7 +2,7 @@ module VendorAPI::ApplicationPresenter::AddSentToProviderDatetime
   def schema
     super.deep_merge!({
       attributes: {
-        sent_to_provider_at: application_choice.sent_to_provider_at.iso8601,
+        sent_to_provider_at: application_choice.sent_to_provider_at&.iso8601,
       },
     })
   end

--- a/spec/presenters/vendor_api/v1.5/application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.5/application_presenter_spec.rb
@@ -16,5 +16,17 @@ RSpec.describe 'ApplicationPresenter' do
     it 'returns the date and time the application was sent to the provider' do
       expect(sent_to_provider_at).to eq('2024-07-10T13:00:00+01:00')
     end
+
+    context 'when sent_provider_at is nil' do
+      let(:application_choice) {
+        create(:application_choice,
+               application_form: create(:application_form, :submitted),
+               sent_to_provider_at: nil)
+      }
+
+      it 'returns nil' do
+        expect(sent_to_provider_at).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

This should only be happening in the Support Console
Raises Sentry error https://dfe-teacher-services.sentry.io/issues/5678398911/?referrer=slack&alert_rule_id=853774&alert_type=issue

## Changes proposed in this pull request

- Added safety operator to handle nil values

## Guidance to review

N/A

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
