### PR TITLE
Fix errors that mobile users are experiencing on apply

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,6 +38,9 @@ private
   def append_info_to_payload(payload)
     super
 
-    payload.merge!(query_params: request_query_params)
+    payload.merge!(
+      query_params: request_query_params,
+      user_agent: request&.user_agent,
+    )
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -100,6 +100,7 @@ module ApplyForPostgraduateTeacherTraining
 
     config.action_dispatch.default_headers = {
       "Feature-Policy" => "accelerometer 'none'; ambient-light-sensor: 'none', autoplay: 'none', battery: 'none', camera 'none'; display-capture: 'none', document-domain: 'none', fullscreen: 'none', geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; midi: 'none', payment 'none'; publickey-credentials-get: 'none', usb 'none', wake-lock: 'none', screen-wake-lock: 'none', web-share: 'none'",
+      'Cache-Control' => 'no-store, no-cache',
     }
 
     config.action_mailer.deliver_later_queue_name = :mailers


### PR DESCRIPTION
## Context

According to the logs we had hundreds errors that users are encountering.

The issue arises because mobile Safari reloads pages from cache after the browser is closed and reopened.

 When this happens, the session cookie that stores the CSRF token is gone, but the form still contains the old token. This mismatch leads to an error when the user tries to submit the form.

Rails stores the authenticity token in a session cookie, which gets deleted when the browser is closed. On mobile Safari, when you reopen the browser, it reloads tabs from cache, but the session cookie is gone. As a result, the authenticity token in the form can't be verified when the form is submitted.

## Solution

* Add the user agent on the logs to help to understand the issue faster (it took me 3 days to understand the issue!)
* Add custom headers

Instruct Safari (and other browsers) to request a fresh version of the page before resubmitting it

1. no-store: Prevents the response from being cached by the browser, ensuring it is fetched anew with every request.
2. no-cache: Requires caches to validate the resource before using it, ensuring that any changes are accounted for before serving the cached version.
