### PR TITLE
[2269] Emails explaining reject by default to candidates

### DIFF
--- a/app/helpers/cycle_timetable_helper.rb
+++ b/app/helpers/cycle_timetable_helper.rb
@@ -48,4 +48,8 @@ module_function
   def application_deadline_has_passed_email_date(year = CycleTimetable.current_year)
     CycleTimetable.apply_deadline(year) + 1.day
   end
+
+  def reject_by_default_explainer_date(year = CycleTimetable.current_year)
+    CycleTimetable.reject_by_default(year) + 1.day
+  end
 end

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -11,6 +11,8 @@ class CandidateMailer < ApplicationMailer
       duplicate_match_email
       application_rejected
       application_deadline_has_passed
+      respond_to_offer_before_deadline
+      reject_by_default_explainer
     ],
   )
   include QualificationValueHelper
@@ -431,6 +433,33 @@ class CandidateMailer < ApplicationMailer
     email_for_candidate(
       application_form,
       subject: I18n.t!('candidate_mailer.application_deadline_has_passed.subject'),
+    )
+  end
+
+  def respond_to_offer_before_deadline(application_form)
+    @decline_by_default_deadline = CycleTimetable.decline_by_default_date.to_fs(:govuk_date)
+    year = application_form.recruitment_cycle_year
+    @this_academic_year = CycleTimetable.cycle_year_range(year)
+    @next_academic_year = CycleTimetable.cycle_year_range(year + 1)
+    @apply_reopens_date = CycleTimetable.apply_reopens.to_fs(:govuk_date)
+    email_for_candidate(
+      application_form,
+      subject: I18n.t!(
+        'candidate_mailer.respond_to_offer_before_deadline.subject',
+        decline_by_default_date: @decline_by_default_deadline,
+      ),
+    )
+  end
+
+  def reject_by_default_explainer(application_form)
+    year = application_form.recruitment_cycle_year
+    @this_academic_year = CycleTimetable.cycle_year_range(year)
+    @next_academic_year = CycleTimetable.cycle_year_range(year + 1)
+    @apply_reopens_date = CycleTimetable.apply_reopens.to_fs(:govuk_date)
+
+    email_for_candidate(
+      application_form,
+      subject: I18n.t!('candidate_mailer.reject_by_default_explainer.subject'),
     )
   end
 

--- a/app/services/email_timetable.rb
+++ b/app/services/email_timetable.rb
@@ -32,4 +32,8 @@ class EmailTimetable < CycleTimetable
     # For 2024, date confirmed is Wednesday 17 July at 6pm
     apply_deadline - 2.months
   end
+
+  def self.send_reject_by_default_explainer_to_candidates?
+    current_date.to_date == (reject_by_default + 1.day).to_date
+  end
 end

--- a/app/views/candidate_mailer/reject_by_default_explainer.text.erb
+++ b/app/views/candidate_mailer/reject_by_default_explainer.text.erb
@@ -1,0 +1,17 @@
+<% if @application_form.first_name.present? %>
+  Dear <%= @application_form.first_name %>
+<% end %>
+
+Your application for teacher training starting in the  <%= @this_academic_year %> academic year has been rejected automatically.
+
+This is because the provider did not respond before their deadline. If you have any questions about this, please contact the provider.
+
+# What happens next
+
+You can update your details to get ready to apply for courses starting in the <%= @next_academic_year %> academic year. You will be able to apply for these courses from <%= @apply_reopens_date %>.
+
+[Sign into your account to update your details](<%= candidate_magic_link(@application_form.candidate) %>).
+
+# Get help
+
+Call <%= t('get_into_teaching.tel') %> or [chat online](<%= t('get_into_teaching.url_online_chat') %>).

--- a/app/views/candidate_mailer/respond_to_offer_before_deadline.text.erb
+++ b/app/views/candidate_mailer/respond_to_offer_before_deadline.text.erb
@@ -1,0 +1,25 @@
+<% if @application_form.first_name.present? %>
+  Dear <%= @application_form.first_name %>
+<% end %>
+
+You have been offered a place on a teacher training course. If you want to accept this place, you must do so by <%= @decline_by_default_deadline %>.
+
+[Sign into your account to accept your place on a teacher training course](<%= candidate_magic_link(@application_form.candidate) %>).
+
+# Your other applications
+
+Your other applications for teacher training starting in the <%= @this_academic_year %> academic year have been rejected automatically.
+
+This is because the provider did not respond before their deadline. If you have any questions about this, please contact the provider.
+
+# What happens next
+
+If you want to accept your offer of a place on a teacher training course, you must do so by <%= @decline_by_default_deadline %>.
+
+If you do not want to accept this offer, you can update your details to get ready to apply for courses starting in the <%= @next_academic_year %> academic year. You will be able to apply for these courses from <%= @apply_reopens_date %>.
+
+[Sign into your account to update your details](<%= candidate_magic_link(@application_form.candidate) %>).
+
+# Get help
+
+Call <%= t('get_into_teaching.tel') %> or [chat online](<%= t('get_into_teaching.url_online_chat') %>).

