### PR TITLE
Use ApplicationExperience#experienceable

### DIFF
--- a/app/models/application_experience.rb
+++ b/app/models/application_experience.rb
@@ -1,8 +1,13 @@
 class ApplicationExperience < ApplicationRecord
-  belongs_to :application_form, touch: true
-  belongs_to :experienceable, polymorphic: true, optional: true
+  belongs_to :application_form, touch: true, optional: true
+  belongs_to :experienceable, polymorphic: true
 
-  before_save -> { self.experienceable = application_form }, if: -> { experienceable.nil? }
+  before_save -> { self.application_form_id = experienceable_id }, if: -> { application_form_id.nil? }
 
   validates :role, :organisation, :start_date, presence: true
+
+  def application_form=(value)
+    super
+    self.experienceable = value
+  end
 end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -12,8 +12,8 @@ class ApplicationForm < ApplicationRecord
   has_many :course_options, through: :application_choices
   has_many :courses, through: :application_choices
   has_many :providers, through: :application_choices
-  has_many :application_work_experiences
-  has_many :application_volunteering_experiences
+  has_many :application_work_experiences, as: :experienceable
+  has_many :application_volunteering_experiences, as: :experienceable
   has_many :application_qualifications
   has_many :application_references
   has_many :application_work_history_breaks

--- a/spec/models/application_experience_spec.rb
+++ b/spec/models/application_experience_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationExperience do
-  it { is_expected.to belong_to(:application_form).touch(true) }
-  it { is_expected.to belong_to(:experienceable).optional }
+  it { is_expected.to belong_to(:application_form).touch(true).optional }
+  it { is_expected.to belong_to(:experienceable) }
 
   it { is_expected.to validate_presence_of(:role) }
   it { is_expected.to validate_presence_of(:organisation) }

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -1,6 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationForm do
+  it { is_expected.to belong_to(:candidate).touch(true) }
+  it { is_expected.to belong_to(:previous_application_form).class_name('ApplicationForm').optional.inverse_of('subsequent_application_form') }
+
+  it { is_expected.to have_one(:subsequent_application_form).class_name('ApplicationForm').with_foreign_key('previous_application_form_id').inverse_of('previous_application_form') }
+  it { is_expected.to have_one(:english_proficiency) }
+
+  it { is_expected.to have_many(:application_choices) }
+  it { is_expected.to have_many(:course_options).through(:application_choices) }
+  it { is_expected.to have_many(:courses).through(:application_choices) }
+  it { is_expected.to have_many(:providers).through(:application_choices) }
+  it { is_expected.to have_many(:application_work_experiences) }
+  it { is_expected.to have_many(:application_volunteering_experiences) }
+  it { is_expected.to have_many(:application_qualifications) }
+  it { is_expected.to have_many(:application_references) }
+  it { is_expected.to have_many(:application_work_history_breaks) }
+  it { is_expected.to have_many(:emails) }
+  it { is_expected.to have_many(:application_feedback) }
+
   describe '#cannot_add_more_choices?' do
     let(:application_form) { create(:application_form) }
 


### PR DESCRIPTION
## Context

Now that all ApplicationExperience records have experienceable columns populated we can use this column to link the ApplicationExperience to the ApplicationForm.

We still need to save the application_form_id on the application_experience because of the db constraint and we also need to set the experienceable value when when we call
`application_experience.application_form=`

Other commits will follow to remove the application_form_id

## Changes proposed in this pull request

ApplicaitonExperience relation to ApplicationForm

## Guidance to review

Pull locally or go on the review app and add/edit work experiences.


https://github.com/user-attachments/assets/e52160d1-4a56-464f-aa46-19deb1aa0789



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
