### PR TITLE
Fix ENIC interruption typo

### DIFF
--- a/config/locales/candidate_interface/interruption.yml
+++ b/config/locales/candidate_interface/interruption.yml
@@ -29,7 +29,7 @@ en:
       enter_enic: Enter a UK ENIC number
       without_entering_enic: Continue without adding a UK ENIC number
     not_needed:
-      more_likely_html: Including a UK ENIC reference number in your application makes youn around <b> 30% more likely to receive an offer.</b>
+      more_likely_html: Including a UK ENIC reference number in your application makes you around <b> 30% more likely to receive an offer.</b>
       apply_for_enic_link: apply for a UK ENIC statement of comparability
       if_you_apply_enic_html: If you %{link} and include the reference number in your application it makes it easier for training providers to understand your qualifications.
       dont_provide_enic: If you don’t include a UK ENIC statement of comparability and the provider asks for one, it could cause delays.

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_with_interruption_pages_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_with_interruption_pages_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe 'Candidate submits the application with interruption pages' do
 
   def then_i_see_a_interruption_page_for_not_needed_enic
     expect(page).to have_content 'You have not included a UK ENIC reference number'
-    expect(page).to have_content 'Including a UK ENIC reference number in your application makes youn around 30% more likely to receive an offer.'
+    expect(page).to have_content 'Including a UK ENIC reference number in your application makes you around 30% more likely to receive an offer.'
     expect(page).to have_current_path(
       candidate_interface_course_choices_course_review_enic_interruption_path(@application_choice.id),
     )


### PR DESCRIPTION
## Context

https://trello.com/c/RobItQ7p/2297-bug-enic-interruption-typo-should-be-you-instead-of-youn

<img width="516" alt="Screenshot 2024-09-11 at 08 04 03" src="https://github.com/user-attachments/assets/3e49b605-bb71-4423-ada6-ca46e73763d7">

## Changes proposed in this pull request

Fix Enic typo

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
