### PR TITLE
SupportInterface: Update Course description Location for auto selected School placements

### DIFF
--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -60,19 +60,28 @@ module SupportInterface
     def course_candidate_applied_for_row
       return unless application_choice.different_offer?
 
-      { key: 'Course applied for', value: render(CourseOptionDetailsComponent.new(course_option: application_choice.course_option)) }
+      {
+        key: 'Course applied for',
+        value: render(CourseOptionDetailsComponent.new(course_option: application_choice.course_option, application_choice:)),
+      }
     end
 
     def course_offered_by_provider_row
       return unless application_choice.different_offer?
 
-      { key: 'Course offered', value: render(CourseOptionDetailsComponent.new(course_option: application_choice.current_course_option)) }.merge(change_course_offered_link)
+      {
+        key: 'Course offered',
+        value: render(CourseOptionDetailsComponent.new(course_option: application_choice.current_course_option, application_choice:)),
+      }.merge(change_course_offered_link)
     end
 
     def course_row
       return if application_choice.different_offer?
 
-      { key: 'Course', value: render(CourseOptionDetailsComponent.new(course_option: application_choice.course_option)) }.merge(change_course_choice_link).merge(change_course_offered_link)
+      {
+        key: 'Course',
+        value: render(CourseOptionDetailsComponent.new(course_option: application_choice.course_option, application_choice:)),
+      }.merge(change_course_choice_link).merge(change_course_offered_link)
     end
 
     def rejected_at_or_by_default_at_row

--- a/app/components/support_interface/course_option_details_component.rb
+++ b/app/components/support_interface/course_option_details_component.rb
@@ -4,8 +4,10 @@ module SupportInterface
 
     attr_reader :course_option
 
-    def initialize(course_option:)
+    def initialize(course_option:, application_choice:)
       @course_option = course_option
+      @school_placement_auto_selected = application_choice.school_placement_auto_selected?
+      @course_option_is_original = application_choice.original_course_option == course_option
     end
 
     def rows
@@ -15,7 +17,7 @@ module SupportInterface
         { key: 'Course type', value: course_option.course.course_type.capitalize },
         { key: 'Cycle', value: course_option.course.recruitment_cycle_year },
         { key: 'Full time or part time', value: course_option.study_mode.humanize },
-        { key: 'Location', value: course_option.site.name_and_code },
+        { key: location_key, value: course_option.site.name_and_code },
       ]
 
       if accredited_body.present?
@@ -29,6 +31,15 @@ module SupportInterface
 
     def accredited_body
       course_option.course.accredited_provider
+    end
+
+    def location_key
+      if @course_option_is_original
+        text = 'not ' if @school_placement_auto_selected
+        "Location (#{text}selected by candidate)"
+      else
+        'Location'
+      end
     end
   end
 end

--- a/spec/components/previews/support_interface/course_option_details_component_preview.rb
+++ b/spec/components/previews/support_interface/course_option_details_component_preview.rb
@@ -1,0 +1,24 @@
+module SupportInterface
+  class CourseOptionDetailsComponentPreview < ViewComponent::Preview
+    def school_auto_selected
+      application_choice = FactoryBot.build_stubbed(:application_choice, school_placement_auto_selected: true)
+      course_option = application_choice.current_course_option
+
+      render SupportInterface::CourseOptionDetailsComponent.new(application_choice:, course_option:)
+    end
+
+    def school_candidate_selected
+      application_choice = FactoryBot.build_stubbed(:application_choice, school_placement_auto_selected: false)
+      course_option = application_choice.current_course_option
+
+      render SupportInterface::CourseOptionDetailsComponent.new(application_choice:, course_option:)
+    end
+
+    def with_accredited_body
+      application_choice = ApplicationChoice.joins(course_option: { course: :accredited_provider }).first
+      course_option = application_choice.current_course_option
+
+      render SupportInterface::CourseOptionDetailsComponent.new(application_choice:, course_option:)
+    end
+  end
+end

--- a/spec/components/support_interface/course_option_details_component_spec.rb
+++ b/spec/components/support_interface/course_option_details_component_spec.rb
@@ -1,17 +1,73 @@
 require 'rails_helper'
 
 RSpec.describe SupportInterface::CourseOptionDetailsComponent do
-  it 'renders postgraduate course' do
-    postgraduate_course_option = create(:course_option)
-    result = render_inline(described_class.new(course_option: postgraduate_course_option))
-    expect(result.css('.govuk-summary-list__key').text).to include('Course type')
-    expect(result.css('.govuk-summary-list__value').text).to include('Postgraduate')
+  subject(:render_component) do
+    render_inline(
+      described_class.new(
+        course_option: @course_option,
+        application_choice: @application_choice,
+      ),
+    )
   end
 
