### PR TITLE
Assume order of conditions is not preserved

### DIFF
--- a/spec/system/provider_interface/change_existing_offer_ske_standard_flow_spec.rb
+++ b/spec/system/provider_interface/change_existing_offer_ske_standard_flow_spec.rb
@@ -309,7 +309,7 @@ RSpec.describe 'Provider changes an existing offer' do
 
   def and_the_conditions_of_the_original_offer_are_filled_in
     expect(find("input[value='Fitness to train to teach check']")).to be_checked
-    expect(page).to have_field('Condition 1', with: 'Be cool')
+    expect(page).to have_field('Condition', with: 'Be cool')
   end
 
   def when_i_add_a_further_condition
@@ -324,8 +324,9 @@ RSpec.describe 'Provider changes an existing offer' do
   end
 
   def then_the_correct_conditions_are_displayed
-    expect(page).to have_field('Condition 2', with: 'A* on Maths A Level')
-    expect(page).to have_no_field('Condition 3', with: 'Go to the cinema')
+    expect(page).to have_field('Condition', with: 'A* on Maths A Level')
+    expect(page).to have_field('Condition', with: 'Be cool')
+    expect(page).to have_no_field('Condition', with: 'Go to the cinema')
   end
 
   def then_the_review_page_is_loaded


### PR DESCRIPTION
## Context
We have received this flaky test failure a few times. 

<img width="958" alt="image" src="https://github.com/user-attachments/assets/fcd82a27-aef4-424f-b185-c9cf8b15e12e">

## Changes proposed in this pull request

I haven't been able to recreate this locally, but my best guess is that the order of the conditions is not preserved when editing. So I have just made sure that the condition fields are present, but left it looser as to which condition field matches which value (eg Condition 1 might be 'Be Cool', or it might be 'A* on Maths A Level'.)

## Guidance to review

If you have any better ideas about what might be the problem, or if you are able to recreate it, let me know!

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
