### PR TITLE
remove ApplicationQualification#equivalency_details

### DIFF
--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -1,5 +1,4 @@
 class ApplicationQualification < ApplicationRecord
-  self.ignored_columns += %w[equivalency_details]
   include TouchApplicationChoices
   include TouchApplicationFormState
 


### PR DESCRIPTION
## Context

`ApplicationQualifications#equivalency_details` has been droped https://github.com/DFE-Digital/apply-for-teacher-training/pull/9648 just need to remove the ignored column
