### PR TITLE
Renamed candidate_interface_continuous_applications_choices instances

### DIFF
--- a/app/components/candidate_interface/application_choice_list_component.rb
+++ b/app/components/candidate_interface/application_choice_list_component.rb
@@ -20,7 +20,7 @@ module CandidateInterface
       @tabs.map do |tab|
         ApplicationTab.new(
           text: I18n.t("candidate_interface.application_tabs.#{tab}"),
-          link: candidate_interface_continuous_applications_choices_path(current_tab_name: tab),
+          link: candidate_interface_application_choices_path(current_tab_name: tab),
           active?: tab == current_tab_name,
         )
       end

--- a/app/components/candidate_interface/application_review_and_submit_component.html.erb
+++ b/app/components/candidate_interface/application_review_and_submit_component.html.erb
@@ -28,6 +28,6 @@
   <div class="govuk-button-group app-course-choice__confirm-submission">
     <%= govuk_button_to('Review application', review_path, method: :get) %>
 
-    <%= govuk_link_to('Save as draft', candidate_interface_continuous_applications_choices_path) %>
+    <%= govuk_link_to('Save as draft', candidate_interface_application_choices_path) %>
   </div>
 <% end %>

--- a/app/controllers/candidate_interface/after_sign_in_controller.rb
+++ b/app/controllers/candidate_interface/after_sign_in_controller.rb
@@ -29,7 +29,7 @@ module CandidateInterface
   private
 
     def course_choices_page
-      candidate_interface_continuous_applications_choices_path
+      candidate_interface_application_choices_path
     end
 
     def confirm_selection_page

--- a/app/controllers/candidate_interface/application_choices_controller.rb
+++ b/app/controllers/candidate_interface/application_choices_controller.rb
@@ -40,7 +40,7 @@ module CandidateInterface
     def destroy
       CandidateInterface::DeleteApplicationChoice.new(application_choice:).call
 
-      redirect_to candidate_interface_continuous_applications_choices_path
+      redirect_to candidate_interface_application_choices_path
     end
 
   private
@@ -49,7 +49,7 @@ module CandidateInterface
       CandidateInterface::SubmitApplicationChoice.new(@application_choice).call
       flash[:success] = t('application_form.submit_application_success.title')
 
-      redirect_to candidate_interface_continuous_applications_choices_path
+      redirect_to candidate_interface_application_choices_path
     end
 
     def application_choice

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -81,7 +81,7 @@ module CandidateInterface
       )
 
       if current_application.application_choices.any? && completed_application_form.valid?
-        redirect_to candidate_interface_continuous_applications_choices_path
+        redirect_to candidate_interface_application_choices_path
       else
         redirect_to candidate_interface_details_path
       end

--- a/app/controllers/candidate_interface/continuous_applications_controller.rb
+++ b/app/controllers/candidate_interface/continuous_applications_controller.rb
@@ -8,7 +8,7 @@ module CandidateInterface
   private
 
     def redirect_to_your_applications_if_submitted
-      redirect_to candidate_interface_continuous_applications_choices_path unless application_choice.unsubmitted?
+      redirect_to candidate_interface_application_choices_path unless application_choice.unsubmitted?
     end
 
     def verify_continuous_applications

--- a/app/controllers/candidate_interface/course_choices/base_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/base_controller.rb
@@ -95,15 +95,15 @@ module CandidateInterface
     private
 
       def redirect_to_your_applications_if_cycle_is_over
-        redirect_to candidate_interface_continuous_applications_choices_path unless CycleTimetable.can_add_course_choice?(current_application)
+        redirect_to candidate_interface_application_choices_path unless CycleTimetable.can_add_course_choice?(current_application)
       end
 
       def redirect_to_your_applications_if_maximum_amount_of_choices_have_been_used
-        redirect_to candidate_interface_continuous_applications_choices_path unless current_application.can_add_more_choices?
+        redirect_to candidate_interface_application_choices_path unless current_application.can_add_more_choices?
       end
 
       def redirect_to_your_applications_if_maximum_amount_of_unsuccessful_applications_have_been_reached
-        redirect_to candidate_interface_continuous_applications_choices_path if current_application.application_limit_reached?
+        redirect_to candidate_interface_application_choices_path if current_application.application_limit_reached?
       end
     end
   end

--- a/app/controllers/candidate_interface/course_choices/duplicate_course_selection_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/duplicate_course_selection_controller.rb
@@ -24,7 +24,7 @@ module CandidateInterface
       end
 
       def set_backlink
-        @backlink = candidate_interface_continuous_applications_choices_path if request.referer.blank?
+        @backlink = candidate_interface_application_choices_path if request.referer.blank?
       end
     end
   end

