### PR TITLE
Add flight check for undergraduate courses when candidate has a degree

### DIFF
--- a/app/components/candidate_interface/application_review_and_submit_component.rb
+++ b/app/components/candidate_interface/application_review_and_submit_component.rb
@@ -22,6 +22,8 @@ module CandidateInterface
     def review_path
       if short_personal_statement?
         candidate_interface_course_choices_course_review_interruption_path(application_choice.id)
+      elsif application_choice.undergraduate_course_and_application_form_with_degree?
+        candidate_interface_course_choices_course_review_undergraduate_interruption_path(application_choice.id)
       elsif application_choice.application_form.qualifications_enic_reasons_waiting_or_maybe? || application_choice.application_form.any_qualification_enic_reason_not_needed?
         candidate_interface_course_choices_course_review_enic_interruption_path(application_choice.id)
       else

--- a/app/components/candidate_interface/continue_without_editing.html.erb
+++ b/app/components/candidate_interface/continue_without_editing.html.erb
@@ -1,0 +1,1 @@
+<%= govuk_link_to(t('review_interruption.continue_without_editing'), continue_without_editing) %>

--- a/app/components/candidate_interface/continue_without_editing.rb
+++ b/app/components/candidate_interface/continue_without_editing.rb
@@ -1,0 +1,20 @@
+module CandidateInterface
+  class ContinueWithoutEditing < ViewComponent::Base
+    attr_reader :current_application, :application_choice
+
+    def initialize(current_application:, application_choice:)
+      @current_application = current_application
+      @application_choice = application_choice
+    end
+
+    def continue_without_editing
+      if application_choice.undergraduate_course_and_application_form_with_degree?
+        candidate_interface_course_choices_course_review_undergraduate_interruption_path(application_choice.id)
+      elsif current_application.qualifications_enic_reasons_waiting_or_maybe? || current_application.any_qualification_enic_reason_not_needed?
+        candidate_interface_course_choices_course_review_enic_interruption_path(@application_choice.id)
+      else
+        candidate_interface_course_choices_course_review_and_submit_path(@application_choice.id)
+      end
+    end
+  end
+end

--- a/app/controllers/candidate_interface/course_choices/review_interruption_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/review_interruption_controller.rb
@@ -7,17 +7,6 @@ module CandidateInterface
         @application_choice = current_application.application_choices.find(params[:application_choice_id])
         @word_count = current_application.becoming_a_teacher.scan(/\S+/).size
       end
-
-      def x_continue_without_editing_path
-        if application_choice.undergraduate_course_and_application_form_with_degree?
-          candidate_interface_course_choices_course_review_undergraduate_interruption_path(application_choice.id)
-        elsif current_application.qualifications_enic_reasons_waiting_or_maybe? || current_application.any_qualification_enic_reason_not_needed?
-          candidate_interface_course_choices_course_review_enic_interruption_path(@application_choice.id)
-        else
-          candidate_interface_course_choices_course_review_and_submit_path(@application_choice.id)
-        end
-      end
-      helper_method :x_continue_without_editing_path
     end
   end
 end

--- a/app/controllers/candidate_interface/course_choices/review_interruption_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/review_interruption_controller.rb
@@ -8,7 +8,7 @@ module CandidateInterface
         @word_count = current_application.becoming_a_teacher.scan(/\S+/).size
       end
 
-      def continue_without_editing_path
+      def x_continue_without_editing_path
         if application_choice.undergraduate_course_and_application_form_with_degree?
           candidate_interface_course_choices_course_review_undergraduate_interruption_path(application_choice.id)
         elsif current_application.qualifications_enic_reasons_waiting_or_maybe? || current_application.any_qualification_enic_reason_not_needed?
@@ -17,7 +17,7 @@ module CandidateInterface
           candidate_interface_course_choices_course_review_and_submit_path(@application_choice.id)
         end
       end
-      helper_method :continue_without_editing_path
+      helper_method :x_continue_without_editing_path
     end
   end
 end

--- a/app/controllers/candidate_interface/course_choices/review_interruption_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/review_interruption_controller.rb
@@ -7,6 +7,17 @@ module CandidateInterface
         @application_choice = current_application.application_choices.find(params[:application_choice_id])
         @word_count = current_application.becoming_a_teacher.scan(/\S+/).size
       end
