### PR TITLE
[2179] backfilling english proficiency records

### DIFF
--- a/app/services/data_migrations/backfill_english_proficiency_records_for_carried_over_applications.rb
+++ b/app/services/data_migrations/backfill_english_proficiency_records_for_carried_over_applications.rb
@@ -1,0 +1,42 @@
+module DataMigrations
+  class BackfillEnglishProficiencyRecordsForCarriedOverApplications
+    TIMESTAMP = 20240815092638
+    MANUAL_RUN = false
+
+    IGNORED_ATTRIBUTES = %w[id created_at updated_at application_form_id].freeze
+
+    def change
+      problem_application_forms.find_each do |application_form|
+        previous_english_proficiency = application_form.previous_application_form.english_proficiency
+
+        efl_qualification = if previous_english_proficiency.efl_qualification.present?
+                              previous_english_proficiency.efl_qualification_type.constantize.new(
+                                **previous_english_proficiency.efl_qualification.attributes.except(*IGNORED_ATTRIBUTES),
+                              )
+                            end
+        EnglishProficiency.create!(
+          **previous_english_proficiency.attributes.except(*IGNORED_ATTRIBUTES),
+          efl_qualification:,
+          application_form:,
+        )
+      end
+    end
+
+    def problem_application_forms
+      ApplicationForm
+        .current_cycle
+        .unsubmitted
+        .where.missing(:english_proficiency)
+        .where(efl_completed: true)
+        .where(previous_application_form_id: previous_applications_with_english_proficiencies_ids)
+        .includes(previous_application_form: :english_proficiency)
+    end
+
+    def previous_applications_with_english_proficiencies_ids
+      ApplicationForm
+        .where('recruitment_cycle_year < ?', 2024)
+        .where.associated(:english_proficiency)
+        .pluck(:id)
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillEnglishProficiencyRecordsForCarriedOverApplications',
   'DataMigrations::CleanupApplicationExperiencesExperienceable',
   'DataMigrations::BackfillExperienceableForApplicationForms',
   'DataMigrations::BackfillWeek42PerformanceReportData',

