### PR TITLE
Restrict access to /provider/activity

### DIFF
--- a/app/controllers/provider_interface/activity_log_controller.rb
+++ b/app/controllers/provider_interface/activity_log_controller.rb
@@ -5,6 +5,8 @@ module ProviderInterface
     PAGY_PER_PAGE = 50
 
     def index
+      redirect_to provider_interface_applications_path
+
       application_choices = GetApplicationChoicesForProviders.call(
         providers: current_provider_user.providers,
       )

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -78,7 +78,6 @@ class NavigationItems
         items << NavigationItem.new('Applications', provider_interface_applications_path, active?(current_controller, %w[application_choices decisions offer_changes notes interviews offers feedback conditions reconfirm_deferred_offers]), [])
         items << NavigationItem.new('Interview schedule', provider_interface_interview_schedule_path, active?(current_controller, %w[interview_schedules]), [])
         items << NavigationItem.new('Reports', provider_interface_reports_path, active?(current_controller, %w[reports application_data_export hesa_export recruitment_performance_reports]))
-        items << NavigationItem.new('Activity log', provider_interface_activity_log_path, active?(current_controller, %w[activity_log]), [])
       end
 
       items

--- a/spec/system/provider_interface/see_activity_log_spec.rb
+++ b/spec/system/provider_interface/see_activity_log_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'See activity log' do
   include CourseOptionHelpers
   include DfESignInHelpers
 
-  scenario 'Provider visits application page' do
+  scenario 'Provider visits application page', skip: "We are taking the activity page down to improve it's performance" do
     given_i_am_a_provider_user_authenticated_with_dfe_sign_in
     and_i_have_a_manage_account
     and_my_organisation_has_applications


### PR DESCRIPTION
## Context

This page is very slow and whilst we are working on a fix, for now we will take it down until the fix is ready to be deployed

https://www.skylight.io/app/applications/t8bEzG0cuIkd/recent/6h/endpoints/ProviderInterface::ActivityLogController%23index?responseType=html

## Changes proposed in this pull request

redirect to application_choices index page if you try to access /provider/activity

## Guidance to review


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
