### PR TITLE
Renamed translation keys

### DIFF
--- a/app/components/candidate_interface/application_choice_status_tag_component.rb
+++ b/app/components/candidate_interface/application_choice_status_tag_component.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   class ApplicationChoiceStatusTagComponent < ::CandidateInterface::ApplicationStatusTagComponent
     def text
-      t("continuous_applications.candidate_application_states.#{application_choice.status}")
+      t("application_choice_states.#{application_choice.status}")
     end
 
     def colour

--- a/app/components/candidate_interface/application_status_tag_component.html.erb
+++ b/app/components/candidate_interface/application_status_tag_component.html.erb
@@ -11,7 +11,7 @@
   <% elsif @application_choice.unsubmitted? && @application_choice.course_available? %>
     <p class="govuk-body govuk-!-margin-top-2">
       <%= govuk_link_to candidate_interface_course_choices_course_review_path(@application_choice) do %>
-        <%= t('application_form.continuous_applications.courses.continue_application') %>
+        <%= t('application_form.courses.continue_application') %>
         <span class="govuk-visually-hidden"> <%= @application_choice.current_course.provider.name %></span>
       <% end %>
     </p>

--- a/app/components/shared/state_explanation_component.html.erb
+++ b/app/components/shared/state_explanation_component.html.erb
@@ -11,7 +11,7 @@
         <% if ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER.include?(state_name.to_sym) %>
           <dt>Appears to candidate as</dd>
           <% component = CandidateInterface::ApplicationChoiceStatusTagComponent.new(application_choice: Struct.new(:status).new(state_name)) %>
-          <dd><%= govuk_tag(text: t("continuous_applications.candidate_application_states.#{state_name}"), colour: component.colour) %></dd>
+          <dd><%= govuk_tag(text: t("application_choice_states.#{state_name}"), colour: component.colour) %></dd>
           <dt>Appears to provider as</dd>
           <% component = ProviderInterface::ApplicationStatusTagComponent.new(application_choice: Struct.new(:status).new(state_name)) %>
           <dd><%= govuk_tag(text: t("provider_application_states.#{state_name}"), colour: component.colour) %></dd>

--- a/app/views/candidate_interface/application_choices/confirm_destroy.html.erb
+++ b/app/views/candidate_interface/application_choices/confirm_destroy.html.erb
@@ -1,11 +1,11 @@
-<% content_for :title, t('page_titles.continuous_applications_destroy_course_choice') %>
+<% content_for :title, t('page_titles.destroy_course_choice') %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_choices_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @application_choice, url: candidate_interface_course_choices_confirm_destroy_course_choice_path(@application_choice.id), method: :delete do |f| %>
       <h1 class="govuk-heading-l">
-        <%= t('page_titles.continuous_applications_destroy_course_choice') %>
+        <%= t('page_titles.destroy_course_choice') %>
       </h1>
 
       <div class="govuk-button-group app-course-choice__confirm-submission">

--- a/app/views/candidate_interface/application_choices/confirm_destroy.html.erb
+++ b/app/views/candidate_interface/application_choices/confirm_destroy.html.erb
@@ -9,7 +9,7 @@
       </h1>
 
       <div class="govuk-button-group app-course-choice__confirm-submission">
-        <%= f.govuk_submit t('application_form.continuous_applications.courses.confirm_delete'), warning: true %>
+        <%= f.govuk_submit t('application_form.courses.confirm_delete'), warning: true %>
 
         <%= govuk_link_to 'Cancel', candidate_interface_course_choices_course_review_path(@application_choice.id) %>
       </div>

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -42,23 +42,22 @@ en:
     unknown_state:
       name: Unknown!
       description: This application is in a state that we do not recognise. Please report this to a developer.
