### PR TITLE
Use application_choice polymorphic associations

### DIFF
--- a/app/components/shared/work_history_and_unpaid_experience_component.rb
+++ b/app/components/shared/work_history_and_unpaid_experience_component.rb
@@ -1,7 +1,10 @@
 class WorkHistoryAndUnpaidExperienceComponent < WorkHistoryComponent
-  def initialize(application_form:, editable: false)
+  def initialize(application_form:, editable: false, application_choice: nil)
     @application_form = application_form
-    @work_history_with_breaks ||= WorkHistoryWithBreaks.new(application_form, include_unpaid_experience: true)
+    @work_history_with_breaks ||= WorkHistoryWithBreaks.new(
+      application_choice || application_form,
+      include_unpaid_experience: true,
+    )
     @editable = editable
   end
 

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -25,6 +25,10 @@ class ApplicationChoice < ApplicationRecord
   has_many :notes, dependent: :destroy
   has_many :interviews, dependent: :destroy
 
+  has_many :work_experiences, as: :experienceable, class_name: 'ApplicationWorkExperience'
+  has_many :volunteering_experiences, as: :experienceable, class_name: 'ApplicationVolunteeringExperience'
+  has_many :work_history_breaks, as: :breakable, class_name: 'ApplicationWorkHistoryBreak'
+
   validates_with ReapplyValidator, reappliable: true
 
   has_associated_audits
@@ -66,6 +70,24 @@ class ApplicationChoice < ApplicationRecord
   scope :decision_pending_and_inactive, -> { where(status: ApplicationStateChange::DECISION_PENDING_AND_INACTIVE_STATUSES) }
   scope :accepted, -> { where(status: ApplicationStateChange::ACCEPTED_STATES) }
   scope :inactive_past_day, -> { inactive.where(inactive_at: 1.day.ago..Time.zone.now) }
+
+  def application_work_experiences
+    return application_form.application_work_experiences if work_experiences.blank?
+
+    work_experiences
+  end
+
+  def application_volunteering_experiences
+    return application_form.application_volunteering_experiences if volunteering_experiences.blank?
+
+    volunteering_experiences
+  end
+
+  def application_work_history_breaks
+    return application_form.application_work_history_breaks if work_history_breaks.blank?
+
+    work_history_breaks
+  end
 
   def submitted?
     !unsubmitted?

--- a/app/presenters/concerns/work_experience_api_data.rb
+++ b/app/presenters/concerns/work_experience_api_data.rb
@@ -6,8 +6,8 @@ module WorkExperienceAPIData
   def work_history_break_explanation
     @work_history_break_explanation ||= if application_form.work_history_breaks
                                           application_form.work_history_breaks
-                                        elsif application_form.application_work_history_breaks.any?
-                                          application_form.application_work_history_breaks.map do |work_break|
+                                        elsif application_choice.application_work_history_breaks.any?
+                                          application_choice.application_work_history_breaks.map do |work_break|
                                             format_work_break(work_break)
                                           end.join("\n\n")
                                         else
@@ -18,13 +18,13 @@ module WorkExperienceAPIData
   end
 
   def work_experience_jobs
-    application_form.application_work_experiences.map do |experience|
+    application_choice.application_work_experiences.map do |experience|
       experience_to_hash(experience)
     end
   end
 
   def work_experience_volunteering
-    application_form.application_volunteering_experiences.map do |experience|
+    application_choice.application_volunteering_experiences.map do |experience|
       experience_to_hash(experience)
     end
   end

--- a/app/services/work_history_with_breaks.rb
+++ b/app/services/work_history_with_breaks.rb
@@ -1,15 +1,17 @@
 class WorkHistoryWithBreaks
-  attr_accessor :application_form, :work_history, :existing_breaks, :unpaid_work, :include_unpaid_experience
+  attr_accessor :work_history, :existing_breaks, :unpaid_work, :include_unpaid_experience
+  attr_reader :experienceable
 
-  def initialize(application_form, include_unpaid_experience: false)
+  # experienceable can be ApplicationForm or ApplicationChoice
+  def initialize(experienceable, include_unpaid_experience: false)
     @include_unpaid_experience = include_unpaid_experience
