### PR TITLE
Warm the Vendor API cache

### DIFF
--- a/app/queries/provider_latest_api_version_query.rb
+++ b/app/queries/provider_latest_api_version_query.rb
@@ -1,0 +1,13 @@
+class ProviderLatestAPIVersionQuery
+  def initialize(provider_id:)
+    @provider_id = provider_id
+  end
+
+  def call
+    VendorAPIRequest
+      .select("substring(request_path, '/api/v(.*)/applications') api_version")
+      .where(provider_id: @provider_id)
+      .order(api_version: :desc)
+      .first&.api_version
+  end
+end

--- a/app/queries/providers_for_vendor_api_cache_warming_query.rb
+++ b/app/queries/providers_for_vendor_api_cache_warming_query.rb
@@ -1,0 +1,8 @@
+class ProvidersForVendorAPICacheWarmingQuery
+  def call(since: 1.month.ago)
+    Provider
+      .joins(:vendor_api_tokens)
+      .where('vendor_api_tokens.last_used_at > ?', since)
+      .distinct
+  end
+end

--- a/app/services/warm_cache.rb
+++ b/app/services/warm_cache.rb
@@ -2,8 +2,7 @@ class WarmCache
   def call
     r = {}
     # Get all provider who have an api token that has been used in the past 6.months
-    Provider.joins(:vendor_api_tokens)
-      .where('vendor_api_tokens.last_used_at > ?', 1.month.ago).distinct.each do |provider|
+    ProvidersForVendorAPICacheWarmingQuery.new.call.each do |provider|
       Rails.logger.tagged('Warm Cache').info "Provider cached: #{provider.id}"
       # Find the api version they last used
       vendor_version = VendorAPIRequest

--- a/app/services/warm_cache.rb
+++ b/app/services/warm_cache.rb
@@ -1,0 +1,36 @@
+class WarmCache
+  def call
+    r = {}
+    # Get all provider who have an api token that has been used in the past 6.months
+    Provider.joins(:vendor_api_tokens)
+      .where('vendor_api_tokens.last_used_at > ?', 1.month.ago).distinct.each do |provider|
+      Rails.logger.tagged('Warm Cache').info "Provider cached: #{provider.id}"
+      # Find the api version they last used
+      vendor_version = VendorAPIRequest
+        .where(provider_id: provider.id)
+        .select("regexp_matches(request_path, '/api/v(.*)/applications') result")
+        .order(created_at: :desc)
+        .first&.result&.first
+
+      # skip as we couldn't find any api requests
+      next unless vendor_version
+
+      r[provider.name] = []
+
+      # For each of the application choices
+      # generate a cache entry
+      ApplicationChoice.joins(course_option: { course: :provider })
+        .where(course_options: { courses: { provider_id: provider.id } })
+        .where('application_choices.updated_at between (?) and (?)', Date.new(2024, 9, 2), Date.new(2024, 9, 5))
+        .where.not(application_choices: { status: ['unsubmitted'] })
+        .find_each do |application_choice|
+        presenter = VendorAPI::ApplicationPresenter.new(vendor_version, application_choice)
+        presenter.as_json
+        presenter.serialized_json
+        Rails.logger.tagged('Warm Cache').info "ApplicationChoice cached: #{application_choice.id}"
+        r[provider.name] << application_choice.id
+      end
+    end
+    r
+  end
+end

--- a/app/services/warm_cache.rb
+++ b/app/services/warm_cache.rb
@@ -1,7 +1,7 @@
 class WarmCache
   def call
     # Get all provider who have an api token that has been used in the past month
-    ProvidersForVendorAPICacheWarmingQuery.new.call.each do |provider|
+    ProvidersForVendorAPICacheWarmingQuery.new.call.find_each do |provider|
       # Find the api version they last used
       api_version = ProviderLatestAPIVersionQuery.new(provider_id: provider.id).call
 

--- a/app/services/warm_cache.rb
+++ b/app/services/warm_cache.rb
@@ -14,7 +14,6 @@ class WarmCache
 
       # Run a background job for each provider to cache their applications
       Rails.logger.tagged('WarmCache').info "VendorAPIWarmCacheProviderWorker enqueued for provider id #{provider.id} with api version #{api_version}"
-      binding.pry
       ::VendorAPIWarmCacheProviderWorker.perform_async(api_version, provider.id)
     end
   end

--- a/app/services/warm_cache.rb
+++ b/app/services/warm_cache.rb
@@ -3,11 +3,7 @@ class WarmCache
     # Get all provider who have an api token that has been used in the past month
     ProvidersForVendorAPICacheWarmingQuery.new.call.each do |provider|
       # Find the api version they last used
