### PR TITLE
Backfill ApplicationExperience#experienceable

### DIFF
--- a/app/services/data_migrations/backfill_experienceable_for_application_forms.rb
+++ b/app/services/data_migrations/backfill_experienceable_for_application_forms.rb
@@ -1,0 +1,12 @@
+module DataMigrations
+  class BackfillExperienceableForApplicationForms
+    TIMESTAMP = 20240809162421
+    MANUAL_RUN = false
+
+    def change
+      ApplicationExperience.where(experienceable_id: nil, experienceable_type: nil).in_batches do |batch_experiences|
+        batch_experiences.update_all("experienceable_id = application_form_id, experienceable_type = 'ApplicationForm'")
+      end
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillExperienceableForApplicationForms',
   'DataMigrations::BackfillWeek42PerformanceReportData',
   'DataMigrations::BackfillEnicReason',
   'DataMigrations::RemoveRecruitmentPerformanceReportFeatureFlag',

--- a/spec/services/data_migrations/backfill_experienceable_for_application_forms_spec.rb
+++ b/spec/services/data_migrations/backfill_experienceable_for_application_forms_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillExperienceableForApplicationForms do
+  it 'backfills application experiences with experienceable id and type nil' do
+    volunteering_experience = create(
+      :application_volunteering_experience,
+      application_form: create(:application_form),
+    )
+    work_experience = create(
+      :application_work_experience,
+      application_form: create(:application_form),
+    )
+
+    described_class.new.change
+
+    expect(volunteering_experience.reload.experienceable_id).to eq(volunteering_experience.application_form_id)
+    expect(volunteering_experience.experienceable_type).to eq('ApplicationForm')
+    expect(work_experience.reload.experienceable_id).to eq(work_experience.application_form_id)
+    expect(work_experience.experienceable_type).to eq('ApplicationForm')
+  end
+end


### PR DESCRIPTION
## Context

In commit 5009767441 we introduced the ApplicationExperience#experienceable column. This will eventually replace the `application_id` column.

Before that though we need to backfill this column with application_form ids and types.

There are 1082609 records that will need updating, we are using `update_all` with batches of 1000 

The task on my local finished in under 20 seconds, for 1 million records. Ram usage was under 400MB. CPU was at 50%. Not very accurate obviously but it's an indication 🤷🏻 

![Screenshot from 2024-08-12 10-53-31](https://github.com/user-attachments/assets/6fcc1e02-a9f6-4dee-ae0c-79c9507112e7)


## Changes proposed in this pull request

Data migration

## Guidance to review

Pull on local and run the migration

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
