### PR TITLE
[2155] Part 1 UX changes for between cycles

### DIFF
--- a/app/components/candidate_interface/carry_over_interstitial_component.html.erb
+++ b/app/components/candidate_interface/carry_over_interstitial_component.html.erb
@@ -12,7 +12,16 @@
     <p class="govuk-body">
       Continue your application to apply for courses starting in the <%= next_academic_cycle %> academic year instead.
     </p>
+  </div>
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_button_to t('continue'), candidate_interface_carry_over_path %>
+  </div>
 
-    <%= govuk_button_to 'Continue', candidate_interface_carry_over_path, class: 'govuk-!-margin-bottom-5' %>
+  <div class="govuk-grid-column-full">
+    <%= render CandidateInterface::ApplicationChoiceListComponent.new(
+      application_form: @application_form,
+      application_choices:,
+      current_tab_name: params[:current_tab_name],
+    ) %>
   </div>
 </div>

--- a/app/components/candidate_interface/carry_over_interstitial_component.rb
+++ b/app/components/candidate_interface/carry_over_interstitial_component.rb
@@ -14,6 +14,14 @@ module CandidateInterface
       academic_cycle_name(next_recruitment_cycle_year)
     end
 
+    def application_choices
+      CandidateInterface::SortApplicationChoices.call(
+        application_choices: @application_form.application_choices
+                                              .includes(:course, :site, :provider, :current_course, :current_course_option, :interviews)
+                                              .includes(offer: :conditions),
+      )
+    end
+
   private
 
     def academic_cycle_name(year)

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -282,11 +282,13 @@ class ApplicationForm < ApplicationRecord
   end
 
   def carry_over?
-    previous_recruitment_cycle? && (not_submitted_and_deadline_has_passed? || unsuccessful_and_apply_deadline_has_passed?)
-  end
+    return false unless CycleTimetable.apply_deadline_has_passed?(self)
 
-  def not_submitted_and_deadline_has_passed?
-    !submitted? && CycleTimetable.apply_deadline_has_passed?(self)
+    !submitted? ||
+      application_choices.blank? ||
+      application_choices.map(&:status).map(&:to_sym).all? do |status|
+        ApplicationStateChange::CARRY_OVER_ELIGIBLE_STATES.include?(status)
+      end
   end
 
   def unsuccessful_and_apply_deadline_has_passed?
@@ -670,10 +672,6 @@ private
       self.support_reference = GenerateSupportReference.call
       break unless ApplicationForm.exists?(support_reference:)
     end
-  end
-
-  def previous_recruitment_cycle?
-    RecruitmentCycle.current_year >= recruitment_cycle_year
   end
 
   def deferred?

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -9,6 +9,7 @@ class ApplicationStateChange
   OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer offer_withdrawn]).freeze
   POST_OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer_withdrawn]).freeze
   UNSUCCESSFUL_STATES = %i[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn application_not_sent inactive].freeze
+  CARRY_OVER_ELIGIBLE_STATES = (UNSUCCESSFUL_STATES - %i[inactive]).freeze
   SUCCESSFUL_STATES = %i[pending_conditions offer offer_deferred recruited].freeze
   DECISION_PENDING_STATUSES = %i[awaiting_provider_decision interviewing].freeze
   DECISION_PENDING_AND_INACTIVE_STATUSES = %i[awaiting_provider_decision interviewing inactive].freeze

--- a/app/views/candidate_interface/continuous_applications_choices/index.html.erb
+++ b/app/views/candidate_interface/continuous_applications_choices/index.html.erb
@@ -23,6 +23,7 @@
         </li>
       </ul>
 
+      <%= render CandidateInterface::ApplicationChoiceListComponent.new(application_form: current_application, application_choices: @application_choices, current_tab_name: params[:current_tab_name]) %>
   <% else %>
 
     <% if @application_form_presenter.application_limit_reached? %>
@@ -61,8 +62,8 @@
           </p>
         <% end %>
       <% end %>