--- a/app/workers/end_of_cycle/send_reject_by_default_explainer_email_to_candidates_worker.rb
+++ b/app/workers/end_of_cycle/send_reject_by_default_explainer_email_to_candidates_worker.rb
@@ -1,0 +1,37 @@
+module EndOfCycle
+  class SendRejectByDefaultExplainerEmailToCandidatesWorker
+    include Sidekiq::Worker
+
+    BATCH_SIZE = 120
+
+    def perform
+      return unless EmailTimetable.send_reject_by_default_explainer_to_candidates?
+
+      BatchDelivery.new(relation:, batch_size: BATCH_SIZE).each do |batch_time, application_forms|
+        SendRejectByDefaultExplainerEmailToCandidatesBatchWorker.perform_at(batch_time, application_forms.pluck(:id))
+      end
+    end
+
+    def relation
+      ApplicationForm
+        .current_cycle
+        .joins(:candidate).where(candidates: { submission_blocked: false, account_locked: false })
+        .joins(:application_choices).where('application_choices.rejected_by_default': true)
+        .distinct
+    end
+  end
+
+  class SendRejectByDefaultExplainerEmailToCandidatesBatchWorker
+    include Sidekiq::Worker
+
+    def perform(application_form_ids)
+      ApplicationForm.where(id: application_form_ids).includes(:application_choices).find_each do |application_form|
+        if application_form.application_choices.pluck(:status).include?('offer')
+          CandidateMailer.respond_to_offer_before_deadline(application_form).deliver_later
+        else
+          CandidateMailer.reject_by_default_explainer(application_form).deliver_later
+        end
+      end
+    end
+  end
+end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -42,6 +42,7 @@ class Clock
   every(1.day, 'SendNewCycleStartedEmailToCandidatesWorker', at: '10:00') { SendNewCycleHasStartedEmailToCandidatesWorker.new.perform }
   every(1.day, 'EndOfCycle::SendRejectByDefaultReminderToProvidersWorker') { EndOfCycle::SendRejectByDefaultReminderToProvidersWorker.new.perform }
   every(1.day, 'EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesWorker', at: '09:00') { EndOfCycle::SendApplicationDeadlineHasPassedEmailToCandidatesWorker.new.perform }
+  every(1.day, 'EndOfCycle:SendRejectByDefaultExplainerToCandidatesWorker', at: '09:01') { EndOfCycle::SendRejectByDefaultExplainerEmailToCandidatesWorker.new.perform }
 
   every(1.day, 'TriggerFullSyncIfFindClosed', at: '00:05') { TeacherTrainingPublicAPI::TriggerFullSyncIfFindClosed.call }
   every(1.day, 'NudgeCandidatesWorker', at: '10:00') { NudgeCandidatesWorker.perform_async }

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -85,6 +85,10 @@ en:
       subject: Submit your teacher training application before %{apply_deadline}
     application_deadline_has_passed:
       subject: The application deadline has passed
+    respond_to_offer_before_deadline:
+      subject: Accept your place on a teacher training course by %{decline_by_default_date}
+    reject_by_default_explainer:
+      subject: Your application has been rejected automatically
     new_cycle_has_started:
       subject: Apply for teacher training starting in the %{academic_year} academic year
     find_has_opened:

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -493,6 +493,18 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.application_deadline_has_passed(application_form)
   end
 
+  def respond_to_offer_before_deadline
+    application_form = FactoryBot.build(:application_form, first_name: 'Bart')
+
+    CandidateMailer.respond_to_offer_before_deadline(application_form)
+  end
+
+  def reject_by_default_explainer
+    application_form = FactoryBot.build(:application_form, first_name: 'Lisa')
+
+    CandidateMailer.reject_by_default_explainer(application_form)
+  end
+
   def new_cycle_has_started
     application_form = FactoryBot.build(:completed_application_form, first_name: 'Tester')
 

--- a/spec/services/email_timetable_spec.rb
+++ b/spec/services/email_timetable_spec.rb
@@ -78,4 +78,18 @@ RSpec.describe EmailTimetable do
       end
     end
   end
