### PR TITLE
Remove application_form from ApplicationExperience

### DIFF
--- a/app/models/application_experience.rb
+++ b/app/models/application_experience.rb
@@ -1,13 +1,19 @@
 class ApplicationExperience < ApplicationRecord
-  belongs_to :application_form, touch: true, optional: true
-  belongs_to :experienceable, polymorphic: true
+  belongs_to :experienceable, polymorphic: true, touch: true
 
   before_save -> { self.application_form_id = experienceable_id }, if: -> { application_form_id.nil? }
 
+  after_commit do
+    if application_form
+      experienceable.touch_choices
+    end
+  end
+
   validates :role, :organisation, :start_date, presence: true
 
-  def application_form=(value)
-    super
-    self.experienceable = value
+  audited associated_with: :experienceable
+
+  def application_form
+    experienceable if experienceable_type == 'ApplicationForm'
   end
 end

--- a/app/models/application_volunteering_experience.rb
+++ b/app/models/application_volunteering_experience.rb
@@ -1,5 +1,2 @@
 class ApplicationVolunteeringExperience < ApplicationExperience
-  include TouchApplicationChoices
-
-  audited associated_with: :application_form
 end

--- a/app/models/application_work_experience.rb
+++ b/app/models/application_work_experience.rb
@@ -1,12 +1,8 @@
 class ApplicationWorkExperience < ApplicationExperience
-  include TouchApplicationChoices
-
   validates :commitment, presence: true
 
   enum commitment: {
     full_time: 'Full time',
     part_time: 'Part time',
   }
-
-  audited associated_with: :application_form
 end

--- a/spec/components/candidate_interface/volunteering_review_component_spec.rb
+++ b/spec/components/candidate_interface/volunteering_review_component_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe CandidateInterface::VolunteeringReviewComponent, type: :component
 
     context 'when volunteering experience are editable but not deletable' do
       it 'renders component without an delete link' do
-        create(:application_volunteering_experience, application_form:)
+        create(:application_volunteering_experience, experienceable: application_form)
         result = render_inline(described_class.new(application_form:, editable: true, deletable: false))
 
         expect(result.text).to include('Change')

--- a/spec/forms/support_interface/application_forms/job_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/job_form_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe SupportInterface::ApplicationForms::JobForm, :with_audited, type:
   end
 
   describe '#update' do
-    let(:job) { create(:application_work_experience, application_form:, role: 'Teacher') }
+    let(:job) { create(:application_work_experience, experienceable: application_form, role: 'Teacher') }
     let(:application_form) { create(:application_form) }
 
     it 'returns false if not valid' do

--- a/spec/forms/support_interface/application_forms/volunteering_role_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/volunteering_role_form_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe SupportInterface::ApplicationForms::VolunteeringRoleForm, :with_a
   end
 
   describe '#update' do
-    let(:volunteering_role) { create(:application_volunteering_experience, application_form:, role: 'Teacher', working_with_children: false) }
+    let(:volunteering_role) { create(:application_volunteering_experience, experienceable: application_form, role: 'Teacher', working_with_children: false) }
     let(:application_form) { create(:application_form) }
 
     let(:form_data) do

--- a/spec/models/application_experience_spec.rb
+++ b/spec/models/application_experience_spec.rb
@@ -1,10 +1,37 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationExperience do
-  it { is_expected.to belong_to(:application_form).touch(true).optional }
-  it { is_expected.to belong_to(:experienceable) }
+  it { is_expected.to belong_to(:experienceable).touch(true) }
 
   it { is_expected.to validate_presence_of(:role) }
   it { is_expected.to validate_presence_of(:organisation) }
   it { is_expected.to validate_presence_of(:start_date) }
+
+  describe 'auditing', :with_audited do
+    it { is_expected.to be_audited.associated_with :experienceable }
+  end
+
+  describe '#application_form' do
+    it 'returns the application_form from experienceable' do
+      application_form = create(:application_form)
+      experience = build(
+        :application_work_experience,
+        experienceable: application_form,
+      )
+
+      expect(experience.application_form).to eq(application_form)
+    end
+
+    context 'when experienceable is not ApplicationForm' do
+      it 'returns nil' do
+        application_choice = create(:application_choice)
+        experience = build(
+          :application_work_experience,
+          experienceable: application_choice,
+        )
+
+        expect(experience.application_form).to be_nil
+      end
+    end
+  end
 end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -460,7 +460,7 @@ RSpec.describe ApplicationForm do
       it 'returns false' do
         application_form = create(:application_form)
         advance_time
