### PR TITLE
Reinstated the `--only` argument oncommit

### DIFF
--- a/config/rubocop/config/oncommit.yml
+++ b/config/rubocop/config/oncommit.yml
@@ -1,8 +1,0 @@
-require:
-  - rubocop-rspec
-  - rubocop-rspec_rails
-  - ../../../lib/rubocop/cop/rspec/no_should_in_specs.rb
-
-RSpec/Dialect:
-  PreferredMethods:
-    feature: :describe

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     ]
   },
   "lint-staged": {
-    "*_spec.rb": "bundle exec rubocop -c config/rubocop/config/oncommit.yml -P --only RSpec/NoShouldInSpecs,RSpec/Dialect"
+    "*_spec.rb": "bundle exec rubocop -P"
   },
   "standard": {
     "env": [

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     ]
   },
   "lint-staged": {
-    "*_spec.rb": "bundle exec rubocop -c config/rubocop/config/oncommit.yml -P"
+    "*_spec.rb": "bundle exec rubocop -c config/rubocop/config/oncommit.yml -P --only RSpec/NoShouldInSpecs,RSpec/Dialect"
   },
   "standard": {
     "env": [


### PR DESCRIPTION
## Context

This was too restrictive

## Changes proposed in this pull request

Reverted a change from #9725 

## Guidance to review

N/A

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
