### PR TITLE
Add degree type content for degrees headers

### DIFF
--- a/app/components/candidate_interface/degree_empty_component.html.erb
+++ b/app/components/candidate_interface/degree_empty_component.html.erb
@@ -1,10 +1,18 @@
-<p class="govuk-body">You need a bachelor’s degree or equivalent to start teacher training.</p>
+<% if @application_form.teacher_degree_apprenticeship_feature_active? %>
+  <h2 class="govuk-heading-s"><%= t('.postgraduate.name') %></h2>
 
-<p class="govuk-body">Add your bachelor’s degree even if you have not got your grade yet.</p>
+  <p class="govuk-body"><%= t('.postgraduate.bachelor_degree') %></p>
+  <p class="govuk-body"><%= t('.postgraduate.add_bachelor_degree') %></p>
 
-<p class="govuk-body">You can also add any other degrees that you have, or you are working towards.</p>
+  <h2 class="govuk-heading-s"><%= t('.undergraduate.name') %></h2>
 
- <p class="govuk-body">Find out how you can get qualified teacher status (QTS) as part of an <%= govuk_link_to_with_utm_params 'undergraduate degree', t('get_into_teaching.url_if_you_dont_have_a_degree'), utm_campaign(params) %> if you do not have a degree yet and are not already studying for one.</p>
+  <p class="govuk-body">
+    <%= t('.undergraduate.bachelor_degree', link: govuk_link_to(t('.undergraduate.teacher_degree_apprenticeship'), t('get_into_teaching.url_teacher_degree_apprenticeship'))).html_safe %>
+  </p>
+<% else %>
+  <p class="govuk-body"><%= t('.postgraduate.bachelor_degree') %></p>
+  <p class="govuk-body"><%= t('.postgraduate.add_bachelor_degree') %></p>
+<% end %>
 
 <% unless @application_form.no_degree_and_degree_completed? %>
   <%= govuk_button_link_to degrees.empty? ? t('application_form.degree.add.button') : t('application_form.degree.another.button'), candidate_interface_degree_country_path, primary: true %>

--- a/app/components/candidate_interface/degree_empty_component.html.erb
+++ b/app/components/candidate_interface/degree_empty_component.html.erb
@@ -7,7 +7,7 @@
   <h2 class="govuk-heading-s"><%= t('.undergraduate.name') %></h2>
 
   <p class="govuk-body">
-    <%= t('.undergraduate.bachelor_degree', link: govuk_link_to(t('.undergraduate.teacher_degree_apprenticeship'), t('get_into_teaching.url_teacher_degree_apprenticeship'))).html_safe %>
+    <%= t('.undergraduate.bachelor_degree_html', link: govuk_link_to(t('.undergraduate.teacher_degree_apprenticeship'), t('get_into_teaching.url_teacher_degree_apprenticeship'))) %>
   </p>
 <% else %>
   <p class="govuk-body"><%= t('.postgraduate.bachelor_degree') %></p>

--- a/config/locales/candidate_interface/degree_empty_component.yml
+++ b/config/locales/candidate_interface/degree_empty_component.yml
@@ -3,7 +3,7 @@ en:
     degree_empty_component:
       undergraduate:
         name: Teacher degree apprenticeships
-        bachelor_degree: You do not need a bachelor’s degree to do a %{link}.
+        bachelor_degree_html: You do not need a bachelor’s degree to do a %{link}.
         teacher_degree_apprenticeship: teacher degree apprenticeship
       postgraduate:
         name: Postgraduate teacher training courses

--- a/config/locales/candidate_interface/degree_empty_component.yml
+++ b/config/locales/candidate_interface/degree_empty_component.yml
@@ -1,0 +1,11 @@
+en:
+  candidate_interface:
+    degree_empty_component:
+      undergraduate:
+        name: Teacher degree apprenticeships
+        bachelor_degree: You do not need a bachelor’s degree to do a %{link}.
+        teacher_degree_apprenticeship: teacher degree apprenticeship
+      postgraduate:
+        name: Postgraduate teacher training courses
+        bachelor_degree: You need a bachelor’s degree or equivalent to start teacher training.
+        add_bachelor_degree: Add your bachelor’s degree even if you have not got your grade yet. You can also add any other degrees that you have, or you are working towards.

--- a/config/locales/candidate_interface/degree_empty_component.yml
+++ b/config/locales/candidate_interface/degree_empty_component.yml
@@ -7,5 +7,5 @@ en:
         teacher_degree_apprenticeship: teacher degree apprenticeship
       postgraduate:
         name: Postgraduate teacher training courses
-        bachelor_degree: You need a bachelor’s degree or equivalent to start teacher training.
+        bachelor_degree: You need a bachelor’s degree or equivalent to start postgraduate teacher training.
         add_bachelor_degree: Add your bachelor’s degree even if you have not got your grade yet. You can also add any other degrees that you have, or you are working towards.

--- a/spec/components/candidate_interface/degree_empty_component_spec.rb
+++ b/spec/components/candidate_interface/degree_empty_component_spec.rb
@@ -28,6 +28,36 @@ RSpec.describe CandidateInterface::DegreeEmptyComponent, type: :component do
     end
   end
 
+  describe 'when teacher degree apprenticeship feature is on' do
+    subject(:result) { render_inline(described_class.new(application_form:)).text }
+
+    let(:application_form) { create(:application_form, recruitment_cycle_year: 2025) }
+
+    before do
+      FeatureFlag.activate(:teacher_degree_apprenticeship)
+    end
+
+    it 'renders degree types headers' do
+      expect(result).to include('Postgraduate teacher training courses')
+      expect(result).to include('Teacher degree apprenticeships')
+    end
+  end
+
+  describe 'when teacher degree apprenticeship feature is off' do
+    subject(:result) { render_inline(described_class.new(application_form:)).text }
+
+    let(:application_form) { create(:application_form, recruitment_cycle_year: 2024) }
+
+    before do
+      FeatureFlag.deactivate(:teacher_degree_apprenticeship)
+    end
+
+    it 'does not render degree types headers' do
+      expect(result).not_to include('Postgraduate teacher training courses')
+      expect(result).not_to include('Teacher degree apprenticeships')
+    end
+  end
+
   describe 'button text' do
     context 'when only foundation degrees are present' do
       it 'renders add another degree' do


### PR DESCRIPTION
## Context

e need to enable candidates without a degree to apply for TDA courses. The existing intro content on the degree list page was originally written for postgraduate courses. [See live site screenshot](https://trello.com/1/cards/66db306013283cb0ad4f7786/attachments/66db30fe954f9ecac73399a7/download/Screenshot_2024-09-06_at_17.41.51.png).

## Changes proposed in this pull request

**TDA feature flag off**

![screencapture-localhost-3000-candidate-application-degrees-review-2024-09-13-14_26_48](https://github.com/user-attachments/assets/0e39ca96-b333-42c9-97b4-11f8b5658191)

**TDA feature flag on**
![screencapture-localhost-3000-candidate-application-degrees-review-2024-09-13-14_42_28](https://github.com/user-attachments/assets/4ef74ef7-739c-4093-9ce0-5691bb9d3678)

## Guidance to review

1. When teacher degree apprenticeship feature flag is active, content wise all good?
2. When teacher degree apprenticeship feature flag is NOT active, content wise all good? 

