### PR TITLE
Use ApplicationWorkHistoryBreak#breakable column

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -16,7 +16,7 @@ class ApplicationForm < ApplicationRecord
   has_many :application_volunteering_experiences, as: :experienceable
   has_many :application_qualifications
   has_many :application_references
-  has_many :application_work_history_breaks
+  has_many :application_work_history_breaks, as: :breakable
   has_many :emails
 
   belongs_to :previous_application_form, class_name: 'ApplicationForm', optional: true, inverse_of: 'subsequent_application_form'

--- a/app/models/application_work_history_break.rb
+++ b/app/models/application_work_history_break.rb
@@ -1,12 +1,17 @@
 class ApplicationWorkHistoryBreak < ApplicationRecord
   include TouchApplicationChoices
 
-  belongs_to :application_form, touch: true
-  belongs_to :breakable, polymorphic: true, optional: true
+  belongs_to :application_form, touch: true, optional: true
+  belongs_to :breakable, polymorphic: true
 
-  before_save -> { self.breakable = application_form }, if: -> { breakable.nil? }
+  before_save -> { self.application_form_id = breakable_id }, if: -> { application_form_id.nil? }
 
   audited associated_with: :application_form
+
+  def application_form=(value)
+    super
+    self.breakable = value
+  end
 
   def length
     ((end_date.year * 12) + end_date.month) - ((start_date.year * 12) + start_date.month) - 1

--- a/spec/models/application_work_history_break_spec.rb
+++ b/spec/models/application_work_history_break_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationWorkHistoryBreak do
-  it { is_expected.to belong_to(:application_form).touch(true) }
-  it { is_expected.to belong_to(:breakable).optional }
+  it { is_expected.to belong_to(:application_form).touch(true).optional }
+  it { is_expected.to belong_to(:breakable) }
 
   describe 'auditing', :with_audited do
     it { is_expected.to be_audited.associated_with :application_form }


### PR DESCRIPTION
## Context

We migrated all the data in ba80a6f22b419ad720ac7988499cfc6edbb634aa

Now we can use the breakable columns to link to an application_form

## Changes proposed in this pull request

Use the `breakable` column

## Guidance to review

Create a work break on review or locally


https://github.com/user-attachments/assets/6dfb3081-b1b6-4378-9df4-a293d4b78603



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
