### PR TITLE
CandidateInterface: Location display in UI

### DIFF
--- a/app/components/candidate_interface/application_review_component.rb
+++ b/app/components/candidate_interface/application_review_component.rb
@@ -95,6 +95,8 @@ module CandidateInterface
     end
 
     def location_row
+      return if application_choice.school_placement_auto_selected?
+
       {
         key: 'Location',
         value: current_course_option.site_name,

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -118,6 +118,8 @@ module CandidateInterface
     end
 
     def location_row(application_choice)
+      return if application_choice.school_placement_auto_selected?
+
       {
         key: 'Location',
         value: "#{application_choice.current_site.name}\n#{application_choice.current_site.full_address}",

--- a/app/components/candidate_interface/course_review_component.rb
+++ b/app/components/candidate_interface/course_review_component.rb
@@ -31,6 +31,8 @@ module CandidateInterface
     end
 
     def location_row(application_choice)
+      return if application_choice.school_placement_auto_selected?
+
       {
         key: 'Location',
         value: "#{application_choice.current_site.name}\n#{application_choice.current_site.full_address}",

--- a/app/components/candidate_interface/offer_review_component.rb
+++ b/app/components/candidate_interface/offer_review_component.rb
@@ -11,7 +11,7 @@ module CandidateInterface
         course_row,
         (salary_row if @course_choice.current_course.salary_details),
         (fee_row if @course_choice.current_course.fee?),
-        location_row,
+        (location_row if @course_choice.school_placement_auto_selected?),
         (ske_conditions_row if @course_choice.offer.ske_conditions.any?),
         (reference_condition_row if @course_choice.offer.reference_condition.present?),
         (conditions_row if @course_choice.offer.conditions.any?),

--- a/app/controllers/candidate_interface/decisions_controller.rb
+++ b/app/controllers/candidate_interface/decisions_controller.rb
@@ -110,20 +110,13 @@ module CandidateInterface
     end
 
     def course_choice_rows
-      [
-        {
-          key: 'Provider',
-          value: @application_choice.current_course.provider.name,
-        },
-        {
-          key: 'Course',
-          value: @application_choice.current_course.name_and_code,
-        },
-        {
-          key: 'Location',
-          value: @application_choice.current_course_option.site.name,
-        },
-      ]
+      [].tap do |collection|
+        collection << { key: 'Provider', value: @application_choice.current_course.provider.name }
+        collection << { key: 'Course', value: @application_choice.current_course.name_and_code }
+        if @application_choice.school_placement_auto_selected?
+          collection << { key: 'Location', value: @application_choice.current_course_option.site.name }
+        end
+      end
     end
     helper_method :course_choice_rows
   end

--- a/app/services/candidate_interface/course_selection_store.rb
+++ b/app/services/candidate_interface/course_selection_store.rb
@@ -40,8 +40,12 @@ module CandidateInterface
     end
 
     def save_application_choice(choice)
-      choice.tap do
-        choice.configure_initial_course_choice!(course_option)
+      choice.tap do |c|
+        c.configure_initial_course_choice!(course_option)
+
+        if choice.provider
+          choice.update(school_placement_auto_selected: !choice.provider.selectable_school?)
+        end
       end
     end
   end

--- a/app/views/candidate_mailer/change_course.text.erb
+++ b/app/views/candidate_mailer/change_course.text.erb
@@ -7,7 +7,9 @@ The new details are:
 ^ Training provider: <%= @current_course_option.course.provider.name %>
 ^ Course: <%= @current_course_option.course.name_and_code %>
 ^ Full time or part time: <%= @current_course_option.course.study_mode.humanize %>
+<% unless @application_choice.school_placement_auto_selected %>
 ^ Location: <%= @current_course_option.site.name %>
+<% end %>
 ^ Qualification: <%= @qualification %>
 
 If you were not expecting this change, contact <%= @current_course_option.course.provider.name %> to find out more.

--- a/app/views/candidate_mailer/changed_offer.text.erb
+++ b/app/views/candidate_mailer/changed_offer.text.erb
@@ -9,7 +9,9 @@ The new offer is:
 ^ Training provider: <%= @current_course_option.course.provider.name %>
 ^ Course: <%= @current_course_option.course.name_and_code %>
 ^ Full time or part time: <%= @current_course_option.course.study_mode.humanize %>
+<% unless @application_choice.school_placement_auto_selected %>
 ^ Location: <%= @current_course_option.site.name %>
+<% end %>
 ^ Qualification: <%= @qualification %>
 
 <% if @conditions.blank? %>

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -48,6 +48,21 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, :mid_cycle, typ
       end
     end
 
+    context 'when the placement school is auto selected' do
+      let(:application_form) { create_application_form_with_course_choices(statuses: %w[unsubmitted]) }
+
+      before do
+        build(:course_option, course: application_form.application_choices.first.course)
+        application_form.application_choices.first.update(school_placement_auto_selected: true)
+      end
+
+      it 'renders without the location row' do
+        result = render_inline(described_class.new(application_form:))
+
+        expect(result.css('.govuk-summary-list__key').text).not_to include('Location')
+      end
+    end
+
     context 'When a course has both study modes available' do
       let(:application_form) { create_application_form_with_course_choices(statuses: %w[unsubmitted]) }
       let(:application_choice) { application_form.application_choices.first }

--- a/spec/components/candidate_interface/offer_review_component_spec.rb
+++ b/spec/components/candidate_interface/offer_review_component_spec.rb
@@ -66,10 +66,39 @@ RSpec.describe CandidateInterface::OfferReviewComponent do
     end
   end
 
-  it 'renders component with correct values for the location' do
-    result = render_inline(described_class.new(course_choice: application_choice))
+  context 'location row' do
+    let(:application_choice) do
+      build_stubbed(:application_choice,
+                    :offered,
+                    offer: build(:offer, conditions:),
+                    course_option:,
+                    school_placement_auto_selected:,
+                    application_form:)
+    end
 
-    expect(result.css('.govuk-summary-list__value').text).to include(course_option.site.name)
+    context 'when school is selected by candidate' do
+      let(:school_placement_auto_selected) { false }
+
+      it 'renders component with correct values for the location' do
+        render_inline(described_class.new(course_choice: application_choice))
+
+        within('.govuk-summary-list__value') do
+          expect(page).to have_content(course_option.site.name)
+        end
+      end
+    end
+
+    context 'when school is auto selected' do
+      let(:school_placement_auto_selected) { true }
+
+      it 'does not render the location row' do
+        render_inline(described_class.new(course_choice: application_choice))
+
+        within('.govuk-summary-list__value') do
+          expect(page).to have_no_content(course_option.site.name)
+        end
+      end
+    end
   end
 
   context 'when there are conditions' do

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -24,6 +24,8 @@ FactoryBot.define do
       )
     end
 
+    school_placement_auto_selected { false }
+
     current_recruitment_cycle_year { recruitment_cycle_year || course_option.course.recruitment_cycle_year }
     personal_statement { Faker::Lorem.paragraph_by_chars(number: 50) }
     original_course_option { course_option }

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_study_mode_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_study_mode_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'Selecting a study mode' do
     when_i_select_the_single_site_full_time_course
     and_i_visit_my_course_choices_page
     then_the_site_is_resolved_automatically_and_i_see_the_course_choice
+    and_the_application_is_not_school_placement_auto_selected
   end
 
   def given_i_am_signed_in
@@ -153,5 +154,9 @@ RSpec.describe 'Selecting a study mode' do
 
   def then_i_see_the_provider_name_in_caption
     expect(page.first('.govuk-caption-xl').text).to eq('University of Alien Dance')
+  end
+
+  def and_the_application_is_not_school_placement_auto_selected
+    expect(page).to have_content('Location')
   end
 end

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_with_multiple_sites_and_unselectable_school_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_with_multiple_sites_and_unselectable_school_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'Selecting a course with multiple sites when the provider is not 
     and_i_choose_a_course
 
     then_i_am_on_the_application_choice_review_page
+    and_the_application_is_school_placement_auto_selected
   end
 
   def given_i_am_signed_in
@@ -89,5 +90,9 @@ RSpec.describe 'Selecting a course with multiple sites when the provider is not 
     @multi_site_course = create(:course, :open, :with_both_study_modes, name: 'Primary', code: '2XT2', provider: @provider)
     create(:course_option, site: first_site, course: @multi_site_course)
     create(:course_option, site: second_site, course: @multi_site_course)
+  end
+
+  def and_the_application_is_school_placement_auto_selected
+    expect(page).to have_no_content('Location')
   end
 end


### PR DESCRIPTION
## Context

Mark `school_placement_auto_selected` when the candidate creates their `ApplicationChoice`. 
Conditionally show the Location row based on this value.


This is the first of 3 PRs for updating how we display the School Placement (Location) for an `ApplicationChoice`.
This PR focuses on the `CandidateInterface`, and a couple of emails.


## Changes proposed in this pull request

If the candidate has the option to choose a school placement in the course selection journey, we show the Location row in any course summary tables in the candidate interface.
However, if the provider does not permit the candidate to choose a school placement explicitly, we hide the auto selected Location row in the `CandidateInterface`.


## Guidance to review

|`school_placement_auto_selected = true`|`school_placement_auto_selected = false`|
|---|---|
|https://apply-review-9791.test.teacherservices.cloud/support/applications/42|https://apply-review-9791.test.teacherservices.cloud/support/applications/39|
|![image](https://github.com/user-attachments/assets/1a0429a2-42dd-4022-8815-23114bb04ad4)|![image](https://github.com/user-attachments/assets/76380607-6515-467d-901f-722c52b8adae)|


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