-        create(:application_work_experience, application_form:)
+        create(:application_work_experience, experienceable: application_form)
         expect(application_form.blank_application?).to be_falsey
       end
     end

--- a/spec/models/application_volunteering_experience_spec.rb
+++ b/spec/models/application_volunteering_experience_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ApplicationVolunteeringExperience do
   describe 'auditing', :with_audited do
     it 'creates audit entries' do
       application_form = create(:application_form)
-      application_volunteering_experience = create(:application_volunteering_experience, application_form: application_form)
+      application_volunteering_experience = create(:application_volunteering_experience, experienceable: application_form)
       expect(application_volunteering_experience.audits.count).to eq 1
       expect {
         application_volunteering_experience.update!(role: 'Rocket Surgeon')
@@ -13,7 +13,7 @@ RSpec.describe ApplicationVolunteeringExperience do
 
     it 'creates an associated object in each audit record' do
       application_form = create(:application_form)
-      application_volunteering_experience = create(:application_volunteering_experience, application_form: application_form)
+      application_volunteering_experience = create(:application_volunteering_experience, experienceable: application_form)
       expect(application_volunteering_experience.audits.last.associated).to eq application_volunteering_experience.application_form
     end
   end

--- a/spec/models/application_work_experience_spec.rb
+++ b/spec/models/application_work_experience_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ApplicationWorkExperience do
   describe 'auditing', :with_audited do
     it 'creates audit entries' do
       application_form = create(:application_form)
-      application_work_experience = create(:application_work_experience, application_form: application_form)
+      application_work_experience = create(:application_work_experience, experienceable: application_form)
       expect(application_work_experience.audits.count).to be 1
       expect {
         application_work_experience.update!(role: 'Rocket Surgeon')
@@ -13,7 +13,7 @@ RSpec.describe ApplicationWorkExperience do
 
     it 'creates an associated object in each audit record' do
       application_form = create(:application_form)
-      application_work_experience = create(:application_work_experience, application_form: application_form)
+      application_work_experience = create(:application_work_experience, experienceable: application_form)
       expect(application_work_experience.audits.last.associated).to eq application_work_experience.application_form
     end
   end

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -80,8 +80,8 @@ RSpec.describe Candidate do
       candidate = create(:candidate)
       application_form = create(:application_form, candidate:)
       application_choice = create(:application_choice, application_form:)
-      application_work_experience = create(:application_work_experience, application_form:)
-      application_volunteering_experience = create(:application_volunteering_experience, application_form:)
+      application_work_experience = create(:application_work_experience, experienceable: application_form)
+      application_volunteering_experience = create(:application_volunteering_experience, experienceable: application_form)
       application_qualification = create(:application_qualification, application_form:)
       application_reference = create(:reference, application_form:)
 

--- a/spec/models/last_updated_at_spec.rb
+++ b/spec/models/last_updated_at_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe '#update' do
     expect(application_choices.map(&:updated_at)).not_to include(original_time)
   end
 
-  %i[reference application_volunteering_experience application_work_experience application_qualification application_work_history_break].each do |form_attribute|
+  %i[reference application_qualification application_work_history_break].each do |form_attribute|
     it "updates the application_choices when a #{form_attribute} is added" do
       application_form = create(:completed_application_form, application_choices_count: 1)
 
@@ -40,6 +40,31 @@ RSpec.describe '#update' do
     it "updates the application_choices when a #{form_attribute} is deleted" do
       application_form = create(:completed_application_form, application_choices_count: 1)
       model = create(form_attribute, application_form:)
+
+      expect { model.destroy! }
+        .to(change { application_form.application_choices.first.updated_at })
+    end
+  end
+
+  %i[application_volunteering_experience application_work_experience].each do |form_attribute|
+    it "updates the application_choices when #{form_attribute} is added" do
+      application_form = create(:completed_application_form, application_choices_count: 1)
+
+      expect { create(form_attribute, experienceable: application_form) }
+        .to(change { application_form.application_choices.first.updated_at })
+    end
+
+    it "updates the application_choices when #{form_attribute} is updated" do
+      application_form = create(:completed_application_form, application_choices_count: 1)
+      model = create(form_attribute, experienceable: application_form)
+
+      expect { model.update(updated_at: Time.zone.now) }
+        .to(change { application_form.application_choices.first.updated_at })
+    end
+
+    it "updates the application_choices when #{form_attribute} is deleted" do
+      application_form = create(:completed_application_form, application_choices_count: 1)
+      model = create(form_attribute, experienceable: application_form)
 
       expect { model.destroy! }
         .to(change { application_form.application_choices.first.updated_at })

--- a/spec/services/data_migrations/backfill_experienceable_for_application_forms_spec.rb
+++ b/spec/services/data_migrations/backfill_experienceable_for_application_forms_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe DataMigrations::BackfillExperienceableForApplicationForms do
   it 'backfills application experiences with experienceable id and type nil' do
     volunteering_experience = create(
       :application_volunteering_experience,
-      application_form: create(:application_form),
+      experienceable: create(:application_form),
     )
     work_experience = create(
       :application_work_experience,
-      application_form: create(:application_form),
+      experienceable: create(:application_form),
     )
 
     described_class.new.change

--- a/spec/services/data_migrations/cleanup_application_experiences_experienceable_spec.rb
+++ b/spec/services/data_migrations/cleanup_application_experiences_experienceable_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe DataMigrations::CleanupApplicationExperiencesExperienceable do
   it 'backfills application experiences with experienceable id and type nil' do
     volunteering_experience = create(
       :application_volunteering_experience,
-      application_form: create(:application_form),
+      experienceable: create(:application_form),
     )
     work_experience = create(
       :application_work_experience,
-      application_form: create(:application_form),
+      experienceable: create(:application_form),
     )
 
     described_class.new.change

--- a/spec/services/support_interface/work_history_break_export_spec.rb
+++ b/spec/services/support_interface/work_history_break_export_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe SupportInterface::WorkHistoryBreakExport do
     describe 'documentation' do
       before do
         create(:application_work_experience,
-               application_form:,
+               experienceable: application_form,
                start_date: Date.new(2000, 1, 1),
                end_date: Date.new(2005, 12, 31))
         create(:application_work_history_break,
@@ -52,7 +52,7 @@ RSpec.describe SupportInterface::WorkHistoryBreakExport do
 
       it 'creates an output with all the correct columns' do
         create(:application_work_experience,
-               application_form:,
+               experienceable: application_form,
                start_date: Date.new(2000, 1, 1),
                end_date: Date.new(2005, 12, 31))
         create(:application_work_history_break,
@@ -99,7 +99,7 @@ RSpec.describe SupportInterface::WorkHistoryBreakExport do
 
       it 'uses application submitted date for experience end date if experience is ongoing' do
         create(:application_work_experience,
-               application_form:,
+               experienceable: application_form,
                start_date: Date.new(2000, 1, 1),
                end_date: nil)
 
@@ -114,7 +114,7 @@ RSpec.describe SupportInterface::WorkHistoryBreakExport do
                                       submitted_at: nil)
 
         create(:application_work_experience,
-               application_form: new_application_form,
+               experienceable: new_application_form,
                start_date: Date.new(2000, 1, 1),
                end_date: nil)
 
@@ -143,11 +143,11 @@ RSpec.describe SupportInterface::WorkHistoryBreakExport do
 
       it 'counts explained breaks that coincide with volunteering experiences' do
         create(:application_work_experience,
-               application_form:,
+               experienceable: application_form,
                start_date: Date.new(2000, 1, 1),
                end_date: Date.new(2005, 12, 31))
         create(:application_work_experience,
-               application_form:,
+               experienceable: application_form,
                start_date: Date.new(2010, 1, 1),
                end_date: Date.new(2015, 12, 31))
         create(:application_work_history_break,
@@ -156,7 +156,7 @@ RSpec.describe SupportInterface::WorkHistoryBreakExport do
                start_date: Date.new(2016, 1, 1),
                end_date: Date.new(2020, 12, 31))
         create(:application_volunteering_experience,
-               application_form:,
+               experienceable: application_form,
                start_date: Date.new(2017, 1, 1),
                end_date: Date.new(2020, 12, 31))
 
@@ -172,7 +172,7 @@ RSpec.describe SupportInterface::WorkHistoryBreakExport do
     describe 'creates unexplained breaks data' do
       it 'calculates details of unexplained breaks' do
         create(:application_work_experience,
-               application_form:,
+               experienceable: application_form,
                start_date: Date.new(2010, 1, 1),
                end_date: Date.new(2019, 12, 31))
 
@@ -184,19 +184,19 @@ RSpec.describe SupportInterface::WorkHistoryBreakExport do
 
       it 'counts unexplained breaks that coincide with volunteering experiences' do
         create(:application_work_experience,
-               application_form:,
+               experienceable: application_form,
                start_date: Date.new(2005, 1, 1),
                end_date: Date.new(2010, 12, 31))
         create(:application_volunteering_experience,
-               application_form:,
+               experienceable: application_form,
                start_date: Date.new(2011, 1, 1),
                end_date: Date.new(2011, 12, 31))
         create(:application_work_experience,
-               application_form:,
+               experienceable: application_form,
                start_date: Date.new(2015, 1, 1),
                end_date: Date.new(2019, 12, 31))
         create(:application_volunteering_experience,
-               application_form:,
+               experienceable: application_form,
                start_date: Date.new(2020, 1, 1),
                end_date: Date.new(2020, 12, 31))
 
@@ -215,7 +215,7 @@ RSpec.describe SupportInterface::WorkHistoryBreakExport do
                start_year: 2000,
                award_year: 2003)
         create(:application_work_experience,
-               application_form:,
+               experienceable: application_form,
                start_date: Date.new(2010, 1, 1),
                end_date: Date.new(2015, 12, 31))
 

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
     @application_form = create(:completed_application_form, :with_completed_references, candidate: @candidate)
     create(:application_choice, :rejected, application_form: @application_form)
 
-    job = create(:application_work_experience, application_form: @application_form)
+    job = create(:application_work_experience, experienceable: @application_form)
     @application_form.application_work_experiences << [job]
   end
 

--- a/spec/system/candidate_interface/entering_details/candidate_edits_or_deletes_volunteering_section_after_competing_the_section_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_edits_or_deletes_volunteering_section_after_competing_the_section_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate edits their volunteering section' do
+RSpec.describe 'Candidate edits their volunteering section' do
   include CandidateHelper
 
   scenario 'Candidate adds or deletes a role after completing the section' do
@@ -8,28 +8,28 @@ RSpec.feature 'Candidate edits their volunteering section' do
     and_i_have_completed_the_volunteering_section
 
     when_i_visit_the_application_page
-    then_the_volunteering_section_should_be_marked_as_complete
+    then_the_volunteering_section_will_be_marked_as_complete
 
     when_i_click_the_volunteering_section_link
     and_i_click_to_change_my_role
     and_i_change_my_role
     and_i_click_on_save_and_continue
     and_visit_my_application_page
-    then_the_volunteering_section_should_be_marked_as_complete
+    then_the_volunteering_section_will_be_marked_as_complete
 
     when_i_click_the_volunteering_section_link
     and_i_mark_this_section_as_incomplete
     and_i_click_on_continue
-    then_the_volunteering_section_should_be_marked_as_incomplete
+    then_the_volunteering_section_will_be_marked_as_incomplete
 
     when_i_click_the_volunteering_section_link
     and_i_click_delete_role
     and_i_confirm_i_want_to_delete_the_role
     and_visit_my_application_page
-    then_the_volunteering_section_should_be_marked_as_incomplete
+    then_the_volunteering_section_will_be_marked_as_incomplete
 
     when_i_click_the_volunteering_section_link
-    then_i_should_be_see_the_volunteering_page
+    then_i_will_be_see_the_volunteering_page
   end
 
   def given_i_am_signed_in
@@ -39,7 +39,7 @@ RSpec.feature 'Candidate edits their volunteering section' do
 
   def and_i_have_completed_the_volunteering_section
     @application_form = create(:application_form, candidate: @candidate)
-    create(:application_volunteering_experience, application_form: @application_form)
+    create(:application_volunteering_experience, experienceable: @application_form)
     @application_form.update!(volunteering_completed: true)
   end
 
@@ -47,7 +47,7 @@ RSpec.feature 'Candidate edits their volunteering section' do
     visit candidate_interface_continuous_applications_details_path
   end
 
-  def then_the_volunteering_section_should_be_marked_as_complete
+  def then_the_volunteering_section_will_be_marked_as_complete
     expect(page.text).to include 'Unpaid experience Completed'
   end
 
@@ -67,7 +67,7 @@ RSpec.feature 'Candidate edits their volunteering section' do
     click_link_or_button t('save_and_continue')
   end
 
-  def then_the_volunteering_section_should_be_marked_as_incomplete
+  def then_the_volunteering_section_will_be_marked_as_incomplete
     expect(page.text).to include 'Unpaid experience Incomplete'
   end
 
@@ -95,7 +95,7 @@ RSpec.feature 'Candidate edits their volunteering section' do
     click_link_or_button t('application_form.volunteering.delete.confirm')
   end
 
-  def then_i_should_be_see_the_volunteering_page
+  def then_i_will_be_see_the_volunteering_page
     expect(page).to have_current_path(candidate_interface_volunteering_experience_path)
   end
 end

--- a/spec/system/candidate_interface/entering_details/candidate_edits_or_deletes_volunteering_section_with_restructured_work_history_active_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_edits_or_deletes_volunteering_section_with_restructured_work_history_active_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate edits their volunteering section' do
+RSpec.describe 'Candidate edits their volunteering section' do
   include CandidateHelper
 
   scenario 'Candidate adds or deletes a role after completing the section' do
@@ -8,7 +8,7 @@ RSpec.feature 'Candidate edits their volunteering section' do
     and_i_have_completed_the_volunteering_section
 
     when_i_visit_the_application_page
-    then_the_volunteering_section_should_be_marked_as_complete
+    then_the_volunteering_section_will_be_marked_as_complete
 
     when_i_click_the_volunteering_section_link
     and_i_click_to_change_my_role
@@ -17,21 +17,21 @@ RSpec.feature 'Candidate edits their volunteering section' do
     and_i_mark_the_section_as_incomplete
     and_i_click_on_continue
     and_visit_my_application_page
-    then_the_volunteering_section_should_be_marked_as_incomplete
+    then_the_volunteering_section_will_be_marked_as_incomplete
 
     when_i_click_the_volunteering_section_link
     and_i_mark_this_section_as_completed
     and_i_click_on_continue
-    then_the_volunteering_section_should_be_marked_as_complete
+    then_the_volunteering_section_will_be_marked_as_complete
 
     when_i_click_the_volunteering_section_link
     and_i_click_delete_role
     and_i_confirm_i_want_to_delete_the_role
     and_visit_my_application_page
-    then_the_volunteering_section_should_be_marked_as_incomplete
+    then_the_volunteering_section_will_be_marked_as_incomplete
 
     when_i_click_the_volunteering_section_link
-    then_i_should_be_prompted_to_add_new_experience
+    then_i_will_be_prompted_to_add_new_experience
   end
 
   def given_i_am_signed_in
@@ -42,7 +42,7 @@ RSpec.feature 'Candidate edits their volunteering section' do
   def and_i_have_completed_the_volunteering_section
     @application_form = create(:application_form, candidate: @candidate)
     create(:application_volunteering_experience,
-           application_form: @application_form,
+           experienceable: @application_form,
            start_date: 10.months.ago,
            end_date: nil,
            currently_working: true)
@@ -53,7 +53,7 @@ RSpec.feature 'Candidate edits their volunteering section' do
     visit candidate_interface_continuous_applications_details_path
   end
 
-  def then_the_volunteering_section_should_be_marked_as_complete
+  def then_the_volunteering_section_will_be_marked_as_complete
     expect(page.text).to include 'Unpaid experience Completed'
   end
 
@@ -75,7 +75,7 @@ RSpec.feature 'Candidate edits their volunteering section' do
     click_link_or_button t('save_and_continue')
   end
 
-  def then_the_volunteering_section_should_be_marked_as_incomplete
+  def then_the_volunteering_section_will_be_marked_as_incomplete
     expect(page.text).to include 'Unpaid experience Incomplete'
   end
 
@@ -103,7 +103,7 @@ RSpec.feature 'Candidate edits their volunteering section' do
     choose t('application_form.incomplete_radio')
   end
 
-  def then_i_should_be_prompted_to_add_new_experience
+  def then_i_will_be_prompted_to_add_new_experience
     expect(page).to have_current_path(candidate_interface_volunteering_experience_path)
   end
 end

--- a/spec/system/provider_interface/see_individual_application_personal_statement_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_personal_statement_spec.rb
@@ -12,30 +12,30 @@ RSpec.describe 'A Provider viewing an individual application', :with_audited do
 
     when_i_visit_that_application_in_the_provider_interface
 
-    then_i_should_see_the_candidates_degrees
-    and_i_should_see_the_candidates_gcses
-    and_i_should_not_see_the_safeguarding_declaration_details
+    then_i_will_see_the_candidates_degrees
+    and_i_will_see_the_candidates_gcses
+    and_i_will_not_see_the_safeguarding_declaration_details
 
     when_i_am_permitted_to_see_safeguarding_information
     and_i_visit_that_application_in_the_provider_interface
 
-    then_i_should_see_the_safeguarding_declaration_section
-    and_i_should_see_the_candidates_other_qualifications
-    and_i_should_see_the_candidates_work_history_and_unpaid_experience
-    and_i_should_see_the_candidates_personal_statement
-    and_i_should_see_the_candidates_language_skills
-    and_i_should_see_the_disability_disclosure
-    and_i_should_see_diversity_information_section
-    and_i_should_see_a_link_to_download_as_pdf
-    and_i_should_see_the_candidates_references
+    then_i_will_see_the_safeguarding_declaration_section
+    and_i_will_see_the_candidates_other_qualifications
+    and_i_will_see_the_candidates_work_history_and_unpaid_experience
+    and_i_will_see_the_candidates_personal_statement
+    and_i_will_see_the_candidates_language_skills
+    and_i_will_see_the_disability_disclosure
+    and_i_will_see_diversity_information_section
+    and_i_will_see_a_link_to_download_as_pdf
+    and_i_will_see_the_candidates_references
   end
 
-  def and_i_should_not_see_the_safeguarding_declaration_details
+  def and_i_will_not_see_the_safeguarding_declaration_details
     expect(page).to have_content('Criminal record and professional misconduct')
     expect(page).to have_no_content('View information disclosed by the candidate')
   end
 
-  def then_i_should_see_the_safeguarding_declaration_section
+  def then_i_will_see_the_safeguarding_declaration_section
     expect(page).to have_content('Criminal record and professional misconduct')
     expect(page).to have_content(t('provider_interface.safeguarding_declaration_component.has_safeguarding_issues_to_declare'))
   end
@@ -87,7 +87,7 @@ RSpec.describe 'A Provider viewing an individual application', :with_audited do
     create_list(:application_qualification, 3, application_form:, level: :other)
 
     create(:application_work_experience,
-           application_form:,
+           experienceable: application_form,
            role: 'Smuggler',
            organisation: 'The Empire',
            details: 'I used to work for The Empire',
@@ -100,7 +100,7 @@ RSpec.describe 'A Provider viewing an individual application', :with_audited do
            end_date_unknown: false)
 
     create(:application_work_experience,
-           application_form:,
+           experienceable: application_form,
            role: 'Bounty Hunter',
            organisation: 'The Empire',
            details: 'I used to work for The Empire',
@@ -119,7 +119,7 @@ RSpec.describe 'A Provider viewing an individual application', :with_audited do
            end_date: Time.zone.local(2019, 3, 1))
 
     create(:application_volunteering_experience,
-           application_form:,
+           experienceable: application_form,
            role: 'Defence co-ordinator',
            organisation: 'Rebel Alliance',
            details: 'Worked with children to help them survive clone attacks',
@@ -164,19 +164,19 @@ RSpec.describe 'A Provider viewing an individual application', :with_audited do
     :when_i_visit_that_application_in_the_provider_interface,
   )
 
-  def then_i_should_see_the_candidates_degrees
+  def then_i_will_see_the_candidates_degrees
     expect(page).to have_css('[data-qa="degree-qualification"]', count: 1)
   end
 
-  def and_i_should_see_the_candidates_gcses
+  def and_i_will_see_the_candidates_gcses
     expect(page).to have_css('[data-qa="gcse-qualification"]', count: 2)
   end
 
-  def and_i_should_see_the_candidates_other_qualifications
+  def and_i_will_see_the_candidates_other_qualifications
     expect(page).to have_css('[data-qa="qualifications-table-a-levels-and-other-qualifications"] tbody tr', count: 3)
   end
 
-  def and_i_should_see_the_candidates_work_history_and_unpaid_experience
+  def and_i_will_see_the_candidates_work_history_and_unpaid_experience
     within '[data-qa="work-history-and-unpaid-experience"]' do
       within 'section:eq(1)' do
         expect(page).to have_content 'Defence co-ordinator'
@@ -218,20 +218,20 @@ RSpec.describe 'A Provider viewing an individual application', :with_audited do
     end
   end
 
-  def and_i_should_see_the_candidates_personal_statement
+  def and_i_will_see_the_candidates_personal_statement
     expect(page).to have_content 'Personal statement'
     expect(page).to have_content 'This is my personal statement'
     expect(page).to have_content 'Nothing further to add'
   end
 
-  def and_i_should_see_the_candidates_language_skills
+  def and_i_will_see_the_candidates_language_skills
     within '[data-qa="language-skills"]' do
       expect(page).to have_content 'Yes'
       expect(page).to have_content 'I also speak Spanish and German'
     end
   end
 
-  def and_i_should_see_the_candidates_references
+  def and_i_will_see_the_candidates_references
     click_link_or_button 'References'
 
     expect(page).to have_content 'R2D2'
@@ -247,15 +247,15 @@ RSpec.describe 'A Provider viewing an individual application', :with_audited do
     expect(page).to have_no_content 'BB-8'
   end
 
-  def and_i_should_see_the_disability_disclosure
+  def and_i_will_see_the_disability_disclosure
     expect(page).to have_content 'I am hard of hearing'
   end
 
-  def and_i_should_see_diversity_information_section
+  def and_i_will_see_diversity_information_section
     expect(page).to have_content 'Sex, disability and ethnicity'
   end
 
-  def and_i_should_see_a_link_to_download_as_pdf
+  def and_i_will_see_a_link_to_download_as_pdf
     expect(page).to have_link 'Download application (PDF)'
   end
 end

--- a/spec/system/support_interface/change_job_spec.rb
+++ b/spec/system/support_interface/change_job_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Change job' do
+RSpec.describe 'Change job' do
   include DfESignInHelpers
 
   scenario 'Change an individual job on an application form', :with_audited do
@@ -31,7 +31,7 @@ RSpec.feature 'Change job' do
     @application_form = create(:application_form, :submitted)
     @job = create(
       :application_work_experience,
-      application_form: @application_form,
+      experienceable: @application_form,
       currently_working: true,
     )
   end

--- a/spec/system/support_interface/change_volunteering_role_spec.rb
+++ b/spec/system/support_interface/change_volunteering_role_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Change volunteering role' do
+RSpec.describe 'Change volunteering role' do
   include DfESignInHelpers
 
   scenario 'Change an individual volunteering role on an application form', :with_audited do
@@ -31,7 +31,7 @@ RSpec.feature 'Change volunteering role' do
     @application_form = create(:application_form, :submitted)
     @volunteering_role = create(
       :application_volunteering_experience,
-      application_form: @application_form,
+      experienceable: @application_form,
       currently_working: true,
     )
   end


### PR DESCRIPTION
## Context

Currently, the application_experience is linked to an application_form
through the experienceable polymorphic columns on the application_experience
model

This commit removes the old link, through the application_form_id, the
column will be dropped in a future PR.

There are a few places where we want to make sure the experienceable
model is of type `ApplicationForm`, to do this an `application_form`
method in the ApplicationExperince model exists.

We also need to touch the application_form and application_choices like
the old relation did, to replicate the old behavior

## Changes proposed in this pull request

ApplicationExperience model

## Guidance to review

Create and edit work experience on review or local

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