-      api_version = VendorAPIRequest
-        .where(provider_id: provider.id)
-        .select("regexp_matches(request_path, '/api/v(.*)/applications') result")
-        .order(created_at: :desc)
-        .first&.result&.first
+      api_version = ProviderLatestAPIVersionQuery.new(provider_id: provider.id).call
 
       # skip as we couldn't find any api requests
       next unless api_version

--- a/app/services/warm_provider_cache.rb
+++ b/app/services/warm_provider_cache.rb
@@ -6,19 +6,31 @@ class WarmProviderCache
   def call(api_version, provider_id)
     @provider = Provider.find(provider_id)
     @version_number = api_version
-    r = {@provider.name => []}
+    r = { @provider.name => [] }
     # For each of the application choices generate a cache entry
     application_choices_visible_to_provider
       .where('application_choices.updated_at between (?) and (?)', Date.new(2024, 9, 2), Date.new(2024, 9, 5))
-      .where.not(application_choices: { status: ['unsubmitted'] })
       .find_each do |application_choice|
       presenter = VendorAPI::ApplicationPresenter.new(api_version, application_choice)
-      presenter.as_json
-      presenter.serialized_json
+      Rails.cache.write(
+        presenter.send(:cache_key, application_choice, api_version),
+        schema(presenter),
+        expires_in: VendorAPI::ApplicationPresenter::CACHE_EXPIRES_IN,
+      )
+      Rails.cache.write(
+        presenter.send(:cache_key, application_choice, active_version, method: :as_json),
+        schema(presenter),
+        expires_in: VendorAPI::ApplicationPresenter::CACHE_EXPIRES_IN,
+      )
+
       Rails.logger.tagged('WarmProviderCache').info "ApplicationChoice cached: #{application_choice.id}"
       r[@provider.name] << application_choice.id
     end
     r
+  end
+
+  def schema(presenter)
+    @schema ||= presenter.send(:schema)
   end
 
   def current_provider

--- a/app/services/warm_provider_cache.rb
+++ b/app/services/warm_provider_cache.rb
@@ -18,7 +18,7 @@ class WarmProviderCache
         expires_in: VendorAPI::ApplicationPresenter::CACHE_EXPIRES_IN,
       )
       Rails.cache.write(
-        presenter.send(:cache_key, application_choice, active_version, method: :as_json),
+        presenter.send(:cache_key, application_choice, api_version, method: :as_json),
         schema(presenter),
         expires_in: VendorAPI::ApplicationPresenter::CACHE_EXPIRES_IN,
       )

--- a/app/services/warm_provider_cache.rb
+++ b/app/services/warm_provider_cache.rb
@@ -1,0 +1,27 @@
+class WarmProviderCache
+  include VendorAPI::ApplicationDataConcerns
+
+  attr_reader :version_number
+
+  def call(api_version, provider_id)
+    @provider = Provider.find(provider_id)
+    @version_number = api_version
+    r = {@provider.name => []}
+    # For each of the application choices generate a cache entry
+    application_choices_visible_to_provider
+      .where('application_choices.updated_at between (?) and (?)', Date.new(2024, 9, 2), Date.new(2024, 9, 5))
+      .where.not(application_choices: { status: ['unsubmitted'] })
+      .find_each do |application_choice|
+      presenter = VendorAPI::ApplicationPresenter.new(api_version, application_choice)
+      presenter.as_json
+      presenter.serialized_json
+      Rails.logger.tagged('WarmProviderCache').info "ApplicationChoice cached: #{application_choice.id}"
+      r[@provider.name] << application_choice.id
+    end
+    r
+  end
+
+  def current_provider
+    @provider
+  end
+end

--- a/app/services/warm_provider_cache.rb
+++ b/app/services/warm_provider_cache.rb
@@ -6,7 +6,6 @@ class WarmProviderCache
   def call(api_version, provider_id)
     @provider = Provider.find(provider_id)
     @version_number = api_version
-    r = { @provider.name => [] }
     # For each of the application choices generate a cache entry
     application_choices_visible_to_provider
       .where('application_choices.updated_at between (?) and (?)', Date.new(2024, 9, 2), Date.new(2024, 9, 5))
@@ -19,9 +18,7 @@ class WarmProviderCache
       )
 
       Rails.logger.tagged('WarmProviderCache').info "ApplicationChoice cached: #{application_choice.id}"
-      r[@provider.name] << application_choice.id
     end
-    r
   end
 
   def schema(presenter)

--- a/app/services/warm_provider_cache.rb
+++ b/app/services/warm_provider_cache.rb
@@ -17,11 +17,6 @@ class WarmProviderCache
         schema(presenter),
         expires_in: VendorAPI::ApplicationPresenter::CACHE_EXPIRES_IN,
       )
