### PR TITLE
Block submissions to postgraduate courses when candidate has no degrees

### DIFF
--- a/app/forms/candidate_interface/pick_course_form.rb
+++ b/app/forms/candidate_interface/pick_course_form.rb
@@ -56,6 +56,8 @@ module CandidateInterface
     end
 
     def unique_name_for(course)
+      return course.name_code_and_description if course.undergraduate?
+
       if courses_with_names.count(course.name.downcase) == 1
         course.name_and_code
       elsif courses_with_descriptions.count(course.name_and_description.downcase) == 1

--- a/app/services/candidate_interface/application_choice_submission.rb
+++ b/app/services/candidate_interface/application_choice_submission.rb
@@ -11,6 +11,7 @@ module CandidateInterface
               applications_closed: { if: :validate_choice? },
               course_unavailable: { if: :validate_choice? },
               incomplete_primary_course_details: { if: :validate_choice? },
+              incomplete_postgraduate_course_details: { if: :validate_choice? },
               incomplete_undergraduate_course_details: { if: :validate_choice? },
               incomplete_details: { if: :validate_choice? },
               can_add_more_choices: true

--- a/app/validators/incomplete_postgraduate_course_details_validator.rb
+++ b/app/validators/incomplete_postgraduate_course_details_validator.rb
@@ -1,0 +1,25 @@
+class IncompletePostgraduateCourseDetailsValidator < ActiveModel::EachValidator
+  include ActionView::Helpers::UrlHelper
+  include GovukLinkHelper
+  include GovukVisuallyHiddenHelper
+
+  def validate_each(record, attribute, application_choice)
+    return unless application_choice.application_form.teacher_degree_apprenticeship_feature_active?
+    return if application_choice.course.undergraduate?
+
+    if application_choice.application_form.no_degree_and_degree_completed?
+      record.errors.add(
+        attribute,
+        :incomplete_postgraduate_course_details,
+        link_to_degree:,
+      )
+    end
+  end
+
+  def link_to_degree
+    govuk_link_to(
+      'Add your degree (or equivalent)',
+      Rails.application.routes.url_helpers.candidate_interface_degree_university_degree_path,
+    )
+  end
+end

--- a/config/locales/candidate_interface/submit_application.yml
+++ b/config/locales/candidate_interface/submit_application.yml
@@ -46,7 +46,12 @@ en:
                 %{link_to_a_levels} and complete the rest of your details. You can then submit your application.
 
                 Your application will be saved as a draft while you finish adding your details.
+              incomplete_postgraduate_course_details: |-
+                To apply for this course, you need a bachelor’s degree or equivalent qualification.
 
+                %{link_to_degree} and complete the rest of your details. You can then submit your application.
+
+                Your application will be saved as a draft while you finish adding your details.
   application_form:
     submit_application:
       title: Send application to training providers

--- a/spec/forms/candidate_interface/pick_course_form_spec.rb
+++ b/spec/forms/candidate_interface/pick_course_form_spec.rb
@@ -110,12 +110,14 @@ RSpec.describe CandidateInterface::PickCourseForm do
         provider = create(:provider)
         maths_course = create(:course, :open, name: 'Maths', code: '123', description: 'PGCE full time', provider:)
         english_course = create(:course, :open, name: 'English', code: '789', description: 'PGCE with QTS full time', provider:)
+        mathematics_undergraduate_course = create(:course, :open, :teacher_degree_apprenticeship, name: 'Mathematics', code: '790', provider:)
         create(:course_option, course: maths_course)
         create(:course_option, course: english_course)
+        create(:course_option, course: mathematics_undergraduate_course)
 
         form = described_class.new(provider_id: provider.id)
 
-        expect(form.dropdown_available_courses.map(&:name)).to contain_exactly('English (789)', 'Maths (123)')
+        expect(form.dropdown_available_courses.map(&:name)).to contain_exactly('English (789)', 'Maths (123)', 'Mathematics (790) – Teacher degree apprenticeship with QTS')
       end
     end
 

--- a/spec/requests/candidate_interface/reject_submission_blocked_spec.rb
+++ b/spec/requests/candidate_interface/reject_submission_blocked_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Block submission from blocked candidates' do
   include Devise::Test::IntegrationHelpers
-  let(:application_form) { create(:application_form, :completed, submitted_at: nil, candidate:) }
+  let(:application_form) { create(:application_form, :completed, :with_degree, submitted_at: nil, candidate:) }
   let(:choice) { create(:application_choice, :unsubmitted, application_form:) }
 
   context 'when candidate has submission blocked', time: mid_cycle do