-  continuous_applications:
-    candidate_application_states:
-      unsubmitted: Draft
-      awaiting_provider_decision: Awaiting decision
-      inactive: Awaiting decision
-      interviewing: Interviewing
-      conditions_not_met: Conditions not met
-      declined: Offer declined
-      offer: Offer received
-      recruited: Offer confirmed
-      offer_withdrawn: Offer withdrawn
-      cancelled: Application cancelled
-      pending_conditions: Offer accepted
-      rejected: Unsuccessful
-      application_not_sent: Application not sent
-      withdrawn: Application withdrawn
-      offer_deferred: Offer deferred
+  application_choice_states:
+    unsubmitted: Draft
+    awaiting_provider_decision: Awaiting decision
+    inactive: Awaiting decision
+    interviewing: Interviewing
+    conditions_not_met: Conditions not met
+    declined: Offer declined
+    offer: Offer received
+    recruited: Offer confirmed
+    offer_withdrawn: Offer withdrawn
+    cancelled: Application cancelled
+    pending_conditions: Offer accepted
+    rejected: Unsuccessful
+    application_not_sent: Application not sent
+    withdrawn: Application withdrawn
+    offer_deferred: Offer deferred
   candidate_application_states:
     awaiting_provider_decision: Awaiting decision
     inactive: Inactive

--- a/config/locales/candidate_interface/courses.yml
+++ b/config/locales/candidate_interface/courses.yml
@@ -1,17 +1,10 @@
 en:
   application_form:
-    continuous_applications:
-      courses:
-        delete: Remove
-        view_application: View application
-        confirm_delete: Yes I’m sure - delete this application
-        withdraw: Withdraw
-        continue_application: Continue application
-        submit: Do you want to submit your application?
     courses:
       intro: You can apply for up to 4 courses.
       delete: Delete choice
-      confirm_delete: Yes I’m sure - delete this choice
+      confirm_delete: Yes I’m sure - delete this application
+      continue_application: Continue application
       another:
         button: Add another course
       withdraw: Withdraw

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -183,8 +183,7 @@ en:
     course_choices: Course choices
     full_course: Unfortunately, you cannot apply to %{course_name} because it is now full
     closed_course: Unfortunately, you cannot apply to %{course_name} because it is now closed
-    destroy_course_choice: Are you sure you want to delete this choice?
-    continuous_applications_destroy_course_choice: Are you sure you want to delete this draft application?
+    destroy_course_choice: Are you sure you want to delete this draft application?
     do_you_know: Do you know which course you want to apply to?
     find_a_course: Find a course
     which_provider: Which training provider are you applying to?

--- a/spec/components/candidate_interface/application_choice_item_component_spec.rb
+++ b/spec/components/candidate_interface/application_choice_item_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CandidateInterface::ApplicationChoiceItemComponent do
 
   shared_examples 'application choice item' do
     it 'displays correct message' do
-      expect(rendered.text).to include(t("continuous_applications.candidate_application_states.#{application_choice.status}"))
+      expect(rendered.text).to include(t("application_choice_states.#{application_choice.status}"))
       expect(rendered.text).to include(application_choice.current_course.provider.name)
       expect(rendered.text).to include(application_choice.id.to_s)
       expect(rendered.text).to include(application_choice.current_course.name_and_code)

--- a/spec/system/candidate_interface/course_selection/candidate_deletes_application_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_deletes_application_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Candidate edits their choice section' do
   end
 
   def and_i_confirm_i_want_to_delete_the_choice
-    click_link_or_button t('application_form.continuous_applications.courses.confirm_delete')
+    click_link_or_button t('application_form.courses.confirm_delete')
   end
 
   def then_i_see_only_one_application


### PR DESCRIPTION
## Context

We want to remove references to Continuous Applications

## Changes proposed in this pull request

- Renames `continuous_applications.candidate_application_states` to `application_choice_states`
- Renames `application_form.continuous_applications.courses` to `application_form.courses`
- Renames `page_titles.continuous_applications_destroy_course_choice` to `page_titles.destroy_course_choice`

## Guidance to review

- Check translations have been renamed correctly

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
