### PR TITLE
Update applications without english proficiency

### DIFF
--- a/app/services/data_migrations/mark_unsubmitted_applications_without_english_proficiency_as_elf_incomplete.rb
+++ b/app/services/data_migrations/mark_unsubmitted_applications_without_english_proficiency_as_elf_incomplete.rb
@@ -1,0 +1,20 @@
+module DataMigrations
+  class MarkUnsubmittedApplicationsWithoutEnglishProficiencyAsElfIncomplete
+    TIMESTAMP = 20240816134619
+    MANUAL_RUN = false
+
+    def change
+      problem_application_forms.update_all(
+        efl_completed: false, efl_completed_at: nil,
+      )
+    end
+
+    def problem_application_forms
+      ApplicationForm
+        .current_cycle
+        .unsubmitted
+        .where.missing(:english_proficiency)
+        .where(efl_completed: true)
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::MarkUnsubmittedApplicationsWithoutEnglishProficiencyAsElfIncomplete',
   'DataMigrations::BackfillEnglishProficiencyRecordsForCarriedOverApplications',
   'DataMigrations::CleanupApplicationExperiencesExperienceable',
   'DataMigrations::BackfillExperienceableForApplicationForms',

--- a/spec/services/data_migrations/mark_unsubmitted_applications_without_english_proficiency_as_elf_incomplete_spec.rb
+++ b/spec/services/data_migrations/mark_unsubmitted_applications_without_english_proficiency_as_elf_incomplete_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::MarkUnsubmittedApplicationsWithoutEnglishProficiencyAsElfIncomplete do
+  context 'when efl_complete is marked as true and english proficiency record exists' do
+    it 'does not change record' do
+      application_form = create(
+        :application_form,
+        :unsubmitted,
+        efl_completed: true,
+        efl_completed_at: Time.zone.now,
+        english_proficiency: create(:english_proficiency, :with_toefl_qualification),
+      )
+      described_class.new.change
+      expect(application_form.reload.efl_completed).to be(true)
+      expect(application_form.reload.efl_completed_at).not_to be_nil
+    end
+  end
+
+  context 'when english proficiency record does not exists' do
+    describe 'application is in an earlier cycle' do
+      it 'does not change record' do
+        application_form = create(
+          :application_form,
+          :unsubmitted,
+          recruitment_cycle_year: RecruitmentCycle.previous_year,
+          efl_completed: true,
+          efl_completed_at: Time.zone.now,
+        )
+
+        described_class.new.change
+        expect(application_form.reload.efl_completed).to be(true)
+        expect(application_form.reload.efl_completed_at).not_to be_nil
+      end
+    end
+
+    describe 'application has been submitted' do
+      it 'does not change record' do
+        application_form = create(
+          :application_form,
+          :submitted,
+          efl_completed: true,
+          efl_completed_at: Time.zone.now,
+          previous_application_form: create(:application_form, recruitment_cycle_year: RecruitmentCycle.current_year - 1),
+        )
+
+        described_class.new.change
+        expect(application_form.reload.efl_completed).to be(true)
+        expect(application_form.reload.efl_completed_at).not_to be_nil
+      end
+    end
+
+    describe 'from this year and unsubmitted' do
+      it 'updates efl_completed information' do
+        application_form = create(
+          :application_form,
+          :unsubmitted,
+          efl_completed: true,
+          efl_completed_at: Time.zone.now,
+          previous_application_form: create(:application_form, recruitment_cycle_year: RecruitmentCycle.current_year - 1),
+        )
+
+        described_class.new.change
+        expect(application_form.reload.efl_completed).to be(false)
+        expect(application_form.reload.efl_completed_at).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

An [earlier PR](https://github.com/DFE-Digital/apply-for-teacher-training/pull/9699) backfilled english proficiency records. Originally, there were 2050 candidates who had efl_compeleted marked as true, but missing proficiency records. 

After running that data migration, there are still 526 candidates with unsubmitted applications who are missing english proficiency records. 

We have decided (see trello ticket) to update those remaining records `efl_completed` to `false` and `elf_compelted_at` to `nil`.

## Changes proposed in this pull request

Migration to update the remaining application forms still missing english proficiency data.

## Guidance to review

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