-    <% end %>
 
+    <% end %>
     <%= render CandidateInterface::ApplicationChoiceListComponent.new(application_form: current_application, application_choices: @application_choices, current_tab_name: params[:current_tab_name]) %>
   <% end %>
   </div>

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -774,23 +774,63 @@ RSpec.describe ApplicationForm do
     end
   end
 
-  describe '#not_submitted_and_apply_deadline_has_passed?' do
-    context 'application has been submitted' do
-      it 'returns false' do
-        travel_temporarily_to(mid_cycle) do
-          application_form = build(:application_form, submitted_at: 1.day.ago)
+  describe '#carry_over?' do
+    context 'application is unsubmitted' do
+      it 'true when application deadline has passed' do
+        travel_temporarily_to(CycleTimetable.apply_deadline + 1.second) do
+          application_form = build(:application_form, :unsubmitted, application_choices: [build(:application_choice)])
+          expect(application_form.carry_over?).to be(true)
+        end
+      end
 
-          expect(application_form.not_submitted_and_deadline_has_passed?).to be(false)
+      it 'false when application deadline has not passed' do
+        travel_temporarily_to(CycleTimetable.apply_deadline - 1.second) do
+          application_form = build(:application_form, :unsubmitted, application_choices: [build(:application_choice)])
+          expect(application_form.carry_over?).to be(false)
         end
       end
     end
 
-    context 'application has not been submitted and apply deadline has passed' do
-      it 'returns true' do
-        travel_temporarily_to(after_apply_deadline) do
-          application_form = build(:application_form)
+    context 'application does not have application choices' do
+      it 'true when application deadline has passed' do
+        travel_temporarily_to(CycleTimetable.apply_deadline + 1.second) do
+          application_form = build(:application_form, :submitted, application_choices: [])
+          expect(application_form.carry_over?).to be(true)
+        end
+      end
 
-          expect(application_form.not_submitted_and_deadline_has_passed?).to be(true)
+      it 'false when application deadline has not passed' do
+        travel_temporarily_to(CycleTimetable.apply_deadline - 1.second) do
+          application_form = build(:application_form, :submitted, application_choices: [])
+          expect(application_form.carry_over?).to be(false)
+        end
+      end
+    end
+
+    context 'an application choice is awaiting candidate decision' do
+      it 'returns false after the application deadline has passed' do
+        travel_temporarily_to(CycleTimetable.apply_deadline + 1.second) do
+          application_form = build(
+            :application_form,
+            :submitted,
+            application_choices: [build(:application_choice, :offered)],
+          )
+          expect(application_form.carry_over?).to be(false)
+        end
+      end
+    end
+
+    context 'an application choice is awaiting provider decision' do
+      it 'returns false after the application deadline has passed', :aggregate_failures do
+        travel_temporarily_to(CycleTimetable.apply_deadline + 1.second) do
+          %i[awaiting_provider_decision interviewing inactive].each do |awaiting_decision_status|
+            application_form = build(
+              :application_form,
+              :submitted,
+              application_choices: [build(:application_choice, awaiting_decision_status)],
+            )
+            expect(application_form.carry_over?).to be(false)
+          end
         end
       end
     end

--- a/spec/requests/candidate_interface/cycle_redirects_spec.rb
+++ b/spec/requests/candidate_interface/cycle_redirects_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'Cycle redirects' do
       it 'redirects to the application complete page' do
         continuous_applications_routes.each do |path|
           get path
-          expect(response).to redirect_to(candidate_interface_application_complete_path)
+          expect(response).to redirect_to(candidate_interface_start_carry_over_path)
         end
       end
     end
@@ -74,7 +74,7 @@ RSpec.describe 'Cycle redirects' do
       it 'redirects to the complete page' do
         section_routes.each do |path|
           get path
-          expect(response.redirect_url).to include(candidate_interface_application_complete_path)
+          expect(response.redirect_url).to include(candidate_interface_start_carry_over_path)
         end
       end
     end

