### PR TITLE
TDA - prevent candidate from reviewing their application without at least one qualification

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -188,6 +188,7 @@ class Course < ApplicationRecord
     case qualifications.sort
     in ['pgce', 'qts'] then 'QTS with PGCE'
     in ['pgde', 'qts'] then 'PGDE with QTS'
+    in ['qts', 'undergraduate_degree'] then description
     else
       qualifications.first.upcase
     end

--- a/app/services/candidate_interface/application_choice_submission.rb
+++ b/app/services/candidate_interface/application_choice_submission.rb
@@ -11,6 +11,7 @@ module CandidateInterface
               applications_closed: { if: :validate_choice? },
               course_unavailable: { if: :validate_choice? },
               incomplete_primary_course_details: { if: :validate_choice? },
+              incomplete_undergraduate_course_details: { if: :validate_choice? },
               incomplete_details: { if: :validate_choice? },
               can_add_more_choices: true
 

--- a/app/validators/incomplete_undergraduate_course_details_validator.rb
+++ b/app/validators/incomplete_undergraduate_course_details_validator.rb
@@ -1,0 +1,24 @@
+class IncompleteUndergraduateCourseDetailsValidator < ActiveModel::EachValidator
+  include ActionView::Helpers::UrlHelper
+  include GovukLinkHelper
+  include GovukVisuallyHiddenHelper
+
+  def validate_each(record, attribute, application_choice)
+    return unless application_choice.course.teacher_degree_apprenticeship?
+
+    if application_choice.application_form.no_other_qualifications?
+      record.errors.add(
+        attribute,
+        :incomplete_undergraduate_course_details,
+        link_to_a_levels:,
+      )
+    end
+  end
+
+  def link_to_a_levels
+    govuk_link_to(
+      'Add your A level grade (or equivalent)',
+      Rails.application.routes.url_helpers.candidate_interface_other_qualification_type_path,
+    )
+  end
+end

--- a/config/locales/candidate_interface/submit_application.yml
+++ b/config/locales/candidate_interface/submit_application.yml
@@ -40,6 +40,12 @@ en:
                 Visa sponsorship is not available for this course.
 
                 %{link_to_find}.
+              incomplete_undergraduate_course_details: |-
+                To apply for this course, you need an A level or equivalent qualification.
+
+                %{link_to_a_levels} and complete the rest of your details. You can then submit your application.
+
+                Your application will be saved as a draft while you finish adding your details.
 
   application_form:
     submit_application:

--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -40,6 +40,24 @@ task setup_local_dev_data: %i[environment copy_feature_flags_from_production syn
     # But if that changes, we don't want to accidentally hit BigQuery hundreds of times.
     Publications::ProviderRecruitmentPerformanceReportWorker.new.perform(provider_id, cycle_week)
   end
+
+  Rake::Task['create_undergraduate_courses'].invoke
+end
+
+desc 'Create undergraduate courses'
+task create_undergraduate_courses: :environment do
+  Provider.find_each do |provider|
+    FactoryBot.create(
+      :course,
+      :open,
+      :secondary,
+      :teacher_degree_apprenticeship,
+      :available_in_current_and_next_year,
+      :with_course_options,
+      provider:,
+      name: 'Mathematics',
+    )
+  end
 end
 
 desc 'Sync some pilot-enabled providers'

--- a/spec/factories/course.rb
+++ b/spec/factories/course.rb
@@ -76,6 +76,7 @@ FactoryBot.define do
 
       qualifications { %w[qts undergraduate_degree] }
       program_type { 'teacher_degree_apprenticeship' }
+      course_length { '4 years' }
     end
 
     trait :previous_year do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -258,6 +258,13 @@ RSpec.describe Course do
       it { is_expected.to eq('QTS with PGCE') }
     end
 
+    context 'when [qts undergraduate_degree]' do
+      let(:course) { build(:course, qualifications:, description: 'Teacher degree apprenticeship with QTS') }
+      let(:qualifications) { %w[qts undergraduate_degree] }
+
+      it { is_expected.to eq('Teacher degree apprenticeship with QTS') }
+    end
+
     context 'when [qts pgde]' do
       let(:qualifications) { %w[qts pgde] }
 


### PR DESCRIPTION
## Context

DA courses require at least one A level (or other qualification) to be entered.

Candidates can choose not to enter any A levels when they go to the A levels section, and select the option “I do not want to add any A levels and other qualifications”, [see example from the live site](https://trello.com/1/cards/66a117a5a926d070ff95afcd/attachments/66a11b96242c9d3cee906b66/download/Screenshot_2024-07-24_at_16.19.37.png).

This ticket is to add logic to prevent people from reviewing their application if they have not adding at least one qualification to the “A levels and other qualifications” section.

## Changes proposed in this pull request

<img width="637" alt="Screenshot 2024-09-06 at 14 52 44" src="https://github.com/user-attachments/assets/1907d45f-3992-4609-a690-7823c342de20">

## Guidance to review

To test this feature locally or on the review app you need:

1. Set the cycle switcher (visiting /support/settings/cycles) and choose any of these options: "Find has reopened" or "Apply has reopened"
2. Activate the feature flag "Teacher degree apprenticeship"
3. Choose option no A level on A levels and other qualifications section 
4. Submit a undergraduate (TDA) course.
