### PR TITLE
Remove continuous applications from routes

### DIFF
--- a/app/components/candidate_interface/application_choice_item_component.rb
+++ b/app/components/candidate_interface/application_choice_item_component.rb
@@ -29,7 +29,7 @@ class CandidateInterface::ApplicationChoiceItemComponent < ViewComponent::Base
     if application_choice.offer?
       candidate_interface_offer_path(application_choice.id)
     else
-      candidate_interface_continuous_applications_course_review_path(application_choice.id)
+      candidate_interface_course_choices_course_review_path(application_choice.id)
     end
   end
 end

--- a/app/components/candidate_interface/application_review_and_submit_component.html.erb
+++ b/app/components/candidate_interface/application_review_and_submit_component.html.erb
@@ -15,7 +15,7 @@
 <% if errors.map(&:type).intersection([:course_unavailable, :course_closed]).empty? %>
 <h2 class="govuk-heading-m">Delete draft application</h2>
 <p class="govuk-body">
-  You can <%= govuk_link_to('delete your draft application', candidate_interface_continuous_applications_confirm_destroy_course_choice_path(@application_choice.id), data: { action: :delete }) %> if you no longer want to apply for <%= @application_choice.current_course.name_and_code %> at <%= @application_choice.current_course.provider.name %>.
+  You can <%= govuk_link_to('delete your draft application', candidate_interface_course_choices_confirm_destroy_course_choice_path(@application_choice.id), data: { action: :delete }) %> if you no longer want to apply for <%= @application_choice.current_course.name_and_code %> at <%= @application_choice.current_course.provider.name %>.
 </p>
 <% end %>
 

--- a/app/components/candidate_interface/application_review_and_submit_component.rb
+++ b/app/components/candidate_interface/application_review_and_submit_component.rb
@@ -21,9 +21,9 @@ module CandidateInterface
 
     def review_path
       if short_personal_statement?
-        candidate_interface_continuous_applications_course_review_interruption_path(application_choice.id)
+        candidate_interface_course_choices_course_review_interruption_path(application_choice.id)
       else
-        candidate_interface_continuous_applications_course_review_and_submit_path(application_choice.id)
+        candidate_interface_course_choices_course_review_and_submit_path(application_choice.id)
       end
     end
 

--- a/app/components/candidate_interface/application_review_component.html.erb
+++ b/app/components/candidate_interface/application_review_component.html.erb
@@ -1,5 +1,5 @@
 <% if application_choice.inactive? && can_add_more_choices? %>
-  <%= govuk_warning_text(text: "Application submitted #{time_ago_in_words(application_choice.sent_to_provider_at)} ago. You can #{govuk_link_to('add an application', candidate_interface_continuous_applications_do_you_know_the_course_path)} for a different training provider while you wait for a decision on this application.".html_safe) %>
+  <%= govuk_warning_text(text: "Application submitted #{time_ago_in_words(application_choice.sent_to_provider_at)} ago. You can #{govuk_link_to('add an application', candidate_interface_course_choices_do_you_know_the_course_path)} for a different training provider while you wait for a decision on this application.".html_safe) %>
 <% end %>
 
 <%= render SummaryListComponent.new(rows: rows) %>
@@ -20,7 +20,7 @@
     <p class="govuk-body">The provider will review your application and let you know when they have made a decision. In the meantime, you can:</p>
     <ul class="govuk-list govuk-list--bullet">
       <% if can_add_more_choices? %>
-        <li><%= govuk_link_to 'submit another application', candidate_interface_continuous_applications_do_you_know_the_course_path %> while you wait for a decision on this one</li>
+        <li><%= govuk_link_to 'submit another application', candidate_interface_course_choices_do_you_know_the_course_path %> while you wait for a decision on this one</li>
       <% end %>
       <li>contact the provider directly if you have any questions</li>
       <li>find out more about <%= govuk_link_to 'funding your training', t('get_into_teaching.url_funding_and_support'), target: '_blank' %></li>

--- a/app/components/candidate_interface/application_review_component.rb
+++ b/app/components/candidate_interface/application_review_component.rb
@@ -101,7 +101,7 @@ module CandidateInterface
       }.tap do |row|
         if unsubmitted? && current_course.multiple_sites?
           row[:action] = {
-            href: candidate_interface_edit_continuous_applications_course_site_path(application_choice.id, current_course.id, current_course_option.study_mode),
+            href: candidate_interface_edit_course_choices_course_site_path(application_choice.id, current_course.id, current_course_option.study_mode),
             visually_hidden_text: "location for #{current_course.name_and_code}",
           }
         end

--- a/app/components/candidate_interface/application_review_component.rb
+++ b/app/components/candidate_interface/application_review_component.rb
@@ -87,7 +87,7 @@ module CandidateInterface
       }.tap do |row|
         if unsubmitted? && current_course.currently_has_both_study_modes_available?
           row[:action] = {
-            href: candidate_interface_edit_continuous_applications_course_study_mode_path(application_choice.id, current_course.id),
+            href: candidate_interface_edit_course_choices_course_study_mode_path(application_choice.id, current_course.id),
             visually_hidden_text: "full time or part time for #{current_course.name_and_code}",
           }
         end

--- a/app/components/candidate_interface/application_review_component.rb
+++ b/app/components/candidate_interface/application_review_component.rb
@@ -59,7 +59,7 @@ module CandidateInterface
       }.tap do |row|
         if unsubmitted?
           row[:action] = {
-            href: candidate_interface_edit_continuous_applications_which_course_are_you_applying_to_path(application_choice.id),
+            href: candidate_interface_edit_course_choices_which_course_are_you_applying_to_path(application_choice.id),
             visually_hidden_text: "course for #{current_course.name_and_code}",
           }
         end

--- a/app/components/candidate_interface/application_status_tag_component.html.erb
+++ b/app/components/candidate_interface/application_status_tag_component.html.erb
@@ -10,7 +10,7 @@
     </p>
   <% elsif @application_choice.unsubmitted? && @application_choice.course_available? %>
     <p class="govuk-body govuk-!-margin-top-2">
-      <%= govuk_link_to candidate_interface_continuous_applications_course_review_path(@application_choice) do %>
+      <%= govuk_link_to candidate_interface_course_choices_course_review_path(@application_choice) do %>
         <%= t('application_form.continuous_applications.courses.continue_application') %>
         <span class="govuk-visually-hidden"> <%= @application_choice.current_course.provider.name %></span>
       <% end %>

--- a/app/components/candidate_interface/course_choices_row_helper.rb
+++ b/app/components/candidate_interface/course_choices_row_helper.rb
@@ -15,7 +15,7 @@ module CandidateInterface
       }.tap do |row|
         if unsubmitted? && course_full?
           row[:action] = {
-            href: candidate_interface_edit_continuous_applications_which_course_are_you_applying_to_path(application_choice.id),
+            href: candidate_interface_edit_course_choices_which_course_are_you_applying_to_path(application_choice.id),
             visually_hidden_text: "course for #{current_course.name_and_code}",
           }
         end

--- a/app/controllers/candidate_interface/after_sign_in_controller.rb
+++ b/app/controllers/candidate_interface/after_sign_in_controller.rb
@@ -33,7 +33,7 @@ module CandidateInterface
     end
 
     def confirm_selection_page
-      candidate_interface_continuous_applications_course_confirm_selection_path(course_from_find.id)
+      candidate_interface_course_choices_course_confirm_selection_path(course_from_find.id)
     end
 
     def redirect_to_path_if_path_params_are_present

--- a/app/controllers/candidate_interface/course_choices/concerns/duplicate_course_redirect.rb
+++ b/app/controllers/candidate_interface/course_choices/concerns/duplicate_course_redirect.rb
@@ -14,7 +14,7 @@ module CandidateInterface
           course = Course.find(params[:course_id])
           return unless current_application.contains_course?(course)
 
-          redirect_to candidate_interface_continuous_applications_duplicate_course_selection_path(course.provider_id, course.id)
+          redirect_to candidate_interface_course_choices_duplicate_course_selection_path(course.provider_id, course.id)
         end
       end
     end

--- a/app/controllers/candidate_interface/course_choices/concerns/full_course_redirect.rb
+++ b/app/controllers/candidate_interface/course_choices/concerns/full_course_redirect.rb
@@ -14,7 +14,7 @@ module CandidateInterface
           course = Course.find(params[:course_id])
           return if course.available?
 
-          redirect_to candidate_interface_continuous_applications_full_course_selection_path(course.provider_id, course.id)
+          redirect_to candidate_interface_course_choices_full_course_selection_path(course.provider_id, course.id)
         end
       end
     end

--- a/app/controllers/candidate_interface/course_choices/review_and_submit_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/review_and_submit_controller.rb
@@ -15,7 +15,7 @@ module CandidateInterface
       def redirect_to_course_choice_review_unless_ready_to_submit
         return if ready_to_submit?
 
-        redirect_to(candidate_interface_continuous_applications_course_review_path(@application_choice.id))
+        redirect_to(candidate_interface_course_choices_course_review_path(@application_choice.id))
       end
 
       def ready_to_submit?

--- a/app/filters/submission_permission_filter.rb
+++ b/app/filters/submission_permission_filter.rb
@@ -7,7 +7,7 @@ class SubmissionPermissionFilter
 
   delegate :redirect_to,
            :current_candidate,
-           :candidate_interface_continuous_applications_blocked_submissions_path,
+           :candidate_interface_course_choices_blocked_submissions_path,
            to: :controller
 
   def initialize(controller)
@@ -15,6 +15,6 @@ class SubmissionPermissionFilter
   end
 
   def call
-    redirect_to candidate_interface_continuous_applications_blocked_submissions_path if current_candidate.submission_blocked?
+    redirect_to candidate_interface_course_choices_blocked_submissions_path if current_candidate.submission_blocked?
   end
 end

--- a/app/forms/candidate_interface/concerns/course_selection_step_helper.rb
+++ b/app/forms/candidate_interface/concerns/course_selection_step_helper.rb
@@ -8,7 +8,7 @@ module CandidateInterface
 
         route_name = next_step_klass.model_name.singular_route_key
         url_helpers.public_send(
-          "candidate_interface_edit_continuous_applications_#{route_name}_path",
+          "candidate_interface_edit_course_choices_#{route_name}_path",
           edit_next_step_path_arguments,
         )
       end

--- a/app/forms/candidate_interface/course_selection/closed_course_selection_step.rb
+++ b/app/forms/candidate_interface/course_selection/closed_course_selection_step.rb
@@ -6,7 +6,7 @@ module CandidateInterface
       validates :provider_id, :course_id, presence: true
 
       def self.route_name
-        'candidate_interface_continuous_applications_closed_course_selection'
+        'candidate_interface_course_choices_closed_course_selection'
       end
 
       def self.permitted_params

--- a/app/forms/candidate_interface/course_selection/course_review_step.rb
+++ b/app/forms/candidate_interface/course_selection/course_review_step.rb
@@ -2,7 +2,7 @@ module CandidateInterface
   module CourseSelection
     class CourseReviewStep < DfE::Wizard::Step
       def self.route_name
-        'candidate_interface_continuous_applications_course_review'
+        'candidate_interface_course_choices_course_review'
       end
 
       def next_step; end

--- a/app/forms/candidate_interface/course_selection/course_site_step.rb
+++ b/app/forms/candidate_interface/course_selection/course_site_step.rb
@@ -6,7 +6,7 @@ module CandidateInterface
       validates :course_option_id, presence: true
 
       def self.route_name
-        'candidate_interface_continuous_applications_course_site'
+        'candidate_interface_course_choices_course_site'
       end
 
       def self.permitted_params

--- a/app/forms/candidate_interface/course_selection/course_study_mode_step.rb
+++ b/app/forms/candidate_interface/course_selection/course_study_mode_step.rb
@@ -7,7 +7,7 @@ module CandidateInterface
       validates :study_mode, presence: true
 
       def self.route_name