+
+  describe '#send_reject_by_default_explainer_to_candidates?' do
+    it 'returns false if it is not the day after the reject by default date' do
+      travel_temporarily_to(described_class.reject_by_default) do
+        expect(described_class.send_reject_by_default_explainer_to_candidates?).to be false
+      end
+    end
+
+    it 'returns true when it is the day after the reject by default date' do
+      travel_temporarily_to(described_class.reject_by_default + 1.day) do
+        expect(described_class.send_reject_by_default_explainer_to_candidates?).to be true
+      end
+    end
+  end
 end

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -45,6 +45,8 @@ RSpec.describe 'Docs' do
       candidate_mailer-eoc_first_deadline_reminder
       candidate_mailer-eoc_second_deadline_reminder
       candidate_mailer-application_deadline_has_passed
+      candidate_mailer-reject_by_default_explainer
+      candidate_mailer-respond_to_offer_before_deadline
       candidate_mailer-new_cycle_has_started
       candidate_mailer-duplicate_match_email
       candidate_mailer-find_has_opened

--- a/spec/workers/end_of_cycle/send_reject_by_default_explainer_email_to_candidates_batch_worker_spec.rb
+++ b/spec/workers/end_of_cycle/send_reject_by_default_explainer_email_to_candidates_batch_worker_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe EndOfCycle::SendRejectByDefaultExplainerEmailToCandidatesBatchWorker do
+  describe '#perform' do
+    context 'candidate has offers' do
+      it 'enqueues email asking candidate to respond to offers' do
+        application_form = create(:application_form)
+        create(:application_choice, :offered, application_form:)
+        create(:application_choice, :rejected_by_default, application_form:)
+
+        expect { described_class.new.perform([application_form.id]) }
+          .to have_enqueued_mail(CandidateMailer, :respond_to_offer_before_deadline)
+      end
+    end
+
+    context 'candidate does not have offers' do
+      it 'enqueues email telling candidate why their application was rejected' do
+        application_form = create(:application_form)
+        create(:application_choice, :rejected_by_default, application_form:)
+
+        expect { described_class.new.perform([application_form.id]) }
+          .to have_enqueued_mail(CandidateMailer, :reject_by_default_explainer)
+      end
+    end
+  end
+end

--- a/spec/workers/end_of_cycle/send_reject_by_default_explainer_email_to_candidates_worker_spec.rb
+++ b/spec/workers/end_of_cycle/send_reject_by_default_explainer_email_to_candidates_worker_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe EndOfCycle::SendRejectByDefaultExplainerEmailToCandidatesWorker do
+  describe '#perform' do
+    context 'before the date for sending the explainer email', time: reject_by_default_explainer_date - 1.day do
+      it 'does not enqueue the batch worker' do
+        create(:application_choice, :rejected_by_default)
+        allow(EndOfCycle::SendRejectByDefaultExplainerEmailToCandidatesBatchWorker).to receive(:perform_at)
+        described_class.new.perform
+        expect(EndOfCycle::SendRejectByDefaultExplainerEmailToCandidatesBatchWorker).not_to have_received(:perform_at)
+      end
+    end
+
+    context 'after the date for sending the explainer email', time: reject_by_default_explainer_date + 1.day do
+      it 'does not enqueue the batch worker' do
+        create(:application_choice, :rejected_by_default)
+        allow(EndOfCycle::SendRejectByDefaultExplainerEmailToCandidatesBatchWorker).to receive(:perform_at)
+        described_class.new.perform
+        expect(EndOfCycle::SendRejectByDefaultExplainerEmailToCandidatesBatchWorker).not_to have_received(:perform_at)
+      end
+    end
+
+    context 'the date for sending the explainer email', time: reject_by_default_explainer_date do
+      it 'enqueues batch worker' do
+        rejected_with_offer = create(:application_form)
+        create(:application_choice, :rejected_by_default, application_form: rejected_with_offer)
+        create(:application_choice, :offered, application_form: rejected_with_offer)
+
+        rejected_without_offer = create(:application_choice, :rejected_by_default).application_form
+
+        # These applications should not be included
+        create(:application_choice, :inactive)
+        create(:application_choice, :interviewing)
+        create(:application_choice, :awaiting_provider_decision)
+
+        allow(EndOfCycle::SendRejectByDefaultExplainerEmailToCandidatesBatchWorker).to receive(:perform_at)
+        described_class.new.perform
+
+        expect(EndOfCycle::SendRejectByDefaultExplainerEmailToCandidatesBatchWorker)
+          .to have_received(:perform_at).with(kind_of(Time), [rejected_with_offer.id, rejected_without_offer.id])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

We want to send a message to candidates who have had applications rejected by default. We want the message to be different depending on whether or not the candidate has an offer or not.

## Changes proposed in this pull request

- [The email they will receive if they have an offer](https://apply-review-9836.test.teacherservices.cloud/rails/mailers/candidate_mailer/respond_to_offer_before_deadline)

- [The email they will receive if they do NOT have any offers](https://apply-review-9836.test.teacherservices.cloud/rails/mailers/candidate_mailer/reject_by_default_explainer)

## Guidance to review


## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
