### PR TITLE
[2109] Reinstate reject and decline by default jobs for end of cycle only

### DIFF
--- a/app/helpers/cycle_timetable_helper.rb
+++ b/app/helpers/cycle_timetable_helper.rb
@@ -32,4 +32,12 @@ module_function
   def after_reject_by_default(year = CycleTimetable.current_year)
     CycleTimetable.reject_by_default(year) + 1.day
   end
+
+  def reject_by_default_run_date(year = CycleTimetable.current_year)
+    CycleTimetable.reject_by_default(year) + 1.second
+  end
+
+  def decline_by_default_run_date(year = CycleTimetable.current_year)
+    CycleTimetable.decline_by_default_date(year) + 1.second
+  end
 end

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -48,6 +48,7 @@ class ApplicationStateChange
     state :inactive do
       event :make_offer, transitions_to: :offer
       event :reject, transitions_to: :rejected
+      event :reject_by_default, transitions_to: :rejected
       event :withdraw, transitions_to: :withdrawn
       event :interview, transitions_to: :interviewing
     end

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -95,6 +95,18 @@ class CycleTimetable
     date(:reject_by_default, year)
   end
 
+  def self.decline_by_default_date(year = current_year)
+    find_closes(year) - 1.day
+  end
+
+  def self.run_decline_by_default?(year = current_year)
+    current_date.between?(decline_by_default_date(year), find_closes(year))
+  end
+
+  def self.run_reject_by_default?(year = current_year)
+    current_date.between?(reject_by_default(year), reject_by_default + 1.day)
+  end
+
   def self.cancel_unsubmitted_applications?
     current_date.to_date == apply_deadline.to_date
   end

--- a/app/services/end_of_cycle/decline_by_default_service.rb
+++ b/app/services/end_of_cycle/decline_by_default_service.rb
@@ -1,0 +1,26 @@
+module EndOfCycle
+  class DeclineByDefaultService
+    def initialize(application_form)
+      @application_form = application_form
+    end
+
+    def call
+      application_choices_to_decline.find_each do |application_choice|
+        ActiveRecord::Base.transaction do
+          application_choice.update!(
+            declined_by_default: true,
+            declined_at: Time.zone.now,
+            withdrawn_or_declined_for_candidate_by_provider: false,
+          )
+          ApplicationStateChange.new(application_choice).decline_by_default!
+        end
+      end
+    end
+
+  private
+
+    def application_choices_to_decline
+      @application_form.application_choices.offer
+    end
+  end
+end

--- a/app/services/end_of_cycle/reject_by_default_service.rb
+++ b/app/services/end_of_cycle/reject_by_default_service.rb
@@ -1,0 +1,40 @@
+module EndOfCycle
+  class RejectByDefaultService
+    REJECTABLE_STATUSES = ApplicationStateChange::DECISION_PENDING_AND_INACTIVE_STATUSES.freeze
+
+    def initialize(application_form)
+      @application_form = application_form
+    end
+
+    def call
+      application_choices_to_reject.find_each do |application_choice|
+        ActiveRecord::Base.transaction do
+          reject_application_choice!(application_choice)
+          cancel_interviews!(application_choice)
+        end
+      end
+    end
+
+  private
+
+    def application_choices_to_reject
+      @application_choices_to_reject ||= @application_form.application_choices.where(status: REJECTABLE_STATUSES)
+    end
+
+    def reject_application_choice!(application_choice)
+      ApplicationStateChange.new(application_choice).reject_by_default!
+      application_choice.update!(
+        rejected_by_default: true,
+        rejected_at: Time.zone.now,
+      )
+    end
+
+    def cancel_interviews!(application_choice)
+      cancellation_reason = I18n.t('interview_cancellation.reason.application_rejected')
+      application_choice.interviews.kept.upcoming_not_today.each do |interview|
+        interview.update!(cancellation_reason:, cancelled_at: Time.zone.now)
+        CandidateMailer.interview_cancelled(application_choice, interview, cancellation_reason).deliver_later
+      end
+    end
+  end
+end

--- a/app/workers/cancel_unsubmitted_applications_worker.rb
+++ b/app/workers/cancel_unsubmitted_applications_worker.rb
@@ -14,7 +14,6 @@ private
 
     ApplicationForm
       .current_cycle
-      .where.not(application_forms: { candidate_id: Candidate.where(hide_in_reporting: true).select(:id) })
       .includes(:application_choices).where('application_choices.status': 'unsubmitted')
       .distinct
   end