-        'candidate_interface_continuous_applications_course_study_mode'
+        'candidate_interface_course_choices_course_study_mode'
       end
 
       def self.permitted_params

--- a/app/forms/candidate_interface/course_selection/do_you_know_the_course_step.rb
+++ b/app/forms/candidate_interface/course_selection/do_you_know_the_course_step.rb
@@ -5,7 +5,7 @@ module CandidateInterface
       validates :answer, presence: true
 
       def self.route_name
-        'candidate_interface_continuous_applications_do_you_know_the_course'
+        'candidate_interface_course_choices_do_you_know_the_course'
       end
 
       def self.permitted_params

--- a/app/forms/candidate_interface/course_selection/duplicate_course_selection_step.rb
+++ b/app/forms/candidate_interface/course_selection/duplicate_course_selection_step.rb
@@ -6,7 +6,7 @@ module CandidateInterface
       validates :provider_id, :course_id, presence: true
 
       def self.route_name
-        'candidate_interface_continuous_applications_duplicate_course_selection'
+        'candidate_interface_course_choices_duplicate_course_selection'
       end
 
       def self.permitted_params

--- a/app/forms/candidate_interface/course_selection/full_course_selection_step.rb
+++ b/app/forms/candidate_interface/course_selection/full_course_selection_step.rb
@@ -6,7 +6,7 @@ module CandidateInterface
       validates :provider_id, :course_id, presence: true
 
       def self.route_name
-        'candidate_interface_continuous_applications_full_course_selection'
+        'candidate_interface_course_choices_full_course_selection'
       end
 
       def self.permitted_params

--- a/app/forms/candidate_interface/course_selection/go_to_find_explanation_step.rb
+++ b/app/forms/candidate_interface/course_selection/go_to_find_explanation_step.rb
@@ -2,7 +2,7 @@ module CandidateInterface
   module CourseSelection
     class GoToFindExplanationStep < DfE::Wizard::Step
       def self.route_name
-        'candidate_interface_continuous_applications_go_to_find_explanation'
+        'candidate_interface_course_choices_go_to_find_explanation'
       end
 
       def previous_step

--- a/app/forms/candidate_interface/course_selection/provider_selection_step.rb
+++ b/app/forms/candidate_interface/course_selection/provider_selection_step.rb
@@ -5,7 +5,7 @@ module CandidateInterface
       validates :provider_id, presence: true
 
       def self.route_name
-        'candidate_interface_continuous_applications_provider_selection'
+        'candidate_interface_course_choices_provider_selection'
       end
 
       def self.permitted_params

--- a/app/forms/candidate_interface/course_selection/reached_reapplication_limit_step.rb
+++ b/app/forms/candidate_interface/course_selection/reached_reapplication_limit_step.rb
@@ -6,7 +6,7 @@ module CandidateInterface
       validates :provider_id, :course_id, presence: true
 
       def self.route_name
-        'candidate_interface_continuous_applications_reached_reapplication_limit'
+        'candidate_interface_course_choices_reached_reapplication_limit'
       end
 
       def self.permitted_params

--- a/app/forms/candidate_interface/course_selection/which_course_are_you_applying_to_step.rb
+++ b/app/forms/candidate_interface/course_selection/which_course_are_you_applying_to_step.rb
@@ -8,7 +8,7 @@ module CandidateInterface
       validates_with CourseSelectionValidator, on: :course_choice
 
       def self.route_name
-        'candidate_interface_continuous_applications_which_course_are_you_applying_to'
+        'candidate_interface_course_choices_which_course_are_you_applying_to'
       end
 
       def self.permitted_params

--- a/app/validators/course_unavailable_validator.rb
+++ b/app/validators/course_unavailable_validator.rb
@@ -29,6 +29,6 @@ class CourseUnavailableValidator < ActiveModel::EachValidator
 private
 
   def link_to_remove(application_choice)
-    govuk_link_to('Remove this application', Rails.application.routes.url_helpers.candidate_interface_continuous_applications_confirm_destroy_course_choice_path(application_choice.id))
+    govuk_link_to('Remove this application', Rails.application.routes.url_helpers.candidate_interface_course_choices_confirm_destroy_course_choice_path(application_choice.id))
   end
 end

--- a/app/views/candidate_interface/application_choices/confirm_destroy.html.erb
+++ b/app/views/candidate_interface/application_choices/confirm_destroy.html.erb
@@ -11,7 +11,7 @@
       <div class="govuk-button-group app-course-choice__confirm-submission">
         <%= f.govuk_submit t('application_form.continuous_applications.courses.confirm_delete'), warning: true %>
 
-        <%= govuk_link_to 'Cancel', candidate_interface_continuous_applications_course_review_path(@application_choice.id) %>
+        <%= govuk_link_to 'Cancel', candidate_interface_course_choices_course_review_path(@application_choice.id) %>
       </div>
     <% end %>
   </div>

--- a/app/views/candidate_interface/application_choices/confirm_destroy.html.erb
+++ b/app/views/candidate_interface/application_choices/confirm_destroy.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @application_choice, url: candidate_interface_continuous_applications_confirm_destroy_course_choice_path(@application_choice.id), method: :delete do |f| %>
+    <%= form_with model: @application_choice, url: candidate_interface_course_choices_confirm_destroy_course_choice_path(@application_choice.id), method: :delete do |f| %>
       <h1 class="govuk-heading-l">
         <%= t('page_titles.continuous_applications_destroy_course_choice') %>
       </h1>

--- a/app/views/candidate_interface/continuous_applications_choices/index.html.erb
+++ b/app/views/candidate_interface/continuous_applications_choices/index.html.erb
@@ -56,7 +56,7 @@
         </p>
 
         <% if CycleTimetable.can_add_course_choice?(@application_form_presenter.application_form) && @application_form_presenter.can_add_more_choices? %>
-          <%= govuk_button_link_to t('section_items.add_application'), candidate_interface_continuous_applications_do_you_know_the_course_path %>
+          <%= govuk_button_link_to t('section_items.add_application'), candidate_interface_course_choices_do_you_know_the_course_path %>
         <% else %>
           <p class="govuk-body">
             You can find courses from 9am on <%= CycleTimetable.find_reopens.to_fs(:govuk_date) %>. You can keep making changes to your application until then.

--- a/app/views/candidate_interface/course_choices/closed_course_selection/new.html.erb
+++ b/app/views/candidate_interface/course_choices/closed_course_selection/new.html.erb
@@ -10,7 +10,7 @@
     <% if @course.provider.course_options.available.any? %>
       <p class="govuk-body">You can:</p>
       <ul class="govuk-list govuk-list--bullet govuk-!-padding-bottom-8">
-        <li>apply to a <%= govuk_link_to 'different course', candidate_interface_continuous_applications_which_course_are_you_applying_to_path(provider_id: @course.provider.id) %> offered by <%= @course.provider.name %></li>
+        <li>apply to a <%= govuk_link_to 'different course', candidate_interface_course_choices_which_course_are_you_applying_to_path(provider_id: @course.provider.id) %> offered by <%= @course.provider.name %></li>
         <li>apply to a <%= govuk_link_to 'different training provider', candidate_interface_course_choices_provider_selection_path %></li>
       </ul>
     <% else %>

--- a/app/views/candidate_interface/course_choices/closed_course_selection/new.html.erb
+++ b/app/views/candidate_interface/course_choices/closed_course_selection/new.html.erb
@@ -11,10 +11,10 @@
       <p class="govuk-body">You can:</p>
       <ul class="govuk-list govuk-list--bullet govuk-!-padding-bottom-8">
         <li>apply to a <%= govuk_link_to 'different course', candidate_interface_continuous_applications_which_course_are_you_applying_to_path(provider_id: @course.provider.id) %> offered by <%= @course.provider.name %></li>
-        <li>apply to a <%= govuk_link_to 'different training provider', candidate_interface_continuous_applications_provider_selection_path %></li>
+        <li>apply to a <%= govuk_link_to 'different training provider', candidate_interface_course_choices_provider_selection_path %></li>
       </ul>
     <% else %>
