### PR TITLE
[2153] Candidate email deadline passed unsubmitted applications

### DIFF
--- a/app/components/shared/end_of_cycle_emails_component.rb
+++ b/app/components/shared/end_of_cycle_emails_component.rb
@@ -46,6 +46,6 @@ class EndOfCycleEmailsComponent < ViewComponent::Base
   end
 
   def email_date(event)
-    CycleTimetable.send(event).strftime('%e %B %Y')
+    EmailTimetable.send(event).strftime('%e %B %Y')
   end
 end

--- a/app/helpers/cycle_timetable_helper.rb
+++ b/app/helpers/cycle_timetable_helper.rb
@@ -44,4 +44,8 @@ module_function
   def reject_by_default_reminder_run_date(year = CycleTimetable.current_year)
     CycleTimetable.reject_by_default(year) - 2.weeks
   end
+
+  def application_deadline_has_passed_email_date(year = CycleTimetable.current_year)
+    CycleTimetable.apply_deadline(year) + 1.day
+  end
 end

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -10,6 +10,7 @@ class CandidateMailer < ApplicationMailer
       nudge_unsubmitted_with_incomplete_references
       duplicate_match_email
       application_rejected
+      application_deadline_has_passed
     ],
   )
   include QualificationValueHelper
@@ -418,6 +419,18 @@ class CandidateMailer < ApplicationMailer
     email_for_candidate(
       application_form,
       subject: I18n.t!('candidate_mailer.approaching_eoc_second_deadline_reminder.subject', apply_deadline:),
+    )
+  end
+
+  def application_deadline_has_passed(application_form)
+    year = application_form.recruitment_cycle_year
+    @this_academic_year = CycleTimetable.cycle_year_range(year)
+    @next_academic_year = CycleTimetable.cycle_year_range(year + 1)
+    @apply_reopens_date = CycleTimetable.apply_reopens.to_fs(:govuk_date)
+
+    email_for_candidate(
+      application_form,
+      subject: I18n.t!('candidate_mailer.application_deadline_has_passed.subject'),
     )
   end
 

--- a/app/queries/get_applications_to_send_deadline_reminders_to.rb
+++ b/app/queries/get_applications_to_send_deadline_reminders_to.rb
@@ -13,7 +13,7 @@ class GetApplicationsToSendDeadlineRemindersTo
   end
 
   def self.need_to_send_deadline_reminder?
-    CycleTimetable.send_first_end_of_cycle_reminder_to_candidates? ||
-      CycleTimetable.send_second_end_of_cycle_reminder_to_candidates?
+    EmailTimetable.send_first_end_of_cycle_reminder_to_candidates? ||
+      EmailTimetable.send_second_end_of_cycle_reminder_to_candidates?
   end
 end

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -393,6 +393,10 @@ class CycleTimetable
     current_date.to_date == (reject_by_default - 2.weeks).to_date
   end
 
+  def self.send_application_deadline_has_passed_email_to_candidates?
+    current_date.to_date == (apply_deadline + 1.day).to_date
+  end
+
   def self.cycle_year_range(year = current_year)
     "#{year} to #{year + 1}"
   end

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -161,16 +161,6 @@ class CycleTimetable
     real_schedule_for(year).fetch(:holidays)
   end
 
