### PR TITLE
Add SetSelectableSchoolsOnProviders DataMigration

### DIFF
--- a/app/services/data_migrations/set_selectable_schools_on_providers.rb
+++ b/app/services/data_migrations/set_selectable_schools_on_providers.rb
@@ -1,0 +1,11 @@
+module DataMigrations
+  class SetSelectableSchoolsOnProviders
+    TIMESTAMP = 20240829150421
+    MANUAL_RUN = false
+
+    def change
+      provider_codes = %w[E65 2CG 2CH 2CJ 2CK 2C1 1EX 1QU CS01 2X4 1ZO]
+      Provider.where(code: provider_codes).update_all(selectable_school: true)
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::SetSelectableSchoolsOnProviders',
   'DataMigrations::MarkUnsubmittedApplicationsWithoutEnglishProficiencyAsElfIncomplete',
   'DataMigrations::BackfillEnglishProficiencyRecordsForCarriedOverApplications',
   'DataMigrations::BackfillWeek42PerformanceReportData',

--- a/spec/services/data_migrations/set_selectable_schools_on_providers_spec.rb
+++ b/spec/services/data_migrations/set_selectable_schools_on_providers_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::SetSelectableSchoolsOnProviders do
+  it 'sets `selectable_school to true for all providers codes' do
+    target_provider = create(:provider, selectable_school: false, code: '1ZO')
+    ignore_provider = create(:provider, selectable_school: false, code: 'XXX')
+
+    described_class.new.change
+
+    expect(target_provider.reload.selectable_school).to be(true)
+    expect(ignore_provider.reload.selectable_school).to be(false)
+  end
+end


### PR DESCRIPTION
## Context

  Add a DataMigration to update specific providers by setting `selectable_school` to `true`.


## Changes proposed in this pull request

Add DataMigration
Select the Providers by their Code
The source of the list of codes is in a CSV attached to the trello ticket.
Tested locally

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Add PR link to Trello card
