### PR TITLE
Exclude work experiences from provider audits

### DIFF
--- a/app/queries/get_activity_log_events.rb
+++ b/app/queries/get_activity_log_events.rb
@@ -46,6 +46,8 @@ class GetActivityLogEvents
           associated_type = 'ApplicationChoice'
           AND associated_id = ac.id
           AND NOT auditable_type = 'OfferCondition'
+          AND NOT auditable_type = 'ApplicationExperience'
+          AND NOT auditable_type = 'ApplicationWorkHistoryBreak'
         ) OR (
           auditable_type = 'ApplicationForm'
           AND auditable_id = ac.application_form_id

--- a/app/views/provider_interface/activity_log/index.html.erb
+++ b/app/views/provider_interface/activity_log/index.html.erb
@@ -1,4 +1,3 @@
-<% ignored_audits = %w[ApplicationWorkHistoryBreak ApplicationExperience] %>
 <% content_for :browser_title, 'Activity log' %>
 
 <div class="govuk-grid-row">
@@ -8,7 +7,6 @@
     <div class="govuk-!-margin-top-0">
       <% previous_date = '' %>
       <% @events.each do |event| %>
-        <% next if ignored_audits.include?(event.try(:auditable_type)) %>
         <% current_date = event.created_at.to_fs(:govuk_date) %>
         <% if current_date != previous_date %>
           </div>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,29 +3,6 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "16284076c64f5cf82c4de57b76a655983bef3201432a3206f302d6cb49fb2466",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/queries/get_unsubmitted_applications_ready_to_nudge.rb",
-      "line": 35,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "ApplicationForm.where(\"first_nationality IN (#{[[\"AL\", \"Albanian\"], [\"AF\", \"Afghan\"], [\"DZ\", \"Algerian\"], [\"US\", \"American\"], [\"AD\", \"Andorran\"], [\"AO\", \"Angolan\"], [\"AI\", \"Anguillan\"], [\"AR\", \"Argentine\"], [\"AM\", \"Armenian\"], [\"AU\", \"Australian\"], [\"AT\", \"Austrian\"], [\"AZ\", \"Azerbaijani\"], [\"BS\", \"Bahamian\"], [\"BH\", \"Bahraini\"], [\"BD\", \"Bangladeshi\"], [\"BB\", \"Barbadian\"], [\"BY\", \"Belarusian\"], [\"BE\", \"Belgian\"], [\"BZ\", \"Belizean\"], [\"BJ\", \"Beninese\"], [\"BM\", \"Bermudian\"], [\"BT\", \"Bhutanese\"], [\"BO\", \"Bolivian\"], [\"BW\", \"Botswanan\"], [\"BR\", \"Brazilian\"], [\"GB\", \"British\"], [\"VG\", \"British Virgin Islander\"], [\"BN\", \"Bruneian\"], [\"BG\", \"Bulgarian\"], [\"BF\", \"Burkinan\"], [\"MM\", \"Burmese\"], [\"BI\", \"Burundian\"], [\"KH\", \"Cambodian\"], [\"CM\", \"Cameroonian\"], [\"CA\", \"Canadian\"], [\"CV\", \"Cape Verdean\"], [\"KY\", \"Cayman Islander\"], [\"CF\", \"Central African\"], [\"TD\", \"Chadian\"], [\"CL\", \"Chilean\"], [\"CN\", \"Chinese\"], [\"AG\", \"Citizen of Antigua and Barbuda\"], [\"BA\", \"Citizen of Bosnia and Herzegovina\"], [\"GW\", \"Citizen of Guinea-Bissau\"], [\"KI\", \"Citizen of Kiribati\"], [\"SC\", \"Citizen of Seychelles\"], [\"DO\", \"Citizen of the Dominican Republic\"], [\"VU\", \"Citizen of Vanuatu\"], [\"CO\", \"Colombian\"], [\"KM\", \"Comoran\"], [\"CG\", \"Congolese (Congo)\"], [\"CD\", \"Congolese (DRC)\"], [\"CK\", \"Cook Islander\"], [\"CR\", \"Costa Rican\"], [\"HR\", \"Croatian\"], [\"CU\", \"Cuban\"], [\"CY\", \"Cypriot\"], [\"GB\", \"Cymraes\"], [\"GB\", \"Cymro\"], [\"CZ\", \"Czech\"], [\"DK\", \"Danish\"], [\"DJ\", \"Djiboutian\"], [\"DM\", \"Dominican\"], [\"NL\", \"Dutch\"], [\"TL\", \"East Timorese\"], [\"EC\", \"Ecuadorean\"], [\"EG\", \"Egyptian\"], [\"AE\", \"Emirati\"], [\"GB\", \"English\"], [\"GQ\", \"Equatorial Guinean\"], [\"ER\", \"Eritrean\"], [\"EE\", \"Estonian\"], [\"ET\", \"Ethiopian\"], [\"FO\", \"Faroese\"], [\"FJ\", \"Fijian\"], [\"PH\", \"Filipino\"], [\"FI\", \"Finnish\"], [\"FR\", \"French\"], [\"GA\", \"Gabonese\"], [\"GM\", \"Gambian\"], [\"GE\", \"Georgian\"], [\"DE\", \"German\"], [\"GH\", \"Ghanaian\"], [\"GI\", \"Gibraltarian\"], [\"GR\", \"Greek\"], [\"GL\", \"Greenlandic\"], [\"GD\", \"Grenadian\"], [\"GU\", \"Guamanian\"], [\"GT\", \"Guatemalan\"], [\"GN\", \"Guinean\"], [\"GY\", \"Guyanese\"], [\"HT\", \"Haitian\"], [\"HN\", \"Honduran\"], [\"HK\", \"Hong Konger\"], [\"HU\", \"Hungarian\"], [\"IS\", \"Icelandic\"], [\"IN\", \"Indian\"], [\"ID\", \"Indonesian\"], [\"IR\", \"Iranian\"], [\"IQ\", \"Iraqi\"], [\"IE\", \"Irish\"], [\"IL\", \"Israeli\"], [\"IT\", \"Italian\"], [\"CI\", \"Ivorian\"], [\"JM\", \"Jamaican\"], [\"JP\", \"Japanese\"], [\"JO\", \"Jordanian\"], [\"KZ\", \"Kazakh\"], [\"KE\", \"Kenyan\"], [\"KN\", \"Kittitian\"], [\"XK\", \"Kosovan\"], [\"KW\", \"Kuwaiti\"], [\"KG\", \"Kyrgyz\"], [\"LA\", \"Lao\"], [\"LV\", \"Latvian\"], [\"LB\", \"Lebanese\"], [\"LR\", \"Liberian\"], [\"LY\", \"Libyan\"], [\"LI\", \"Liechtenstein citizen\"], [\"LT\", \"Lithuanian\"], [\"LU\", \"Luxembourger\"], [\"MO\", \"Macanese\"], [\"MK\", \"Macedonian\"], [\"MG\", \"Malagasy\"], [\"MW\", \"Malawian\"], [\"MY\", \"Malaysian\"], [\"MV\", \"Maldivian\"], [\"ML\", \"Malian\"], [\"MT\", \"Maltese\"], [\"MH\", \"Marshallese\"], [\"MQ\", \"Martiniquais\"], [\"MR\", \"Mauritanian\"], [\"MU\", \"Mauritian\"], [\"MX\", \"Mexican\"], [\"FM\", \"Micronesian\"], [\"MD\", \"Moldovan\"], [\"MC\", \"Monegasque\"], [\"MN\", \"Mongolian\"], [\"ME\", \"Montenegrin\"], [\"MS\", \"Montserratian\"], [\"MA\", \"Moroccan\"], [\"LS\", \"Mosotho\"], [\"MZ\", \"Mozambican\"], [\"NA\", \"Namibian\"], [\"NR\", \"Nauruan\"], [\"NP\", \"Nepalese\"], [\"NZ\", \"New Zealander\"], [\"NI\", \"Nicaraguan\"], [\"NG\", \"Nigerian\"], [\"NE\", \"Nigerien\"], [\"NU\", \"Niuean\"], [\"KP\", \"North Korean\"], [\"GB\", \"Northern Irish\"], [\"NO\", \"Norwegian\"], [\"OM\", \"Omani\"], [\"PK\", \"Pakistani\"], [\"PW\", \"Palauan\"], [\"PS\", \"Palestinian\"], [\"PA\", \"Panamanian\"], [\"PG\", \"Papua New Guinean\"], [\"PY\", \"Paraguayan\"], [\"PE\", \"Peruvian\"], [\"PN\", \"Pitcairn Islander\"], [\"PL\", \"Polish\"], [\"PT\", \"Portuguese\"], [\"GB\", \"Prydeinig\"], [\"PR\", \"Puerto Rican\"], [\"QA\", \"Qatari\"], [\"RO\", \"Romanian\"], [\"RU\", \"Russian\"], [\"RW\", \"Rwandan\"], [\"SV\", \"Salvadorean\"], [\"SM\", \"Sammarinese\"], [\"WS\", \"Samoan\"], [\"ST\", \"Sao Tomean\"], [\"SA\", \"Saudi Arabian\"], [\"GB\", \"Scottish\"], [\"SN\", \"Senegalese\"], [\"RS\", \"Serbian\"], [\"SL\", \"Sierra Leonean\"], [\"SG\", \"Singaporean\"], [\"SK\", \"Slovak\"], [\"SI\", \"Slovenian\"], [\"SB\", \"Solomon Islander\"], [\"SO\", \"Somali\"], [\"ZA\", \"South African\"], [\"KR\", \"South Korean\"], [\"SS\", \"South Sudanese\"], [\"ES\", \"Spanish\"], [\"LK\", \"Sri Lankan\"], [\"SH\", \"St Helenian\"], [\"LC\", \"St Lucian\"], [\"SD\", \"Sudanese\"], [\"SR\", \"Surinamese\"], [\"SZ\", \"Swazi\"], [\"SE\", \"Swedish\"], [\"CH\", \"Swiss\"], [\"SY\", \"Syrian\"], [\"TW\", \"Taiwanese\"], [\"TJ\", \"Tajik\"], [\"TZ\", \"Tanzanian\"], [\"TH\", \"Thai\"], [\"TG\", \"Togolese\"], [\"TO\", \"Tongan\"], [\"TT\", \"Trinidadian\"], [\"SH\", \"Tristanian\"], [\"TN\", \"Tunisian\"], [\"TR\", \"Turkish\"], [\"TM\", \"Turkmen\"], [\"TC\", \"Turks and Caicos Islander\"], [\"TV\", \"Tuvaluan\"], [\"UG\", \"Ugandan\"], [\"UA\", \"Ukrainian\"], [\"UY\", \"Uruguayan\"], [\"UZ\", \"Uzbek\"], [\"VA\", \"Vatican citizen\"], [\"VE\", \"Venezuelan\"], [\"VN\", \"Vietnamese\"], [\"VC\", \"Vincentian\"], [\"WF\", \"Wallisian\"], [\"GB\", \"Welsh\"], [\"YE\", \"Yemeni\"], [\"ZM\", \"Zambian\"], [\"ZW\", \"Zimbabwean\"]].select do\n code.in?(ApplicationForm::BRITISH_OR_IRISH_NATIONALITIES)\n end.map(&:second).map do\n ActiveRecord::Base.connection.quote(name)\n end.join(\",\")})\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "GetUnsubmittedApplicationsReadyToNudge",
-        "method": "call"
-      },
-      "user_input": "[[\"AL\", \"Albanian\"], [\"AF\", \"Afghan\"], [\"DZ\", \"Algerian\"], [\"US\", \"American\"], [\"AD\", \"Andorran\"], [\"AO\", \"Angolan\"], [\"AI\", \"Anguillan\"], [\"AR\", \"Argentine\"], [\"AM\", \"Armenian\"], [\"AU\", \"Australian\"], [\"AT\", \"Austrian\"], [\"AZ\", \"Azerbaijani\"], [\"BS\", \"Bahamian\"], [\"BH\", \"Bahraini\"], [\"BD\", \"Bangladeshi\"], [\"BB\", \"Barbadian\"], [\"BY\", \"Belarusian\"], [\"BE\", \"Belgian\"], [\"BZ\", \"Belizean\"], [\"BJ\", \"Beninese\"], [\"BM\", \"Bermudian\"], [\"BT\", \"Bhutanese\"], [\"BO\", \"Bolivian\"], [\"BW\", \"Botswanan\"], [\"BR\", \"Brazilian\"], [\"GB\", \"British\"], [\"VG\", \"British Virgin Islander\"], [\"BN\", \"Bruneian\"], [\"BG\", \"Bulgarian\"], [\"BF\", \"Burkinan\"], [\"MM\", \"Burmese\"], [\"BI\", \"Burundian\"], [\"KH\", \"Cambodian\"], [\"CM\", \"Cameroonian\"], [\"CA\", \"Canadian\"], [\"CV\", \"Cape Verdean\"], [\"KY\", \"Cayman Islander\"], [\"CF\", \"Central African\"], [\"TD\", \"Chadian\"], [\"CL\", \"Chilean\"], [\"CN\", \"Chinese\"], [\"AG\", \"Citizen of Antigua and Barbuda\"], [\"BA\", \"Citizen of Bosnia and Herzegovina\"], [\"GW\", \"Citizen of Guinea-Bissau\"], [\"KI\", \"Citizen of Kiribati\"], [\"SC\", \"Citizen of Seychelles\"], [\"DO\", \"Citizen of the Dominican Republic\"], [\"VU\", \"Citizen of Vanuatu\"], [\"CO\", \"Colombian\"], [\"KM\", \"Comoran\"], [\"CG\", \"Congolese (Congo)\"], [\"CD\", \"Congolese (DRC)\"], [\"CK\", \"Cook Islander\"], [\"CR\", \"Costa Rican\"], [\"HR\", \"Croatian\"], [\"CU\", \"Cuban\"], [\"CY\", \"Cypriot\"], [\"GB\", \"Cymraes\"], [\"GB\", \"Cymro\"], [\"CZ\", \"Czech\"], [\"DK\", \"Danish\"], [\"DJ\", \"Djiboutian\"], [\"DM\", \"Dominican\"], [\"NL\", \"Dutch\"], [\"TL\", \"East Timorese\"], [\"EC\", \"Ecuadorean\"], [\"EG\", \"Egyptian\"], [\"AE\", \"Emirati\"], [\"GB\", \"English\"], [\"GQ\", \"Equatorial Guinean\"], [\"ER\", \"Eritrean\"], [\"EE\", \"Estonian\"], [\"ET\", \"Ethiopian\"], [\"FO\", \"Faroese\"], [\"FJ\", \"Fijian\"], [\"PH\", \"Filipino\"], [\"FI\", \"Finnish\"], [\"FR\", \"French\"], [\"GA\", \"Gabonese\"], [\"GM\", \"Gambian\"], [\"GE\", \"Georgian\"], [\"DE\", \"German\"], [\"GH\", \"Ghanaian\"], [\"GI\", \"Gibraltarian\"], [\"GR\", \"Greek\"], [\"GL\", \"Greenlandic\"], [\"GD\", \"Grenadian\"], [\"GU\", \"Guamanian\"], [\"GT\", \"Guatemalan\"], [\"GN\", \"Guinean\"], [\"GY\", \"Guyanese\"], [\"HT\", \"Haitian\"], [\"HN\", \"Honduran\"], [\"HK\", \"Hong Konger\"], [\"HU\", \"Hungarian\"], [\"IS\", \"Icelandic\"], [\"IN\", \"Indian\"], [\"ID\", \"Indonesian\"], [\"IR\", \"Iranian\"], [\"IQ\", \"Iraqi\"], [\"IE\", \"Irish\"], [\"IL\", \"Israeli\"], [\"IT\", \"Italian\"], [\"CI\", \"Ivorian\"], [\"JM\", \"Jamaican\"], [\"JP\", \"Japanese\"], [\"JO\", \"Jordanian\"], [\"KZ\", \"Kazakh\"], [\"KE\", \"Kenyan\"], [\"KN\", \"Kittitian\"], [\"XK\", \"Kosovan\"], [\"KW\", \"Kuwaiti\"], [\"KG\", \"Kyrgyz\"], [\"LA\", \"Lao\"], [\"LV\", \"Latvian\"], [\"LB\", \"Lebanese\"], [\"LR\", \"Liberian\"], [\"LY\", \"Libyan\"], [\"LI\", \"Liechtenstein citizen\"], [\"LT\", \"Lithuanian\"], [\"LU\", \"Luxembourger\"], [\"MO\", \"Macanese\"], [\"MK\", \"Macedonian\"], [\"MG\", \"Malagasy\"], [\"MW\", \"Malawian\"], [\"MY\", \"Malaysian\"], [\"MV\", \"Maldivian\"], [\"ML\", \"Malian\"], [\"MT\", \"Maltese\"], [\"MH\", \"Marshallese\"], [\"MQ\", \"Martiniquais\"], [\"MR\", \"Mauritanian\"], [\"MU\", \"Mauritian\"], [\"MX\", \"Mexican\"], [\"FM\", \"Micronesian\"], [\"MD\", \"Moldovan\"], [\"MC\", \"Monegasque\"], [\"MN\", \"Mongolian\"], [\"ME\", \"Montenegrin\"], [\"MS\", \"Montserratian\"], [\"MA\", \"Moroccan\"], [\"LS\", \"Mosotho\"], [\"MZ\", \"Mozambican\"], [\"NA\", \"Namibian\"], [\"NR\", \"Nauruan\"], [\"NP\", \"Nepalese\"], [\"NZ\", \"New Zealander\"], [\"NI\", \"Nicaraguan\"], [\"NG\", \"Nigerian\"], [\"NE\", \"Nigerien\"], [\"NU\", \"Niuean\"], [\"KP\", \"North Korean\"], [\"GB\", \"Northern Irish\"], [\"NO\", \"Norwegian\"], [\"OM\", \"Omani\"], [\"PK\", \"Pakistani\"], [\"PW\", \"Palauan\"], [\"PS\", \"Palestinian\"], [\"PA\", \"Panamanian\"], [\"PG\", \"Papua New Guinean\"], [\"PY\", \"Paraguayan\"], [\"PE\", \"Peruvian\"], [\"PN\", \"Pitcairn Islander\"], [\"PL\", \"Polish\"], [\"PT\", \"Portuguese\"], [\"GB\", \"Prydeinig\"], [\"PR\", \"Puerto Rican\"], [\"QA\", \"Qatari\"], [\"RO\", \"Romanian\"], [\"RU\", \"Russian\"], [\"RW\", \"Rwandan\"], [\"SV\", \"Salvadorean\"], [\"SM\", \"Sammarinese\"], [\"WS\", \"Samoan\"], [\"ST\", \"Sao Tomean\"], [\"SA\", \"Saudi Arabian\"], [\"GB\", \"Scottish\"], [\"SN\", \"Senegalese\"], [\"RS\", \"Serbian\"], [\"SL\", \"Sierra Leonean\"], [\"SG\", \"Singaporean\"], [\"SK\", \"Slovak\"], [\"SI\", \"Slovenian\"], [\"SB\", \"Solomon Islander\"], [\"SO\", \"Somali\"], [\"ZA\", \"South African\"], [\"KR\", \"South Korean\"], [\"SS\", \"South Sudanese\"], [\"ES\", \"Spanish\"], [\"LK\", \"Sri Lankan\"], [\"SH\", \"St Helenian\"], [\"LC\", \"St Lucian\"], [\"SD\", \"Sudanese\"], [\"SR\", \"Surinamese\"], [\"SZ\", \"Swazi\"], [\"SE\", \"Swedish\"], [\"CH\", \"Swiss\"], [\"SY\", \"Syrian\"], [\"TW\", \"Taiwanese\"], [\"TJ\", \"Tajik\"], [\"TZ\", \"Tanzanian\"], [\"TH\", \"Thai\"], [\"TG\", \"Togolese\"], [\"TO\", \"Tongan\"], [\"TT\", \"Trinidadian\"], [\"SH\", \"Tristanian\"], [\"TN\", \"Tunisian\"], [\"TR\", \"Turkish\"], [\"TM\", \"Turkmen\"], [\"TC\", \"Turks and Caicos Islander\"], [\"TV\", \"Tuvaluan\"], [\"UG\", \"Ugandan\"], [\"UA\", \"Ukrainian\"], [\"UY\", \"Uruguayan\"], [\"UZ\", \"Uzbek\"], [\"VA\", \"Vatican citizen\"], [\"VE\", \"Venezuelan\"], [\"VN\", \"Vietnamese\"], [\"VC\", \"Vincentian\"], [\"WF\", \"Wallisian\"], [\"GB\", \"Welsh\"], [\"YE\", \"Yemeni\"], [\"ZM\", \"Zambian\"], [\"ZW\", \"Zimbabwean\"]].select do\n code.in?(ApplicationForm::BRITISH_OR_IRISH_NATIONALITIES)\n end.map(&:second).map do\n ActiveRecord::Base.connection.quote(name)\n end.join(\",\")",
-      "confidence": "Medium",
-      "cwe_id": [
-        89
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
       "fingerprint": "28d64e5d66c0dce5bb41ca5b85a1751bdd7190b07aa55b1af003c090e7f8863a",
       "check_name": "SQL",
       "message": "Possible SQL injection",
@@ -210,29 +187,6 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "a3e634e3494dc86d9c5c4206853d46de675a023a2dd0bc52edbbe6b56b0cc8c3",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/queries/get_activity_log_events.rb",
-      "line": 68,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "Audited::Audit.select(\"audits.id audit_id, audits.*, ac.id application_choice_id\").includes(:user => ([:provider_user, :support_user]), :auditable => ([:application_form, :course_option, :course, :site, :provider, :accredited_provider, :current_course_option])).joins(\"INNER JOIN (#{application_choices.to_sql}) ac\\n  ON (\\n    auditable_type = 'ApplicationChoice'\\n    AND auditable_id = ac.id\\n    AND action = 'update'\\n    AND ( #{application_choice_audits_filter_sql} )\\n  ) OR (\\n    associated_type = 'ApplicationChoice'\\n    AND associated_id = ac.id\\n    AND NOT auditable_type = 'OfferCondition'\\n  ) OR (\\n    auditable_type = 'ApplicationForm'\\n    AND auditable_id = ac.application_form_id\\n    AND action = 'update'\\n    AND ( #{application_form_audits_filter_sql} )\\n    AND EXISTS (\\n      SELECT 1\\n      WHERE ARRAY[#{DATABASE_CHANGE_KEYS}] @> (\\n        SELECT ARRAY(SELECT jsonb_object_keys(a.audited_changes)\\n        FROM audits a\\n        WHERE a.id = audits.id\\n        )\\n      )\\n    )\\n  )\\n\".squish)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "GetActivityLogEvents",
-        "method": "s(:self).call"
-      },
-      "user_input": "application_choice_audits_filter_sql",
-      "confidence": "Weak",
-      "cwe_id": [
-        89
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
       "fingerprint": "a5a84261000bc24d5d1ff692d262b771f7f2bce9cedd058f1db85cb2b94f0870",
       "check_name": "SQL",
       "message": "Possible SQL injection",
@@ -325,6 +279,29 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
+      "fingerprint": "c70b946ccbfabd084091ad425893a7647560431761faa0f86bf80e95ffa007e1",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/queries/get_activity_log_events.rb",
+      "line": 70,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "Audited::Audit.select(\"audits.id audit_id, audits.*, ac.id application_choice_id\").includes(:user => ([:provider_user, :support_user]), :auditable => ([:application_form, :course_option, :course, :site, :provider, :accredited_provider, :current_course_option])).joins(\"INNER JOIN (#{application_choices.to_sql}) ac\\n  ON (\\n    auditable_type = 'ApplicationChoice'\\n    AND auditable_id = ac.id\\n    AND action = 'update'\\n    AND ( #{application_choice_audits_filter_sql} )\\n  ) OR (\\n    associated_type = 'ApplicationChoice'\\n    AND associated_id = ac.id\\n    AND NOT auditable_type = 'OfferCondition'\\n    AND NOT auditable_type = 'ApplicationExperience'\\n    AND NOT auditable_type = 'ApplicationWorkHistoryBreak'\\n  ) OR (\\n    auditable_type = 'ApplicationForm'\\n    AND auditable_id = ac.application_form_id\\n    AND action = 'update'\\n    AND ( #{application_form_audits_filter_sql} )\\n    AND EXISTS (\\n      SELECT 1\\n      WHERE ARRAY[#{DATABASE_CHANGE_KEYS}] @> (\\n        SELECT ARRAY(SELECT jsonb_object_keys(a.audited_changes)\\n        FROM audits a\\n        WHERE a.id = audits.id\\n        )\\n      )\\n    )\\n  )\\n\".squish)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "GetActivityLogEvents",
+        "method": "s(:self).call"
+      },
+      "user_input": "application_choice_audits_filter_sql",
+      "confidence": "Weak",
+      "cwe_id": [
+        89
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
       "fingerprint": "c72cb22d421486df577321b15e768add7cdaec0bc32aeb44db6d5e996a5f7705",
       "check_name": "SQL",
       "message": "Possible SQL injection",
@@ -369,6 +346,6 @@
       "note": ""
     }
   ],
