### PR TITLE
Implement interruption pages for ENIC

### DIFF
--- a/app/components/candidate_interface/application_review_and_submit_component.rb
+++ b/app/components/candidate_interface/application_review_and_submit_component.rb
@@ -22,6 +22,8 @@ module CandidateInterface
     def review_path
       if short_personal_statement?
         candidate_interface_course_choices_course_review_interruption_path(application_choice.id)
+      elsif application_choice.application_form.qualifications_enic_reasons_waiting_or_maybe? || application_choice.application_form.any_qualification_enic_reason_not_needed?
+        candidate_interface_course_choices_course_review_enic_interruption_path(application_choice.id)
       else
         candidate_interface_course_choices_course_review_and_submit_path(application_choice.id)
       end

--- a/app/controllers/candidate_interface/course_choices/review_enic_interruption_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/review_enic_interruption_controller.rb
@@ -1,0 +1,24 @@
+module CandidateInterface
+  module CourseChoices
+    class ReviewEnicInterruptionController < CandidateInterface::CourseChoices::BaseController
+      before_action :redirect_to_your_applications_if_submitted
+      before_action :viewed_enic_interruption_page, only: :show
+
+      def show
+        set_enic_reviewed_cookie
+      end
+
+    private
+
+      def viewed_enic_interruption_page
+        if cookies[:viewed_enic_interruption_page] == 'true'
+          redirect_to candidate_interface_course_choices_course_review_and_submit_path(@application_choice.id)
+        end
+      end
+
+      def set_enic_reviewed_cookie
+        cookies[:viewed_enic_interruption_page] = { value: 'true' }
+      end
+    end
+  end
+end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -206,6 +206,25 @@ class ApplicationForm < ApplicationRecord
     application_choices.touch_all
   end
 
+  def any_qualification_enic_reason_not_needed?
+    return false if application_qualifications.empty?
+    return false if application_qualifications.all? { |qualification| qualification.enic_reason.nil? }
+
+    non_uk_qualifications = application_qualifications.reject do |qualification|
+      qualification.institution_country.nil? || qualification.institution_country == 'GB' || qualification.enic_reason.nil?
+    end
+
+    non_uk_qualifications.all?(&:enic_reason_not_needed?)
+  end
+
+  def qualifications_enic_reasons_waiting_or_maybe?
+    return false if application_qualifications.empty?
+
+    application_qualifications.count do |qualification|
+      qualification.enic_reason_waiting? || qualification.enic_reason_maybe?
+    end >= 1
+  end
+
   def missing_enic_reference_for_non_uk_qualifications?
     @missing_enic_reference_for_non_uk_qualifications ||= application_qualifications
                                                             .where.not(institution_country: 'GB')

--- a/app/views/candidate_interface/course_choices/review_enic_interruption/_not_needed.html.erb
+++ b/app/views/candidate_interface/course_choices/review_enic_interruption/_not_needed.html.erb
@@ -1,0 +1,16 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <div class="app-grid-column--grey">
+      <h1 class="govuk-heading-l"><%= t('review_enic_interruption.title') %></h1>
+
+      <p class="govuk-body"><%= t('review_enic_interruption.not_needed.more_likely_html') %></p>
+      <p class="govuk-body"><%= t('review_enic_interruption.not_needed.if_you_apply_enic_html', link: govuk_link_to(t('review_enic_interruption.not_needed.apply_for_enic_link'), t('service_name.enic.statement_of_comparability_url'), new_tab: true)) %></p>
+      <p class="govuk-body"><%= t('review_enic_interruption.not_needed.dont_provide_enic') %></p>
+    </div>
+
+    <div class="govuk-button-group app-course-choice__confirm-submission">
+      <%= govuk_button_to(t('review_enic_interruption.not_needed.continue_button_text'), candidate_interface_course_choices_course_review_and_submit_path(@application_choice.id), method: :get) %>
+      <%= govuk_link_to(t('review_enic_interruption.not_needed.save_application_button_text'), candidate_interface_course_choices_course_review_path(@application_choice.id)) %>
+    </div>
+  </div>
+</div>

