### PR TITLE
Assume browser titles are html safe

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,7 +8,7 @@ module ApplicationHelper
 
   def browser_title
     page_browser_title = content_for(:browser_title).presence || content_for(:title)
-    [page_browser_title, service_name, 'GOV.UK'].select(&:present?).join(' - ')
+    [page_browser_title, service_name, 'GOV.UK'].select(&:present?).join(' - ').html_safe
   end
 
   def service_name

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsuccessful_application_to_new_cycle_spec.rb
@@ -88,12 +88,15 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
 
     job = create(:application_work_experience, experienceable: @application_form)
     @application_form.application_work_experiences << [job]
+    @provider = @application_choice.provider
   end
   alias_method :given_i_have_an_application_with_a_rejection, :and_i_have_an_application_with_a_rejection
 
   def given_i_applied_two_years_ago
     @application_form = create(:completed_application_form, recruitment_cycle_year: 2.years.ago.year, candidate: @candidate)
     @application_choice = create(:application_choice, :rejected, application_form: @application_form)
+    @provider = @application_choice.provider
+    @provider.update(name: "St. Mary's")
   end
 
   def and_the_apply_deadline_passes
@@ -131,15 +134,14 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   def and_i_can_view_my_unsuccessful_application
-    click_on @application_choice.provider.name
+    click_on @provider.name
     expect(page)
       .to have_current_path(
         candidate_interface_course_choices_course_review_path(
           application_choice_id: @application_choice.id,
         ),
       )
-    provider_name = smart_quotes(@application_choice.provider.name)
-    expect(page).to have_title("Your application to #{provider_name}")
+    expect(page).to have_title("Your application to #{@provider.name}")
     expect(page).to have_content('Unsuccessful')
   end
 


### PR DESCRIPTION
## Context

We've had a few flaky tests where the page title is being checked. They are flaky when the Faker data provides a name that has an apostrophe or other character in it. 

## Changes proposed in this pull request

Add `html_safe` to browser title so the characters will be renedered.

| Before | After |
| ------ | ------ |
| <img width="237" alt="image" src="https://github.com/user-attachments/assets/4da41269-5026-4967-9884-89b01481e8a5"> | <img width="246" alt="image" src="https://github.com/user-attachments/assets/a85c6ba7-9307-48c6-b04c-f65954372a4e"> |

## Guidance to review


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
