### PR TITLE
TDA - Your details new degree question

### DIFF
--- a/app/components/candidate_interface/degree_empty_component.html.erb
+++ b/app/components/candidate_interface/degree_empty_component.html.erb
@@ -6,4 +6,6 @@
 
  <p class="govuk-body">Find out how you can get qualified teacher status (QTS) as part of an <%= govuk_link_to_with_utm_params 'undergraduate degree', t('get_into_teaching.url_if_you_dont_have_a_degree'), utm_campaign(params) %> if you do not have a degree yet and are not already studying for one.</p>
 
-<%= govuk_button_link_to degrees.empty? ? t('application_form.degree.add.button') : t('application_form.degree.another.button'), candidate_interface_degree_country_path, primary: true %>
+<% unless @application_form.no_degree_and_degree_completed? %>
+  <%= govuk_button_link_to degrees.empty? ? t('application_form.degree.add.button') : t('application_form.degree.another.button'), candidate_interface_degree_country_path, primary: true %>
+<% end %>

--- a/app/components/candidate_interface/no_degree_component.html.erb
+++ b/app/components/candidate_interface/no_degree_component.html.erb
@@ -1,0 +1,3 @@
+<%= render(SummaryCardComponent.new(rows:, editable:)) do %>
+  <%= render(SummaryCardHeaderComponent.new(title: 'Degrees', heading_level: :h2)) %>
+<% end %>

--- a/app/components/candidate_interface/no_degree_component.rb
+++ b/app/components/candidate_interface/no_degree_component.rb
@@ -1,0 +1,20 @@
+module CandidateInterface
+  class NoDegreeComponent < ViewComponent::Base
+    attr_reader :application_form, :editable
+
+    def initialize(application_form:, editable:)
+      @application_form = application_form
+      @editable = editable
+    end
+
+    def rows
+      [
+        {
+          key: 'Do you have a university degree?',
+          value: 'No, I do not have a degree',
+          action: { href: candidate_interface_degree_university_degree_path },
+        },
+      ]
+    end
+  end
+end

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -27,6 +27,12 @@ module CandidateInterface
       end
     end
 
+    def teacher_degree_apprenticeship_feature_active?
+      FeatureFlag.active?(:teacher_degree_apprenticeship) &&
+        current_application.recruitment_cycle_year >= 2025
+    end
+    helper_method :teacher_degree_apprenticeship_feature_active?
+
     def choices_controller?
       ChoicesControllerMatcher.choices_controller?(current_application: current_application, controller_path: controller_path, request: request)
     end

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -27,10 +27,7 @@ module CandidateInterface
       end
     end
 
-    def teacher_degree_apprenticeship_feature_active?
-      FeatureFlag.active?(:teacher_degree_apprenticeship) &&
-        current_application.recruitment_cycle_year >= 2025
-    end
+    delegate :teacher_degree_apprenticeship_feature_active?, to: :current_application
     helper_method :teacher_degree_apprenticeship_feature_active?
 
     def choices_controller?

--- a/app/controllers/candidate_interface/degrees/degree_controller.rb
+++ b/app/controllers/candidate_interface/degrees/degree_controller.rb
@@ -1,6 +1,25 @@
 module CandidateInterface
   module Degrees
     class DegreeController < BaseController
+      def new_university_degree
+        @degree = UniversityDegreeForm.new(current_application:, university_degree_status: current_application.university_degree)
+      end
+
+      def update_university_degree
+        form_params = params.fetch(:candidate_interface_university_degree_form, {}).permit(:university_degree_status)
+        @degree = UniversityDegreeForm.new(form_params.merge(current_application:))
+
+        return render :new_university_degree unless @degree.valid?
+
+        if @degree.degree?
+          current_application.update!(university_degree: true, degrees_completed: false)
+          redirect_to candidate_interface_degree_country_path
+        else
+          current_application.update!(university_degree: false, degrees_completed: true)
+          redirect_to candidate_interface_continuous_applications_details_path
+        end
+      end
+
       def new
         degree_attrs = { application_form_id: current_application.id }
         degree_attrs[:id] = params[:id] if params.key?(:id)

--- a/app/controllers/candidate_interface/degrees/degree_controller.rb
+++ b/app/controllers/candidate_interface/degrees/degree_controller.rb
@@ -16,7 +16,7 @@ module CandidateInterface
           redirect_to candidate_interface_degree_country_path
         else
           current_application.update!(university_degree: false, degrees_completed: true)
-          redirect_to candidate_interface_continuous_applications_details_path
+          redirect_to candidate_interface_details_path
         end
       end
 

--- a/app/controllers/candidate_interface/degrees/destroy_controller.rb
+++ b/app/controllers/candidate_interface/degrees/destroy_controller.rb
@@ -15,6 +15,8 @@ module CandidateInterface
         if current_application.application_qualifications.degrees.blank?
           current_application.update!(degrees_completed: nil)
           @wizard.clear_state!
+
+          return redirect_to candidate_interface_continuous_applications_details_path if teacher_degree_apprenticeship_feature_active?
         end
         redirect_to candidate_interface_degree_review_path
       end

--- a/app/controllers/candidate_interface/degrees/destroy_controller.rb
+++ b/app/controllers/candidate_interface/degrees/destroy_controller.rb
@@ -16,7 +16,7 @@ module CandidateInterface
           current_application.update!(degrees_completed: nil)
           @wizard.clear_state!
 
-          return redirect_to candidate_interface_continuous_applications_details_path if teacher_degree_apprenticeship_feature_active?
+          return redirect_to candidate_interface_details_path if teacher_degree_apprenticeship_feature_active?
         end
         redirect_to candidate_interface_degree_review_path
       end

--- a/app/controllers/candidate_interface/degrees/review_controller.rb
+++ b/app/controllers/candidate_interface/degrees/review_controller.rb
@@ -38,6 +38,8 @@ module CandidateInterface
       end
 
       def set_completed_if_only_foundation_degrees
+        return if current_application.no_degree_and_degree_completed?
+
         if only_foundation_degrees?
           current_application.update!(degrees_completed: nil)
         end

