### PR TITLE
Added the reference to the formatted description on English Proficiency

### DIFF
--- a/app/models/english_proficiency.rb
+++ b/app/models/english_proficiency.rb
@@ -15,6 +15,11 @@ class EnglishProficiency < ApplicationRecord
   def formatted_qualification_description
     return if efl_qualification.blank?
 
-    "Name: #{efl_qualification.name}, Grade: #{efl_qualification.grade}, Awarded: #{efl_qualification.award_year}"
+    name = "Name: #{efl_qualification.name}"
+    grade = "Grade: #{efl_qualification.grade}"
+    award_year = "Awarded: #{efl_qualification.award_year}"
+    reference = "Reference: #{efl_qualification.unique_reference_number}" if efl_qualification.unique_reference_number.present?
+
+    [name, grade, award_year, reference].compact.join(', ')
   end
 end

--- a/config/vendor_api/v1.0.yml
+++ b/config/vendor_api/v1.0.yml
@@ -641,7 +641,7 @@ components:
           maxLength: 10240
           nullable: true
           description: Details of this candidate's English language qualification, if English is not their main language
-          example: 'Name: TOEFL, Grade: 20, Awarded: 1999'
+          example: 'Name: TOEFL, Grade: 20, Awarded: 1999, Reference: 123456'
         other_languages:
           type: string
           maxLength: 10240

--- a/spec/models/english_proficiency_spec.rb
+++ b/spec/models/english_proficiency_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe EnglishProficiency do
       english_proficiency = build(:english_proficiency)
       expected_results = [
         {
-          qualification: build(:ielts_qualification, band_score: '3.5', award_year: '1999'),
-          description: 'Name: IELTS, Grade: 3.5, Awarded: 1999',
+          qualification: build(:ielts_qualification, band_score: '3.5', award_year: '1999', trf_number: '123456'),
+          description: 'Name: IELTS, Grade: 3.5, Awarded: 1999, Reference: 123456',
         },
         {
-          qualification: build(:toefl_qualification, total_score: 30, award_year: '2000'),
-          description: 'Name: TOEFL, Grade: 30, Awarded: 2000',
+          qualification: build(:toefl_qualification, total_score: 30, award_year: '2000', registration_number: '654321'),
+          description: 'Name: TOEFL, Grade: 30, Awarded: 2000, Reference: 654321',
         },
         {
           qualification: build(:other_efl_qualification, name: 'Anglais for Dummies', grade: 'A+++', award_year: '2001'),

--- a/spec/presenters/concerns/candidate_api_data_spec.rb
+++ b/spec/presenters/concerns/candidate_api_data_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe CandidateAPIData do
 
       context 'default' do
         it 'returns a description of the candidate\'s EFL qualification' do
-          expect(presenter.candidate[:english_language_qualifications]).to eq('Name: TOEFL, Grade: 20, Awarded: 1999')
+          expect(presenter.candidate[:english_language_qualifications]).to eq('Name: TOEFL, Grade: 20, Awarded: 1999, Reference: 123456')
         end
       end
 
@@ -238,7 +238,7 @@ RSpec.describe CandidateAPIData do
         end
 
         it 'returns the description of the candidate\'s EFL qualification over it' do
-          expect(presenter.candidate[:english_language_qualifications]).to eq('Name: TOEFL, Grade: 20, Awarded: 1999')
+          expect(presenter.candidate[:english_language_qualifications]).to eq('Name: TOEFL, Grade: 20, Awarded: 1999, Reference: 123456')
         end
       end
 

--- a/spec/presenters/register_api/single_application_presenter_spec.rb
+++ b/spec/presenters/register_api/single_application_presenter_spec.rb
@@ -412,7 +412,7 @@ RSpec.describe RegisterAPI::SingleApplicationPresenter do
 
       response = described_class.new(application_choice).as_json
 
-      expect(response.dig(:attributes, :candidate, :english_language_qualifications)).to eq('Name: TOEFL, Grade: 20, Awarded: 1999')
+      expect(response.dig(:attributes, :candidate, :english_language_qualifications)).to eq('Name: TOEFL, Grade: 20, Awarded: 1999, Reference: 123456')
     end
 
     it 'prefers to return description of the candidate\'s EFL qualification over the deprecated english_language_details' do
@@ -426,7 +426,7 @@ RSpec.describe RegisterAPI::SingleApplicationPresenter do
 
       response = described_class.new(application_choice).as_json
 
-      expect(response.dig(:attributes, :candidate, :english_language_qualifications)).to eq('Name: TOEFL, Grade: 20, Awarded: 1999')
+      expect(response.dig(:attributes, :candidate, :english_language_qualifications)).to eq('Name: TOEFL, Grade: 20, Awarded: 1999, Reference: 123456')
     end
 
     it 'returns english_language_details is a candidate has not provided an EFL qualification' do


### PR DESCRIPTION
## Context

The `EnglishProficiency` model has a method to render out a formatted description of the attached qualification.
These qualifications can be an `IeltsQualification`, a `ToeflQualification` or an `OtheEflQualification`.
All but the `OtherEflQualification` have a unique reference. 

A Vendor API consumer has requested that we add the reference to the formatted description so that they can populate data in their system. 

A full solution to this issue would be to add additional attributes to the API object. We may do this in future. 

## Changes proposed in this pull request

- Added reference data to `EnglishProficiency#formatted_qualification_description`
 
## Guidance to review

N/A

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
