### PR TITLE
Make provider name less likely to be repeated

### DIFF
--- a/spec/factories/provider.rb
+++ b/spec/factories/provider.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :provider do
     code { Faker::Alphanumeric.unique.alphanumeric(number: 3).upcase }
-    name { Faker::University.name }
+    sequence(:name) { |n| "#{Faker::University.name}-#{n}" }
     phone_number { Faker::PhoneNumber.phone_number }
     email_address { Faker::Internet.email }
     region_code { 'london' }


### PR DESCRIPTION
## Context

We have seen warnings about a few flaky tests which indicate that the provider names are not always unique in our tests. This one has come up a couple of times now:

<img width="1043" alt="image" src="https://github.com/user-attachments/assets/3a9e1096-f87b-4bd0-9b51-0b29dc05d83a">

We use `Faker::University.name` to generate provider names. If I generate 1000 names with just Faker, the number of uniq names looks like this:

<img width="644" alt="image" src="https://github.com/user-attachments/assets/de295200-2270-41ce-a93a-e03f0999f150">

## Changes proposed in this pull request

Adding a random number at the end of the name gives us much better results:

<img width="814" alt="image" src="https://github.com/user-attachments/assets/30381d54-5c88-4f6a-874b-1605dc4234ed">

## Guidance to review

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Add PR link to Trello card
