### PR TITLE
Added a `responds_to` check before `#choices_controller?`

### DIFF
--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -21,12 +21,12 @@ class NavigationItems
           NavigationItem.new(
             t('page_titles.your_details'),
             candidate_interface_continuous_applications_details_path,
-            !current_controller.choices_controller?,
+            current_controller.respond_to?(:choices_controller?) ? !current_controller.choices_controller? : false,
           ),
           NavigationItem.new(
             t('page_titles.continuous_applications.your_applications'),
             candidate_interface_continuous_applications_choices_path,
-            current_controller.choices_controller?,
+            current_controller.respond_to?(:choices_controller?) ? current_controller.choices_controller? : false,
           ),
         ]
       end


### PR DESCRIPTION

## Context

Sentry raised a `ActionView::Template::Error` due the to `#choices_controller?` check

https://dfe-teacher-services.sentry.io/issues/5734669496/?alert_rule_id=853774&alert_type=issue&project=1765973

## Changes proposed in this pull request

Added a `responds_to` check before `#choices_controller?`
This will stop controllers that do not implement the `choices_controller?` from erroring

## Guidance to review

N/A

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