+
+      def continue_without_editing_path
+        if application_choice.undergraduate_course_and_application_form_with_degree?
+          candidate_interface_course_choices_course_review_undergraduate_interruption_path(application_choice.id)
+        elsif current_application.qualifications_enic_reasons_waiting_or_maybe? || current_application.any_qualification_enic_reason_not_needed?
+          candidate_interface_course_choices_course_review_enic_interruption_path(@application_choice.id)
+        else
+          candidate_interface_course_choices_course_review_and_submit_path(@application_choice.id)
+        end
+      end
+      helper_method :continue_without_editing_path
     end
   end
 end

--- a/app/controllers/candidate_interface/course_choices/review_undergraduate_interruption_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/review_undergraduate_interruption_controller.rb
@@ -1,0 +1,11 @@
+module CandidateInterface
+  module CourseChoices
+    class ReviewUndergraduateInterruptionController < CandidateInterface::CourseChoices::BaseController
+      before_action :redirect_to_your_applications_if_submitted
+
+      def show
+        @application_choice = current_application.application_choices.find(params[:application_choice_id])
+      end
+    end
+  end
+end

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -297,7 +297,11 @@ class ApplicationChoice < ApplicationRecord
     days_since_calculation(offered_at)
   end
 
-  delegate :teacher_degree_apprenticeship?, to: :current_course
+  delegate :teacher_degree_apprenticeship?, :undergraduate?, to: :current_course
+
+  def undergraduate_course_and_application_form_with_degree?
+    undergraduate? && application_form.degrees?
+  end
 
 private
 

--- a/app/views/candidate_interface/course_choices/review_interruption/show.html.erb
+++ b/app/views/candidate_interface/course_choices/review_interruption/show.html.erb
@@ -19,11 +19,7 @@
 
       <%= govuk_button_to(t('review_interruption.edit_statement_button_text'), candidate_interface_edit_becoming_a_teacher_path, method: :get) %>
 
-      <% if current_application.qualifications_enic_reasons_waiting_or_maybe? || current_application.any_qualification_enic_reason_not_needed? %>
-        <%= govuk_link_to(t('review_interruption.continue_without_editing'), candidate_interface_course_choices_course_review_enic_interruption_path(@application_choice.id)) %>
-      <% else %>
-        <%= govuk_link_to(t('review_interruption.continue_without_editing'), candidate_interface_course_choices_course_review_and_submit_path(@application_choice.id)) %>
-      <% end %>
+      <%= govuk_link_to(t('review_interruption.continue_without_editing'), continue_without_editing_path) %>
     </div>
   </div>
 </div>

--- a/app/views/candidate_interface/course_choices/review_interruption/show.html.erb
+++ b/app/views/candidate_interface/course_choices/review_interruption/show.html.erb
@@ -19,7 +19,7 @@
 
       <%= govuk_button_to(t('review_interruption.edit_statement_button_text'), candidate_interface_edit_becoming_a_teacher_path, method: :get) %>
 
-      <%= govuk_link_to(t('review_interruption.continue_without_editing'), continue_without_editing_path) %>
+      <%= govuk_link_to(t('review_interruption.continue_without_editing'), x_continue_without_editing_path) %>
     </div>
   </div>
 </div>

--- a/app/views/candidate_interface/course_choices/review_interruption/show.html.erb
+++ b/app/views/candidate_interface/course_choices/review_interruption/show.html.erb
@@ -19,7 +19,7 @@
 
       <%= govuk_button_to(t('review_interruption.edit_statement_button_text'), candidate_interface_edit_becoming_a_teacher_path, method: :get) %>
 
-      <%= govuk_link_to(t('review_interruption.continue_without_editing'), x_continue_without_editing_path) %>
+      <%= render CandidateInterface::ContinueWithoutEditing.new(current_application:, application_choice: @application_choice) %>
     </div>
   </div>
 </div>

