### PR TITLE
Renamed continuous_applications_details_path instances

### DIFF
--- a/app/components/candidate_interface/applications_left_message_component.rb
+++ b/app/components/candidate_interface/applications_left_message_component.rb
@@ -21,7 +21,7 @@ module CandidateInterface
     def incomplete_details_message
       return if @completed_application_form_details.valid?
 
-      link = govuk_link_to('your details', candidate_interface_continuous_applications_details_path)
+      link = govuk_link_to('your details', candidate_interface_details_path)
       t('candidate_interface.applications_left_message.incomplete_details_message', link:).html_safe
     end
 

--- a/app/components/candidate_interface/complete_section_component.html.erb
+++ b/app/components/candidate_interface/complete_section_component.html.erb
@@ -1,6 +1,6 @@
 <% if @section_policy.can_edit? %>
   <% if submitted_applications? && form.object.completed.present? %>
-    <%= govuk_button_link_to 'Continue', candidate_interface_continuous_applications_details_path %>
+    <%= govuk_button_link_to 'Continue', candidate_interface_details_path %>
   <% else %>
     <div class="govuk-!-width-two-thirds">
       <%= form.govuk_collection_radio_buttons :completed,

--- a/app/controllers/candidate_interface/adviser_sign_ups_controller.rb
+++ b/app/controllers/candidate_interface/adviser_sign_ups_controller.rb
@@ -11,7 +11,7 @@ module CandidateInterface
 
         track_adviser_sign_up
 
-        redirect_to candidate_interface_continuous_applications_details_path
+        redirect_to candidate_interface_details_path
       else
         track_validation_error(@adviser_sign_up)
         render :new

--- a/app/controllers/candidate_interface/application_feedback_controller.rb
+++ b/app/controllers/candidate_interface/application_feedback_controller.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   class ApplicationFeedbackController < CandidateInterfaceController
     def new
