### PR TITLE
Allow candidate to edit work histories

### DIFF
--- a/app/components/candidate_interface/editable_section_warning.html.erb
+++ b/app/components/candidate_interface/editable_section_warning.html.erb
@@ -1,7 +1,9 @@
 <div class="govuk-inset-text">
   <% if @section_policy.personal_statement? %>
-    Any changes you make to your personal statement will not be included in applications you have already submitted.
+    <%= t('editable_section_warning.not_included_in_submitted_personal_statement') %>
+  <% elsif @section_policy.work_history? %>
+    <%= t('editable_section_warning.not_included_in_submitted') %>
   <% else %>
-    Any changes you make will be included in applications you have already submitted.
+    <%= t('editable_section_warning.included_in_submitted') %>
   <% end %>
 </div>

--- a/app/services/candidate_interface/section_policy.rb
+++ b/app/services/candidate_interface/section_policy.rb
@@ -24,6 +24,15 @@ module CandidateInterface
       @controller_path.classify.eql?('CandidateInterface::PersonalStatement')
     end
 
+    def work_history?
+      controllers = [
+        'CandidateInterface::RestructuredWorkHistory::Review',
+        'CandidateInterface::Volunteering::Review',
+      ]
+
+      controllers.include?(@controller_path.classify)
+    end
+
   private
 
     delegate :any_offer_accepted?, to: :current_application

--- a/config/application.rb
+++ b/config/application.rb
@@ -114,6 +114,8 @@ module ApplyForPostgraduateTeacherTraining
       becoming_a_teacher
       science_gcse
       efl
+      work_history
+      volunteering
     ]
     config.x.sections.editable_window_days = 5
   end

--- a/config/locales/components/candidate_interface/editable_section_warning.yml
+++ b/config/locales/components/candidate_interface/editable_section_warning.yml
@@ -1,0 +1,5 @@
+en:
+  editable_section_warning:
+    not_included_in_submitted_personal_statement: Any changes you make to your personal statement will not be included in applications you have already submitted.
+    not_included_in_submitted: Any changes you make will not be included in applications you have already submitted.
+    included_in_submitted: Any changes you make will be included in applications you have already submitted.

--- a/spec/components/candidate_interface/editable_section_warning_spec.rb
+++ b/spec/components/candidate_interface/editable_section_warning_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CandidateInterface::EditableSectionWarning do
     let(:current_application) { create(:application_form, :completed, submitted_application_choices_count: 1) }
 
     context 'when candidate can edit the section' do
