### PR TITLE
Fix provider audit logs

### DIFF
--- a/app/views/provider_interface/activity_log/index.html.erb
+++ b/app/views/provider_interface/activity_log/index.html.erb
@@ -1,3 +1,4 @@
+<% ignored_audits = %w[ApplicationWorkHistoryBreak ApplicationExperience] %>
 <% content_for :browser_title, 'Activity log' %>
 
 <div class="govuk-grid-row">
@@ -7,6 +8,7 @@
     <div class="govuk-!-margin-top-0">
       <% previous_date = '' %>
       <% @events.each do |event| %>
+        <% next if ignored_audits.include?(event.try(:auditable_type)) %>
         <% current_date = event.created_at.to_fs(:govuk_date) %>
         <% if current_date != previous_date %>
           </div>

--- a/spec/factories/audit.rb
+++ b/spec/factories/audit.rb
@@ -1,4 +1,48 @@
 FactoryBot.define do
+  factory :application_experience_audit, class: 'Audited::Audit' do
+    action { 'create' }
+    user { create(:support_user) }
+    version { 1 }
+    request_uuid { SecureRandom.uuid }
+    created_at { Time.zone.now }
+
+    transient do
+      application_experience { build_stubbed(:application_experience) }
+      application_choice { build_stubbed(:application_choice, :awaiting_provider_decision) }
+      changes { {} }
+    end
+
+    after(:build) do |audit, evaluator|
+      audit.auditable_type = 'ApplicationExperience'
+      audit.auditable_id = evaluator.application_experience.id
+      audit.associated = evaluator.application_choice
+      audit.user_type = evaluator.user.class.to_s
+      audit.audited_changes = evaluator.changes
+    end
+  end
+
+  factory :application_work_history_break_audit, class: 'Audited::Audit' do
+    action { 'create' }
+    user { create(:support_user) }
+    version { 1 }
+    request_uuid { SecureRandom.uuid }
+    created_at { Time.zone.now }
+
+    transient do
+      application_work_history_break { build_stubbed(:application_work_history_break) }
+      application_choice { build_stubbed(:application_choice, :awaiting_provider_decision) }
+      changes { {} }
+    end
+
+    after(:build) do |audit, evaluator|
+      audit.auditable_type = 'ApplicationWorkHistoryBreak'
+      audit.auditable_id = evaluator.application_work_history_break.id
+      audit.associated = evaluator.application_choice
+      audit.user_type = evaluator.user.class.to_s
+      audit.audited_changes = evaluator.changes
+    end
+  end
+
   factory :withdrawn_at_candidates_request_audit, class: 'Audited::Audit' do
     action { 'update' }
     user { create(:provider_user) }

--- a/spec/system/provider_interface/see_activity_log_spec.rb
+++ b/spec/system/provider_interface/see_activity_log_spec.rb
@@ -42,6 +42,18 @@ RSpec.describe 'See activity log' do
 
     @choice2 = create(:application_choice, :rejected, course_option: course_option2)
     create(:application_choice_audit, :with_rejection, application_choice: @choice2)
+    work_experience = create(:application_work_experience, experienceable: @choice2)
+    work_history_break = create(:application_work_history_break, breakable: @choice2)
+    create(
+      :application_experience_audit,
+      application_experience: work_experience,
+      application_choice: @choice2,
+    )
+    create(
+      :application_work_history_break_audit,
+      application_work_history_break: work_history_break,
+      application_choice: @choice2,
+    )
 
     @choice3 = create(:application_choice, :offered, course_option: course_option3)
     create(:application_choice_audit, :with_offer, application_choice: @choice3)


### PR DESCRIPTION
## Context

With the new structure of the application experiences and
application work history breaks.
There are more types of audits being logged. This
broke the `provider/activity` view where the provider
sees what the user has done before submitting the application.

This commit will skip these logs for the moment.

This is a live issue so we're tying to buy some time until we make a
decision if we need to display this information or not.

Sentry error trying to fix
https://dfe-teacher-services.sentry.io/issues/5747124555/?alert_rule_id=4434951&alert_type=issue&environment=production&notification_uuid=85445c09-fb11-4745-9c2b-c615962b569d&project=1765973&referrer=slack


![work](https://github.com/user-attachments/assets/f366cb34-01c9-4140-ae0b-e99b81b5a9b5)


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

The issue is here https://github.com/DFE-Digital/apply-for-teacher-training/blob/75862d2b81f21672ec75b8b8f09f02c3b29552ea/app/components/provider_interface/activity_log_event_component.rb#L68-L77

We will get an answer if we need to show this data or not next week. I'll create a ticket and attach it to this PR


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
