### PR TITLE
Remove references and safeguarding issues from allow edit form

### DIFF
--- a/app/forms/support_interface/editable_until_form.rb
+++ b/app/forms/support_interface/editable_until_form.rb
@@ -8,7 +8,9 @@ module SupportInterface
     validates_with ZendeskUrlValidator
 
     def non_editable_sections
-      Section.non_editable.insert(2, science_gcse).flatten.compact
+      Section.non_editable.insert(2, science_gcse).reject do |section|
+        section.id.in?(%i[references safeguarding_issues])
+      end.flatten.compact
     end
 
     def science_gcse

--- a/spec/system/temporarily_editable_sections_spec.rb
+++ b/spec/system/temporarily_editable_sections_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'Unlocking non editable sections temporarily via support' do
 
     when_i_visit_the_application_page
     and_i_click_to_change_the_editable_sections
+    then_i_do_not_see_references_or_safeguarding
     and_i_click_update
     then_i_see_a_validation_message
 
@@ -70,6 +71,11 @@ RSpec.describe 'Unlocking non editable sections temporarily via support' do
     within_summary_row 'Is this application editable' do
       click_link_or_button 'Change'
     end
+  end
+
+  def then_i_do_not_see_references_or_safeguarding
+    expect(page).to have_no_content 'References'
+    expect(page).to have_no_content 'Safeguarding issues'
   end
 
   def and_i_click_update


### PR DESCRIPTION
## Context

Over the summer the Support team had to deal with a complaint because a candidate was allowed to make changes to their references, affecting the submitted application(s). Instead, the candidate should have been advised that they could edit their references on once they had an offer. 

## Changes proposed in this pull request

Removes the ability for Support to allow candidates to edit references or safeguarding.

| Before | After |
| ------ | ------ |
| <img width="775" alt="image" src="https://github.com/user-attachments/assets/0531583b-a8e1-44a6-b6f0-c85ecec84b0f"> | <img width="823" alt="image" src="https://github.com/user-attachments/assets/66e0e685-d3bd-40dd-ba9a-65d6223386e0"> |

## Guidance to review

To test this locally.
- View a candidate who has a completed application form and a submitted application (no offer)
- You should see the row 'Is this application editable'. 
- Click on 'Change'
- You shouldn't see references or safeguarding

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