--- a/app/controllers/candidate_interface/degrees/university_degree_controller.rb
+++ b/app/controllers/candidate_interface/degrees/university_degree_controller.rb
@@ -1,0 +1,32 @@
+module CandidateInterface
+  module Degrees
+    class UniversityDegreeController < BaseController
+      def new
+        @university_degree_form = UniversityDegreeForm.new(
+          current_application:,
+          university_degree_status: current_application.university_degree,
+        )
+      end
+
+      def update
+        @university_degree_form = UniversityDegreeForm.new(form_params.merge(current_application:))
+
+        return render :new unless @university_degree_form.valid?
+
+        if @university_degree_form.degree?
+          current_application.update!(university_degree: true, degrees_completed: false)
+          redirect_to candidate_interface_degree_country_path
+        else
+          current_application.update!(university_degree: false, degrees_completed: true)
+          redirect_to candidate_interface_details_path
+        end
+      end
+
+    private
+
+      def form_params
+        params.fetch(:candidate_interface_university_degree_form, {}).permit(:university_degree_status)
+      end
+    end
+  end
+end

--- a/app/forms/candidate_interface/university_degree_form.rb
+++ b/app/forms/candidate_interface/university_degree_form.rb
@@ -1,0 +1,13 @@
+module CandidateInterface
+  class UniversityDegreeForm
+    include ActiveModel::Model
+
+    attr_accessor :current_application, :university_degree_status
+
+    validates :university_degree_status, presence: true
+
+    def degree?
+      ActiveModel::Type::Boolean.new.cast(university_degree_status)
+    end
+  end
+end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -648,7 +648,11 @@ class ApplicationForm < ApplicationRecord
   end
 
   def no_degrees?
-    application_qualifications.degrees.count.zero?
+    !degrees?
+  end
+
+  def degrees?
+    application_qualifications.degrees.exists?
   end
 
   def granted_editable_extension?(section_id)

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -639,6 +639,10 @@ class ApplicationForm < ApplicationRecord
     module_function :by_column, :by_section
   end
 
+  def teacher_degree_apprenticeship_feature_active?
+    FeatureFlag.active?(:teacher_degree_apprenticeship) && recruitment_cycle_year >= 2025
+  end
+
   def no_degree_and_degree_not_completed?
     no_degrees? && !degrees_completed?
   end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -639,6 +639,18 @@ class ApplicationForm < ApplicationRecord
     module_function :by_column, :by_section
   end
 
+  def no_degree_and_degree_not_completed?
+    no_degrees? && !degrees_completed?
+  end
+
+  def no_degree_and_degree_completed?
+    no_degrees? && degrees_completed?
+  end
+
+  def no_degrees?
+    application_qualifications.degrees.count.zero?
+  end
+
   def granted_editable_extension?(section_id)
     editable_extension? && Array(editable_sections).map(&:to_sym).include?(section_id)
   end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -15,6 +15,7 @@ module CandidateInterface
              :previous_application_form,
              :phase,
              :personal_details_completed,
+             :no_degree_and_degree_not_completed?,
              :support_reference, to: :application_form
 
     def initialize(application_form)

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -16,6 +16,7 @@ module CandidateInterface
              :phase,
              :personal_details_completed,
              :no_degree_and_degree_not_completed?,
+             :teacher_degree_apprenticeship_feature_active?,
              :support_reference, to: :application_form
 
     def initialize(application_form)
@@ -198,7 +199,11 @@ module CandidateInterface
     end
 
     def degrees_path
-      Rails.application.routes.url_helpers.candidate_interface_degree_review_path
+      if no_degree_and_degree_not_completed? && teacher_degree_apprenticeship_feature_active?
+        Rails.application.routes.url_helpers.candidate_interface_degree_university_degree_path
+      else
+        Rails.application.routes.url_helpers.candidate_interface_degree_review_path
+      end
     end
 
     def other_qualification_path

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -49,6 +49,10 @@ class DuplicateApplication
         new_application_form.update!(degrees_completed: false)
       end
 
+      if original_application_form.degrees?
+        new_application_form.update!(university_degree: true)
+      end
+
       original_references = original_application_form.application_references
         .includes([:reference_tokens])
         .creation_order

--- a/app/views/candidate_interface/degrees/degree/new_country.html.erb
+++ b/app/views/candidate_interface/degrees/degree/new_country.html.erb
@@ -1,7 +1,12 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
   <% content_for :title, title_with_error_prefix(t('page_titles.degree_country'), @wizard.errors.any?) %>
-  <% content_for :before_content, govuk_back_link_to(candidate_interface_degree_review_path) %>
+
+  <% if teacher_degree_apprenticeship_feature_active? %>
+    <% content_for :before_content, govuk_back_link_to(candidate_interface_degree_university_degree_path) %>
+  <% else %>
+    <% content_for :before_content, govuk_back_link_to(candidate_interface_degree_review_path) %>
+  <% end %>
 
   <%= form_with model: @wizard, url: candidate_interface_degree_country_path do |f| %>
     <%= f.govuk_error_summary %>

--- a/app/views/candidate_interface/degrees/degree/new_university_degree.html.erb
+++ b/app/views/candidate_interface/degrees/degree/new_university_degree.html.erb
@@ -1,0 +1,35 @@
+<%= content_for :page_title, title_with_error_prefix('Do you have a university degree', @degree.errors.any?) %>
+<% content_for :before_content do %>
+  <%= govuk_back_link(
+    text: 'Back',
+    href: candidate_interface_continuous_applications_details_path,
+  ) %>
+<% end %>
+
+<%= form_with(model: @degree, url: candidate_interface_degree_university_degree_path) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= f.govuk_radio_buttons_fieldset :university_degree_status, legend: { text: 'Do you have a university degree?', size: 'l', tag: 'h1' } do %>
+
+      <p class="govuk-body">
+        You need a bachelor’s degree or equivalent to do postgraduate teacher training. You do not need a degree to apply for a <%= govuk_link_to 'teacher degree apprenticeship (TDA)', 'https://getintoteaching.education.gov.uk/train-to-be-a-teacher/teacher-degree-apprenticeships' %>.
+      </p>
+
+      <p class="govuk-body">
+        Add your bachelor's degree even if you have not got your grade yet.
+      </p>
+
+      <p class="govuk-body">
+        You can also add any other degrees that you have, or you are working towards.
+      </p>
+
+      <%= f.govuk_radio_button :university_degree_status, 'true', label: { text: 'Yes, I have a degree or am studying for one' }, link_errors: true %>
+      <%= f.govuk_radio_button :university_degree_status, 'false', label: { text: 'No, I do not have a degree' } %>
+      <% end %>
+
+      <%= f.govuk_submit 'Continue' %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/candidate_interface/degrees/degree/new_university_degree.html.erb
+++ b/app/views/candidate_interface/degrees/degree/new_university_degree.html.erb
@@ -14,22 +14,25 @@
       <%= f.govuk_radio_buttons_fieldset :university_degree_status, legend: { size: 'l', tag: 'h1' } do %>
 
       <p class="govuk-body">