--- a/spec/requests/candidate_interface/personal_statement_spec.rb
+++ b/spec/requests/candidate_interface/personal_statement_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'CandidateInterface::PersonalStatementController' do
       it 'redirects to the dashboard' do
         get candidate_interface_becoming_a_teacher_show_path
 
-        expect(response).to redirect_to(candidate_interface_application_complete_path)
+        expect(response).to redirect_to(candidate_interface_start_carry_over_path)
       end
     end
 
@@ -69,7 +69,7 @@ RSpec.describe 'CandidateInterface::PersonalStatementController' do
         it 'redirects to the complete page' do
           patch candidate_interface_new_becoming_a_teacher_path, params: params
 
-          expect(response).to redirect_to(candidate_interface_application_complete_path)
+          expect(response).to redirect_to(candidate_interface_start_carry_over_path)
         end
       end
 
@@ -145,7 +145,7 @@ RSpec.describe 'CandidateInterface::PersonalStatementController' do
         it 'redirects to the complete page' do
           patch candidate_interface_edit_becoming_a_teacher_path, params: params
 
-          expect(response).to redirect_to(candidate_interface_application_complete_path)
+          expect(response).to redirect_to(candidate_interface_start_carry_over_path)
         end
       end
 

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_after_rejecting_offer_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_after_rejecting_offer_between_cycles_spec.rb
@@ -1,0 +1,112 @@
+require 'rails_helper'
+
+RSpec.describe 'Carry over after rejecting offer', time: CycleTimetableHelper.mid_cycle do
+  include CandidateHelper
+
+  scenario 'candidate declines offers after apply deadline has passed' do
+    given_i_have_two_offers
+    and_the_apply_deadline_passes
+    when_i_sign_in
+    then_i_see_both_offers
+    and_i_am_not_on_the_carry_over_page
+
+    and_i_cannot_navigate_to_the_carry_over_page
+    and_i_can_navigate_to_the_application_choices_page
+
+    when_i_decline_the_first_offer
+    then_the_first_offer_is_declined
+    and_i_am_not_on_the_carry_over_page
+    and_i_see_one_offer_and_one_declined_application
+
+    and_i_cannot_navigate_to_the_carry_over_page
+    and_i_can_navigate_to_the_application_choices_page
+
+    when_i_decline_the_remaining_offer
+    then_the_second_offer_is_declined
+    then_i_am_on_the_carry_over_page
+    and_i_am_able_to_carry_over_my_application
+  end
+
+private
+
+  def given_i_have_two_offers
+    @first_application_with_offer = create(:application_choice, :offered)
+    @application_form = @first_application_with_offer.application_form
+    @candidate = @application_form.candidate
+    @second_application_with_offer = create(:application_choice, :offered, application_form: @application_form)
+  end
+
+  def and_the_apply_deadline_passes
+    advance_time_to(after_apply_deadline)
+  end
+
+  def when_i_sign_in
+    login_as @candidate
+    visit root_path
+  end
+
+  def then_i_see_both_offers
+    expect(page).to have_content @first_application_with_offer.current_provider.name
+    expect(page).to have_content @second_application_with_offer.current_provider.name
+    expect(page).to have_content('Offer received').twice
+  end
+
+  def then_the_first_offer_is_declined
+    offer_is_declined(@first_application_with_offer.reload)
+  end
+
+  def then_the_second_offer_is_declined
+    offer_is_declined(@second_application_with_offer.reload)
+  end
+
+  def offer_is_declined(application_with_offer)
+    expect(page).to have_content 'You have declined your offer'
+    expect(application_with_offer.reload.status).to eq 'declined'
+  end
+
+  def and_i_am_not_on_the_carry_over_page
+    expect(page).to have_current_path candidate_interface_continuous_applications_choices_path
+    expect(page).to have_content 'Your applications'
+  end
+
+  def and_i_cannot_navigate_to_the_carry_over_page
+    visit candidate_interface_start_carry_over_path
+    expect(page).to have_current_path candidate_interface_continuous_applications_details_path
+  end
+
+  def and_i_can_navigate_to_the_application_choices_page
+    visit candidate_interface_continuous_applications_choices_path
+    expect(page).to have_current_path candidate_interface_continuous_applications_choices_path
+  end
+
+  def and_i_see_one_offer_and_one_declined_application
+    expect(page).to have_content 'Declined'
+    expect(page).to have_content('Offer received').once
+  end
+
+  def when_i_decline_the_first_offer
+    decline_offer(@first_application_with_offer)
+  end
+
+  def when_i_decline_the_remaining_offer
+    decline_offer(@second_application_with_offer)
+  end
+
+  def decline_offer(application_with_offer)
+    click_on application_with_offer.current_provider.name
+    expect(page).to have_content 'Details of offer'
+    choose 'Decline offer'
+    click_on 'Continue'
+    click_on 'Yes I’m sure – decline this offer'
+  end
+
+  def then_i_am_on_the_carry_over_page
+    expect(page).to have_current_path candidate_interface_start_carry_over_path
+    expect(page).to have_content 'Continue your application'
+  end
+
+  def and_i_am_able_to_carry_over_my_application
+    click_on 'Continue'
+    expect(page).to have_current_path candidate_interface_continuous_applications_details_path
+  end
+end

