### PR TITLE
Populate experienceable for remaining envs

### DIFF
--- a/app/services/data_migrations/cleanup_application_experiences_experienceable.rb
+++ b/app/services/data_migrations/cleanup_application_experiences_experienceable.rb
@@ -1,0 +1,20 @@
+module DataMigrations
+  class CleanupApplicationExperiencesExperienceable < ActiveRecord::Migration[7.1]
+    disable_ddl_transaction!
+
+    TIMESTAMP = 20240813173942
+    MANUAL_RUN = false
+
+    def change
+      batch = 0
+      ApplicationExperience.where(experienceable_id: nil, experienceable_type: nil).in_batches do |batch_experiences|
+        batch_experiences.update_all("experienceable_id = application_form_id, experienceable_type = 'ApplicationForm'")
+        sleep(0.01)
+        batch += 1
+        Rails.logger.info "Running batch: #{batch}"
+      rescue ActiveRecord::StatementInvalid => e
+        Rails.logger.info "Error: #{e.message}"
+      end
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::CleanupApplicationExperiencesExperienceable',
   'DataMigrations::BackfillExperienceableForApplicationForms',
   'DataMigrations::BackfillWeek42PerformanceReportData',
   'DataMigrations::BackfillEnicReason',

--- a/spec/services/data_migrations/cleanup_application_experiences_experienceable_spec.rb
+++ b/spec/services/data_migrations/cleanup_application_experiences_experienceable_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::CleanupApplicationExperiencesExperienceable do
+  it 'backfills application experiences with experienceable id and type nil' do
+    volunteering_experience = create(
+      :application_volunteering_experience,
+      application_form: create(:application_form),
+    )
+    work_experience = create(
+      :application_work_experience,
+      application_form: create(:application_form),
+    )
+
+    described_class.new.change
+
+    expect(volunteering_experience.reload.experienceable_id).to eq(volunteering_experience.application_form_id)
+    expect(volunteering_experience.experienceable_type).to eq('ApplicationForm')
+    expect(work_experience.reload.experienceable_id).to eq(work_experience.application_form_id)
+    expect(work_experience.experienceable_type).to eq('ApplicationForm')
+  end
+end


### PR DESCRIPTION
## Context

This is a copy of DataMigrations::BackfillExperienceableForApplicationForms But this will run automatically when the build starts and runs the migrations.

In production this won't do anything as there are no records to update but this will update other envs like sandbox and local ones.

## Changes proposed in this pull request

Cleanup data migration

## Guidance to review

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Add PR link to Trello card