-      redirect_to candidate_interface_continuous_applications_details_path if params[:original_controller].nil?
+      redirect_to candidate_interface_details_path if params[:original_controller].nil?
       @application_feedback_form = CandidateInterface::ApplicationFeedbackForm.new(
         path: params[:path],
         page_title: params[:page_title],

--- a/app/controllers/candidate_interface/apply_from_find_controller.rb
+++ b/app/controllers/candidate_interface/apply_from_find_controller.rb
@@ -16,7 +16,7 @@ module CandidateInterface
       @course = apply_from_find.course
 
       if apply_from_find.candidate_has_application_in_wrong_cycle?
-        redirect_to candidate_interface_continuous_applications_details_path
+        redirect_to candidate_interface_details_path
       elsif apply_from_find.course_in_apply_database_and_candidate_signed_in?
         current_candidate.update!(course_from_find_id: @course.id)
         redirect_to candidate_interface_interstitial_path

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -62,7 +62,7 @@ module CandidateInterface
     end
 
     def redirect_to_details_if_submitted
-      redirect_to candidate_interface_continuous_applications_details_path if current_application.submitted?
+      redirect_to candidate_interface_details_path if current_application.submitted?
     end
 
     def redirect_to_post_offer_dashboard_if_accepted_deferred_or_recruited
@@ -83,7 +83,7 @@ module CandidateInterface
       if current_application.application_choices.any? && completed_application_form.valid?
         redirect_to candidate_interface_continuous_applications_choices_path
       else
-        redirect_to candidate_interface_continuous_applications_details_path
+        redirect_to candidate_interface_details_path
       end
     end
 

--- a/app/controllers/candidate_interface/carry_over_controller.rb
+++ b/app/controllers/candidate_interface/carry_over_controller.rb
@@ -9,7 +9,7 @@ module CandidateInterface
 
     def create
       CarryOverApplication.new(current_application).call
-      redirect_to candidate_interface_continuous_applications_details_path
+      redirect_to candidate_interface_details_path
     end
   end
 end

--- a/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
@@ -16,7 +16,7 @@ module CandidateInterface
       def complete
         @component_instance = ChooseEflReviewComponent.call(english_proficiency)
         @section_complete_form = SectionCompleteForm.new(completion_params)
-        @return_to = return_to_after_edit(default: candidate_interface_continuous_applications_details_path)
+        @return_to = return_to_after_edit(default: candidate_interface_details_path)
 
         if @section_complete_form.save(current_application, :efl_completed)
           redirect_to @return_to[:back_path]

--- a/app/controllers/candidate_interface/gcse/type_controller.rb
+++ b/app/controllers/candidate_interface/gcse/type_controller.rb
@@ -87,7 +87,7 @@ module CandidateInterface
 
     def redirect_to_application_form_if_current_qualification_missing
       if current_qualification.blank?
-        redirect_to candidate_interface_continuous_applications_details_path
+        redirect_to candidate_interface_details_path
       end
     end
 

--- a/app/controllers/candidate_interface/personal_statement_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement_controller.rb
@@ -26,7 +26,7 @@ module CandidateInterface
 
       if @becoming_a_teacher_form.save(current_application)
         if @becoming_a_teacher_form.blank?
-          redirect_to candidate_interface_continuous_applications_details_path
+          redirect_to candidate_interface_details_path
         else
           redirect_to candidate_interface_becoming_a_teacher_show_path
         end
@@ -46,7 +46,7 @@ module CandidateInterface
 
       if @becoming_a_teacher_form.save(current_application)
         if @becoming_a_teacher_form.blank?
-          redirect_to candidate_interface_continuous_applications_details_path
+          redirect_to candidate_interface_details_path
         else
           redirect_to @return_to[:back_path]
         end

--- a/app/controllers/candidate_interface/prefill_application_form_controller.rb
+++ b/app/controllers/candidate_interface/prefill_application_form_controller.rb
@@ -16,7 +16,7 @@ module CandidateInterface
           return redirect_to candidate_interface_continuous_applications_choices_path
         end
 
-        redirect_to candidate_interface_continuous_applications_details_path
+        redirect_to candidate_interface_details_path
       else
         track_validation_error(@prefill_application_or_not_form)
         render :new
@@ -29,7 +29,7 @@ module CandidateInterface
       application_form = current_candidate.application_forms.first
       return if application_form.nil? || application_form.blank_application?
 
-      redirect_to candidate_interface_continuous_applications_details_path
+      redirect_to candidate_interface_details_path
     end
 
     def prefill_candidate_application_form

--- a/app/controllers/candidate_interface/restructured_work_history/review_controller.rb
+++ b/app/controllers/candidate_interface/restructured_work_history/review_controller.rb
@@ -9,7 +9,7 @@ module CandidateInterface
     def complete
       @application_form = current_application
       @section_complete_form = SectionCompleteForm.new(form_params)
-      @return_to = return_to_after_edit(default: candidate_interface_continuous_applications_details_path)
+      @return_to = return_to_after_edit(default: candidate_interface_details_path)
 
       if @section_complete_form.save(current_application, :work_history_completed)
         redirect_to_new_continuous_applications_if_eligible

--- a/app/controllers/candidate_interface/section_controller.rb
+++ b/app/controllers/candidate_interface/section_controller.rb
@@ -24,12 +24,12 @@ module CandidateInterface
     def verify_edit_authorized_section
       unless @section_policy.can_edit?
         Rails.logger.info("Not authorized for controller '#{@section_policy.controller_path}' and action '#{@section_policy.action_name}'")
-        redirect_to candidate_interface_continuous_applications_details_path
+        redirect_to candidate_interface_details_path
       end
     end
 
     def verify_delete_authorized_section
-      redirect_to candidate_interface_continuous_applications_details_path unless @section_policy.can_delete?
+      redirect_to candidate_interface_details_path unless @section_policy.can_delete?
     end
   end
 end

--- a/app/controllers/concerns/back_links.rb
+++ b/app/controllers/concerns/back_links.rb
@@ -18,7 +18,7 @@ module BackLinks
     if request.path.match?(/withdraw/)
       candidate_interface_continuous_applications_choices_path
     else
-      candidate_interface_continuous_applications_details_path
+      candidate_interface_details_path
     end
   end
 

--- a/app/filters/already_carried_over_filter.rb
+++ b/app/filters/already_carried_over_filter.rb
@@ -1,11 +1,11 @@
 class AlreadyCarriedOverFilter < ApplicationFilter
-  delegate :candidate_interface_continuous_applications_details_path,
+  delegate :candidate_interface_details_path,
            :candidate_interface_start_carry_over_path,
            to: :controller
 
   def call
     return if current_application.carry_over?
 
-    redirect_to candidate_interface_continuous_applications_details_path
+    redirect_to candidate_interface_details_path
   end
 end

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -28,7 +28,7 @@ class NavigationItems
         [
           NavigationItem.new(
             t('page_titles.your_details'),
-            candidate_interface_continuous_applications_details_path,
+            candidate_interface_details_path,
             current_controller.respond_to?(:choices_controller?) ? !current_controller.choices_controller? : false,
           ),
           NavigationItem.new(

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -8,7 +8,7 @@ module ViewHelper
 
     text = if force_text.present?
              body
-           elsif url.to_s.end_with?(candidate_interface_continuous_applications_details_path)
+           elsif url.to_s.end_with?(candidate_interface_details_path)
              'Back to your details'
            elsif url.to_s.end_with?(candidate_interface_continuous_applications_choices_path)
              'Back to your applications'

--- a/app/validators/incomplete_details_validator.rb
+++ b/app/validators/incomplete_details_validator.rb
@@ -20,6 +20,6 @@ class IncompleteDetailsValidator < ActiveModel::EachValidator
 private
 
   def link_to_details
-    govuk_link_to('complete your details', Rails.application.routes.url_helpers.candidate_interface_continuous_applications_details_path)
+    govuk_link_to('complete your details', Rails.application.routes.url_helpers.candidate_interface_details_path)
   end
 end

--- a/app/validators/incomplete_primary_course_details_validator.rb
+++ b/app/validators/incomplete_primary_course_details_validator.rb
@@ -31,6 +31,6 @@ private
   end
 
   def link_to_details
-    govuk_link_to('Add your science GCSE grade (or equivalent)', Rails.application.routes.url_helpers.candidate_interface_continuous_applications_details_path)
+    govuk_link_to('Add your science GCSE grade (or equivalent)', Rails.application.routes.url_helpers.candidate_interface_details_path)
   end
 end

--- a/app/views/candidate_interface/adviser_sign_ups/new.html.erb
+++ b/app/views/candidate_interface/adviser_sign_ups/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.new_adviser_sign_up'), @adviser_sign_up.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_continuous_applications_details_path, t('application_form.adviser_sign_up.back')) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_details_path, t('application_form.adviser_sign_up.back')) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/course_choices/review_enic_interruption/_waiting_maybe.html.erb
+++ b/app/views/candidate_interface/course_choices/review_enic_interruption/_waiting_maybe.html.erb
@@ -10,7 +10,7 @@
     </div>
 
     <div class="govuk-button-group app-course-choice__confirm-submission">
-      <%= govuk_button_to(t('review_enic_interruption.waiting_maybe.enter_enic'), candidate_interface_continuous_applications_details_path, method: :get) %>
+      <%= govuk_button_to(t('review_enic_interruption.waiting_maybe.enter_enic'), candidate_interface_details_path, method: :get) %>
       <%= govuk_link_to(t('review_enic_interruption.waiting_maybe.without_entering_enic'), candidate_interface_course_choices_course_review_and_submit_path(@application_choice.id)) %>
     </div>
   </div>

--- a/app/views/candidate_interface/decisions/withdraw.html.erb
+++ b/app/views/candidate_interface/decisions/withdraw.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.decisions.withdraw') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_continuous_applications_details_path, back_link_text, force_text: true) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_details_path, back_link_text, force_text: true) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/feedback_form/thank_you.html.erb
+++ b/app/views/candidate_interface/feedback_form/thank_you.html.erb
@@ -8,7 +8,7 @@
     </h1>
 
     <p class="govuk-body">
-      <%= govuk_link_to 'Go to your application dashboard', candidate_interface_continuous_applications_details_path %>
+      <%= govuk_link_to 'Go to your application dashboard', candidate_interface_details_path %>
     </p>
   </div>
 </div>

--- a/app/views/candidate_interface/personal_statement/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/show.html.erb
@@ -49,7 +49,7 @@
       section_review: @application_form.reviewable?(:becoming_a_teacher),
     )) %>
   <% else %>
-    <%= govuk_button_link_to 'Continue', candidate_interface_continuous_applications_details_path %>
+    <%= govuk_button_link_to 'Continue', candidate_interface_details_path %>
   <% end %>
 
 <% end %>

--- a/app/views/candidate_interface/submitted_application_form/review_submitted.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/review_submitted.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, t('page_titles.submitted_application') %>
 
-<% content_for :before_content, govuk_back_link_to(candidate_interface_continuous_applications_details_path, back_link_text, force_text: true) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_details_path, back_link_text, force_text: true) %>
 
 <h1 class="govuk-heading-xl">
   <%= t('page_titles.submitted_application') %>

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -58,7 +58,7 @@ namespace :candidate_interface, path: '/candidate' do
   end
 
   scope '/application' do
