### PR TITLE
Skip school selection in CourseSelection based on `Provider#selectable_school`

### DIFF
--- a/app/forms/candidate_interface/concerns/course_selection_step_helper.rb
+++ b/app/forms/candidate_interface/concerns/course_selection_step_helper.rb
@@ -21,7 +21,9 @@ module CandidateInterface
         course.currently_has_both_study_modes_available?
       end
 
-      delegate :multiple_sites?, to: :course
+      def multiple_sites?
+        course.multiple_sites? && provider.selectable_school?
+      end
 
       def provider_exists?
         Provider.exists?(provider_id)

--- a/app/forms/candidate_interface/course_selection/which_course_are_you_applying_to_step.rb
+++ b/app/forms/candidate_interface/course_selection/which_course_are_you_applying_to_step.rb
@@ -53,6 +53,8 @@ module CandidateInterface
         end
       end
 
+      # When editing an application choice, we want to load the show path for
+      # some steps that don't have an edit action / template
       def next_edit_step_path(next_step_klass)
         classes_without_edit = [DuplicateCourseSelectionStep, FullCourseSelectionStep, ClosedCourseSelectionStep]
         return next_step_path(next_step_klass) if classes_without_edit.include?(next_step_klass)

--- a/app/forms/candidate_interface/course_selection/which_course_are_you_applying_to_step.rb
+++ b/app/forms/candidate_interface/course_selection/which_course_are_you_applying_to_step.rb
@@ -54,7 +54,8 @@ module CandidateInterface
       end
 
       def next_edit_step_path(next_step_klass)
-        return next_step_path(next_step_klass) unless next_step_klass.new.next_step
+        classes_without_edit = [DuplicateCourseSelectionStep, FullCourseSelectionStep, ClosedCourseSelectionStep]
+        return next_step_path(next_step_klass) if classes_without_edit.include?(next_step_klass)
 
         super
       end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -62,6 +62,12 @@ class Provider < ApplicationRecord
     provider_agreements.any?
   end
 
