### PR TITLE
[2168] Carry over english proficiency data when duplicating application form

### DIFF
--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -70,6 +70,19 @@ class DuplicateApplication
 
       new_application_form.update!(references_completed: false)
 
+      if original_application_form.english_proficiency.present?
+        efl_qualification = if original_application_form.english_proficiency.efl_qualification.present?
+                              original_application_form.english_proficiency.efl_qualification_type.constantize.new(
+                                **original_application_form.english_proficiency.efl_qualification.attributes.except(*IGNORED_CHILD_ATTRIBUTES),
+                              )
+                            end
+        EnglishProficiency.create!(
+          **original_application_form.english_proficiency.attributes.except(*IGNORED_CHILD_ATTRIBUTES),
+          efl_qualification:,
+          application_form: new_application_form,
+        )
+      end
+
       original_application_form.application_work_history_breaks.each do |w|
         new_application_form.application_work_history_breaks.create!(
           w.attributes.except(*IGNORED_CHILD_ATTRIBUTES),

--- a/spec/services/duplicate_application_spec.rb
+++ b/spec/services/duplicate_application_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe DuplicateApplication do
         full_work_history: true,
         recruitment_cycle_year:,
         references_count: 0,
+        efl_completed: true,
       )
       create_list(:reference, 2, feedback_status: :feedback_provided, application_form: @original_application_form)
       create(:reference, feedback_status: :feedback_refused, application_form: @original_application_form)
@@ -45,6 +46,27 @@ RSpec.describe DuplicateApplication do
   it 'does not carry over any equality and diversity data' do
     expect(duplicate_application_form.equality_and_diversity).to be_nil
     expect(duplicate_application_form.equality_and_diversity_completed).to be_nil
+  end
+
+  context 'english proficiency' do
+    it 'carries over english proficiency data where qualification is not needed' do
+      create(:english_proficiency, :qualification_not_needed, application_form: @original_application_form)
+      result = duplicate_application_form
+
+      expect(result.efl_completed).to be true
+      expect(result.english_proficiency.present?).to be(true)
+      expect(result.english_proficiency.efl_qualification).to be_nil
+    end
+
+    it 'carries over english proficiency data with elf qualification' do
+      create(:english_proficiency, :with_toefl_qualification, application_form: @original_application_form)
+      result = duplicate_application_form
+
+      expect(result.efl_completed).to be true
+      expect(result.english_proficiency.present?).to be(true)
+      expect(result.english_proficiency.efl_qualification.present?).to be(true)
+      expect(result.english_proficiency.efl_qualification_type).to eq 'ToeflQualification'
+    end
   end
 
   context 'when application form is unsuccessful' do


### PR DESCRIPTION
## Context

If an application form is carried over into the next recruitment cycle with the EFL section completed, the data is lost (i.e. it’s not carried over).

This bug has existed for the lifetime of the Apply service.

There is a separate ticket for backfilling the data.

## Changes proposed in this pull request

- Copies english proficiency record when duplicating application form

## Guidance to review

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