-    get '/details', to: 'details#index', as: :continuous_applications_details
+    get '/details', to: 'details#index', as: :details
     get '/choices(/:current_tab_name)', to: 'application_choices#index', as: :continuous_applications_choices
 
     get '/prefill', to: 'prefill_application_form#new'

--- a/spec/controllers/concerns/back_links_spec.rb
+++ b/spec/controllers/concerns/back_links_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe BackLinks do
       let(:application_form) { create(:application_form) }
 
       it 'returns path to application details' do
-        expect(instance.send(:application_form_path)).to eq routes.candidate_interface_continuous_applications_details_path
+        expect(instance.send(:application_form_path)).to eq routes.candidate_interface_details_path
       end
     end
 

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ViewHelper do
 
     context 'when path ends with candidate/application/details' do
       it 'renders a link with the text Back to your details' do
-        anchor_tag = helper.govuk_back_link_to(candidate_interface_continuous_applications_details_path)
+        anchor_tag = helper.govuk_back_link_to(candidate_interface_details_path)
 
         expect(anchor_tag).to eq('<a class="govuk-back-link govuk-!-display-none-print" href="/candidate/application/details">Back to your details</a>')
       end

--- a/spec/requests/candidate_interface/after_sign_in_redirects_spec.rb
+++ b/spec/requests/candidate_interface/after_sign_in_redirects_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'After sign in redirects' do
 
       it 'redirects to application details path' do
         get candidate_interface_interstitial_path
-        expect(response).to redirect_to(candidate_interface_continuous_applications_details_path)
+        expect(response).to redirect_to(candidate_interface_details_path)
       end
     end
 

--- a/spec/requests/candidate_interface/authentication_spec.rb
+++ b/spec/requests/candidate_interface/authentication_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe 'Authentication for candidates' do
   end
 
   it 'redirects the user if the token is invalid' do
-    get candidate_interface_continuous_applications_details_path(token: '123')
+    get candidate_interface_details_path(token: '123')
 
     expect(response).to have_http_status(:found)
   end
 
   it 'redirects the user if the token is missing from the URL' do
-    get candidate_interface_continuous_applications_details_path
+    get candidate_interface_details_path
 
     expect(response).to have_http_status(:found)
   end
@@ -22,7 +22,7 @@ RSpec.describe 'Authentication for candidates' do
     magic_link_token = MagicLinkToken.new
     create(:candidate, magic_link_token: magic_link_token.encrypted, magic_link_token_sent_at: 2.days.ago)
 
-    get candidate_interface_continuous_applications_details_path(token: magic_link_token.raw)
+    get candidate_interface_details_path(token: magic_link_token.raw)
 
     expect(response).to have_http_status(:found)
   end

--- a/spec/requests/candidate_interface/cycle_redirects_spec.rb
+++ b/spec/requests/candidate_interface/cycle_redirects_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Cycle redirects' do
   let(:candidate) { create(:candidate) }
   let(:continuous_applications_routes) do
     [
-      candidate_interface_continuous_applications_details_path,
+      candidate_interface_details_path,
       candidate_interface_continuous_applications_choices_path,
     ]
   end
@@ -27,14 +27,14 @@ RSpec.describe 'Cycle redirects' do
     context 'when accessing the carry over route', time: mid_cycle do
       it 'redirects to the application details' do
         get candidate_interface_start_carry_over_path
-        expect(response).to redirect_to(candidate_interface_continuous_applications_details_path)
+        expect(response).to redirect_to(candidate_interface_details_path)
       end
     end
 
     context 'when accessing the complete route' do
       it 'redirects to the application details' do
         get candidate_interface_application_complete_path
-        expect(response).to redirect_to(candidate_interface_continuous_applications_details_path)
+        expect(response).to redirect_to(candidate_interface_details_path)
       end
     end
   end

--- a/spec/requests/candidate_interface/gcse/type_controller_spec.rb
+++ b/spec/requests/candidate_interface/gcse/type_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'CandidateInterface::GCSE::TypeController' do
       %w[maths english science].each do |subject|
         get "/candidate/application/gcse/#{subject}/edit"
 
-        expect(response).to redirect_to candidate_interface_continuous_applications_details_path
+        expect(response).to redirect_to candidate_interface_details_path
       end
     end
   end
@@ -22,7 +22,7 @@ RSpec.describe 'CandidateInterface::GCSE::TypeController' do
       %w[maths english science].each do |subject|
         patch "/candidate/application/gcse/#{subject}/edit"
 
-        expect(response).to redirect_to candidate_interface_continuous_applications_details_path
+        expect(response).to redirect_to candidate_interface_details_path
       end
     end
   end

--- a/spec/requests/candidate_interface/prefill_application_form_controller_spec.rb
+++ b/spec/requests/candidate_interface/prefill_application_form_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe CandidateInterface::PrefillApplicationFormController do
       get candidate_interface_prefill_path
 
       expect(response).to have_http_status(:found)
-      expect(response).to redirect_to(candidate_interface_continuous_applications_details_path)
+      expect(response).to redirect_to(candidate_interface_details_path)
     end
   end
 

--- a/spec/requests/provider_interface/provider_user_impersonates_candidate_spec.rb
+++ b/spec/requests/provider_interface/provider_user_impersonates_candidate_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'POST /provider/candidates/:id/impersonate' do
       post provider_interface_impersonate_candidate_path(unrelated_application.application_form.candidate)
       expect(response).to have_http_status :found
 
-      get candidate_interface_continuous_applications_details_path
+      get candidate_interface_details_path
       expect(response).to have_http_status :found # no candidate session redirects to candidate_interface_path
     end
 

--- a/spec/services/candidate_interface/application_choice_submission_spec.rb
+++ b/spec/services/candidate_interface/application_choice_submission_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe CandidateInterface::ApplicationChoiceSubmission do
       end
 
       def link_to_details_error_message
