### PR TITLE
Update activity log query

### DIFF
--- a/app/queries/get_activity_log_events.rb
+++ b/app/queries/get_activity_log_events.rb
@@ -48,7 +48,7 @@ class GetActivityLogEvents
     SQL
 
     where_auditable_is_application_form = Audited::Audit
-      .where(auditable_id: application_choices.pluck(:application_form_id).uniq, auditable_type: 'ApplicationForm', action: :update)
+      .where(auditable_id: application_choices.select(:application_form_id).distinct, auditable_type: 'ApplicationForm', action: :update)
       .where(application_form_audits_filter_sql)
       .where(application_form_changes_exist)
 

--- a/spec/queries/get_activity_log_events_spec.rb
+++ b/spec/queries/get_activity_log_events_spec.rb
@@ -62,22 +62,6 @@ RSpec.describe GetActivityLogEvents, :with_audited do
 
       expect(result.first).to eq(expected)
     end
-
-    it 'defaults the query date range to the earliest scoped application form creation' do
-      application_form_1 = create(:application_form, created_at: DateTime.new(2010, 1, 1))
-      application_choice_1 = create(:application_choice, application_form: application_form_1, status: :awaiting_provider_decision)
-      create_audit_for_application_choice application_choice_1
-
-      application_form_2 = create(:application_form, created_at: DateTime.new(2020, 1, 1))
-      application_choice_2 = create(:application_choice, application_form: application_form_2, status: :awaiting_provider_decision)
-      create_audit_for_application_choice application_choice_2
-
-      application_form_3 = create(:application_form, created_at: DateTime.now)
-      application_choice_3 = create(:application_choice, application_form: application_form_3, status: :awaiting_provider_decision)
-      create_audit_for_application_choice application_choice_3
-
-      expect(described_class.call(application_choices: ApplicationChoice.where(id: [application_choice_2, application_choice_3]))).not_to include(application_choice_1)
-    end
   end
 
   context 'includes all and only relevant audits' do

--- a/spec/queries/get_activity_log_events_spec.rb
+++ b/spec/queries/get_activity_log_events_spec.rb
@@ -292,7 +292,7 @@ RSpec.describe GetActivityLogEvents, :with_audited do
     it '<50ms for 1000 application choices' do
       skip 'This spec takes a long time and should be run manually'
 
-      # TestSuiteTimeMachine.revert_to_real_world_time
+      TestSuiteTimeMachine.revert_to_real_world_time
 
       1000.times do
         %i[course_provider_a course_provider_b course_unrelated ratified_course_provider_b ratified_course_unrelated].each do |course|


### PR DESCRIPTION
## Context

The `/provider/acitivity` page is [slow](https://www.skylight.io/app/applications/t8bEzG0cuIkd/recent/6h/endpoints/ProviderInterface::ActivityLogController%23index?responseType=html), this became an issue when we ran this DB migration https://github.com/DFE-Digital/apply-for-teacher-training/pull/9741. This created a lot of audits for the query to go through.

Previously the query would do an inner join on all audits and filter out the ones we didn't need.

This PR tries to filter out the audits we don't need first and then do the inner join.

We need an inner join to put an application_choice_id on every audit this query returns, this is needed on the view.

Changing the query this way, improved the response time, this is based on 20 million audits on local. Hopefully this is enough to make the page work

| New query | Old Query |
| ------------- | ------------- |
| 5.5 seconds | 50 seconds|
 
Co-authored by @dcyoung-dev 

## Changes proposed in this pull request

Updated the provider activity log query

## Guidance to review

Go on review app and check if the /provider/activity works
Does the SQL make sense?


https://github.com/user-attachments/assets/e80a572d-7c89-4192-84d2-cbf787be994f



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
