### PR TITLE
Write to ApplicationWorkHistoryBreak#breakable

### DIFF
--- a/app/models/application_work_history_break.rb
+++ b/app/models/application_work_history_break.rb
@@ -2,6 +2,9 @@ class ApplicationWorkHistoryBreak < ApplicationRecord
   include TouchApplicationChoices
 
   belongs_to :application_form, touch: true
+  belongs_to :breakable, polymorphic: true, optional: true
+
+  before_save -> { self.breakable = application_form }, if: -> { breakable.nil? }
 
   audited associated_with: :application_form
 

--- a/spec/forms/candidate_interface/restructured_work_history/work_history_break_form_spec.rb
+++ b/spec/forms/candidate_interface/restructured_work_history/work_history_break_form_spec.rb
@@ -86,10 +86,14 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::WorkHistoryBreakForm
 
     it 'creates a new work experience if valid' do
       application_form = create(:application_form)
+      expected_data = data.merge(
+        breakable_id: application_form.id,
+        breakable_type: 'ApplicationForm',
+      )
       work_break = described_class.new(form_data)
       saved_work_break = work_break.save(application_form)
 
-      expect(saved_work_break).to have_attributes(data)
+      expect(saved_work_break).to have_attributes(expected_data)
     end
   end
 
@@ -112,6 +116,12 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::WorkHistoryBreakForm
       work_break.update(application_work_history_break)
 
       expect(application_work_history_break.reason).to eq('Updated reason.')
+      expect(application_work_history_break.breakable_id).to eq(
+        application_work_history_break.application_form_id,
+      )
+      expect(application_work_history_break.breakable_type).to eq(
+        'ApplicationForm',
+      )
     end
   end
 end

--- a/spec/models/application_work_history_break_spec.rb
+++ b/spec/models/application_work_history_break_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationWorkHistoryBreak do
+  it { is_expected.to belong_to(:application_form).touch(true) }
+  it { is_expected.to belong_to(:breakable).optional }
+
+  describe 'auditing', :with_audited do
+    it { is_expected.to be_audited.associated_with :application_form }
+  end
+
+  describe '#length' do
+    it 'calculates the length of the break' do
+      work_history_break = build(
+        :application_work_history_break,
+        start_date: Date.new(2020, 8, 14),
+        end_date: Date.new(2024, 8, 14),
+      )
+
+      expect(work_history_break.length).to eq(47)
+    end
+  end
+end


### PR DESCRIPTION
## Context

`ApplicationWorkHistoryBreak` is going to be a polymorphic table, we want
it to belong to an application_form or an application_choice.

This will help us make the application work experiences editable on the
application form.

This commit will save the link between the
application_work_history_break and the application_form in the
polymorphic columns, another commit will follow to back-fill the data
## Changes proposed in this pull request

## Guidance to review

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