--- a/spec/services/data_migrations/backfill_english_proficiency_records_for_carried_over_applications_spec.rb
+++ b/spec/services/data_migrations/backfill_english_proficiency_records_for_carried_over_applications_spec.rb
@@ -1,0 +1,123 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillEnglishProficiencyRecordsForCarriedOverApplications do
+  let(:data_migration) { described_class.new.change }
+
+  context 'when efl_complete is marked as true and english proficiency record exists' do
+    it 'does not change the application' do
+      create(
+        :application_form,
+        :unsubmitted,
+        efl_completed: true,
+        efl_completed_at: Time.zone.now,
+        english_proficiency: create(:english_proficiency, :with_toefl_qualification),
+        previous_application_form: create(:application_form, recruitment_cycle_year: RecruitmentCycle.current_year - 1),
+      )
+      expect { data_migration }.to not_change(EnglishProficiency, :count)
+    end
+  end
+
+  context 'when efl_complete is marked as true without proficiency record, but one exists on previous application' do
+    describe 'an efl_qualification exists' do
+      it 'copies english proficiency and associated efl qualification' do
+        previous_application_form = create(:application_form, recruitment_cycle_year: RecruitmentCycle.current_year - 1)
+        previous_english_proficiency = create(
+          :english_proficiency,
+          :with_toefl_qualification,
+          application_form: previous_application_form,
+        )
+
+        application_form = create(
+          :application_form,
+          :unsubmitted,
+          efl_completed: true,
+          efl_completed_at: Time.zone.now,
+          previous_application_form:,
+        )
+        expect { data_migration }.to change(EnglishProficiency, :count).by(1)
+        expect(application_form.english_proficiency.efl_qualification.present?).to be(true)
+        expect(application_form.english_proficiency.efl_qualification_type).to eq previous_english_proficiency.efl_qualification_type
+      end
+    end
+
+    describe 'an efl_qualification does NOT exists' do
+      it 'copies the english proficiency record without an efl qualifications' do
+        previous_application_form = create(:application_form, recruitment_cycle_year: RecruitmentCycle.current_year - 1)
+        create(:english_proficiency, :no_qualification, application_form: previous_application_form)
+
+        application_form = create(
+          :application_form,
+          :unsubmitted,
+          efl_completed: true,
+          efl_completed_at: Time.zone.now,
+          previous_application_form:,
+        )
+        expect { data_migration }.to change(EnglishProficiency, :count).by(1)
+        expect(application_form.english_proficiency.efl_qualification.present?).to be(false)
+        expect(application_form.english_proficiency.qualification_status).to eq('no_qualification')
+      end
+    end
+  end
+
+  context 'where previous application does not exists' do
+    it 'does not create an english proficiency' do
+      create(
+        :application_form,
+        :unsubmitted,
+        efl_completed: true,
+        efl_completed_at: Time.zone.now,
+      )
+
+      expect { data_migration }.to not_change(EnglishProficiency, :count)
+    end
+  end
+
+  context 'when efl_complete is marked as true and english proficiency record does not exists on previous application' do
+    it 'does not add an english proficiency' do
+      create(
+        :application_form,
+        :unsubmitted,
+        efl_completed: true,
+        efl_completed_at: Time.zone.now,
+        previous_application_form: create(:application_form, recruitment_cycle_year: RecruitmentCycle.previous_year),
+      )
+
+      expect { data_migration }.to not_change(EnglishProficiency, :count)
+    end
+  end
+
+  context 'application from earlier cycle' do
+    it 'does not add an english proficiency' do
+      previous_application_form = create(:application_form, recruitment_cycle_year: RecruitmentCycle.previous_year - 1)
+      create(:english_proficiency, :no_qualification, application_form: previous_application_form)
+
+      create(
+        :application_form,
+        :unsubmitted,
+        recruitment_cycle_year: RecruitmentCycle.previous_year,
+        efl_completed: true,
+        efl_completed_at: Time.zone.now,
+        previous_application_form:,
+      )
+
+      expect { data_migration }.to not_change(EnglishProficiency, :count)
+    end
+  end
+
+  describe 'submitted application' do
+    it 'does not create an english proficiency record' do
+      previous_application_form = create(:application_form, recruitment_cycle_year: RecruitmentCycle.previous_year)
+      create(:english_proficiency, :no_qualification, application_form: previous_application_form)
+
+      create(
+        :application_form,
+        :submitted,
+        efl_completed: true,
+        efl_completed_at: Time.zone.now,
+        previous_application_form:,
+      )
+
+      expect { data_migration }.to not_change(EnglishProficiency, :count)
+    end
+  end
+end


### PR DESCRIPTION
## Context
We have [fixed a bug](https://github.com/DFE-Digital/apply-for-teacher-training/pull/9688) where english proficiency records were not being carried over to new applications. This ticket is to backfill the data for current candidates. 

There are currently [2050 candidates who have `efl_completed` marked as `true`, but are missing english proficiency records](https://www.apply-for-teacher-training.service.gov.uk/support/blazer/queries/948-applications-with-missing-english-proficiency-data).

The reason we are only backfilling 2024 applications is that anyone who starts an application from a previous cycle NOW, will have the data carried over because of the bug fix mentioned above. 

## Changes proposed in this pull request
Data migration to backfill data. 

Locally I created 2000 application forms that needed to be updated and ran the job. It took 7 seconds.

## Guidance to review

You can run locally to test performance:
First create records that will need updating: 
```
2050.times do 
  previous_application_form = FactoryBot.create(:application_form, recruitment_cycle_year: RecruitmentCycle.current_year - 1)
  previous_english_proficiency = FactoryBot.create(
          :english_proficiency,
          :with_toefl_qualification,
          application_form: previous_application_form,
        )
  application_form = FactoryBot.create(
          :application_form,
          :unsubmitted,
          efl_completed: true,
          efl_completed_at: Time.zone.now,
          previous_application_form:,
        )
end
``` 
(stare into space for a bit, as this will take awhile to create all the records)
Then run the job
`DataMigrations::BackfillEnglishProficiencyRecordsForCarriedOverApplications.new.change`

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