--- a/spec/requests/candidate_interface/submission_spec.rb
+++ b/spec/requests/candidate_interface/submission_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Submit to continuous apps' do
   before { sign_in candidate }
 
   context 'when submitting to current cycle', time: mid_cycle do
-    let(:application_form) { create(:application_form, :completed, submitted_at: nil) }
+    let(:application_form) { create(:application_form, :completed, :with_degree, submitted_at: nil) }
 
     before do
       post candidate_interface_course_choices_submit_course_choice_path(choice.id)
@@ -27,7 +27,7 @@ RSpec.describe 'Submit to continuous apps' do
 
   context 'when old cycles trying to cheat and submit into the new cycle' do
     let(:application_form) do
-      create(:application_form, :completed, submitted_at: nil, recruitment_cycle_year: CycleTimetable.previous_year)
+      create(:application_form, :completed, :with_degree, submitted_at: nil, recruitment_cycle_year: CycleTimetable.previous_year)
     end
 
     it 'be successful' do

--- a/spec/services/candidate_interface/application_choice_submission_spec.rb
+++ b/spec/services/candidate_interface/application_choice_submission_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe CandidateInterface::ApplicationChoiceSubmission do
 
     context 'immigration_status validation' do
       let(:course) { create(:course, :with_course_options, :open, level: 'secondary') }
