### PR TITLE
1336 apply manage update our privacy links to direct to dfes new central privacy notice

### DIFF
--- a/app/controllers/provider_interface/content_controller.rb
+++ b/app/controllers/provider_interface/content_controller.rb
@@ -15,15 +15,15 @@ module ProviderInterface
     def privacy; end
 
     def service_privacy_notice
-      render_content_page :service_privacy_notice,
-                          breadcrumb_title: 'privacy_notices',
-                          breadcrumb_path: provider_interface_privacy_path
+      render_deprecated_privacy_notice_pages :service_privacy_notice,
+                                             breadcrumb_title: 'privacy_notices',
+                                             breadcrumb_path: provider_interface_privacy_path
     end
 
     def online_chat_privacy_notice
-      render_content_page :online_chat_privacy_notice,
-                          breadcrumb_title: 'privacy_notices',
-                          breadcrumb_path: provider_interface_privacy_path
+      render_deprecated_privacy_notice_pages :online_chat_privacy_notice,
+                                             breadcrumb_title: 'privacy_notices',
+                                             breadcrumb_path: provider_interface_privacy_path
     end
 
     def cookies_page

--- a/app/controllers/provider_interface/provider_agreements_controller.rb
+++ b/app/controllers/provider_interface/provider_agreements_controller.rb
@@ -10,6 +10,10 @@ module ProviderInterface
       end
     end
 
+    def old_data_sharing_agreement
+      render :old_data_sharing_agreement
+    end
+
     def create_data_sharing_agreement
       if current_provider_user.impersonator && HostingEnvironment.production?
         flash[:warning] = 'Cannot be signed by a support user'

--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -1,5 +1,27 @@
 module ContentHelper
   def render_content_page(page_name, breadcrumb_title: nil, breadcrumb_path: nil, locals: {})
