### PR TITLE
[2221] New content for new cycle has started email

### DIFF
--- a/app/components/shared/end_of_cycle_emails_component.rb
+++ b/app/components/shared/end_of_cycle_emails_component.rb
@@ -19,7 +19,7 @@ class EndOfCycleEmailsComponent < ViewComponent::Base
         candidates_size: candidates_to_notify_about_find_and_apply,
       },
       {
-        link: preview_email_link('Apply has opened', path: 'candidate_mailer/new_cycle_has_started_with_unsuccessful_application'),
+        link: preview_email_link('Apply has opened', path: 'candidate_mailer/new_cycle_has_started'),
         date: email_date(:apply_reopens),
         candidates_size: candidates_to_notify_about_find_and_apply,
       },

--- a/app/queries/get_unsuccessful_and_unsubmitted_candidates.rb
+++ b/app/queries/get_unsuccessful_and_unsubmitted_candidates.rb
@@ -4,9 +4,13 @@ class GetUnsuccessfulAndUnsubmittedCandidates
     # Candidates who didn't have successful applications last year
     Candidate
       .left_outer_joins(:application_forms)
-      .where.not(candidates: { unsubscribed_from_emails: true })
-      .where.not(candidates: { submission_blocked: true })
-      .where.not(candidates: { account_locked: true })
+      .where(
+        {
+          submission_blocked: false,
+          account_locked: false,
+          unsubscribed_from_emails: false,
+        },
+      )
       .where(
         '(application_forms.recruitment_cycle_year = (:previous_recruitment_year) AND NOT EXISTS (:successful))',
         previous_recruitment_year:,
@@ -22,9 +26,13 @@ class GetUnsuccessfulAndUnsubmittedCandidates
             recruitment_cycle_year: RecruitmentCycle.current_year,
             submitted_at: nil,
           })
-          .where.not(candidates: { unsubscribed_from_emails: true })
-          .where.not(candidates: { submission_blocked: true })
-          .where.not(candidates: { account_locked: true }),
+          .where(
+            {
+              submission_blocked: false,
+              account_locked: false,
+              unsubscribed_from_emails: false,
+            },
+          ),
       )
       .distinct
   end

--- a/app/views/candidate_mailer/new_cycle_has_started.erb
+++ b/app/views/candidate_mailer/new_cycle_has_started.erb
@@ -8,13 +8,9 @@ Courses can fill up quickly, so apply as soon as you are ready.
 
 [Sign into your account to apply for courses](<%= candidate_magic_link(@application_form.candidate) %>).
 
-Training providers offer places on courses as people apply throughout the year. Courses stay open until they are full.
-
-[Read how the application process works](<%= candidate_interface_guidance_url %>).
-
 # Get a teacher training adviser
 
-A teacher training adviser can help you write a strong application:
+A teacher training adviser can help you write a strong application.
 
 [Get a teacher training adviser](<%= email_link_with_utm_params I18n.t('get_into_teaching.url_get_an_adviser_start'), 'new_cycle_has_started', @application_form.phase %>)
 
@@ -24,4 +20,6 @@ All our advisers are experienced former teachers who provide free, one-to-one su
 
 Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'find_has_opened', @application_form.phase %>).
 
-<%= t('get_into_teaching.opening_times') %>.
+---
+
+[Unsubscribe from these emails](<%= candidate_unsubscribe_link(@application_form.candidate) %>). You will still receive essential updates about your application.

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -791,7 +791,7 @@ RSpec.describe CandidateMailer do
   end
 
   describe '.new_cycle_has_started', time: mid_cycle do
-    context "when the candidate's application was unsubmitted" do
+    context 'when the candidate has included a first name' do
       let(:application_form) { build_stubbed(:application_form, first_name: 'Fred', submitted_at: nil) }
       let(:email) { mailer.new_cycle_has_started(application_form) }
 
@@ -799,22 +799,8 @@ RSpec.describe CandidateMailer do
         'a mail with subject and content',
         "Apply for teacher training starting in the #{CycleTimetable.current_year} to #{CycleTimetable.next_year} academic year",
         'greeting' => 'Dear Fred',
-        'academic_year' => "#{CycleTimetable.current_year} to #{CycleTimetable.next_year}",
+        'academic_year' => "You can now apply for teacher training courses that start in the #{CycleTimetable.current_year} to #{CycleTimetable.next_year} academic year.",
         'details' => 'Courses can fill up quickly, so apply as soon as you are ready.',
-      )
-    end
-
-    context "when the candidate's application was unsuccessful" do
-      let(:application_choice) { build_stubbed(:application_choice, :rejected) }
-      let(:application_form) { build_stubbed(:application_form, first_name: 'Fred', application_choices: [application_choice]) }
-      let(:email) { mailer.new_cycle_has_started(application_form) }
-
-      it_behaves_like(
-        'a mail with subject and content',
-        "Apply for teacher training starting in the #{CycleTimetable.current_year} to #{CycleTimetable.next_year} academic year",
-        'greeting' => 'Dear Fred',
-        'academic_year' => "#{CycleTimetable.current_year} to #{CycleTimetable.next_year}",
-        'details' => 'Training providers offer places on courses as people apply throughout the year. Courses stay open until they are full.',
       )
     end
 

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -493,15 +493,8 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.application_deadline_has_passed(application_form)
   end
 
-  def new_cycle_has_started_with_no_first_name_and_unsubmitted_application
-    application_form = FactoryBot.build(:application_form, first_name: nil, submitted_at: nil)
-
-    CandidateMailer.new_cycle_has_started(application_form)
-  end
-
-  def new_cycle_has_started_with_unsuccessful_application
-    application_choice = FactoryBot.create(:application_choice, :rejected)
-    application_form = FactoryBot.build(:completed_application_form, first_name: 'Tester', application_choices: [application_choice])
+  def new_cycle_has_started
+    application_form = FactoryBot.build(:completed_application_form, first_name: 'Tester')
 
     CandidateMailer.new_cycle_has_started(application_form)
   end


### PR DESCRIPTION
## Context

When apply opens we send an email to candidates who:
- Started but did not submit an application in the 2024 cycle
- Submitted application choices, but not successfully

## Changes proposed in this pull request

Small content changes to the email. The worker already exists. 

## Guidance to review
Preview of email locally or in review app `rails/mailers/candidate_mailer/new_cycle_has_started`

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
