### PR TITLE
Stop trying to generate reports in seeds

### DIFF
--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -31,26 +31,6 @@ task setup_local_dev_data: %i[environment copy_feature_flags_from_production syn
   puts 'Finding duplicate applications'
   UpdateDuplicateMatchesWorker.new.perform
 
-  puts 'Creating recruitment performance reports'
-  if !HostingEnvironment.development?
-    puts 'Testing presence of WIF config'
-    puts
-    puts
-    puts "ENV['AZURE_CLIENT_ID'] : #{ENV['AZURE_CLIENT_ID']}"
-    puts "ENV['AZURE_FEDERATED_TOKEN_FILE'] : #{ENV['AZURE_FEDERATED_TOKEN_FILE']}"
-    puts
-    puts
-    puts 'Skipping Report generation in development mode. WIF is not possible in dev.'
-    cycle_week = CycleTimetable.current_cycle_week.pred
-
-    Publications::NationalRecruitmentPerformanceReportWorker.new.perform(cycle_week)
-    Provider.pluck(:id).first(16).each do |provider_id|
-      # Limiting the number of reports generated to 16 -- that's the number of providers we currently create here
-      # But if that changes, we don't want to accidentally hit BigQuery hundreds of times.
-      Publications::ProviderRecruitmentPerformanceReportWorker.new.perform(provider_id, cycle_week)
-    end
-  end
-
   Rake::Task['create_undergraduate_courses'].invoke
 end
 

--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -33,6 +33,13 @@ task setup_local_dev_data: %i[environment copy_feature_flags_from_production syn
 
   puts 'Creating recruitment performance reports'
   if !HostingEnvironment.development?
+    puts 'Testing presence of WIF config'
+    puts
+    puts
+    puts "ENV['AZURE_CLIENT_ID'] : #{ENV['AZURE_CLIENT_ID']}"
+    puts "ENV['AZURE_FEDERATED_TOKEN_FILE'] : #{ENV['AZURE_FEDERATED_TOKEN_FILE']}"
+    puts
+    puts
     puts 'Skipping Report generation in development mode. WIF is not possible in dev.'
     cycle_week = CycleTimetable.current_cycle_week.pred
 

--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -32,13 +32,16 @@ task setup_local_dev_data: %i[environment copy_feature_flags_from_production syn
   UpdateDuplicateMatchesWorker.new.perform
 
   puts 'Creating recruitment performance reports'
-  cycle_week = CycleTimetable.current_cycle_week.pred
+  if !HostingEnvironment.development?
+    puts 'Skipping Report generation in development mode. WIF is not possible in dev.'
+    cycle_week = CycleTimetable.current_cycle_week.pred
 
-  Publications::NationalRecruitmentPerformanceReportWorker.new.perform(cycle_week)
-  Provider.pluck(:id).first(16).each do |provider_id|
-    # Limiting the number of reports generated to 16 -- that's the number of providers we currently create here
-    # But if that changes, we don't want to accidentally hit BigQuery hundreds of times.
-    Publications::ProviderRecruitmentPerformanceReportWorker.new.perform(provider_id, cycle_week)
+    Publications::NationalRecruitmentPerformanceReportWorker.new.perform(cycle_week)
+    Provider.pluck(:id).first(16).each do |provider_id|
+      # Limiting the number of reports generated to 16 -- that's the number of providers we currently create here
+      # But if that changes, we don't want to accidentally hit BigQuery hundreds of times.
+      Publications::ProviderRecruitmentPerformanceReportWorker.new.perform(provider_id, cycle_week)
+    end
   end
 
   Rake::Task['create_undergraduate_courses'].invoke


### PR DESCRIPTION
## Context

We cannot generate a performance report locally anymore because the reporting system depends on WIF authentication.
This task also cannot run during the setup of a review app becuase the task is run on the web pods and WIF is only enabled on the worker pods.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
