### PR TITLE
Backfill work experiences and histories on application choices

### DIFF
--- a/app/services/data_migrations/backfill_application_choices_with_work_experiences.rb
+++ b/app/services/data_migrations/backfill_application_choices_with_work_experiences.rb
@@ -1,0 +1,34 @@
+module DataMigrations
+  class BackfillApplicationChoicesWithWorkExperiences
+    TIMESTAMP = 20240822105049
+    MANUAL_RUN = true
+
+    def change
+      time_now = Time.zone.now
+
+      choices_without_work_histories.each_slice(5000).with_index do |ids, index|
+        next_batch_time = time_now + index.minutes
+        MigrateApplicationChoicesWorker.perform_at(next_batch_time, ids)
+      end
+    end
+
+    def choices_without_work_histories
+      sql = <<-SQL
+       SELECT "application_choices".id FROM "application_choices" LEFT OUTER JOIN "application_experiences" "work_experiences" ON
+       "work_experiences"."experienceable_type" = 'ApplicationChoice' AND "work_experiences"."experienceable_id" = "application_choices"."id" AND
+       "work_experiences"."type" = 'ApplicationWorkExperience' WHERE "application_choices"."status" != 'unsubmitted' AND "work_experiences"."id" IS NULL
+       union
+       SELECT "application_choices".id FROM "application_choices" LEFT OUTER JOIN "application_experiences" "volunteering_experiences" ON
+       "volunteering_experiences"."experienceable_type" = 'ApplicationChoice' AND "volunteering_experiences"."experienceable_id" = "application_choices"."id" AND
+       "volunteering_experiences"."type" = 'ApplicationVolunteeringExperience' WHERE "application_choices"."status" != 'unsubmitted' AND
+       "volunteering_experiences"."id" IS NULL
+       union
+       SELECT "application_choices".id FROM "application_choices" LEFT OUTER JOIN "application_work_history_breaks" "work_history_breaks" ON
+       "work_history_breaks"."breakable_type" = 'ApplicationChoice' AND "work_history_breaks"."breakable_id" = "application_choices"."id" WHERE
+       "application_choices"."status" != 'unsubmitted' AND "work_history_breaks"."id" IS NULL
+      SQL
+
+      ApplicationChoice.find_by_sql(sql).map(&:id)
+    end
+  end
+end

--- a/app/services/data_migrations/backfill_application_choices_with_work_experiences.rb
+++ b/app/services/data_migrations/backfill_application_choices_with_work_experiences.rb
@@ -28,7 +28,7 @@ module DataMigrations
        "application_choices"."status" != 'unsubmitted' AND "work_history_breaks"."id" IS NULL
       SQL
 
-      ApplicationChoice.find_by_sql(sql).map(&:id)
+      ApplicationChoice.find_by_sql(sql).pluck(:id)
     end
   end
 end

--- a/app/workers/migrate_application_choices_worker.rb
+++ b/app/workers/migrate_application_choices_worker.rb
@@ -7,18 +7,20 @@ class MigrateApplicationChoicesWorker
     errors = []
 
     ApplicationChoice.where(id: choice_ids).find_each(batch_size: 100) do |choice|
-      application_form = choice.application_form
+      ActiveRecord::Base.transaction do
+        application_form = choice.application_form
 
-      if choice.work_experiences.blank? && application_form.application_work_experiences.any?
-        choice.work_experiences = application_form.application_work_experiences.map(&:dup)
-      end
+        if choice.work_experiences.blank? && application_form.application_work_experiences.any?
+          choice.work_experiences = application_form.application_work_experiences.map(&:dup)
+        end
 
-      if choice.volunteering_experiences.blank? && application_form.application_volunteering_experiences.any?
-        choice.volunteering_experiences = application_form.application_volunteering_experiences.map(&:dup)
-      end
+        if choice.volunteering_experiences.blank? && application_form.application_volunteering_experiences.any?
+          choice.volunteering_experiences = application_form.application_volunteering_experiences.map(&:dup)
+        end
 
