### PR TITLE
[2260] Only render prompts to add applications before the apply deadline

### DIFF
--- a/app/helpers/application_details_helper.rb
+++ b/app/helpers/application_details_helper.rb
@@ -1,5 +1,0 @@
-module ApplicationDetailsHelper
-  def completed_application_form?(application_form)
-    @completed_application_form ||= CandidateInterface::CompletedApplicationForm.new(application_form:).valid?
-  end
-end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -335,12 +335,22 @@ module CandidateInterface
       application_form.right_to_work_or_study.present?
     end
 
+    def can_submit_more_applications?
+      completed_application_form? && # The form is complete
+        can_add_more_choices? && # They have not submitted the max number of choices
+        CycleTimetable.can_add_course_choice?(application_form) # The apply deadline for this form has not passed
+    end
+
   private
 
     def show_review_volunteering?
       no_volunteering_confirmed = application_form.volunteering_experience == false && application_form.application_volunteering_experiences.empty?
 
       volunteering_completed? || volunteering_added? || no_volunteering_confirmed
+    end
+
+    def completed_application_form?
+      @completed_application_form ||= CandidateInterface::CompletedApplicationForm.new(application_form:).valid?
     end
   end
 end

--- a/app/views/candidate_interface/shared/_details.html.erb
+++ b/app/views/candidate_interface/shared/_details.html.erb
@@ -48,15 +48,6 @@
       </ol>
     </section>
 
-    <% if !CycleTimetable.can_add_course_choice?(@application_form_presenter.application_form) %>
-      <section class="govuk-!-margin-bottom-8">
-        <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.courses') %></h2>
-        <p class="govuk-body">
-          You can find courses from 9am on <%= CycleTimetable.find_reopens.to_fs(:govuk_date) %>. You can keep making changes to your application until then.
-        </p>
-      </section>
-    <% end %>
-
     <% cache(@application_cache_key, expires_in: 5.minutes) do %>
       <%= render '/candidate_interface/shared/task_list', application_form: @application_form_presenter.application_form, application_form_presenter: @application_form_presenter %>
     <% end %>

--- a/app/views/candidate_interface/shared/_details.html.erb
+++ b/app/views/candidate_interface/shared/_details.html.erb
@@ -15,7 +15,7 @@
     <p class="govuk-body">
       <% message = 'Your details will be shared with the training provider when you apply.' %>
 
-      <% if completed_application_form?(@application_form_presenter.application_form) %>
+      <% if @application_form_presenter.can_submit_more_applications? %>
         You can <%= govuk_link_to 'add your applications', candidate_interface_application_choices_path %>.<br>
         <br>
         <%= message %>
@@ -66,9 +66,7 @@
       <p class='govuk-body'>You can no longer submit applications from this account. Visit your other account to continue your application.</p>
       <p class='govuk-body'>You can apply for up to <%= max_course_choices %> courses at a time.</p>
       <p class='govuk-body'>Email becomingateacher@digital.education.gov.uk if you have any questions.</p>
-    <% elsif completed_application_form?(@application_form_presenter.application_form) &&
-        CycleTimetable.can_add_course_choice?(@application_form_presenter.application_form) &&
-        @application_form_presenter.can_add_more_choices? %>
+    <% elsif @application_form_presenter.can_submit_more_applications? %>
       <div class="app-grid-column--grey">
         <h2 class="govuk-heading-m">You have completed your details</h2>
         <p class="govuk-body">You can now start applying to courses.</p>

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -718,4 +718,42 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
       end
     end
   end
+
+  describe '#can_submit_more_applications?' do
+    context 'completed form, without choices, before the deadline', time: mid_cycle do
+      it 'returns true' do
+        application_form = create(:application_form, :completed, application_choices: [])
+        presenter = described_class.new(application_form)
+
+        expect(presenter.can_submit_more_applications?).to be true
+      end
+    end
+
+    context 'form is not complete', time: mid_cycle do
+      it 'returns false' do
+        application_form = create(:application_form)
+        presenter = described_class.new(application_form)
+
+        expect(presenter.can_submit_more_applications?).to be false
+      end
+    end
+
+    context 'the maximum number of choices has been met', time: mid_cycle do
+      it 'returns false' do
+        application_form = create(:application_form, :completed, submitted_application_choices_count: 4)
+        presenter = described_class.new(application_form)
+
+        expect(presenter.can_submit_more_applications?).to be false
+      end
+    end
+
+    context 'the apply deadline has passed for this form', time: after_apply_deadline do
+      it 'returns false' do
+        application_form = create(:application_form, :completed, application_choices: [])
+        presenter = described_class.new(application_form)
+
+        expect(presenter.can_submit_more_applications?).to be false
+      end
+    end
+  end
 end

--- a/spec/system/candidate_interface/entering_details/candidate_marking_section_complete_or_incomplete_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_marking_section_complete_or_incomplete_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'Marking section as complete or incomplete' do
     then_i_do_not_see_the_incomplete_text
   end
 
-  scenario 'completion info text' do
+  scenario 'completion info text', time: mid_cycle do
     given_i_have_a_completed_application_form
     when_i_sign_in
     then_i_dont_see_the_incomplete_applications_text

--- a/spec/system/candidate_interface/entering_details/candidate_views_details_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_views_details_between_cycles_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe 'Viewing application details between cycles' do
+  include CandidateHelper
+
+  scenario 'Candidate has an inflight application', time: mid_cycle do
+    given_i_have_an_inflight_application
+    and_the_apply_deadline_passes
+    when_i_view_the_application_details_page
+    then_i_am_not_prompted_to_add_applications
+  end
+
+private
+
+  def given_i_have_an_inflight_application
+    @application_form = create(:application_form, :completed, submitted_application_choices_count: 1)
+  end
+
+  def and_the_apply_deadline_passes
+    advance_time_to(after_apply_deadline)
+  end
+
+  def when_i_view_the_application_details_page
+    login_as(current_candidate)
+    visit root_path
+    click_on 'Your details'
+  end
+
+  def then_i_am_not_prompted_to_add_applications
+    expect(page).to have_text('Your details')
+    expect(page).to have_no_text('You can add your applications.')
+    expect(page).to have_no_text('You can now start applying to courses.')
+  end
+end


### PR DESCRIPTION
## Context
At the bug party we found a couple of confusing bits of text on the details page. 

## Changes proposed in this pull request

This PR 
- Removes a section about courses that only appears after the deadline
- Conditionally renders text prompting candidates to add applications
- Cleans up some of the logic in the view and presenter
- removes helper (if we are using a presenter, we don't need the helper as well)

| Before | After|
| ------ | ------ |
| <img width="934" alt="image" src="https://github.com/user-attachments/assets/1534d3d9-9581-4d76-b27d-6ffd9e89f22f"> | <img width="937" alt="image" src="https://github.com/user-attachments/assets/815e7e30-0b0b-4f81-a41d-90d925a158ff"> |

## Guidance to review

- Use the cycle switcher to 'After apply deadline'
- Sign in as a candidate who has an inflight application (eg awaiting provider decision)
- you should no longer be prompted to add an application or see the 'Courses' section
-
## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