--- a/spec/system/candidate_interface/carry_over/candidate_has_application_rejected_by_default_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_has_application_rejected_by_default_spec.rb
@@ -1,0 +1,134 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidate has an application where provider does not make a decision' do
+  include CandidateHelper
+
+  before do
+    TestSuiteTimeMachine.travel_permanently_to(mid_cycle)
+    @candidate = create(:candidate)
+  end
+
+  context 'Application choice is awaiting provider decisions' do
+    scenario 'Candidate can carry over only after application is rejected by default' do
+      given_i_have_an_application_awaiting_provider_decision
+      and_the_apply_deadline_has_passed
+      when_i_sign_in
+      and_i_navigate_to_my_applications
+      then_i_see_my_application_is_awaiting_provider_decision
+      then_i_cannot_carry_over_my_application
+
+      when_i_visit_the_start_carry_over_page_directly
+      then_i_am_redirected_to_details_page
+
+      when_the_reject_by_default_deadline_has_passed
+      and_i_sign_in
+      then_i_see_my_application_is_now_unsuccessful
+      and_i_can_carry_over_my_application
+    end
+  end
+
+  context 'Application choice is inactive' do
+    scenario 'Candidate can carry over only after application is rejected by default' do
+      given_i_have_an_inactive_application
+      and_the_apply_deadline_has_passed
+      when_i_sign_in
+      and_i_navigate_to_my_applications
+      then_i_see_my_application_is_awaiting_provider_decision
+      then_i_cannot_carry_over_my_application
+
+      when_i_visit_the_start_carry_over_page_directly
+      then_i_am_redirected_to_details_page
+
+      when_the_reject_by_default_deadline_has_passed
+      and_i_sign_in
+      then_i_see_my_application_is_now_unsuccessful
+      and_i_can_carry_over_my_application
+    end
+  end
+
+  context 'Application choice is interviewing' do
+    scenario 'Candidate can carry over only after application is rejected by default' do
+      given_i_have_an_application_with_interviewing_status
+      and_the_apply_deadline_has_passed
+      when_i_sign_in
+      and_i_navigate_to_my_applications
+      then_i_see_my_application_is_interviewing
+      then_i_cannot_carry_over_my_application
+
+      when_i_visit_the_start_carry_over_page_directly
+      then_i_am_redirected_to_details_page
+
+      when_the_reject_by_default_deadline_has_passed
+      and_i_sign_in
+      then_i_see_my_application_is_now_unsuccessful
+      and_i_can_carry_over_my_application
+    end
+  end
+
+private
+
+  def given_i_have_an_application_awaiting_provider_decision
+    @awaiting_provider_decision_application = create(:application_choice, :awaiting_provider_decision, candidate: @candidate)
+  end
+
+  def given_i_have_an_application_with_interviewing_status
+    @interviewing_application = create(:application_choice, :interviewing, candidate: @candidate)
+  end
+
+  def given_i_have_an_inactive_application
+    @inactive_application = create(:application_choice, :inactive, candidate: @candidate)
+  end
+
+  def and_the_apply_deadline_has_passed
+    advance_time_to(cancel_application_deadline + 1.second)
+    CancelUnsubmittedApplicationsWorker.perform_sync
+  end
+
+  def when_i_sign_in
+    logout
+    login_as @candidate
+    visit root_path
+  end
+  alias_method :and_i_sign_in, :when_i_sign_in
+
+  def and_i_navigate_to_my_applications
+    click_on 'Your applications'
+  end
+
+  def then_i_see_my_application_is_awaiting_provider_decision
+    expect(page).to have_current_path candidate_interface_continuous_applications_choices_path
+    expect(page).to have_content 'Awaiting decision'
+  end
+
+  def then_i_see_my_application_is_interviewing
+    expect(page).to have_content 'Interviewing'
+  end
+
+  def then_i_see_my_application_is_now_unsuccessful
+    expect(page).to have_content 'Unsuccessful'
+  end
+
+  def then_i_cannot_carry_over_my_application
+    expect(page).to have_current_path candidate_interface_continuous_applications_choices_path
+    expect(page).to have_content("Applications for courses starting in September #{RecruitmentCycle.current_year} are closed.")
+  end
+  alias_method :and_i_cannot_carry_over_my_application, :then_i_cannot_carry_over_my_application
+
+  def when_i_visit_the_start_carry_over_page_directly
+    visit candidate_interface_start_carry_over_path
+  end
+
+  def then_i_am_redirected_to_details_page
+    expect(page).to have_current_path candidate_interface_continuous_applications_details_path
+  end
+
+  def and_i_can_carry_over_my_application
+    click_on 'Continue'
+    expect(page).to have_current_path candidate_interface_continuous_applications_details_path
+  end
+
+  def when_the_reject_by_default_deadline_has_passed
+    advance_time_to(reject_by_default_run_date)
+    EndOfCycle::RejectByDefaultWorker.perform_sync
+  end
+end