--- a/app/workers/end_of_cycle/decline_by_default_worker.rb
+++ b/app/workers/end_of_cycle/decline_by_default_worker.rb
@@ -1,0 +1,22 @@
+module EndOfCycle
+  class DeclineByDefaultWorker
+    include Sidekiq::Worker
+
+    def perform
+      declineable_applications.each do |application_form|
+        EndOfCycle::DeclineByDefaultService.new(application_form).call
+      end
+    end
+
+  private
+
+    def declineable_applications
+      return [] unless CycleTimetable.run_decline_by_default?
+
+      ApplicationForm
+        .current_cycle
+        .includes(:application_choices).where('application_choices.status': 'offer')
+        .distinct
+    end
+  end
+end

--- a/app/workers/end_of_cycle/reject_by_default_worker.rb
+++ b/app/workers/end_of_cycle/reject_by_default_worker.rb
@@ -1,0 +1,22 @@
+module EndOfCycle
+  class RejectByDefaultWorker
+    include Sidekiq::Worker
+
+    def perform
+      rejectable_applications.each do |application_form|
+        EndOfCycle::RejectByDefaultService.new(application_form).call
+      end
+    end
+
+  private
+
+    def rejectable_applications
+      return [] unless CycleTimetable.run_reject_by_default?
+
+      ApplicationForm
+        .current_cycle
+        .includes(:application_choices).where('application_choices.status': EndOfCycle::RejectByDefaultService::REJECTABLE_STATUSES)
+        .distinct
+    end
+  end
+end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -47,7 +47,13 @@ class Clock
   every(1.day, 'SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesWorker', at: '10:00') { SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesWorker.perform_async }
   every(1.day, 'DfE::Analytics::EntityTableCheckJob', at: '00:30') { DfE::Analytics::EntityTableCheckJob.perform_later }
 
+  # End of cycle application choice status jobs
+  # change unsubmitted application choices to 'application_not_sent'
   every(1.day, 'CancelUnsubmittedApplicationsWorker', at: '19:00') { CancelUnsubmittedApplicationsWorker.perform_async }
+  # Reject any application choices that are still awaiting provider decision (interviewing, inactive, and awaiting decision)
+  every(1.day, 'EndOfCycle::RejectByDefaultWorker', at: '00:01') { EndOfCycle::RejectByDefaultWorker.perform_async }
+  # Decline any offers that are awaiting candidate decision
+  every(1.day, 'EndOfCycle::DeclineByDefaultWorker', at: '00:01') { EndOfCycle::DeclineByDefaultWorker.perform_async }
 
   # Daily jobs - mon-thurs only
   every(1.day, 'SendStatsSummaryToSlack', at: '17:00', if: ->(period) { period.wday.between?(1, 4) }) { SendStatsSummaryToSlack.new.perform }

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -284,7 +284,7 @@ en:
       description: |
         An application is inactive if the provider does not make an offer within 30 working days after they have received an application.
 
-    awaiting_provider_decision-reject_by_default:
+    awaiting_provider_decision-reject_by_default: &awaiting_provider_decision-reject_by_default
       name: Rejected by default
       by: system
       description: |
@@ -294,6 +294,8 @@ en:
     inactive-interview: *awaiting_provider_decision-interview
     inactive-reject: *awaiting_provider_decision-reject
     inactive-withdraw: *awaiting_provider_decision-withdraw
+    inactive-reject_by_default: *awaiting_provider_decision-reject_by_default
+
 
     interviewing-make_offer:
       name: Provider makes offer

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -678,4 +678,68 @@ RSpec.describe CycleTimetable do
       end
     end
   end
+
+  describe '#run_decline_by_default?' do
+    before { TestSuiteTimeMachine.travel_permanently_to(date) }
+
+    context 'after find closes' do
+      let(:date) { described_class.find_closes + 1.minute }
+
+      it 'returns false' do
+        expect(described_class.run_decline_by_default?).to be false
+      end
+    end
+
+    context 'after reject by default' do
+      let(:date) { described_class.reject_by_default }
+
+      it 'returns false' do
+        expect(described_class.run_decline_by_default?).to be false
+      end
+    end
+
+    context 'more than a day before find closes' do
+      let(:date) { described_class.find_closes - 25.hours }
+
+      it 'returns false' do
+        expect(described_class.run_decline_by_default?).to be false
+      end
+    end
+
+    context 'day before find closes' do
+      let(:date) { described_class.find_closes - 23.hours }
+
+      it 'returns true' do
+        expect(described_class.run_decline_by_default?).to be true
+      end
+    end
+  end
+
+  describe '#run_reject_by_default?' do
+    before { TestSuiteTimeMachine.travel_permanently_to(date) }
+
+    context 'before reject by default date' do
+      let(:date) { described_class.reject_by_default - 1.minute }
+
+      it 'returns false' do
+        expect(described_class.run_reject_by_default?).to be false
+      end
+    end
+
+    context 'over a day after the reject by default date' do
+      let(:date) { described_class.reject_by_default + 1.day + 1.second }
+
+      it 'returns false' do
+        expect(described_class.run_reject_by_default?).to be false
+      end
+    end
+
+    context 'within one day of the reject by default date' do
+      let(:date) { described_class.reject_by_default + 1.day }
+
+      it 'returns true' do
+        expect(described_class.run_reject_by_default?).to be true
+      end
+    end
+  end
 end

