### PR TITLE
Dup work experiences and histories on choice

### DIFF
--- a/app/models/application_experience.rb
+++ b/app/models/application_experience.rb
@@ -2,12 +2,6 @@ class ApplicationExperience < ApplicationRecord
   self.ignored_columns += %w[application_form_id]
   belongs_to :experienceable, polymorphic: true, touch: true
 
-  after_commit do
-    if application_form
-      experienceable.touch_choices
-    end
-  end
-
   validates :role, :organisation, :start_date, presence: true
 
   audited associated_with: :experienceable

--- a/app/models/application_work_history_break.rb
+++ b/app/models/application_work_history_break.rb
@@ -5,12 +5,6 @@ class ApplicationWorkHistoryBreak < ApplicationRecord
 
   audited associated_with: :breakable
 
-  after_commit do
-    if application_form
-      breakable.touch_choices
-    end
-  end
-
   def application_form
     breakable if breakable_type == 'ApplicationForm'
   end

--- a/app/services/candidate_interface/submit_application_choice.rb
+++ b/app/services/candidate_interface/submit_application_choice.rb
@@ -17,6 +17,9 @@ module CandidateInterface
         application_form.update!(submitted_at:) unless application_form.submitted_applications?
         application_choice.update!(sent_to_provider_at:)
         application_choice.update!(reject_by_default_at: inactive_date, reject_by_default_days: inactive_days)
+        application_choice.work_experiences = application_form.application_work_experiences.map(&:dup)
+        application_choice.volunteering_experiences = application_form.application_volunteering_experiences.map(&:dup)
+        application_choice.work_history_breaks = application_form.application_work_history_breaks.map(&:dup)
         ApplicationStateChange.new(application_choice).send_to_provider!
 
         SendNewApplicationEmailToProvider.new(application_choice:).call

--- a/spec/models/last_updated_at_spec.rb
+++ b/spec/models/last_updated_at_spec.rb
@@ -46,54 +46,6 @@ RSpec.describe '#update' do
     end
   end
 
-  it 'updates the application_choices when a application_work_history_break is added' do
-    application_form = create(:completed_application_form, application_choices_count: 1)
-
-    expect { create(:application_work_history_break, breakable: application_form) }
-      .to(change { application_form.application_choices.first.updated_at })
-  end
-
-  it 'updates the application_choices when a application_work_history_break is updated' do
-    application_form = create(:completed_application_form, application_choices_count: 1)
-    model = create(:application_work_history_break, breakable: application_form)
-
-    expect { model.update(updated_at: Time.zone.now) }
-      .to(change { application_form.application_choices.first.updated_at })
-  end
-
-  it 'updates the application_choices when a application_work_history_break is deleted' do
-    application_form = create(:completed_application_form, application_choices_count: 1)
-    model = create(:application_work_history_break, breakable: application_form)
-
-    expect { model.destroy! }
-      .to(change { application_form.application_choices.first.updated_at })
-  end
-
-  %i[application_volunteering_experience application_work_experience].each do |form_attribute|
-    it "updates the application_choices when #{form_attribute} is added" do
-      application_form = create(:completed_application_form, application_choices_count: 1)
-
-      expect { create(form_attribute, experienceable: application_form) }
-        .to(change { application_form.application_choices.first.updated_at })
-    end
-
-    it "updates the application_choices when #{form_attribute} is updated" do
-      application_form = create(:completed_application_form, application_choices_count: 1)
-      model = create(form_attribute, experienceable: application_form)
-
-      expect { model.update(updated_at: Time.zone.now) }
-        .to(change { application_form.application_choices.first.updated_at })
-    end
-
-    it "updates the application_choices when #{form_attribute} is deleted" do
-      application_form = create(:completed_application_form, application_choices_count: 1)
-      model = create(form_attribute, experienceable: application_form)
-
-      expect { model.destroy! }
-        .to(change { application_form.application_choices.first.updated_at })
-    end
-  end
-
   it 'does not update application_choices when unrelated models that touch the form are updated' do
     application_form = create(:completed_application_form, application_choices_count: 1)
     feedback = create(:application_feedback, application_form:)

--- a/spec/services/candidate_interface/submit_application_choice_spec.rb
+++ b/spec/services/candidate_interface/submit_application_choice_spec.rb
@@ -74,6 +74,60 @@ RSpec.describe CandidateInterface::SubmitApplicationChoice do
           submit_application
         }.to have_enqueued_mail(ProviderMailer, :application_submitted)
       end
+
+      it 'duplicates the work experiences on the application_choice' do
+        work_experience = create(
+          :application_work_experience,
+          experienceable: application_form,
+        )
+
+        expect {
+          submit_application
+        }.to change(application_choice.work_experiences, :count).by(1)
+
+        expect(application_choice.work_experiences.pluck(:details)).to eq(
+          [work_experience.details],
+        )
+        expect(application_choice.work_experiences.ids).not_to eq(
+          application_form.application_work_experiences.ids,
+        )
+      end
+
+      it 'duplicates the volunteering experiences on the application_choice' do
+        volunteering_experience = create(
+          :application_volunteering_experience,
+          experienceable: application_form,
+        )
+
+        expect {
+          submit_application
+        }.to change(application_choice.volunteering_experiences, :count).by(1)
+
+        expect(application_choice.volunteering_experiences.pluck(:details)).to eq(
+          [volunteering_experience.details],
+        )
+        expect(application_choice.volunteering_experiences.ids).not_to eq(
+          application_form.application_volunteering_experiences.ids,
+        )
+      end
+
+      it 'duplicates the work history breaks on the application_choice' do
+        work_history_break = create(
+          :application_work_history_break,
+          breakable: application_form,
+        )
+
+        expect {
+          submit_application
+        }.to change(application_choice.work_history_breaks, :count).by(1)
+
+        expect(application_choice.work_history_breaks.pluck(:reason)).to eq(
+          [work_history_break.reason],
+        )
+        expect(application_choice.work_history_breaks.ids).not_to eq(
+          application_form.application_work_history_breaks.ids,
+        )
+      end
     end
   end
 end

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe 'Vendor receives the application', time: CycleTimetableHelper.mid
         work_experience: {
           jobs: [
             {
-              id: @application.application_work_experiences.first.id,
+              id: @application.application_choices.first.application_work_experiences.first.id,
               start_date: '2014-05-01',
               end_date: '2019-01-01',
               role: 'Chief Terraforming Officer',
@@ -249,7 +249,7 @@ RSpec.describe 'Vendor receives the application', time: CycleTimetableHelper.mid
           ],
           volunteering: [
             {
-              id: @application.application_volunteering_experiences.first.id,
+              id: @application.application_choices.first.application_volunteering_experiences.first.id,
               start_date: '2014-05-01',
               end_date: '2019-01-01',
               role: 'Tour guide',


### PR DESCRIPTION
## Context

To allow the user to edit the work experiences or histories we will duplicate  the experiences and histories on the application choice from the application form.

This will allow the user to edit the experiences or histories on the application_form and the edits will be applied to future application choices.

The current application_choices will have the old info

## Changes proposed in this pull request

dup data in `SubmitApplicationChoice` service

## Guidance to review

Submit an application choice and check if the work experiences and histories have been saved on the application choice. Locally or on Review

``` ruby
ApplicationChoice.last.work_experiences
ApplicationChoice.last.volunteering_experiences
ApplicationChoice.last.work_history_breaks
```

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