-        link_to_details = govuk_link_to('Add your science GCSE grade (or equivalent)', Rails.application.routes.url_helpers.candidate_interface_continuous_applications_details_path)
+        link_to_details = govuk_link_to('Add your science GCSE grade (or equivalent)', Rails.application.routes.url_helpers.candidate_interface_details_path)
         t('activemodel.errors.models.candidate_interface/application_choice_submission.attributes.application_choice.incomplete_details_including_primary_course_details', link_to_details:)
       end
 
@@ -280,7 +280,7 @@ RSpec.describe CandidateInterface::ApplicationChoiceSubmission do
 
       def incomplete_details_error_message
         <<~MSG.chomp
-          You cannot submit this application until you #{govuk_link_to('complete your details', Rails.application.routes.url_helpers.candidate_interface_continuous_applications_details_path)}.
+          You cannot submit this application until you #{govuk_link_to('complete your details', Rails.application.routes.url_helpers.candidate_interface_details_path)}.
 
           Your application will be saved as a draft while you finish adding your details.
         MSG

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -36,7 +36,7 @@ module CandidateHelper
     #
     ##########################################
 
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
 
     click_link_or_button t('page_titles.personal_information.heading')
     candidate_fills_in_personal_details(international:)
@@ -122,7 +122,7 @@ module CandidateHelper
     #
     ###############################################
 
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
 
     click_link_or_button 'Science GCSE or equivalent'
     candidate_explains_a_missing_gcse
@@ -199,7 +199,7 @@ module CandidateHelper
   end
 
   def mark_references_as_complete
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
 
     click_link_or_button 'References to be requested if you accept an offer'
 
@@ -402,7 +402,7 @@ module CandidateHelper
     #
     ##########################################
 
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
 
     click_link_or_button t('page_titles.personal_information.heading')
     candidate_fills_in_personal_details(international:)
@@ -654,7 +654,7 @@ module CandidateHelper
       relationship: 'First boss',
     )
 
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def candidate_fills_in_their_maths_gcse
@@ -763,7 +763,7 @@ module CandidateHelper
   end
 
   def then_i_can_add_course_choices
-    expect(page).to have_current_path(candidate_interface_continuous_applications_details_path)
+    expect(page).to have_current_path(candidate_interface_details_path)
     click_link_or_button 'Your applications'
     expect(page).to have_current_path(candidate_interface_continuous_applications_choices_path)
     expect(page).to have_content('You can add up to 4 applications at a time.')
@@ -780,7 +780,7 @@ module CandidateHelper
   end
 
   def then_i_am_on_your_details_page
-    expect(page).to have_current_path(candidate_interface_continuous_applications_details_path)
+    expect(page).to have_current_path(candidate_interface_details_path)
   end
 
   def then_i_am_on_the_post_offer_dashboard

--- a/spec/support/test_helpers/efl_helper.rb
+++ b/spec/support/test_helpers/efl_helper.rb
@@ -4,7 +4,7 @@ module EFLHelper
       first_nationality: 'Hong Konger',
       second_nationality: 'Pakistani',
     )
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def when_i_click_on_the_efl_section_link

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_becomes_eligible_for_adviser_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_becomes_eligible_for_adviser_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Candidate becomes eligible for an adviser' do
   end
 
   def and_i_visit_the_application_form_page
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def and_the_candidate_does_not_matchback

--- a/spec/system/candidate_interface/adviser_sign_up/candidate_signs_up_for_an_adviser_spec.rb
+++ b/spec/system/candidate_interface/adviser_sign_up/candidate_signs_up_for_an_adviser_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe 'Candidate signs up for an adviser', :js do
   end
 
   def and_i_visit_your_details_page
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def when_i_click_on_the_adviser_cta
@@ -110,7 +110,7 @@ RSpec.describe 'Candidate signs up for an adviser', :js do
   end
 
   def then_i_am_redirected_to_your_details_page
-    expect(page).to have_current_path(candidate_interface_continuous_applications_details_path)
+    expect(page).to have_current_path(candidate_interface_details_path)
   end
 
   def and_i_see_the_success_message

--- a/spec/system/candidate_interface/candidate_session_timeout_spec.rb
+++ b/spec/system/candidate_interface/candidate_session_timeout_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Candidate viewing booked interviews' do
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def and_seven_days_pass

--- a/spec/system/candidate_interface/candidate_unsubscribe_from_emails_spec.rb
+++ b/spec/system/candidate_interface/candidate_unsubscribe_from_emails_spec.rb
@@ -73,7 +73,7 @@ private
   end
   alias_method :then_i_see_unsubscribe_confirmation, :and_i_see_unsubscribe_confirmation
   def and_i_am_on_application_details_page
-    expect(page).to have_current_path candidate_interface_continuous_applications_details_path, ignore_query: true
+    expect(page).to have_current_path candidate_interface_details_path, ignore_query: true
   end
 
   def and_i_am_on_the_sign_in_page

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_after_rejecting_offer_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_after_rejecting_offer_between_cycles_spec.rb
@@ -71,7 +71,7 @@ private
 
   def and_i_cannot_navigate_to_the_carry_over_page
     visit candidate_interface_start_carry_over_path
-    expect(page).to have_current_path candidate_interface_continuous_applications_details_path
+    expect(page).to have_current_path candidate_interface_details_path
   end
 
   def and_i_can_navigate_to_the_application_choices_page
@@ -107,6 +107,6 @@ private
 
   def and_i_am_able_to_carry_over_my_application
     click_on 'Update your details'
-    expect(page).to have_current_path candidate_interface_continuous_applications_details_path
+    expect(page).to have_current_path candidate_interface_details_path
   end
 end

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_different_application_states_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_different_application_states_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe 'Carry over application to a new cycle in different states', time
   end
 
   def and_i_am_in_your_details_page
-    expect(page).to have_current_path(candidate_interface_continuous_applications_details_path)
+    expect(page).to have_current_path(candidate_interface_details_path)
   end
 
   def when_i_visit_any_page

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_spec.rb
@@ -179,7 +179,7 @@ private
   end
 
   def then_i_am_redirected_to_continuous_application_details_page
-    expect(page).to have_current_path candidate_interface_continuous_applications_details_path
+    expect(page).to have_current_path candidate_interface_details_path
     then_i_see_a_copy_of_my_application
   end
 