--- a/spec/system/candidate_interface/carry_over/candidate_receives_offer_betwen_cycles_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_receives_offer_betwen_cycles_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidate receives an offer between cycles' do
+  include CandidateHelper
+
+  before do
+    TestSuiteTimeMachine.travel_permanently_to(mid_cycle)
+    @application_form = create(:completed_application_form)
+    @candidate = @application_form.candidate
+  end
+
+  scenario 'candidate can reject offer' do
+    given_i_am_awaiting_provider_decision
+    and_the_apply_deadline_passes
+    when_the_provider_makes_an_offer
+    and_i_sign_in
+    and_i_navigate_to_my_application_choices
+    then_i_can_navigate_to_the_offer
+    and_i_can_decline_the_offer
+    and_i_can_carry_over_my_application
+  end
+
+  scenario 'candidate can accept offer' do
+    given_i_am_awaiting_provider_decision
+    and_the_apply_deadline_passes
+    when_the_provider_makes_an_offer
+    and_i_sign_in
+    and_i_navigate_to_my_application_choices
+    then_i_can_navigate_to_the_offer
+    and_i_can_accept_the_offer
+
+    when_i_visit_the_start_carry_over_page_directly
+    then_i_am_redirected_to_my_accepted_offer
+  end
+
+private
+
+  def given_i_am_awaiting_provider_decision
+    @application_choice = create(:application_choice, :awaiting_provider_decision, application_form: @application_form)
+  end
+
+  def and_i_sign_in
+    login_as @candidate
+    visit root_path
+  end
+
+  def and_the_apply_deadline_passes
+    advance_time_to(after_apply_deadline)
+  end
+
+  def when_the_provider_makes_an_offer
+    create(:unconditional_offer, application_choice: @application_choice)
+    ApplicationStateChange.new(@application_choice).make_offer!
+  end
+
+  def and_i_navigate_to_my_application_choices
+    click_on 'Your applications'
+  end
+
+  def and_i_can_decline_the_offer
+    choose 'Decline offer'
+    click_on 'Continue'
+    click_on 'Yes I’m sure – decline this offer'
+    expect(page).to have_content 'You have declined your offer'
+    expect(@application_choice.reload.status).to eq 'declined'
+  end
+
+  def and_i_can_accept_the_offer
+    choose 'Accept offer'
+    click_on 'Continue'
+    click_on 'Accept offer'
+    expect(page).to have_content 'You have accepted your offer'
+  end
+
+  def then_i_can_navigate_to_the_offer
+    expect(page).to have_current_path candidate_interface_continuous_applications_choices_path
+    expect(page).to have_content 'Offer received'
+    click_on @application_choice.provider.name
+  end
+
+  def and_i_can_carry_over_my_application
+    expect(page).to have_current_path candidate_interface_start_carry_over_path
+    click_on 'Continue'
+    expect(page).to have_current_path candidate_interface_continuous_applications_details_path
+  end
+
+  def when_i_visit_the_start_carry_over_page_directly
+    visit candidate_interface_start_carry_over_path
+  end
+
+  def then_i_am_redirected_to_my_accepted_offer
+    expect(page).to have_current_path candidate_interface_application_offer_dashboard_path
+  end
+end


