### PR TITLE
Update reopen banner with new content

### DIFF
--- a/app/components/candidate_interface/reopen_banner_component.html.erb
+++ b/app/components/candidate_interface/reopen_banner_component.html.erb
@@ -1,4 +1,9 @@
 <%= govuk_notification_banner(title_text: t('notification_banner.important')) do |notification_banner| %>
-  <% notification_banner.with_heading(text: "Applications for courses starting in the #{CycleTimetable.cycle_year_range(cycle_year)} academic year are closed") %>
-  <p class="govuk-body">Submit your application from <%= reopen_date[:time] %> on <%= reopen_date[:date] %> for courses starting in the <%= CycleTimetable.cycle_year_range(cycle_year + 1) %> academic year.</p>
+  <% notification_banner.with_heading(text: t('reopen_banner_component.heading')) %>
+  <p class="govuk-body">
+    <%= t('reopen_banner_component.deadline_has_passed', academic_year:) %>
+  </p>
+  <p class="govuk-body">
+    <%= t('reopen_banner_component.when_apply_opens', apply_opens_date:, next_academic_year:) %>
+  </p>
 <% end %>

--- a/app/components/candidate_interface/reopen_banner_component.rb
+++ b/app/components/candidate_interface/reopen_banner_component.rb
@@ -1,8 +1,7 @@
 class CandidateInterface::ReopenBannerComponent < ViewComponent::Base
-  attr_accessor :phase, :flash_empty
+  attr_accessor :flash_empty
 
   def initialize(flash_empty:)
-    @phase = phase
     @flash_empty = flash_empty
   end
 
@@ -16,25 +15,28 @@ private
     CycleTimetable.between_cycles?
   end
 
-  def reopen_date
-    if Time.zone.now < CycleTimetable.date(:apply_opens)
-      {
-        date: CycleTimetable.apply_opens.to_fs(:govuk_date),
-        time: CycleTimetable.apply_opens.to_fs(:govuk_time),
-      }
-    else
-      {
-        date: CycleTimetable.apply_reopens.to_fs(:govuk_date),
-        time: CycleTimetable.apply_reopens.to_fs(:govuk_time),
-      }
-    end
+  def academic_year
+    CycleTimetable.cycle_year_range(year)
   end
 
-  def cycle_year
-    @_cycle_year ||= if Time.zone.now < CycleTimetable.apply_opens
-                       CycleTimetable.current_year - 1
-                     else
-                       CycleTimetable.current_year
-                     end
+  def next_academic_year
+    CycleTimetable.cycle_year_range(year + 1)
+  end
+
+  def apply_opens_date
+    date = if Time.zone.now.before? CycleTimetable.apply_opens
+             CycleTimetable.apply_opens
+           else
+             CycleTimetable.apply_reopens
+           end
+    date.to_fs(:govuk_date)
+  end
+
+  def year
+    if Time.zone.now.before? CycleTimetable.apply_opens
+      CycleTimetable.previous_year
+    else
+      CycleTimetable.current_year
+    end
   end
 end

--- a/config/locales/components/candidate_interface/reopen_banner_component.yml
+++ b/config/locales/components/candidate_interface/reopen_banner_component.yml
@@ -1,0 +1,7 @@
+en:
+  reopen_banner_component:
+    heading: The application deadline has passed
+    deadline_has_passed: >
+      The application deadline has passed for courses starting in the %{academic_year} academic year.
+    when_apply_opens: >
+      From %{apply_opens_date} you will be able to apply for courses starting in the %{next_academic_year} academic year.

--- a/spec/components/previews/candidate_interface/reopen_banner_alert_preview.rb
+++ b/spec/components/previews/candidate_interface/reopen_banner_alert_preview.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class ReopenBannerAlertPreview < ViewComponent::Preview
-    def twenty_twenty_four
+    def reopen_banner_component
       render CandidateInterface::ReopenBannerComponentPreviewComponent.new(
         flash_empty: true,
       )


### PR DESCRIPTION
## Context

Some content changes to the banner we show candidates after the apply deadline has passed.

## Changes proposed in this pull request

| Before | After |
| ------ | ------|
| <img width="928" alt="image" src="https://github.com/user-attachments/assets/237b330c-3a95-4a97-8eab-e677ec253e58"> | <img width="929" alt="image" src="https://github.com/user-attachments/assets/9ea6e04f-057e-4ef2-a924-20e44366dd48"> |


## Guidance to review

Can be viewed locally or on the review app at `/rails/view_components/candidate_interface/reopen_banner_alert/reopen_banner_component`

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