-      if choice.work_history_breaks.blank? && application_form.application_work_history_breaks.any?
-        choice.work_history_breaks = application_form.application_work_history_breaks.map(&:dup)
+        if choice.work_history_breaks.blank? && application_form.application_work_history_breaks.any?
+          choice.work_history_breaks = application_form.application_work_history_breaks.map(&:dup)
+        end
       end
     rescue ActiveRecord::RecordInvalid => e
       errors << "Error choice id #{choice.id}: #{e.message}"

--- a/app/workers/migrate_application_choices_worker.rb
+++ b/app/workers/migrate_application_choices_worker.rb
@@ -6,7 +6,7 @@ class MigrateApplicationChoicesWorker
   def perform(choice_ids)
     errors = []
 
-    ApplicationChoice.find(choice_ids).each do |choice|
+    ApplicationChoice.where(id: choice_ids).find_each(batch_size: 100) do |choice|
       application_form = choice.application_form
 
       if choice.work_experiences.blank? && application_form.application_work_experiences.any?

--- a/app/workers/migrate_application_choices_worker.rb
+++ b/app/workers/migrate_application_choices_worker.rb
@@ -1,0 +1,37 @@
+class MigrateApplicationChoicesWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :low_priority
+
+  def perform(choice_ids)
+    errors = []
+
+    ApplicationChoice.find(choice_ids).each do |choice|
+      application_form = choice.application_form
+
+      if choice.work_experiences.blank? && application_form.application_work_experiences.any?
+        choice.work_experiences = application_form.application_work_experiences.map(&:dup)
+      end
+
+      if choice.volunteering_experiences.blank? && application_form.application_volunteering_experiences.any?
+        choice.volunteering_experiences = application_form.application_volunteering_experiences.map(&:dup)
+      end
+
+      if choice.work_history_breaks.blank? && application_form.application_work_history_breaks.any?
+        choice.work_history_breaks = application_form.application_work_history_breaks.map(&:dup)
+      end
+    rescue ActiveRecord::RecordInvalid => e
+      errors << "Error choice id #{choice.id}: #{e.message}"
+    end
+
+    if errors
+      errors.each do |error|
+        Rails.logger.info error
+      end
+
+      Rails.logger.info "#{errors.count} errors"
+    end
+
+    Rails.logger.info 'No errors' if errors.blank?
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::BackfillApplicationChoicesWithWorkExperiences',
   'DataMigrations::MarkUnsubmittedApplicationsWithoutEnglishProficiencyAsElfIncomplete',
   'DataMigrations::BackfillEnglishProficiencyRecordsForCarriedOverApplications',
   'DataMigrations::BackfillWeek42PerformanceReportData',

--- a/spec/services/data_migrations/backfill_application_choices_with_work_experiences_spec.rb
+++ b/spec/services/data_migrations/backfill_application_choices_with_work_experiences_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillApplicationChoicesWithWorkExperiences do
+  describe '#change' do
+    it 'enques jobs to MigrateApplicationChoicesWorker' do
+      application_form = create(:application_form)
+      create(:application_choice, :awaiting_provider_decision, application_form:)
+
+      expect { described_class.new.change }.to change(
+        MigrateApplicationChoicesWorker.jobs, :size
+      ).by(1)
+    end
+  end
+
+  describe '#choices_without_work_histories' do
+    it 'returns all the application choices that need to be backfilled' do
+      application_form = create(:application_form)
+      choice1 = create(:application_choice, :awaiting_provider_decision, application_form:)
+      choice2 = create(:application_choice, :awaiting_provider_decision, application_form:)
+      create(
+        :application_work_experience,
+        experienceable: choice2,
+      )
+      create(
+        :application_work_history_break,
+        breakable: choice2,
+      )
+      choice3 = create(:application_choice, :awaiting_provider_decision, application_form:)
+      create(
+        :application_work_experience,
+        experienceable: choice3,
+      )
+      create(
+        :application_volunteering_experience,
+        experienceable: choice3,
+      )
+      choice4 = create(:application_choice, :awaiting_provider_decision, application_form:)
+      create(
+        :application_work_experience,
+        experienceable: choice4,
+      )
+      create(
+        :application_volunteering_experience,
+        experienceable: choice4,
+      )
+      create(
+        :application_work_history_break,
+        breakable: choice4,
+      )
+
+      expect(described_class.new.choices_without_work_histories).to include(
+        choice1.id, choice2.id, choice3.id
+      )
+      expect(described_class.new.choices_without_work_histories).not_to include(
+        choice4.id,
+      )
+    end
+  end
+end

