### PR TITLE
Ignore ApplicationWorkHistoryBreak#application_form_id

### DIFF
--- a/app/models/application_work_history_break.rb
+++ b/app/models/application_work_history_break.rb
@@ -1,7 +1,7 @@
 class ApplicationWorkHistoryBreak < ApplicationRecord
-  belongs_to :breakable, polymorphic: true, touch: true
+  self.ignored_columns += %w[application_form_id]
 
-  before_save -> { self.application_form_id = breakable_id }, if: -> { application_form_id.nil? }
+  belongs_to :breakable, polymorphic: true, touch: true
 
   audited associated_with: :breakable
 

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -86,6 +86,11 @@ class Candidate < ApplicationRecord
       experienceable_id: application_form_ids,
       experienceable_type: 'ApplicationForm',
     ).delete_all
+
+    ApplicationWorkHistoryBreak.where(
+      breakable_id: application_form_ids,
+      breakable_type: 'ApplicationForm',
+    ).delete_all
   end
 
 private

--- a/app/workers/delete_test_applications.rb
+++ b/app/workers/delete_test_applications.rb
@@ -23,5 +23,6 @@ private
 
   def delete_work_experiences(ids)
     ApplicationExperience.where(experienceable_id: ids, experienceable_type: 'ApplicationForm').delete_all
+    ApplicationWorkHistoryBreak.where(breakable_id: ids, breakable_type: 'ApplicationForm').delete_all
   end
 end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -190,7 +190,6 @@ shared:
     - degree_institution_uuid
     - degree_grade_uuid
   application_work_history_breaks:
-    - application_form_id
     - breakable_type
     - breakable_id
     - created_at

--- a/spec/forms/candidate_interface/restructured_work_history/work_history_break_form_spec.rb
+++ b/spec/forms/candidate_interface/restructured_work_history/work_history_break_form_spec.rb
@@ -116,12 +116,6 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::WorkHistoryBreakForm
       work_break.update(application_work_history_break)
 
       expect(application_work_history_break.reason).to eq('Updated reason.')
-      expect(application_work_history_break.breakable_id).to eq(
-        application_work_history_break.application_form_id,
-      )
-      expect(application_work_history_break.breakable_type).to eq(
-        'ApplicationForm',
-      )
     end
   end
 end

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe Candidate do
       application_choice = create(:application_choice, application_form:)
       application_work_experience = create(:application_work_experience, experienceable: application_form)
       application_volunteering_experience = create(:application_volunteering_experience, experienceable: application_form)
+      application_work_history_break = create(:application_work_history_break, breakable: application_form)
       application_qualification = create(:application_qualification, application_form:)
       application_reference = create(:reference, application_form:)
 
@@ -92,6 +93,7 @@ RSpec.describe Candidate do
       expect { application_choice.reload }.to raise_error(ActiveRecord::RecordNotFound)
       expect { application_work_experience.reload }.to raise_error(ActiveRecord::RecordNotFound)
       expect { application_volunteering_experience.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { application_work_history_break.reload }.to raise_error(ActiveRecord::RecordNotFound)
       expect { application_qualification.reload }.to raise_error(ActiveRecord::RecordNotFound)
       expect { application_reference.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end


### PR DESCRIPTION
## Context

We don't need the application_form_id on the
application_work_history_break table, we use the breakable column to
link it to an application form.

This commit ignores the application_form_id and makes sure the deletion
of the history break is going to happen when deleting a candidate, just
like before.

We made application_form_id nullable here
https://github.com/DFE-Digital/apply-for-teacher-training/commit/9d60480d2c5c74222a3168de6908431ab185f438

## Changes proposed in this pull request

Ignore `application_form_id`
Delete application_work_history_break when the candidate is deleted. Cascading deletes don't work with polymorphic relations.

## Guidance to review

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
