### PR TITLE
Implement prompt candidates about ENIC in rejection email

### DIFF
--- a/app/views/candidate_mailer/tailored_rejection_advice/_unverified_qualifications_tailored_advice.text.erb
+++ b/app/views/candidate_mailer/tailored_rejection_advice/_unverified_qualifications_tailored_advice.text.erb
@@ -1,3 +1,16 @@
-To help show your qualifications, you can [get a certified statement of your exam results](<%= t('govuk.replacement_exam_certificate_url') %>) if you did your GCSEs and A levels in the UK.
+<% if @application_choice.application_form.missing_enic_reference_for_non_uk_qualifications? %>
+  Showing providers how your qualifications compare to UK ones with a statement of comparability makes you around 30% more likely to receive an offer.
 
-You should also be able to request a copy of your degree certificate from the organisation where you studied in the UK.
+  You can [apply for a statement of comparability ](<%= t('service_name.enic.statement_of_comparability_url') %>) from UK European Network of Information Centres (UK ENIC).
+
+  If you want to apply again you should:
+  - check that your details are still correct
+  - add your UK ENIC statement of comparability to your profile
+  - make sure you’re happy with your personal statement
+  - find a course and submit another application
+
+<% else %>
+  To help show your qualifications, you can [get a certified statement of your exam results](<%= t('govuk.replacement_exam_certificate_url') %>) if you did your GCSEs and A levels in the UK.
+
+  You should also be able to request a copy of your degree certificate from the organisation where you studied in the UK.
+<% end %>

--- a/spec/mailers/candidate_mailer_application_rejected_tailored_advice_spec.rb
+++ b/spec/mailers/candidate_mailer_application_rejected_tailored_advice_spec.rb
@@ -231,4 +231,23 @@ RSpec.describe 'Tailored advice for rejected applications' do
     expect(email.body).to have_text('It is worth looking at the feedback the course provider has given to understand why your application was not accepted. This will help you to decide on your next steps.').once
     expect(email.body).to have_text('Find out what to do if your application was unsuccessful').once
   end
+
+  it 'shows the enic statement content' do
+    structured_rejection_reasons = {
+      selected_reasons: [
+        { id: 'qualifications', label: 'Qualifications', selected_reasons: [
+          { id: 'unverified_qualifications', label: 'Cant verify' },
+        ] },
+      ],
+    }
+
+    application_form = create(:application_form, :minimum_info)
+    application_choice = create(:application_choice, :rejected_reasons, structured_rejection_reasons:, application_form: application_form)
+    create(:degree_qualification, enic_reference: nil, institution_country: 'FR', application_form: application_form)
+
+    email = CandidateMailer.application_rejected(application_choice)
+
+    expect(email.body).to have_text('Showing providers how your qualifications compare to UK ones with a statement of comparability makes you around 30% more likely to receive an offer.').once
+    expect(email.body).not_to have_text('You should also be able to request a copy of your degree certificate from the organisation where you studied in the UK.').once
+  end
 end


### PR DESCRIPTION
## Context

Following the [design exploration](https://lucid.app/lucidspark/9d9c536a-955c-488d-9141-0dce99b7b2a4/edit?viewport_loc=26999%2C-4398%2C22661%2C12483%2C0_0&invitationId=inv_f2b2354f-bbbd-4633-94f4-9a698d3b8d91) completed in [Explore how we might improve communicating the enic service to international candidatesDESIGNING 🎨](https://trello.com/c/NxlYoNYH/1220-explore-how-we-might-improve-communicating-the-enic-service-to-international-candidates) it was decided that we should prompt rejected candidates about the ENIC service.

Ticket: https://trello.com/c/e8aq9tms/1300-implement-prompt-candidates-about-enic-in-rejection-email

## Changes proposed in this pull request

To update the rejection email to show the enic related content if;
- Candidate has selected Qualification from outside the UK for any (maths/English/Science GCSE/Degree) qualification
- Candidate has not entered a UK ENIC Reference number for any of their qualifications
- Provider has selected ‘unable to verify qualifications’ as a rejection reason

## Guidance to review

- Submit an application following the above criteria
- Sign in as a provider and reject the application with the rejection reason of `unverified_qualifications` 
- Candidate should then get a rejection email, which shows the ENIC related content.

Email:
<img width="463" alt="Screenshot 2024-09-03 at 13 07 57" src="https://github.com/user-attachments/assets/44d777b4-439e-4101-aceb-54dbfad87670">

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