+  def selectable_school?
+    return true unless CycleTimetable.current_year >= 2025
+
+    super
+  end
+
   def lacks_admin_users?
     courses.any? &&
       !(provider_permissions.exists?(manage_users: true) &&

--- a/spec/forms/candidate_interface/course_selection/course_study_mode_step_spec.rb
+++ b/spec/forms/candidate_interface/course_selection/course_study_mode_step_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe CandidateInterface::CourseSelection::CourseStudyModeStep do
       end
     end
 
-    context 'when course has multiple sites and provider school is not selectable' do
+    context 'when course has multiple sites and provider school is not selectable', time: CycleTimetableHelper.mid_cycle(2025) do
       let(:provider) { create(:provider, selectable_school: false) }
 
       before do

--- a/spec/forms/candidate_interface/course_selection/course_study_mode_step_spec.rb
+++ b/spec/forms/candidate_interface/course_selection/course_study_mode_step_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe CandidateInterface::CourseSelection::CourseStudyModeStep do
   end
 
   describe '#next_step' do
-    let(:provider) { create(:provider) }
+    let(:provider) { create(:provider, selectable_school: true) }
     let(:course) do
       create(
         :course,
@@ -39,6 +39,19 @@ RSpec.describe CandidateInterface::CourseSelection::CourseStudyModeStep do
 
       it 'returns :course_site' do
         expect(course_study_mode_step.next_step).to be(:course_site)
+      end
+    end
+
+    context 'when course has multiple sites and provider school is not selectable' do
+      let(:provider) { create(:provider, selectable_school: false) }
+
+      before do
+        create(:course_option, site: create(:site, provider:), course:)
+        create(:course_option, site: create(:site, provider:), course:)
+      end
+
+      it 'returns :course_review' do
+        expect(course_study_mode_step.next_step).to be(:course_review)
       end
     end
 

--- a/spec/forms/candidate_interface/course_selection/which_course_are_you_applying_to_step_spec.rb
+++ b/spec/forms/candidate_interface/course_selection/which_course_are_you_applying_to_step_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe CandidateInterface::CourseSelection::WhichCourseAreYouApplyingToS
   subject(:which_course_are_you_applying_to_step) { described_class.new(provider_id:, course_id:, wizard:) }
 
   let(:candidate) { create(:candidate) }
-  let(:provider) { create(:provider) }
+  let(:provider) { create(:provider, selectable_school: true) }
   let(:course) do
     create(
       :course,
@@ -114,7 +114,7 @@ RSpec.describe CandidateInterface::CourseSelection::WhichCourseAreYouApplyingToS
   end
 
   describe '#next_step' do
-    let(:provider) { create(:provider) }
+    let(:provider) { create(:provider, selectable_school: true) }
     let(:course) do
       create(
         :course,
@@ -160,6 +160,19 @@ RSpec.describe CandidateInterface::CourseSelection::WhichCourseAreYouApplyingToS
 
       it 'returns :course_site' do
         expect(which_course_are_you_applying_to_step.next_step).to be(:course_site)
+      end
+    end
+
+    context 'when course has multiple sites and provider school is not selectable' do
+      let(:provider) { create(:provider, selectable_school: false) }
+
+      before do
+        create(:course_option, site: create(:site, provider:), course:)
+        create(:course_option, site: create(:site, provider:), course:)
+      end
+
+      it 'returns :course_review' do
+        expect(which_course_are_you_applying_to_step.next_step).to be(:course_review)
       end
     end
 

--- a/spec/forms/candidate_interface/course_selection/which_course_are_you_applying_to_step_spec.rb
+++ b/spec/forms/candidate_interface/course_selection/which_course_are_you_applying_to_step_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe CandidateInterface::CourseSelection::WhichCourseAreYouApplyingToS
       end
     end
 
-    context 'when course has multiple sites and provider school is not selectable' do
+    context 'when course has multiple sites and provider school is not selectable', time: CycleTimetableHelper.mid_cycle(2025) do
       let(:provider) { create(:provider, selectable_school: false) }
 
       before do

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -54,4 +54,38 @@ RSpec.describe Provider do
       expect(described_class.with_courses).to eq([provider])
     end
   end
+
+  describe 'selectable_school?' do
+    context 'provider is selectable_school' do
+      let(:provider) { create(:provider, selectable_school: true) }
+
+      context 'when Current Cycle is 2024', time: mid_cycle(2024) do
+        it 'is not selectable school' do
+          expect(provider).to be_selectable_school
+        end
+      end
+
+      context 'when Current Cycle is greater than 2024', time: mid_cycle(2025) do
+        it 'is selectable school' do
+          expect(provider).to be_selectable_school
+        end
+      end
+    end
+
+    context 'provider is not selectable_school' do
+      let(:provider) { create(:provider, selectable_school: false) }
+
+      context 'when Current Cycle is 2024', time: mid_cycle(2024) do
+        it 'is not selectable school' do
+          expect(provider).to be_selectable_school
+        end
+      end
+
+      context 'when Current Cycle is greater than 2024', time: mid_cycle(2025) do
+        it 'is not selectable school' do
+          expect(provider).not_to be_selectable_school
+        end
+      end
+    end
+  end
 end

--- a/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_not_signed_in_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_not_signed_in_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
   end
 
   def and_the_course_i_selected_only_has_one_site
-    @course = create(:course, :open, name: 'Potions')
+    @course = create(:course, :open, name: 'Potions', provider: create(:provider, selectable_school: true))
     @site = create(:site, provider: @course.provider)
     create(:course_option, site: @site, course: @course)
   end
@@ -151,6 +151,7 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
       :course,
       :open,
       :with_both_study_modes,
+      provider: create(:provider, selectable_school: true),
       name: 'Herbology',
     )
     @site1 = create(:site, provider: @course_with_multiple_sites.provider)
@@ -198,7 +199,7 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
 private
 
   def application_choice_for_candidate(candidate:, application_choice_count:)
-    provider = create(:provider)
+    provider = create(:provider, selectable_school: true)
     application_form = create(:application_form, candidate:)
     application_choice_count.times { course_option_for_provider(provider:) }
     provider.courses.each do |course|

--- a/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_with_a_course_with_multiple_sites_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_with_a_course_with_multiple_sites_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Candidate arrives from Find with provider and course with multip
   end
 
   def given_there_is_a_provider_with_a_course_that_is_only_accepting_applications_on_apply
-    @provider = create(:provider, code: '8N5', name: 'Snape University')
+    @provider = create(:provider, code: '8N5', name: 'Snape University', selectable_school: true)
     @course = create(:course, :open, name: 'Potions', provider: @provider)
     first_site = create(
       :site,

--- a/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_with_a_course_with_multiple_study_modes_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_with_a_course_with_multiple_study_modes_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Candidate arrives from Find with provider and course with multip
   end
 
   def given_there_is_a_provider_with_a_course_that_is_only_accepting_applications_on_apply
-    @provider = create(:provider, name: 'Vim masters')
+    @provider = create(:provider, name: 'Vim masters', selectable_school: true)
 
     @first_site = create(:site, provider: @provider, name: 'Site 1')
     @second_site = create(:site, provider: @provider, name: 'Site 2')

--- a/spec/system/candidate_interface/course_selection/candidate_edits_course_choices_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_edits_course_choices_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'Candidate edits course choices' do
   end
 
   def and_there_is_a_course_with_one_course_option
-    @provider = create(:provider)
+    @provider = create(:provider, selectable_school: true)
     create(:course, :open, name: 'English', provider: @provider, study_mode: :full_time)
 
     course_option_for_provider(provider: @provider, course: @provider.courses.first)

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_study_mode_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_study_mode_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Selecting a study mode' do
   end
 
   def and_there_are_course_options
-    @provider = create(:provider, name: 'University of Alien Dance')
+    @provider = create(:provider, name: 'University of Alien Dance', selectable_school: true)
 
     @first_site = create(:site, provider: @provider, name: 'Site 1')
     @second_site = create(:site, provider: @provider, name: 'Site 2')

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_with_multiple_sites_and_unselectable_school_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_with_multiple_sites_and_unselectable_school_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Selecting a course with multiple sites when the provider is not selectable_school' do
+RSpec.describe 'Selecting a course with multiple sites when the provider is not selectable_school', time: CycleTimetableHelper.mid_cycle(2025) do
   include CandidateHelper
 
   it 'Candidate skips the school selection' do

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_with_multiple_sites_and_unselectable_school_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_with_multiple_sites_and_unselectable_school_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.describe 'Selecting a course with multiple sites when the provider is not selectable_school' do
+  include CandidateHelper
+
+  it 'Candidate skips the school selection' do
+    given_i_am_signed_in
+    and_there_are_course_options
+
+    when_i_visit_the_site
+    and_i_click_on_course_choices
+
+    and_i_choose_that_i_know_where_i_want_to_apply
+    and_i_click_continue
+    and_i_choose_a_provider
+    and_i_choose_a_course
+
+    then_i_am_on_the_application_choice_review_page
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def when_i_visit_the_site
+    visit candidate_interface_continuous_applications_details_path
+  end
+
+  def and_i_click_on_course_choices
+    click_link_or_button 'Your application'
+    click_link_or_button 'Add application'
+  end
+
+  def and_i_choose_that_i_know_where_i_want_to_apply
+    choose 'Yes, I know where I want to apply'
+    and_i_click_continue
+  end
+
+  def when_i_choose_that_i_know_where_i_want_to_apply
+    and_i_choose_that_i_know_where_i_want_to_apply
+  end
+
+  def and_i_choose_a_provider
+    select 'Gorse SCITT (1N1)'
+    click_link_or_button t('continue')
+  end
+
+  def and_i_choose_a_course
+    choose 'Primary (2XT2)'
+    click_link_or_button t('continue')
+  end
+
+  def when_i_click_continue
+    click_link_or_button t('continue')
+  end
+
+  def and_i_click_continue
+    when_i_click_continue
+  end
+
+  def application_choice
+    current_candidate.current_application.application_choices.last
+  end
+
+  def and_there_are_course_options
+    @provider = create(:provider, name: 'Gorse SCITT', code: '1N1', selectable_school: false)
+    first_site = create(
+      :site,
+      name: 'Main site',
+      code: '-',
+      provider: @provider,
+      address_line1: 'Gorse SCITT',
+      address_line2: 'C/O The Bruntcliffe Academy',
+      address_line3: 'Bruntcliffe Lane',
+      address_line4: 'MORLEY, lEEDS',
+      postcode: 'LS27 0LZ',
+    )
+    second_site = create(
+      :site,
+      name: 'Harehills Primary School',
+      code: '1',
+      provider: @provider,
+      address_line1: 'Darfield Road',
+      address_line2: '',
+      address_line3: 'Leeds',
+      address_line4: 'West Yorkshire',
+      postcode: 'LS8 5DQ',
+    )
+    @multi_site_course = create(:course, :open, :with_both_study_modes, name: 'Primary', code: '2XT2', provider: @provider)
+    create(:course_option, site: first_site, course: @multi_site_course)
+    create(:course_option, site: second_site, course: @multi_site_course)
+  end
+end

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_with_multiple_sites_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_with_multiple_sites_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'Selecting a course with multiple sites' do
   end
 
   def and_there_are_course_options
-    @provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
+    @provider = create(:provider, name: 'Gorse SCITT', code: '1N1', selectable_school: true)
     first_site = create(
       :site,
       name: 'Main site',

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_with_multiple_study_modes_sites_and_unselectable_school_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_with_multiple_study_modes_sites_and_unselectable_school_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Selecting a course with multiple study modes and sites when the provider is not selectable_school' do
   include CandidateHelper
 
-  it 'Candidate skips the school selection' do
+  it 'Candidate skips the school selection', time: CycleTimetableHelper.mid_cycle(2025) do
     given_i_am_signed_in
     and_there_are_course_options
 

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_with_multiple_study_modes_sites_and_unselectable_school_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_with_multiple_study_modes_sites_and_unselectable_school_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+
+RSpec.describe 'Selecting a course with multiple study modes and sites when the provider is not selectable_school' do
+  include CandidateHelper
+
+  it 'Candidate skips the school selection' do
+    given_i_am_signed_in
+    and_there_are_course_options
+
+    when_i_visit_the_site
+    and_i_click_on_course_choices
+
+    and_i_choose_that_i_know_where_i_want_to_apply
+    and_i_click_continue
+    and_i_choose_a_provider
+    and_i_choose_a_course
+    and_i_choose_part_time
+
+    then_i_am_on_the_application_choice_review_page
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def when_i_visit_the_site
+    visit candidate_interface_continuous_applications_details_path
+  end
+
+  def and_i_click_on_course_choices
+    click_link_or_button 'Your application'
+    click_link_or_button 'Add application'
+  end
+
+  def and_i_choose_that_i_know_where_i_want_to_apply
+    choose 'Yes, I know where I want to apply'
+    and_i_click_continue
+  end
+
+  def when_i_choose_that_i_know_where_i_want_to_apply
+    and_i_choose_that_i_know_where_i_want_to_apply
+  end
+
+  def and_i_choose_a_provider
+    select 'Gorse SCITT (1N1)'
+    click_link_or_button t('continue')
+  end
+
+  def and_i_choose_a_course
+    choose 'Primary (2XT2)'
+    click_link_or_button t('continue')
+  end
+
+  def and_i_choose_part_time
+    choose 'Part time'
+    click_link_or_button t('continue')
+  end
+
+  def when_i_click_continue
+    click_link_or_button t('continue')
+  end
+
+  def and_i_click_continue
+    when_i_click_continue
+  end
+
+  def application_choice
+    current_candidate.current_application.application_choices.last
+  end
+
+  def and_there_are_course_options
+    @provider = create(:provider, name: 'Gorse SCITT', code: '1N1', selectable_school: false)
+    first_site = create(
+      :site,
+      name: 'Main site',
+      code: '-',
+      provider: @provider,
+      address_line1: 'Gorse SCITT',
+      address_line2: 'C/O The Bruntcliffe Academy',
+      address_line3: 'Bruntcliffe Lane',
+      address_line4: 'MORLEY, lEEDS',
+      postcode: 'LS27 0LZ',
+    )
+    second_site = create(
+      :site,
+      name: 'Harehills Primary School',
+      code: '1',
+      provider: @provider,
+      address_line1: 'Darfield Road',
+      address_line2: '',
+      address_line3: 'Leeds',
+      address_line4: 'West Yorkshire',
+      postcode: 'LS8 5DQ',
+    )
+    @multi_site_course = create(:course, :open, :with_both_study_modes, name: 'Primary', code: '2XT2', provider: @provider)
+    create(:course_option, site: first_site, course: @multi_site_course, study_mode: :part_time)
+    create(:course_option, site: first_site, course: @multi_site_course, study_mode: :full_time)
+    create(:course_option, site: second_site, course: @multi_site_course, study_mode: :part_time)
+    create(:course_option, site: second_site, course: @multi_site_course, study_mode: :full_time)
+  end
+end


### PR DESCRIPTION
## Context

Starting in the 2025 Recruitment Cycle we will be hiding the `CourseSiteStep` (picking a placement school) in the `CourseSelectionWizard` for certain providers.
For these providers' courses, we will automatically choose a placement school. This happens already if the provider has only one placement school.
We will also hide the Location row of the Application Review component if we have automatically selected a School.

## Changes proposed in this pull request

1. Automatically choose a placement school unless the provider is `selectable_school`.
2. Enable the feature to be enabled only after the 2024 recruitment cycle
3. Set `ApplicationChoice#school_placement_auto_selected` for applications to providers that have `selectable_school` set to false.
4. Hide the Location row in the Course Review if the School was automatically selected

## Guidance to review

1. Selectable school factory defaults
Q: Should factories reflect the most common conditions or the most complex conditions by default?
For example, adding selectable_school to Provider.
In production the default will be false.
99%+ providers will have this as false.
This makes the Course selection journey simpler. But it also means we have to set selectable_school to true if we want to test existing examples.
Would you set the factory by default to true or false

2. Whats the best way to clean up the recruitment cycle check for enabling the feature? 

#### Testing

The environment is already set up to after apply opens in 2025.

|Provider|id|course|selectable_school|sites|
|---|---|---|---|---|
|NIoT@Harris Initial Teacher Education|16| any|`true`|  many|
|Keele and North Staffordshire Teacher Education (24J)| 3|  Primary (3-7) (2Q5R) | `false`|3|


### Video
As described above, Harris is `selectable_school` `true` and Keele is `selectable_school` `false`

[selectable_school-2025.webm](https://github.com/user-attachments/assets/195aafe9-c4bc-448f-89c2-6b7f0afa943e)


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