-    @application_form = application_form
-    @work_history = application_form.application_work_experiences.sort_by(&:start_date)
-    @existing_breaks = application_form.application_work_history_breaks.sort_by(&:start_date)
+    @experienceable = experienceable
+    @work_history = experienceable.application_work_experiences.sort_by(&:start_date)
+    @existing_breaks = experienceable.application_work_history_breaks.sort_by(&:start_date)
     @current_job = nil
 
     if include_unpaid_experience
-      @unpaid_work = application_form.application_volunteering_experiences.sort_by(&:start_date)
+      @unpaid_work = experienceable.application_volunteering_experiences.sort_by(&:start_date)
     end
   end
 
@@ -35,7 +37,9 @@ class WorkHistoryWithBreaks
 private
 
   def submitted_at
-    application_form.submitted_at || Time.zone.now
+    experienceable.try(:submitted_at) ||
+      experienceable.application_form.submitted_at ||
+      Time.zone.now
   end
 
   def month_range(start_date:, end_date:)

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -71,7 +71,10 @@
 
 <%= render ProviderInterface::SafeguardingDeclarationComponent.new(application_choice: @application_choice, current_provider_user: current_provider_user) %>
 
-<%= render WorkHistoryAndUnpaidExperienceComponent.new(application_form: @application_choice.application_form) %>
+<%= render WorkHistoryAndUnpaidExperienceComponent.new(
+  application_form: @application_choice.application_form,
+  application_choice: @application_choice,
+) %>
 
 <%= render ProviderInterface::QualificationsComponent.new(application_form: @application_choice.application_form, application_choice: @application_choice) %>
 

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationChoice do
+  it { is_expected.to have_many(:work_experiences).class_name('ApplicationWorkExperience') }
+  it { is_expected.to have_many(:volunteering_experiences).class_name('ApplicationVolunteeringExperience') }
+  it { is_expected.to have_many(:work_history_breaks).class_name('ApplicationWorkHistoryBreak') }
+
   describe 'auditing', :with_audited do
     it 'creates audit entries' do
       application_choice = create(:application_choice, status: 'unsubmitted')
@@ -632,6 +636,99 @@ RSpec.describe ApplicationChoice do
 
       it 'is not recently updated' do
         expect(choice).not_to be_updated_recently_since_submitted
+      end
+    end
+  end
+
+  describe '#application_work_experiences' do
+    context 'when application_choice has work experiences' do
+      it 'returns the application choice work experiences' do
+        application_form = create(:application_form)
+        create(:application_work_experience, experienceable: application_form)
+        choice = create(:application_choice, application_form:)
+        create(:application_work_experience, experienceable: choice)
+
+        expect(choice.application_work_experiences).to eq(choice.work_experiences)
+        expect(choice.application_work_experiences).not_to eq(
+          application_form.application_work_experiences,
+        )
+      end
+    end
+
+    context 'when application_choice has no work experiences' do
+      it 'returns the application form work experiences' do
+        application_form = create(:application_form)
+        create(:application_work_experience, experienceable: application_form)
+        choice = create(:application_choice, application_form:)
+
+        expect(choice.application_work_experiences).to eq(
+          application_form.application_work_experiences,
+        )
+        expect(choice.application_work_experiences).not_to eq(
+          choice.work_experiences,
+        )
+      end
+    end
+  end
+
+  describe '#application_volunteering_experiences' do
+    context 'when application_choice has volunteering experiences' do
+      it 'returns the application choice volunteering experiences' do
+        application_form = create(:application_form)
+        create(:application_volunteering_experience, experienceable: application_form)
+        choice = create(:application_choice, application_form:)
+        create(:application_volunteering_experience, experienceable: choice)
+
+        expect(choice.application_volunteering_experiences).to eq(choice.volunteering_experiences)
+        expect(choice.application_volunteering_experiences).not_to eq(
+          application_form.application_volunteering_experiences,
+        )
+      end
+    end
+
+    context 'when application_choice has no volunteering experiences' do
+      it 'returns the application form volunteering experiences' do
+        application_form = create(:application_form)
+        create(:application_volunteering_experience, experienceable: application_form)
+        choice = create(:application_choice, application_form:)
+
+        expect(choice.application_volunteering_experiences).to eq(
+          application_form.application_volunteering_experiences,
+        )
+        expect(choice.application_volunteering_experiences).not_to eq(
+          choice.volunteering_experiences,
+        )
+      end
+    end
+  end
+
+  describe '#application_work_history_breaks' do
+    context 'when application_choice has volunteering experiences' do
+      it 'returns the application choice volunteering experiences' do
+        application_form = create(:application_form)
+        create(:application_work_history_break, breakable: application_form)
+        choice = create(:application_choice, application_form:)
+        create(:application_work_history_break, breakable: choice)
+
+        expect(choice.application_work_history_breaks).to eq(choice.work_history_breaks)
+        expect(choice.application_work_history_breaks).not_to eq(
+          application_form.application_work_history_breaks,
+        )
+      end
+    end
+
+    context 'when application_choice has no volunteering experiences' do
+      it 'returns the application form volunteering experiences' do
+        application_form = create(:application_form)
+        create(:application_work_history_break, breakable: application_form)
+        choice = create(:application_choice, application_form:)
+
+        expect(choice.application_work_history_breaks).to eq(
+          application_form.application_work_history_breaks,
+        )
+        expect(choice.application_work_history_breaks).not_to eq(
+          choice.work_history_breaks,
+        )
       end
     end
   end