--- a/spec/services/end_of_cycle/reject_by_default_service_spec.rb
+++ b/spec/services/end_of_cycle/reject_by_default_service_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe EndOfCycle::RejectByDefaultService do
+  describe '#call' do
+    it 'only rejects application choices in rejectable states' do
+      application_form = create(:application_form)
+      inactive_choice = create(:application_choice, :inactive, application_form:)
+      interviewing_choice = create(:application_choice, :interviewing, application_form:)
+      awaiting_decision_choice = create(:application_choice, :awaiting_provider_decision, application_form:)
+      offered_choice = create(:application_choice, :offer, application_form:)
+
+      described_class.new(application_form).call
+
+      expect(inactive_choice.reload.status).to eq('rejected')
+      expect(inactive_choice.rejected_by_default).to be(true)
+      expect(interviewing_choice.reload.status).to eq('rejected')
+      expect(interviewing_choice.rejected_by_default).to be(true)
+      expect(awaiting_decision_choice.reload.status).to eq('rejected')
+      expect(awaiting_decision_choice.rejected_by_default).to be(true)
+
+      expect(offered_choice.reload.status).to eq('offer')
+      expect(offered_choice.rejected_by_default).to be(false)
+    end
+
+    it 'cancels interviews' do
+      application_form = create(:application_form)
+      interviewing_choice = create(:application_choice, :interviewing, application_form:)
+      interview = interviewing_choice.interviews.kept.upcoming_not_today.first
+
+      described_class.new(application_form).call
+
+      expect(interview.reload.cancellation_reason).to eq('Your application was unsuccessful.')
+    end
+  end
+end

--- a/spec/workers/cancel_unsubmitted_applications_worker_spec.rb
+++ b/spec/workers/cancel_unsubmitted_applications_worker_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe CancelUnsubmittedApplicationsWorker do
             expect(unsubmitted_application_from_this_year.reload.application_choices.first).to be_application_not_sent
             expect(unsubmitted_application_from_last_year.reload.application_choices.first).not_to be_application_not_sent
             expect(rejected_application_from_this_year.reload.application_choices.first).not_to be_application_not_sent
-            expect(hidden_application_from_this_year.reload.application_choices.first).not_to be_application_not_sent
+            expect(hidden_application_from_this_year.reload.application_choices.first).to be_application_not_sent
             expect(unsubmitted_cancelled_application_from_this_year.reload.application_choices.first).to be_application_not_sent
           end
         end