### PR DESCRIPTION
## Context

We have identified the desired user journeys for candidates with applications in different states throughout the end-of-cycle period. This PR address two of the major changes. A second PR addresses the third.

## Changes proposed in this pull request
The three major UX changes for end of cycle are:
- Allow users to continue to view their application choices until they have carried over an application. Not doing so meant that people were unable navigate to offers or view what applications were awaiting provider decision.
- Do not allow candidates with inactive applications to carry over. We should treat inactive applications like 'awaiting provider decision'. They are rejected by default on the 24th.
- (this is done in a [second PR](https://github.com/DFE-Digital/apply-for-teacher-training/pull/9687) to keep things easier to review) We had multiple carry over experiences -- sometimes people were redirected to the applications page with some inset text. Sometimes they were sent to the Carry over page. Now they will all of the same experience of going to the carry over page, keeping things much simpler

I've also
- Added lots of tests for candidates as they move through the end of cycle period with application choices in different states. 
- Deleted skipped tests that are no longer relevant
- Updated skipped tests so they can be run again
- Removed hard coded dates from specs

### Candidate with offer between cycles
| Before | After |
| ------ | ----- |
|  ![image](https://github.com/user-attachments/assets/5320e191-6204-4083-a4de-e1c5b9967929) | ![image](https://github.com/user-attachments/assets/8e46213c-5403-4a08-b79c-37fb3ae91514)|

### Inactive applications between cycles
| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/b55e8f08-b6ee-4aa2-908d-18509793a21b) | ![image](https://github.com/user-attachments/assets/4d0d2dbb-7a9b-40a3-b95b-74b52fc8a965) |


## Guidance to review

If you use the cycle switcher, you'll need to run various jobs to simulate the different stages of the end-of-cycle period:
- For immediately after the application deadline:`CancelUnsubmittedApplicationsWorker`
- For rejecting by default: `EndOfCycle::RejectByDefaultWorker`
- For decline by default: `EndOfCycle::DeclineByDefaultWorker`

You'll have to do a bit of wrangling to get them to run though because they rely on dates that you can advance to specifically with the cycle switcher. 

Please note this is not the end of the end-of-cycle work. Content is being written and there will be at least two more PRs to clean up redirects and remove the multiple carry over experiences. 


## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