@@ -225,7 +225,7 @@ private
   def and_i_sign_in_again
     logout
     login_as(current_candidate)
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def and_my_application_is_on_the_new_cycle

--- a/spec/system/candidate_interface/carry_over/candidate_does_not_act_on_offer_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_does_not_act_on_offer_spec.rb
@@ -147,7 +147,7 @@ private
 
   def and_i_can_carry_over_my_application
     click_on 'Update your details'
-    expect(page).to have_current_path candidate_interface_continuous_applications_details_path
+    expect(page).to have_current_path candidate_interface_details_path
   end
 
   def then_i_cannot_carry_over_my_application
@@ -164,6 +164,6 @@ private
   end
 
   def then_i_am_redirected_to_details_page
-    expect(page).to have_current_path candidate_interface_continuous_applications_details_path
+    expect(page).to have_current_path candidate_interface_details_path
   end
 end

--- a/spec/system/candidate_interface/carry_over/candidate_has_application_rejected_by_default_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_has_application_rejected_by_default_spec.rb
@@ -122,12 +122,12 @@ private
   end
 
   def then_i_am_redirected_to_details_page
-    expect(page).to have_current_path candidate_interface_continuous_applications_details_path
+    expect(page).to have_current_path candidate_interface_details_path
   end
 
   def and_i_can_carry_over_my_application
     click_on 'Update your details'
-    expect(page).to have_current_path candidate_interface_continuous_applications_details_path
+    expect(page).to have_current_path candidate_interface_details_path
   end
 
   def when_the_reject_by_default_deadline_has_passed

--- a/spec/system/candidate_interface/carry_over/candidate_receives_offer_betwen_cycles_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_receives_offer_betwen_cycles_spec.rb
@@ -81,7 +81,7 @@ private
   def and_i_can_carry_over_my_application
     expect(page).to have_current_path candidate_interface_start_carry_over_path
     click_on 'Update your details'
-    expect(page).to have_current_path candidate_interface_continuous_applications_details_path
+    expect(page).to have_current_path candidate_interface_details_path
   end
 
   def when_i_visit_the_start_carry_over_page_directly

--- a/spec/system/candidate_interface/carry_over/candidate_views_and_withdraws_after_apply_deadline_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_views_and_withdraws_after_apply_deadline_spec.rb
@@ -75,7 +75,7 @@ private
 
   def and_i_can_carry_over_my_application
     click_on 'Update your details'
-    expect(page).to have_current_path candidate_interface_continuous_applications_details_path
+    expect(page).to have_current_path candidate_interface_details_path
     expect(@candidate.current_application.previous_application_form_id).to eq @application_form.id
   end
 end

--- a/spec/system/candidate_interface/course_selection/candidate_changes_course_and_reaches_limit_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_changes_course_and_reaches_limit_spec.rb
@@ -79,6 +79,6 @@ RSpec.describe 'Changing a course' do
   end
 
   def when_i_visit_my_details_page
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 end

--- a/spec/system/candidate_interface/course_selection/candidate_deletes_application_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_deletes_application_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'Candidate edits their choice section' do
   end
 
   def and_visit_my_application_page
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def and_if_i_try_manually_to_enter_on_delete_the_url_for_my_submitted_choice

--- a/spec/system/candidate_interface/course_selection/candidate_reaching_reapplication_limit_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_reaching_reapplication_limit_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Selecting a course' do
   end
 
   def when_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def and_i_click_on_course_choices

--- a/spec/system/candidate_interface/course_selection/candidate_reapplying_to_a_course_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_reapplying_to_a_course_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'Selecting a course' do
   end
 
   def when_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def and_i_click_on_course_choices

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'Selecting a course' do
   end
 
   def when_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def and_i_click_on_course_choices

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_closed_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_closed_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Selecting a course' do
   end
 
   def when_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def and_i_click_on_course_choices

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_full_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_full_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Selecting a course' do
   end
 
   def when_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def and_i_click_on_course_choices

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_with_multiple_sites_and_unselectable_school_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_with_multiple_sites_and_unselectable_school_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Selecting a course with multiple sites when the provider is not 
   end
 
   def when_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def and_i_click_on_course_choices

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_with_multiple_sites_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_with_multiple_sites_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Selecting a course with multiple sites' do
   end
 
   def when_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def and_i_click_on_course_choices

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_with_multiple_study_modes_sites_and_unselectable_school_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_with_multiple_study_modes_sites_and_unselectable_school_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Selecting a course with multiple study modes and sites when the 
   end
 
   def when_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def and_i_click_on_course_choices

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_duplicate_course_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_duplicate_course_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'Selecting a course' do
   end
 
   def when_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def and_i_click_on_course_choices

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_duplicate_course_when_editing_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_duplicate_course_when_editing_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Selecting a course' do
   end
 
   def when_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def and_i_click_on_course_choices

--- a/spec/system/candidate_interface/course_selection/candidate_visiting_selection_flow_for_selected_course_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_visiting_selection_flow_for_selected_course_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Selecting a course' do
   end
 
   def when_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def and_i_visit_the_study_mode_selection_for_my_existing_course_selection

--- a/spec/system/candidate_interface/entering_details/candidate_account_locking_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_account_locking_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Candidate account locking' do
   end
 
   def and_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def and_my_account_is_locked

--- a/spec/system/candidate_interface/entering_details/candidate_becoming_a_teacher_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_becoming_a_teacher_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Entering "Why do you want to be a teacher?"' do
   end
 
   def and_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def when_i_click_on_becoming_a_teacher

--- a/spec/system/candidate_interface/entering_details/candidate_can_edit_some_sections_after_first_submission_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_can_edit_some_sections_after_first_submission_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'A candidate can edit some sections after first submission' do
   end
 
   def and_i_visit_your_details_page
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def when_i_click_on_the_section_in_your_details_page

--- a/spec/system/candidate_interface/entering_details/candidate_can_not_edit_some_personal_details_after_first_submission_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_can_not_edit_some_personal_details_after_first_submission_spec.rb
@@ -89,5 +89,5 @@ def when_i_try_to_visit_the_immigration_status_page
 end
 
 def then_i_am_redirected_to_your_details_page
-  expect(page).to have_current_path candidate_interface_continuous_applications_details_path
+  expect(page).to have_current_path candidate_interface_details_path
 end