-      Rails.cache.write(
-        presenter.send(:cache_key, application_choice, api_version, method: :as_json),
-        schema(presenter),
-        expires_in: VendorAPI::ApplicationPresenter::CACHE_EXPIRES_IN,
-      )
 
       Rails.logger.tagged('WarmProviderCache').info "ApplicationChoice cached: #{application_choice.id}"
       r[@provider.name] << application_choice.id

--- a/app/workers/vendor_api_warm_cache_provider_worker.rb
+++ b/app/workers/vendor_api_warm_cache_provider_worker.rb
@@ -1,0 +1,7 @@
+class VendorAPIWarmCacheProviderWorker
+  include Sidekiq::Worker
+
+  def perform(api_version, provider_id)
+    WarmProviderCache.new.call(api_version, provider_id)
+  end
+end

--- a/app/workers/vendor_api_warm_cache_worker.rb
+++ b/app/workers/vendor_api_warm_cache_worker.rb
@@ -1,7 +1,0 @@
-class VendorAPIWarmCacheWorker
-  include Sidekiq::Worker
-
-  def perform
-    WarmCache.call
-  end
-end

--- a/app/workers/vendor_api_warm_cache_worker.rb
+++ b/app/workers/vendor_api_warm_cache_worker.rb
@@ -1,0 +1,7 @@
+class VendorAPIWarmCacheWorker
+  include Sidekiq::Worker
+
+  def perform
+    WarmCache.call
+  end
+end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -26,7 +26,7 @@ class Clock
   every(1.hour, 'DetectInvariantsHourlyCheck', at: '**:30') { DetectInvariantsHourlyCheck.perform_async }
 
   # Warm the Vendor API cache for ApplicationChoices
-  every(23.hours, 'WarmCacheWorker') { ::WarmCache.new.call }
+  every(12.hours, 'WarmCacheWorker', at: ['06:00', '18:00']) { ::WarmCache.new.call }
 
   # Daily jobs
   every(1.day, 'Chasers::Candidate::OfferWorker', at: '10:30') { Chasers::Candidate::OfferWorker.perform_async }

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -25,6 +25,9 @@ class Clock
   every(1.hour, 'UpdateDuplicateMatchesWorker', at: '**:25') { UpdateDuplicateMatchesWorker.perform_async('notify_slack_at' => 13) }
   every(1.hour, 'DetectInvariantsHourlyCheck', at: '**:30') { DetectInvariantsHourlyCheck.perform_async }
 
+  # Warm the Vendor API cache for ApplicationChoices
+  every(23.hours, 'WarmCacheWorker') { ::WarmCacheWorker.perform_async }
+
   # Daily jobs
   every(1.day, 'Chasers::Candidate::OfferWorker', at: '10:30') { Chasers::Candidate::OfferWorker.perform_async }
 

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -26,7 +26,7 @@ class Clock
   every(1.hour, 'DetectInvariantsHourlyCheck', at: '**:30') { DetectInvariantsHourlyCheck.perform_async }
 
   # Warm the Vendor API cache for ApplicationChoices
-  every(23.hours, 'WarmCacheWorker') { ::WarmCache.call }
+  every(23.hours, 'WarmCacheWorker') { ::WarmCache.new.call }
 
   # Daily jobs
   every(1.day, 'Chasers::Candidate::OfferWorker', at: '10:30') { Chasers::Candidate::OfferWorker.perform_async }

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -26,7 +26,7 @@ class Clock
   every(1.hour, 'DetectInvariantsHourlyCheck', at: '**:30') { DetectInvariantsHourlyCheck.perform_async }
 
   # Warm the Vendor API cache for ApplicationChoices
-  every(23.hours, 'WarmCacheWorker') { ::WarmCacheWorker.perform_async }
+  every(23.hours, 'WarmCacheWorker') { ::WarmCache.call }
 
   # Daily jobs
   every(1.day, 'Chasers::Candidate::OfferWorker', at: '10:30') { Chasers::Candidate::OfferWorker.perform_async }

--- a/spec/queries/provider_latest_api_version_query_spec.rb
+++ b/spec/queries/provider_latest_api_version_query_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe ProviderLatestAPIVersionQuery do
+  subject(:query) do
+    described_class.new(provider_id: provider.id).call
+  end
+
+  let(:vendor_api_requests) do
+    [
+      create(:vendor_api_request, request_path: '/api/v1.1/applications'),
+      create(:vendor_api_request, request_path: '/api/v1.5/applications'),
+    ]
+  end
+  let!(:provider) { create(:provider, vendor_api_requests:) }
+
+  context 'when there are multiple api versions' do
+    it 'does not return the provider' do
+      expect(query).to eq('1.5')
+    end
+  end
+
+  context 'when a provider has no api requests' do
+    let(:vendor_api_requests) { [] }
+
+    it 'only returns one row per provider' do
+      expect(query).to be_nil
+    end
+  end
+end

