### PR TITLE
Backfill ApplicationWorkHistoryBreak#breakable

### DIFF
--- a/app/services/data_migrations/backfill_application_work_history_breaks.rb
+++ b/app/services/data_migrations/backfill_application_work_history_breaks.rb
@@ -1,0 +1,23 @@
+module DataMigrations
+  class BackfillApplicationWorkHistoryBreaks < ActiveRecord::Migration[7.1]
+    disable_ddl_transaction!
+
+    TIMESTAMP = 20240819153131
+    MANUAL_RUN = false
+
+    def change
+      batch = 0
+
+      ApplicationWorkHistoryBreak.where(breakable_id: nil, breakable_type: nil).in_batches do |batch_work_breaks|
+        batch_work_breaks.update_all("breakable_id = application_form_id, breakable_type = 'ApplicationForm'")
+        sleep(0.01)
+        batch += 1
+        Rails.logger.info "Running batch: #{batch}"
+      rescue ActiveRecord::StatementInvalid => e
+        Rails.logger.info "Error: #{e.message}"
+      end
+
+      Rails.logger.info 'Finished!'
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillApplicationWorkHistoryBreaks',
   'DataMigrations::MarkUnsubmittedApplicationsWithoutEnglishProficiencyAsElfIncomplete',
   'DataMigrations::BackfillEnglishProficiencyRecordsForCarriedOverApplications',
   'DataMigrations::BackfillWeek42PerformanceReportData',

--- a/spec/services/data_migrations/backfill_application_work_history_breaks_spec.rb
+++ b/spec/services/data_migrations/backfill_application_work_history_breaks_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillApplicationWorkHistoryBreaks do
+  it 'backfills application work history breaks with breakable id and type nil' do
+    work_history_break = create(
+      :application_work_history_break,
+      application_form: create(:application_form),
+    )
+
+    described_class.new.change
+
+    expect(work_history_break.reload.breakable_id).to eq(work_history_break.application_form_id)
+    expect(work_history_break.breakable_type).to eq('ApplicationForm')
+  end
+end


### PR DESCRIPTION
## Context

`ApplicationWorkHistoryBreak` is going to be a polymorphic table, we want it to belong to an application_form or an application_choice.

This will help us make the application work experiences editable on the application form.

This commit backfills application_work_history_breaks polymorphic columns.

## Changes proposed in this pull request

Data migration for backfill

## Guidance to review

We have 150k records in production that need updating. I choose this migration to run automatically when building. Mainly because of `disable_ddl_transaction!` this should not make the whole migration one transaction so all the records should not be in memory and we already run a much bigger migration in https://github.com/DFE-Digital/apply-for-teacher-training/pull/9671 over 1 million records and the pod did not die.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