--- a/app/controllers/candidate_interface/decisions_controller.rb
+++ b/app/controllers/candidate_interface/decisions_controller.rb
@@ -32,7 +32,7 @@ module CandidateInterface
       decline = DeclineOffer.new(application_choice: @application_choice.reload)
       decline.save!
       flash[:success] = "You have declined your offer for #{@application_choice.current_course.name_and_code} at #{@application_choice.provider.name}"
-      redirect_to candidate_interface_continuous_applications_choices_path
+      redirect_to candidate_interface_application_choices_path
     end
 
     def accept_offer
@@ -44,7 +44,7 @@ module CandidateInterface
 
       if @accept_offer.save!
         flash[:success] = "You have accepted your offer for #{@application_choice.current_course.name_and_code} at #{@application_choice.provider.name}"
-        redirect_to candidate_interface_continuous_applications_choices_path
+        redirect_to candidate_interface_application_choices_path
       else
         track_validation_error(@accept_offer)
         render :accept_offer
@@ -72,7 +72,7 @@ module CandidateInterface
       if @withdrawal_feedback_form.save(@application_choice)
         flash[:success] = "Your application for #{@application_choice.current_course.name_and_code} at #{@application_choice.provider.name} has been withdrawn"
 
-        redirect_to candidate_interface_continuous_applications_choices_path
+        redirect_to candidate_interface_application_choices_path
       else
         track_validation_error(@withdrawal_feedback_form)
         @provider = @application_choice.provider

--- a/app/controllers/candidate_interface/prefill_application_form_controller.rb
+++ b/app/controllers/candidate_interface/prefill_application_form_controller.rb
@@ -13,7 +13,7 @@ module CandidateInterface
         if @prefill_application_or_not_form.prefill?
           prefill_candidate_application_form
           flash[:info] = 'This application has been prefilled with example data'
-          return redirect_to candidate_interface_continuous_applications_choices_path
+          return redirect_to candidate_interface_application_choices_path
         end
 
         redirect_to candidate_interface_details_path

--- a/app/controllers/concerns/back_links.rb
+++ b/app/controllers/concerns/back_links.rb
@@ -16,7 +16,7 @@ module BackLinks
     return '' unless defined?(current_application)
 
     if request.path.match?(/withdraw/)
-      candidate_interface_continuous_applications_choices_path
+      candidate_interface_application_choices_path
     else
       candidate_interface_details_path
     end

--- a/app/forms/candidate_interface/course_selection/find_course_selection_step.rb
+++ b/app/forms/candidate_interface/course_selection/find_course_selection_step.rb
@@ -21,7 +21,7 @@ module CandidateInterface
       end
 
       def exit_path
-        url_helpers.candidate_interface_continuous_applications_choices_path
+        url_helpers.candidate_interface_application_choices_path
       end
 
       def next_step

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -20,7 +20,7 @@ class NavigationItems
         [
           NavigationItem.new(
             t('page_titles.your_applications'),
-            candidate_interface_continuous_applications_choices_path,
+            candidate_interface_application_choices_path,
             true,
           ),
         ]
@@ -33,7 +33,7 @@ class NavigationItems
           ),
           NavigationItem.new(
             t('page_titles.your_applications'),
-            candidate_interface_continuous_applications_choices_path,
+            candidate_interface_application_choices_path,
             current_controller.respond_to?(:choices_controller?) ? current_controller.choices_controller? : false,
           ),
         ]

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -10,7 +10,7 @@ module ViewHelper
              body
            elsif url.to_s.end_with?(candidate_interface_details_path)
              'Back to your details'
-           elsif url.to_s.end_with?(candidate_interface_continuous_applications_choices_path)
+           elsif url.to_s.end_with?(candidate_interface_application_choices_path)
              'Back to your applications'
            end
 