--- a/app/views/candidate_interface/course_choices/review_enic_interruption/_waiting_maybe.html.erb
+++ b/app/views/candidate_interface/course_choices/review_enic_interruption/_waiting_maybe.html.erb
@@ -1,0 +1,17 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <div class="app-grid-column--grey">
+      <h1 class="govuk-heading-l"><%= t('review_enic_interruption.title') %></h1>
+
+      <p class="govuk-body"><%= t('review_enic_interruption.waiting_maybe.planned_link_html', link: govuk_link_to(t('review_enic_interruption.waiting_maybe.enic_link_text'), t('service_name.enic.statement_of_comparability_url'), new_tab: true)) %></p>
+      <p class="govuk-body"><%= t('review_enic_interruption.waiting_maybe.if_you_have_enic') %></p>
+      <p class="govuk-body"><%= t('review_enic_interruption.waiting_maybe.save_as_draft_html', link: govuk_link_to(t('review_enic_interruption.waiting_maybe.save_this_as_draft'), candidate_interface_course_choices_course_review_path(@application_choice.id))) %></p>
+      <p class="govuk-body"><%= t('review_enic_interruption.waiting_maybe.without_enic') %></p>
+    </div>
+
+    <div class="govuk-button-group app-course-choice__confirm-submission">
+      <%= govuk_button_to(t('review_enic_interruption.waiting_maybe.enter_enic'), candidate_interface_continuous_applications_details_path, method: :get) %>
+      <%= govuk_link_to(t('review_enic_interruption.waiting_maybe.without_entering_enic'), candidate_interface_course_choices_course_review_and_submit_path(@application_choice.id)) %>
+    </div>
+  </div>
+</div>

--- a/app/views/candidate_interface/course_choices/review_enic_interruption/show.html.erb
+++ b/app/views/candidate_interface/course_choices/review_enic_interruption/show.html.erb
@@ -1,0 +1,10 @@
+<% content_for :title, t('page_titles.application_review_and_submit', provider_name: @application_choice.provider.name) %>
+<% content_for(:before_content, govuk_back_link_to(candidate_interface_continuous_applications_choices_path)) %>
+
+<% if current_application.qualifications_enic_reasons_waiting_or_maybe? %>
+  <%= render 'waiting_maybe' %>
+<% end %>
+
+<% if current_application.any_qualification_enic_reason_not_needed? %>
+  <%= render 'not_needed' %>
+<% end %>

--- a/app/views/candidate_interface/course_choices/review_interruption/show.html.erb
+++ b/app/views/candidate_interface/course_choices/review_interruption/show.html.erb
@@ -4,21 +4,26 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
     <div class="app-grid-column--grey">
-      <h1 class="govuk-heading-l">Give your application the best chance of success</h1>
-      <p class="govuk-body">Your personal statement is <%= "#{@word_count} #{'word'.pluralize(@word_count)}" %>.</p>
-      <p class="govuk-body">90% of successful candidates write about <%= ApplicationForm::RECOMMENDED_PERSONAL_STATEMENT_WORD_COUNT %> words or more for their personal statement.</p>
-      <p class="govuk-body">Increase your chances of getting an offer by adding more information to your personal statement.</p>
+      <h1 class="govuk-heading-l"><%= t('review_interruption.title') %></h1>
+      <p class="govuk-body"><%= t('review_interruption.statement_count', word_count: "#{@word_count} #{'word'.pluralize(@word_count)}") %></p>
+      <p class="govuk-body"><%= t('review_interruption.success_percentage', word_count: ApplicationForm::RECOMMENDED_PERSONAL_STATEMENT_WORD_COUNT) %></p>
+      <p class="govuk-body"><%= t('review_interruption.increase_chances') %></p>
     </div>
 
     <div class="govuk-button-group app-course-choice__confirm-submission">
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-          Would you like to edit your personal statement before submitting your application?
+          <%= t('review_interruption.edit_statement') %>
         </legend>
       </fieldset>
 
