### PR TITLE
Make sure references from old cycles are editable in support

### DIFF
--- a/app/forms/support_interface/application_forms/edit_reference_details_form.rb
+++ b/app/forms/support_interface/application_forms/edit_reference_details_form.rb
@@ -21,12 +21,14 @@ module SupportInterface
       def save(reference)
         return false unless valid?
 
-        reference.update!(
-          name:,
-          email_address:,
-          relationship:,
-          audit_comment:,
-        )
+        ApplicationForm.with_unsafe_application_choice_touches do
+          reference.update!(
+            name:,
+            email_address:,
+            relationship:,
+            audit_comment:,
+          )
+        end
       end
     end
   end

--- a/app/forms/support_interface/application_forms/edit_reference_feedback_form.rb
+++ b/app/forms/support_interface/application_forms/edit_reference_feedback_form.rb
@@ -16,10 +16,12 @@ module SupportInterface
       def save(reference)
         return false unless valid?
 
-        reference.update!(
-          feedback:,
-          audit_comment:,
-        )
+        ApplicationForm.with_unsafe_application_choice_touches do
+          reference.update!(
+            feedback:,
+            audit_comment:,
+          )
+        end
       end
     end
   end

--- a/spec/forms/support_interface/application_forms/edit_reference_details_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/edit_reference_details_form_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ApplicationForms::EditReferenceDetailsForm do
+  let(:reference) { create(:reference, name: 'John Doe', email_address: 'john.doe@example.com', relationship: 'Colleague') }
+
+  describe 'validations' do
+    subject { described_class.new }
+
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:email_address) }
+    it { is_expected.to allow_value('john.doe@example.com').for(:email_address) }
+    it { is_expected.not_to allow_value('invalid-email').for(:email_address) }
+    it { is_expected.to validate_presence_of(:relationship) }
+    it { is_expected.to validate_presence_of(:audit_comment) }
+  end
+
+  describe '.build_from_reference' do
+    it 'initializes the form with details from the reference' do
+      form = described_class.build_from_reference(reference)
+
+      expect(form.name).to eq('John Doe')
+      expect(form.email_address).to eq('john.doe@example.com')
+      expect(form.relationship).to eq('Colleague')
+    end
+  end
+
+  describe '#save' do
+    subject(:form) { described_class.new(valid_attributes) }
+
+    let(:valid_attributes) do
+      {
+        name: 'Jane Doe',
+        email_address: 'jane.doe@example.com',
+        relationship: 'Manager',
+        audit_comment: 'Updated reference details',
+      }
+    end
+
+    context 'when form is from this cycle' do
+      it 'updates the reference with the provided attributes' do
+        form.save(reference)
+        reference.reload
+        expect(reference.name).to eq('Jane Doe')
+        expect(reference.email_address).to eq('jane.doe@example.com')
+        expect(reference.relationship).to eq('Manager')
+      end
+    end
+
+    context 'when from old cycle' do
+      let(:application_form) do
+        create(
+          :application_form,
+          :with_accepted_offer,
+          recruitment_cycle_year: RecruitmentCycle.previous_year,
+        )
+      end
+      let(:reference) do
+        ApplicationForm.with_unsafe_application_choice_touches do
+          create(:reference, :feedback_requested, application_form:)
+        end
+      end
+
+      before do
+        RequestStore.store[:allow_unsafe_application_choice_touches] = false
+      end
+
+      it 'updates the reference with the provided attributes' do
+        form.save(reference)
+        reference.reload
+        expect(reference.name).to eq('Jane Doe')
+        expect(reference.email_address).to eq('jane.doe@example.com')
+        expect(reference.relationship).to eq('Manager')
+      end
+    end
+  end
+end

--- a/spec/forms/support_interface/application_forms/edit_reference_feedback_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/edit_reference_feedback_form_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ApplicationForms::EditReferenceFeedbackForm do
+  subject { described_class.new }
+
+  let(:reference) { create(:reference, feedback: 'Some feedback') }
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:feedback) }
+    it { is_expected.to validate_presence_of(:audit_comment) }
+    it { is_expected.to validate_presence_of(:send_emails) }
+  end
+
+  describe '.build_from_reference' do
+    it 'initializes the form with feedback from the reference' do
+      form = described_class.build_from_reference(reference)
+
+      expect(form.feedback).to eq('Some feedback')
+    end
+  end
+
+  describe '#save' do
+    subject(:form) { described_class.new(valid_attributes) }
+
+    let(:valid_attributes) do
+      {
+        feedback: 'Updated feedback',
+        audit_comment: 'Audit comment',
+        send_emails: true,
+      }
+    end
+
+    context 'when from this cycle' do
+      it 'updates the reference with the provided attributes' do
+        form.save(reference)
+        expect(reference.reload.feedback).to eq('Updated feedback')
+      end
+    end
+
+    context 'when from old cycle' do
+      let(:application_form) do
+        create(
+          :application_form,
+          :with_accepted_offer,
+          recruitment_cycle_year: RecruitmentCycle.previous_year,
+        )
+      end
+      let(:reference) do
+        ApplicationForm.with_unsafe_application_choice_touches do
+          create(:reference, :feedback_requested, application_form:)
+        end
+      end
+
+      before do
+        RequestStore.store[:allow_unsafe_application_choice_touches] = false
+      end
+
+      it 'updates the reference with the provided attributes' do
+        form.save(reference)
+        expect(reference.reload.feedback).to eq('Updated feedback')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Before this commit, support users are experiencing a 500 error when editing references from old cycle.

## Changes proposed in this pull request

Make sure references from old cycles are editable without errors on support interface.

## Guidance to review

1. Can you edit references (details and feedback) from an application from an old cycle?