--- a/app/views/candidate_interface/application_choices/confirm_destroy.html.erb
+++ b/app/views/candidate_interface/application_choices/confirm_destroy.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.continuous_applications_destroy_course_choice') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_continuous_applications_choices_path) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_choices_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/course_choices/do_you_know_which_course/new.html.erb
+++ b/app/views/candidate_interface/course_choices/do_you_know_which_course/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.do_you_know'), @wizard.current_step.errors.any?) %>
-<% content_for(:before_content, govuk_back_link_to(@wizard.previous_step_path(fallback: candidate_interface_continuous_applications_choices_path))) %>
+<% content_for(:before_content, govuk_back_link_to(@wizard.previous_step_path(fallback: candidate_interface_application_choices_path))) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/course_choices/review/show.html.erb
+++ b/app/views/candidate_interface/course_choices/review/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.application_review', provider_name: @application_choice.provider.name) %>
-<% content_for(:before_content, govuk_back_link_to(candidate_interface_continuous_applications_choices_path)) %>
+<% content_for(:before_content, govuk_back_link_to(candidate_interface_application_choices_path)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">

--- a/app/views/candidate_interface/course_choices/review_and_submit/show.html.erb
+++ b/app/views/candidate_interface/course_choices/review_and_submit/show.html.erb
@@ -23,7 +23,7 @@
     <div class="govuk-button-group app-course-choice__confirm-submission">
       <%= govuk_button_to('Confirm and submit application', candidate_interface_course_choices_submit_course_choice_path(@application_choice.id), method: :post) %>
 
-      <%= govuk_link_to('Save as draft', candidate_interface_continuous_applications_choices_path) %>
+      <%= govuk_link_to('Save as draft', candidate_interface_application_choices_path) %>
     </div>
   </div>
 </div>

--- a/app/views/candidate_interface/course_choices/review_enic_interruption/show.html.erb
+++ b/app/views/candidate_interface/course_choices/review_enic_interruption/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.application_review_and_submit', provider_name: @application_choice.provider.name) %>
-<% content_for(:before_content, govuk_back_link_to(candidate_interface_continuous_applications_choices_path)) %>
+<% content_for(:before_content, govuk_back_link_to(candidate_interface_application_choices_path)) %>
 
 <% if current_application.qualifications_enic_reasons_waiting_or_maybe? %>
   <%= render 'waiting_maybe' %>

--- a/app/views/candidate_interface/course_choices/review_interruption/show.html.erb
+++ b/app/views/candidate_interface/course_choices/review_interruption/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.application_review_and_submit', provider_name: @application_choice.provider.name) %>
-<% content_for(:before_content, govuk_back_link_to(candidate_interface_continuous_applications_choices_path)) %>
+<% content_for(:before_content, govuk_back_link_to(candidate_interface_application_choices_path)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">

--- a/app/views/candidate_interface/shared/_details.html.erb
+++ b/app/views/candidate_interface/shared/_details.html.erb
@@ -16,7 +16,7 @@
       <% message = 'Your details will be shared with the training provider when you apply.' %>
 
       <% if completed_application_form?(@application_form_presenter.application_form) %>
-        You can <%= govuk_link_to 'add your applications', candidate_interface_continuous_applications_choices_path %>.<br>
+        You can <%= govuk_link_to 'add your applications', candidate_interface_application_choices_path %>.<br>
         <br>
         <%= message %>
       <% else %>

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -59,7 +59,7 @@ namespace :candidate_interface, path: '/candidate' do
 
   scope '/application' do
     get '/details', to: 'details#index', as: :details
-    get '/choices(/:current_tab_name)', to: 'application_choices#index', as: :continuous_applications_choices
+    get '/choices(/:current_tab_name)', to: 'application_choices#index', as: :application_choices
 
     get '/prefill', to: 'prefill_application_form#new'
     post '/prefill', to: 'prefill_application_form#create'

--- a/spec/controllers/concerns/back_links_spec.rb
+++ b/spec/controllers/concerns/back_links_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe BackLinks do
       end
 
       it 'returns path to application choices' do
-        expect(instance.send(:application_form_path)).to eq routes.candidate_interface_continuous_applications_choices_path
+        expect(instance.send(:application_form_path)).to eq routes.candidate_interface_application_choices_path
       end
     end
   end

--- a/spec/requests/candidate_interface/after_sign_in_redirects_spec.rb
+++ b/spec/requests/candidate_interface/after_sign_in_redirects_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'After sign in redirects' do
     it 'redirects to your applications and shows a message to the candidate' do
       create(:application_choice, :awaiting_provider_decision, application_form:, course_option: create(:course_option, course: course_from_find))
       get candidate_interface_interstitial_path
-      expect(response).to redirect_to(candidate_interface_continuous_applications_choices_path)
+      expect(response).to redirect_to(candidate_interface_application_choices_path)
       follow_redirect!
       expect(response.body).to include("You have already added an application for #{course_from_find.name}")
     end
@@ -80,7 +80,7 @@ RSpec.describe 'After sign in redirects' do
     it 'redirects to your applications and shows a message to the candidate' do
       create_list(:application_choice, ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES, :awaiting_provider_decision, application_form:)
       get candidate_interface_interstitial_path
-      expect(response).to redirect_to(candidate_interface_continuous_applications_choices_path)
+      expect(response).to redirect_to(candidate_interface_application_choices_path)
       follow_redirect!
       expect(response.body).to include(I18n.t('errors.messages.too_many_course_choices', max_applications: ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES, course_name: course_from_find.name))
     end
@@ -90,7 +90,7 @@ RSpec.describe 'After sign in redirects' do
     it 'redirects to your applications and shows a message to the candidate' do
       create_list(:application_choice, ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS, :rejected, application_form:)
       get candidate_interface_interstitial_path
-      expect(response).to redirect_to(candidate_interface_continuous_applications_choices_path)
+      expect(response).to redirect_to(candidate_interface_application_choices_path)
       follow_redirect!
       expect(response.body).to include(I18n.t('errors.messages.too_many_unsuccessful_choices', max_unsuccessful_applications: ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS))
     end

--- a/spec/requests/candidate_interface/choose_course_spec.rb
+++ b/spec/requests/candidate_interface/choose_course_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'continuous applications redirects' do
 
       get candidate_interface_course_choices_course_confirm_selection_path(course.id)
 
-      expect(response).to redirect_to(candidate_interface_continuous_applications_choices_path)
+      expect(response).to redirect_to(candidate_interface_application_choices_path)
     end
   end
 end

--- a/spec/requests/candidate_interface/cycle_redirects_spec.rb
+++ b/spec/requests/candidate_interface/cycle_redirects_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Cycle redirects' do
   let(:continuous_applications_routes) do
     [
       candidate_interface_details_path,
-      candidate_interface_continuous_applications_choices_path,
+      candidate_interface_application_choices_path,
     ]
   end
 

--- a/spec/requests/candidate_interface/delete_application_choice_spec.rb
+++ b/spec/requests/candidate_interface/delete_application_choice_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'DELETE /candidate/application/continuous-applications/delete/:ap
     it 'destroys the application choice and redirects to review' do
       delete candidate_interface_course_choices_confirm_destroy_course_choice_path(application_choice)
       expect(ApplicationChoice.exists?(application_choice.id)).to be_falsey
-      expect(response).to redirect_to(candidate_interface_continuous_applications_choices_path)
+      expect(response).to redirect_to(candidate_interface_application_choices_path)
     end
   end
 
@@ -25,7 +25,7 @@ RSpec.describe 'DELETE /candidate/application/continuous-applications/delete/:ap
     it 'does not destroy the application choice and redirects to review' do
       delete candidate_interface_course_choices_confirm_destroy_course_choice_path(application_choice)
       expect(ApplicationChoice.exists?(application_choice.id)).to be_truthy
-      expect(response).to redirect_to(candidate_interface_continuous_applications_choices_path)
+      expect(response).to redirect_to(candidate_interface_application_choices_path)
     end
   end
 end

--- a/spec/requests/candidate_interface/edit_application_choice_spec.rb
+++ b/spec/requests/candidate_interface/edit_application_choice_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Edit courses on continuous applications' do
     it 'redirects to "your applications" tab' do
       paths.each do |path|
         get path
-        expect(response).to redirect_to(candidate_interface_continuous_applications_choices_path)
+        expect(response).to redirect_to(candidate_interface_application_choices_path)
       end
     end
   end

--- a/spec/requests/candidate_interface/reject_submission_blocked_spec.rb
+++ b/spec/requests/candidate_interface/reject_submission_blocked_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Block submission from blocked candidates' do
                  submit_answer: true,
                },
              }
