### PR TITLE
Fix experiences & histories when submitting choice

### DIFF
--- a/app/services/candidate_interface/submit_application_choice.rb
+++ b/app/services/candidate_interface/submit_application_choice.rb
@@ -17,9 +17,9 @@ module CandidateInterface
         application_form.update!(submitted_at:) unless application_form.submitted_applications?
         application_choice.update!(sent_to_provider_at:)
         application_choice.update!(reject_by_default_at: inactive_date, reject_by_default_days: inactive_days)
-        application_choice.work_experiences = application_form.application_work_experiences.map(&:dup)
-        application_choice.volunteering_experiences = application_form.application_volunteering_experiences.map(&:dup)
-        application_choice.work_history_breaks = application_form.application_work_history_breaks.map(&:dup)
+        set_work_experiences
+        set_volunteering_experiences
+        set_work_history_breaks
         ApplicationStateChange.new(application_choice).send_to_provider!
 
         SendNewApplicationEmailToProvider.new(application_choice:).call
@@ -33,5 +33,31 @@ module CandidateInterface
     alias effective_date current_time
     alias submitted_at current_time
     alias sent_to_provider_at current_time
+
+  private
+
+    def set_work_experiences
+      if application_choice.work_experiences.any?
+        application_choice.work_experiences.map(&:delete)
+      end
+
+      application_choice.work_experiences = application_form.application_work_experiences.map(&:dup)
+    end
+
+    def set_volunteering_experiences
+      if application_choice.volunteering_experiences.any?
+        application_choice.volunteering_experiences.map(&:delete)
+      end
+
+      application_choice.volunteering_experiences = application_form.application_volunteering_experiences.map(&:dup)
+    end
+
+    def set_work_history_breaks
+      if application_choice.work_history_breaks.any?
+        application_choice.work_history_breaks.map(&:delete)
+      end
+
+      application_choice.work_history_breaks = application_form.application_work_history_breaks.map(&:dup)
+    end
   end
 end

--- a/spec/services/candidate_interface/submit_application_choice_spec.rb
+++ b/spec/services/candidate_interface/submit_application_choice_spec.rb
@@ -93,6 +93,31 @@ RSpec.describe CandidateInterface::SubmitApplicationChoice do
         )
       end
 
+      it 'duplicates the work experiences on the application_choice even if work_experiences exist' do
+        work_experience = create(
+          :application_work_experience,
+          experienceable: application_form,
+        )
+
+        choice_work_experience = create(
+          :application_work_experience,
+          experienceable: application_choice,
+        )
+
+        unexpected_ids = application_form.application_work_experiences.ids << choice_work_experience.id
+
+        expect {
+          submit_application
+        }.not_to change(application_choice.work_experiences, :count)
+
+        expect(application_choice.work_experiences.pluck(:details)).to eq(
+          [work_experience.details],
+        )
+        expect(application_choice.work_experiences.ids).not_to eq(
+          unexpected_ids,
+        )
+      end
+
       it 'duplicates the volunteering experiences on the application_choice' do
         volunteering_experience = create(
           :application_volunteering_experience,
@@ -111,6 +136,31 @@ RSpec.describe CandidateInterface::SubmitApplicationChoice do
         )
       end
 
+      it 'duplicates the volunteering experiences on the application_choice even if volunteering_experiences exist' do
+        volunteering_experience = create(
+          :application_volunteering_experience,
+          experienceable: application_form,
+        )
+
+        choice_volunteering_experience = create(
+          :application_volunteering_experience,
+          experienceable: application_choice,
+        )
+
+        unexpected_ids = application_form.application_volunteering_experiences.ids << choice_volunteering_experience.id
+
+        expect {
+          submit_application
+        }.not_to change(application_choice.volunteering_experiences, :count)
+
+        expect(application_choice.volunteering_experiences.pluck(:details)).to eq(
+          [volunteering_experience.details],
+        )
+        expect(application_choice.volunteering_experiences.ids).not_to eq(
+          unexpected_ids,
+        )
+      end
+
       it 'duplicates the work history breaks on the application_choice' do
         work_history_break = create(
           :application_work_history_break,
@@ -126,6 +176,31 @@ RSpec.describe CandidateInterface::SubmitApplicationChoice do
         )
         expect(application_choice.work_history_breaks.ids).not_to eq(
           application_form.application_work_history_breaks.ids,
+        )
+      end
+
+      it 'duplicates the work history breaks on the application_choice even if work history breaks exist' do
+        work_history_break = create(
+          :application_work_history_break,
+          breakable: application_form,
+        )
+
+        choice_work_history_break = create(
+          :application_work_history_break,
+          breakable: application_choice,
+        )
+
+        unexpected_ids = application_form.application_work_history_breaks.ids << choice_work_history_break.id
+
+        expect {
+          submit_application
+        }.not_to change(application_choice.work_history_breaks, :count)
+
+        expect(application_choice.work_history_breaks.pluck(:reason)).to eq(
+          [work_history_break.reason],
+        )
+        expect(application_choice.work_history_breaks.ids).not_to eq(
+          unexpected_ids,
         )
       end
     end


### PR DESCRIPTION
## Context

There seems to be a very rare edge case when submitting an application choice. If the choice has work experiences or histories already we cannot dup the work experiences and histories from the application_form.

This commit fixes this by removing any existing work experiences and histories from the application choice one by one before duping the application form ones.

Because we set the work experiences on the choice with the `=` sign. This will try to delete all records existing and set new records. But there's a `PG::NotNullViolation` on the `experienceable_type` that stops the `delete_all` method. We need to delete a record one by one.

Sentry error https://dfe-teacher-services.sentry.io/issues/5763701042/?notification_uuid=af1ee505-a0d7-4b60-a9e3-462a23fad910&project=1765973&referrer=assigned_activity-slack


## Changes proposed in this pull request

Delete any existing records on the application choice before duping the application form ones

## Guidance to review

This is quite tricky to test. The specs should have covered the edge case.
I have not managed to figure out how this happened in production.
But a simple application choice submission won't hurt on local or review.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