-        You need a bachelor’s degree or equivalent to do postgraduate teacher training. You do not need a degree to apply for a <%= govuk_link_to 'teacher degree apprenticeship (TDA)', 'https://getintoteaching.education.gov.uk/train-to-be-a-teacher/teacher-degree-apprenticeships' %>.
+        <%= t(
+          '.degree_requirements',
+          link: govuk_link_to(t('.teacher_degree_apprenticeship'), t('get_into_teaching.url_teacher_degree_apprenticeship')),
+        ).html_safe %>
       </p>
 
       <p class="govuk-body">
-        Add your bachelor's degree even if you have not got your grade yet.
+        <%= t('.bachelor_degree_content') %>
       </p>
 
       <p class="govuk-body">
-        You can also add any other degrees that you have, or you are working towards.
+        <%= t('.other_degrees_content') %>
       </p>
 
         <%= f.govuk_radio_button :university_degree_status, 'true', link_errors: true %>
         <%= f.govuk_radio_button :university_degree_status, 'false' %>
       <% end %>
 
-      <%= f.govuk_submit 'Continue' %>
+      <%= f.govuk_submit t('continue') %>
     </div>
   </div>
 <% end %>

--- a/app/views/candidate_interface/degrees/degree/new_university_degree.html.erb
+++ b/app/views/candidate_interface/degrees/degree/new_university_degree.html.erb
@@ -2,7 +2,7 @@
 <% content_for :before_content do %>
   <%= govuk_back_link(
     text: 'Back',
-    href: candidate_interface_continuous_applications_details_path,
+    href: candidate_interface_details_path,
   ) %>
 <% end %>
 

--- a/app/views/candidate_interface/degrees/degree/new_university_degree.html.erb
+++ b/app/views/candidate_interface/degrees/degree/new_university_degree.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, title_with_error_prefix('Do you have a university degree', @degree.errors.any?) %>
+<%= content_for :browser_title, title_with_error_prefix(t('page_titles.university_degree'), @degree.errors.any?) %>
 <% content_for :before_content do %>
   <%= govuk_back_link(
     text: 'Back',
@@ -11,7 +11,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= f.govuk_radio_buttons_fieldset :university_degree_status, legend: { text: 'Do you have a university degree?', size: 'l', tag: 'h1' } do %>
+      <%= f.govuk_radio_buttons_fieldset :university_degree_status, legend: { size: 'l', tag: 'h1' } do %>
 
       <p class="govuk-body">
         You need a bachelor’s degree or equivalent to do postgraduate teacher training. You do not need a degree to apply for a <%= govuk_link_to 'teacher degree apprenticeship (TDA)', 'https://getintoteaching.education.gov.uk/train-to-be-a-teacher/teacher-degree-apprenticeships' %>.
@@ -25,8 +25,8 @@
         You can also add any other degrees that you have, or you are working towards.
       </p>
 
-      <%= f.govuk_radio_button :university_degree_status, 'true', label: { text: 'Yes, I have a degree or am studying for one' }, link_errors: true %>
-      <%= f.govuk_radio_button :university_degree_status, 'false', label: { text: 'No, I do not have a degree' } %>
+        <%= f.govuk_radio_button :university_degree_status, 'true', link_errors: true %>
+        <%= f.govuk_radio_button :university_degree_status, 'false' %>
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/app/views/candidate_interface/degrees/review/show.html.erb
+++ b/app/views/candidate_interface/degrees/review/show.html.erb
@@ -12,6 +12,7 @@
       <%= render CandidateInterface::EditableSectionWarning.new(section_policy: @section_policy, current_application: @application_form) %>
 
       <% degree_empty_component = CandidateInterface::DegreeEmptyComponent.new(application_form: @application_form) %>
+
       <% unless degree_empty_component.render? || !@section_policy.can_edit? %>
         <%= govuk_button_link_to t('application_form.degree.another.button'), candidate_interface_degree_country_path(context: :new_degree), secondary: true %>
       <% end %>
@@ -19,7 +20,23 @@
   </div>
 
   <%= render degree_empty_component %>
-  <%= render CandidateInterface::DegreeReviewComponent.new(application_form: @application_form, editable: @section_policy.can_edit?, deletable: @section_policy.can_delete?) %>
+
+  <% if @application_form.no_degree_and_degree_completed? %>
+    <%= render(SummaryCardComponent.new(
+      rows: [
+        {
+          key: 'Do you have a university degree?',
+          value: 'No, I do not have a degree',
+          action: { href: candidate_interface_degree_university_degree_path },
+        },
+      ],
+    )) do %>
+      <%= render(SummaryCardHeaderComponent.new(title: 'Degrees', heading_level: :h2)) %>
+    <% end %>
+  <% else %>
+    <%= render CandidateInterface::DegreeReviewComponent.new(application_form: @application_form, editable: @section_policy.can_edit?, deletable: @section_policy.can_delete?) %>
+  <% end %>
+
   <% unless degree_empty_component.render? %>
     <%= render CandidateInterface::CompleteSectionComponent.new(section_policy: @section_policy, form: f, hint_text: t('application_form.degree.review.complete_hint_text')) %>
   <% end %>

--- a/app/views/candidate_interface/degrees/review/show.html.erb
+++ b/app/views/candidate_interface/degrees/review/show.html.erb
@@ -22,17 +22,7 @@
   <%= render degree_empty_component %>
 
   <% if @application_form.no_degree_and_degree_completed? %>
-    <%= render(SummaryCardComponent.new(
-      rows: [
-        {
-          key: 'Do you have a university degree?',
-          value: 'No, I do not have a degree',
-          action: { href: candidate_interface_degree_university_degree_path },
-        },
-      ],
-    )) do %>
-      <%= render(SummaryCardHeaderComponent.new(title: 'Degrees', heading_level: :h2)) %>
-    <% end %>
+    <%= render CandidateInterface::NoDegreeComponent.new(application_form: @application_form, editable: @section_policy.can_edit?) %>
   <% else %>
     <%= render CandidateInterface::DegreeReviewComponent.new(application_form: @application_form, editable: @section_policy.can_edit?, deletable: @section_policy.can_delete?) %>
   <% end %>

--- a/app/views/candidate_interface/degrees/university_degree/new.html.erb
+++ b/app/views/candidate_interface/degrees/university_degree/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :browser_title, title_with_error_prefix(t('page_titles.university_degree'), @degree.errors.any?) %>
+<%= content_for :browser_title, title_with_error_prefix(t('page_titles.university_degree'), @university_degree_form.errors.any?) %>
 <% content_for :before_content do %>
   <%= govuk_back_link(
     text: 'Back',
@@ -6,7 +6,7 @@
   ) %>
 <% end %>
 
-<%= form_with(model: @degree, url: candidate_interface_degree_university_degree_path) do |f| %>
+<%= form_with(model: @university_degree_form, url: candidate_interface_degree_university_degree_path) do |f| %>
   <%= f.govuk_error_summary %>
 
   <div class="govuk-grid-row">

--- a/app/views/candidate_interface/shared/_task_list.html.erb
+++ b/app/views/candidate_interface/shared/_task_list.html.erb
@@ -40,13 +40,24 @@
         path: application_form_presenter.other_qualification_path,
       )) %>
     </li>