-        expect(response).to redirect_to(candidate_interface_continuous_applications_choices_path)
+        expect(response).to redirect_to(candidate_interface_application_choices_path)
         follow_redirect!
         expect(response.body).to include(t('application_form.submit_application_success.title'))
       end

--- a/spec/requests/candidate_interface/review_and_submit_spec.rb
+++ b/spec/requests/candidate_interface/review_and_submit_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Redirects when reviewing before submission' do
       application_form = create(:completed_application_form, candidate:)
       application_choice = create(:application_choice, :awaiting_provider_decision, application_form:)
       get candidate_interface_course_choices_course_review_and_submit_path(application_choice.id)
-      expect(response).to redirect_to(candidate_interface_continuous_applications_choices_path)
+      expect(response).to redirect_to(candidate_interface_application_choices_path)
     end
   end
 
@@ -32,7 +32,7 @@ RSpec.describe 'Redirects when reviewing before submission' do
       application_choice = create(:application_choice, :unsubmitted, application_form:)
       travel_temporarily_to(after_apply_deadline) do
         get candidate_interface_course_choices_course_review_and_submit_path(application_choice.id)
-        expect(response).to redirect_to(candidate_interface_continuous_applications_choices_path)
+        expect(response).to redirect_to(candidate_interface_application_choices_path)
       end
     end
   end

--- a/spec/requests/candidate_interface/submission_spec.rb
+++ b/spec/requests/candidate_interface/submission_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Submit to continuous apps' do
     end
 
     it 'be successful' do