-      let(:section_policy) { instance_double(CandidateInterface::SectionPolicy, can_edit?: true, personal_statement?: false) }
+      let(:section_policy) { instance_double(CandidateInterface::SectionPolicy, can_edit?: true, personal_statement?: false, work_history?: false) }
 
       it 'renders message' do
         expect(result.text).to include(
@@ -25,6 +25,16 @@ RSpec.describe CandidateInterface::EditableSectionWarning do
         it 'renders message' do
           expect(result.text).to include(
             'Any changes you make to your personal statement will not be included in applications you have already submitted.',
+          )
+        end
+      end
+
+      context 'when the canidate can edit the section and it is the work_history' do
+        let(:section_policy) { instance_double(CandidateInterface::SectionPolicy, can_edit?: true, personal_statement?: false, work_history?: true) }
+
+        it 'renders message' do
+          expect(result.text).to include(
+            'Any changes you make will not be included in applications you have already submitted.',
           )
         end
       end

--- a/spec/factories/application_volunteering_experience.rb
+++ b/spec/factories/application_volunteering_experience.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :application_volunteering_experience do
     role { ['Teacher', 'Teaching Assistant'].sample }
+    currently_working { true }
     organisation { Faker::Educator.secondary_school }
     details { Faker::Lorem.paragraph_by_chars(number: 300) }
     working_with_children { [true, true, true, false].sample }

--- a/spec/services/candidate_interface/section_policy_spec.rb
+++ b/spec/services/candidate_interface/section_policy_spec.rb
@@ -49,6 +49,22 @@ RSpec.describe CandidateInterface::SectionPolicy do
           expect(section_policy.can_edit?).to be false
         end
       end
+
+      context 'when accessing work history' do
+        let(:controller_path) { 'candidate_interface/restructured_work_history/review' }
+
+        it 'returns true' do
+          expect(section_policy.can_edit?).to be true
+        end
+      end
+
+      context 'when accessing volunteering experiences' do
+        let(:controller_path) { 'candidate_interface/volunteering/review' }
+
+        it 'returns true' do
+          expect(section_policy.can_edit?).to be true
+        end
+      end
     end
 
     context 'when candidates already submitted and adds a primary course choice and visits science GCSE' do
@@ -255,6 +271,32 @@ RSpec.describe CandidateInterface::SectionPolicy do
         it 'returns false' do
           expect(section_policy.can_edit?).to be false
         end
+      end
+    end
+  end
+
+  describe '#work_history?' do
+    context 'with work_history controller' do
+      let(:controller_path) { 'candidate_interface/restructured_work_history/review' }
+
+      it 'returns true' do
+        expect(section_policy.work_history?).to be true
+      end
+    end
+
+    context 'with volinteering experiences controller' do
+      let(:controller_path) { 'candidate_interface/volunteering/review' }
+
+      it 'returns true' do
+        expect(section_policy.work_history?).to be true
+      end
+    end
+
+    context 'without work history controllers' do
+      let(:controller_path) { 'candidate_interface/personal_details/review' }
+
+      it 'returns true' do
+        expect(section_policy.work_history?).to be false
       end
     end
   end

--- a/spec/system/candidate_interface/entering_details/candidate_can_not_edit_some_sections_after_first_submission_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_can_not_edit_some_sections_after_first_submission_spec.rb
@@ -16,8 +16,6 @@ RSpec.describe 'A candidate can not edit some sections after first submission' d
     NonEditableSection.new(:degree, 'Degree'),
     NonEditableSection.new(:references, 'References to be requested if you accept an offer'),
     NonEditableSection.new(:safeguarding, 'Declare any safeguarding issues'),
-    NonEditableSection.new(:work_history, 'Work history'),
-    NonEditableSection.new(:unpaid_experience, 'Unpaid experience'),
   ].each do |section|
     scenario "candidate can not edit section '#{section.title}' after submission" do
       @section = section

--- a/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_can_add_jobs_if_they_have_a_submitted_application_spec.rb
+++ b/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_can_add_jobs_if_they_have_a_submitted_application_spec.rb
@@ -3,12 +3,12 @@ require 'rails_helper'
 RSpec.describe 'Trying to enter work history' do
   include CandidateHelper
 
-  scenario 'Candidate does not see Add job or Add another job buttons' do
+  scenario 'Candidate does see Add job or Add another job buttons' do
     given_i_am_signed_in
     and_i_have_completed_work_history
     and_i_have_a_submitted_application
     when_i_view_work_history
-    then_i_do_not_see_an_option_to_add_another_job
+    then_i_do_see_an_option_to_add_another_job
   end
 
   def given_i_am_signed_in
@@ -31,9 +31,8 @@ RSpec.describe 'Trying to enter work history' do
     create(:application_choice, :awaiting_provider_decision, application_form: @application_form_can_complete_work_history)
   end
 
-  def then_i_do_not_see_an_option_to_add_another_job
+  def then_i_do_see_an_option_to_add_another_job
     expect(page).to have_content 'Work history'
-    expect(page).to have_no_content 'Add another job'
-    expect(page).to have_no_content 'Add job'
+    expect(page).to have_content 'Add another job'
   end
 end


### PR DESCRIPTION
## Context

We want to allow the candidate to edit their work histories, this will only edit work experiences, volunteering_experiences and work history breaks on the application form.

The application choices that are submitted will still have the old work histories. This is because each submitted application choice has its own work history.

So the user will be able to edit their work histories but only for new application choices.


## Changes proposed in this pull request

Added `work_history` and `volunteering` to config/application, to allow them to be editable here https://github.com/DFE-Digital/apply-for-teacher-training/blob/2e4d5b973402ba4a7b012feaa4ef5688adaabae4/app/services/section.rb#L80

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Go on review and edit an application form's  work experiences. The form needs to have choices submitted 

https://github.com/user-attachments/assets/48f7e506-d722-46df-9492-18f27e9a0a8a



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [X] Tested by running locally
- [X] Add PR link to Trello card