-    <li class="app-task-list__item">
-      <%= render(TaskListItemComponent.new(
-        text: t('page_titles.degree'),
-        completed: application_form_presenter.degrees_completed?,
-        path: application_form_presenter.degrees_path,
-      )) %>
-    </li>
+
+    <% if application_form_presenter.no_degree_and_degree_not_completed? && teacher_degree_apprenticeship_feature_active? %>
+      <li class="app-task-list__item">
+        <%= render(TaskListItemComponent.new(
+            text: t('page_titles.degree'),
+            completed: application_form_presenter.degrees_completed?,
+            path: candidate_interface_degree_university_degree_path,
+          )) %>
+      </li>
+    <% else %>
+      <li class="app-task-list__item">
+        <%= render(TaskListItemComponent.new(
+          text: t('page_titles.degree'),
+          completed: application_form_presenter.degrees_completed?,
+          path: application_form_presenter.degrees_path,
+        )) %>
+      </li>
+    <% end %>
   </ol>
 </section>
 

--- a/app/views/candidate_interface/shared/_task_list.html.erb
+++ b/app/views/candidate_interface/shared/_task_list.html.erb
@@ -41,23 +41,13 @@
       )) %>
     </li>
 
-    <% if application_form_presenter.no_degree_and_degree_not_completed? && teacher_degree_apprenticeship_feature_active? %>
-      <li class="app-task-list__item">
-        <%= render(TaskListItemComponent.new(
-            text: t('page_titles.degree'),
-            completed: application_form_presenter.degrees_completed?,
-            path: candidate_interface_degree_university_degree_path,
-          )) %>
-      </li>
-    <% else %>
-      <li class="app-task-list__item">
-        <%= render(TaskListItemComponent.new(
-          text: t('page_titles.degree'),
-          completed: application_form_presenter.degrees_completed?,
-          path: application_form_presenter.degrees_path,
-        )) %>
-      </li>
-    <% end %>
+    <li class="app-task-list__item">
+      <%= render(TaskListItemComponent.new(
+        text: t('page_titles.degree'),
+        completed: application_form_presenter.degrees_completed?,
+        path: application_form_presenter.degrees_path,
+      )) %>
+    </li>
   </ol>
 </section>
 

--- a/config/locales/candidate_interface/degree.yml
+++ b/config/locales/candidate_interface/degree.yml
@@ -1,8 +1,8 @@
 en:
   candidate_interface:
     degrees:
-      degree:
-        new_university_degree:
+      university_degree:
+        new:
           teacher_degree_apprenticeship: teacher degree apprenticeship (TDA)
           degree_requirements: You need a bachelor’s degree or equivalent to do postgraduate teacher training. You do not need a degree to apply for a %{link}
           bachelor_degree_content: Add your bachelor’s degree even if you have not got your grade yet.

--- a/config/locales/candidate_interface/degree.yml
+++ b/config/locales/candidate_interface/degree.yml
@@ -4,7 +4,7 @@ en:
       university_degree:
         new:
           teacher_degree_apprenticeship: teacher degree apprenticeship (TDA)
-          degree_requirements: You need a bachelor’s degree or equivalent to do postgraduate teacher training. You do not need a degree to apply for a %{link}
+          degree_requirements: You need a bachelor’s degree or equivalent to do postgraduate teacher training. You do not need a degree to apply for a %{link}.
           bachelor_degree_content: Add your bachelor’s degree even if you have not got your grade yet.
           other_degrees_content: You can also add any other degrees that you have, or you are working towards.
   helpers:

--- a/config/locales/candidate_interface/degree.yml
+++ b/config/locales/candidate_interface/degree.yml
@@ -117,6 +117,10 @@ en:
   activemodel:
     errors:
       models:
+        candidate_interface/university_degree_form:
+          attributes:
+            university_degree_status:
+              blank: "Select whether you have a university degree"
         candidate_interface/degree_wizard:
           attributes:
             uk_or_non_uk:

--- a/config/locales/candidate_interface/degree.yml
+++ b/config/locales/candidate_interface/degree.yml
@@ -1,4 +1,15 @@
 en:
+  helpers:
+    legend:
+      candidate_interface_university_degree_form:
+        university_degree_status: Do you have a university degree?
+    label:
+      candidate_interface_university_degree_form:
+        university_degree_status_options:
+          'true': Yes, I have a degree or am studying for one
+          'false': No, I do not have a degree
+  page_titles:
+    university_degree: Do you have a university degree
   application_form:
     degree:
       qualification:

--- a/config/locales/candidate_interface/degree.yml
+++ b/config/locales/candidate_interface/degree.yml
@@ -1,4 +1,12 @@
 en:
+  candidate_interface:
+    degrees:
+      degree:
+        new_university_degree:
+          teacher_degree_apprenticeship: teacher degree apprenticeship (TDA)
+          degree_requirements: You need a bachelor’s degree or equivalent to do postgraduate teacher training. You do not need a degree to apply for a %{link}
+          bachelor_degree_content: Add your bachelor’s degree even if you have not got your grade yet.
+          other_degrees_content: You can also add any other degrees that you have, or you are working towards.
   helpers:
     legend:
       candidate_interface_university_degree_form:

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -305,8 +305,8 @@ namespace :candidate_interface, path: '/candidate' do
         get '/country' => 'degrees/degree#new_country', as: :degree_country
         post '/country' => 'degrees/degree#update_country'
 
