### PR TITLE
Fix for primary navigation highlighting

### DIFF
--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -2,14 +2,6 @@ module CandidateInterface
   class CandidateInterfaceController < ApplicationController
     include BackLinks
 
-    APPLICATION_CHOICE_CONTROLLER_PATHS = [
-      'continuous_applications_choices', # controller for Your applications
-      'continuous_applications/course_choices', # the course choice wizard
-      'continuous_applications/application_choices', # deleting an application choice
-      'decisions', # withdrawing from a course offer
-      'candidate_interface/apply_from_find',
-    ].freeze
-
     before_action :protect_with_basic_auth
     before_action :authenticate_candidate!
     before_action :set_user_context
@@ -35,17 +27,8 @@ module CandidateInterface
       end
     end
 
-    # Should the current request be considered as made under the Your
-    # applications tab
     def choices_controller?
-      return false if current_application.v23?
-
-      @choices_controller ||= begin
-        choices_controllers = Regexp.compile(APPLICATION_CHOICE_CONTROLLER_PATHS.join('|'))
-
-        controller_path.match?(choices_controllers) ||
-          (controller_path.match('candidate_interface/guidance') && request.referer&.match?('choices'))
-      end
+      ChoicesControllerMatcher.choices_controller?(current_application: current_application, controller_path: controller_path, request: request)
     end
 
     def back_link_text

--- a/app/services/candidate_interface/choices_controller_matcher.rb
+++ b/app/services/candidate_interface/choices_controller_matcher.rb
@@ -2,10 +2,10 @@
 
 class CandidateInterface::ChoicesControllerMatcher
   APPLICATION_CHOICE_CONTROLLER_PATHS = [
-    'continuous_applications_choices', # controller for Your applications
-    'continuous_applications/course_choices', # the course choice wizard
-    'continuous_applications/application_choices', # deleting an application choice
-    'decisions', # withdrawing from a course offer
+    'candidate_interface/continuous_applications_choices', # controller for Your applications
+    'candidate_interface/course_choices', # the course choice wizard
+    'candidate_interface/application_choices', # deleting an application choice
+    'candidate_interface/decisions', # withdrawing from a course offer
     'candidate_interface/apply_from_find',
   ].freeze
 

--- a/app/services/candidate_interface/choices_controller_matcher.rb
+++ b/app/services/candidate_interface/choices_controller_matcher.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CandidateInterface::ChoicesControllerMatcher
+  APPLICATION_CHOICE_CONTROLLER_PATHS = [
+    'continuous_applications_choices', # controller for Your applications
+    'continuous_applications/course_choices', # the course choice wizard
+    'continuous_applications/application_choices', # deleting an application choice
+    'decisions', # withdrawing from a course offer
+    'candidate_interface/apply_from_find',
+  ].freeze
+
+  def self.choices_controller?(current_application:, controller_path:, request:)
+    return false if current_application.v23?
+
+    choices_controllers = Regexp.compile(APPLICATION_CHOICE_CONTROLLER_PATHS.join('|'))
+
+    controller_path.match?(choices_controllers) ||
+      (controller_path.match?('candidate_interface/guidance') && request.referer&.match?('choices'))
+  end
+end

--- a/spec/services/candidate_interface/choices_controller_matcher_spec.rb
+++ b/spec/services/candidate_interface/choices_controller_matcher_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe CandidateInterface::ChoicesControllerMatcher, type: :model do
     it { is_expected.to be_falsey }
 
     [
-      'continuous_applications_choices', # controller for Your applications
-      'continuous_applications/course_choices', # the course choice wizard
-      'continuous_applications/application_choices', # deleting an application choice
-      'decisions', # withdrawing from a course offer
+      'candidate_interface/continuous_applications_choices', # controller for Your applications
+      'candidate_interface/course_choices', # the course choice wizard
+      'candidate_interface/application_choices', # deleting an application choice
+      'candidate_interface/decisions', # withdrawing from a course offer
       'candidate_interface/apply_from_find',
 
-      'continuous_applications/course_choices/do_you_know_which_course',
+      'candidate_interface/course_choices/do_you_know_which_course',
     ].each do |controller_path_under_test|
       context "when controller path is '#{controller_path_under_test}'" do
         let(:controller_path) { controller_path_under_test }