-  def self.apply_deadline_first_reminder
-    # For 2024, date confirmed is Wednesday 17 July at 6pm
-    apply_deadline - 2.months
-  end
-
-  def self.apply_deadline_second_reminder
-    # For 2024, date confirmed is Monday 19 August at 6pm
-    (apply_deadline - 1.month).next_weekday
-  end
-
   def self.between_cycles?
     current_date.before?(apply_opens) || # In the current cycle, when find is open, but apply is not
       (CYCLE_DATES[next_year].present? && # We need to evaluated the next year to compare these dates
@@ -371,30 +361,6 @@ class CycleTimetable
     recruitment_cycle_year = application_form.recruitment_cycle_year
 
     current_date > apply_deadline(recruitment_cycle_year)
-  end
-
-  def self.send_first_end_of_cycle_reminder_to_candidates?
-    current_date.to_date == apply_deadline_first_reminder.to_date
-  end
-
-  def self.send_second_end_of_cycle_reminder_to_candidates?
-    current_date.to_date == apply_deadline_second_reminder.to_date
-  end
-
-  def self.send_find_has_opened_email?
-    current_date.to_date == find_opens.to_date
-  end
-
-  def self.send_new_cycle_has_started_email?
-    current_date.to_date == apply_opens.to_date
-  end
-
-  def self.send_reject_by_default_reminder_to_providers?
-    current_date.to_date == (reject_by_default - 2.weeks).to_date
-  end
-
-  def self.send_application_deadline_has_passed_email_to_candidates?
-    current_date.to_date == (apply_deadline + 1.day).to_date
   end
 
   def self.cycle_year_range(year = current_year)

--- a/app/services/email_timetable.rb
+++ b/app/services/email_timetable.rb
@@ -1,0 +1,35 @@
+class EmailTimetable < CycleTimetable
+  def self.send_reject_by_default_reminder_to_providers?
+    current_date.to_date == (reject_by_default - 2.weeks).to_date
+  end
+
+  def self.send_first_end_of_cycle_reminder_to_candidates?
+    current_date.to_date == apply_deadline_first_reminder.to_date
+  end
+
+  def self.send_second_end_of_cycle_reminder_to_candidates?
+    current_date.to_date == apply_deadline_second_reminder.to_date
+  end
+
+  def self.send_find_has_opened_email?
+    current_date.to_date == find_opens.to_date
+  end
+
+  def self.send_new_cycle_has_started_email?
+    current_date.to_date == apply_opens.to_date
+  end
+
+  def self.send_application_deadline_has_passed_email_to_candidates?
+    current_date.to_date == (apply_deadline + 1.day).to_date
+  end
+
+  def self.apply_deadline_second_reminder
+    # For 2024, date confirmed is Monday 19 August at 6pm
+    (apply_deadline - 1.month).next_weekday
+  end
+
+  def self.apply_deadline_first_reminder
+    # For 2024, date confirmed is Wednesday 17 July at 6pm
+    apply_deadline - 2.months
+  end
+end

--- a/app/views/candidate_mailer/application_deadline_has_passed.text.erb
+++ b/app/views/candidate_mailer/application_deadline_has_passed.text.erb
@@ -1,0 +1,15 @@
+<% if @application_form.first_name.present? %>
+  Dear <%= @application_form.first_name %>
+<% end %>
+
+The application deadline has passed for teacher training courses starting in the <%= @this_academic_year %> academic year.
+
+# What happens next?
+
+You can update your details to get ready to apply for courses starting in the <%= @next_academic_year %> academic year. You will be able to apply for these courses from <%= @apply_reopens_date %>.
+
+[Sign into your account to update your details](<%= candidate_magic_link(@application_form.candidate) %>).
+
+# Get help
+
+Call <%= t('get_into_teaching.tel') %> or [chat online](<%= t('get_into_teaching.url_online_chat') %>).

--- a/app/workers/end_of_cycle/send_application_deadline_has_passed_email_to_candidates_worker.rb
+++ b/app/workers/end_of_cycle/send_application_deadline_has_passed_email_to_candidates_worker.rb
@@ -5,7 +5,7 @@ module EndOfCycle
     BATCH_SIZE = 120
 
     def perform
-      return unless send_application_deadline_has_passed_email_to_candidates?
+      return unless EmailTimetable.send_application_deadline_has_passed_email_to_candidates?
 
       BatchDelivery.new(relation:, batch_size: BATCH_SIZE).each do |batch_time, application_forms|
         SendApplicationDeadlineHasPassedEmailToCandidatesBatchWorker.perform_at(batch_time, application_forms.pluck(:id))
@@ -19,12 +19,6 @@ module EndOfCycle
         .current_cycle
         .unsubmitted
         .distinct
-    end
-
-  private
-
-    def send_application_deadline_has_passed_email_to_candidates?
-      CycleTimetable.send_application_deadline_has_passed_email_to_candidates?
     end
   end
 

--- a/app/workers/end_of_cycle/send_application_deadline_has_passed_email_to_candidates_worker.rb
+++ b/app/workers/end_of_cycle/send_application_deadline_has_passed_email_to_candidates_worker.rb
@@ -1,0 +1,40 @@
+module EndOfCycle
+  class SendApplicationDeadlineHasPassedEmailToCandidatesWorker
+    include Sidekiq::Worker
+
+    BATCH_SIZE = 120
+
+    def perform
+      return unless send_application_deadline_has_passed_email_to_candidates?
+
+      BatchDelivery.new(relation:, batch_size: BATCH_SIZE).each do |batch_time, application_forms|
+        SendApplicationDeadlineHasPassedEmailToCandidatesBatchWorker.perform_at(batch_time, application_forms.pluck(:id))
+      end
+    end
+
+    def relation
+      ApplicationForm
+        .joins(:candidate)
+        .where(candidates: { submission_blocked: false, account_locked: false })
+        .current_cycle
+        .unsubmitted
+        .distinct
+    end
+
+  private
+
+    def send_application_deadline_has_passed_email_to_candidates?
+      CycleTimetable.send_application_deadline_has_passed_email_to_candidates?
+    end
+  end
+
+  class SendApplicationDeadlineHasPassedEmailToCandidatesBatchWorker
+    include Sidekiq::Worker
+
+    def perform(application_form_ids)
+      ApplicationForm.where(id: application_form_ids).find_each do |application_form|
+        CandidateMailer.application_deadline_has_passed(application_form).deliver_later
+      end
+    end
+  end
+end

--- a/app/workers/end_of_cycle/send_reject_by_default_reminder_to_providers_worker.rb
+++ b/app/workers/end_of_cycle/send_reject_by_default_reminder_to_providers_worker.rb
@@ -22,7 +22,7 @@ module EndOfCycle
   private
 
     def do_not_send_email
-      !CycleTimetable.send_reject_by_default_reminder_to_providers?
+      !EmailTimetable.send_reject_by_default_reminder_to_providers?
     end
   end
 

--- a/app/workers/send_eoc_deadline_reminder_email_to_candidates_worker.rb
+++ b/app/workers/send_eoc_deadline_reminder_email_to_candidates_worker.rb
@@ -21,9 +21,9 @@ class SendEocDeadlineReminderEmailToCandidatesWorker
 private
 
   def chaser_type
-    if CycleTimetable.send_first_end_of_cycle_reminder_to_candidates?
+    if EmailTimetable.send_first_end_of_cycle_reminder_to_candidates?
       :eoc_first_deadline_reminder
-    elsif CycleTimetable.send_second_end_of_cycle_reminder_to_candidates?
+    elsif EmailTimetable.send_second_end_of_cycle_reminder_to_candidates?
       :eoc_second_deadline_reminder
     end
   end

--- a/app/workers/send_find_has_opened_email_to_candidates_worker.rb
+++ b/app/workers/send_find_has_opened_email_to_candidates_worker.rb
@@ -4,7 +4,7 @@ class SendFindHasOpenedEmailToCandidatesWorker
   BATCH_SIZE = 120
 
   def perform
-    return unless CycleTimetable.send_find_has_opened_email?
+    return unless EmailTimetable.send_find_has_opened_email?
 
     BatchDelivery.new(relation: GetUnsuccessfulAndUnsubmittedCandidates.call, stagger_over: 12.hours, batch_size: BATCH_SIZE).each do |batch_time, records|
       SendFindHasOpenedEmailToCandidatesBatchWorker.perform_at(

--- a/app/workers/send_new_cycle_has_started_email_to_candidates_worker.rb
+++ b/app/workers/send_new_cycle_has_started_email_to_candidates_worker.rb
@@ -4,7 +4,7 @@ class SendNewCycleHasStartedEmailToCandidatesWorker
   BATCH_SIZE = 120
 
   def perform
-    return unless CycleTimetable.send_new_cycle_has_started_email?
+    return unless EmailTimetable.send_new_cycle_has_started_email?
 
     BatchDelivery.new(
       relation: GetUnsuccessfulAndUnsubmittedCandidates.call,

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -41,6 +41,7 @@ class Clock
   every(1.day, 'SendFindHasOpenedEmailToCandidatesWorker', at: '12:00') { SendFindHasOpenedEmailToCandidatesWorker.new.perform }
   every(1.day, 'SendNewCycleStartedEmailToCandidatesWorker', at: '10:00') { SendNewCycleHasStartedEmailToCandidatesWorker.new.perform }
   every(1.day, 'EndOfCycle::SendRejectByDefaultReminderToProvidersWorker') { EndOfCycle::SendRejectByDefaultReminderToProvidersWorker.new.perform }
+  every(1.day, 'EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesWorker', at: '09:00') { EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesWorker.new.perform }
 
   every(1.day, 'TriggerFullSyncIfFindClosed', at: '00:05') { TeacherTrainingPublicAPI::TriggerFullSyncIfFindClosed.call }
   every(1.day, 'NudgeCandidatesWorker', at: '10:00') { NudgeCandidatesWorker.perform_async }

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -83,6 +83,8 @@ en:
       subject: Submit your teacher training application before courses fill up
     approaching_eoc_second_deadline_reminder:
       subject: Submit your teacher training application before %{apply_deadline}
+    application_deadline_has_passed:
+      subject: The application deadline has passed
     new_cycle_has_started:
       subject: Apply for teacher training starting in the %{academic_year} academic year
     find_has_opened:

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -484,6 +484,15 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.eoc_second_deadline_reminder(application_form)
   end
 
+  def application_deadline_has_passed
+    application_form = FactoryBot.build(
+      :application_form,
+      first_name: 'Rocket',
+    )
+
+    CandidateMailer.application_deadline_has_passed(application_form)
+  end
+
   def new_cycle_has_started_with_no_first_name_and_unsubmitted_application
     application_form = FactoryBot.build(:application_form, first_name: nil, submitted_at: nil)
 

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -299,34 +299,6 @@ RSpec.describe CycleTimetable do
     end
   end
 
-  describe '#send_first_end_of_cycle_reminder_to_candidates?' do
-    it 'returns false if it is not the reminder date' do
-      travel_temporarily_to(described_class.apply_deadline_first_reminder - 1.day) do
-        expect(described_class.send_first_end_of_cycle_reminder_to_candidates?).to be false
-      end
-    end
-
-    it 'returns true when it is the first apply deadline reminder date' do
-      travel_temporarily_to(described_class.apply_deadline_first_reminder) do
-        expect(described_class.send_first_end_of_cycle_reminder_to_candidates?).to be true
-      end
-    end
-  end
-
-  describe '#send_second_end_of_cycle_reminder_to_candidates?' do
-    it 'returns false if it is not the reminder date' do
-      travel_temporarily_to(described_class.apply_deadline_second_reminder - 1.day) do
-        expect(described_class.send_second_end_of_cycle_reminder_to_candidates?).to be false
-      end
-    end
-
-    it 'returns true when it is the second apply deadline reminder date' do
-      travel_temporarily_to(described_class.apply_deadline_second_reminder) do
-        expect(described_class.send_second_end_of_cycle_reminder_to_candidates?).to be true
-      end
-    end
-  end
-
   describe '.next_apply_deadline' do
     context 'after cycle start and before apply deadline' do
       it 'returns apply_deadline' do
@@ -429,24 +401,6 @@ RSpec.describe CycleTimetable do
     end
   end
 
-  describe '.send_find_has_opened_email?' do
-    context 'it is before find reopens' do
-      it 'returns false' do
-        travel_temporarily_to(described_class.find_opens - 1.hour) do
-          expect(described_class.send_find_has_opened_email?).to be(false)
-        end
-      end
-    end
-
-    context 'it is after find reopens' do
-      it 'returns true' do
-        travel_temporarily_to(described_class.find_opens + 1.hour) do
-          expect(described_class.send_find_has_opened_email?).to be(true)
-        end
-      end
-    end
-  end
-
   describe '.service_opens_today?' do
     let(:year) { RecruitmentCycle.current_year }
 
@@ -471,24 +425,6 @@ RSpec.describe CycleTimetable do
     it 'is false when the service is Find and the time is outside of business hours' do
       travel_temporarily_to(12.hours.since(described_class.find_opens(year))) do
         expect(described_class.service_opens_today?(:find, year:)).to be false
-      end
-    end
-  end
-
-  describe '.send_new_cycle_has_started_email?' do
-    context 'it is before apply reopens' do
-      it 'returns false' do
-        travel_temporarily_to(described_class.apply_reopens - 1.day) do
-          expect(described_class.send_new_cycle_has_started_email?).to be(false)
-        end
-      end
-    end
-
-    context 'it is after apply reopens' do
-      it 'returns true' do
-        travel_temporarily_to(described_class.apply_opens) do
-          expect(described_class.send_new_cycle_has_started_email?).to be(true)
-        end
       end
     end
   end

--- a/spec/services/email_timetable_spec.rb
+++ b/spec/services/email_timetable_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe EmailTimetable do
+  describe '#send_first_end_of_cycle_reminder_to_candidates?' do
+    it 'returns false if it is not the reminder date' do
+      travel_temporarily_to(described_class.apply_deadline_first_reminder - 1.day) do
+        expect(described_class.send_first_end_of_cycle_reminder_to_candidates?).to be false
+      end
+    end
+
+    it 'returns true when it is the first apply deadline reminder date' do
+      travel_temporarily_to(described_class.apply_deadline_first_reminder) do
+        expect(described_class.send_first_end_of_cycle_reminder_to_candidates?).to be true
+      end
+    end
+  end
+
+  describe '#send_second_end_of_cycle_reminder_to_candidates?' do
+    it 'returns false if it is not the reminder date' do
+      travel_temporarily_to(described_class.apply_deadline_second_reminder - 1.day) do
+        expect(described_class.send_second_end_of_cycle_reminder_to_candidates?).to be false
+      end
+    end
+
+    it 'returns true when it is the second apply deadline reminder date' do
+      travel_temporarily_to(described_class.apply_deadline_second_reminder) do
+        expect(described_class.send_second_end_of_cycle_reminder_to_candidates?).to be true
+      end
+    end
+  end
+
+  describe '.send_find_has_opened_email?' do
+    context 'it is before find reopens' do
+      it 'returns false' do
+        travel_temporarily_to(described_class.find_opens - 1.hour) do
+          expect(described_class.send_find_has_opened_email?).to be(false)
+        end
+      end
+    end
+
+    context 'it is after find reopens' do
+      it 'returns true' do
+        travel_temporarily_to(described_class.find_opens + 1.hour) do
+          expect(described_class.send_find_has_opened_email?).to be(true)
+        end
+      end
+    end
+  end
+
+  describe '.send_new_cycle_has_started_email?' do
+    context 'it is before apply reopens' do
+      it 'returns false' do
+        travel_temporarily_to(described_class.apply_reopens - 1.day) do
+          expect(described_class.send_new_cycle_has_started_email?).to be(false)
+        end
+      end
+    end
+
+    context 'it is after apply reopens' do
+      it 'returns true' do
+        travel_temporarily_to(described_class.apply_opens) do
+          expect(described_class.send_new_cycle_has_started_email?).to be(true)
+        end
+      end
+    end
+  end
+
+  describe '#send_application_deadline_has_passed_email_to_candidates?' do
+    it 'returns false if it is not the day after the apply deadline' do
+      travel_temporarily_to(described_class.apply_deadline) do
+        expect(described_class.send_application_deadline_has_passed_email_to_candidates?).to be false
+      end
+    end
+
+    it 'returns true if it is the day after the apply deadline' do
+      travel_temporarily_to(described_class.apply_deadline + 1.day) do
+        expect(described_class.send_application_deadline_has_passed_email_to_candidates?).to be true
+      end
+    end
+  end
+end

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe 'Docs' do
       provider_mailer-fallback_sign_in_email
       candidate_mailer-eoc_first_deadline_reminder
       candidate_mailer-eoc_second_deadline_reminder
+      candidate_mailer-application_deadline_has_passed
       candidate_mailer-new_cycle_has_started
       candidate_mailer-duplicate_match_email
       candidate_mailer-find_has_opened

--- a/spec/workers/end_of_cycle/send_application_deadline_has_passed_email_to_candidates_batch_worker_spec.rb
+++ b/spec/workers/end_of_cycle/send_application_deadline_has_passed_email_to_candidates_batch_worker_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesBatchWorker do
+  describe '#perform' do
+    it 'calls candidate mailer with application form' do
+      application_form = create(:application_form, :unsubmitted)
+
+      expect { described_class.new.perform([application_form.id]) }.to have_enqueued_mail(CandidateMailer, :application_deadline_has_passed)
+    end
+  end
+end

--- a/spec/workers/end_of_cycle/send_application_deadline_has_passed_email_to_candidates_worker_spec.rb
+++ b/spec/workers/end_of_cycle/send_application_deadline_has_passed_email_to_candidates_worker_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesWorker do
+  describe '#perform' do
+    context 'is before the date for sending the reminder', time: application_deadline_has_passed_email_date - 1.day do
+      it 'does not enqueue the batch worker' do
+        create(:application_form, :unsubmitted)
+
+        allow(EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesBatchWorker).to receive(:perform_at)
+        described_class.new.perform
+        expect(EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesBatchWorker).not_to have_received(:perform_at)
+      end
+    end
+
+    context 'is after the date for sending the reminder', time: application_deadline_has_passed_email_date + 1.day do
+      it 'does not enqueue the batch worker' do
+        create(:application_form, :unsubmitted)
+
+        allow(EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesBatchWorker).to receive(:perform_at)
+        described_class.new.perform
+        expect(EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesBatchWorker).not_to have_received(:perform_at)
+      end
+    end
+
+    context 'is on the date for sending the email', time: application_deadline_has_passed_email_date do
+      it 'enqueues the batch worker' do
+        unsubmitted_application_form = create(:application_form, :unsubmitted)
+
+        # These two application forms should not be included
+        create(:application_form, :submitted)
+        create(:application_form, recruitment_cycle_year: RecruitmentCycle.previous_year)
+
+        # These two won't be sent because these candidates should not receive emails
+        blocked_submission_candidate = create(:candidate, submission_blocked: true)
+        create(:application_form, :unsubmitted, candidate: blocked_submission_candidate)
+
+        account_locked_candidate = create(:candidate, account_locked: true)
+        create(:application_form, :unsubmitted, candidate: account_locked_candidate)
+
+        allow(EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesBatchWorker).to receive(:perform_at)
+        described_class.new.perform
+
+        expect(EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesBatchWorker)
+          .to have_received(:perform_at).with(kind_of(Time), [unsubmitted_application_form.id])
+      end
+    end
+  end
+end

--- a/spec/workers/send_eoc_deadline_reminder_email_to_candidates_worker_spec.rb
+++ b/spec/workers/send_eoc_deadline_reminder_email_to_candidates_worker_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe SendEocDeadlineReminderEmailToCandidatesWorker, :sidekiq do
   describe '#perform' do
     it 'returns an application when the deadline is 2 months away' do
-      travel_temporarily_to(CycleTimetable.apply_deadline_first_reminder) do
+      travel_temporarily_to(EmailTimetable.apply_deadline_first_reminder) do
         candidate = create(:candidate)
 
         create(
@@ -22,7 +22,7 @@ RSpec.describe SendEocDeadlineReminderEmailToCandidatesWorker, :sidekiq do
     end
 
     it 'does not return an application where the candidate account is locked' do
-      allow(CycleTimetable).to receive(:send_first_end_of_cycle_reminder_to_candidates?).and_return(true)
+      allow(EmailTimetable).to receive(:send_first_end_of_cycle_reminder_to_candidates?).and_return(true)
 
       unsubscribed_candidate = create(:candidate, account_locked: true)
       create(:application_form, candidate: unsubscribed_candidate)
@@ -35,7 +35,7 @@ RSpec.describe SendEocDeadlineReminderEmailToCandidatesWorker, :sidekiq do
     end
 
     it 'does not return an application where the candidate is unsubscribed' do
-      allow(CycleTimetable).to receive(:send_first_end_of_cycle_reminder_to_candidates?).and_return(true)
+      allow(EmailTimetable).to receive(:send_first_end_of_cycle_reminder_to_candidates?).and_return(true)
 
       unsubscribed_candidate = create(:candidate, unsubscribed_from_emails: true)
       create(:application_form, candidate: unsubscribed_candidate)
@@ -48,7 +48,7 @@ RSpec.describe SendEocDeadlineReminderEmailToCandidatesWorker, :sidekiq do
     end
 
     it 'does not return an application where the candidate submission is blocked' do
-      allow(CycleTimetable).to receive(:send_first_end_of_cycle_reminder_to_candidates?).and_return(true)
+      allow(EmailTimetable).to receive(:send_first_end_of_cycle_reminder_to_candidates?).and_return(true)
 
       unsubscribed_candidate = create(:candidate, submission_blocked: true)
       create(:application_form, candidate: unsubscribed_candidate)
@@ -61,7 +61,7 @@ RSpec.describe SendEocDeadlineReminderEmailToCandidatesWorker, :sidekiq do
     end
 
     it 'returns an application when the deadline is 1 month away' do
-      travel_temporarily_to(CycleTimetable.apply_deadline_second_reminder) do
+      travel_temporarily_to(EmailTimetable.apply_deadline_second_reminder) do
         candidate = create(:candidate)
 
         create(
@@ -80,7 +80,7 @@ RSpec.describe SendEocDeadlineReminderEmailToCandidatesWorker, :sidekiq do
     end
 
     it 'does not return an application when the deadline is 3 months away' do
-      travel_temporarily_to(CycleTimetable.apply_deadline_first_reminder - 1.month) do
+      travel_temporarily_to(EmailTimetable.apply_deadline_first_reminder - 1.month) do
         candidate = create(:candidate)
 
         create(
@@ -118,7 +118,7 @@ RSpec.describe SendEocDeadlineReminderEmailToCandidatesWorker, :sidekiq do
     end
 
     it 'does not return an application form from the previous cycle' do
-      travel_temporarily_to(CycleTimetable.apply_deadline_first_reminder) do
+      travel_temporarily_to(EmailTimetable.apply_deadline_first_reminder) do
         candidate = create(:candidate)
 
         create(

--- a/spec/workers/send_find_has_opened_email_to_candidates_worker_spec.rb
+++ b/spec/workers/send_find_has_opened_email_to_candidates_worker_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe SendFindHasOpenedEmailToCandidatesWorker, :sidekiq do
   describe '#perform' do
     context "it is time to send the 'find has opened' email" do
       it 'sends emails to candidates who have unsuccessful or unsubmitted applications from the previous cycle' do
-        allow(CycleTimetable).to receive(:send_find_has_opened_email?).and_return(true)
+        allow(EmailTimetable).to receive(:send_find_has_opened_email?).and_return(true)
 
         candidate_1, candidate_2 = setup_candidates
 
@@ -43,7 +43,7 @@ RSpec.describe SendFindHasOpenedEmailToCandidatesWorker, :sidekiq do
 
     context "it is not time to send the 'find has opened' email" do
       it 'does not send the email' do
-        allow(CycleTimetable).to receive(:send_find_has_opened_email?).and_return(false)
+        allow(EmailTimetable).to receive(:send_find_has_opened_email?).and_return(false)
         setup_candidates
 
         described_class.new.perform
@@ -54,7 +54,7 @@ RSpec.describe SendFindHasOpenedEmailToCandidatesWorker, :sidekiq do
 
     context "it is time to send the 'find has opened' email but one candidate has already received it" do
       it 'does not send the email' do
-        allow(CycleTimetable).to receive(:send_find_has_opened_email?).and_return(true)
+        allow(EmailTimetable).to receive(:send_find_has_opened_email?).and_return(true)
         candidate_1, candidate_2 = setup_candidates
         candidate_1.current_application.chasers_sent.create(
           chaser_type: :find_has_opened,

--- a/spec/workers/send_new_cycle_has_started_email_to_candidates_worker_spec.rb
+++ b/spec/workers/send_new_cycle_has_started_email_to_candidates_worker_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe SendNewCycleHasStartedEmailToCandidatesWorker, :sidekiq do
   describe '#perform' do
     context "it is time to send the 'new cycle has started' email" do
       it 'sends emails to candidates who have unsuccessful or unsubmitted applications from the previous cycle' do
-        allow(CycleTimetable).to receive(:send_new_cycle_has_started_email?).and_return(true)
+        allow(EmailTimetable).to receive(:send_new_cycle_has_started_email?).and_return(true)
 
         candidate_1, candidate_2 = setup_candidates
 
@@ -43,7 +43,7 @@ RSpec.describe SendNewCycleHasStartedEmailToCandidatesWorker, :sidekiq do
 
     context "it is not time to send the 'new cycle has started' email" do
       it 'does not send the email' do
-        allow(CycleTimetable).to receive(:send_new_cycle_has_started_email?).and_return(false)
+        allow(EmailTimetable).to receive(:send_new_cycle_has_started_email?).and_return(false)
         setup_candidates
 
         described_class.new.perform
@@ -54,7 +54,7 @@ RSpec.describe SendNewCycleHasStartedEmailToCandidatesWorker, :sidekiq do
 
     context "it is time to send the 'new cycle has started' email but one candidate has already received it" do
       it 'does not send the email' do
-        allow(CycleTimetable).to receive_messages(send_new_cycle_has_started_email?: true, apply_opens: 1.day.ago)
+        allow(EmailTimetable).to receive_messages(send_new_cycle_has_started_email?: true, apply_opens: 1.day.ago)
         candidate_1, candidate_2 = setup_candidates
         candidate_1.current_application.chasers_sent.create(
           chaser_type: :new_cycle_has_started,


### PR DESCRIPTION
## Context

We want to send a message to candidates who have missed the application deadline, letting them know that they can start working on their application for next year. 

## Changes proposed in this pull request

- Email template
- Worker for sending the email in batches
- Refactored the email-related methods to their own class, away from the CycleTimetable class which is becoming a bit bloated

## Guidance to review

It might be easier to look at individual commits since this includes a bit of refactoring. 
The email preview can be viewed locally or in the review app here: `/rails/mailers/candidate_mailer/application_deadline_has_passed`

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