-        get '/do-you-have-a-degree' => 'degrees/degree#new_university_degree', as: :degree_university_degree
-        post '/do-you-have-a-degree' => 'degrees/degree#update_university_degree'
+        get '/do-you-have-a-degree' => 'degrees/university_degree#new', as: :degree_university_degree
+        post '/do-you-have-a-degree' => 'degrees/university_degree#update'
 
         get '/edit/:id/:step' => 'degrees/degree#edit', as: :degree_edit
 

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -305,6 +305,9 @@ namespace :candidate_interface, path: '/candidate' do
         get '/country' => 'degrees/degree#new_country', as: :degree_country
         post '/country' => 'degrees/degree#update_country'
 
+        get '/do-you-have-a-degree' => 'degrees/degree#new_university_degree', as: :degree_university_degree
+        post '/do-you-have-a-degree' => 'degrees/degree#update_university_degree'
+
         get '/edit/:id/:step' => 'degrees/degree#edit', as: :degree_edit
 
         get '/level' => 'degrees/degree#new_degree_level', as: :degree_degree_level

--- a/spec/components/candidate_interface/no_degree_component_spec.rb
+++ b/spec/components/candidate_interface/no_degree_component_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::NoDegreeComponent, type: :component do
+  let(:component) { described_class.new(application_form:, editable:) }
+  let(:application_form) { create(:application_form) }
+
+  subject(:result) { render_inline component }
+
+  context 'when editable' do
+    let(:editable) { true }
+
+    it 'renders change link' do
+      expect(result.text).to include('Change')
+    end
+  end
+
+  context 'when not editable' do
+    let(:editable) { false }
+
+    it 'does not render change link' do
+      expect(result.text).not_to include('Change')
+    end
+  end
+end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -1220,4 +1220,44 @@ RSpec.describe ApplicationForm do
       end
     end
   end
+
+  describe '#teacher_degree_apprenticeship_feature_active?' do
+    let(:application_form) { build(:application_form) }
+
+    context 'when the teacher degree apprenticeship feature flag is active and recruitment cycle year is 2025 or later' do
+      it 'returns true' do
+        FeatureFlag.activate(:teacher_degree_apprenticeship)
+        application_form.recruitment_cycle_year = 2025
+
+        expect(application_form.teacher_degree_apprenticeship_feature_active?).to be true
+      end
+    end
+
+    context 'when the teacher degree apprenticeship feature flag is active but recruitment cycle year is before 2025' do
+      it 'returns false' do
+        FeatureFlag.activate(:teacher_degree_apprenticeship)
+        application_form.recruitment_cycle_year = 2024
+
+        expect(application_form.teacher_degree_apprenticeship_feature_active?).to be false
+      end
+    end
+
+    context 'when the teacher degree apprenticeship feature flag is not active but recruitment cycle year is 2025 or later' do
+      it 'returns false' do
+        FeatureFlag.deactivate(:teacher_degree_apprenticeship)
+        application_form.recruitment_cycle_year = 2025
+
+        expect(application_form.teacher_degree_apprenticeship_feature_active?).to be false
+      end
+    end
+
+    context 'when the teacher degree apprenticeship feature flag is not active and recruitment cycle year is before 2025' do
+      it 'returns false' do
+        FeatureFlag.deactivate(:teacher_degree_apprenticeship)
+        application_form.recruitment_cycle_year = 2024
+
+        expect(application_form.teacher_degree_apprenticeship_feature_active?).to be false
+      end
+    end
+  end
 end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -924,6 +924,91 @@ RSpec.describe ApplicationForm do
     end
   end
 
+  describe '#no_degree_and_degree_not_completed?' do
+    context 'when there are no degrees and the degree is not completed' do
+      let(:application_form) { create(:application_form, degrees_completed: false) }
+
+      it 'returns true' do
+        expect(application_form.no_degree_and_degree_not_completed?).to be true
+      end
+    end
+
+    context 'when there are degrees or the degree is completed' do
+      let(:application_form_with_degrees) { create(:application_form, :with_degree, degrees_completed: false) }
+      let(:application_form_completed) { create(:application_form, degrees_completed: true) }
+
+      it 'returns false if degrees exist' do
+        expect(application_form_with_degrees.no_degree_and_degree_not_completed?).to be false
+      end
+
+      it 'returns false if degree is completed' do
+        expect(application_form_completed.no_degree_and_degree_not_completed?).to be false
+      end
+    end
+  end
+
+  describe '#no_degree_and_degree_completed?' do
+    context 'when there are no degrees and the degree is completed' do
+      let(:application_form) { create(:application_form, degrees_completed: true) }
+
+      it 'returns true' do
+        expect(application_form.no_degree_and_degree_completed?).to be true
+      end
+    end
+
+    context 'when there are degrees' do
+      let(:application_form_with_degrees) { create(:application_form, :with_degree, degrees_completed: true) }
+
+      it 'returns false if degrees exist' do
+        expect(application_form_with_degrees.no_degree_and_degree_completed?).to be false
+      end
+    end
+
+    context 'when there no degree the degree is not completed' do
+      let(:application_form_not_completed) { create(:application_form, degrees_completed: false) }
+
+      it 'returns false if degree is not completed' do
+        expect(application_form_not_completed.no_degree_and_degree_completed?).to be false
+      end
+    end
+  end
+
+  describe '#no_degrees?' do
+    context 'when there are no degrees' do
+      let(:application_form) { create(:application_form) }
+
+      it 'returns true' do
+        expect(application_form.no_degrees?).to be true
+      end
+    end
+
+    context 'when there are degrees' do
+      let(:application_form_with_degrees) { create(:application_form, :with_degree) }
+
+      it 'returns false' do
+        expect(application_form_with_degrees.no_degrees?).to be false
+      end
+    end
+  end
+
+  describe '#degrees?' do
+    context 'when there are degrees' do
+      let(:application_form_with_degrees) { create(:application_form, :with_degree) }
+
+      it 'returns true' do
+        expect(application_form_with_degrees.degrees?).to be true
+      end
+    end
+
+    context 'when there are no degrees' do
+      let(:application_form) { create(:application_form) }
+
+      it 'returns false' do
+        expect(application_form.degrees?).to be false
+      end
+    end
+  end
+
   describe '#qualifications_completed?' do
     context 'when `degrees_completed` is false' do
       let(:application_form) do

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -24,6 +24,66 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
     end
   end
 
