### PR TITLE
Move field from pii to hidden pii

### DIFF
--- a/config/analytics_hidden_pii.yml
+++ b/config/analytics_hidden_pii.yml
@@ -1,0 +1,15 @@
+---
+shared:
+  application_forms:
+    - support_reference
+    - candidate_id
+  candidates:
+    - id
+  support_users:
+    - dfe_sign_in_uid
+  provider_users:
+    - dfe_sign_in_uid
+  validation_errors:
+    - user_id
+  emails:
+    - subject

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -1,14 +1,2 @@
-shared:
-  application_forms:
-    - support_reference
-    - candidate_id
-  candidates:
-    - id
-  support_users:
-    - dfe_sign_in_uid
-  provider_users:
-    - dfe_sign_in_uid
-  validation_errors:
-    - user_id
-  emails:
-    - subject
+---
+shared: {}


### PR DESCRIPTION
### Context

We are sending the hidden PII fields separately from other fields that we send to Bigquery.

This means on Bigquery the fields will obfuscated depending on the policy permissions the user has when querying.

For more information about the hidden API there are more details in the Readme:
https://github.com/DFE-Digital/dfe-analytics
