### PR TITLE
[1884] Add 2026 cycle dates to codebase

### DIFF
--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -402,16 +402,4 @@ class CycleTimetable
   end
 
   private_class_method :last_recruitment_cycle_year?
-
-  # Only use this to update the holidays for the current cycle when travelling time
-  def self.reset_holidays
-    BusinessTime::Config.holidays.clear
-    Holidays.between(Date.civil(2019, 1, 1), 2.years.from_now, :gb_eng, :observed).map do |holiday|
-      BusinessTime::Config.holidays << holiday[:date]
-    end
-
-    CycleTimetable.holidays.each_value do |date_range|
-      BusinessTime::Config.holidays += date_range.to_a
-    end
-  end
 end

--- a/config/initializers/cycle_timetables.rb
+++ b/config/initializers/cycle_timetables.rb
@@ -37,10 +37,23 @@ CURRENT_CYCLE_DATES = {
     show_deadline_banner: Time.zone.local(2025, 7, 1, 9), # 12 weeks before Apply deadline
     apply_deadline: Time.zone.local(2025, 9, 16, 18),
     reject_by_default: Time.zone.local(2025, 9, 24, 23, 59, 59), # 1 week and a day after apply deadline
-    find_closes: Time.zone.local(2025, 10, 1, 23, 59, 59), # The evening before the find opens in the new cycle
+    find_closes: Time.zone.local(2025, 9, 30, 23, 59, 59), # The evening before the find opens in the new cycle
     holidays: {
       christmas: Date.new(2024, 12, 18)..Date.new(2025, 1, 5),
       easter: Date.new(2025, 3, 18)..Date.new(2025, 4, 1),
+    },
+  },
+  2026 => {
+    find_opens: Time.zone.local(2025, 10, 1, 9), # CONFIRMED
+    apply_opens: Time.zone.local(2025, 10, 8, 9), # CONFIRMED
+    show_summer_recruitment_banner: Time.zone.local(2026, 7, 1), # TBD
+    show_deadline_banner: Time.zone.local(2026, 7, 1, 9), # TBD
+    apply_deadline: Time.zone.local(2026, 9, 16, 18), # CONFIRMED
+    reject_by_default: Time.zone.local(2026, 9, 24, 23, 59, 59), # CONFIRMED
+    find_closes: Time.zone.local(2026, 9, 30, 23, 59, 59), # CONFIRMED
+    holidays: {
+      christmas: Date.new(2026, 12, 18)..Date.new(2026, 1, 5), # TBD
+      easter: Date.new(2026, 3, 18)..Date.new(2026, 4, 1), # TBD
     },
   },
 }.freeze

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -529,25 +529,6 @@ RSpec.describe CycleTimetable do
     end
   end
 
-  describe 'reset_holidays' do
-    it 'updates holidays when timetravelling' do
-      travel_temporarily_to('10 Dec 2024') do
-        described_class.reset_holidays
-        expect(30.business_days.from_now).to eq(Time.zone.parse('7 Feb 2025'))
-      end
-
-      travel_temporarily_to('10 Dec 2025') do
-        described_class.reset_holidays
-        expect(30.business_days.from_now).to eq(Time.zone.parse('26 Jan 2026'))
-      end
-
-      travel_temporarily_to('10 Dec 2024') do
-        described_class.reset_holidays
-        expect(30.business_days.from_now).to eq(Time.zone.parse('7 Feb 2025'))
-      end
-    end
-  end
-
   describe '.current_cycle_week' do
     # Sunday the week before find opens
     let(:date) { Time.zone.local(2023, 10, 1) }


### PR DESCRIPTION
## Context

As we approach the new cycle, we will need to have the _next_ cycle defined, so adding it now. There are still some dates to be confirmed, but the opening dates and reject by default dates are agreed. 

## Changes proposed in this pull request

- Added dates with an note about what needs to be confirmed later.
- Removed the method `reset_holidays` -- the tests for this broke when I added the dates. I have had a look and this is not used anywhere in the codebase. As it seems fragile and isn't used elsewhere, I've deleted it. 
- Moved the find closes date for 2025 back one day. The find opening date for 2026 the first _Wednesday_ in October instead of Tuesday (to stay in October). So the close day for the year before had to move back by a day.

## Guidance to review


## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
