### PR TITLE
Reinstate test

### DIFF
--- a/spec/system/provider_interface/see_individual_application_as_pdf_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_as_pdf_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Provider sees an application as PDF' do
   include CourseOptionHelpers
   include DfESignInHelpers
 
-  it 'viewing application in PDF format', skip: 'Fails on CI since chromium update, pending until alternative to grover is found or new version of chrome' do
+  it 'viewing application in PDF format' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_permitted_to_see_applications_for_my_provider
     and_i_sign_in_to_the_provider_interface


### PR DESCRIPTION
## Context

See [PR for skipping the test](https://github.com/DFE-Digital/apply-for-teacher-training/pull/9613) and this [slack thread](https://ukgovernmentdfe.slack.com/archives/C05D5S8C6PJ/p1722436298468499) for context.

Chromium version has been updated
`(1/1) Installing chromium-chromedriver (127.0.6533.99-r0)`

## Changes proposed in this pull request

This just reinstates a test for downloading PDFs that was temporarily disabled.

## Guidance to review

All tests pass now on CI, so 

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