-      <p class="govuk-body">You can apply to a <%= govuk_link_to 'different training provider', candidate_interface_continuous_applications_provider_selection_path %>.</p>
+      <p class="govuk-body">You can apply to a <%= govuk_link_to 'different training provider', candidate_interface_course_choices_provider_selection_path %>.</p>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/course_choices/course_site/edit.html.erb
+++ b/app/views/candidate_interface/course_choices/course_site/edit.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(
           model: @wizard.current_step,
-          url: candidate_interface_edit_continuous_applications_course_site_path(
+          url: candidate_interface_edit_course_choices_course_site_path(
             @application_choice.id,
             params[:course_id],
             params[:study_mode],

--- a/app/views/candidate_interface/course_choices/course_study_mode/edit.html.erb
+++ b/app/views/candidate_interface/course_choices/course_study_mode/edit.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(
           model: @wizard.current_step,
-          url: candidate_interface_edit_continuous_applications_course_study_mode_path(@application_choice.id, @application_choice.current_course.id),
+          url: candidate_interface_edit_course_choices_course_study_mode_path(@application_choice.id, @application_choice.current_course.id),
           method: :patch,
         ) do |f| %>
       <%= render 'form_fields', f: %>

--- a/app/views/candidate_interface/course_choices/duplicate_course_selection/new.html.erb
+++ b/app/views/candidate_interface/course_choices/duplicate_course_selection/new.html.erb
@@ -11,7 +11,7 @@
       <p class="govuk-body">You can:</p>
       <ul class="govuk-list govuk-list--bullet">
 
-        <li>apply to a <%= govuk_link_to 'different course', candidate_interface_continuous_applications_which_course_are_you_applying_to_path(provider_id: @course.provider.id) %> offered by <%= @course.provider.name %></li>
+        <li>apply to a <%= govuk_link_to 'different course', candidate_interface_course_choices_which_course_are_you_applying_to_path(provider_id: @course.provider.id) %> offered by <%= @course.provider.name %></li>
         <li>apply to a <%= govuk_link_to 'different training provider', candidate_interface_course_choices_provider_selection_path %></li>
       </ul>
     <% else %>

--- a/app/views/candidate_interface/course_choices/duplicate_course_selection/new.html.erb
+++ b/app/views/candidate_interface/course_choices/duplicate_course_selection/new.html.erb
@@ -12,10 +12,10 @@
       <ul class="govuk-list govuk-list--bullet">
 
         <li>apply to a <%= govuk_link_to 'different course', candidate_interface_continuous_applications_which_course_are_you_applying_to_path(provider_id: @course.provider.id) %> offered by <%= @course.provider.name %></li>
-        <li>apply to a <%= govuk_link_to 'different training provider', candidate_interface_continuous_applications_provider_selection_path %></li>
+        <li>apply to a <%= govuk_link_to 'different training provider', candidate_interface_course_choices_provider_selection_path %></li>
       </ul>
     <% else %>
-      <p class="govuk-body">You can apply to a <%= govuk_link_to 'different training provider', candidate_interface_continuous_applications_provider_selection_path %>.</p>
+      <p class="govuk-body">You can apply to a <%= govuk_link_to 'different training provider', candidate_interface_course_choices_provider_selection_path %>.</p>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/course_choices/find_course_selection/new.html.erb
+++ b/app/views/candidate_interface/course_choices/find_course_selection/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @wizard.current_step, url: candidate_interface_continuous_applications_course_confirm_selection_path(@wizard.current_step.course_id), method: :post do |f| %>
+    <%= form_with model: @wizard.current_step, url: candidate_interface_course_choices_course_confirm_selection_path(@wizard.current_step.course_id), method: :post do |f| %>
       <%= f.hidden_field :course_id %>
       <%= f.govuk_error_summary %>
 

--- a/app/views/candidate_interface/course_choices/full_course_selection/new.html.erb
+++ b/app/views/candidate_interface/course_choices/full_course_selection/new.html.erb
@@ -10,7 +10,7 @@
     <% if @course.provider.course_options.available.any? %>
       <p class="govuk-body">You can:</p>
       <ul class="govuk-list govuk-list--bullet govuk-!-padding-bottom-8">
-        <li>apply to a <%= govuk_link_to 'different course', candidate_interface_continuous_applications_which_course_are_you_applying_to_path(provider_id: @course.provider.id) %> offered by <%= @course.provider.name %></li>
+        <li>apply to a <%= govuk_link_to 'different course', candidate_interface_course_choices_which_course_are_you_applying_to_path(provider_id: @course.provider.id) %> offered by <%= @course.provider.name %></li>
         <li>apply to a <%= govuk_link_to 'different training provider', candidate_interface_course_choices_provider_selection_path %></li>
       </ul>
     <% else %>

--- a/app/views/candidate_interface/course_choices/full_course_selection/new.html.erb
+++ b/app/views/candidate_interface/course_choices/full_course_selection/new.html.erb
@@ -11,10 +11,10 @@
       <p class="govuk-body">You can:</p>
       <ul class="govuk-list govuk-list--bullet govuk-!-padding-bottom-8">
         <li>apply to a <%= govuk_link_to 'different course', candidate_interface_continuous_applications_which_course_are_you_applying_to_path(provider_id: @course.provider.id) %> offered by <%= @course.provider.name %></li>
-        <li>apply to a <%= govuk_link_to 'different training provider', candidate_interface_continuous_applications_provider_selection_path %></li>
+        <li>apply to a <%= govuk_link_to 'different training provider', candidate_interface_course_choices_provider_selection_path %></li>
       </ul>
     <% else %>
-      <p class="govuk-body">You can apply to a <%= govuk_link_to 'different training provider', candidate_interface_continuous_applications_provider_selection_path %>.</p>
+      <p class="govuk-body">You can apply to a <%= govuk_link_to 'different training provider', candidate_interface_course_choices_provider_selection_path %>.</p>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/course_choices/reached_reapplication_limit/new.html.erb
+++ b/app/views/candidate_interface/course_choices/reached_reapplication_limit/new.html.erb
@@ -13,10 +13,10 @@
       <ul class="govuk-list govuk-list--bullet">
 
         <li>apply to a <%= govuk_link_to 'different course', candidate_interface_continuous_applications_which_course_are_you_applying_to_path(provider_id: @course.provider.id) %> offered by <%= @course.provider.name %></li>
-        <li>apply to a <%= govuk_link_to 'different training provider', candidate_interface_continuous_applications_provider_selection_path %></li>
+        <li>apply to a <%= govuk_link_to 'different training provider', candidate_interface_course_choices_provider_selection_path %></li>
       </ul>
     <% else %>
-      <p class="govuk-body">You can apply to a <%= govuk_link_to 'different training provider', candidate_interface_continuous_applications_provider_selection_path %>.</p>
+      <p class="govuk-body">You can apply to a <%= govuk_link_to 'different training provider', candidate_interface_course_choices_provider_selection_path %>.</p>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/course_choices/reached_reapplication_limit/new.html.erb
+++ b/app/views/candidate_interface/course_choices/reached_reapplication_limit/new.html.erb
@@ -12,7 +12,7 @@
       <p class="govuk-body">Instead, you must:</p>
       <ul class="govuk-list govuk-list--bullet">
 
-        <li>apply to a <%= govuk_link_to 'different course', candidate_interface_continuous_applications_which_course_are_you_applying_to_path(provider_id: @course.provider.id) %> offered by <%= @course.provider.name %></li>
+        <li>apply to a <%= govuk_link_to 'different course', candidate_interface_course_choices_which_course_are_you_applying_to_path(provider_id: @course.provider.id) %> offered by <%= @course.provider.name %></li>
         <li>apply to a <%= govuk_link_to 'different training provider', candidate_interface_course_choices_provider_selection_path %></li>
       </ul>
     <% else %>

--- a/app/views/candidate_interface/course_choices/review_and_submit/show.html.erb
+++ b/app/views/candidate_interface/course_choices/review_and_submit/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.application_review_and_submit', provider_name: @application_choice.provider.name) %>
-<% content_for(:before_content, govuk_back_link_to(candidate_interface_continuous_applications_course_review_path(@application_choice.id), 'Back to your application')) %>
+<% content_for(:before_content, govuk_back_link_to(candidate_interface_course_choices_course_review_path(@application_choice.id), 'Back to your application')) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">

--- a/app/views/candidate_interface/course_choices/review_and_submit/show.html.erb
+++ b/app/views/candidate_interface/course_choices/review_and_submit/show.html.erb
@@ -21,7 +21,7 @@
     </p>
 
     <div class="govuk-button-group app-course-choice__confirm-submission">
-      <%= govuk_button_to('Confirm and submit application', candidate_interface_continuous_applications_submit_course_choice_path(@application_choice.id), method: :post) %>
+      <%= govuk_button_to('Confirm and submit application', candidate_interface_course_choices_submit_course_choice_path(@application_choice.id), method: :post) %>
 
       <%= govuk_link_to('Save as draft', candidate_interface_continuous_applications_choices_path) %>
     </div>

--- a/app/views/candidate_interface/course_choices/review_interruption/show.html.erb
+++ b/app/views/candidate_interface/course_choices/review_interruption/show.html.erb
@@ -18,7 +18,7 @@
       </fieldset>
 
       <%= govuk_button_to('Edit your personal statement', candidate_interface_edit_becoming_a_teacher_path, method: :get) %>
-      <%= govuk_link_to('Continue without editing', candidate_interface_continuous_applications_course_review_and_submit_path(@application_choice.id)) %>
+      <%= govuk_link_to('Continue without editing', candidate_interface_course_choices_course_review_and_submit_path(@application_choice.id)) %>
     </div>
   </div>
 </div>

--- a/app/views/candidate_interface/course_choices/which_course_are_you_applying_to/edit.html.erb
+++ b/app/views/candidate_interface/course_choices/which_course_are_you_applying_to/edit.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(
       model: @wizard.current_step,
-      url: candidate_interface_edit_continuous_applications_which_course_are_you_applying_to_path(@application_choice.id),
+      url: candidate_interface_edit_course_choices_which_course_are_you_applying_to_path(@application_choice.id),
       method: :patch,
     ) do |f| %>
       <%= render 'form_fields', f: %>

--- a/app/views/candidate_interface/course_choices/which_course_are_you_applying_to/edit.html.erb
+++ b/app/views/candidate_interface/course_choices/which_course_are_you_applying_to/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.which_course'), @wizard.current_step.errors.any?) %>
-<% content_for(:before_content, govuk_back_link_to(candidate_interface_continuous_applications_course_review_path(@application_choice.id))) %>
+<% content_for(:before_content, govuk_back_link_to(candidate_interface_course_choices_course_review_path(@application_choice.id))) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/shared/_details.html.erb
+++ b/app/views/candidate_interface/shared/_details.html.erb
@@ -72,7 +72,7 @@
       <div class="app-grid-column--grey">
         <h2 class="govuk-heading-m">You have completed your details</h2>
         <p class="govuk-body">You can now start applying to courses.</p>
-        <%= govuk_button_link_to t('section_items.add_application'), candidate_interface_continuous_applications_do_you_know_the_course_path %>
+        <%= govuk_button_link_to t('section_items.add_application'), candidate_interface_course_choices_do_you_know_the_course_path %>
       </div>
     <% end %>
   </div>

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -359,9 +359,9 @@ namespace :candidate_interface, path: '/candidate' do
       get '/provider/:provider_id/courses/:course_id/full' => 'course_choices/full_course_selection#new', as: :course_choices_full_course_selection
       get '/provider/:provider_id/courses/:course_id/closed' => 'course_choices/closed_course_selection#new', as: :course_choices_closed_course_selection
 
-      get '/provider/:provider_id/courses/:course_id' => 'course_choices/course_study_mode#new', as: :continuous_applications_course_study_mode
+      get '/provider/:provider_id/courses/:course_id' => 'course_choices/course_study_mode#new', as: :course_choices_course_study_mode
       post '/provider/:provider_id/courses/:course_id' => 'course_choices/course_study_mode#create'
-      get '/:application_choice_id/courses/:course_id/edit' => 'course_choices/course_study_mode#edit', as: :edit_continuous_applications_course_study_mode
+      get '/:application_choice_id/courses/:course_id/edit' => 'course_choices/course_study_mode#edit', as: :edit_course_choices_course_study_mode
       patch '/:application_choice_id/courses/:course_id/edit' => 'course_choices/course_study_mode#update'
 
       get '/provider/:provider_id/courses/:course_id/:study_mode' => 'course_choices/course_site#new', as: :continuous_applications_course_site

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -344,9 +344,9 @@ namespace :candidate_interface, path: '/candidate' do
       get '/provider' => 'course_choices/provider_selection#new', as: :course_choices_provider_selection
       post '/provider' => 'course_choices/provider_selection#create'
 
-      get '/provider/:provider_id/course' => 'course_choices/which_course_are_you_applying_to#new', as: :continuous_applications_which_course_are_you_applying_to
+      get '/provider/:provider_id/course' => 'course_choices/which_course_are_you_applying_to#new', as: :course_choices_which_course_are_you_applying_to
       post '/provider/:provider_id/course' => 'course_choices/which_course_are_you_applying_to#create'
-      get '/:application_choice_id/courses/edit' => 'course_choices/which_course_are_you_applying_to#edit', as: :edit_continuous_applications_which_course_are_you_applying_to
+      get '/:application_choice_id/courses/edit' => 'course_choices/which_course_are_you_applying_to#edit', as: :edit_course_choices_which_course_are_you_applying_to
       patch '/:application_choice_id/courses/edit' => 'course_choices/which_course_are_you_applying_to#update'
 
       get '/:application_choice_id/review' => 'course_choices/review#show', as: :continuous_applications_course_review

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -336,7 +336,7 @@ namespace :candidate_interface, path: '/candidate' do
     end
 
     scope '/course-choices' do
-      get '/choose' => 'course_choices/do_you_know_which_course#new', as: :continuous_applications_do_you_know_the_course
+      get '/choose' => 'course_choices/do_you_know_which_course#new', as: :course_choices_do_you_know_the_course
       post '/choose' => 'course_choices/do_you_know_which_course#create'
 
       get '/go-to-find' => 'course_choices/go_to_find#new', as: :continuous_applications_go_to_find_explanation

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -355,7 +355,7 @@ namespace :candidate_interface, path: '/candidate' do
       get '/blocked-submissions' => 'course_choices/blocked_submissions#show', as: :course_choices_blocked_submissions
 
       get '/provider/:provider_id/courses/:course_id/reached-reapplication-limit' => 'course_choices/reached_reapplication_limit#new', as: :course_choices_reached_reapplication_limit
-      get '/provider/:provider_id/courses/:course_id/duplicate' => 'course_choices/duplicate_course_selection#new', as: :continuous_applications_duplicate_course_selection
+      get '/provider/:provider_id/courses/:course_id/duplicate' => 'course_choices/duplicate_course_selection#new', as: :course_choices_duplicate_course_selection
       get '/provider/:provider_id/courses/:course_id/full' => 'course_choices/full_course_selection#new', as: :continuous_applications_full_course_selection
       get '/provider/:provider_id/courses/:course_id/closed' => 'course_choices/closed_course_selection#new', as: :continuous_applications_closed_course_selection
 

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -369,7 +369,7 @@ namespace :candidate_interface, path: '/candidate' do
       get '/:application_choice_id/courses/:course_id/:study_mode/edit' => 'course_choices/course_site#edit', as: :edit_course_choices_course_site
       patch '/:application_choice_id/courses/:course_id/:study_mode/edit' => 'course_choices/course_site#update'
 
-      get '/confirm-selection/:course_id' => 'course_choices/find_course_selection#new', as: :continuous_applications_course_confirm_selection
+      get '/confirm-selection/:course_id' => 'course_choices/find_course_selection#new', as: :course_choices_course_confirm_selection
       post '/confirm-selection/:course_id' => 'course_choices/find_course_selection#create'
 
       post '/:id/submit' => 'application_choices#submit', as: :continuous_applications_submit_course_choice

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -354,7 +354,7 @@ namespace :candidate_interface, path: '/candidate' do
       get '/:application_choice_id/review-and-submit' => 'course_choices/review_and_submit#show', as: :course_choices_course_review_and_submit
       get '/blocked-submissions' => 'course_choices/blocked_submissions#show', as: :course_choices_blocked_submissions
 
-      get '/provider/:provider_id/courses/:course_id/reached-reapplication-limit' => 'course_choices/reached_reapplication_limit#new', as: :continuous_applications_reached_reapplication_limit
+      get '/provider/:provider_id/courses/:course_id/reached-reapplication-limit' => 'course_choices/reached_reapplication_limit#new', as: :course_choices_reached_reapplication_limit
       get '/provider/:provider_id/courses/:course_id/duplicate' => 'course_choices/duplicate_course_selection#new', as: :continuous_applications_duplicate_course_selection
       get '/provider/:provider_id/courses/:course_id/full' => 'course_choices/full_course_selection#new', as: :continuous_applications_full_course_selection
       get '/provider/:provider_id/courses/:course_id/closed' => 'course_choices/closed_course_selection#new', as: :continuous_applications_closed_course_selection

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -357,7 +357,7 @@ namespace :candidate_interface, path: '/candidate' do
       get '/provider/:provider_id/courses/:course_id/reached-reapplication-limit' => 'course_choices/reached_reapplication_limit#new', as: :course_choices_reached_reapplication_limit
       get '/provider/:provider_id/courses/:course_id/duplicate' => 'course_choices/duplicate_course_selection#new', as: :course_choices_duplicate_course_selection
       get '/provider/:provider_id/courses/:course_id/full' => 'course_choices/full_course_selection#new', as: :course_choices_full_course_selection
-      get '/provider/:provider_id/courses/:course_id/closed' => 'course_choices/closed_course_selection#new', as: :continuous_applications_closed_course_selection
+      get '/provider/:provider_id/courses/:course_id/closed' => 'course_choices/closed_course_selection#new', as: :course_choices_closed_course_selection
 
       get '/provider/:provider_id/courses/:course_id' => 'course_choices/course_study_mode#new', as: :continuous_applications_course_study_mode
       post '/provider/:provider_id/courses/:course_id' => 'course_choices/course_study_mode#create'

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -356,7 +356,7 @@ namespace :candidate_interface, path: '/candidate' do
 
       get '/provider/:provider_id/courses/:course_id/reached-reapplication-limit' => 'course_choices/reached_reapplication_limit#new', as: :course_choices_reached_reapplication_limit
       get '/provider/:provider_id/courses/:course_id/duplicate' => 'course_choices/duplicate_course_selection#new', as: :course_choices_duplicate_course_selection
-      get '/provider/:provider_id/courses/:course_id/full' => 'course_choices/full_course_selection#new', as: :continuous_applications_full_course_selection
+      get '/provider/:provider_id/courses/:course_id/full' => 'course_choices/full_course_selection#new', as: :course_choices_full_course_selection
       get '/provider/:provider_id/courses/:course_id/closed' => 'course_choices/closed_course_selection#new', as: :continuous_applications_closed_course_selection
 
       get '/provider/:provider_id/courses/:course_id' => 'course_choices/course_study_mode#new', as: :continuous_applications_course_study_mode

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -372,7 +372,7 @@ namespace :candidate_interface, path: '/candidate' do
       get '/confirm-selection/:course_id' => 'course_choices/find_course_selection#new', as: :course_choices_course_confirm_selection
       post '/confirm-selection/:course_id' => 'course_choices/find_course_selection#create'
 
-      post '/:id/submit' => 'application_choices#submit', as: :continuous_applications_submit_course_choice
+      post '/:id/submit' => 'application_choices#submit', as: :course_choices_submit_course_choice
       get '/delete/:id' => 'application_choices#confirm_destroy', as: :continuous_applications_confirm_destroy_course_choice
       delete '/delete/:id' => 'application_choices#destroy'
     end

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -341,7 +341,7 @@ namespace :candidate_interface, path: '/candidate' do
 
       get '/go-to-find' => 'course_choices/go_to_find#new', as: :course_choices_go_to_find_explanation
 
-      get '/provider' => 'course_choices/provider_selection#new', as: :continuous_applications_provider_selection
+      get '/provider' => 'course_choices/provider_selection#new', as: :course_choices_provider_selection
       post '/provider' => 'course_choices/provider_selection#create'
 
       get '/provider/:provider_id/course' => 'course_choices/which_course_are_you_applying_to#new', as: :continuous_applications_which_course_are_you_applying_to

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -335,7 +335,7 @@ namespace :candidate_interface, path: '/candidate' do
       delete '/delete/:id' => 'degrees/destroy#destroy'
     end
 
-    scope '/continuous-applications' do
+    scope '/course-choices' do
       get '/choose' => 'course_choices/do_you_know_which_course#new', as: :continuous_applications_do_you_know_the_course
       post '/choose' => 'course_choices/do_you_know_which_course#create'
 

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -373,7 +373,7 @@ namespace :candidate_interface, path: '/candidate' do
       post '/confirm-selection/:course_id' => 'course_choices/find_course_selection#create'
 
       post '/:id/submit' => 'application_choices#submit', as: :course_choices_submit_course_choice
-      get '/delete/:id' => 'application_choices#confirm_destroy', as: :continuous_applications_confirm_destroy_course_choice
+      get '/delete/:id' => 'application_choices#confirm_destroy', as: :course_choices_confirm_destroy_course_choice
       delete '/delete/:id' => 'application_choices#destroy'
     end
 

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -349,9 +349,9 @@ namespace :candidate_interface, path: '/candidate' do
       get '/:application_choice_id/courses/edit' => 'course_choices/which_course_are_you_applying_to#edit', as: :edit_course_choices_which_course_are_you_applying_to
       patch '/:application_choice_id/courses/edit' => 'course_choices/which_course_are_you_applying_to#update'
 
-      get '/:application_choice_id/review' => 'course_choices/review#show', as: :continuous_applications_course_review
-      get '/:application_choice_id/review-interruption' => 'course_choices/review_interruption#show', as: :continuous_applications_course_review_interruption
-      get '/:application_choice_id/review-and-submit' => 'course_choices/review_and_submit#show', as: :continuous_applications_course_review_and_submit
+      get '/:application_choice_id/review' => 'course_choices/review#show', as: :course_choices_course_review
+      get '/:application_choice_id/review-interruption' => 'course_choices/review_interruption#show', as: :course_choices_course_review_interruption
+      get '/:application_choice_id/review-and-submit' => 'course_choices/review_and_submit#show', as: :course_choices_course_review_and_submit
       get '/blocked-submissions' => 'course_choices/blocked_submissions#show', as: :continuous_applications_blocked_submissions
 
       get '/provider/:provider_id/courses/:course_id/reached-reapplication-limit' => 'course_choices/reached_reapplication_limit#new', as: :continuous_applications_reached_reapplication_limit

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -364,9 +364,9 @@ namespace :candidate_interface, path: '/candidate' do
       get '/:application_choice_id/courses/:course_id/edit' => 'course_choices/course_study_mode#edit', as: :edit_course_choices_course_study_mode
       patch '/:application_choice_id/courses/:course_id/edit' => 'course_choices/course_study_mode#update'
 
-      get '/provider/:provider_id/courses/:course_id/:study_mode' => 'course_choices/course_site#new', as: :continuous_applications_course_site
+      get '/provider/:provider_id/courses/:course_id/:study_mode' => 'course_choices/course_site#new', as: :course_choices_course_site
       post '/provider/:provider_id/courses/:course_id/:study_mode' => 'course_choices/course_site#create'
-      get '/:application_choice_id/courses/:course_id/:study_mode/edit' => 'course_choices/course_site#edit', as: :edit_continuous_applications_course_site
+      get '/:application_choice_id/courses/:course_id/:study_mode/edit' => 'course_choices/course_site#edit', as: :edit_course_choices_course_site
       patch '/:application_choice_id/courses/:course_id/:study_mode/edit' => 'course_choices/course_site#update'
 
       get '/confirm-selection/:course_id' => 'course_choices/find_course_selection#new', as: :continuous_applications_course_confirm_selection

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -339,7 +339,7 @@ namespace :candidate_interface, path: '/candidate' do
       get '/choose' => 'course_choices/do_you_know_which_course#new', as: :course_choices_do_you_know_the_course
       post '/choose' => 'course_choices/do_you_know_which_course#create'
 
-      get '/go-to-find' => 'course_choices/go_to_find#new', as: :continuous_applications_go_to_find_explanation
+      get '/go-to-find' => 'course_choices/go_to_find#new', as: :course_choices_go_to_find_explanation
 
       get '/provider' => 'course_choices/provider_selection#new', as: :continuous_applications_provider_selection
       post '/provider' => 'course_choices/provider_selection#create'

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -352,7 +352,7 @@ namespace :candidate_interface, path: '/candidate' do
       get '/:application_choice_id/review' => 'course_choices/review#show', as: :course_choices_course_review
       get '/:application_choice_id/review-interruption' => 'course_choices/review_interruption#show', as: :course_choices_course_review_interruption
       get '/:application_choice_id/review-and-submit' => 'course_choices/review_and_submit#show', as: :course_choices_course_review_and_submit
-      get '/blocked-submissions' => 'course_choices/blocked_submissions#show', as: :continuous_applications_blocked_submissions
+      get '/blocked-submissions' => 'course_choices/blocked_submissions#show', as: :course_choices_blocked_submissions
 
       get '/provider/:provider_id/courses/:course_id/reached-reapplication-limit' => 'course_choices/reached_reapplication_limit#new', as: :continuous_applications_reached_reapplication_limit
       get '/provider/:provider_id/courses/:course_id/duplicate' => 'course_choices/duplicate_course_selection#new', as: :continuous_applications_duplicate_course_selection

--- a/spec/forms/candidate_interface/course_selection/closed_course_selection_step_spec.rb
+++ b/spec/forms/candidate_interface/course_selection/closed_course_selection_step_spec.rb
@@ -4,6 +4,6 @@ RSpec.describe CandidateInterface::CourseSelection::ClosedCourseSelectionStep do
   subject { described_class.new.class.route_name }
 
   describe '.route_name' do
-    it { is_expected.to eq('candidate_interface_continuous_applications_closed_course_selection') }
+    it { is_expected.to eq('candidate_interface_course_choices_closed_course_selection') }
   end
 end

--- a/spec/forms/candidate_interface/course_selection/course_review_step_spec.rb
+++ b/spec/forms/candidate_interface/course_selection/course_review_step_spec.rb
@@ -4,6 +4,6 @@ RSpec.describe CandidateInterface::CourseSelection::CourseReviewStep do
   subject { described_class.new.class.route_name }
 
   describe '.route_name' do
-    it { is_expected.to eq('candidate_interface_continuous_applications_course_review') }
+    it { is_expected.to eq('candidate_interface_course_choices_course_review') }
   end
 end

--- a/spec/forms/candidate_interface/course_selection/course_site_step_spec.rb
+++ b/spec/forms/candidate_interface/course_selection/course_site_step_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CandidateInterface::CourseSelection::CourseSiteStep do
   describe '.route_name' do
     subject { course_site_step.class.route_name }
 
-    it { is_expected.to eq('candidate_interface_continuous_applications_course_site') }
+    it { is_expected.to eq('candidate_interface_course_choices_course_site') }
   end
 
   describe 'validations' do

--- a/spec/forms/candidate_interface/course_selection/course_study_mode_step_spec.rb
+++ b/spec/forms/candidate_interface/course_selection/course_study_mode_step_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CandidateInterface::CourseSelection::CourseStudyModeStep do
   describe '.route_name' do
     subject { course_study_mode_step.class.route_name }
 
-    it { is_expected.to eq('candidate_interface_continuous_applications_course_study_mode') }
+    it { is_expected.to eq('candidate_interface_course_choices_course_study_mode') }
   end
 
   describe 'validations' do

--- a/spec/forms/candidate_interface/course_selection/do_you_know_the_course_step_spec.rb
+++ b/spec/forms/candidate_interface/course_selection/do_you_know_the_course_step_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CandidateInterface::CourseSelection::DoYouKnowTheCourseStep do
   describe '.route_name' do
     subject { do_you_know_the_course_step.class.route_name }
 
-    it { is_expected.to eq('candidate_interface_continuous_applications_do_you_know_the_course') }
+    it { is_expected.to eq('candidate_interface_course_choices_do_you_know_the_course') }
   end
 
   context 'when the answer is yes' do

--- a/spec/forms/candidate_interface/course_selection/duplicate_course_selection_step_spec.rb
+++ b/spec/forms/candidate_interface/course_selection/duplicate_course_selection_step_spec.rb
@@ -4,6 +4,6 @@ RSpec.describe CandidateInterface::CourseSelection::DuplicateCourseSelectionStep
   subject { described_class.new.class.route_name }
 
   describe '.route_name' do
-    it { is_expected.to eq('candidate_interface_continuous_applications_duplicate_course_selection') }
+    it { is_expected.to eq('candidate_interface_course_choices_duplicate_course_selection') }
   end
 end

--- a/spec/forms/candidate_interface/course_selection/full_course_selection_step_spec.rb
+++ b/spec/forms/candidate_interface/course_selection/full_course_selection_step_spec.rb
@@ -4,6 +4,6 @@ RSpec.describe CandidateInterface::CourseSelection::FullCourseSelectionStep do
   subject { described_class.new.class.route_name }
 
   describe '.route_name' do
-    it { is_expected.to eq('candidate_interface_continuous_applications_full_course_selection') }
+    it { is_expected.to eq('candidate_interface_course_choices_full_course_selection') }
   end
 end

--- a/spec/forms/candidate_interface/course_selection/go_to_find_explanation_step_spec.rb
+++ b/spec/forms/candidate_interface/course_selection/go_to_find_explanation_step_spec.rb
@@ -4,6 +4,6 @@ RSpec.describe CandidateInterface::CourseSelection::GoToFindExplanationStep do
   subject { described_class.new.class.route_name }
 
   describe '.route_name' do
-    it { is_expected.to eq('candidate_interface_continuous_applications_go_to_find_explanation') }
+    it { is_expected.to eq('candidate_interface_course_choices_go_to_find_explanation') }
   end
 end

--- a/spec/forms/candidate_interface/course_selection/provider_selection_step_spec.rb
+++ b/spec/forms/candidate_interface/course_selection/provider_selection_step_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CandidateInterface::CourseSelection::ProviderSelectionStep do
   describe '.route_name' do
     subject { provider_selection_step.class.route_name }
 
-    it { is_expected.to eq('candidate_interface_continuous_applications_provider_selection') }
+    it { is_expected.to eq('candidate_interface_course_choices_provider_selection') }
   end
 
   it 'returns the correct next step' do

--- a/spec/forms/candidate_interface/course_selection/reached_reapplication_limit_step_spec.rb
+++ b/spec/forms/candidate_interface/course_selection/reached_reapplication_limit_step_spec.rb
@@ -4,6 +4,6 @@ RSpec.describe CandidateInterface::CourseSelection::ReachedReapplicationLimitSte
   subject { described_class.new.class.route_name }
 
   describe '.route_name' do
-    it { is_expected.to eq('candidate_interface_continuous_applications_reached_reapplication_limit') }
+    it { is_expected.to eq('candidate_interface_course_choices_reached_reapplication_limit') }
   end
 end

--- a/spec/forms/candidate_interface/course_selection/which_course_are_you_applying_to_step_spec.rb
+++ b/spec/forms/candidate_interface/course_selection/which_course_are_you_applying_to_step_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe CandidateInterface::CourseSelection::WhichCourseAreYouApplyingToS
   describe '.route_name' do
     subject { which_course_are_you_applying_to_step.class.route_name }
 
-    it { is_expected.to eq('candidate_interface_continuous_applications_which_course_are_you_applying_to') }
+    it { is_expected.to eq('candidate_interface_course_choices_which_course_are_you_applying_to') }
   end
 
   describe 'validations' do

--- a/spec/requests/candidate_interface/after_sign_in_redirects_spec.rb
+++ b/spec/requests/candidate_interface/after_sign_in_redirects_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe 'After sign in redirects' do
   context 'when candidate can confirm the course selected' do
     it 'redirects to confirm selection page' do
       get candidate_interface_interstitial_path
-      expect(response).to redirect_to(candidate_interface_continuous_applications_course_confirm_selection_path(course_from_find.id))
+      expect(response).to redirect_to(candidate_interface_course_choices_course_confirm_selection_path(course_from_find.id))
     end
   end
 end

--- a/spec/requests/candidate_interface/continuous_applications_choose_course_spec.rb
+++ b/spec/requests/candidate_interface/continuous_applications_choose_course_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'continuous applications redirects' do
       provider = create(:provider, code: '8N5', name: 'Snape University')
       course = create(:course, name: 'Potions', provider:)
 
-      get candidate_interface_continuous_applications_course_confirm_selection_path(course.id)
+      get candidate_interface_course_choices_course_confirm_selection_path(course.id)
 
       expect(response).to redirect_to(candidate_interface_continuous_applications_choices_path)
     end

--- a/spec/requests/candidate_interface/continuous_applications_reject_submission_blocked_spec.rb
+++ b/spec/requests/candidate_interface/continuous_applications_reject_submission_blocked_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Block submission from blocked candidates' do
 
     context 'when tries to submit' do
       it 'renders interstitial page' do
-        post candidate_interface_continuous_applications_submit_course_choice_path(choice.id),
+        post candidate_interface_course_choices_submit_course_choice_path(choice.id),
              params: {
                candidate_interface_continuous_applications_submit_application_form: {
                  submit_answer: true,
@@ -44,7 +44,7 @@ RSpec.describe 'Block submission from blocked candidates' do
 
     context 'when tries to submit' do
       it 'redirects to your applications' do
-        post candidate_interface_continuous_applications_submit_course_choice_path(choice.id),
+        post candidate_interface_course_choices_submit_course_choice_path(choice.id),
              params: {
                candidate_interface_continuous_applications_submit_application_form: {
                  submit_answer: true,

--- a/spec/requests/candidate_interface/continuous_applications_reject_submission_blocked_spec.rb
+++ b/spec/requests/candidate_interface/continuous_applications_reject_submission_blocked_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Block submission from blocked candidates' do
 
     context 'when accessing the review and submit path' do
       it 'renders interstitial page' do
-        get candidate_interface_continuous_applications_course_review_and_submit_path(application_choice_id: choice.id)
+        get candidate_interface_course_choices_course_review_and_submit_path(application_choice_id: choice.id)
         expect(response).to redirect_to(candidate_interface_continuous_applications_blocked_submissions_path)
       end
     end
@@ -37,7 +37,7 @@ RSpec.describe 'Block submission from blocked candidates' do
 
     context 'when accessing the review and submit path' do
       it 'renders successfully' do
-        get candidate_interface_continuous_applications_course_review_and_submit_path(application_choice_id: choice.id)
+        get candidate_interface_course_choices_course_review_and_submit_path(application_choice_id: choice.id)
         expect(response).to have_http_status(:success)
       end
     end

--- a/spec/requests/candidate_interface/continuous_applications_reject_submission_blocked_spec.rb
+++ b/spec/requests/candidate_interface/continuous_applications_reject_submission_blocked_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Block submission from blocked candidates' do
     context 'when accessing the review and submit path' do
       it 'renders interstitial page' do
         get candidate_interface_course_choices_course_review_and_submit_path(application_choice_id: choice.id)
-        expect(response).to redirect_to(candidate_interface_continuous_applications_blocked_submissions_path)
+        expect(response).to redirect_to(candidate_interface_course_choices_blocked_submissions_path)
       end
     end
 
@@ -25,7 +25,7 @@ RSpec.describe 'Block submission from blocked candidates' do
                  submit_answer: true,
                },
              }
-        expect(response).to redirect_to(candidate_interface_continuous_applications_blocked_submissions_path)
+        expect(response).to redirect_to(candidate_interface_course_choices_blocked_submissions_path)
       end
     end
   end

--- a/spec/requests/candidate_interface/continuous_applications_review_and_submit_spec.rb
+++ b/spec/requests/candidate_interface/continuous_applications_review_and_submit_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Redirects when reviewing before submission' do
     it 'redirects to application choices' do
       application_form = create(:completed_application_form, candidate:)
       application_choice = create(:application_choice, :awaiting_provider_decision, application_form:)
-      get candidate_interface_continuous_applications_course_review_and_submit_path(application_choice.id)
+      get candidate_interface_course_choices_course_review_and_submit_path(application_choice.id)
       expect(response).to redirect_to(candidate_interface_continuous_applications_choices_path)
     end
   end
@@ -21,8 +21,8 @@ RSpec.describe 'Redirects when reviewing before submission' do
     it 'redirects to reviews course choice' do
       application_form = create(:application_form, :minimum_info, candidate:)
       application_choice = create(:application_choice, :unsubmitted, application_form:)
-      get candidate_interface_continuous_applications_course_review_and_submit_path(application_choice.id)
-      expect(response).to redirect_to(candidate_interface_continuous_applications_course_review_path(application_choice.id))
+      get candidate_interface_course_choices_course_review_and_submit_path(application_choice.id)
+      expect(response).to redirect_to(candidate_interface_course_choices_course_review_path(application_choice.id))
     end
   end
 end

--- a/spec/requests/candidate_interface/continuous_applications_submission_spec.rb
+++ b/spec/requests/candidate_interface/continuous_applications_submission_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Submit to continuous apps' do
     let(:application_form) { create(:application_form, :completed, submitted_at: nil) }
 
     before do
-      post candidate_interface_continuous_applications_submit_course_choice_path(choice.id)
+      post candidate_interface_course_choices_submit_course_choice_path(choice.id)
     end
 
     it 'be successful' do
@@ -31,7 +31,7 @@ RSpec.describe 'Submit to continuous apps' do
     end
 
     it 'be successful' do
-      post candidate_interface_continuous_applications_submit_course_choice_path(choice.id)
+      post candidate_interface_course_choices_submit_course_choice_path(choice.id)
       expect(response).to redirect_to(candidate_interface_start_carry_over_path)
     end
 

--- a/spec/requests/candidate_interface/delete_application_choice_spec.rb
+++ b/spec/requests/candidate_interface/delete_application_choice_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'DELETE /candidate/application/continuous-applications/delete/:ap
     let(:application_choice) { create(:application_choice, :unsubmitted, application_form:) }
 
     it 'destroys the application choice and redirects to review' do
-      delete candidate_interface_continuous_applications_confirm_destroy_course_choice_path(application_choice)
+      delete candidate_interface_course_choices_confirm_destroy_course_choice_path(application_choice)
       expect(ApplicationChoice.exists?(application_choice.id)).to be_falsey
       expect(response).to redirect_to(candidate_interface_continuous_applications_choices_path)
     end
@@ -23,7 +23,7 @@ RSpec.describe 'DELETE /candidate/application/continuous-applications/delete/:ap
     let(:application_choice) { create(:application_choice, :awaiting_provider_decision, application_form:) }
 
     it 'does not destroy the application choice and redirects to review' do
-      delete candidate_interface_continuous_applications_confirm_destroy_course_choice_path(application_choice)
+      delete candidate_interface_course_choices_confirm_destroy_course_choice_path(application_choice)
       expect(ApplicationChoice.exists?(application_choice.id)).to be_truthy
       expect(response).to redirect_to(candidate_interface_continuous_applications_choices_path)
     end

--- a/spec/requests/candidate_interface/edit_application_choice_spec.rb
+++ b/spec/requests/candidate_interface/edit_application_choice_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Edit courses on continuous applications' do
     [
       candidate_interface_edit_course_choices_which_course_are_you_applying_to_path(application_choice.id),
       candidate_interface_edit_continuous_applications_course_site_path(application_choice.id, current_course.id, current_course.study_mode),
-      candidate_interface_edit_continuous_applications_course_study_mode_path(application_choice.id, current_course.id),
+      candidate_interface_edit_course_choices_course_study_mode_path(application_choice.id, current_course.id),
     ]
   end
 

--- a/spec/requests/candidate_interface/edit_application_choice_spec.rb
+++ b/spec/requests/candidate_interface/edit_application_choice_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Edit courses on continuous applications' do
   let(:paths) do
     [
       candidate_interface_edit_course_choices_which_course_are_you_applying_to_path(application_choice.id),
-      candidate_interface_edit_continuous_applications_course_site_path(application_choice.id, current_course.id, current_course.study_mode),
+      candidate_interface_edit_course_choices_course_site_path(application_choice.id, current_course.id, current_course.study_mode),
       candidate_interface_edit_course_choices_course_study_mode_path(application_choice.id, current_course.id),
     ]
   end

--- a/spec/requests/candidate_interface/edit_application_choice_spec.rb
+++ b/spec/requests/candidate_interface/edit_application_choice_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Edit courses on continuous applications' do
   let(:current_course) { application_choice.current_course }
   let(:paths) do
     [
-      candidate_interface_edit_continuous_applications_which_course_are_you_applying_to_path(application_choice.id),
+      candidate_interface_edit_course_choices_which_course_are_you_applying_to_path(application_choice.id),
       candidate_interface_edit_continuous_applications_course_site_path(application_choice.id, current_course.id, current_course.study_mode),
       candidate_interface_edit_continuous_applications_course_study_mode_path(application_choice.id, current_course.id),
     ]

--- a/spec/requests/candidate_interface/get_go_to_find_spec.rb
+++ b/spec/requests/candidate_interface/get_go_to_find_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'GET course_choices/go_to_find' do
   end
 
   it 'is a successful request' do
-    get candidate_interface_continuous_applications_go_to_find_explanation_path
+    get candidate_interface_course_choices_go_to_find_explanation_path
 
     expect(response).to have_http_status(:success)
   end

--- a/spec/services/candidate_interface/application_choice_submission_spec.rb
+++ b/spec/services/candidate_interface/application_choice_submission_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe CandidateInterface::ApplicationChoiceSubmission do
         <<~MSG.chomp
           You cannot submit this application as the course is no longer available.
 
-          #{govuk_link_to('Remove this application', Rails.application.routes.url_helpers.candidate_interface_continuous_applications_confirm_destroy_course_choice_path(application_choice.id))} and search for other courses.
+          #{govuk_link_to('Remove this application', Rails.application.routes.url_helpers.candidate_interface_course_choices_confirm_destroy_course_choice_path(application_choice.id))} and search for other courses.
         MSG
       end
     end

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -769,7 +769,7 @@ module CandidateHelper
     expect(page).to have_current_path(candidate_interface_continuous_applications_choices_path)
     expect(page).to have_content('You can add up to 4 applications at a time.')
     click_link_or_button 'Add application'
-    expect(page).to have_current_path(candidate_interface_continuous_applications_do_you_know_the_course_path)
+    expect(page).to have_current_path(candidate_interface_course_choices_do_you_know_the_course_path)
   end
 
   def application_choice

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -758,7 +758,7 @@ module CandidateHelper
   def then_i_should_be_on_the_application_choice_review_page
     expect(application_choice).to be_present
     expect(page).to have_current_path(
-      candidate_interface_continuous_applications_course_review_path(application_choice_id: application_choice.id),
+      candidate_interface_course_choices_course_review_path(application_choice_id: application_choice.id),
     )
   end
   alias then_i_am_on_the_application_choice_review_page then_i_should_be_on_the_application_choice_review_page
@@ -834,7 +834,7 @@ module CandidateHelper
 
   def then_i_should_be_on_the_review_and_submit_page
     expect(page).to have_current_path(
-      candidate_interface_continuous_applications_course_review_and_submit_path(@application_choice.id),
+      candidate_interface_course_choices_course_review_and_submit_path(@application_choice.id),
     )
   end
   alias then_i_am_on_the_review_and_submit_page then_i_should_be_on_the_review_and_submit_page

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
@@ -158,7 +158,7 @@ private
 
   def then_i_see_the_course_choice_review_page
     expect(page).to have_current_path(
-      candidate_interface_continuous_applications_course_review_path(
+      candidate_interface_course_choices_course_review_path(
         application_choice_id: application_choice.id,
       ),
     )

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
     click_on @application_choice.provider.name
     expect(page)
       .to have_current_path(
-        candidate_interface_continuous_applications_course_review_path(
+        candidate_interface_course_choices_course_review_path(
           application_choice_id: @application_choice.id,
         ),
       )

--- a/spec/system/candidate_interface/carry_over/candidate_views_and_withdraws_after_apply_deadline_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_views_and_withdraws_after_apply_deadline_spec.rb
@@ -49,7 +49,7 @@ private
     click_on @application_choice.provider.name
     expect(page)
       .to have_current_path(
-        candidate_interface_continuous_applications_course_review_path(
+        candidate_interface_course_choices_course_review_path(
           application_choice_id: @application_choice.id,
         ),
       )

--- a/spec/system/candidate_interface/continuous_applications/carry_over/candidate_carries_over_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/carry_over/candidate_carries_over_spec.rb
@@ -205,7 +205,7 @@ private
   end
 
   def when_i_visit_add_course_url
-    visit candidate_interface_continuous_applications_do_you_know_the_course_path
+    visit candidate_interface_course_choices_do_you_know_the_course_path
   end
 
   def then_i_am_redirect_to_your_applications_tab

--- a/spec/system/candidate_interface/continuous_applications/course_selection/backlinks_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/backlinks_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate edits course choices' do
+RSpec.describe 'Candidate edits course choices' do
   include CandidateHelper
   include CourseOptionHelpers
 
@@ -96,7 +96,7 @@ RSpec.feature 'Candidate edits course choices' do
   end
 
   def then_i_be_on_the_application_choice_review_page
-    expect(page).to have_current_path(/candidate\/application\/continuous-applications\/[0-9]*\/review/)
+    expect(page).to have_current_path(/candidate\/application\/course-choices\/[0-9]*\/review/)
   end
 
   def when_i_visit_the_review_page_directly

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_and_says_no_to_course_choice_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_and_says_no_to_course_choice_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate arrives from Find with provider and course params' do
+RSpec.describe 'Candidate arrives from Find with provider and course params' do
   include CandidateHelper
 
   scenario 'The provider is only accepting applications on the Apply service' do
@@ -47,7 +47,7 @@ RSpec.feature 'Candidate arrives from Find with provider and course params' do
 
   def then_i_am_redirected_to_the_course_confirm_selection_page
     expect(page).to have_current_path(
-      candidate_interface_continuous_applications_course_confirm_selection_path(@course.id),
+      candidate_interface_course_choices_course_confirm_selection_path(@course.id),
     )
   end
 

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_not_signed_in_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_not_signed_in_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
 
   def then_i_see_the_course_choices_site_page
     expect(page).to have_current_path(
-      candidate_interface_continuous_applications_course_site_path(
+      candidate_interface_course_choices_course_site_path(
         @course_with_multiple_sites.provider.id,
         @course_with_multiple_sites.id,
         :part_time,

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_not_signed_in_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_not_signed_in_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
 
   def then_i_see_the_courses_review_page
     expect(page).to have_current_path(
-      candidate_interface_continuous_applications_course_review_path(
+      candidate_interface_course_choices_course_review_path(
         application_choice_id: @candidate.current_application.application_choices.last.id,
       ),
     )

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_only_open_on_apply_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_only_open_on_apply_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Candidate arrives from Find with provider and course params' do
   end
 
   def then_i_am_redirected_to_the_full_course_path
-    expect(page).to have_current_path candidate_interface_continuous_applications_full_course_selection_path(
+    expect(page).to have_current_path candidate_interface_course_choices_full_course_selection_path(
       @provider.id,
       @course.id,
     )

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_only_open_on_apply_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_only_open_on_apply_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'Candidate arrives from Find with provider and course params' do
 
   def then_i_am_redirected_to_the_course_confirm_selection_page
     expect(page).to have_current_path(
-      candidate_interface_continuous_applications_course_confirm_selection_path(@course.id),
+      candidate_interface_course_choices_course_confirm_selection_path(@course.id),
     )
   end
 

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_only_open_on_apply_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_only_open_on_apply_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate arrives from Find with provider and course params' do
+RSpec.describe 'Candidate arrives from Find with provider and course params' do
   include CandidateHelper
 
   scenario 'The provider is only accepting applications on the Apply service' do
@@ -70,7 +70,7 @@ RSpec.feature 'Candidate arrives from Find with provider and course params' do
 
   def then_i_am_redirected_to_the_course_review_path
     expect(page).to have_current_path(
-      candidate_interface_continuous_applications_course_review_path(application_choice_id: application_choice.id),
+      candidate_interface_course_choices_course_review_path(application_choice_id: application_choice.id),
     )
   end
 end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_with_multiple_sites_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_with_multiple_sites_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'Candidate arrives from Find with provider and course with multip
 
   def then_i_am_redirected_to_the_course_confirm_selection_page
     expect(page).to have_current_path(
-      candidate_interface_continuous_applications_course_confirm_selection_path(@course.id),
+      candidate_interface_course_choices_course_confirm_selection_path(@course.id),
     )
   end
 

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_with_multiple_sites_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_with_multiple_sites_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate arrives from Find with provider and course with multiple sites' do
+RSpec.describe 'Candidate arrives from Find with provider and course with multiple sites' do
   include CandidateHelper
 
   scenario 'The provider is only accepting applications on the Apply service' do
@@ -96,7 +96,7 @@ RSpec.feature 'Candidate arrives from Find with provider and course with multipl
 
   def then_i_am_redirected_to_the_course_review_path
     expect(page).to have_current_path(
-      candidate_interface_continuous_applications_course_review_path(application_choice_id: application_choice.id),
+      candidate_interface_course_choices_course_review_path(application_choice_id: application_choice.id),
     )
   end
 end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_with_multiple_sites_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_with_multiple_sites_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'Candidate arrives from Find with provider and course with multip
 
   def then_i_am_redirected_to_the_course_site_path
     expect(page).to have_current_path(
-      candidate_interface_continuous_applications_course_site_path(
+      candidate_interface_course_choices_course_site_path(
         @provider.id,
         @course.id,
         'full_time',

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_with_multiple_study_modes_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_with_multiple_study_modes_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'Candidate arrives from Find with provider and course with multip
 
   def then_i_am_redirected_to_the_course_confirm_selection_page
     expect(page).to have_current_path(
-      candidate_interface_continuous_applications_course_confirm_selection_path(@course.id),
+      candidate_interface_course_choices_course_confirm_selection_path(@course.id),
     )
   end
 

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_with_multiple_study_modes_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_with_multiple_study_modes_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate arrives from Find with provider and course with multiple study modes' do
+RSpec.describe 'Candidate arrives from Find with provider and course with multiple study modes' do
   include CandidateHelper
 
   scenario 'The provider is only accepting applications on the Apply service' do
@@ -120,7 +120,7 @@ RSpec.feature 'Candidate arrives from Find with provider and course with multipl
 
   def then_i_am_redirected_to_the_course_review_path
     expect(page).to have_current_path(
-      candidate_interface_continuous_applications_course_review_path(application_choice_id: application_choice.id),
+      candidate_interface_course_choices_course_review_path(application_choice_id: application_choice.id),
     )
   end
 

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_with_multiple_study_modes_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_with_multiple_study_modes_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe 'Candidate arrives from Find with provider and course with multip
 
   def then_i_am_redirected_to_the_course_site_path
     expect(page).to have_current_path(
-      candidate_interface_continuous_applications_course_site_path(
+      candidate_interface_course_choices_course_site_path(
         @provider.id,
         @course.id,
         'part_time',

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_with_multiple_study_modes_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_arrives_from_find_with_a_course_with_multiple_study_modes_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe 'Candidate arrives from Find with provider and course with multip
   def then_i_am_redirect_to_the_course_study_mode_path
     expect(page).to have_text 'Full time or part time?'
     expect(page).to have_current_path(
-      candidate_interface_continuous_applications_course_study_mode_path(@provider.id, @course.id),
+      candidate_interface_course_choices_course_study_mode_path(@provider.id, @course.id),
     )
   end
 

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_changes_course_and_reaches_limit_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_changes_course_and_reaches_limit_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Changing a course' do
+RSpec.describe 'Changing a course' do
   include CandidateHelper
 
   it 'Candidate changes course to one they have already been rejected from twice' do
@@ -75,7 +75,7 @@ RSpec.feature 'Changing a course' do
   end
 
   def then_i_am_on_the_reached_reapplication_limit_page
-    expect(page.current_url).to end_with(candidate_interface_continuous_applications_reached_reapplication_limit_path(provider_id: @provider.id, course_id: @course.id))
+    expect(page.current_url).to end_with(candidate_interface_course_choices_reached_reapplication_limit_path(provider_id: @provider.id, course_id: @course.id))
   end
 
   def when_i_visit_my_details_page

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_deletes_application_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_deletes_application_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate edits their choice section' do
+RSpec.describe 'Candidate edits their choice section' do
   include CandidateHelper
 
   it 'Candidate deletes and adds additional courses' do
@@ -12,10 +12,10 @@ RSpec.feature 'Candidate edits their choice section' do
     and_i_click_delete_your_draft_application
     and_i_confirm_i_want_to_delete_the_choice
     and_visit_my_application_page
-    then_i_should_see_only_one_application
+    then_i_see_only_one_application
     and_if_i_try_manually_to_enter_on_delete_the_url_for_my_submitted_choice
-    then_i_should_be_on_the_my_application_page
-    and_my_submitted_choice_should_be_displayed
+    then_i_am_on_the_my_application_page
+    and_my_submitted_choice_is_displayed
   end
 
   it 'Candidate deletes course choice from the review page' do
@@ -25,16 +25,16 @@ RSpec.feature 'Candidate edits their choice section' do
     when_i_visit_the_course_choice_review_page
     and_i_click_delete_your_draft_application
     and_i_click_cancel
-    then_i_should_be_on_the_course_choice_review_page
+    then_i_am_on_the_course_choice_review_page
 
     when_i_visit_the_course_choice_review_page
     and_i_click_delete_your_draft_application
     and_i_confirm_i_want_to_delete_the_choice
     and_visit_my_application_page
-    then_i_should_see_only_one_application
+    then_i_see_only_one_application
     and_if_i_try_manually_to_enter_on_delete_the_url_for_my_submitted_choice
-    then_i_should_be_on_the_my_application_page
-    and_my_submitted_choice_should_be_displayed
+    then_i_am_on_the_my_application_page
+    and_my_submitted_choice_is_displayed
   end
 
   def given_i_am_signed_in
@@ -57,7 +57,7 @@ RSpec.feature 'Candidate edits their choice section' do
     click_link_or_button t('application_form.continuous_applications.courses.confirm_delete')
   end
 
-  def then_i_should_see_only_one_application
+  def then_i_see_only_one_application
     expect(page).to have_no_content(@first_application_choice.current_course.name_and_code)
   end
 
@@ -69,16 +69,16 @@ RSpec.feature 'Candidate edits their choice section' do
     visit candidate_interface_continuous_applications_confirm_destroy_course_choice_path(@second_application_choice.id)
   end
 
-  def then_i_should_be_on_the_my_application_page
+  def then_i_am_on_the_my_application_page
     expect(page).to have_current_path(candidate_interface_continuous_applications_choices_path)
   end
 
-  def and_my_submitted_choice_should_be_displayed
+  def and_my_submitted_choice_is_displayed
     expect(page).to have_content(@second_application_choice.current_course.name_and_code)
   end
 
   def when_i_visit_the_course_choice_review_page
-    visit candidate_interface_continuous_applications_course_review_path(@first_application_choice.id)
+    visit candidate_interface_course_choices_course_review_path(@first_application_choice.id)
   end
 
   def and_i_click_delete_your_draft_application
@@ -89,7 +89,7 @@ RSpec.feature 'Candidate edits their choice section' do
     click_link_or_button 'Cancel'
   end
 
-  def then_i_should_be_on_the_course_choice_review_page
-    expect(page).to have_current_path(candidate_interface_continuous_applications_course_review_path(@first_application_choice.id))
+  def then_i_am_on_the_course_choice_review_page
+    expect(page).to have_current_path(candidate_interface_course_choices_course_review_path(@first_application_choice.id))
   end
 end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_deletes_application_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_deletes_application_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'Candidate edits their choice section' do
   end
 
   def and_if_i_try_manually_to_enter_on_delete_the_url_for_my_submitted_choice
-    visit candidate_interface_continuous_applications_confirm_destroy_course_choice_path(@second_application_choice.id)
+    visit candidate_interface_course_choices_confirm_destroy_course_choice_path(@second_application_choice.id)
   end
 
   def then_i_am_on_the_my_application_page

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_edits_course_choices_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_edits_course_choices_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate edits course choices' do
+RSpec.describe 'Candidate edits course choices' do
   include CandidateHelper
   include CourseOptionHelpers
 
@@ -256,7 +256,7 @@ RSpec.feature 'Candidate edits course choices' do
   end
 
   def then_i_am_on_the_application_choice_review_page
-    expect(page).to have_current_path(/candidate\/application\/continuous-applications\/[0-9]*\/review/)
+    expect(page).to have_current_path(/candidate\/application\/course-choices\/[0-9]*\/review/)
   end
 
   def and_i_click_to_continue_my_application

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_edits_course_choices_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_edits_course_choices_spec.rb
@@ -260,6 +260,6 @@ RSpec.describe 'Candidate edits course choices' do
   end
 
   def and_i_click_to_continue_my_application
-    page.find_link(nil, href: candidate_interface_continuous_applications_course_review_path(@application_choice.id)).click
+    page.find_link(nil, href: candidate_interface_course_choices_course_review_path(@application_choice.id)).click
   end
 end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_reaching_reapplication_limit_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_reaching_reapplication_limit_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Selecting a course' do
+RSpec.describe 'Selecting a course' do
   include CandidateHelper
 
   it 'Candidate selects a course they have already been rejected from twice' do
@@ -75,6 +75,6 @@ RSpec.feature 'Selecting a course' do
   end
 
   def then_i_am_on_the_course_choice_page
-    expect(page.current_url).to end_with(candidate_interface_continuous_applications_which_course_are_you_applying_to_path(provider_id: @provider.id))
+    expect(page.current_url).to end_with(candidate_interface_course_choices_which_course_are_you_applying_to_path(provider_id: @provider.id))
   end
 end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_reapplying_to_a_course_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_reapplying_to_a_course_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Selecting a course' do
+RSpec.describe 'Selecting a course' do
   include CandidateHelper
 
   it 'Candidate selects a course they are reapplying to' do
@@ -31,7 +31,7 @@ RSpec.feature 'Selecting a course' do
   def then_i_am_on_the_application_choice_review_page
     expect(application_choice).to be_present
     expect(page).to have_current_path(
-      candidate_interface_continuous_applications_course_review_path(application_choice_id: application_choice.id),
+      candidate_interface_course_choices_course_review_path(application_choice_id: application_choice.id),
     )
   end
 

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_study_mode_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_study_mode_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Selecting a study mode' do
+RSpec.describe 'Selecting a study mode' do
   include CandidateHelper
 
   scenario 'Candidate selects different study modes' do
@@ -93,7 +93,7 @@ RSpec.feature 'Selecting a study mode' do
   end
 
   def and_i_visit_my_course_choices_page
-    visit candidate_interface_continuous_applications_course_review_path(@current_candidate.application_choices.last.id)
+    visit candidate_interface_course_choices_course_review_path(@current_candidate.application_choices.last.id)
   end
 
   def then_i_see_my_course_choice

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_that_is_closed_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_that_is_closed_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Selecting a course' do
+RSpec.describe 'Selecting a course' do
   include CandidateHelper
 
   it 'Candidate selects a course that is closed' do
@@ -88,6 +88,6 @@ RSpec.feature 'Selecting a course' do
   end
 
   def then_i_be_on_the_course_choice_page
-    expect(page.current_url).to end_with(candidate_interface_continuous_applications_which_course_are_you_applying_to_path(provider_id: @provider.id))
+    expect(page.current_url).to end_with(candidate_interface_course_choices_which_course_are_you_applying_to_path(provider_id: @provider.id))
   end
 end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_that_is_full_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_that_is_full_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Selecting a course' do
+RSpec.describe 'Selecting a course' do
   include CandidateHelper
 
   it 'Candidate selects a course that is full' do
@@ -88,6 +88,6 @@ RSpec.feature 'Selecting a course' do
   end
 
   def then_i_be_on_the_course_choice_page
-    expect(page.current_url).to end_with(candidate_interface_continuous_applications_which_course_are_you_applying_to_path(provider_id: @provider.id))
+    expect(page.current_url).to end_with(candidate_interface_course_choices_which_course_are_you_applying_to_path(provider_id: @provider.id))
   end
 end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_with_multiple_sites_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_course_with_multiple_sites_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Selecting a course with multiple sites' do
+RSpec.describe 'Selecting a course with multiple sites' do
   include CandidateHelper
 
   it 'Candidate selects a course choice' do
@@ -104,7 +104,7 @@ RSpec.feature 'Selecting a course with multiple sites' do
 
   def then_i_choose_a_location_preference
     expect(page).to have_current_path(
-      candidate_interface_continuous_applications_course_site_path(
+      candidate_interface_course_choices_course_site_path(
         @provider.id,
         @multi_site_course.id,
         'full_time',

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_duplicate_course_site_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_duplicate_course_site_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Selecting a course', :js do
   end
 
   def visit_course_selection_page
-    visit "/candidate/application/continuous-applications/provider/#{@provider.id}/courses/#{@course.id}/full_time"
+    visit "/candidate/application/course-choices/provider/#{@provider.id}/courses/#{@course.id}/full_time"
   end
 
   def then_i_am_on_the_application_choice_duplicate_page

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_duplicate_course_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_duplicate_course_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Selecting a course' do
+RSpec.describe 'Selecting a course' do
   include CandidateHelper
 
   it 'Candidate selects a course they have already applied to' do
@@ -73,6 +73,6 @@ RSpec.feature 'Selecting a course' do
   end
 
   def then_i_am_on_the_course_choice_page
-    expect(page.current_url).to end_with(candidate_interface_continuous_applications_which_course_are_you_applying_to_path(provider_id: @provider.id))
+    expect(page.current_url).to end_with(candidate_interface_course_choices_which_course_are_you_applying_to_path(provider_id: @provider.id))
   end
 end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_duplicate_course_when_editing_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_duplicate_course_when_editing_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'Selecting a course' do
   end
 
   def and_i_click_to_view_the_first_application
-    page.find_link(nil, href: candidate_interface_continuous_applications_course_review_path(@application_one.id)).click
+    page.find_link(nil, href: candidate_interface_course_choices_course_review_path(@application_one.id)).click
   end
 
   def when_i_click_back

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_duplicate_course_when_editing_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_selecting_a_duplicate_course_when_editing_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Selecting a course' do
+RSpec.describe 'Selecting a course' do
   include CandidateHelper
 
   it 'Candidate selects a course they have already applied to when editing' do
@@ -67,6 +67,6 @@ RSpec.feature 'Selecting a course' do
   end
 
   def then_i_am_on_the_course_choice_page
-    expect(page).to have_current_path(candidate_interface_continuous_applications_which_course_are_you_applying_to_path(@provider))
+    expect(page).to have_current_path(candidate_interface_course_choices_which_course_are_you_applying_to_path(@provider))
   end
 end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_visiting_selection_flow_for_selected_course_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_visiting_selection_flow_for_selected_course_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Selecting a course' do
+RSpec.describe 'Selecting a course' do
   include CandidateHelper
 
   it 'Candidate is redirected when visiting later steps on a duplicate course selection' do
@@ -53,7 +53,7 @@ RSpec.feature 'Selecting a course' do
   end
 
   def then_i_am_redirected_to_the_duplicate_course_selection_step
-    expect(page).to have_current_path(candidate_interface_continuous_applications_duplicate_course_selection_path(@course_one.provider.id, @course_one.id))
+    expect(page).to have_current_path(candidate_interface_course_choices_duplicate_course_selection_path(@course_one.provider.id, @course_one.id))
   end
 
   def when_i_click_the_back_link

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_visiting_selection_flow_for_selected_course_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_visiting_selection_flow_for_selected_course_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Selecting a course' do
   end
 
   def and_i_visit_the_study_mode_selection_for_my_existing_course_selection
-    visit candidate_interface_continuous_applications_course_study_mode_path(provider_id: @course_one.provider_id, course_id: @course_one.id)
+    visit candidate_interface_course_choices_course_study_mode_path(provider_id: @course_one.provider_id, course_id: @course_one.id)
   end
 
   def when_i_visit_the_sites_selection_for_my_existing_course_selection

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_visiting_selection_flow_for_selected_course_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_visiting_selection_flow_for_selected_course_spec.rb
@@ -65,6 +65,6 @@ RSpec.describe 'Selecting a course' do
   end
 
   def when_i_come_from_find_and_arrive_on_confirm_selection_page
-    visit candidate_interface_continuous_applications_course_confirm_selection_path(course_id: @course_one.id)
+    visit candidate_interface_course_choices_course_confirm_selection_path(course_id: @course_one.id)
   end
 end

--- a/spec/system/candidate_interface/continuous_applications/course_selection/candidate_visiting_selection_flow_for_selected_course_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/course_selection/candidate_visiting_selection_flow_for_selected_course_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'Selecting a course' do
   end
 
   def when_i_visit_the_sites_selection_for_my_existing_course_selection
-    visit candidate_interface_continuous_applications_course_site_path(provider_id: @course_one.provider_id, course_id: @course_one.id, study_mode: :full_time)
+    visit candidate_interface_course_choices_course_site_path(provider_id: @course_one.provider_id, course_id: @course_one.id, study_mode: :full_time)
   end
 
   def then_i_am_redirected_to_the_duplicate_course_selection_step

--- a/spec/system/candidate_interface/continuous_applications/submitting/candidate_can_not_submit_with_incomplete_details_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/submitting/candidate_can_not_submit_with_incomplete_details_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate submits the application' do
+RSpec.describe 'Candidate submits the application' do
   include CandidateHelper
   include SignInHelper
   before do
@@ -45,11 +45,11 @@ RSpec.feature 'Candidate submits the application' do
   end
 
   def when_i_go_to_secondary_review_page
-    visit candidate_interface_continuous_applications_course_review_path(@secondary_application_choice)
+    visit candidate_interface_course_choices_course_review_path(@secondary_application_choice)
   end
 
   def when_i_go_to_primary_review_page
-    visit candidate_interface_continuous_applications_course_review_path(@primary_application_choice)
+    visit candidate_interface_course_choices_course_review_path(@primary_application_choice)
   end
 
   def then_i_see_an_error_message

--- a/spec/system/candidate_interface/continuous_applications/submitting/candidate_tries_to_submit_an_application_for_course_unavailable_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/submitting/candidate_tries_to_submit_an_application_for_course_unavailable_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate tries to submit an application choice when the course is unavailable' do
+RSpec.describe 'Candidate tries to submit an application choice when the course is unavailable' do
   include SignInHelper
   include CandidateHelper
   before do
@@ -92,7 +92,7 @@ RSpec.feature 'Candidate tries to submit an application choice when the course i
   end
 
   def when_i_visit_the_review_page_directly
-    visit candidate_interface_continuous_applications_course_review_path(@application_choice.id)
+    visit candidate_interface_course_choices_course_review_path(@application_choice.id)
   end
 
   def when_i_click_to_remove_the_application

--- a/spec/system/candidate_interface/continuous_applications/viewing-application-choices/candidate_sees_all_their_applications_spec.rb
+++ b/spec/system/candidate_interface/continuous_applications/viewing-application-choices/candidate_sees_all_their_applications_spec.rb
@@ -10,28 +10,28 @@ RSpec.describe 'Candidates sees all their applications' do
   scenario 'showing all tabs' do
     given_i_have_application_choices_in_all_states_possible_for_the_navigation
     when_i_visit_my_applications
-    then_i_should_see_all_the_tabs
+    then_i_see_all_the_tabs
     when_i_visit_my_applications_passing_an_non_existent_tab_name
-    then_i_should_see_all_the_tabs
-    and_all_applications_tab_should_be_selected
+    then_i_see_all_the_tabs
+    and_all_applications_tabs_are_selected
   end
 
   scenario 'showing some tabs depending of what kind of application choices states candidate has' do
     given_i_have_application_choices_in_some_states
     when_i_visit_my_applications
-    then_i_should_only_see_the_tabs_related_to_the_application_choice_states_that_i_have
+    then_i_only_see_the_tabs_related_to_the_application_choice_states_that_i_have
     when_i_click_in_the_drafts_tab
-    then_i_should_see_only_the_draft_applications
+    then_i_only_see_the_draft_applications
     when_i_click_to_view_my_application
-    then_i_should_be_in_view_my_application_page
+    then_i_am_on_the_view_my_application_page
     when_i_visit_my_applications
     and_i_click_to_view_the_offers_tab
-    then_i_should_see_only_the_offers_applications
+    then_i_only_see_the_offers_applications
     when_i_click_to_view_my_application
-    then_i_should_be_on_the_details_offer_page
+    then_i_am_on_the_details_offer_page
     when_i_visit_my_applications
     and_i_click_to_view_the_unsuccessful_tab
-    then_i_should_see_only_the_unsuccessful_applications
+    then_i_only_see_the_unsuccessful_applications
   end
 
   def given_i_have_application_choices_in_all_states_possible_for_the_navigation
@@ -40,7 +40,7 @@ RSpec.describe 'Candidates sees all their applications' do
     end
   end
 
-  def then_i_should_see_all_the_tabs
+  def then_i_see_all_the_tabs
     I18n.t('candidate_interface.application_tabs').each_value do |tab|
       expect(tabs).to include(tab)
     end
@@ -52,7 +52,7 @@ RSpec.describe 'Candidates sees all their applications' do
     end
   end
 
-  def then_i_should_only_see_the_tabs_related_to_the_application_choice_states_that_i_have
+  def then_i_only_see_the_tabs_related_to_the_application_choice_states_that_i_have
     expect(tabs).to eq(['All applications', 'Offers received', 'Draft', 'Unsuccessful'])
   end
 
@@ -60,13 +60,13 @@ RSpec.describe 'Candidates sees all their applications' do
     click_link_or_button 'Draft'
   end
 
-  def then_i_should_see_only_the_draft_applications
+  def then_i_only_see_the_draft_applications
     and_i_should_only_see_applications_in(state: :unsubmitted)
   end
 
-  def then_i_should_be_in_view_my_application_page
+  def then_i_am_on_the_view_my_application_page
     expect(page).to have_current_path(
-      candidate_interface_continuous_applications_course_review_path(@application_choice.id),
+      candidate_interface_course_choices_course_review_path(@application_choice.id),
     )
   end
 
@@ -74,11 +74,11 @@ RSpec.describe 'Candidates sees all their applications' do
     click_link_or_button 'Offers received'
   end
 
-  def then_i_should_see_only_the_offers_applications
+  def then_i_only_see_the_offers_applications
     and_i_should_only_see_applications_in(state: :offer)
   end
 
-  def then_i_should_be_on_the_details_offer_page
+  def then_i_am_on_the_details_offer_page
     expect(page).to have_current_path(
       candidate_interface_offer_path(@application_choice.id),
     )
@@ -88,7 +88,7 @@ RSpec.describe 'Candidates sees all their applications' do
     click_link_or_button 'Unsuccessful'
   end
 
-  def then_i_should_see_only_the_unsuccessful_applications
+  def then_i_only_see_the_unsuccessful_applications
     and_i_should_only_see_applications_in(state: :rejected)
   end
 
@@ -96,7 +96,7 @@ RSpec.describe 'Candidates sees all their applications' do
     visit candidate_interface_continuous_applications_choices_path(current_tab_name: 'this-does-not-exist')
   end
 
-  def and_all_applications_tab_should_be_selected
+  def and_all_applications_tabs_are_selected
     current_tab = tabs_links.find { |tab_link| tab_link['aria-current'].present? }
 
     expect(current_tab).to be_present
@@ -122,7 +122,7 @@ private
       )
     else
       expect(application_link[:href]).to eq(
-        candidate_interface_continuous_applications_course_review_path(@application_choice.id),
+        candidate_interface_course_choices_course_review_path(@application_choice.id),
       )
     end
   end

--- a/spec/system/candidate_interface/entering_details/candidate_viewing_a_science_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_viewing_a_science_gcse_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'Candidate viewing Science GCSE' do
 
   def when_i_go_to_view_my_application
     @application_choice = current_candidate.current_application.application_choices.unsubmitted.first
-    page.find_link(nil, href: candidate_interface_continuous_applications_course_review_path(@application_choice.id)).click
+    page.find_link(nil, href: candidate_interface_course_choices_course_review_path(@application_choice.id)).click
   end
 
   def then_i_dont_see_a_science_gcse_validation_error

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_continuous_applications_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_continuous_applications_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate accepts an offer' do
+RSpec.describe 'Candidate accepts an offer' do
   include CourseOptionHelpers
   include CandidateHelper
 
@@ -519,7 +519,7 @@ RSpec.feature 'Candidate accepts an offer' do
   end
 
   def when_i_try_to_visit_the_course_selection
-    visit candidate_interface_continuous_applications_do_you_know_the_course_path
+    visit candidate_interface_course_choices_do_you_know_the_course_path
   end
 
   def then_i_be_redirected_to_the_offer_dashboard


### PR DESCRIPTION
## Context

We are trying to pay down tech debt left over from Continuous Applications

## Changes proposed in this pull request

- Renames routes from `/continuous-applications` to `/course-choices`
- Renames named routes replacing `continuous_applications` with `course_choices`

## Guidance to review

N/A

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