-  "updated": "2024-03-15 09:07:25 +0000",
+  "updated": "2024-08-27 15:35:00 +0100",
   "brakeman_version": "6.1.2"
 }

--- a/spec/queries/get_activity_log_events_spec.rb
+++ b/spec/queries/get_activity_log_events_spec.rb
@@ -240,6 +240,29 @@ RSpec.describe GetActivityLogEvents, :with_audited do
 
       expect(result).not_to include(excluded)
     end
+
+    it 'excludes audits for ApplicationExperience and ApplicationWorkHistoryBreak' do
+      choice = create_application_choice_for_course course_provider_a
+      work_experience = create(:application_work_experience, experienceable: choice)
+      work_history_break = create(:application_work_history_break, breakable: choice)
+      create(
+        :application_experience_audit,
+        application_experience: work_experience,
+        application_choice: choice,
+      )
+      create(
+        :application_work_history_break_audit,
+        application_work_history_break: work_history_break,
+        application_choice: choice,
+      )
+
+      work_experience_audit = work_experience.audits.last
+      work_break_audit = work_history_break.audits.last
+
+      result = service_call
+
+      expect(result).not_to include(work_experience_audit, work_break_audit)
+    end
   end
 
   context 'sorts events in reverse chronological order' do


### PR DESCRIPTION
## Context

With c5c12877533088397b8197de742204bde6028a2a we save application_experiences and application_work_history_breaks for the application_choice. Part of allowing the user to edit work experiences and histories.

This creates audits that the `/provider/activity` view tries to show. These audits don't need to be shown to the provider. The work histories and breaks cannot be edited on the application_choice, they can be edited on the application_form.

So the provider doesn't need to see any audits related to work histories and breaks on the application_choice.

This commit removes these audits from the sql query for this provider view

## Changes proposed in this pull request

Changed `app/queries/get_activity_log_events.rb`

Reverts the temporary fix applied https://github.com/DFE-Digital/apply-for-teacher-training/pull/9749 No longer needed

## Guidance to review

Submit a new application choice on review and go to `provider/activity` as a provider
You should see this page without issue and without work histories or breaks.

![Screenshot from 2024-08-27 16-00-19](https://github.com/user-attachments/assets/4768940d-bbf3-43d2-a202-51c3d7a6ef9b)


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