--- a/app/views/candidate_interface/course_choices/review_undergraduate_interruption/show.html.erb
+++ b/app/views/candidate_interface/course_choices/review_undergraduate_interruption/show.html.erb
@@ -1,0 +1,21 @@
+<% content_for :title, t('page_titles.application_review_and_submit', provider_name: @application_choice.provider.name) %>
+<% content_for(:before_content, govuk_back_link_to(candidate_interface_application_choices_path)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <div class="app-grid-column--grey">
+      <h1 class="govuk-heading-l"><%= t('review_undergraduate_interruption.title') %></h1>
+      <p class="govuk-body"><%= t('review_undergraduate_interruption.eligible_postgraduate') %></p>
+      <p class="govuk-body"><%= t('review_undergraduate_interruption.course_length') %></p>
+      <p class="govuk-body"><%= t('review_undergraduate_interruption.teacher_training_advisor') %></p>
+    </div>
+
+    <div class="govuk-button-group app-course-choice__confirm-submission">
+      <h2 class="govuk-heading-s"><%= t('review_undergraduate_interruption.would_you_like_to_continue') %></h2>
+
+      <%= govuk_button_to(t('review_undergraduate_interruption.continue'), candidate_interface_course_choices_course_review_and_submit_path(@application_choice.id), method: :get) %>
+
+      <%= govuk_link_to(t('review_undergraduate_interruption.go_to_account'), candidate_interface_details_path) %>
+    </div>
+  </div>
+</div>

--- a/app/views/candidate_interface/course_choices/review_undergraduate_interruption/show.html.erb
+++ b/app/views/candidate_interface/course_choices/review_undergraduate_interruption/show.html.erb
@@ -7,7 +7,12 @@
       <h1 class="govuk-heading-l"><%= t('review_undergraduate_interruption.title') %></h1>
       <p class="govuk-body"><%= t('review_undergraduate_interruption.eligible_postgraduate') %></p>
       <p class="govuk-body"><%= t('review_undergraduate_interruption.course_length') %></p>
-      <p class="govuk-body"><%= t('review_undergraduate_interruption.teacher_training_advisor') %></p>
+      <p class="govuk-body">
+        <%= govuk_link_to t('review_undergraduate_interruption.find_out'), t('get_into_teaching.url_ways_to_train') %>.
+      </p>
+      <p class="govuk-body">
+        <%= t('review_undergraduate_interruption.teacher_training_advisor', link: govuk_link_to(t('review_undergraduate_interruption.teacher_training_advisor_link_text'), t('get_into_teaching.url_get_an_adviser_signup'))).html_safe %>
+      </p>
     </div>
 
     <div class="govuk-button-group app-course-choice__confirm-submission">

--- a/config/locales/candidate_interface/interruption.yml
+++ b/config/locales/candidate_interface/interruption.yml
@@ -7,6 +7,14 @@ en:
     edit_statement: Would you like to edit your personal statement before submitting your application?
     edit_statement_button_text: Edit your personal statement
     continue_without_editing: Continue without editing
+  review_undergraduate_interruption:
+    title: Are you sure you want to apply for a teacher degree apprenticeship?
+    eligible_postgraduate: You've told us you have a degree, which might make you eligible for postgraduate teacher training.
+    course_length: Teacher degree apprenticeships are 4 years, and postgraduate teacher training courses are usually one year.
+    teacher_training_advisor: For support and advice, you can also speak to a teacher training adviser for free. They can help you understand which courses would be best for you.
+    would_you_like_to_continue: Would you like to continue and apply for this course?
+    continue: Continue and apply for this course
+    go_to_account: Go to your account
   review_enic_interruption:
     title: You have not included a UK ENIC reference number
     waiting_maybe:

--- a/config/locales/candidate_interface/interruption.yml
+++ b/config/locales/candidate_interface/interruption.yml
@@ -11,7 +11,9 @@ en:
     title: Are you sure you want to apply for a teacher degree apprenticeship?
     eligible_postgraduate: You've told us you have a degree, which might make you eligible for postgraduate teacher training.
     course_length: Teacher degree apprenticeships are 4 years, and postgraduate teacher training courses are usually one year.
-    teacher_training_advisor: For support and advice, you can also speak to a teacher training adviser for free. They can help you understand which courses would be best for you.
+    find_out: Find out about the different ways to train to be a teacher
+    teacher_training_advisor: For support and advice, you can also speak to a %{link} for free. They can help you understand which courses would be best for you.
+    teacher_training_advisor_link_text: teacher training adviser
     would_you_like_to_continue: Would you like to continue and apply for this course?
     continue: Continue and apply for this course
     go_to_account: Go to your account

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -365,6 +365,7 @@ namespace :candidate_interface, path: '/candidate' do
       get '/:application_choice_id/review' => 'course_choices/review#show', as: :course_choices_course_review
       get '/:application_choice_id/review-interruption' => 'course_choices/review_interruption#show', as: :course_choices_course_review_interruption
       get '/:application_choice_id/review-enic-interruption' => 'course_choices/review_enic_interruption#show', as: :course_choices_course_review_enic_interruption
+      get '/:application_choice_id/review-undergraduate-interruption' => 'course_choices/review_undergraduate_interruption#show', as: :course_choices_course_review_undergraduate_interruption
       get '/:application_choice_id/review-and-submit' => 'course_choices/review_and_submit#show', as: :course_choices_course_review_and_submit
       get '/blocked-submissions' => 'course_choices/blocked_submissions#show', as: :course_choices_blocked_submissions
 

--- a/spec/components/candidate_interface/continue_without_editing_spec.rb
+++ b/spec/components/candidate_interface/continue_without_editing_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::ContinueWithoutEditing, type: :component do
+  include Rails.application.routes.url_helpers
+  let(:application_choice) { create(:application_choice, application_form: current_application) }
+  let(:current_application) { create(:application_form) }
+
+  subject(:component) do
+    render_inline(
+      described_class.new(
+        current_application:,
+        application_choice:,
+      ),
+    )
+  end
+
+  describe '#continue_without_editing' do
+    context 'when application_choice has an undergraduate course and application form has a degree' do
+      before do
+        allow(application_choice).to receive(:undergraduate_course_and_application_form_with_degree?).and_return(true)
+      end
+
+      it 'renders the undergraduate interruption path' do
+        expect(component.css('a').attribute('href').value).to eq(
+          candidate_interface_course_choices_course_review_undergraduate_interruption_path(application_choice.id),
+        )
+      end
+    end
+
+    context 'when qualifications ENIC reasons are waiting or maybe' do
+      before do
+        allow(application_choice).to receive(:undergraduate_course_and_application_form_with_degree?).and_return(false)
+        allow(current_application).to receive(:qualifications_enic_reasons_waiting_or_maybe?).and_return(true)
+      end
+
+      it 'renders the ENIC interruption path' do
+        expect(component.css('a').attribute('href').value).to eq(
+          candidate_interface_course_choices_course_review_enic_interruption_path(application_choice.id),
+        )
+      end
+    end
+
+    context 'when ENIC reasons are not needed' do
+      before do
+        allow(application_choice).to receive(:undergraduate_course_and_application_form_with_degree?).and_return(false)
+        allow(current_application).to receive_messages(qualifications_enic_reasons_waiting_or_maybe?: false, any_qualification_enic_reason_not_needed?: true)
+      end
+
+      it 'renders the ENIC interruption path' do
+        expect(component.css('a').attribute('href').value).to eq(
+          candidate_interface_course_choices_course_review_enic_interruption_path(application_choice.id),
+        )
+      end
+    end
+
+    context 'when no special conditions are met' do
+      before do
+        allow(application_choice).to receive(:undergraduate_course_and_application_form_with_degree?).and_return(false)
+        allow(current_application).to receive_messages(qualifications_enic_reasons_waiting_or_maybe?: false, any_qualification_enic_reason_not_needed?: false)
+      end
+
+      it 'renders the review and submit path' do
+        expect(component.css('a').attribute('href').value).to eq(
+          candidate_interface_course_choices_course_review_and_submit_path(application_choice.id),
+        )
+      end
+    end
+  end
+end

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -732,4 +732,43 @@ RSpec.describe ApplicationChoice do
       end
     end
   end
+
+  describe '#undergraduate_course_and_application_form_with_degree?' do
+    let(:application_choice) { create(:application_choice, current_course_option: current_course_option, application_form:) }
+    let(:application_form) { create(:application_form) }
+    let(:current_course_option) { create(:course_option, course: current_course) }
+    let(:current_course) { create(:course, program_type: 'teacher_degree_apprenticeship') }
+
+    context 'when the course is an undergraduate and the application form has a degree' do
+      it 'returns true' do
+        create(:application_qualification, level: 'degree', application_form:)
+
+        expect(application_choice.undergraduate_course_and_application_form_with_degree?).to be(true)
+      end
+    end
+
+    context 'when the course is not undergraduate but the application form has a degree' do
+      let(:current_course) { create(:course, program_type: 'pg_teaching_apprenticeship') }
+
+      it 'returns false' do
+        create(:application_qualification, level: 'degree', application_form:)
+
+        expect(application_choice.undergraduate_course_and_application_form_with_degree?).to be(false)
+      end
+    end
+
+    context 'when the course is undergraduate but the application form does not have a degree' do
+      it 'returns false' do
+        expect(application_choice.undergraduate_course_and_application_form_with_degree?).to be(false)
+      end
+    end
+
+    context 'when neither the course is undergraduate nor the application form has a degree' do
+      let(:current_course) { create(:course, program_type: 'pg_teaching_apprenticeship') }
+
+      it 'returns false' do
+        expect(application_choice.undergraduate_course_and_application_form_with_degree?).to be(false)
+      end
+    end
+  end
 end

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -811,6 +811,7 @@ module CandidateHelper
     when_i_visit_my_applications
     when_i_click_to_view_my_application
   end
+  alias when_i_continue_with_my_application and_i_continue_with_my_application
 
   def when_i_click_to_view_my_application
     click_link_or_button @application_choice.current_course.provider.name

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_with_interruption_pages_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_with_interruption_pages_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'Candidate submits the application with interruption pages' do
 
   scenario 'Candidate submits an teacher degree apprenticeship course having a personal statement less than 500 words and a degree', :js, time: mid_cycle do
     given_i_am_signed_in
-    when_i_have_completed_my_undergraduate_application_and_have_added_primary_as_a_course_choice_with_short_personal_statement_and_a_degree
+    when_i_have_completed_application_to_primary_course_choice_with_short_personal_statement
     and_course_choice_is_undergraduate
     and_i_have_a_degree
     and_i_continue_with_my_application
@@ -97,7 +97,7 @@ RSpec.describe 'Candidate submits the application with interruption pages' do
     add_not_needed_qualification
   end
 
-  def when_i_have_completed_my_undergraduate_application_and_have_added_primary_as_a_course_choice_with_short_personal_statement_and_a_degree
+  def when_i_have_completed_application_to_primary_course_choice_with_short_personal_statement
     given_i_have_a_primary_course_choice(application_form_completed: true, personal_statement_words: 4)
   end
 

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_with_interruption_pages_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_with_interruption_pages_spec.rb
@@ -59,6 +59,8 @@ RSpec.describe 'Candidate submits the application with interruption pages' do
   scenario 'Candidate submits an teacher degree apprenticeship course having a personal statement less than 500 words and a degree', :js, time: mid_cycle do
     given_i_am_signed_in
     when_i_have_completed_my_undergraduate_application_and_have_added_primary_as_a_course_choice_with_short_personal_statement_and_a_degree
+    and_course_choice_is_undergraduate
+    and_i_have_a_degree
     and_i_continue_with_my_application
 
     when_i_save_as_draft
@@ -97,8 +99,6 @@ RSpec.describe 'Candidate submits the application with interruption pages' do
 
   def when_i_have_completed_my_undergraduate_application_and_have_added_primary_as_a_course_choice_with_short_personal_statement_and_a_degree
     given_i_have_a_primary_course_choice(application_form_completed: true, personal_statement_words: 4)
-    and_course_choice_is_undergraduate
-    and_i_have_a_degree
   end
 
   def and_course_choice_is_undergraduate

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_with_interruption_pages_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_with_interruption_pages_spec.rb
@@ -56,9 +56,72 @@ RSpec.describe 'Candidate submits the application with interruption pages' do
     then_the_viewed_enic_interruption_page_cookie_to_be_set
   end
 
+  scenario 'Candidate submits an teacher degree apprenticeship course having a personal statement less than 500 words and a degree', :js, time: mid_cycle do
+    given_i_am_signed_in
+    when_i_have_completed_my_undergraduate_application_and_have_added_primary_as_a_course_choice_with_short_personal_statement_and_a_degree
+    and_i_continue_with_my_application
+
+    when_i_save_as_draft
+    and_i_am_redirected_to_the_application_dashboard
+    and_my_application_is_still_unsubmitted
+    and_i_continue_with_my_application
+
+    when_i_click_to_review_my_application
+    then_i_see_a_interruption_page_for_personal_statement
+    when_i_continue_without_editing
+    then_i_see_a_interruption_page_for_degree_warning
+    when_i_click_to_continue_and_apply_for_the_course
+    then_i_see_the_review_and_submit_page
+  end
+
+  scenario 'Candidate submits an teacher degree apprenticeship course having a degree with long personal statement and with ENIC', :js, time: mid_cycle do
+    given_i_am_signed_in
+    when_i_have_completed_my_undergraduate_application_and_have_added_primary_as_a_course_choice
+    and_i_continue_with_my_application
+
+    when_i_save_as_draft
+    and_i_am_redirected_to_the_application_dashboard
+    and_my_application_is_still_unsubmitted
+    and_i_continue_with_my_application
+
+    when_i_click_to_review_my_application
+    then_i_see_a_interruption_page_for_degree_warning
+    when_i_click_to_continue_and_apply_for_the_course
+    then_i_see_the_review_and_submit_page
+  end
+
   def when_i_have_completed_my_application_and_have_added_primary_as_a_course_choice_with_not_needed_qualification
     given_i_have_a_primary_course_choice(application_form_completed: true, personal_statement_words: 4)
     add_not_needed_qualification
+  end
+
+  def when_i_have_completed_my_undergraduate_application_and_have_added_primary_as_a_course_choice_with_short_personal_statement_and_a_degree
+    given_i_have_a_primary_course_choice(application_form_completed: true, personal_statement_words: 4)
+    and_course_choice_is_undergraduate
+    and_i_have_a_degree
+  end
+
+  def and_course_choice_is_undergraduate
+    @application_choice.course.update!(
+      build(:course, :teacher_degree_apprenticeship)
+      .attributes
+      .symbolize_keys
+      .slice(:apprenticeship, :full_time, :description, :qualifications, :program_type, :course_length),
+    )
+  end
+
+  def when_i_have_completed_my_undergraduate_application_and_have_added_primary_as_a_course_choice
+    given_i_have_a_primary_course_choice(application_form_completed: true, personal_statement_words: 500)
+    and_i_have_a_degree
+    and_course_choice_is_undergraduate
+  end
+
+  def and_i_have_a_degree
+    create(
+      :degree_qualification,
+      application_form: @application_choice.application_form,
+      institution_country: 'GB',
+    )
   end
 
   def when_i_have_completed_my_application_and_have_added_primary_as_a_course_choice_with_waiting_or_maybe_qualification
@@ -122,6 +185,11 @@ RSpec.describe 'Candidate submits the application with interruption pages' do
     expect(page).to have_content 'Your personal statement is 4 words.'
   end
 
+  def then_i_see_a_interruption_page_for_degree_warning
+    expect(page).to have_content('Are you sure you want to apply for a teacher degree apprenticeship?')
+    expect(page).to have_content('Teacher degree apprenticeships are 4 years, and postgraduate teacher training courses are usually one year.')
+  end
+
   def then_i_see_a_interruption_page_for_not_needed_enic
     expect(page).to have_content 'You have not included a UK ENIC reference number'
     expect(page).to have_content 'Including a UK ENIC reference number in your application makes youn around 30% more likely to receive an offer.'
@@ -140,5 +208,16 @@ RSpec.describe 'Candidate submits the application with interruption pages' do
 
   def then_the_viewed_enic_interruption_page_cookie_to_be_set
     expect(page.driver.browser.manage.cookie_named('viewed_enic_interruption_page')[:value]).to eq('true')
+  end
+
+  def when_i_click_to_continue_and_apply_for_the_course
+    click_link_or_button 'Continue and apply for this course'
+  end
+
+  def then_i_see_the_review_and_submit_page
+    expect(page).to have_current_path(
+      candidate_interface_course_choices_course_review_and_submit_path(@application_choice.id),
+    )
+    expect(page).to have_content('Review your application')
   end
 end

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_with_interruption_pages_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_with_interruption_pages_spec.rb
@@ -78,7 +78,9 @@ RSpec.describe 'Candidate submits the application with interruption pages' do
 
   scenario 'Candidate submits an teacher degree apprenticeship course having a degree with long personal statement and with ENIC', :js, time: mid_cycle do
     given_i_am_signed_in
-    when_i_have_completed_my_undergraduate_application_and_have_added_primary_as_a_course_choice
+    when_i_have_completed_application_to_primary_course_choice_with_long_personal_statement
+    and_i_have_a_degree
+    and_course_choice_is_undergraduate
     and_i_continue_with_my_application
 
     when_i_save_as_draft
@@ -110,10 +112,8 @@ RSpec.describe 'Candidate submits the application with interruption pages' do
     )
   end
 
