### PR TITLE
Fix BackfillExperienceableForApplicationForms

### DIFF
--- a/app/services/data_migrations/backfill_experienceable_for_application_forms.rb
+++ b/app/services/data_migrations/backfill_experienceable_for_application_forms.rb
@@ -1,11 +1,12 @@
 module DataMigrations
   class BackfillExperienceableForApplicationForms
     TIMESTAMP = 20240809162421
-    MANUAL_RUN = false
+    MANUAL_RUN = true
 
     def change
       ApplicationExperience.where(experienceable_id: nil, experienceable_type: nil).in_batches do |batch_experiences|
         batch_experiences.update_all("experienceable_id = application_form_id, experienceable_type = 'ApplicationForm'")
+        sleep(0.01)
       end
     end
   end


### PR DESCRIPTION
## Context

Turn this data migration into a manual one and added a small sleep

We'll run this migration manually

Before, the pod would timeout and try to do the migration again when it was restarting

## Guidance to review

Run `rake data:migrate:manual[DataMigrations::BackfillExperienceableForApplicationForms]` on local
