### PR TITLE
[2262] Do not render text about max applications after apply deadline

### DIFF
--- a/app/views/candidate_interface/decisions/withdraw.html.erb
+++ b/app/views/candidate_interface/decisions/withdraw.html.erb
@@ -9,7 +9,9 @@
 
     <%= render(SummaryListComponent.new(rows: course_choice_rows)) %>
 
-    <p class="govuk-body">Once you have a total of <%= ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS %> unsuccessful or withdrawn applications, you will not be able to apply for any more courses until October <%= RecruitmentCycle.real_current_year %>.</p>
+    <% unless CycleTimetable.between_cycles? %>
+      <p class="govuk-body">Once you have a total of <%= ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS %> unsuccessful or withdrawn applications, you will not be able to apply for any more courses until October <%= RecruitmentCycle.real_current_year %>.</p>
+    <% end %>
 
     <p class="govuk-body">Do not withdraw if you need to change information on your application. Tell your training provider instead.</p>
 

--- a/spec/system/candidate_interface/withdraws/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/withdraws/candidate_withdraws_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'A candidate withdraws their application', :bullet do
     Bullet.raise = true
   end
 
-  scenario 'successful withdrawal' do
+  scenario 'successful withdrawal', time: mid_cycle do
     given_i_am_signed_in_as_a_candidate
     and_i_have_multiple_application_choice_awaiting_provider_decision
 
@@ -46,7 +46,26 @@ RSpec.describe 'A candidate withdraws their application', :bullet do
     and_the_candidate_has_received_an_email
   end
 
-  scenario 'withdrawal for application choice with interviewing status' do
+  scenario 'withdrawing after the apply deadline', time: after_apply_deadline do
+    given_i_am_signed_in_as_a_candidate
+    and_i_have_multiple_application_choice_awaiting_provider_decision
+
+    when_i_visit_my_applications
+    and_i_click_the_withdraw_link_on_my_first_choice
+    then_i_see_a_confirmation_page_without_max_application_warning
+    and_i_do_not_see_the_interview_related_text
+
+    when_i_click_to_confirm_withdrawal
+    then_i_see_the_withdraw_choice_reason_page
+    and_the_provider_has_received_an_email
+
+    when_i_select_my_reasons
+    and_i_click_continue
+    then_i_see_my_application_dashboard
+    and_i_am_thanked_for_my_feedback
+  end
+
+  scenario 'withdrawal for application choice with interviewing status', time: mid_cycle do
     given_i_am_signed_in_as_a_candidate
     and_i_have_an_application_choice_with_the_status_interviewing
 
@@ -90,6 +109,11 @@ RSpec.describe 'A candidate withdraws their application', :bullet do
 
   def then_i_see_a_confirmation_page
     expect(page).to have_content("Once you have a total of #{ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS} unsuccessful or withdrawn applications, you will not be able to apply for any more courses until October #{RecruitmentCycle.real_current_year}")
+    expect(page).to have_content('Do not withdraw if you need to change information on your application. Tell your training provider instead.')
+  end
+
+  def then_i_see_a_confirmation_page_without_max_application_warning
+    expect(page).to have_no_content("Once you have a total of #{ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS} unsuccessful or withdrawn applications, you will not be able to apply for any more courses until October #{RecruitmentCycle.real_current_year}")
     expect(page).to have_content('Do not withdraw if you need to change information on your application. Tell your training provider instead.')
   end
 


### PR DESCRIPTION
## Context

We show content on the withdrawal page that implies the candidate can still apply for courses even though the deadline has passed.

## Changes proposed in this pull request

Conditionally render the text, only if the candidate is withdrawing before the apply deadline.

| Before | After |
| ------ | ------ |
| <img width="867" alt="image" src="https://github.com/user-attachments/assets/1ee261e3-220c-4b2d-8740-e8810c625021"> | <img width="915" alt="image" src="https://github.com/user-attachments/assets/4f8ad3f4-311b-4bf2-8344-3085882f612a"> |

## Guidance to review
- Use the cycle switcher to move forward to after the apply deadline
- Sign in as a candidate with a submitted application (awaiting provider decision)
- Withdraw the application -- you shouldn't see the text telling them about the number of withdrawals they are allowed to make this cycle. 
- Switch back to mid-cycle
- refresh the withdrawal page -- now you will see the text about the max number of applications.


## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
