### PR TITLE
Amend our 'active users' export on Apply Support Console to exclude users that aren't associated with a Provider

### DIFF
--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -7,9 +7,9 @@ class DataExport < ApplicationRecord
       class: SupportInterface::ActiveProviderUserPermissionsExport,
     },
     active_provider_users: {
-      name: 'Active provider users',
+      name: 'Active users affiliated with a Provider',
       export_type: 'active_provider_users',
-      description: 'The list of provider users that have signed in to apply at least once.',
+      description: 'The list of all users affiliated with a provider who have signed in to Manage at least once.',
       class: SupportInterface::ActiveProviderUsersExport,
     },
     applications_by_subject_route_and_degree_grade: {

--- a/app/services/support_interface/active_provider_users_export.rb
+++ b/app/services/support_interface/active_provider_users_export.rb
@@ -1,7 +1,11 @@
 module SupportInterface
   class ActiveProviderUsersExport
     def data_for_export(*)
-      active_provider_users = ProviderUser.includes(:providers).where.not(last_signed_in_at: nil)
+      active_provider_users = ProviderUser
+                                .where.not(last_signed_in_at: nil)
+                                .includes(:providers)
+                                .joins(:provider_permissions)
+                                .distinct
 
       active_provider_users.find_each(batch_size: 100).map do |provider_user|
         {

--- a/spec/services/support_interface/active_provider_users_export_spec.rb
+++ b/spec/services/support_interface/active_provider_users_export_spec.rb
@@ -42,5 +42,24 @@ RSpec.describe SupportInterface::ActiveProviderUsersExport do
         )
       end
     end
+
+    it 'only returns users if they are assosiated to a provider' do
+      travel_temporarily_to(2020, 5, 1, 12, 0, 0) do
+        provider1 = create(:provider, name: 'A is the first letter')
+        provider_user1 = create(:provider_user, providers: [provider1], last_signed_in_at: 5.days.ago)
+        create(:provider_user, providers: [], last_signed_in_at: 5.days.ago)
+
+        expect(described_class.new.data_for_export).to eq(
+          [
+            {
+              provider_full_name: provider_user1.full_name,
+              provider_email_address: provider_user1.email_address,
+              providers: provider1.name,
+              last_signed_in_at: 5.days.ago,
+            },
+          ],
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

Ticket: https://trello.com/c/XbWPnLsJ/2166-amend-our-active-users-export-on-apply-support-console-to-exclude-users-that-arent-associated-with-a-provider

The Apply Support console has an “Active provider users” export. This can be navigated to via “Providers” > “Provider users” > “Download active provide users (CSV)” (which takes you to a landing page of various export).

We use this “Active provider users” export to produce a recipient list for manually crafted communications to all provider users (the instructions for which are here [How we compile a distribution list for all providers.docx](https://educationgovuk.sharepoint.com/:w:/r/sites/TeacherServices/Shared%20Documents/Find%20and%20Apply%20Team/11.%20Knowledge%20Base/How%20we%20compile%20a%20distribution%20list%20for%20all%20providers.docx?d=w86cc532602b44ad9853060956e2bb84e&csf=1&web=1&e=5724ZR)). An example of such email would be the BAT newsletter.

On 8th Aug 2024 a user replied to the Support team from one of these emails to request that they not be included any more. This user is not associated with any providers.

## Changes proposed in this pull request

Update the export query to check that the user is associated to a provider as well as check that they have a `last_signed_in_at` valye

## Guidance to review

- Create 2 users, one with a provider one without.
- Run the export 
- You should only see one user as the 2nd user does not have a provider

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