-      let(:application_form) { create(:application_form, :completed) }
+      let(:application_form) { create(:application_form, :completed, :with_degree) }
       let(:application_choice) { create(:application_choice, :unsubmitted, course:, application_form:) }
       let(:link_to_find) do
         govuk_link_to(
@@ -185,6 +185,7 @@ RSpec.describe CandidateInterface::ApplicationChoiceSubmission do
           create(
             :application_form,
             :completed,
+            :with_degree,
             first_nationality: 'American',
             right_to_work_or_study: 'no',
             efl_completed: true,
@@ -240,7 +241,7 @@ RSpec.describe CandidateInterface::ApplicationChoiceSubmission do
 
     context 'applications_closed validation' do
       let(:course) { create(:course, :with_course_options, :open, level: 'secondary') }
-      let(:application_form) { create(:application_form, :completed) }
+      let(:application_form) { create(:application_form, :completed, :with_degree) }
       let(:application_choice) { create(:application_choice, :unsubmitted, course:, application_form:) }
 
       context 'when apply is open and course is open for applications' do
@@ -285,7 +286,7 @@ RSpec.describe CandidateInterface::ApplicationChoiceSubmission do
     context 'course_unavailable validation' do
       let(:course) { build(:course, :open, course_options: []) }
       let(:course_option) { create(:course_option, course: course) }
-      let(:application_form) { create(:application_form, :completed) }
+      let(:application_form) { create(:application_form, :completed, :with_degree) }
       let(:application_choice) { create(:application_choice, :unsubmitted, application_form:) }
 
       context 'all validations pass' do
@@ -340,7 +341,7 @@ RSpec.describe CandidateInterface::ApplicationChoiceSubmission do
     context 'incomplete_primary_course_details validation' do
       let(:course_option) { create(:course_option, course:) }
       let(:course) { create(:course, :open, :primary, :with_course_options) }
-      let(:application_form) { create(:application_form, :completed) }
+      let(:application_form) { create(:application_form, :completed, :with_degree) }
       let(:application_choice) { create(:application_choice, :unsubmitted, application_form:, course:) }
 
       context 'when all sections are completed' do
@@ -364,7 +365,7 @@ RSpec.describe CandidateInterface::ApplicationChoiceSubmission do
       context 'when secondary course choice with only science gcse section incomplete' do
         let(:course) { create(:course, :open, :secondary) }
         let(:course_option) { create(:course_option, course:) }
-        let(:application_form) { create(:application_form, :completed, science_gcse_completed: false) }
+        let(:application_form) { create(:application_form, :completed, :with_degree, science_gcse_completed: false) }
         let(:application_choice) { create(:application_choice, :unsubmitted, course_option:, application_form:) }
 
         it 'is valid' do
@@ -410,7 +411,7 @@ RSpec.describe CandidateInterface::ApplicationChoiceSubmission do
     end
 
     context 'incomplete_details validation' do
-      let(:application_form) { create(:application_form, :completed) }
+      let(:application_form) { create(:application_form, :completed, :with_degree) }
       let(:application_choice) { create(:application_choice, :unsubmitted, application_form:) }
 
       context 'valid' do
@@ -440,7 +441,7 @@ RSpec.describe CandidateInterface::ApplicationChoiceSubmission do
 
     context 'add more course choices validation' do
       context 'when candidate can submit further applications' do
-        let(:application_form) { create(:completed_application_form, submitted_application_choices_count: 3) }
+        let(:application_form) { create(:completed_application_form, :with_degree, submitted_application_choices_count: 3) }
         let(:application_choice) { create(:application_choice, :unsubmitted, application_form:) }
 
         it 'is valid' do
@@ -449,7 +450,7 @@ RSpec.describe CandidateInterface::ApplicationChoiceSubmission do
       end
 
       context 'when candidate has conditions not met and can submit further applications' do
-        let(:application_form) { create(:completed_application_form) }
+        let(:application_form) { create(:completed_application_form, :with_degree) }
         let(:application_choice) { create(:application_choice, :unsubmitted, application_form:) }
 
         it 'is valid' do
@@ -459,7 +460,7 @@ RSpec.describe CandidateInterface::ApplicationChoiceSubmission do
       end
 
       context 'when candidate can not submit further applications' do
-        let(:application_form) { create(:completed_application_form, submitted_application_choices_count: 4) }
+        let(:application_form) { create(:completed_application_form, :with_degree, submitted_application_choices_count: 4) }
         let(:application_choice) { create(:application_choice, :unsubmitted, application_form:) }
 
         it 'adds error to application choice' do
@@ -471,7 +472,7 @@ RSpec.describe CandidateInterface::ApplicationChoiceSubmission do
       end
 
       context 'when candidate does not reach the maximum unsuccessful choices' do
-        let(:application_form) { create(:completed_application_form, submitted_application_choices_count: 3) }
+        let(:application_form) { create(:completed_application_form, :with_degree, submitted_application_choices_count: 3) }
         let(:application_choice) { create(:application_choice, :unsubmitted, application_form:) }
 
         it 'is valid' do

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -788,7 +788,7 @@ module CandidateHelper
   end
 
   def and_i_have_one_application_in_draft
-    @application_form = create(:application_form, :completed, candidate: @current_candidate)
+    @application_form = create(:application_form, :completed, :with_degree, candidate: @current_candidate)
     @application_choice = create(:application_choice, :unsubmitted, application_form: @application_form)
   end
 

--- a/spec/system/candidate_interface/carry_over/candidate_can_submit_in_next_cycle_when_cycle_switched_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_can_submit_in_next_cycle_when_cycle_switched_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe 'Carry over next cycle with cycle switcher', time: CycleTimetable
     @application_form = create(
       :completed_application_form,
       :with_gcses,
+      :with_degree,
       date_of_birth: Date.new(1964, 9, 1),
       submitted_at: nil,
       candidate: @candidate,

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_unsubmitted_application_with_a_course_to_new_cycle_spec.rb
@@ -46,6 +46,7 @@ private
       :completed_application_form,
       :eligible_for_free_school_meals,
       :with_gcses,
+      :with_degree,
       submitted_at: nil,
       candidate: @candidate,
       safeguarding_issues_status: :no_safeguarding_issues_to_declare,

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_and_prefills_application_in_sandbox_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_and_prefills_application_in_sandbox_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'Candidate signs in and prefills application in Sandbox', :sandbo
   scenario 'User is directed to prefill option page and chooses to prefill the application' do
     and_a_course_is_available
     and_i_am_a_candidate_with_a_blank_application
+    and_teacher_degree_apprenticeship_feature_is_off
 
     when_i_fill_in_the_sign_in_form
     and_i_click_on_the_link_in_my_email_and_sign_in
@@ -23,6 +24,10 @@ RSpec.describe 'Candidate signs in and prefills application in Sandbox', :sandbo
 
   def and_a_course_is_available
     @course_option = create(:course_option, course: create(:course, :open, recruitment_cycle_year: RecruitmentCycle.current_year))
+  end
+
+  def and_teacher_degree_apprenticeship_feature_is_off
+    FeatureFlag.deactivate(:teacher_degree_apprenticeship)
   end
 
   def and_i_am_a_candidate_with_a_blank_application

--- a/spec/system/candidate_interface/submitting/candidate_submits_a_duplicate_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submits_a_duplicate_application_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Submitting a duplicate application' do
 
   def given_i_have_an_account_submission_blocked
     @candidate = create(:candidate, submission_blocked: true)
-    @application_form = create(:application_form, :completed, candidate: @candidate, submitted_at: nil)
+    @application_form = create(:application_form, :completed, :with_degree, candidate: @candidate, submitted_at: nil)
   end
 
   def when_i_try_to_submit_an_application

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe 'Candidate submits the application' do
 
   scenario 'Candidate with a completed application' do
     given_i_am_signed_in
-
     when_i_have_completed_my_application_and_have_added_primary_as_a_course_choice
     and_i_continue_with_my_application
 
@@ -102,7 +101,7 @@ RSpec.describe 'Candidate submits the application' do
     @course = create(:course, :open, name: 'Primary', code: '2XT2', provider: @provider)
     @course_option = create(:course_option, site:, course: @course)
     current_candidate.application_forms.delete_all
-    current_candidate.application_forms << build(:application_form, completed_section_trait, becoming_a_teacher: 'I want to teach')
+    current_candidate.application_forms << create(:application_form, completed_section_trait, :with_degree, becoming_a_teacher: 'I want to teach')
     @application_choice = create(:application_choice, :unsubmitted, course_option: @course_option, application_form: current_candidate.current_application)
   end
 

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_with_interruption_pages_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_with_interruption_pages_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe 'Candidate submits the application with interruption pages' do
     @course = create(:course, :open, name: 'Primary', code: '2XT2', provider: @provider)
     @course_option = create(:course_option, site:, course: @course)
     current_candidate.application_forms.delete_all
-    current_candidate.application_forms << build(:application_form, completed_section_trait, becoming_a_teacher: Faker::Lorem.words(number: personal_statement_words))
+    current_candidate.application_forms << create(:application_form, completed_section_trait, :with_degree, becoming_a_teacher: Faker::Lorem.words(number: personal_statement_words))
     @application_choice = create(:application_choice, :unsubmitted, course_option: @course_option, application_form: current_candidate.current_application)
   end
 

--- a/spec/system/candidate_interface/submitting/candidate_tries_to_submit_after_exceeding_the_maximum_amount_of_choices_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_tries_to_submit_after_exceeding_the_maximum_amount_of_choices_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Candidate submits an application up to 4 choices' do
 
   def and_i_have_a_conditions_not_met_application_and_one_free_slot_to_submit
     current_candidate.current_application.destroy!
-    application_form = create(:application_form, :completed, candidate: current_candidate)
+    application_form = create(:application_form, :completed, :with_degree, candidate: current_candidate)
     create(:application_choice, :awaiting_provider_decision, application_form:)
     create(:application_choice, :awaiting_provider_decision, application_form:)
     create(:application_choice, :awaiting_provider_decision, application_form:)

--- a/spec/system/candidate_interface/submitting/candidate_tries_to_submit_after_exceeding_the_maximum_amount_of_unsuccessful_choices_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_tries_to_submit_after_exceeding_the_maximum_amount_of_unsuccessful_choices_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Candidate submits the application' do
 
   def and_i_have_19_unsuccessful_applications
     current_candidate.application_forms.delete_all
-    current_candidate.application_forms << build(:application_form, :completed)
+    current_candidate.application_forms << create(:application_form, :completed, :with_degree)
     current_candidate.current_application.application_choices << build_list(:application_choice, 14, :withdrawn)
   end
 

--- a/spec/system/candidate_interface/submitting/candidate_tries_to_submit_postgraduate_course_without_degrees_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_tries_to_submit_postgraduate_course_without_degrees_spec.rb
@@ -1,0 +1,121 @@
+require 'rails_helper'
+
+RSpec.describe 'Submitting a postgraduate course' do
+  include CandidateHelper
+
+  before do
+    given_i_am_on_the_cycle_when_candidates_can_enter_details_for_undergraduate_course
+    and_teacher_degree_apprenticeship_feature_flag_is_on
+    given_i_am_signed_in
+  end
+
+  scenario 'Candidate does not have a degree' do
+    given_there_are_postgraduate_courses
+    and_i_have_all_sections_completed_except_degrees
+    when_i_view_the_degree_section
+    when_i_answer_no
+    and_i_click_continue
+    then_i_can_see_degrees_section_is_completed
+
+    when_i_click_degree_section
+    then_i_see_that_i_do_not_have_a_degree
+
+    when_i_try_to_apply_for_an_postgraduate_course
+    then_i_see_that_i_need_degrees_to_apply_for_an_postgraduate_course
+  end
+
+  def given_i_am_on_the_cycle_when_candidates_can_enter_details_for_undergraduate_course
+    TestSuiteTimeMachine.travel_permanently_to(
+      CycleTimetableHelper.mid_cycle(2025),
+    )
+  end
+
+  def and_teacher_degree_apprenticeship_feature_flag_is_on
+    FeatureFlag.activate(:teacher_degree_apprenticeship)
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def given_there_are_postgraduate_courses
+    create(
+      :course,
+      :open,
+      :secondary,
+      :with_course_options,
+      provider: create(:provider, name: 'Oxford University', code: 'DCBA'),
+      name: 'Mathematics',
+      code: 'ABCD',
+      recruitment_cycle_year: 2025,
+    )
+  end
+
+  def and_i_have_all_sections_completed_except_degrees
+    current_candidate.application_forms.delete_all
+    current_candidate.application_forms << create(
+      :application_form,
+      :completed,
+      degrees_completed: false,
+      application_qualifications: [],
+    )
+  end
+
+  def when_i_view_the_degree_section
+    visit candidate_interface_details_path
+    when_i_click_on_degree
+  end
+
+  def when_i_click_on_degree
+    click_link_or_button 'Degree'
+  end
+
+  def when_i_answer_no
+    choose 'No, I do not have a degree'
+  end
+
+  def when_i_answer_yes
+    choose 'Yes, I have a degree or am studying for one'
+  end
+
+  def then_i_can_see_degrees_section_is_completed
+    expect(page).to have_current_path(candidate_interface_details_path)
+    expect(page).to have_content('Degree Completed')
+  end
+
+  def and_i_click_continue
+    click_link_or_button 'Continue'
+  end
+  alias_method :when_i_click_continue, :and_i_click_continue
+
+  def when_i_click_degree_section
+    click_link_or_button 'Degree'
+  end
+
+  def and_i_click_save_and_continue
+    click_link_or_button 'Save and continue'
+  end
+
+  def then_i_see_that_i_do_not_have_a_degree
+    expect(page).to have_content('Do you have a university degree? No, I do not have a degree Change')
+  end
+
+  def when_i_try_to_apply_for_an_postgraduate_course
+    visit candidate_interface_application_choices_path
+    click_link_or_button 'Add application'
+    choose 'Yes, I know where I want to apply'
+    click_link_or_button t('continue')
+
+    select 'Oxford University (DCBA)'
+    click_link_or_button t('continue')
+
+    choose 'Mathematics (ABCD)'
+    click_link_or_button t('continue')
+  end
+
+  def then_i_see_that_i_need_degrees_to_apply_for_an_postgraduate_course
+    expect(page).to have_content(
+      'To apply for this course, you need a bachelor’s degree or equivalent qualification. Add your degree (or equivalent) and complete the rest of your details. You can then submit your application. Your application will be saved as a draft while you finish adding your details.',
+    )
+  end
+end

--- a/spec/system/candidate_interface/submitting/candidate_with_no_right_to_work_tries_to_submit_course_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_with_no_right_to_work_tries_to_submit_course_spec.rb
@@ -97,6 +97,7 @@ RSpec.describe 'Candidate with no right to work or study' do
     @application_form = create(
       :application_form,
       :completed,
+      :with_degree,
       candidate: current_candidate,
       first_nationality: 'Indian',
       second_nationality: nil,


### PR DESCRIPTION
## Context

As part of enabling TDA applications, we have made a change in the ‘Your Details’ in apply.

In the ‘Degree’ section, we have added a radio button question to the initial screen of the section. [See example](https://trello.com/1/cards/66cf30bbfb30dfdad251bc7c/attachments/66cf3243418f19737d45128d/download/Screenshot_2024-08-28_at_15.18.49.png). This allows the section to be marked as ‘Complete’ if a candidate does not have a degree.

We need now to make sure we validate on submission that candidates should have degrees when submitting to a postgraduate course.

## Changes proposed in this pull request

<img width="637" alt="Screenshot 2024-09-06 at 17 40 06" src="https://github.com/user-attachments/assets/cc77cf3a-37f0-4e93-825a-3a2d664ce267">

## Guidance to review

To test this feature locally or on the review app you need:

1. Set the cycle switcher (visiting /support/settings/cycles) and choose any of these options: "Find has reopened" or "Apply has reopened"
2. Activate the feature flag "Teacher degree apprenticeship"
3. Choose option no on the degrees section
4. Try to submit a postgraduate course.