--- a/spec/queries/providers_for_vendor_api_cache_warming_query_spec.rb
+++ b/spec/queries/providers_for_vendor_api_cache_warming_query_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe ProvidersForVendorAPICacheWarmingQuery do
+  include CourseOptionHelpers
+  let(:primary_api_token) { build(:vendor_api_token, last_used_at: 1.week.ago) }
+  let(:vendor_api_tokens) { [primary_api_token, build(:vendor_api_token, last_used_at: 1.week.ago)] }
+  let!(:provider) { create(:provider, vendor_api_tokens:) }
+
+  context 'when a provider has multiple api tokens' do
+    it 'only returns one row per provider' do
+      expect(described_class.new.call.length).to eq(1)
+    end
+  end
+
+  context 'when the last_used_at is nil' do
+    let(:primary_api_token) { build(:vendor_api_token, last_used_at: nil) }
+    let(:vendor_api_tokens) { [primary_api_token] }
+
+    it 'does not return the provider' do
+      expect(described_class.new.call).not_to include(provider)
+    end
+  end
+
+  context 'when the last_used_at is greater than the since param' do
+    let(:primary_api_token) { build(:vendor_api_token, last_used_at: 2.months.ago) }
+    let(:vendor_api_tokens) { [primary_api_token] }
+
+    it 'does not return the provider' do
+      expect(described_class.new.call(since: 1.month.ago)).not_to include(provider)
+    end
+  end
+end

--- a/spec/services/warm_cache_spec.rb
+++ b/spec/services/warm_cache_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe WarmCache do
+  include VendorAPISpecHelpers
+  before do
+    @application_choice = create_application_choice_for_currently_authenticated_provider
+    api_token
+    create(:vendor_api_request, provider: currently_authenticated_provider, request_path: '/api/v1.1/applications')
+  end
+
+  describe '#call' do
+    it 'caches all relevant application choices' do
+      token = currently_authenticated_provider.vendor_api_tokens.last
+      token.update(last_used_at: 1.week.ago)
+      @application_choice.update(updated_at: Time.zone.local(2024, 9, 4, 14, 0))
+      expect(described_class.new.call).to eq(currently_authenticated_provider.name => [@application_choice.id])
+    end
+  end
+end

--- a/spec/services/warm_provider_cache_spec.rb
+++ b/spec/services/warm_provider_cache_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe WarmProviderCache do
+  around do |example|
+    original_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    example.run
+    Rails.cache = original_cache
+  end
+
+  describe '#call' do
+    it 'caches application_choices of a provider' do
+      choice = create(
+        :application_choice,
+        :awaiting_provider_decision,
+        updated_at: Time.zone.local(2024, 9, 4, 14, 0),
+      )
+
+      described_class.new.call('1.1', choice.provider.id)
+
+      cached_choice = Rails.cache.read("vendor_api-1.1-application_choices/#{choice.id}-20240904130000000000")
+      expect(cached_choice[:id]).to eq(choice.id.to_s)
+    end
+  end
+end

--- a/spec/support_specs/clockwork_spec.rb
+++ b/spec/support_specs/clockwork_spec.rb
@@ -101,4 +101,30 @@ RSpec.describe Clockwork, :clockwork do
       expect(Clockwork::Test.manager.send(:history).jobs).not_to include('Schedule Recruitment Performance reports')
     end
   end
+
+  describe 'Warm provider cache' do
+    it 'runs at 6 AM' do
+      start_time = Time.zone.now.beginning_of_week.change(hour: 5)
+      end_time = Time.zone.now.beginning_of_week.change(hour: 7)
+      Clockwork::Test.run(
+        start_time:,
+        end_time:,
+        tick_speed: 1.hour,
+      )
+
+      expect(Clockwork::Test).to have_run('WarmCacheWorker').once
+    end
+
+    it 'runs at 6 PM' do
+      start_time = Time.zone.now.beginning_of_week.change(hour: 17)
+      end_time = Time.zone.now.beginning_of_week.change(hour: 19)
+      Clockwork::Test.run(
+        start_time:,
+        end_time:,
+        tick_speed: 1.hour,
+      )
+
+      expect(Clockwork::Test).to have_run('WarmCacheWorker').once
+    end
+  end
 end


### PR DESCRIPTION
## Context

The `ApplicationChoice#index` is slow at the best of times.
We have a situation where there are 1000s of records being returned for a very small duration of 2 days.

In order to help speed up the response to API clients, we can warm the cache.


## Changes proposed in this pull request

 - Add WarmCache service
 - Run WarmCache in the WarmCacheWorker
 - Schedule the Worker to run every 23 hours.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