+  describe '#degrees_path' do
+    let(:presenter) { described_class.new(application_form) }
+
+    context 'when there are no degrees and the degree is not completed, and the teacher degree apprenticeship feature is active' do
+      let(:application_form) do
+        create(
+          :application_form,
+          application_qualifications: [],
+          degrees_completed: false,
+          recruitment_cycle_year: 2025,
+        )
+      end
+
+      before do
+        FeatureFlag.activate(:teacher_degree_apprenticeship)
+      end
+
+      it 'returns the university degree path' do
+        expect(presenter.degrees_path).to eq(Rails.application.routes.url_helpers.candidate_interface_degree_university_degree_path)
+      end
+    end
+
+    context 'when there are no degrees and the degree is not completed, but the teacher degree apprenticeship feature is not active' do
+      let(:application_form) do
+        create(
+          :application_form,
+          application_qualifications: [],
+          degrees_completed: false,
+          recruitment_cycle_year: 2024,
+        )
+      end
+
+      before do
+        FeatureFlag.deactivate(:teacher_degree_apprenticeship)
+      end
+
+      it 'returns the degree review path' do
+        expect(presenter.degrees_path).to eq(Rails.application.routes.url_helpers.candidate_interface_degree_review_path)
+      end
+    end
+
+    context 'when there are degrees or the degree is completed' do
+      let(:application_form) do
+        create(
+          :application_form,
+          :with_degree,
+          recruitment_cycle_year: 2025,
+        )
+      end
+
+      before do
+        FeatureFlag.activate(:teacher_degree_apprenticeship)
+      end
+
+      it 'returns the degree review path' do
+        expect(presenter.degrees_path).to eq(Rails.application.routes.url_helpers.candidate_interface_degree_review_path)
+      end
+    end
+  end
+
   describe '#personal_details_completed?' do
     it 'returns true if personal details section is completed' do
       application_form = build(:application_form, personal_details_completed: true)

--- a/spec/services/duplicate_application_spec.rb
+++ b/spec/services/duplicate_application_spec.rb
@@ -44,6 +44,19 @@ RSpec.describe DuplicateApplication do
     expect(duplicate_application_form.equality_and_diversity_completed).to be_nil
   end
 
+  context 'when candidates has degrees' do
+    it 'sets university degree to true' do
+      create(:degree_qualification, :bachelor, application_form: @original_application_form)
+      expect(duplicate_application_form.university_degree).to be true
+    end
+  end
+
+  context 'when candidates does not have degrees' do
+    it 'does not set university degree' do
+      expect(duplicate_application_form.university_degree).to be_nil
+    end
+  end
+
   context 'english proficiency' do
     it 'carries over english proficiency data where qualification is not needed' do
       create(:english_proficiency, :qualification_not_needed, application_form: @original_application_form)

--- a/spec/system/candidate_interface/entering_details/degrees/backlinks_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/backlinks_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'Degrees' do
   scenario 'Candidate editing degree' do
     given_i_am_signed_in
     and_i_have_completed_the_degree_section
+    and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
     when_i_view_the_degree_section
     and_i_click_to_change_my_undergraduate_degree_type
     and_i_click_the_back_link
@@ -62,6 +63,10 @@ RSpec.describe 'Degrees' do
   def given_i_am_signed_in
     @candidate = create(:candidate)
     login_as(@candidate)
+  end
+
+  def and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
+    FeatureFlag.deactivate(:teacher_degree_apprenticeship)
   end
 
   def and_i_have_completed_the_degree_section

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_adding_unknown_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_adding_unknown_degrees_spec.rb
@@ -2,6 +2,9 @@ require 'rails_helper'
 
 RSpec.describe 'Adding an unknown degree', :js do
   include CandidateHelper
+  before do
+    given_teacher_degree_apprenticeship_redirect_feature_flag_is_off
+  end
 
   scenario 'Candidate enters their degree' do
     given_i_am_signed_in
@@ -72,6 +75,10 @@ RSpec.describe 'Adding an unknown degree', :js do
     given_i_am_at_the_degree_subject_page
     when_i_fill_in_the_subject_with_a_custom_subject_that_has_an_incorrect_auto_suggestion
     then_the_custom_subject_remains_filled_in
+  end
+
+  def given_teacher_degree_apprenticeship_redirect_feature_flag_is_off
+    FeatureFlag.deactivate(:teacher_degree_apprenticeship)
   end
 
   def given_i_am_at_the_degree_subject_page

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_delete_and_replace_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_delete_and_replace_degrees_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Deleting and replacing a degree' do
 
   scenario 'Candidate deletes and replaces their degree' do
     given_i_am_signed_in
+    and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
     and_i_have_completed_the_degree_section
     when_i_view_the_degree_section
     and_i_click_on_change_country
@@ -39,6 +40,10 @@ RSpec.describe 'Deleting and replacing a degree' do
   def given_i_am_signed_in
     @candidate = create(:candidate)
     login_as(@candidate)
+  end
+
+  def and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
+    FeatureFlag.deactivate(:teacher_degree_apprenticeship)
   end
 
   def when_i_view_the_degree_section

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_editing_international_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_editing_international_degrees_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Editing a degree' do
 
   before do
     given_i_am_signed_in
+    and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
     when_i_view_the_degree_section
     and_i_create_an_international_degree
   end
@@ -22,6 +23,10 @@ RSpec.describe 'Editing a degree' do
     and_i_choose_uk
     and_i_click_on_save_and_continue
     then_i_start_the_add_degree_flow_from_the_beginning
+  end
+
+  def and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
+    FeatureFlag.deactivate(:teacher_degree_apprenticeship)
   end
 
   def then_i_start_the_add_degree_flow_from_the_beginning

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_degrees_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Entering a degree' do
 
   scenario 'Candidate enters their degree' do
     given_i_am_signed_in
+    and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
     when_i_view_the_degree_section
 
     # Add degree
@@ -69,6 +70,10 @@ RSpec.describe 'Entering a degree' do
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
+  end
+
+  def and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
+    FeatureFlag.deactivate(:teacher_degree_apprenticeship)
   end
 
   def when_i_view_the_degree_section

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degree_without_a_grade_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degree_without_a_grade_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Entering an international doctorate degree' do
 
   scenario 'Candidate enters their degree' do
     given_i_am_signed_in
+    and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
     when_i_view_the_degree_section
 
     and_i_click_add_degree
@@ -35,6 +36,10 @@ private
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
+  end
+
+  def and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
+    FeatureFlag.deactivate(:teacher_degree_apprenticeship)
   end
 
   def when_i_view_the_degree_section

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degree_without_an_enic_reason_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degree_without_an_enic_reason_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Entering an international doctorate degree' do
 
   scenario 'Candidate enters their degree without an enic reason' do
     given_i_am_signed_in
