### PR TITLE
Attempt to fix Grover

### DIFF
--- a/config/initializers/grover.rb
+++ b/config/initializers/grover.rb
@@ -9,7 +9,7 @@ Grover.configure do |config|
     },
     print_background: true,
     scale: 0.8,
-    launch_args: ['--disable-dev-shm-usage', '--no-sandbox', '--disable-setuid-sandbox'],
+    launch_args: ['--disable-gpu', '--disable-dev-shm-usage', '--no-sandbox', '--disable-setuid-sandbox'],
   }
   config.ignore_path = /^(?!\/provider\/applications\/\d+)/
 end


### PR DESCRIPTION
## Context

We are experiencing timeout issues when users download PDFs in the provider interface (download applications and references)

The response for downloading PDFs is reaching 3.3 minutes then a Grover timeout happens with the spike in CPU usage.

**Then the cpu usage skyrocket and  prod containers are restarted several times AND making Apply to be very slow.**

## Issues in other repos:

https://github.com/Studiosity/grover/issues/248
https://github.com/Studiosity/grover/issues/233


## Solution

Tried this: https://github.com/Studiosity/grover/issues/248#issuecomment-2264783556