-  it 'renders undergraduate course' do
-    undergraduate_course_option = create(:course_option, course: create(:course, :teacher_degree_apprenticeship))
-    result = render_inline(described_class.new(course_option: undergraduate_course_option))
-    expect(result.css('.govuk-summary-list__key').text).to include('Course type')
-    expect(result.css('.govuk-summary-list__value').text).to include('Undergraduate')
+  describe 'Course type' do
+    it 'renders postgraduate course' do
+      @application_choice = build_stubbed(:application_choice)
+      @course_option = @application_choice.course_option
+
+      expect(render_component.css('.govuk-summary-list__key').text).to include('Course type')
+      expect(render_component.css('.govuk-summary-list__value').text).to include('Postgraduate')
+    end
+
+    it 'renders undergraduate course' do
+      @application_choice = build_stubbed(:application_choice, course_option: build_stubbed(:course_option, :tda))
+      @course_option = @application_choice.course_option
+
+      expect(render_component.css('.govuk-summary-list__key').text).to include('Course type')
+      expect(render_component.css('.govuk-summary-list__value').text).to include('Undergraduate')
+    end
+  end
+
+  describe 'Location' do
+    context 'when it is the applications original course option and the location is auto selected' do
+      it 'renders auto selected Location' do
+        @application_choice = build_stubbed(:application_choice,
+                                            course_option: build_stubbed(:course_option),
+                                            original_course_option: build_stubbed(:course_option))
+        @course_option = @application_choice.original_course_option
+        location = @course_option.site.name_and_code
+
+        expect(render_component.css('.govuk-summary-list__key').text).to include('Location (selected by candidate)')
+        expect(render_component.css('.govuk-summary-list__value').text).to include(location)
+      end
+    end
+
+    context 'when it is the applications original course option and the location is not auto selected' do
+      it 'renders not auto selected Location' do
+        @application_choice = build_stubbed(:application_choice,
+                                            course_option: build_stubbed(:course_option),
+                                            original_course_option: build_stubbed(:course_option),
+                                            school_placement_auto_selected: true)
+        @course_option = @application_choice.original_course_option
+        location = @course_option.site.name_and_code
+
+        expect(render_component.css('.govuk-summary-list__key').text).to include('Location (not selected by candidate)')
+        expect(render_component.css('.govuk-summary-list__value').text).to include(location)
+      end
+    end
+
+    context 'when the course option is not the original course option' do
+      it 'renders undergraduate course' do
+        @application_choice = build_stubbed(:application_choice,
+                                            course_option: build_stubbed(:course_option),
+                                            original_course_option: build_stubbed(:course_option))
+        @course_option = @application_choice.current_course_option
+        location = @course_option.site.name_and_code
+
+        expect(render_component.css('.govuk-summary-list__key').text).to include('Location')
+        expect(render_component.css('.govuk-summary-list__key').text).not_to include('Location (')
+        expect(render_component.css('.govuk-summary-list__value').text).to include(location)
+      end
+    end
   end
 end

--- a/spec/factories/course_option.rb
+++ b/spec/factories/course_option.rb
@@ -14,6 +14,10 @@ FactoryBot.define do
       course { association :course, :open, recruitment_cycle_year: }
     end
 
+    trait :tda do
+      course { association :course, :open, :teacher_degree_apprenticeship, recruitment_cycle_year: }
+    end
+
     trait :with_course_uuid do
       course { association :course, :uuid, recruitment_cycle_year: }
     end


### PR DESCRIPTION
## Context

Display the context of the course school placement (location) on tables in the Support Interface.


## Changes proposed in this pull request

Update `SupportInterface::CourseOptionDetailsComponent` to accept a `course_option` and an `application_choice`.
This is necessary to know whether the course option being displayed was the one that was chosen by the Candidate.

If the courses' provider allows candidates to choose a school placement, we show that the location on the application was chosen by the candidate. Other wise we show that it was not chosen by the candidate.

In the case where a Support user changes the course in the SupportInterface or the Provider changes the course in the ProviderInterface, the original_course_option will remain as the location chosen by the candidate and the `course_option` and `current_course_option` will not display any context around how the location was selected.

## Guidance to review

I've written the tests for CourseOptionDetailsComponent with instance variables so they can affect the `subject` but can also be defined within the `it` block. 
Let me know if this is not to your liking.

#### Review app

https://apply-review-9799.test.teacherservices.cloud/support/applications/40

|ApplicationChoice|auto_selected?|
|---|---|
|76|false|
|77|true|

|76|77|
|---|---|
|![image](https://github.com/user-attachments/assets/5a9cea9a-8873-4662-a63c-79ea442722c0)|![image](https://github.com/user-attachments/assets/e68602f1-8739-40b5-87bd-a8d395b30d0d)|


### Offered course option only shows Location
![image](https://github.com/user-attachments/assets/bef6d812-bdce-4df8-9246-8e2357ceb60c)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Add PR link to Trello card