+    and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
     when_i_view_the_degree_section
 
     and_i_click_add_degree
@@ -23,6 +24,10 @@ private
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
+  end
+
+  def and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
+    FeatureFlag.deactivate(:teacher_degree_apprenticeship)
   end
 
   def when_i_view_the_degree_section

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degrees_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Entering an international degree' do
 
   scenario 'Candidate enters their degree' do
     given_i_am_signed_in
+    and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
     when_i_view_the_degree_section
 
     # Add degree
@@ -69,6 +70,10 @@ RSpec.describe 'Entering an international degree' do
     and_that_the_section_is_completed
     when_i_click_on_degree
     then_i_can_check_my_answers
+  end
+
+  def and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
+    FeatureFlag.deactivate(:teacher_degree_apprenticeship)
   end
 
   def given_i_am_signed_in

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_masters_degree_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_masters_degree_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Entering a Masters degree' do
 
   scenario 'Candidate enters their Masters degree' do
     given_i_am_signed_in
+    and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
     when_i_view_the_degree_section
 
     # Add degree
@@ -61,6 +62,10 @@ RSpec.describe 'Entering a Masters degree' do
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
+  end
+
+  def and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
+    FeatureFlag.deactivate(:teacher_degree_apprenticeship)
   end
 
   def when_i_view_the_degree_section

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_phd_degree_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_phd_degree_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Entering a PhD' do
 
   scenario 'Candidate enters their PhD' do
     given_i_am_signed_in
+    and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
     when_i_view_the_degree_section
 
     # Add degree
@@ -57,6 +58,10 @@ RSpec.describe 'Entering a PhD' do
 
     # Review
     then_i_can_check_my_phd
+  end
+
+  def and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
+    FeatureFlag.deactivate(:teacher_degree_apprenticeship)
   end
 
   def given_i_am_signed_in

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_university_degree_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_university_degree_spec.rb
@@ -45,6 +45,26 @@ RSpec.describe 'Entering a degree' do
     and_i_click_continue
     then_i_can_see_the_country_page
     and_the_back_link_points_to_the_university_degree_page
+
+    when_i_finish_adding_a_degree
+    then_i_am_on_the_review_page
+
+    when_i_click_to_delete_a_degree
+    and_i_confirm_the_deletion
+    then_i_am_on_your_details_page
+
+    when_i_view_the_degree_section
+    then_i_can_see_the_university_degree_page
+    when_i_answer_yes
+    and_i_click_continue
+    and_i_finish_adding_a_degree
+
+    when_i_click_to_add_another_degree
+    and_i_finish_adding_a_degree
+    when_i_click_to_delete_a_degree
+    and_i_confirm_the_deletion
+    then_i_am_on_the_review_page
+    and_i_still_have_one_degree
   end
 
   def given_i_am_on_the_cycle_when_candidates_can_enter_details_for_undergraduate_course
@@ -121,6 +141,10 @@ RSpec.describe 'Entering a degree' do
     click_link_or_button 'Change'
   end
 
+  def and_i_click_save_and_continue
+    click_link_or_button 'Save and continue'
+  end
+
   def and_i_see_that_i_do_not_have_a_degree
     expect(page).to have_content('Do you have a university degree? No, I do not have a degree Change')
   end
@@ -135,5 +159,55 @@ RSpec.describe 'Entering a degree' do
 
   def back_link
     find('a', text: 'Back')[:href]
+  end
+
+  def when_i_finish_adding_a_degree
+    choose 'United Kingdom'
+    and_i_click_save_and_continue
+
+    choose 'Bachelor degree'
+    and_i_click_save_and_continue
+
+    select 'Astronomy', from: 'What subject is your degree?'
+    and_i_click_save_and_continue
+
+    choose 'Bachelor of Science (BSc)'
+    and_i_click_save_and_continue
+
+    select 'London School of Science and Technology', from: 'candidate_interface_degree_wizard[university]'
+    and_i_click_save_and_continue
+
+    choose 'Yes'
+    and_i_click_save_and_continue
+
+    choose 'First-class honours'
+    and_i_click_save_and_continue
+
+    fill_in 'What year did you start your degree?', with: '2020'
+    and_i_click_save_and_continue
+
+    fill_in 'What year did you graduate?', with: '2024'
+    and_i_click_save_and_continue
+  end
+  alias_method :and_i_finish_adding_a_degree, :when_i_finish_adding_a_degree
+
+  def then_i_am_on_the_review_page
+    expect(page).to have_current_path(candidate_interface_degree_review_path)
+  end
+
+  def when_i_click_to_delete_a_degree
+    click_link_or_button 'Delete degree', match: :first
+  end
+
+  def and_i_confirm_the_deletion
+    click_link_or_button 'Yes I’m sure - delete this degree'
+  end
+
+  def when_i_click_to_add_another_degree
+    click_link_or_button 'Add another degree'
+  end
+
+  def and_i_still_have_one_degree
+    expect(page).to have_content('BSc (Hons) Astronomy').once
   end
 end

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_university_degree_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_university_degree_spec.rb
@@ -13,6 +13,9 @@ RSpec.describe 'Entering a degree' do
     when_i_view_the_degree_section
     then_i_can_see_the_university_degree_page
 
+    when_i_click_continue
+    then_i_see_the_error_message_to_answer_the_degree_question
+
     when_i_answer_no
     and_i_click_continue
     then_i_can_see_degrees_section_is_completed
@@ -96,6 +99,7 @@ RSpec.describe 'Entering a degree' do
   def and_i_click_continue
     click_link_or_button 'Continue'
   end
+  alias_method :when_i_click_continue, :and_i_click_continue
 
   def when_i_click_degree_section
     click_link_or_button 'Degree'
@@ -123,6 +127,10 @@ RSpec.describe 'Entering a degree' do
 
   def and_i_see_the_no_degree_option_chosen
     expect(find_field('No, I do not have a degree').checked?).to be true