--- a/spec/services/work_history_with_breaks_spec.rb
+++ b/spec/services/work_history_with_breaks_spec.rb
@@ -64,6 +64,32 @@ RSpec.describe WorkHistoryWithBreaks do
           expect(timeline[2]).to eq(volunteering_experience1)
           expect(timeline[3]).to eq(job1)
         end
+
+        # rubocop:disable RSpec/NestedGroups
+        context 'with application_choice' do
+          it 'renders both paid and unpaid experieence in descending order by start date' do
+            application_form = create(:application_form)
+            choice = create(:application_choice, application_form:)
+            volunteering_experience1 = create(:application_volunteering_experience, experienceable: choice, start_date: february2019)
+            volunteering_experience2 = create(:application_volunteering_experience, experienceable: choice, start_date: february2020)
+            job1 = create(:application_work_experience, start_date: february2015, end_date: nil, experienceable: choice)
+            job2 = create(:application_work_experience, start_date: september2019, end_date: nil, experienceable: choice)
+            break1 = create(:application_work_history_break, start_date: september2019, end_date: november2019, breakable: choice)
+            break2 = create(:application_work_history_break, start_date: november2019, end_date: january2020, breakable: choice)
+
+            work_history_with_breaks = described_class.new(choice, include_unpaid_experience: true)
+            timeline = work_history_with_breaks.timeline
+
+            expect(timeline.count).to eq(6)
+            expect(timeline[0]).to eq(volunteering_experience2)
+            expect(timeline[1]).to eq(break2)
+            expect(timeline[2]).to eq(break1)
+            expect(timeline[3]).to eq(job2)
+            expect(timeline[4]).to eq(volunteering_experience1)
+            expect(timeline[5]).to eq(job1)
+          end
+        end
+        # rubocop:enable RSpec/NestedGroups
       end
     end
 


### PR DESCRIPTION
## Context

In the future, every application choice will have an application_experience or application_work_history_break. Through the exprienceable or breakable polymorphic columns.

This will allow the user to edit work experienceas or work history breaks for new application choices.

To enable this feature we must get the work expeirences and histories through the application_choice on the provider interface and vendor api.

We would look if the application_choice has the data we need and if not we go to the application_form.

Eventually when we migrate the data making every application_choice have work experiences or work history breaks, this logic will not be needed.

The application_form will continue to have work experiences and work_history_breaks. We will just duplicate the data

## Changes proposed in this pull request

ApplicationChoice model
Work history components

## Guidance to review

View someone's work history on review from the point of view of support/provider and vendor API. 


https://github.com/user-attachments/assets/06879595-7295-4219-94ac-1b519a74cac4



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