--- a/spec/services/candidate_interface/choices_controller_matcher_spec.rb
+++ b/spec/services/candidate_interface/choices_controller_matcher_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::ChoicesControllerMatcher, type: :model do
+  describe '.choices_controller?' do
+    subject {
+      described_class.choices_controller?(
+        current_application:,
+        controller_path:,
+        request:,
+      )
+    }
+
+    let(:current_application) { instance_double(ApplicationForm, v23?: false) }
+    let(:controller_path) { '' }
+    let(:request) { instance_double(ActionDispatch::Request, referer: nil) }
+
+    it { is_expected.to be_falsey }
+
+    [
+      'continuous_applications_choices', # controller for Your applications
+      'continuous_applications/course_choices', # the course choice wizard
+      'continuous_applications/application_choices', # deleting an application choice
+      'decisions', # withdrawing from a course offer
+      'candidate_interface/apply_from_find',
+
+      'continuous_applications/course_choices/do_you_know_which_course',
+    ].each do |controller_path_under_test|
+      context "when controller path is '#{controller_path_under_test}'" do
+        let(:controller_path) { controller_path_under_test }
+
+        it { is_expected.to be_truthy }
+      end
+
+      context "when controller path is '#{controller_path_under_test}' and the application is v23" do
+        let(:controller_path) { controller_path_under_test }
+        let(:current_application) { instance_double(ApplicationForm, v23?: true) }
+
+        it { is_expected.to be_falsey }
+      end
+    end
+
+    context "when controller path is 'candidate_interface/guidance'" do
+      let(:controller_path) { 'candidate_interface/guidance' }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when controller path is 'candidate_interface/guidance' and referer does not matches 'choices'" do
+      let(:controller_path) { 'candidate_interface/guidance' }
+      let(:request) { instance_double(ActionDispatch::Request, referer: 'anything') }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when controller path is 'candidate_interface/guidance' and referer matches 'choices'" do
+      let(:controller_path) { 'candidate_interface/guidance' }
+      let(:request) { instance_double(ActionDispatch::Request, referer: 'choices') }
+
+      it { is_expected.to be_truthy }
+    end
+  end
+end

--- a/spec/system/candidate_interface/navigation_tabs_spec.rb
+++ b/spec/system/candidate_interface/navigation_tabs_spec.rb
@@ -9,8 +9,9 @@ RSpec.describe 'Primary Navigation' do
     then_i_see_your_application_as_active
   end
 
-  scenario 'highlights the primary navigation correct item for continuous applications', :js do
+  scenario 'highlights the primary navigation correct item for continuous applications' do
     given_i_am_signed_in
+    and_i_have_submitted_applications
     when_i_visit_the_application_dashboard
     then_i_see_your_details_as_active
 
@@ -18,6 +19,12 @@ RSpec.describe 'Primary Navigation' do
     then_i_see_your_details_as_active
 
     when_i_click_on_your_applications
+    then_i_see_your_applications_as_active
+
+    when_i_click_on_an_application
+    then_i_see_your_applications_as_active
+
+    when_i_click_on_change_course
     then_i_see_your_applications_as_active
 
     when_i_visit_guidance_page_without_referer
@@ -42,6 +49,19 @@ RSpec.describe 'Primary Navigation' do
     )
   end
 
+  def and_i_have_submitted_applications
+    application_form = create(
+      :application_form,
+      :unsubmitted,
+      candidate: current_candidate,
+    )
+    @application_choice = create(
+      :application_choice,
+      :unsubmitted,
+      application_form:,
+    )
+  end
+
   def when_i_visit_the_application_dashboard
     visit(candidate_interface_continuous_applications_details_path)
   end
@@ -52,6 +72,14 @@ RSpec.describe 'Primary Navigation' do
 
   def when_i_click_on_your_applications
     click_link_or_button 'Your applications'
+  end
+
+  def when_i_click_on_an_application
+    click_link_or_button @application_choice.current_course.provider.name
+  end
+
+  def when_i_click_on_change_course
+    click_link_or_button 'Change'
   end
 
   def then_i_see_your_details_as_active


### PR DESCRIPTION
## Context

When refactoring the controllers in #9632 we introduced a bug where the Navigation Items where not being set as active on the correct pages

## Changes proposed in this pull request

- Extracted logic for making Navigation Items active or not
- Bolstered tests
- Updated the controller paths which activate/deactivate Navigation Items

## Guidance to review

- Using the review app check that the active state is applied to the correct tabs across multiple pages

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