+    render_markdown_content(
+      'rendered_markdown_template',
+      page_name,
+      breadcrumb_title:,
+      breadcrumb_path:,
+      locals:,
+    )
+  end
+
+  def render_deprecated_privacy_notice_pages(page_name, breadcrumb_title: nil, breadcrumb_path: nil, locals: {})
+    render_markdown_content(
+      'rendered_old_privacy_notices_markdown',
+      page_name,
+      breadcrumb_title:,
+      breadcrumb_path:,
+      locals:,
+    )
+  end
+
+private
+
+  def render_markdown_content(template_name, page_name, breadcrumb_title: nil, breadcrumb_path: nil, locals: {})
     raw_content = File.read("app/views/content/#{page_name}.md")
     content_with_erb_tags_replaced = ApplicationController.renderer.render(
       inline: raw_content,
@@ -9,6 +31,7 @@ module ContentHelper
     @page_name = page_name
     @breadcrumb_title = breadcrumb_title
     @breadcrumb_path = breadcrumb_path
-    render 'rendered_markdown_template'
+
+    render template_name
   end
 end

--- a/app/views/candidate_interface/sign_up/new.html.erb
+++ b/app/views/candidate_interface/sign_up/new.html.erb
@@ -13,7 +13,7 @@
 
       <%= f.govuk_email_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, hint: { text: t('authentication.sign_up.email_address.hint_label') }, width: 'two-thirds', autocomplete: 'email', spellcheck: false %>
 
-      <p class="govuk-body govuk-!-margin-bottom-6">By continuing, you agree to our <%= govuk_link_to 'terms and conditions', candidate_interface_terms_path %> and <%= govuk_link_to 'privacy notice', candidate_interface_privacy_policy_path %>.</p>
+      <p class="govuk-body govuk-!-margin-bottom-6">By continuing, you agree to our <%= govuk_link_to 'terms and conditions', candidate_interface_terms_path %> and <%= govuk_link_to 'privacy notice', t('personal_information_charter.url') %>.</p>
 
       <%= f.govuk_submit t('continue') %>
     <% end %>

--- a/app/views/content/service_privacy_notice_candidate.html.erb
+++ b/app/views/content/service_privacy_notice_candidate.html.erb
@@ -1,5 +1,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= govuk_notification_banner(title_text: 'Important') do |notification_banner| %>
+      <% notification_banner.with_heading(text: 'This policy has been replaced') %>
+      <p class="govuk-body">
+        As of September 2024, visit the GOV.UK website for the <%= govuk_link_to('up-to-date Department for Education privacy policy', t('personal_information_charter.url')) %>.
+      </p>
+    <% end %>
     <h1 class="govuk-heading-l"><%= t('page_titles.service_privacy_notice') %></h1>
 
     <h2 class="govuk-heading-m">Who we are</h2>

--- a/app/views/content/terms_candidate.html.erb
+++ b/app/views/content/terms_candidate.html.erb
@@ -123,7 +123,7 @@
 
     <p class="govuk-body">You can <%= govuk_link_to('make a complaint or give feedback about this service', candidate_interface_complaints_path) %>.</p>
 
-    <p class="govuk-body">Our <%= govuk_link_to('privacy notice', candidate_interface_privacy_policy_path) %> explains how we keep your data safe.</p>
+    <p class="govuk-body">Our <%= govuk_link_to('privacy notice', t('personal_information_charter.url')) %> explains how we keep your data safe.</p>
 
     <h2 class="govuk-heading-m">Changes to these terms and conditions</h2>
 

--- a/app/views/layouts/_footer_meta_candidate.html.erb
+++ b/app/views/layouts/_footer_meta_candidate.html.erb
@@ -15,7 +15,7 @@
     <%= link_to t('layout.support_links.cookies'), candidate_interface_cookies_path, class: 'govuk-footer__link' %>
   </li>
   <li class="govuk-footer__inline-list-item">
-    <%= link_to t('layout.support_links.privacy_policy'), candidate_interface_privacy_policy_path, class: 'govuk-footer__link' %>
+    <%= link_to t('layout.support_links.privacy_policy'), t('personal_information_charter.url'), class: 'govuk-footer__link' %>
   </li>
   <li class="govuk-footer__inline-list-item">
     <%= link_to t('layout.support_links.terms_of_use'), candidate_interface_terms_path, class: 'govuk-footer__link' %>

--- a/app/views/layouts/_footer_meta_provider.html.erb
+++ b/app/views/layouts/_footer_meta_provider.html.erb
@@ -41,7 +41,7 @@
     <%= link_to t('layout.support_links.cookies'), provider_interface_cookies_path, class: 'govuk-footer__link' %>
   </li>
   <li class="govuk-footer__inline-list-item">
-    <%= link_to t('layout.support_links.privacy'), provider_interface_privacy_path, class: 'govuk-footer__link' %>
+    <%= link_to t('layout.support_links.privacy_policy'), t('personal_information_charter.url'), class: 'govuk-footer__link' %>
   </li>
     <li class="govuk-footer__inline-list-item">
       <%= link_to t('layout.support_links.guidance_for_using_ai'), provider_interface_guidance_for_using_ai_path, class: 'govuk-footer__link' %>

--- a/app/views/provider_interface/content/privacy.html.erb
+++ b/app/views/provider_interface/content/privacy.html.erb
@@ -2,6 +2,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= govuk_notification_banner(title_text: 'Important') do |notification_banner| %>
+      <% notification_banner.with_heading(text: 'These policy have been replaced') %>
+      <p class="govuk-body">
+        These policy notices are for reference only. As of September 2024, visit the GOV.UK website for the
+        <%= govuk_link_to('up-to-date Department for Education privacy policy', t('personal_information_charter.url')) %>.
+      </p>
+    <% end %>
     <h1 class="govuk-heading-l"><%= t('page_titles.privacy_notices') %></h1>
     <ul class="govuk-list govuk-list--spaced">
       <li>

--- a/app/views/provider_interface/content/rendered_old_privacy_notices_markdown.html.erb
+++ b/app/views/provider_interface/content/rendered_old_privacy_notices_markdown.html.erb
@@ -1,0 +1,24 @@
+<%= content_for :title, t("page_titles.#{@page_name}") %>
+
+<% if @breadcrumb_title && @breadcrumb_path %>
+  <% content_for :before_content do %>
+    <%= breadcrumbs({
+                      t("page_titles.#{@breadcrumb_title}") => @breadcrumb_path,
+                      t("page_titles.#{@page_name}") => nil,
+                    }) %>
+  <% end %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_notification_banner(title_text: 'Important') do |notification_banner| %>
+      <% notification_banner.with_heading(text: 'This policy has been replaced') %>
+      <p class="govuk-body">
+        As of September 2024, visit the GOV.UK website for the <%= govuk_link_to('up-to-date Department for Education privacy policy', t('personal_information_charter.url')) %>.
+      </p>
+    <% end %>
+    <h1 class="govuk-heading-l"><%= t("page_titles.#{@page_name}") %></h1>
+
+    <%= @converted_markdown %>
+  </div>
+</div>

--- a/app/views/provider_interface/provider_agreements/data_sharing_agreement.html.erb
+++ b/app/views/provider_interface/provider_agreements/data_sharing_agreement.html.erb
@@ -220,7 +220,7 @@
     <p class="govuk-body">Participants will not be asked to share information related to their private or family lives.</p>
 
     <h3 class="govuk-heading-m" id="section-3-3">Privacy notices</h3>
-    <p class="govuk-body">Please see the <%= govuk_link_to 'Apply for teacher training privacy policy for candidates, referees and provider staff', provider_interface_service_privacy_notice_path %>.</p>
+    <p class="govuk-body">Please see the <%= govuk_link_to 'Apply for teacher training privacy policy for candidates, referees and provider staff', t('personal_information_charter.url') %>.</p>
     <p class="govuk-body">DfE will make data subjects aware of how their data will be processed before data is collected through Apply for teacher training.</p>
     <p class="govuk-body">Please see DfE’s Personal Information Charter for more details on the organisation’s data storage and sharing policies.</p>
     <p class="govuk-body">By agreeing to this data sharing agreement, DfE and the provider confirm that their respective privacy policies explain the data sharing activities outlined in this agreement.</p>

--- a/app/views/provider_interface/provider_agreements/old_data_sharing_agreement.html.erb
+++ b/app/views/provider_interface/provider_agreements/old_data_sharing_agreement.html.erb
@@ -1,0 +1,347 @@
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_notification_banner(title_text: 'Important') do |notification_banner| %>
+      <% notification_banner.with_heading(text: 'This policy has been replaced') %>
+      <p class="govuk-body">
+        This data sharing agreement refers to an out-of-date privacy policy. It has been replaced as of September 2024.
+      </p>
+    <% end %>
+      <h1 class="govuk-heading-xl govuk-!-margin-bottom-3"><%= t('page_titles.data_sharing_agreement') %></h1>
+      <p class="govuk-body-l">This agreement applies to personal data shared between the Department for Education (DfE) and ‘the provider’, as part of Apply for teacher training.</p>
+
+        <p class="govuk-body">Our data sharing agreement sets out how you should use and look after the data we share with you. Please read the data sharing agreement below in full to check you can meet your responsibilities.</p>
+        <p class="govuk-body">Once you have read it, please scroll to the bottom of the page to accept it.</p>
+
+      <h2 class="govuk-heading-m">Contents</h2>
+      <ol class="app-contents-list__list">
+        <li class="app-contents-list__list-item app-contents-list__list-item--parent">
+          <%= govuk_link_to 'Section 1: Introduction', '#section-1', class: 'app-contents-list__link' %>
+          <ol class="app-contents-list__nested-list">
+            <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
+              <%= govuk_link_to 'Background', '#section-1-1', class: 'app-contents-list__link' %>
+            </li>
+          </ol>
+        </li>
+        <li class="app-contents-list__list-item app-contents-list__list-item--parent">
+          <%= govuk_link_to 'Section 2: What personal data DfE and the provider process/share and why', '#section-2', class: 'app-contents-list__link' %>
+          <ol class="app-contents-list__nested-list">
+            <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
+              <%= govuk_link_to 'What data DfE and the provider will process/share', '#section-2-1', class: 'app-contents-list__link' %>
+            </li>
+            <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
+              <%= govuk_link_to 'What the provider can use personal data for', '#section-2-2', class: 'app-contents-list__link' %>
+            </li>
+            <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
+              <%= govuk_link_to 'What DfE can use personal data for', '#section-2-3', class: 'app-contents-list__link' %>
+            </li>
+          </ol>
+        </li>
+        <li class="app-contents-list__list-item app-contents-list__list-item--parent">
+          <%= govuk_link_to 'Section 3: DfE’s legal basis for sharing/processing personal', '#section-3', class: 'app-contents-list__link' %>
+          <ol class="app-contents-list__nested-list">
+            <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
+              <%= govuk_link_to 'Lawful conditions for sharing/processing personal data', '#section-3-1', class: 'app-contents-list__link' %>
+            </li>
+            <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
+              <%= govuk_link_to 'The right to respect for private and family life', '#section-3-2', class: 'app-contents-list__link' %>
+            </li>
+            <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
+              <%= govuk_link_to 'Privacy notices', '#section-3-3', class: 'app-contents-list__link' %>
+            </li>
+          </ol>
+        </li>
+        <li class="app-contents-list__list-item app-contents-list__list-item--parent">
+          <%= govuk_link_to 'Section 4: Data handling', '#section-4', class: 'app-contents-list__link' %>
+          <ol class="app-contents-list__nested-list">
+            <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
+              <%= govuk_link_to 'Process and systems used for sharing data', '#section-4-1', class: 'app-contents-list__link' %>
+            </li>
+            <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
+              <%= govuk_link_to 'Accuracy of the shared data', '#section-4-2', class: 'app-contents-list__link' %>
+            </li>
+            <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
+              <%= govuk_link_to 'Assurance of compliance', '#section-4-3', class: 'app-contents-list__link' %>
+            </li>
+            <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
+              <%= govuk_link_to 'Third party disclosure', '#section-4-4', class: 'app-contents-list__link' %>
+            </li>
+            <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
+              <%= govuk_link_to 'Handling subject access requests (SARs)', '#section-4-5', class: 'app-contents-list__link' %>
+            </li>
+            <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
+              <%= govuk_link_to 'Handling Freedom of Information Act Requests', '#section-4-6', class: 'app-contents-list__link' %>
+            </li>
+            <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
+              <%= govuk_link_to 'Data storage', '#section-4-7', class: 'app-contents-list__link' %>
+            </li>
+            <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
+              <%= govuk_link_to 'Retention schedule', '#section-4-8', class: 'app-contents-list__link' %>
+            </li>
+            <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
+              <%= govuk_link_to 'Destruction schedule', '#section-4-9', class: 'app-contents-list__link' %>
+            </li>
+          </ol>
+        </li>
+        <li class="app-contents-list__list-item app-contents-list__list-item--parent">
+          <%= govuk_link_to 'Section 5: Security breaches', '#section-5', class: 'app-contents-list__link' %>
+          <ol class="app-contents-list__nested-list">
+            <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
+              <%= govuk_link_to 'Security incidents', '#section-5-1', class: 'app-contents-list__link' %>
+            </li>
+            <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
+              <%= govuk_link_to 'Consequences of security incident', '#section-5-2', class: 'app-contents-list__link' %>
+            </li>
+          </ol>
+        </li>
+        <li class="app-contents-list__list-item app-contents-list__list-item--parent">
+          <%= govuk_link_to 'Section 6: Issues, disputes and resolution between participants', '#section-6', class: 'app-contents-list__link' %>
+          <ol class="app-contents-list__nested-list">
+            <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
+              <%= govuk_link_to 'Resolving disputes', '#section-6-1', class: 'app-contents-list__link' %>
+            </li>
+          </ol>
+        </li>
+        <li class="app-contents-list__list-item app-contents-list__list-item--parent">
+          <%= govuk_link_to 'Section 7: Termination', '#section-7', class: 'app-contents-list__link' %>
+          <ol class="app-contents-list__nested-list">
+            <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
+              <%= govuk_link_to 'When to terminate this agreement', '#section-7-1', class: 'app-contents-list__link' %>
+            </li>
+          </ol>
+        </li>
+      </ol>
+
+      <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-6 govuk-!-margin-bottom-6">
+
+      <h2 class="govuk-heading-l" id="section-1">
+        <span class="govuk-caption-l">Section 1</span>
+        Introduction
+      </h2>
+      <h3 class="govuk-heading-m" id="section-1-1">Background</h3>
+      <h4 class="govuk-heading-s">What is Apply for teacher training?</h4>
+      <p class="govuk-body">Apply for teacher training is a new service designed by the Department for Education (DfE).</p>
+      <p class="govuk-body">It will replace UCAS Teacher Training as the new route into initial teacher training.</p>
+      <p class="govuk-body">Apply for teacher training and the data processing activities described in this document operate under the Secretary of State for Education’s ministerial common law powers.</p>
+
+      <h4 class="govuk-heading-s">Why is DfE developing this service?</h4>
+      <p class="govuk-body">DfE research showed that teacher training candidates and training providers find the current application and selection process difficult.</p>
+      <p class="govuk-body">DfE is trying to reduce the number of people dropping out of applying for teacher training by building a new application process.</p>
+      <p class="govuk-body">Apply for teacher training will eventually share data with approximately 2,000 teacher training providers.</p>
+      <p class="govuk-body">DfE is trialling the service with selected teacher training providers. The trial will help DfE improve the service and inform government policy relating to teacher retention and recruitment.</p>
+
+      <h4 class="govuk-heading-s">Why do we need this data sharing agreement?</h4>
+      <p class="govuk-body">To run this service, DfE and teacher training providers need to share personal data. This includes sharing the data of:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>teacher training applicants</li>
+        <li>staff processing applications (within DfE/within the teacher training organisation)</li>
+        <li>candidates’ referees</li>
+      </ul>
+      <p class="govuk-body">This data sharing agreement sets out DfE’s and the provider’s responsibilities when looking after this personal data.</p>
+
+      <h2 class="govuk-heading-l" id="section-2">
+        <span class="govuk-caption-l">Section 2</span>
+        What personal data DfE and the provider process/share and why
+      </h2>
+      <h3 class="govuk-heading-m" id="section-2-1">What data DfE and the provider will process/share</h3>
+      <h4 class="govuk-heading-s">Candidates</h4>
+      <p class="govuk-body">DfE and the provider will process and share some information about candidates including their:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>name</li>
+        <li>address</li>
+        <li>date of birth</li>
+        <li>phone number</li>
+        <li>email address</li>
+        <li>any other personal/special category data that they choose to include in their application form (such as whether they’re disabled)</li>
+      </ul>
+      <p class="govuk-body">DfE will also get information from the provider about candidates, such as:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>whether candidates were successful in their application (as well as the reasons why/why not)</li>
+        <li>whether candidates met their conditions (including passing an enhanced DBS check)</li>
+        <li>whether candidates enrolled</li>
+      </ul>
+
+      <h4 class="govuk-heading-s">Referees</h4>
+      <p class="govuk-body">DfE and the provider will process and share some information about referees so that references can be processed. This includes their:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>name</li>
+        <li>email address</li>
+        <li>relationship to the candidate</li>
+      </ul>
+
+      <h4 class="govuk-heading-s">Staff</h4>
+      <p class="govuk-body">DfE and the provider may also share the names and contact details of relevant staff within DfE/within the teacher training organisation so that applications can be processed.</p>
+      <p class="govuk-body">It is the provider’s responsibility to communicate this to relevant staff within their organisation.</p>
+
+      <h3 class="govuk-heading-m" id="section-2-2">What the provider can use personal data for</h3>
+      <p class="govuk-body">The provider can use data to process teacher training applications in the ways outlined by this data sharing agreement.</p>
+      <p class="govuk-body">Processing teacher training applications for the provider means:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>getting in touch with a candidate about their application/the information they submitted - for example, to ask if a candidate needs reasonable adjustments to attend an interview</li>
+        <li>getting in touch with referees/candidates/relevant DfE staff if there has been a data security issue</li>
+        <li>making decisions on applications</li>
+        <li>getting statistics for internal use</li>
+        <li>contacting relevant staff at DfE if necessary to process an application</li>
+      </ul>
+
+      <h3 class="govuk-heading-m" id="section-2-3">What DfE can use personal data for</h3>
+      <p class="govuk-body">DfE can use data to process teacher training applications, build a better teacher training application process and get insight to inform government policy.</p>
+      <p class="govuk-body">This includes (but may not be limited to):</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>processing funding/bursary payments</li>
+        <li>analysing teacher training applications</li>
+        <li>analysing feedback from candidates and providers</li>
+        <li>getting in touch with candidates regarding their application</li>
+        <li>getting in touch with provider staff, candidates or referees if there has been a data security issue</li>
+        <li>getting in touch with relevant staff within the teacher training organisation, if necessary, to process an application</li>
+      </ul>
+      <p class="govuk-body">DfE will also share some of the data it collects through Apply for teacher training with UCAS. This is so that DfE can:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>ensure candidates are using the two services according to DfE/UCAS policies, and contact candidates if they accept offers on both services</li>
+        <li>allow DfE/UCAS to see how many people are applying for teacher training across UCAS and Apply for teacher training, in order to carry out statistical analysis</li>
+      </ul>
+
+      <h2 class="govuk-heading-l" id="section-3">
+        <span class="govuk-caption-l">Section 3</span>
+        DfE’s legal basis for sharing/<wbr>processing personal data
+      </h2>
+      <h3 class="govuk-heading-m" id="section-3-1">Lawful conditions for sharing/<wbr>processing personal data</h3>
+      <p class="govuk-body">Apply for teacher training and the data processing activities described in this document operate under the Secretary of State for Education’s Ministerial common law powers.</p>
+      <p class="govuk-body">Apply for teacher training is in the public interest, as outlined under the following legislation:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>Article 6(1)(e) and Article 9(2)(g) of the General Data Protection Regulation</li>
+        <li>Section 8 of the Data Protection Act 2018</li>
+      </ul>
+
+      <h3 class="govuk-heading-m" id="section-3-2">The right to respect for private and family life</h3>
+      <p class="govuk-body">Participants will not be asked to share information related to their private or family lives.</p>
+
+      <h3 class="govuk-heading-m" id="section-3-3">Privacy notices</h3>
+      <p class="govuk-body">Please see the <%= govuk_link_to 'Apply for teacher training privacy policy for candidates, referees and provider staff', provider_interface_service_privacy_notice_path %>.</p>
+      <p class="govuk-body">DfE will make data subjects aware of how their data will be processed before data is collected through Apply for teacher training.</p>
+      <p class="govuk-body">Please see DfE’s Personal Information Charter for more details on the organisation’s data storage and sharing policies.</p>
+      <p class="govuk-body">By agreeing to this data sharing agreement, DfE and the provider confirm that their respective privacy policies explain the data sharing activities outlined in this agreement.</p>
+      <p class="govuk-body">Privacy policies should outline the purposes of processing data, and the lawful basis for doing so.</p>
+
+      <h2 class="govuk-heading-l" id="section-4">
+        <span class="govuk-caption-l">Section 2</span>
+        Data handling
+      </h2>
+      <h3 class="govuk-heading-m" id="section-4-1">Process and systems used for sharing data</h3>
+      <p class="govuk-body">DfE and the provider are joint data controllers for the data collected through Apply for teacher training.</p>
+      <p class="govuk-body">DfE gives the provider access to the data through a digital service that allows providers to sign in securely.</p>
+      <p class="govuk-body">Later on in the trial of the service, DfE will give relevant providers access to data through API systems which integrate with providers’ student record systems.</p>
+      <p class="govuk-body">DfE uses Zendesk, a customer relationship management system, to handle queries from providers. Zendesk uses various safeguards to look after data.</p>
+      <p class="govuk-body">DfE may also use G Suite to collect and share information, such as references, with the provider.</p>
+      <p class="govuk-body">DfE and the provider may also share some data through other channels, such as by phone or email.</p>
+      <p class="govuk-body">Refer to section on ‘Third party disclosure’ for more information on how DfE shares data.</p>
+
+      <h3 class="govuk-heading-m" id="section-4-2">Accuracy of the shared data</h3>
+      <p class="govuk-body">DfE undertakes to ensure that the data given to the provider accurately reflects the information given to DfE, though the format may be different.</p>
+
+      <h3 class="govuk-heading-m" id="section-4-3">Assurance of compliance</h3>
+      <p class="govuk-body">DfE’s Personal Information Charter explains the standards expected of DfE when holding personal information.</p>
+      <p class="govuk-body">By signing this agreement, the provider confirms that:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>their organisation is compliant with GDPR</li>
+        <li>data will be held in secure systems in line with data protection legislation</li>
+        <li>data will be held for only as long as needed for the purposes outlined in this agreement, and destroyed when no longer needed</li>
+        <li>they will comply with the security requirements for holding official data</li>
+        <li>it is in the interest of both parties to comply with data protection legislation (to protect people’s rights and minimise data processing risks, such as reputational damage)</li>
+      </ul>
+
+      <h3 class="govuk-heading-m" id="section-4-4">Third party disclosure</h3>
+      <p class="govuk-body">Within DfE, access to data will be restricted to teams that need it for processing applications, building a better teacher training application and getting insight to inform government policy.</p>
+      <p class="govuk-body">DfE uses some third-party data processors, including Google Analytics, G Suite, Zendesk and Microsoft Azure.</p>
+      <p class="govuk-body">Providers must follow guidance from the Information Commissioner’s Office on appointing and using appropriate data processors.</p>
+      <p class="govuk-body">It is the provider’s responsibility to ensure that data subjects know who processes data on their behalf and under what legal authority.</p>
+      <p class="govuk-body">By signing this agreement, the provider confirms that:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>their data sharing practices comply with data protection legislation</li>
+        <li>their data sharing practices minimise the risk of individuals being identified by unauthorised parties, using appropriate safeguards to look after shared data</li>
+        <li>they will only share data for the purposes outlined in this agreement</li>
+        <li>they hold data in strict confidence and have appropriate safeguards in place to protect data against unlawful or unauthorised processing</li>
+      </ul>
+
+      <h3 class="govuk-heading-m" id="section-4-5">Handling subject access requests (SARs)</h3>
+      <p class="govuk-body">DfE will manage SARs regarding any information DfE holds.</p>
+      <p class="govuk-body">DfE and the provider will contact each other immediately if they get a request for:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>rectification of information (Article 16 of GDPR)</li>
+        <li>erasure of information (Article 17 of GDPR)</li>
+        <li>restriction to process information (Article 18 of GDPR)</li>
+      </ul>
+      <p class="govuk-body">For other types of SAR, the provider must notify DFE within 5 working days.</p>
+      <p class="govuk-body">Data subjects wanting to make a SAR can email DfE at <%= bat_contact_mail_to %>.</p>
+
+      <h3 class="govuk-heading-m" id="section-4-6">Handling Freedom of Information Act Requests</h3>
+      <p class="govuk-body">DfE takes responsibility for responding to Freedom of Information Act Requests regarding Apply for teacher training data processing/sharing practices.</p>
+      <p class="govuk-body">DfE will contact the provider if any support is needed to process a request.</p>
+
+      <h3 class="govuk-heading-m" id="section-4-7">Data storage</h3>
+      <p class="govuk-body">The provider must store shared data securely.</p>
+      <p class="govuk-body">Data should be encrypted at rest, using modern, full disk encryption such as Windows BitLocker, or Linux/dm-crypt.</p>
+      <p class="govuk-body">The data must be retained in a way that is compliant with EU data protection legislation.</p>
+      <p class="govuk-body">By signing this agreement, DfE and the provider agree to:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>hold data in strict confidence</li>
+        <li>have appropriate safeguards in place to protect data against unlawful or unauthorised processing</li>
+      </ul>
+
+      <h3 class="govuk-heading-m" id="section-4-8">Retention schedule </h3>
+      <p class="govuk-body">Personal data must be kept only as long as needed to carry out the activities outlined in this document.</p>
+      <p class="govuk-body">DfE will keep data for 7 years.</p>
+      <p class="govuk-body">The provider must set an appropriate time limit, in line with the General Data Protection Regulation, for retaining data before erasure or review.</p>
+
+      <h3 class="govuk-heading-m" id="section-4-9">Destruction schedule</h3>
+      <p class="govuk-body">The provider should destroy the data when it is no longer needed, or when the retention schedule has expired.</p>
+      <p class="govuk-body">The provider should follow the NCSC guidance for secure sanitisation.</p>
+
+      <h2 class="govuk-heading-l" id="section-5">
+        <span class="govuk-caption-l">Section 5</span>
+        Security breaches
+      </h2>
+      <h3 class="govuk-heading-m" id="section-5-1">Security incidents</h3>
+      <p class="govuk-body">DfE and the provider are responsible for notifying each other in writing in the event of loss or unauthorised disclosure of information within 24 hours of the event being discovered.</p>
+      <p class="govuk-body">The designated points of contact will discuss and agree the next steps relating to the incident, taking specialist advice where appropriate.</p>
+      <p class="govuk-body">Such arrangements will include (but will not be limited to):</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>containing the incident and mitigating any ongoing risk</li>
+        <li>recovering information</li>
+        <li>assessing whether the Information Commissioner should be notified or whether data protection officers or data subjects need to be notified</li>
+      </ul>
+      <p class="govuk-body">The arrangements may vary in each case, depending on the sensitivity of the information and the nature of the loss or unauthorised disclosure.</p>
+      <p class="govuk-body">Where appropriate and if relevant to the incident, disciplinary misconduct action/criminal proceedings will be considered.</p>
+
+      <h3 class="govuk-heading-m" id="section-5-2">Consequences of security incident</h3>
+      <p class="govuk-body">Any security incident that occurs will not impact DfE’s ongoing cooperation with the provider.</p>
+      <p class="govuk-body">In the event of a personal data breach (or where there is a reason to believe that an incident could arise) DfE and the provider will delay data transfers until the signatories of this agreement are satisfied that the cause/incident is resolved.</p>
+      <p class="govuk-body">If the issue cannot be resolved or if it is very serious, data sharing will not start again until DfE and the provider are satisfied that the cause/incident is resolved.</p>
+      <p class="govuk-body">The DfE contact would raise the incident with the DfE departmental security team and complete formal procedures in the event of a personal data breach.</p>
+
+      <h2 class="govuk-heading-l" id="section-6">
+        <span class="govuk-caption-l">Section 6</span>
+        Issues, disputes and resolution between participants
+      </h2>
+      <h3 class="govuk-heading-m" id="section-6-1">Resolving disputes</h3>
+      <p class="govuk-body">Any issues or disputes that arise as a result of the data sharing covered by this agreement must be directed to the relevant contact points at DfE and the provider.</p>
+      <p class="govuk-body">DfE and the provider will be responsible for escalating the issue as necessary within their organisations.</p>
+      <p class="govuk-body">Where a problem arises it should be reported as soon as possible.</p>
+      <p class="govuk-body">Should the problem be of an urgent nature, it must be reported by phone immediately, and followed up in writing the same day.</p>
+      <p class="govuk-body">If the problem is not of an urgent nature it can be reported in writing within 24 hours of the problem occurring.</p>
+
+      <h2 class="govuk-heading-l" id="section-7">
+        <span class="govuk-caption-l">Section 7</span>
+        Termination
+      </h2>
+      <h3 class="govuk-heading-m" id="section-7-1">When to terminate this agreement</h3>
+      <p class="govuk-body">Both participants to this DSA reserve the right to terminate this DSA with three months’ notice in the following circumstances:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>by reason of cost, resources or other factors beyond the control of DfE or the provider</li>
+        <li>if any change occurs which, in the opinion of DfE and the provider, significantly impairs the value of the data sharing arrangement in meeting their objectives</li>
+      </ul>
+      <p class="govuk-body">In the event of a significant security breach or other serious breach of the terms of this DSA by either participant, the DSA will be terminated or suspended immediately without notice.</p>
+
+      <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-6 govuk-!-margin-bottom-6">
+  </div>
+</div>

--- a/config/routes/provider.rb
+++ b/config/routes/provider.rb
@@ -19,6 +19,7 @@ namespace :provider_interface, path: '/provider' do
 
   get '/data-sharing-agreements/new', to: 'provider_agreements#new_data_sharing_agreement', as: :new_data_sharing_agreement
   post '/data-sharing-agreements', to: 'provider_agreements#create_data_sharing_agreement', as: :create_data_sharing_agreement
+  get '/old-data-sharing-agreement', to: 'provider_agreements#old_data_sharing_agreement', as: :old_data_sharing_agreement
 
   get '/activity' => 'activity_log#index', as: :activity_log
 

--- a/spec/system/candidate_interface/candidate_content_spec.rb
+++ b/spec/system/candidate_interface/candidate_content_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe 'Candidate content' do
     when_i_click_on_complaints
     then_i_can_see_the_complaints_page
 
-    when_i_click_on_the_privacy_policy
-    then_i_can_see_the_privacy_policy
-
     when_i_click_on_the_terms_of_use
     then_i_can_see_the_terms_candidate
 
     when_click_on_guidance_for_using_ai
     then_i_can_see_the_ai_guidance
+
+    when_i_click_on_the_privacy_policy
+    then_i_can_see_the_privacy_policy
   end
 
   def when_click_on_guidance_for_using_ai
@@ -83,7 +83,7 @@ RSpec.describe 'Candidate content' do
   end
 
   def then_i_can_see_the_privacy_policy
-    expect(page).to have_content(t('page_titles.service_privacy_notice'))
+    expect(current_url).to eq t('personal_information_charter.url')
   end
 
   def when_i_click_on_the_terms_of_use

--- a/spec/system/provider_interface/provider_content_spec.rb
+++ b/spec/system/provider_interface/provider_content_spec.rb
@@ -13,16 +13,6 @@ RSpec.describe 'Provider content' do
     then_i_can_see_the_cookies_page
     and_i_can_opt_in_to_tracking_website_usage
 
-    when_i_click_on_privacy
-    then_i_can_see_the_privacy_notices
-
-    when_i_click_on_service_privacy_notice
-    then_i_can_see_the_service_privacy_notice
-
-    when_i_click_on_privacy
-    and_i_click_on_online_chat_privacy_notice
-    then_i_can_see_the_online_chat_privacy_notice
-
     when_i_click_on_the_service_guidance
     then_i_can_see_the_service_guidance_provider
 
@@ -31,6 +21,9 @@ RSpec.describe 'Provider content' do
 
     when_i_click_on_the_roadmap
     then_i_can_see_the_roadmap
+
+    when_i_click_on_privacy
+    then_i_see_the_privacy_notice_page
   end
 
   def when_click_on_guidance_for_using_ai
@@ -79,24 +72,8 @@ RSpec.describe 'Provider content' do
     within('.govuk-footer') { click_link_or_button t('layout.support_links.privacy') }
   end
 
-  def then_i_can_see_the_privacy_notices
-    expect(page).to have_content(t('page_titles.privacy_notices'))
-  end
-
-  def when_i_click_on_service_privacy_notice
-    click_link_or_button 'Service privacy notice'
-  end
-
-  def then_i_can_see_the_service_privacy_notice
-    expect(page).to have_content(t('page_titles.service_privacy_notice'))
-  end
-
-  def and_i_click_on_online_chat_privacy_notice
-    click_link_or_button 'Online chat privacy notice'
-  end
-
-  def then_i_can_see_the_online_chat_privacy_notice
-    expect(page).to have_content(t('page_titles.online_chat_privacy_notice'))
+  def then_i_see_the_privacy_notice_page
+    expect(current_url).to eq t('personal_information_charter.url')
   end
 
   def when_i_click_on_the_service_guidance


### PR DESCRIPTION
## Context

DfE has recognised the need for centralised information and related processes; a central privacy notice is now live ([DfE Personal Information Charter](https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter)) and we are required to configure all our Services to point to it as soon as is reasonably possible.

However, we want the existing privacy notices and data sharing agreements to be available if required so people can still view them if required, since that is what they have actually signed up to in some cases.

## Changes proposed in this pull request

- Update links to point to the new privacy notice
- Add banner on the old pages to let users know that the notices are out-of-date
- Add a separate link to view the old data sharing agreement.

https://github.com/user-attachments/assets/9ae313b7-cd56-4244-885d-d894455389f4


We aren't linking to any of the old notices in the application, but we want to be able to give people direct links if required. 

## Guidance to review

Can you think of any other privacy notices or related that need to be updated? 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