-  def when_i_have_completed_my_undergraduate_application_and_have_added_primary_as_a_course_choice
+  def when_i_have_completed_application_to_primary_course_choice_with_long_personal_statement
     given_i_have_a_primary_course_choice(application_form_completed: true, personal_statement_words: 500)
-    and_i_have_a_degree
-    and_course_choice_is_undergraduate
   end
 
   def and_i_have_a_degree

--- a/spec/system/candidate_interface/submitting/candidate_submitting_undergraduate_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_undergraduate_application_spec.rb
@@ -1,0 +1,170 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidate submits the application' do
+  include CandidateHelper
+  include SignInHelper
+
+  scenario 'Candidate with a completed application' do
+    given_i_am_signed_in
+
+    when_i_have_completed_my_application_and_have_added_undergraduate_primary_as_a_course_choice
+    and_i_continue_with_my_application
+    and_i_save_as_draft
+    then_i_am_redirected_to_the_application_dashboard
+
+    when_i_continue_with_my_application
+    and_i_choose_to_submit
+    then_i_can_see_my_application_has_been_successfully_submitted
+    and_i_am_redirected_to_the_application_dashboard
+    and_my_application_is_submitted
+    then_i_can_see_my_submitted_application
+    and_i_can_see_i_have_three_choices_left
+
+    when_i_click_to_view_my_application
+    then_i_can_review_my_submitted_application
+  end
+
+  scenario 'Candidate with a primary application missing the science GCSE' do
+    given_i_am_signed_in
+
+    when_i_have_completed_my_application_and_have_added_undergraduate_primary_as_a_course_choice
+    when_i_have_not_completed_science_gcse
+    and_i_continue_with_my_application
+
+    then_i_see_an_error_message_that_i_must_complete_the_science_gcse
+
+    when_i_click_on_the_error_message
+    then_i_am_on_science_gcse_section
+  end
+
+  def when_i_have_completed_my_application_and_have_added_undergraduate_primary_as_a_course_choice
+    given_i_have_a_primary_course_choice(application_form_completed: true)
+  end
+
+  def when_i_have_an_incomplete_application_and_have_added_primary_as_a_course_choice
+    given_i_have_a_primary_course_choice(application_form_completed: false)
+  end
+
+  def given_i_have_a_primary_course_choice(application_form_completed:)
+    completed_section_trait = application_form_completed.present? ? :completed : :minimum_info
+
+    @provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
+    site = create(
+      :site,
+      name: 'Main site',
+      code: '-',
+      provider: @provider,
+      address_line1: 'Gorse SCITT',
+      address_line2: 'C/O The Bruntcliffe Academy',
+      address_line3: 'Bruntcliffe Lane',
+      address_line4: 'MORLEY, lEEDS',
+      postcode: 'LS27 0LZ',
+    )
+    @course = create(:course, :teacher_degree_apprenticeship, :open, name: 'Primary', code: '2XT2', provider: @provider)
+    @course_option = create(:course_option, site:, course: @course)
+    current_candidate.application_forms.delete_all
+    current_candidate.application_forms << build(:application_form, completed_section_trait, university_degree: false)
+    @application_choice = create(:application_choice, :unsubmitted, course_option: @course_option, application_form: current_candidate.current_application)
+  end
+
+  def when_i_have_not_completed_science_gcse
+    @application_choice.application_form.update!(science_gcse_completed: false)
+  end
+
+  def and_i_save_as_draft
+    click_link_or_button 'Save as draft'
+  end
+
+  def when_i_choose_to_submit
+    when_i_click_to_review_my_application
+    when_i_click_to_submit_my_application
+  end
+  alias_method :and_i_choose_to_submit, :when_i_choose_to_submit
+
+  def and_i_can_see_my_course_choices
+    expect(page).to have_content 'Gorse SCITT'
+    expect(page).to have_content 'Primary (2XT2)'
+  end
+
+  def then_i_see_an_error_message_that_i_must_choose_an_option
+    expect(page).to have_content 'There is a problem'
+    expect(page).to have_content 'Select if you want to submit your application or save it as a draft'
+  end
+
+  def then_i_see_an_error_message_that_i_must_complete_the_science_gcse
+    expect(page).to have_content 'To apply for a Primary course, you need a GCSE in science at grade 4 (C) or above, or equivalent.'
+    expect(page).to have_content 'Your application will be saved as a draft while you finish adding your details.'
+  end
+
+  def then_i_can_see_my_application_has_been_successfully_submitted
+    expect(page).to have_content 'Application submitted'
+  end
+
+  def and_i_am_redirected_to_the_application_dashboard
+    expect(page).to have_content t('page_titles.application_dashboard')
+    expect(page).to have_content 'Gorse SCITT'
+  end
+  alias_method :then_i_am_redirected_to_the_application_dashboard, :and_i_am_redirected_to_the_application_dashboard
+
+  def and_my_application_is_submitted
+    expect(@application_choice.reload).to be_awaiting_provider_decision
+  end
+
+  def then_i_can_see_my_submitted_application
+    expect(@current_candidate.current_application.application_choices).to contain_exactly(@application_choice)
+    expect(page).to have_content 'Gorse SCITT'
+    expect(page).to have_content 'Primary (2XT2)'
+    expect(page).to have_content 'Awaiting decision'
+  end
+
+  def then_i_can_review_my_submitted_application
+    expect(@current_candidate.current_application.application_choices).to contain_exactly(@application_choice)
+    expect(page).to have_content 'Gorse SCITT'
+    expect(page).to have_content 'Awaiting decision'
+    expect(page).to have_content @application_choice.sent_to_provider_at.to_fs(:govuk_date_and_time)
+    expect(page).to have_content 'Primary (2XT2)'
+    expect(page).to have_content 'Full time'
+    expect(page).to have_content 'Main site'
+    expect(page).to have_content 'Qualifications Teacher degree apprenticeship with QTS'
+    expect(page).to have_content @application_choice.personal_statement
+  end
+
+  def and_i_can_see_i_have_three_choices_left
+    expect(page).to have_content 'You can add 3 more applications.'
+  end
+
+  def when_i_have_three_further_draft_choices
+    @current_candidate.current_application.application_choices << build_list(:application_choice, 3, :unsubmitted)
+    @application_choice = @current_candidate.current_application.application_choices.unsubmitted.first
+  end
+
+  def then_i_can_no_longer_add_more_course_choices
+    visit current_path
+    expect(page).to have_content 'You cannot add any more applications.'
+    expect(page).to have_content 'You can add more applications if'
+    expect(page).to have_content 'one of your submitted applications becomes unsuccessful'
+    expect(page).to have_content 'you withdraw or remove an application'
+  end
+  alias_method :then_i_still_cannot_add_course_choices, :then_i_can_no_longer_add_more_course_choices
+
+  def when_one_of_my_applications_becomes_inactive
+    @current_candidate.current_application.application_choices.where(status: 'awaiting_provider_decision').first.update!(status: 'inactive')
+  end
+
+  def then_i_am_able_to_add_another_choice
+    visit current_path
+    expect(page).to have_content 'You can add 1 more application.'
+  end
+
+  def when_i_go_back
+    click_link_or_button 'Back'
+  end
+
+  def when_i_click_on_the_error_message
+    click_link_or_button 'Add your science GCSE grade (or equivalent)'
+  end
+
+  def then_i_am_on_science_gcse_section
+    expect(page).to have_current_path(candidate_interface_gcse_details_new_type_path(subject: 'science'))
+  end
+end


### PR DESCRIPTION
## Context

TDA is an undergraduate route into teaching, and applications are primarily for those who do not have a degree.

Those who have a degree are still able to apply, however there are other quicker and more suitable routes into teaching for them.

This commit is to add a flight check to TDA applications where the candidate has added at least one degree, to encourage them to consider alternatives.

## Changes

![screencapture-localhost-3000-candidate-application-course-choices-2893-review-undergraduate-interruption-2024-09-09-10_36_27](https://github.com/user-attachments/assets/971e6327-faf8-4881-a3fa-d6e9de1be1cc)


## Guidance to review

To test this feature locally or on the review app you need:

1. Set the cycle switcher (visiting /support/settings/cycles) and choose any of these options: "Find has reopened" or "Apply has reopened"
2. Activate the feature flag "Teacher degree apprenticeship"
3. Run the rake task to create TDA courses: `rake create_undergraduate_courses`
4. Choose option no on the degrees section
5. Try to submit a undergraduate course with degrees.


