### PR TITLE
Delete unwanted audits

### DIFF
--- a/app/services/data_migrations/delete_work_history_audits.rb
+++ b/app/services/data_migrations/delete_work_history_audits.rb
@@ -1,0 +1,24 @@
+module DataMigrations
+  class DeleteWorkHistoryAudits
+    TIMESTAMP = 20240917154444
+    MANUAL_RUN = false
+    BATCH_SIZE = 5000
+
+    def change
+      relation.in_batches(of: BATCH_SIZE) do |batch|
+        DeleteAuditsWorker.perform_async(batch.ids)
+      end
+    end
+
+    def relation
+      Audited::Audit
+        .where('created_at >= ? and created_at <= ?', DateTime.new(2024, 9, 3, 11), DateTime.new(2024, 9, 3, 20))
+        .where(user_type: nil, user_id: nil)
+        .where(action: :create)
+        .where(username: '(Automated process)')
+        .where(associated_type: 'ApplicationChoice')
+        .where(auditable_type: %w[ApplicationExperience ApplicationWorkHistoryBreak])
+        .order(id: :asc)
+    end
+  end
+end

--- a/app/workers/delete_audits_worker.rb
+++ b/app/workers/delete_audits_worker.rb
@@ -1,0 +1,8 @@
+class DeleteAuditsWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :low_priority
+
+  def perform(audit_ids)
+    Audited::Audit.where(id: audit_ids).delete_all
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -5,6 +5,7 @@ DATA_MIGRATION_SERVICES = [
   'DataMigrations::BackfillWithdrawalReasons',
   'DataMigrations::RemoveTeacherDegreeApprenticeshipFeatureFlag',
   'DataMigrations::RevertApplicationChoicesUpdatedAt',
+  'DataMigrations::DeleteWorkHistoryAudits',
   'DataMigrations::BackfillApplicationChoicesWithWorkExperiences',
   'DataMigrations::MarkUnsubmittedApplicationsWithoutEnglishProficiencyAsElfIncomplete',
   'DataMigrations::BackfillEnglishProficiencyRecordsForCarriedOverApplications',

--- a/spec/factories/audit.rb
+++ b/spec/factories/audit.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     created_at { Time.zone.now }
 
     transient do
-      application_experience { build_stubbed(:application_experience) }
+      application_experience { build_stubbed(:application_work_experience) }
       application_choice { build_stubbed(:application_choice, :awaiting_provider_decision) }
       changes { {} }
     end
@@ -18,7 +18,7 @@ FactoryBot.define do
       audit.auditable_type = 'ApplicationExperience'
       audit.auditable_id = evaluator.application_experience.id
       audit.associated = evaluator.application_choice
-      audit.user_type = evaluator.user.class.to_s
+      audit.user_type = evaluator.user.class.to_s unless evaluator.username == '(Automated process)'
       audit.audited_changes = evaluator.changes
     end
   end
@@ -40,7 +40,7 @@ FactoryBot.define do
       audit.auditable_type = 'ApplicationWorkHistoryBreak'
       audit.auditable_id = evaluator.application_work_history_break.id
       audit.associated = evaluator.application_choice
-      audit.user_type = evaluator.user.class.to_s
+      audit.user_type = evaluator.user.class.to_s unless evaluator.username == '(Automated process)'
       audit.audited_changes = evaluator.changes
     end
   end

--- a/spec/services/data_migrations/delete_work_history_audits_spec.rb
+++ b/spec/services/data_migrations/delete_work_history_audits_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::DeleteWorkHistoryAudits do
+  describe '#change' do
+    it 'enques jobs to DeleteAuditsWorker' do
+      create(
+        :application_work_history_break_audit,
+        user_type: nil,
+        user_id: nil,
+        created_at: DateTime.new(2024, 9, 3, 12),
+        action: 'create',
+        username: '(Automated process)',
+      )
+
+      expect { described_class.new.change }.to change(
+        DeleteAuditsWorker.jobs, :size
+      ).by(1)
+    end
+  end
+
+  describe '#relation' do
+    it 'returns the audits that need deleting' do
+      work_break = create(
+        :application_work_history_break_audit,
+        action: 'create',
+        user_type: nil,
+        user_id: nil,
+        username: '(Automated process)',
+        created_at: DateTime.new(2024, 9, 3, 12),
+      )
+      work_break_2 = create(
+        :application_work_history_break_audit,
+        action: 'create',
+        user_type: nil,
+        user_id: nil,
+        username: '(Automated process)',
+        created_at: DateTime.new(2024, 9, 3, 18),
+      )
+      work_experience = create(
+        :application_experience_audit,
+        action: 'create',
+        user_type: nil,
+        user_id: nil,
+        username: '(Automated process)',
+        created_at: DateTime.new(2024, 9, 3, 18),
+      )
+      work_break_with_provider_username = create(
+        :application_work_history_break_audit,
+        action: 'create',
+        username: 'Provider',
+      )
+      work_break_with_update_action = create(
+        :application_work_history_break_audit,
+        action: 'update',
+        username: '(Automated process)',
+        user_type: nil,
+        user_id: nil,
+      )
+      work_break_outside_time_range = create(
+        :application_work_history_break_audit,
+        action: 'create',
+        username: '(Automated process)',
+        user_type: nil,
+        user_id: nil,
+        created_at: DateTime.new(2024, 9, 4, 18),
+      )
+      work_break_with_provider_user_type = create(
+        :application_work_history_break_audit,
+        action: 'create',
+        username: '(Automated process)',
+        created_at: DateTime.new(2024, 9, 3, 18),
+        user_type: 'Provider',
+      )
+      work_experience_outside_time_range = create(
+        :application_experience_audit,
+        action: 'create',
+        user_type: nil,
+        user_id: nil,
+        created_at: DateTime.new(2024, 9, 4, 18),
+      )
+      application_form_audit = create(
+        :application_form_audit,
+        action: 'create',
+        user_type: nil,
+        user_id: nil,
+        username: '(Automated process)',
+        created_at: DateTime.new(2024, 9, 3, 12),
+      )
+
+      expect(described_class.new.relation).to include(work_break, work_break_2, work_experience)
+      expect(described_class.new.relation).not_to include(
+        work_break_with_provider_username,
+        work_break_with_update_action,
+        work_break_outside_time_range,
+        work_break_with_provider_user_type,
+        work_experience_outside_time_range,
+        application_form_audit,
+      )
+    end
+  end
+end

--- a/spec/workers/delete_audits_worker_spec.rb
+++ b/spec/workers/delete_audits_worker_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe DeleteAuditsWorker do
+  describe '#perform' do
+    it 'deletes audits by id' do
+      audit_1 = create(:application_work_history_break_audit)
+      audit_2 = create(:application_work_history_break_audit)
+      audit_3 = create(:application_work_history_break_audit)
+      audit_ids = [audit_1.id, audit_2.id]
+
+      described_class.new.perform(audit_ids)
+
+      expect(Audited::Audit.where(id: audit_ids)).not_to exist
+      expect(Audited::Audit.where(id: audit_3.id)).to exist
+    end
+  end
+end


### PR DESCRIPTION
## Context

By running this data migration https://github.com/DFE-Digital/apply-for-teacher-training/pull/9741 we created a lot of audit records, almost 3 million more than we should have.

Because of these audits, we think the `/provider/activity` page is unusable now. There are too many records the query for the page needs to go over.

This PR tries to remove those 3 million audits. It gets all the audits within the interval the data migration ran and deletes them.

We only intend to delete audits for `ApplicationExperience` and `ApplicationWorkHistoryBreak` that are associated with `ApplicationChoice`, these audits don't have a user attached to them and the username '(Automated process)'


Explain the query that will loop through audits and create workers, in production blazer https://www.apply-for-teacher-training.service.gov.uk/support/blazer/queries/983-delete-audits-query-explain


## Changes proposed in this pull request

Data migration

## Guidance to review

- I've run this migration on local with over 3 million records to enque with a DB of over 60 million audits, the migration did manage to enqueu all the workers and the workers were fast in doing their job.

- This will probably create over 2000 jobs for the `low_priority` queue but the jobs should finish quite quick as we are just deleting records via SQL, not Active Record

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
