### PR TITLE
TDA  - update degree completed content

### DIFF
--- a/app/views/candidate_interface/degrees/review/show.html.erb
+++ b/app/views/candidate_interface/degrees/review/show.html.erb
@@ -28,6 +28,10 @@
   <% end %>
 
   <% unless degree_empty_component.render? %>
-    <%= render CandidateInterface::CompleteSectionComponent.new(section_policy: @section_policy, form: f, hint_text: teacher_degree_apprenticeship_feature_active? ? t('application_form.degree.review.teacher_degree_apprenticeship_feature_flag_on.complete_hint_text') : t('application_form.degree.review.complete_hint_text')) %>
+    <%= render CandidateInterface::CompleteSectionComponent.new(
+      section_policy: @section_policy,
+      form: f,
+      hint_text: (teacher_degree_apprenticeship_feature_active? ? t('application_form.degree.review.teacher_degree_apprenticeship_feature_flag_on.complete_hint_text') : t('application_form.degree.review.complete_hint_text')).html_safe,
+    ) %>
   <% end %>
 <% end %>

--- a/app/views/candidate_interface/degrees/review/show.html.erb
+++ b/app/views/candidate_interface/degrees/review/show.html.erb
@@ -28,6 +28,6 @@
   <% end %>
 
   <% unless degree_empty_component.render? %>
-    <%= render CandidateInterface::CompleteSectionComponent.new(section_policy: @section_policy, form: f, hint_text: t('application_form.degree.review.complete_hint_text')) %>
+    <%= render CandidateInterface::CompleteSectionComponent.new(section_policy: @section_policy, form: f, hint_text: teacher_degree_apprenticeship_feature_active? ? t('application_form.degree.review.tda_complete_hint_text') : t('application_form.degree.review.complete_hint_text')) %>
   <% end %>
 <% end %>

--- a/app/views/candidate_interface/degrees/review/show.html.erb
+++ b/app/views/candidate_interface/degrees/review/show.html.erb
@@ -28,6 +28,6 @@
   <% end %>
 
   <% unless degree_empty_component.render? %>
-    <%= render CandidateInterface::CompleteSectionComponent.new(section_policy: @section_policy, form: f, hint_text: teacher_degree_apprenticeship_feature_active? ? t('application_form.degree.review.tda_complete_hint_text') : t('application_form.degree.review.complete_hint_text')) %>
+    <%= render CandidateInterface::CompleteSectionComponent.new(section_policy: @section_policy, form: f, hint_text: teacher_degree_apprenticeship_feature_active? ? t('application_form.degree.review.teacher_degree_apprenticeship_feature_flag_on.complete_hint_text') : t('application_form.degree.review.complete_hint_text')) %>
   <% end %>
 <% end %>

--- a/config/locales/candidate_interface/degree.yml
+++ b/config/locales/candidate_interface/degree.yml
@@ -84,6 +84,7 @@ en:
         hint: For example, 2019
       review:
         complete_hint_text: Check the entry requirements for your chosen course. Providers usually ask for a degree at 2:2 or above. Contact the training provider if you do not have the right degree level.
+        tda_complete_hint_text: Check the entry requirements for your chosen course. Postgraduate courses usually require a bachelor’s degree at 2:2 or above. Contact the training provider if you do not have the right degree level. Teacher degree apprenticeships do not require a degree.
         not_specified: Not entered
       another:
         button: Add another degree

--- a/config/locales/candidate_interface/degree.yml
+++ b/config/locales/candidate_interface/degree.yml
@@ -84,7 +84,8 @@ en:
         hint: For example, 2019
       review:
         complete_hint_text: Check the entry requirements for your chosen course. Providers usually ask for a degree at 2:2 or above. Contact the training provider if you do not have the right degree level.
-        tda_complete_hint_text: Check the entry requirements for your chosen course. Postgraduate courses usually require a bachelor’s degree at 2:2 or above. Contact the training provider if you do not have the right degree level. Teacher degree apprenticeships do not require a degree.
+        teacher_degree_apprenticeship_feature_flag_on:
+          complete_hint_text: Check the entry requirements for your chosen course. Postgraduate courses usually require a bachelor’s degree at 2:2 or above. Contact the training provider if you do not have the right degree level. Teacher degree apprenticeships do not require a degree.
         not_specified: Not entered
       another:
         button: Add another degree

--- a/config/locales/candidate_interface/degree.yml
+++ b/config/locales/candidate_interface/degree.yml
@@ -85,7 +85,7 @@ en:
       review:
         complete_hint_text: Check the entry requirements for your chosen course. Providers usually ask for a degree at 2:2 or above. Contact the training provider if you do not have the right degree level.
         teacher_degree_apprenticeship_feature_flag_on:
-          complete_hint_text: Check the entry requirements for your chosen course. Postgraduate courses usually require a bachelor’s degree at 2:2 or above. Contact the training provider if you do not have the right degree level. Teacher degree apprenticeships do not require a degree.
+          complete_hint_text: Check the entry requirements for your chosen course. Postgraduate courses usually require a bachelor’s degree at 2:2 or above. Contact the training provider if you do not have the right degree level. <p class=\"govuk-block\">Teacher degree apprenticeships do not require a degree.</p>
         not_specified: Not entered
       another:
         button: Add another degree

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_university_degree_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_university_degree_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe 'Entering a degree' do
 
     when_i_finish_adding_a_degree
     then_i_am_on_the_review_page
+    and_i_can_see_the_degrees_section_content
 
     when_i_click_to_delete_a_degree
     and_i_confirm_the_deletion
@@ -209,5 +210,11 @@ RSpec.describe 'Entering a degree' do
 
   def and_i_still_have_one_degree
     expect(page).to have_content('BSc (Hons) Astronomy').once
+  end
+
+  def and_i_can_see_the_degrees_section_content
+    expect(page).to have_content(
+      'Check the entry requirements for your chosen course. Postgraduate courses usually require a bachelor’s degree at 2:2 or above. Contact the training provider if you do not have the right degree level. Teacher degree apprenticeships do not require a degree.',
+    )
   end
 end

--- a/spec/views/degrees/show.html.erb_spec.rb
+++ b/spec/views/degrees/show.html.erb_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'candidate_interface/degrees/review/show' do
     # rubocop:disable RSpec/AnyInstance
     without_partial_double_verification do
       allow_any_instance_of(ActionView::Base).to receive(:current_application).and_return(application_form)
+      allow_any_instance_of(ActionView::Base).to receive(:teacher_degree_apprenticeship_feature_active?).and_return(false)
     end
     # rubocop:enable RSpec/AnyInstance
 


### PR DESCRIPTION
## Context

Currently, once a candidate has added a degree they are asked if the section is completed. This includes content that refers to postgraduate entry requirements. 

[See live site example](https://trello.com/1/cards/66a111b862659e62151cb5e9/attachments/66a11276fd27460123ce0beb/download/Screenshot_2024-07-24_at_15.34.35.png).

This PR is to update the content, so that it caters for both undergraduate and postgraduate candidates.