--- a/spec/system/candidate_interface/entering_details/candidate_can_not_edit_some_sections_after_first_submission_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_can_not_edit_some_sections_after_first_submission_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'A candidate can not edit some sections after first submission' d
   end
 
   def and_i_visit_your_details_page
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def when_i_click_on_the_section_in_your_details_page
@@ -196,7 +196,7 @@ RSpec.describe 'A candidate can not edit some sections after first submission' d
   end
 
   def and_i_be_redirected_to_your_details_page
-    expect(page).to have_current_path candidate_interface_continuous_applications_details_path
+    expect(page).to have_current_path candidate_interface_details_path
   end
 
   def section_status

--- a/spec/system/candidate_interface/entering_details/candidate_changes_contact_details_address_from_international_to_uk_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_changes_contact_details_address_from_international_to_uk_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Candidate updates their contact information from an internationa
   end
 
   def and_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def when_i_click_on_contact_information

--- a/spec/system/candidate_interface/entering_details/candidate_choosing_no_volunteering_and_school_experience_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_choosing_no_volunteering_and_school_experience_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Choosing no volunteering and school experience' do
   end
 
   def and_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def when_i_click_on_volunteering_with_children_and_young_people

--- a/spec/system/candidate_interface/entering_details/candidate_completes_contact_details_with_a_missing_address_feature_flag_disabled_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_completes_contact_details_with_a_missing_address_feature_flag_disabled_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Candidate attempts to submit their application without a valid a
   end
 
   def when_i_click_contact_details_link_from_dashboard
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
     click_link_or_button 'Contact information'
   end
 

--- a/spec/system/candidate_interface/entering_details/candidate_deletes_and_adds_other_qualifications_after_completing_the_section_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_deletes_and_adds_other_qualifications_after_completing_the_section_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Candidates academic and other relevant qualifications' do
   end
 
   def when_i_visit_the_application_page
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def and_i_visit_the_application_page
@@ -61,7 +61,7 @@ RSpec.describe 'Candidates academic and other relevant qualifications' do
   end
 
   def and_visit_my_application_page
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def and_i_click_to_change_my_qualification

--- a/spec/system/candidate_interface/entering_details/candidate_edits_or_deletes_volunteering_section_after_competing_the_section_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_edits_or_deletes_volunteering_section_after_competing_the_section_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Candidate edits their volunteering section' do
   end
 
   def when_i_visit_the_application_page
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def then_the_volunteering_section_will_be_marked_as_complete

--- a/spec/system/candidate_interface/entering_details/candidate_edits_or_deletes_volunteering_section_with_restructured_work_history_active_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_edits_or_deletes_volunteering_section_with_restructured_work_history_active_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Candidate edits their volunteering section' do
   end
 
   def when_i_visit_the_application_page
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def then_the_volunteering_section_will_be_marked_as_complete

--- a/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'Entering their contact information' do
   end
 
   def and_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def when_i_click_on_contact_information

--- a/spec/system/candidate_interface/entering_details/candidate_entering_disability_info_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_disability_info_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Entering their disability information' do
   end
 
   def and_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def when_i_enter_equality_and_diversity_section

--- a/spec/system/candidate_interface/entering_details/candidate_entering_english_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_english_gcse_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'Candidate entering GCSE English details' do
   end
 
   def and_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def and_i_click_on_the_english_gcse_link

--- a/spec/system/candidate_interface/entering_details/candidate_entering_equality_and_diversity_information_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_equality_and_diversity_information_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe 'Entering their equality and diversity information' do
   end
 
   def and_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def and_i_click_on_the_equality_and_diversity_section

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_international_science_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_international_science_qualification_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe 'Candidate entering GCSE Science details' do
   end
 
   def and_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def then_i_see_qualification_year_page

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_science_award_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_science_award_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'Candidate entering GCSE Science details' do
   end
 
   def and_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def then_i_see_the_multiple_science_gcses_grade_page

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_spec.rb
@@ -193,6 +193,6 @@ RSpec.describe 'Candidate entering GCSE details' do
   end
 
   def then_i_am_returned_to_the_application_form_details
-    expect(page).to have_current_path candidate_interface_continuous_applications_details_path
+    expect(page).to have_current_path candidate_interface_details_path
   end
 end

--- a/spec/system/candidate_interface/entering_details/candidate_entering_interview_preferences_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_interview_preferences_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Entering interview preferences' do
   end
 
   def and_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def when_i_click_on_interview_preferences

--- a/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_btec_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_btec_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Entering their other qualifications' do
   end
 
   def and_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def when_i_click_on_other_qualifications

--- a/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_no_qualification_option_choice_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_no_qualification_option_choice_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'Entering their other qualifications' do
   end
 
   def and_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def then_i_see_the_other_qualifications_section_is_incomplete

--- a/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe 'Entering their other qualifications', :mid_cycle do
   end
 
   def and_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def when_i_click_on_other_qualifications

--- a/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Entering their personal details' do
   end
 
   def and_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def when_i_click_on_personal_information

--- a/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_when_requiring_visa_2022_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_when_requiring_visa_2022_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Entering personal details', time: CycleTimetableHelper.mid_cycle
 
   def and_i_am_signed_in
     create_and_sign_in_candidate
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def and_i_can_complete_personal_information_stating_that_i_need_a_visa_sponsorship

--- a/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_when_requiring_visa_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_personal_details_when_requiring_visa_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Entering personal details', time: Time.zone.local(RecruitmentCyc
 
   def and_i_am_signed_in
     create_and_sign_in_candidate
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def and_i_can_complete_personal_information_with_non_british_or_irish_nationality

--- a/spec/system/candidate_interface/entering_details/candidate_entering_suitability_to_work_with_children_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_suitability_to_work_with_children_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Entering their suitability to work with children' do
   end
 
   def when_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def then_i_see_declaring_any_safeguarding_issues

--- a/spec/system/candidate_interface/entering_details/candidate_entering_volunteering_experience_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_volunteering_experience_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Entering volunteering experience' do
   end
 
   def and_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def when_i_click_on_unpaid_experience

--- a/spec/system/candidate_interface/entering_details/candidate_marking_section_complete_or_incomplete_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_marking_section_complete_or_incomplete_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe 'Marking section as complete or incomplete' do
   alias_method :when_i_mark_a_section_as_incomplete, :and_i_mark_a_section_as_incomplete
 
   def then_i_am_redirected_to_your_details_page