-      expect(response).to redirect_to(candidate_interface_continuous_applications_choices_path)
+      expect(response).to redirect_to(candidate_interface_application_choices_path)
       follow_redirect!
       expect(response.body).to include(I18n.t('application_form.submit_application_success.title'))
     end

--- a/spec/requests/provider_interface/provider_user_impersonates_candidate_spec.rb
+++ b/spec/requests/provider_interface/provider_user_impersonates_candidate_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'POST /provider/candidates/:id/impersonate' do
         post provider_interface_impersonate_candidate_path(application_choice.application_form.candidate)
         expect(response).to have_http_status :found
 
-        get candidate_interface_continuous_applications_choices_path
+        get candidate_interface_application_choices_path
         expect(response.redirect_url).to eq candidate_interface_start_carry_over_url
       end
     end

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -105,7 +105,7 @@ module CandidateHelper
     #
     ##########################################
 
-    visit candidate_interface_continuous_applications_choices_path
+    visit candidate_interface_application_choices_path
     click_link_or_button 'Add application'
     choose 'Yes, I know where I want to apply'
     click_link_or_button t('continue')
@@ -131,7 +131,7 @@ module CandidateHelper
   end
 
   def candidate_submits_application
-    visit candidate_interface_continuous_applications_choices_path
+    visit candidate_interface_application_choices_path
 
     click_link_or_button 'Gorse SCITT'
     click_link_or_button 'Review application'
@@ -229,7 +229,7 @@ module CandidateHelper
   end
 
   def candidate_fills_in_apply_again_course_choice
-    visit candidate_interface_continuous_applications_choices_path
+    visit candidate_interface_application_choices_path
     click_link_or_button 'Add application'
 
     choose 'Yes, I know where I want to apply'
@@ -354,7 +354,7 @@ module CandidateHelper
   end
 
   def candidate_reviews_application
-    visit candidate_interface_continuous_applications_choices_path
+    visit candidate_interface_application_choices_path
 
     click_link_or_button 'Gorse SCITT'
     click_link_or_button 'Review application'
@@ -362,7 +362,7 @@ module CandidateHelper
   end
 
   def candidate_fills_in_secondary_course_choice_with_incomplete_details
-    visit candidate_interface_continuous_applications_choices_path
+    visit candidate_interface_application_choices_path
     click_link_or_button 'Add application'
     choose 'Yes, I know where I want to apply'
     click_link_or_button t('continue')
@@ -376,7 +376,7 @@ module CandidateHelper
   alias candidate_adds_a_draft_application candidate_fills_in_secondary_course_choice_with_incomplete_details
 
   def candidate_fills_in_secondary_course_choice
-    visit candidate_interface_continuous_applications_choices_path
+    visit candidate_interface_application_choices_path
     click_link_or_button 'Add application'
     choose 'Yes, I know where I want to apply'
     click_link_or_button t('continue')
@@ -765,7 +765,7 @@ module CandidateHelper
   def then_i_can_add_course_choices
     expect(page).to have_current_path(candidate_interface_details_path)
     click_link_or_button 'Your applications'
-    expect(page).to have_current_path(candidate_interface_continuous_applications_choices_path)
+    expect(page).to have_current_path(candidate_interface_application_choices_path)
     expect(page).to have_content('You can add up to 4 applications at a time.')
     click_link_or_button 'Add application'
     expect(page).to have_current_path(candidate_interface_course_choices_do_you_know_the_course_path)
@@ -804,7 +804,7 @@ module CandidateHelper
   end
 
   def when_i_visit_my_applications
-    visit candidate_interface_continuous_applications_choices_path
+    visit candidate_interface_application_choices_path
   end
 
   def and_i_continue_with_my_application

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_after_rejecting_offer_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_after_rejecting_offer_between_cycles_spec.rb
@@ -65,7 +65,7 @@ private
   end
 
   def and_i_am_not_on_the_carry_over_page
-    expect(page).to have_current_path candidate_interface_continuous_applications_choices_path
+    expect(page).to have_current_path candidate_interface_application_choices_path
     expect(page).to have_content 'Your applications'
   end
 
@@ -75,8 +75,8 @@ private
   end
 
   def and_i_can_navigate_to_the_application_choices_page
-    visit candidate_interface_continuous_applications_choices_path
-    expect(page).to have_current_path candidate_interface_continuous_applications_choices_path
+    visit candidate_interface_application_choices_path
+    expect(page).to have_current_path candidate_interface_application_choices_path
   end
 
   def and_i_see_one_offer_and_one_declined_application

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_spec.rb
@@ -207,7 +207,7 @@ private
   end
 
   def then_i_am_redirect_to_your_applications_tab