-      <%= govuk_button_to('Edit your personal statement', candidate_interface_edit_becoming_a_teacher_path, method: :get) %>
-      <%= govuk_link_to('Continue without editing', candidate_interface_course_choices_course_review_and_submit_path(@application_choice.id)) %>
+      <%= govuk_button_to(t('review_interruption.edit_statement_button_text'), candidate_interface_edit_becoming_a_teacher_path, method: :get) %>
+
+      <% if current_application.qualifications_enic_reasons_waiting_or_maybe? || current_application.any_qualification_enic_reason_not_needed? %>
+        <%= govuk_link_to(t('review_interruption.continue_without_editing'), candidate_interface_course_choices_course_review_enic_interruption_path(@application_choice.id)) %>
+      <% else %>
+        <%= govuk_link_to(t('review_interruption.continue_without_editing'), candidate_interface_course_choices_course_review_and_submit_path(@application_choice.id)) %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/config/locales/candidate_interface/interruption.yml
+++ b/config/locales/candidate_interface/interruption.yml
@@ -1,0 +1,27 @@
+en:
+  review_interruption:
+    title: Give your application the best chance of success
+    statement_count: Your personal statement is %{word_count}.
+    success_percentage: 90% of successful candidates write about %{word_count} words or more for their personal statement.
+    increase_chances: Increase your chances of getting an offer by adding more information to your personal statement.
+    edit_statement: Would you like to edit your personal statement before submitting your application?
+    edit_statement_button_text: Edit your personal statement
+    continue_without_editing: Continue without editing
+  review_enic_interruption:
+    title: You have not included a UK ENIC reference number
+    waiting_maybe:
+      enic_link_text: apply for a statement of comparability from UK ENIC
+      planned_link_html: You have said you had, or planned to %{link} but you have not added the reference number to this application.
+      if_you_have_enic: If you have a UK ENIC reference number, you should add it to your qualifications details.
+      save_this_as_draft: save this application as a draft
+      save_as_draft_html: If you are still waiting then you can %{link} and come back to add your UK ENIC reference number later.
+      without_enic: You can also submit your application without the UK ENIC reference number and contact the training provider when it arrives.
+      enter_enic: Enter a UK ENIC number
+      without_entering_enic: Continue without adding a UK ENIC number
+    not_needed:
+      more_likely_html: Including a UK ENIC reference number in your application makes youn around <b> 30% more likely to receive an offer.</b>
+      apply_for_enic_link: apply for a UK ENIC statement of comparability
+      if_you_apply_enic_html: If you %{link} and include the reference number in your application it makes it easier for training providers to understand your qualifications.
+      dont_provide_enic: If you don’t include a UK ENIC statement of comparability and the provider asks for one, it could cause delays.
+      continue_button_text: Continue without a UK ENIC number
+      save_application_button_text: Save this application as a draft

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -361,6 +361,7 @@ namespace :candidate_interface, path: '/candidate' do
 
       get '/:application_choice_id/review' => 'course_choices/review#show', as: :course_choices_course_review
       get '/:application_choice_id/review-interruption' => 'course_choices/review_interruption#show', as: :course_choices_course_review_interruption
+      get '/:application_choice_id/review-enic-interruption' => 'course_choices/review_enic_interruption#show', as: :course_choices_course_review_enic_interruption
       get '/:application_choice_id/review-and-submit' => 'course_choices/review_and_submit#show', as: :course_choices_course_review_and_submit
       get '/blocked-submissions' => 'course_choices/blocked_submissions#show', as: :course_choices_blocked_submissions
 

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -333,6 +333,41 @@ RSpec.describe ApplicationForm do
     end
   end
 
