### PR TITLE
Remove unused config in hidden PII

### DIFF
--- a/config/analytics_hidden_pii.yml
+++ b/config/analytics_hidden_pii.yml
@@ -5,8 +5,6 @@ shared:
     - candidate_id
   candidates:
     - id
-  support_users:
-    - dfe_sign_in_uid
   provider_users:
     - dfe_sign_in_uid
   validation_errors:


### PR DESCRIPTION
## Context

The dfe sign uid for support users is on the blocklist so this is not needed for hidden PII for a field we don't send to Bigquery.