+  end
+
+  def then_i_see_the_error_message_to_answer_the_degree_question
+    expect(page).to have_content('Select whether you have a university degree')
   end
 
   def back_link

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_university_degree_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_university_degree_spec.rb
@@ -1,0 +1,131 @@
+require 'rails_helper'
+
+RSpec.describe 'Entering a degree' do
+  include CandidateHelper
+
+  before do
+    given_i_am_on_the_cycle_when_candidates_can_enter_details_for_undergraduate_course
+    and_teacher_degree_apprenticeship_feature_flag_is_active
+  end
+
+  scenario 'Candidate does not have a degree' do
+    given_i_am_signed_in
+    when_i_view_the_degree_section
+    then_i_can_see_the_university_degree_page
+
+    when_i_answer_no
+    and_i_click_continue
+    then_i_can_see_degrees_section_is_completed
+
+    # test that clicking on review degrees section
+    # doesn't change the section to incomplete
+    when_i_click_degree_section
+    and_i_click_back
+    then_i_can_see_degrees_section_is_completed
+
+    when_i_click_degree_section
+    then_i_do_not_see_the_button_to_add_a_degree
+    and_i_am_on_the_degree_review_page
+    and_i_see_that_i_do_not_have_a_degree
+
+    when_i_click_to_change
+    then_i_can_see_the_university_degree_page
+    and_i_see_the_no_degree_option_chosen
+  end
+
+  scenario 'Candidate does have a university degree' do
+    given_i_am_signed_in
+    when_i_view_the_degree_section
+    then_i_can_see_the_university_degree_page
+
+    when_i_answer_yes
+    and_i_click_continue
+    then_i_can_see_the_country_page
+    and_the_back_link_points_to_the_university_degree_page
+  end
+
+  def given_i_am_on_the_cycle_when_candidates_can_enter_details_for_undergraduate_course
+    TestSuiteTimeMachine.advance_time_to(
+      CycleTimetableHelper.after_apply_deadline(2024),
+    )
+  end
+
+  def and_teacher_degree_apprenticeship_feature_flag_is_active
+    FeatureFlag.activate(:teacher_degree_apprenticeship)
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def when_i_view_the_degree_section
+    visit candidate_interface_continuous_applications_details_path
+    when_i_click_on_degree
+  end
+
+  def when_i_click_on_degree
+    click_link_or_button 'Degree'
+  end
+
+  def then_i_can_see_the_university_degree_page
+    expect(page).to have_current_path(candidate_interface_degree_university_degree_path)
+    expect(page).to have_content('Do you have a university degree?')
+  end
+
+  def when_i_answer_no
+    choose 'No, I do not have a degree'
+  end
+
+  def when_i_answer_yes
+    choose 'Yes, I have a degree or am studying for one'
+  end
+
+  def then_i_can_see_degrees_section_is_completed
+    expect(page).to have_current_path(candidate_interface_continuous_applications_details_path)
+    expect(page).to have_content('Degree Completed')
+  end
+
+  def then_i_can_see_the_country_page
+    expect(page).to have_content('Which country was the degree from?')
+  end
+
+  def and_the_back_link_points_to_the_university_degree_page
+    expect(back_link).to eq(candidate_interface_degree_university_degree_path)
+  end
+
+  def and_i_click_continue
+    click_link_or_button 'Continue'
+  end
+
+  def when_i_click_degree_section
+    click_link_or_button 'Degree'
+  end
+
+  def and_i_click_back
+    click_link_or_button 'Back'
+  end
+
+  def then_i_do_not_see_the_button_to_add_a_degree
+    expect(page).to have_no_content('Add a degree')
+  end
+
+  def and_i_am_on_the_degree_review_page
+    expect(page).to have_current_path(candidate_interface_degree_review_path)
+  end
+
+  def when_i_click_to_change
+    click_link_or_button 'Change'
+  end
+
+  def and_i_see_that_i_do_not_have_a_degree
+    expect(page).to have_content('Do you have a university degree? No, I do not have a degree Change')
+  end
+
+  def and_i_see_the_no_degree_option_chosen
+    expect(find_field('No, I do not have a degree').checked?).to be true
+  end
+
+  def back_link
+    find('a', text: 'Back')[:href]
+  end
+end

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_university_degree_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_university_degree_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Entering a degree' do
 
   before do
     given_i_am_on_the_cycle_when_candidates_can_enter_details_for_undergraduate_course
-    and_teacher_degree_apprenticeship_feature_flag_is_active
+    and_teacher_degree_apprenticeship_feature_flag_is_on
   end
 
   scenario 'Candidate does not have a degree' do
@@ -48,12 +48,12 @@ RSpec.describe 'Entering a degree' do
   end
 
   def given_i_am_on_the_cycle_when_candidates_can_enter_details_for_undergraduate_course
-    TestSuiteTimeMachine.advance_time_to(
+    TestSuiteTimeMachine.travel_permanently_to(
       CycleTimetableHelper.after_apply_deadline(2024),
     )
   end
 
-  def and_teacher_degree_apprenticeship_feature_flag_is_active
+  def and_teacher_degree_apprenticeship_feature_flag_is_on
     FeatureFlag.activate(:teacher_degree_apprenticeship)
   end
 

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_university_degree_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_university_degree_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'Entering a degree' do
   end
 
   def when_i_view_the_degree_section
-    visit candidate_interface_continuous_applications_details_path
+    visit candidate_interface_details_path
     when_i_click_on_degree
   end
 
@@ -104,7 +104,7 @@ RSpec.describe 'Entering a degree' do
   end
 
   def then_i_can_see_degrees_section_is_completed
-    expect(page).to have_current_path(candidate_interface_continuous_applications_details_path)
+    expect(page).to have_current_path(candidate_interface_details_path)
     expect(page).to have_content('Degree Completed')
   end
 


### PR DESCRIPTION
## Context

We need to enable candidates without a degree to apply for TDA courses. We want them to be able to mark all section as complete in the task list, so they can feel confident they have done everything they need in order to apply for courses.

## Changes proposed in this pull request

The page view is updated to include a question if they have a degree or not.
If they have a degree the flow proceeds to what is currently live.
If they do not have a degree, they are taken back to the tasklist with the section marked as complete.

![screencapture-localhost-3000-candidate-application-degrees-do-you-have-a-degree-2024-09-02-17_16_41](https://github.com/user-attachments/assets/0f7de545-20cd-48a5-a87e-20abf6450c18)


## Guidance to review

To test this feature locally or on the review app you need:

1. Set the cycle switcher (visiting `/support/settings/cycles`) and choose any of these options: "Find has reopened" or "Apply has reopened"
2. Activate the feature flag "Teacher degree apprenticeship"

### Scenario 1: Postgraduate route on carry over (from 2024 to 2025)

If you carry over a candidate that already has a degree, the university question won't be show and the field would be set to true.

### Scenario 2:  Carry over (from 2024 to 2025) a candidate without degrees

On these case the new question should be shown.
     
### Scenario 3: New account

On these case the new question should be shown.

### Scenario 4: 2024 candidate

The new question should not be shown by any user flow because this is only for the next cycle.