-    expect(page).to have_current_path(candidate_interface_continuous_applications_details_path)
+    expect(page).to have_current_path(candidate_interface_details_path)
   end
 
   def when_i_mark_a_section_as_complete
@@ -154,7 +154,7 @@ RSpec.describe 'Marking section as complete or incomplete' do
   end
 
   def when_i_visit_the_details_page
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def then_i_see_the_complete_details_text

--- a/spec/system/candidate_interface/entering_details/candidate_personal_statement_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_personal_statement_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Entering "Personal statement"' do
   end
 
   def and_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def when_i_click_on_personal_statement

--- a/spec/system/candidate_interface/entering_details/candidate_viewing_a_science_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_viewing_a_science_gcse_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Candidate viewing Science GCSE' do
   end
 
   def and_i_am_on_your_application_page
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
   alias_method :when_i_am_on_your_application_page, :and_i_am_on_your_application_page
 

--- a/spec/system/candidate_interface/entering_details/degrees/backlinks_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/backlinks_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'Degrees' do
   end
 
   def when_i_view_the_degree_section
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
     when_i_click_on_degree
   end
   alias_method :when_the_user_visits_degree_section_using_address_bar, :when_i_view_the_degree_section

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_adding_unknown_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_adding_unknown_degrees_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe 'Adding an unknown degree', :js do
   end
 
   def when_i_view_the_degree_section
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
     when_i_click_on_degree
   end
 

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_delete_and_replace_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_delete_and_replace_degrees_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Deleting and replacing a degree' do
   end
 
   def when_i_view_the_degree_section
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
     when_i_click_on_degree
   end
 
@@ -238,7 +238,7 @@ RSpec.describe 'Deleting and replacing a degree' do
   end
 
   def when_i_return_to_the_application_form
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def then_the_degree_section_is_incomplete

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_editing_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_editing_degrees_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe 'Editing a degree' do
   end
 
   def when_i_view_the_degree_section
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
     when_i_click_on_degree
   end
 

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_editing_international_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_editing_international_degrees_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Editing a degree' do
   end
 
   def when_i_view_the_degree_section
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
     when_i_click_on_degree
   end
 

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_degrees_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'Entering a degree' do
   end
 
   def when_i_view_the_degree_section
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
     when_i_click_on_degree
   end
 

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degree_without_a_grade_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degree_without_a_grade_spec.rb
@@ -38,7 +38,7 @@ private
   end
 
   def when_i_view_the_degree_section
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
     when_i_click_on_degree
   end
 

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degree_without_an_enic_reason_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degree_without_an_enic_reason_spec.rb
@@ -26,7 +26,7 @@ private
   end
 
   def when_i_view_the_degree_section
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
     when_i_click_on_degree
   end
 

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degrees_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe 'Entering an international degree' do
   end
 
   def when_i_view_the_degree_section
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
     when_i_click_on_degree
   end
 

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_masters_degree_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_masters_degree_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Entering a Masters degree' do
   end
 
   def when_i_view_the_degree_section
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
     when_i_click_on_degree
   end
 

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_phd_degree_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_phd_degree_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Entering a PhD' do
   end
 
   def when_i_view_the_degree_section
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
     when_i_click_on_degree
   end
 

--- a/spec/system/candidate_interface/entering_details/international_candidate_enters_their_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/international_candidate_enters_their_other_qualification_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'Non-uk Other qualifications', mid_cycle: false do
   end
 
   def and_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def and_i_am_an_international_candidate

--- a/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_cannot_add_jobs_if_they_have_a_submitted_application_spec.rb
+++ b/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_cannot_add_jobs_if_they_have_a_submitted_application_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Trying to enter work history' do
   end
 
   def when_i_view_work_history
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
     click_on 'Work history'
   end
 

--- a/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_deleting_work_history_spec.rb
+++ b/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_deleting_work_history_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Entering their work history' do
   end
 
   def and_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def when_i_click_on_work_history

--- a/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_entering_restructured_work_history_add_job_spec.rb
+++ b/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_entering_restructured_work_history_add_job_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Candidate submits restructured work history' do
   end
 
   def and_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def when_i_click_on_work_history

--- a/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_entering_work_history_breaks_spec.rb
+++ b/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_entering_work_history_breaks_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Entering reasons for their work history breaks' do
   end
 
   def and_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def when_i_click_on_work_history
@@ -192,7 +192,7 @@ RSpec.describe 'Entering reasons for their work history breaks' do
   end
 
   def when_i_visit_the_application_form_page
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def then_the_work_history_section_is_complete

--- a/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_entering_work_history_full_time_education_spec.rb
+++ b/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_entering_work_history_full_time_education_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Entering their work history' do
   end
 
   def and_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def when_i_click_on_work_history

--- a/spec/system/candidate_interface/entering_details/view_efl_form_spec.rb
+++ b/spec/system/candidate_interface/entering_details/view_efl_form_spec.rb
@@ -20,12 +20,12 @@ RSpec.describe 'View EFL form' do
   end
 
   def then_i_cannot_see_the_efl_section_link
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
     expect(page).to have_no_link efl_link_text
   end
 
   def then_i_can_see_the_efl_section_link
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
     expect(page).to have_link efl_link_text
   end
 

--- a/spec/system/candidate_interface/feedback/candidate_provides_feedback_while_completing_their_application_spec.rb
+++ b/spec/system/candidate_interface/feedback/candidate_provides_feedback_while_completing_their_application_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Candidate provides feedback during the application process' do
   end
 
   def when_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def and_i_click_on_the_references_section

--- a/spec/system/candidate_interface/navigation_tabs_spec.rb
+++ b/spec/system/candidate_interface/navigation_tabs_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe 'Primary Navigation' do
   end
 
   def when_i_visit_the_application_dashboard
-    visit(candidate_interface_continuous_applications_details_path)
+    visit(candidate_interface_details_path)
   end
 
   def when_i_click_on_personal_information

--- a/spec/system/candidate_interface/references/backlinks_spec.rb
+++ b/spec/system/candidate_interface/references/backlinks_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'References' do
   end
 
   def when_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def and_i_click_add_your_references