+  describe '#qualifications_enic_reasons_waiting_or_maybe?' do
+    it 'returns true if 1 or more qualifications have an enic_reason of waiting or maybe' do
+      application_form = create(:application_form)
+      create(:degree_qualification, enic_reference: '12345', institution_country: 'GB', enic_reason: 'waiting', application_form: application_form)
+
+      expect(application_form.qualifications_enic_reasons_waiting_or_maybe?).to be(true)
+    end
+
+    it 'returns false if no qualifications have an enic_reason of waiting or maybe' do
+      application_form = create(:application_form)
+      create(:degree_qualification, enic_reference: '12345', institution_country: 'GB', enic_reason: 'not_needed', application_form: application_form)
+
+      expect(application_form.qualifications_enic_reasons_waiting_or_maybe?).to be(false)
+    end
+  end
+
+  describe '#any_qualification_enic_reason_not_needed?' do
+    it 'returns true if ALL qualifications have an enic_reason of not_needed' do
+      application_form = create(:application_form)
+      create(:degree_qualification, enic_reference: '12345', institution_country: 'GB', enic_reason: 'not_needed', application_form: application_form)
+      create(:degree_qualification, enic_reference: '12346', institution_country: 'GB', enic_reason: 'not_needed', application_form: application_form)
+      create(:degree_qualification, enic_reference: '12347', institution_country: 'GB', enic_reason: 'not_needed', application_form: application_form)
+
+      expect(application_form.any_qualification_enic_reason_not_needed?).to be(true)
+    end
+
+    it 'returns false if any qualification has an enic_reason that is not_needed' do
+      application_form = create(:application_form)
+      create(:degree_qualification, enic_reference: '12345', institution_country: 'GB', enic_reason: 'not_needed', application_form: application_form)
+      create(:degree_qualification, enic_reference: '12348', institution_country: 'GB', enic_reason: 'obtained', application_form: application_form)
+
+      expect(application_form.qualifications_enic_reasons_waiting_or_maybe?).to be(false)
+    end
+  end
+
   describe '#missing_enic_reference_for_non_uk_qualifications?' do
     it 'returns false if there are no application_qualifications which are non_uk and have no enic_reference' do
       application_form = create(:application_form)

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_with_interruption_pages_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_with_interruption_pages_spec.rb
@@ -1,0 +1,144 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidate submits the application with interruption pages' do
+  include CandidateHelper
+  include SignInHelper
+
+  scenario 'Candidate submits an application with all applications having an enic_reason of not_needed and personal statement less than 500 words', :js, time: mid_cycle do
+    given_i_am_signed_in
+
+    when_i_have_completed_my_application_and_have_added_primary_as_a_course_choice_with_not_needed_qualification
+    and_i_continue_with_my_application
+
+    when_i_save_as_draft
+    and_i_am_redirected_to_the_application_dashboard
+    and_my_application_is_still_unsubmitted
+    and_i_continue_with_my_application
+
+    when_i_click_to_review_my_application
+    then_i_see_a_interruption_page_for_personal_statement
+    when_i_continue_without_editing
+    then_i_see_a_interruption_page_for_not_needed_enic
+    then_the_viewed_enic_interruption_page_cookie_to_be_set
+  end
+
+  scenario 'Candidate submits an application with an application having an enic_reason of maybe and personal statement less than 500 words', :js, time: mid_cycle do
+    given_i_am_signed_in
+
+    when_i_have_completed_my_application_and_have_added_primary_as_a_course_choice_with_waiting_or_maybe_qualification
+    and_i_continue_with_my_application
+
+    when_i_save_as_draft
+    and_i_am_redirected_to_the_application_dashboard
+    and_my_application_is_still_unsubmitted
+    and_i_continue_with_my_application
+
+    when_i_click_to_review_my_application
+    then_i_see_a_interruption_page_for_personal_statement
+    when_i_continue_without_editing
+    then_i_see_a_interruption_page_for_waiting_or_maybe_enic
+    then_the_viewed_enic_interruption_page_cookie_to_be_set
+  end
+
+  scenario 'Candidate submits an application with an application having an enic_reason of maybe and personal statement of 500 words', :js, time: mid_cycle do
+    given_i_am_signed_in
+
+    when_i_have_completed_my_application_and_have_added_primary_as_a_course_choice_with_waiting_or_maybe_qualification_and_personal_statement_500_words
+    and_i_continue_with_my_application
+
+    when_i_save_as_draft
+    and_i_am_redirected_to_the_application_dashboard
+    and_my_application_is_still_unsubmitted
+    and_i_continue_with_my_application
+
+    when_i_click_to_review_my_application
+    then_i_see_a_interruption_page_for_waiting_or_maybe_enic
+    then_the_viewed_enic_interruption_page_cookie_to_be_set
+  end
+
+  def when_i_have_completed_my_application_and_have_added_primary_as_a_course_choice_with_not_needed_qualification
+    given_i_have_a_primary_course_choice(application_form_completed: true, personal_statement_words: 4)
+    add_not_needed_qualification
+  end
+
+  def when_i_have_completed_my_application_and_have_added_primary_as_a_course_choice_with_waiting_or_maybe_qualification
+    given_i_have_a_primary_course_choice(application_form_completed: true, personal_statement_words: 4)
+    add_waiting_or_maybe_qualification
+  end
+
+  def when_i_have_completed_my_application_and_have_added_primary_as_a_course_choice_with_waiting_or_maybe_qualification_and_personal_statement_500_words
+    given_i_have_a_primary_course_choice(application_form_completed: true, personal_statement_words: 500)
+    add_waiting_or_maybe_qualification
+  end
+
+  def given_i_have_a_primary_course_choice(application_form_completed:, personal_statement_words:)
+    completed_section_trait = application_form_completed.present? ? :completed : :minimum_info
+
+    @provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
+    site = create(
+      :site,
+      name: 'Main site',
+      code: '-',
+      provider: @provider,
+      address_line1: 'Gorse SCITT',
+      address_line2: 'C/O The Bruntcliffe Academy',
+      address_line3: 'Bruntcliffe Lane',
+      address_line4: 'MORLEY, lEEDS',
+      postcode: 'LS27 0LZ',
+    )
+    @course = create(:course, :open, name: 'Primary', code: '2XT2', provider: @provider)
+    @course_option = create(:course_option, site:, course: @course)
+    current_candidate.application_forms.delete_all
+    current_candidate.application_forms << build(:application_form, completed_section_trait, becoming_a_teacher: Faker::Lorem.words(number: personal_statement_words))
+    @application_choice = create(:application_choice, :unsubmitted, course_option: @course_option, application_form: current_candidate.current_application)
+  end
+
+  def add_not_needed_qualification
+    @application_choice.application_form.application_qualifications << build(:application_qualification, enic_reason: 'not_needed')
+  end
+
+  def add_waiting_or_maybe_qualification
+    @application_choice.application_form.application_qualifications << build(:application_qualification, enic_reason: 'maybe')
+  end
+
+  def when_i_save_as_draft
+    click_link_or_button 'Save as draft'
+  end
+
+  def and_my_application_is_still_unsubmitted
+    expect(@application_choice.reload).to be_unsubmitted
+  end
+
+  def and_i_am_redirected_to_the_application_dashboard
+    expect(page).to have_content t('page_titles.application_dashboard')
+    expect(page).to have_content 'Gorse SCITT'
+  end
+
+  def when_i_go_back
+    click_link_or_button 'Back'
+  end
+
+  def then_i_see_a_interruption_page_for_personal_statement
+    expect(page).to have_content 'Your personal statement is 4 words.'
+  end
+
+  def then_i_see_a_interruption_page_for_not_needed_enic
+    expect(page).to have_content 'You have not included a UK ENIC reference number'
+    expect(page).to have_content 'Including a UK ENIC reference number in your application makes youn around 30% more likely to receive an offer.'
+    expect(page).to have_current_path(
+      candidate_interface_course_choices_course_review_enic_interruption_path(@application_choice.id),
+    )
+  end
+
+  def then_i_see_a_interruption_page_for_waiting_or_maybe_enic
+    expect(page).to have_content 'You have not included a UK ENIC reference number'
+    expect(page).to have_content 'If you have a UK ENIC reference number, you should add it to your qualifications details.'
+    expect(page).to have_current_path(
+      candidate_interface_course_choices_course_review_enic_interruption_path(@application_choice.id),
+    )
+  end
+
+  def then_the_viewed_enic_interruption_page_cookie_to_be_set
+    expect(page.driver.browser.manage.cookie_named('viewed_enic_interruption_page')[:value]).to eq('true')
+  end
+end


### PR DESCRIPTION
## Context

Ticket: https://trello.com/c/Hj1zFHAV/2052-implement-interruption-pages-for-enic

### Expected Behaviour:

If a candidate has selected I am waiting for it to arrive or
I will apply for one in future on any qualification entry page
And they select Review application on an application review page
Then they will see the waiting future variation of the interruption page.

If a candidate has selected I do not need a statement of comparability on all qualification entry page
And they select Review application on an application review page
Then they will see the don’t want variation of the interruption page.

## Changes proposed in this pull request

To add a new enic interruption page which appears after the personal statement interruption page. The content will be dynamic depending on which behaviour path is chosen as mentioned above

## Guidance to review
- Add details and  **do not need a statement of comparability on all qualification**
- The review the application, you should then see the interruption page for that scenario
- Add details and  select **I am waiting for it to arrive or I will apply for one in future on any qualification entry page**
- The review the application, you should then see the interruption page for that scenario

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
