### PR TITLE
[2173] Extra test dates to ensure suite passes between cycles

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -197,7 +197,7 @@ jobs:
             integration_candidate,
           ]
         feature-flags: [on, off]
-        offset-date: [real_world]
+        offset-date: [real_world, after_apply_deadline, before_apply_reopens, after_apply_reopens]
         include:
           - tests: unit_shared
             include-pattern: spec/.*_spec.rb

--- a/spec/queries/providers_for_recruitment_performance_report_query_spec.rb
+++ b/spec/queries/providers_for_recruitment_performance_report_query_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ProvidersForRecruitmentPerformanceReportQuery do
     end
   end
 
-  it 'selects providers only with submitted applications this cycle before the current week' do
+  it 'selects providers only with submitted applications this cycle before the current week', time: mid_cycle do
     TestSuiteTimeMachine.travel_temporarily_to(1.year.ago) do
       application_choice_offer_from_last_cycle
     end
@@ -27,7 +27,7 @@ RSpec.describe ProvidersForRecruitmentPerformanceReportQuery do
     expect(query).to contain_exactly(application_last_week)
   end
 
-  it 'selects distinct providers when a provider has more than one application' do
+  it 'selects distinct providers when a provider has more than one application', time: mid_cycle do
     TestSuiteTimeMachine.travel_temporarily_to(1.week.ago) do
       application_last_week
       create(:application_choice, :awaiting_provider_decision, course_option: application_last_week.course_options.first)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,7 +23,16 @@ abort('The Rails environment is running in production mode!') if Rails.env.produ
 require 'rspec/rails'
 require 'dotenv/rails'
 
-TestSuiteTimeMachine.pretend_it_is(ENV.fetch('TEST_DATE_AND_TIME', 'real_world'))
+STANDARD_TEST_DATES = {
+  'after_apply_deadline' => (CycleTimetable.apply_deadline + 1.hour).to_fs,
+  'before_apply_reopens' => (CycleTimetable.apply_reopens - 1.day).to_fs,
+  'after_apply_reopens' => (CycleTimetable.apply_reopens + 1.day).to_fs,
+}.freeze
+
+test_date_time_var = ENV.fetch('TEST_DATE_AND_TIME', 'real_world')
+test_date_time = STANDARD_TEST_DATES.fetch(test_date_time_var, test_date_time_var)
+
+TestSuiteTimeMachine.pretend_it_is(test_date_time)
 
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 require 'capybara/rails'

--- a/spec/services/candidate_interface/application_choice_submission_spec.rb
+++ b/spec/services/candidate_interface/application_choice_submission_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CandidateInterface::ApplicationChoiceSubmission do
 
   let(:routes) { Rails.application.routes.url_helpers }
 
-  describe 'validations' do
+  describe 'validations', time: mid_cycle do
     context 'immigration_status validation' do
       let(:course) { create(:course, :with_course_options, :open, level: 'secondary') }
       let(:application_form) { create(:application_form, :completed) }

--- a/spec/workers/send_new_cycle_has_started_email_to_candidates_worker_spec.rb
+++ b/spec/workers/send_new_cycle_has_started_email_to_candidates_worker_spec.rb
@@ -54,7 +54,8 @@ RSpec.describe SendNewCycleHasStartedEmailToCandidatesWorker, :sidekiq do
 
     context "it is time to send the 'new cycle has started' email but one candidate has already received it" do
       it 'does not send the email' do
-        allow(EmailTimetable).to receive_messages(send_new_cycle_has_started_email?: true, apply_opens: 1.day.ago)
+        allow(EmailTimetable).to receive(:send_new_cycle_has_started_email?).and_return(true)
+        allow(CycleTimetable).to receive(:apply_opens).and_return(1.day.ago)
         candidate_1, candidate_2 = setup_candidates
         candidate_1.current_application.chasers_sent.create(
           chaser_type: :new_cycle_has_started,


### PR DESCRIPTION
## Context

As the end-of-cycle period approaches, we have (for the past two cycles) run the test suite at different dates and found a slew of tests fail. (see [previous PR](https://github.com/DFE-Digital/apply-for-teacher-training/pull/9738) as well as this one for things that have had to be fixed this year). 

We don't want to wait until nearing the end of cycle to surface these issues.

## Changes proposed in this pull request

Running multiple dates has no real impact on the time taken to run the test suite (still about 13 minutes), so this PR introduces running the tests (1) after the apply deadline, and immediately (2) before and (3) after apply reopens, in addition to (4) real_world.

I expect that we will still want to run the tests at different dates as we approach the end of cycle, but having just three extra dates will ensure most problematic tests are caught well in advance. 

I have opted not to do `7.days.from.now` as originally suggested because a week from now is usually just mid cycle and will only help us a week before the cycle starts to change -- that's too late to be helpful.

## Guidance to review

Any thoughts about the dates?

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