--- a/spec/system/candidate_interface/references/candidate_add_references_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_add_references_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe 'References' do
   end
 
   def when_i_visit_the_site
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def when_i_click_on_references_section
@@ -349,7 +349,7 @@ RSpec.describe 'References' do
   end
 
   def then_i_am_redirected_to_my_application_or_details
-    expect(page).to have_current_path candidate_interface_continuous_applications_details_path
+    expect(page).to have_current_path candidate_interface_details_path
   end
 
   def and_i_delete_the_second_referee

--- a/spec/system/candidate_interface/references/candidate_adding_incomplete_referees_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_adding_incomplete_referees_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe 'Candidate adding incomplete referees' do
   end
 
   def then_i_get_redirected_to_the_application_page
-    expect(page).to have_current_path candidate_interface_continuous_applications_details_path
+    expect(page).to have_current_path candidate_interface_details_path
   end
 
   def given_i_am_signed_in

--- a/spec/system/candidate_interface/signup_and_signin/candidate_account_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_account_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe 'Candidate account' do
 
   def when_i_signed_in_more_than_a_week_ago
     travel_temporarily_to(7.days.from_now + 1.second) do
-      visit candidate_interface_continuous_applications_details_path
+      visit candidate_interface_details_path
     end
   end
 

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_and_starts_blank_application_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_and_starts_blank_application_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'Candidate signs in and starts blank application in Sandbox', :sa
   end
 
   def then_i_am_taken_to_the_blank_application_page
-    expect(page).to have_current_path(candidate_interface_continuous_applications_details_path)
+    expect(page).to have_current_path(candidate_interface_details_path)
     expect(page).to have_no_content 'This application has been prefilled with example data'
     expect(page).to have_content 'Personal information Incomplete'
   end

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_with_the_penultimate_valid_token_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_with_the_penultimate_valid_token_spec.rb
@@ -53,6 +53,6 @@ RSpec.describe 'Candidate tries to sign up using magic link with an invalid toke
   end
 
   def then_i_see_my_application_form
-    expect(page).to have_current_path(candidate_interface_continuous_applications_details_path)
+    expect(page).to have_current_path(candidate_interface_details_path)
   end
 end

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe 'Candidate tries to sign up using magic link with an invalid toke
   end
 
   def then_i_see_my_application_form
-    expect(page).to have_current_path(candidate_interface_continuous_applications_details_path)
+    expect(page).to have_current_path(candidate_interface_details_path)
   end
 
   def when_click_on_the_apply_for_teacher_training_link_in_the_header
@@ -79,6 +79,6 @@ RSpec.describe 'Candidate tries to sign up using magic link with an invalid toke
   end
 
   def then_i_see_the_application_page
-    expect(page).to have_current_path(candidate_interface_continuous_applications_details_path)
+    expect(page).to have_current_path(candidate_interface_details_path)
   end
 end

--- a/spec/system/candidate_interface/signup_and_signin/candidate_views_guidance_from_unsubmitted_application_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_views_guidance_from_unsubmitted_application_spec.rb
@@ -34,6 +34,6 @@ RSpec.describe 'Candidate signs in and starts blank application' do
   end
 
   def then_i_am_taken_to_the_application_page
-    expect(page).to have_current_path(candidate_interface_continuous_applications_details_path)
+    expect(page).to have_current_path(candidate_interface_details_path)
   end
 end

--- a/spec/system/candidate_interface/submitting/candidate_is_redirected_away_from_complete_page_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_is_redirected_away_from_complete_page_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Redirects away from complete page' do
   def expected_path
     case @status.to_sym
     when :unsubmitted, :cancelled, :awaiting_provider_decision, :inactive, :interviewing, :application_not_sent, :offer_withdrawn, :declined, :withdrawn, :conditions_not_met, :offer, :rejected
-      candidate_interface_continuous_applications_details_path
+      candidate_interface_details_path
     when :pending_conditions, :offer_deferred, :recruited
       candidate_interface_application_offer_dashboard_path
     end

--- a/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_details_section_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_reviews_completed_application_and_updates_personal_details_section_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe 'Candidate is redirected correctly' do
   end
 
   def and_i_visit_the_application_form_page
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
   end
 
   def when_i_click_change_name

--- a/spec/system/candidate_interface/submitting/candidate_with_no_right_to_work_tries_to_submit_course_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_with_no_right_to_work_tries_to_submit_course_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe 'Candidate with no right to work or study' do
   end
 
   def when_i_choose_a_provider
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
     click_link_or_button 'Your application'
     click_link_or_button 'Add application'
     choose 'Yes, I know where I want to apply'

--- a/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'International candidate submits the application' do
     # Consider moving some of this into CandidateHelper once International
     # feature flags have been removed, especially the efl_section.
     given_courses_exist
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
 
     click_link_or_button t('page_titles.personal_information.heading')
     candidate_fills_in_personal_details(international: true)

--- a/spec/system/support_interface/validation_errors_candidate_spec.rb
+++ b/spec/system/support_interface/validation_errors_candidate_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Validation errors Candidate' do
   end
 
   def and_i_enter_invalid_contact_details
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
     click_link_or_button t('page_titles.contact_information')
     fill_in t('application_form.contact_details.phone_number.label'), with: 'ABCDEF'
     click_link_or_button t('save_and_continue')

--- a/spec/system/support_interface/validation_errors_candidate_summary_spec.rb
+++ b/spec/system/support_interface/validation_errors_candidate_summary_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Validation errors candidate summary' do
   end
 
   def and_i_enter_invalid_contact_details
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
     click_link_or_button t('page_titles.contact_information')
     fill_in t('application_form.contact_details.phone_number.label'), with: 'ABCDEF'
     click_link_or_button t('save_and_continue')

--- a/spec/system/temporarily_editable_sections_spec.rb
+++ b/spec/system/temporarily_editable_sections_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe 'Unlocking non editable sections temporarily via support' do
   end
 
   def and_i_am_redirected_to_your_details_page
-    expect(page).to have_current_path candidate_interface_continuous_applications_details_path
+    expect(page).to have_current_path candidate_interface_details_path
   end
 
   def and_candidate_can_not_delete_degrees


### PR DESCRIPTION
## Context

Removal of Continuous Applications

## Changes proposed in this pull request

- Renamed `continuous_applications_details` path helpers to `details`
  - This has been a find&replace job searching `continuous_applications_details_` and replacing with `details_`

## Guidance to review

- Check all replaced instances are path helpers

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