--- a/spec/workers/migrate_application_choices_worker_spec.rb
+++ b/spec/workers/migrate_application_choices_worker_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe MigrateApplicationChoicesWorker do
     end
 
     context 'with errors' do
-      it 'dups the working experiences and histories from application_form to choice' do
+      it 'rescues ActiveRecord::RecordInvalid exceptions and logs the errors' do
         application_form = create(
           :completed_application_form,
           volunteering_experiences_count: 1,

--- a/spec/workers/migrate_application_choices_worker_spec.rb
+++ b/spec/workers/migrate_application_choices_worker_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe MigrateApplicationChoicesWorker do
+  describe '#perform' do
+    it 'dups the working experiences and histories from application_form to choice' do
+      application_form = create(
+        :completed_application_form,
+        volunteering_experiences_count: 1,
+        full_work_history: true,
+      )
+      application_form_2 = create(
+        :completed_application_form,
+        volunteering_experiences_count: 1,
+        full_work_history: true,
+      )
+      choice = create(:application_choice, application_form:)
+      choice_with_data_migrated = create(
+        :application_choice,
+        application_form: application_form_2,
+      )
+      create(
+        :application_work_experience,
+        experienceable: choice_with_data_migrated,
+      )
+      create(
+        :application_volunteering_experience,
+        experienceable: choice_with_data_migrated,
+      )
+      create(
+        :application_work_history_break,
+        breakable: choice_with_data_migrated,
+      )
+      choice_ids = [choice.id, choice_with_data_migrated.id]
+      allow(Rails.logger).to receive(:info)
+
+      expect {
+        described_class.new.perform(choice_ids)
+      }.to change(choice.work_experiences, :count).by(2)
+        .and change(choice.volunteering_experiences, :count).by(1)
+        .and change(choice.work_history_breaks, :count).by(1)
+        .and not_change(choice_with_data_migrated.work_experiences, :count)
+        .and not_change(choice_with_data_migrated.volunteering_experiences, :count)
+        .and not_change(choice_with_data_migrated.work_history_breaks, :count)
+      expect(Rails.logger).to have_received(:info).with('No errors')
+    end
+
+    context 'with errors' do
+      it 'dups the working experiences and histories from application_form to choice' do
+        application_form = create(
+          :completed_application_form,
+          volunteering_experiences_count: 1,
+          full_work_history: true,
+        )
+        choice = create(:application_choice, application_form:)
+        choice_ids = [choice.id]
+
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(ApplicationChoice).to receive(:work_experiences=)
+          .and_raise(ActiveRecord::RecordInvalid)
+        # rubocop:enable RSpec/AnyInstance
+        allow(Rails.logger).to receive(:info)
+
+        described_class.new.perform(choice_ids)
+        expect(Rails.logger).to have_received(:info).with("Error choice id #{choice.id}: Record invalid")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

We need to backfill all application_choices without working experiences or work history breaks.

This is part of allowing the user to edit work experiences for future application_choices.

There are about 592k application choices that need updating. This data migration gets all the application choices without work_experiences, volunteering_experiences or work_history_breaks and spins up sidekiq workers each with 5k choices to update.

I couldn't use the `BatchDelivery` class as the object from the SQL query is not the correct `ActiveRecord::Relation` object.

The jobs will use the `low_priority` queue. The migration will enqueue a job every 1 minutes spreading them over 2 hours. This doesn't really mean that all the jobs will finish within 2 hours. 

Depending on how the infrastructure is handling these requests to DB, we could increase the sidekiq workers. There will be a lot of writes to DB.

Each application_choice will have to initialize an active record object because we need to dup work_experiences and an application choice, a choice can have 3 writes to the DB 🙃 

## Changes proposed in this pull request

Data migration and sidekiq job to do the migration

## Guidance to review

- Do the queries look right?
- Should we spread the jobs over a longer period? Personally, I think we will hit a bottleneck where some jobs will be enqueued, waiting for others to finish so not sure about spreading them over a longer period
- Can we make this more efficient?

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
