### PR TITLE
Added database indexing on the emails table

### DIFF
--- a/db/migrate/20240807160614_add_index_on_email_created_at.rb
+++ b/db/migrate/20240807160614_add_index_on_email_created_at.rb
@@ -1,0 +1,7 @@
+class AddIndexOnEmailCreatedAt < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :emails, :created_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -501,6 +501,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_08_124535) do
     t.datetime "updated_at", null: false
     t.string "delivery_status", default: "unknown", null: false
     t.index ["application_form_id"], name: "index_emails_on_application_form_id"
+    t.index ["created_at"], name: "index_emails_on_created_at"
     t.index ["notify_reference"], name: "index_emails_on_notify_reference"
   end
 


### PR DESCRIPTION
## Context

The current emails table has no indexing on the `id` column. This is causing page load errors when trying to view the Email Logs.

## Changes proposed in this pull request

Added index on emails.id and emails.created_at

Adding both of these indexes locally reduced the count on the emails table from ~11s down to ~200ms based on 10 million rows

**We probably want to run this when the service is quiet due to potential RAM requirements**

## Guidance to review

<details>
<summary>Generate 10m rows in the emails table locally</summary>

```sql
INSERT INTO bat_apply_development.public.emails
(
    "to",
    subject,
    mailer,
    mail_template,
    body,
    notify_reference,
    application_form_id,
    created_at,
    updated_at,
    delivery_status
)
SELECT
--     TO
'email_' || seq || '@example.com',
--     SUBJECT
'This is some subject' || seq,
--     MAILER
(
    CASE (RANDOM() * 3)::INT
        WHEN 0 THEN 'provider_mailer'
        WHEN 1 THEN 'authentication_mailer'
        WHEN 2 THEN 'candidate_mailer'
        ELSE 'support_mailer'
        END
    ),
--     MAIL_TEMPLATE
(
    CASE (RANDOM() * 3)::INT
        WHEN 0 THEN 'nudge_unsubmitted'
        WHEN 1 THEN 'permissions_updated'
        WHEN 2 THEN 'sign_up_email'
        ELSE 'confirm_sign_in'
        END
    ),
--     BODY
'This is some body' || seq,
-- NOTIFY REFERENCE,
'notify_reference_' || seq,
-- APPLICATION_FORM_ID
(RANDOM() * 50 + 1)::INT,
-- CREATED AT
NOW(),
-- UPDATED AT
NOW(),
-- DELIVERY STATUS
'pending'
FROM GENERATE_SERIES(1, 10000000) AS seq
```
</details>


<details>
<summary>Analyse the emails count query: note the Execution Time</summary>

```sql
EXPLAIN (ANALYSE) SELECT COUNT(*) FROM "emails" WHERE (created_at >= '2024-07-08 23:00:00')
```
</details>

<details>
<summary>Run migrations in this PR</summary>

```shell
rails db:migrate
```
</details>

<details>
<summary>Analyse and compare the emails count query: note the Execution Time</summary>

```sql
EXPLAIN (ANALYSE) SELECT COUNT(*) FROM "emails" WHERE (created_at >= '2024-07-08 23:00:00')
```
</details>

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
