### PR TITLE
Remind candidates about decline by default date when approaching end …

### DIFF
--- a/app/views/candidate_mailer/new_offer_made.text.erb
+++ b/app/views/candidate_mailer/new_offer_made.text.erb
@@ -10,4 +10,8 @@ Congratulations! You have an offer from <%= @provider_name %> to study <%= @cour
 
 Contact <%= @provider_name %> if you have any questions about this.
 
+<% if (CycleTimetable.decline_by_default_date - 4.weeks).before? Time.zone.now %>
+  If you want to accept this offer, you must do so by <%= I18n.l(CycleTimetable.decline_by_default_date.to_date, format: :no_year) %>. If you have not responded by then, the offer will be automatically declined on your behalf.
+<% end %>
+
 [Sign into your account to respond to your offer](<%= candidate_magic_link(@application_form.candidate) %>).


### PR DESCRIPTION
## Context

When a Provider actions their decision to Offer a Candidate a place on an ITT course, we send an email to the Candidate - Congratulations! You have an offer…

The candidate has until the end of the recruitment cycle (the date at which we “decline by default” their offer on their behalf) to respond to it.

Towards the end of past recruitment cycles we’ve tended to additionally send manually crafted emails to Candidates to remind them to respond to their offer. This takes time and effort for us to query, draft and send. Rather than simply automating that additional nudge, we’d like to adapt our existing transactional email to include a conditional prompt about the deadline if the offer is being made near the end of the cycle.

## Changes proposed in this pull request

Text that renders conditionally on the offer email when we are four weeks away from the decline by default date

## Guidance to review
Locally (or in the review app)
- View the mailer `/rails/mailers/candidate_mailer/new_offer_made`
- The text should not be rendered as it is about 6 weeks before the decline by default date.
- Use the cycle switcher to advance to the apply deadline
- Then view the mailer again.
- Now you should see the deadline reminder text. 

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