--- a/spec/workers/end_of_cycle/decline_by_default_worker_spec.rb
+++ b/spec/workers/end_of_cycle/decline_by_default_worker_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe EndOfCycle::DeclineByDefaultWorker do
+  describe '#perform' do
+    context 'for previous cycle, current cycle, next cycle' do
+      [RecruitmentCycle.previous_year, RecruitmentCycle.current_year, RecruitmentCycle.next_year].each do |year|
+        context 'after the decline by default date', time: decline_by_default_run_date(year) do
+          it 'calls DeclineByDefaultService' do
+            declineable = create(:application_choice, :offer)
+            decline_service = spy
+            allow(EndOfCycle::DeclineByDefaultService)
+              .to receive(:new)
+              .with(declineable.application_form)
+              .and_return(decline_service)
+            described_class.new.perform
+            expect(decline_service).to have_received(:call)
+          end
+
+          it 'changes inactive application to declined by default' do
+            declineable = create(:application_choice, :offer)
+            described_class.new.perform
+
+            expect(declineable.reload.status).to eq 'declined'
+            expect(declineable.declined_by_default).to be true
+          end
+        end
+
+        context 'between cycles, but not on decline by default date', time: after_apply_deadline(year) do
+          it 'does not run DeclineByDefaultService' do
+            declineable = create(:application_choice, :offer)
+
+            task = described_class.new.perform
+
+            expect(task).to eq []
+            expect(declineable.reload.status).to eq 'offer'
+          end
+        end
+
+        context 'in mid-cycle', time: mid_cycle(year) do
+          it 'does not run DeclineByDefaultService' do
+            declineable = create(:application_choice, :offer)
+
+            task = described_class.new.perform
+
+            expect(task).to eq []
+            expect(declineable.reload.status).to eq 'offer'
+          end
+        end
+
+        context 'after_apply_reopens', time: after_apply_reopens(year) do
+          it 'does not run once the new cycle starts' do
+            declineable = create(:application_choice, :offer)
+
+            task = described_class.new.perform
+
+            expect(task).to eq []
+            expect(declineable.reload.status).to eq 'offer'
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/workers/end_of_cycle/reject_by_default_worker_spec.rb
+++ b/spec/workers/end_of_cycle/reject_by_default_worker_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe EndOfCycle::RejectByDefaultWorker do
+  describe '#perform' do
+    context 'for previous cycle, current cycle, next cycle' do
+      [RecruitmentCycle.previous_year, RecruitmentCycle.current_year, RecruitmentCycle.next_year].each do |year|
+        context 'after the reject by default date', time: reject_by_default_run_date(year) do
+          it 'calls EndOfCycleRejectByDefaultService' do
+            rejection_service = spy
+            rejectable = create(:application_choice, :inactive)
+            allow(EndOfCycle::RejectByDefaultService).to receive(:new).with(rejectable.application_form).and_return(rejection_service)
+            described_class.new.perform
+
+            expect(rejection_service).to have_received(:call)
+          end
+
+          it 'changes rejectable application to rejected by default' do
+            inactive_choice = create(:application_choice, :inactive)
+            interviewing_choice = create(:application_choice, :interviewing)
+            awaiting_decision_choice = create(:application_choice, :awaiting_provider_decision)
+            offered_choice = create(:application_choice, :offer)
+
+            described_class.new.perform
+
+            expect(inactive_choice.reload.status).to eq('rejected')
+            expect(inactive_choice.rejected_by_default).to be(true)
+            expect(interviewing_choice.reload.status).to eq('rejected')
+            expect(interviewing_choice.rejected_by_default).to be(true)
+            expect(awaiting_decision_choice.reload.status).to eq('rejected')
+            expect(awaiting_decision_choice.rejected_by_default).to be(true)
+
+            expect(offered_choice.reload.status).to eq('offer')
+            expect(offered_choice.rejected_by_default).to be(false)
+          end
+        end
+
+        context 'between cycles, but not on reject by default date', time: after_apply_deadline(year) do
+          it 'does not run RejectionByDefaultService' do
+            rejectable = create(:application_choice, :inactive)
+
+            task = described_class.new.perform
+
+            expect(task).to eq []
+            expect(rejectable.reload.status).to eq 'inactive'
+          end
+        end
+
+        context 'in mid-cycle', time: mid_cycle(year) do
+          it 'does not run RejectionByDefaultService' do
+            rejectable = create(:application_choice, :inactive)
+
+            task = described_class.new.perform
+
+            expect(task).to eq []
+            expect(rejectable.reload.status).to eq 'inactive'
+          end
+        end
+
+        context 'after_apply_reopens', time: after_apply_reopens(year) do
+          it 'does not run once the new cycle starts' do
+            rejectable = create(:application_choice, :inactive)
+
+            task = described_class.new.perform
+
+            expect(task).to eq []
+            expect(rejectable.reload.status).to eq 'inactive'
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Three things should happen during the end of cycle period to change the state of application choices
- **Application deadline**: Unsubmitted applications are cancelled (transition to `application_not_sent`). This is already implemented
- **Reject by default date**: All applications awaiting provider decision are rejected. i.e. `awaiting provider decision`, `interviewing`, and `inactive` all transition to `rejected`). 
- **The day before find opens**: Offers that have not been accepted by candidates are declined by default

## Changes proposed in this pull request

Implements the two missing jobs: 
- reject by default
- decline by default

## Guidance to review
It's a bit difficult to run using the cycle switcher in the review app, because the 'Apply deadline has passed ' option is too soon, and the 'Find has closed' option is too late.

Locally, you can manually adjust the dates for the 2024 cycle so you can run them. 

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