-    expect(page).to have_current_path candidate_interface_continuous_applications_choices_path
+    expect(page).to have_current_path candidate_interface_application_choices_path
   end
 
   def when_i_visit_the_old_complete_page

--- a/spec/system/candidate_interface/carry_over/candidate_does_not_act_on_offer_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_does_not_act_on_offer_spec.rb
@@ -151,7 +151,7 @@ private
   end
 
   def then_i_cannot_carry_over_my_application
-    expect(page).to have_current_path candidate_interface_continuous_applications_choices_path
+    expect(page).to have_current_path candidate_interface_application_choices_path
     apply_reopens_date = I18n.l(CycleTimetable.apply_reopens.to_date, format: :no_year).strip
     expect(page).to have_content(
       "If your application(s) are not successful, or you do not accept any offers, you will be able to apply for courses starting in the #{CycleTimetable.cycle_year_range(RecruitmentCycle.next_year)} academic year from #{apply_reopens_date}.",

--- a/spec/system/candidate_interface/carry_over/candidate_has_application_rejected_by_default_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_has_application_rejected_by_default_spec.rb
@@ -96,7 +96,7 @@ private
   end
 
   def then_i_see_my_application_is_awaiting_provider_decision
-    expect(page).to have_current_path candidate_interface_continuous_applications_choices_path
+    expect(page).to have_current_path candidate_interface_application_choices_path
     expect(page).to have_content 'Awaiting decision'
   end
 
@@ -110,7 +110,7 @@ private
 
   def then_i_cannot_carry_over_my_application
     apply_reopens_date = I18n.l(CycleTimetable.apply_reopens.to_date, format: :no_year).strip
-    expect(page).to have_current_path candidate_interface_continuous_applications_choices_path
+    expect(page).to have_current_path candidate_interface_application_choices_path
     expect(page).to have_content(
       "If your application(s) are not successful, or you do not accept any offers, you will be able to apply for courses starting in the #{CycleTimetable.cycle_year_range(RecruitmentCycle.next_year)} academic year from #{apply_reopens_date}.",
     )

--- a/spec/system/candidate_interface/carry_over/candidate_receives_offer_betwen_cycles_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_receives_offer_betwen_cycles_spec.rb
@@ -73,7 +73,7 @@ private
   end
 
   def then_i_can_navigate_to_the_offer
-    expect(page).to have_current_path candidate_interface_continuous_applications_choices_path
+    expect(page).to have_current_path candidate_interface_application_choices_path
     expect(page).to have_content 'Offer received'
     click_on @application_choice.provider.name
   end

--- a/spec/system/candidate_interface/carry_over/candidate_views_and_withdraws_after_apply_deadline_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_views_and_withdraws_after_apply_deadline_spec.rb
@@ -40,7 +40,7 @@ private
   end
 
   def then_i_see_my_applications_page
-    expect(page).to have_current_path candidate_interface_continuous_applications_choices_path
+    expect(page).to have_current_path candidate_interface_application_choices_path
     expect(page).to have_content 'Your applications'
     expect(page).to have_content 'Awaiting decision'
   end

--- a/spec/system/candidate_interface/course_selection/backlinks_spec.rb
+++ b/spec/system/candidate_interface/course_selection/backlinks_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'Candidate edits course choices' do
   end
 
   def when_i_visit_my_application_page
-    visit candidate_interface_continuous_applications_choices_path
+    visit candidate_interface_application_choices_path
   end
 
   def and_i_click_on_course_choices
@@ -112,7 +112,7 @@ RSpec.describe 'Candidate edits course choices' do
   end
 
   def then_i_see_the_application_page
-    expect(page).to have_current_path(candidate_interface_continuous_applications_choices_path)
+    expect(page).to have_current_path(candidate_interface_application_choices_path)
   end
 
   def and_i_save_the_review_page_url_for_later

--- a/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_and_says_no_to_course_choice_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_and_says_no_to_course_choice_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'Candidate arrives from Find with provider and course params' do
 
   def then_i_am_redirected_to_your_applications_tab
     expect(page).to have_current_path(
-      candidate_interface_continuous_applications_choices_path,
+      candidate_interface_application_choices_path,
     )
   end
 end

--- a/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_with_duplicate_application_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_with_duplicate_application_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'Candidate arrives from Find with provider and course that is alr
 
   def then_i_am_redirected_to_your_applications_tab
     expect(page).to have_current_path(
-      candidate_interface_continuous_applications_choices_path,
+      candidate_interface_application_choices_path,
     )
   end
 

--- a/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_with_max_applications_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_with_max_applications_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Candidate arrives from Find with provider and course that is alr
 
   def then_i_am_redirected_to_your_applications_tab
     expect(page).to have_current_path(
-      candidate_interface_continuous_applications_choices_path,
+      candidate_interface_application_choices_path,
     )
   end
 

--- a/spec/system/candidate_interface/course_selection/candidate_deletes_application_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_deletes_application_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Candidate edits their choice section' do
   end
 
   def when_i_visit_the_course_choices_page
-    visit candidate_interface_continuous_applications_choices_path
+    visit candidate_interface_application_choices_path
   end
 
   def and_i_confirm_i_want_to_delete_the_choice
@@ -70,7 +70,7 @@ RSpec.describe 'Candidate edits their choice section' do
   end
 
   def then_i_am_on_the_my_application_page
-    expect(page).to have_current_path(candidate_interface_continuous_applications_choices_path)
+    expect(page).to have_current_path(candidate_interface_application_choices_path)
   end
 
   def and_my_submitted_choice_is_displayed

--- a/spec/system/candidate_interface/course_selection/candidate_edits_course_choices_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_edits_course_choices_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe 'Candidate edits course choices' do
   end
 
   def when_i_visit_my_application_page
-    visit candidate_interface_continuous_applications_choices_path
+    visit candidate_interface_application_choices_path
   end
 
   def and_i_click_on_course_choices

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe 'Selecting a course' do
   end
 
   def then_i_am_on_the_application_choices_page
-    expect(page.current_url).to end_with(candidate_interface_continuous_applications_choices_path)
+    expect(page.current_url).to end_with(candidate_interface_application_choices_path)
   end
 
   def when_the_course_is_full

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_study_mode_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_study_mode_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'Selecting a study mode' do
   end
 
   def when_i_select_a_part_time_course
-    visit candidate_interface_continuous_applications_choices_path
+    visit candidate_interface_application_choices_path
     click_link_or_button 'Add application'
 
     choose 'Yes, I know where I want to apply'
@@ -126,7 +126,7 @@ RSpec.describe 'Selecting a study mode' do
   end
 
   def when_i_select_the_single_site_full_time_course
-    visit candidate_interface_continuous_applications_choices_path
+    visit candidate_interface_application_choices_path
     click_link_or_button 'Add application'
 
     choose 'Yes, I know where I want to apply'

--- a/spec/system/candidate_interface/course_selection/candidate_visiting_selection_flow_for_selected_course_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_visiting_selection_flow_for_selected_course_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'Selecting a course' do
   end
 
   def then_i_am_on_my_applications_page
-    expect(page).to have_current_path(candidate_interface_continuous_applications_choices_path)
+    expect(page).to have_current_path(candidate_interface_application_choices_path)
   end
 
   def when_i_come_from_find_and_arrive_on_confirm_selection_page

--- a/spec/system/candidate_interface/entering_details/candidate_marking_section_complete_or_incomplete_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_marking_section_complete_or_incomplete_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe 'Marking section as complete or incomplete' do
   end
 
   def then_i_am_redirected_to_your_applications_page
-    expect(page).to have_current_path candidate_interface_continuous_applications_choices_path
+    expect(page).to have_current_path candidate_interface_application_choices_path
   end
 
   def mark_section(section:, complete:)
@@ -138,7 +138,7 @@ RSpec.describe 'Marking section as complete or incomplete' do
   end
 
   def when_i_visit_the_applications_page
-    visit candidate_interface_continuous_applications_choices_path
+    visit candidate_interface_application_choices_path
   end
 
   def then_i_see_the_incomplete_applications_text

--- a/spec/system/candidate_interface/entering_details/candidate_viewing_a_science_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_viewing_a_science_gcse_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'Candidate viewing Science GCSE' do
   end
 
   def choose_a_secondary_course
-    visit candidate_interface_continuous_applications_choices_path
+    visit candidate_interface_application_choices_path
     click_link_or_button t('section_items.add_application')
     candidate_fills_in_secondary_course_choice
   end
@@ -87,7 +87,7 @@ RSpec.describe 'Candidate viewing Science GCSE' do
   end
 
   def when_i_choose_a_primary_course
-    visit candidate_interface_continuous_applications_choices_path
+    visit candidate_interface_application_choices_path
     click_link_or_button 'Add application'
     candidate_fills_in_primary_course_choice_without_science_gcse
   end

--- a/spec/system/candidate_interface/feedback/candidate_submits_application_with_feedback_form_previously_completed_spec.rb
+++ b/spec/system/candidate_interface/feedback/candidate_submits_application_with_feedback_form_previously_completed_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Candidate submits application with feedback form previously comp
   end
 
   def and_i_see_the_application_dashboard_and_success_message
-    expect(page).to have_current_path(candidate_interface_continuous_applications_choices_path)
+    expect(page).to have_current_path(candidate_interface_application_choices_path)
     expect(page).to have_content('Application submitted')
   end
 end

--- a/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawals/candidate_accepts_offer_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe 'Candidate accepts an offer' do
   end
 
   def when_i_visit_the_application_dashboard
-    visit candidate_interface_continuous_applications_choices_path
+    visit candidate_interface_application_choices_path
   end
 
   def then_i_see_the_offer

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_and_prefills_application_in_sandbox_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_and_prefills_application_in_sandbox_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'Candidate signs in and prefills application in Sandbox', :sandbo
   end
 
   def then_i_am_taken_to_your_applications_page
-    expect(page).to have_current_path(candidate_interface_continuous_applications_choices_path)
+    expect(page).to have_current_path(candidate_interface_application_choices_path)
   end
 
   def and_there_is_a_flash_saying_the_application_was_prefilled

--- a/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe 'International candidate submits the application' do
   end
 
   def then_i_can_see_my_application_has_been_successfully_submitted
-    expect(page).to have_current_path candidate_interface_continuous_applications_choices_path
+    expect(page).to have_current_path candidate_interface_application_choices_path
     expect(page).to have_content 'Application submitted'
   end
 

--- a/spec/system/candidate_interface/submitting/redirect_to_your_applications_spec.rb
+++ b/spec/system/candidate_interface/submitting/redirect_to_your_applications_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Candidate submission' do
   end
 
   def then_i_am_on_your_applications_page
-    expect(page).to have_current_path candidate_interface_continuous_applications_choices_path
+    expect(page).to have_current_path candidate_interface_application_choices_path
   end
 
   def given_i_have_in_progress_application_form

--- a/spec/system/candidate_interface/viewing-application-choices/candidate_sees_all_their_applications_spec.rb
+++ b/spec/system/candidate_interface/viewing-application-choices/candidate_sees_all_their_applications_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe 'Candidates sees all their applications' do
   end
 
   def when_i_visit_my_applications_passing_an_non_existent_tab_name
-    visit candidate_interface_continuous_applications_choices_path(current_tab_name: 'this-does-not-exist')
+    visit candidate_interface_application_choices_path(current_tab_name: 'this-does-not-exist')
   end
 
   def and_all_applications_tabs_are_selected

--- a/spec/system/candidate_interface/withdraws/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/withdraws/candidate_withdraws_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe 'A candidate withdraws their application', :bullet do
   end
 
   def then_i_see_my_application_dashboard
-    expect(page).to have_current_path candidate_interface_continuous_applications_choices_path
+    expect(page).to have_current_path candidate_interface_application_choices_path
   end
 
   def and_i_am_thanked_for_my_feedback

--- a/spec/system/candidate_interface/withdraws/candidate_withdraws_with_upcoming_interviews_spec.rb
+++ b/spec/system/candidate_interface/withdraws/candidate_withdraws_with_upcoming_interviews_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'A candidate withdraws with upcoming interviews' do
   end
 
   def when_i_visit_the_application_dashboard
-    visit candidate_interface_continuous_applications_choices_path
+    visit candidate_interface_application_choices_path
   end
 
   def and_i_click_the_withdraw_link_on_my_first_choice
@@ -66,7 +66,7 @@ RSpec.describe 'A candidate withdraws with upcoming interviews' do
   end
 
   def then_i_see_my_application_dashboard
-    expect(page).to have_current_path candidate_interface_continuous_applications_choices_path
+    expect(page).to have_current_path candidate_interface_application_choices_path
   end
 
   def and_that_my_application_has_been_withdrawn

--- a/spec/system/provider_interface/provider_acts_as_candidate_on_sandbox_spec.rb
+++ b/spec/system/provider_interface/provider_acts_as_candidate_on_sandbox_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'A Provider can sign in as a candidate' do
   end
 
   def then_i_am_redirected_to_the_candidate_interface
-    expect(page).to have_current_path(candidate_interface_continuous_applications_choices_path)
+    expect(page).to have_current_path(candidate_interface_application_choices_path)
   end
 
   def and_i_see_a_flash_message


### PR DESCRIPTION
## Context

Removal of Continuous Applications

## Changes proposed in this pull request

Renamed `candidate_interface_continuous_applications_choices_` to `candidate_interface_application_choices_`

This was a find & replace job searching for `candidate_interface_continuous_applications_choices_` and replacing with `candidate_interface_application_choices_`

The `routes/candidate.rb` file was manually updated to replace `continuous_applications_choices` with `application_choices`

## Guidance to review

- Check all replaced instances are path helpers

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
