### PR TITLE
Quick fix so we can run the job manually

### DIFF
--- a/app/services/candidate_interface/cancel_unsubmitted_application_at_end_of_cycle.rb
+++ b/app/services/candidate_interface/cancel_unsubmitted_application_at_end_of_cycle.rb
@@ -7,6 +7,8 @@ module CandidateInterface
     def call
       @application_form.application_choices.unsubmitted.each do |application_choice|
         ApplicationStateChange.new(application_choice).reject_at_end_of_cycle!
+      rescue ActiveRecord::RecordInvalid => e
+        Rails.logger.warn "Unable to reject application #{application_choice.id}. Error: #{e}"
       end
     end
   end

--- a/app/workers/cancel_unsubmitted_applications_worker.rb
+++ b/app/workers/cancel_unsubmitted_applications_worker.rb
@@ -1,8 +1,8 @@
 class CancelUnsubmittedApplicationsWorker
   include Sidekiq::Worker
 
-  def perform
-    return unless CycleTimetable.cancel_unsubmitted_applications?
+  def perform(force: false)
+    return unless CycleTimetable.cancel_unsubmitted_applications? || force
 
     unsubmitted_applications_from_earlier_cycle.find_each do |application_form|
       CandidateInterface::CancelUnsubmittedApplicationAtEndOfCycle.new(application_form).call


### PR DESCRIPTION
## Context

We ran a job to transition all draft applications to `application_not_sent`. Of the 19785 draft application choices, 16965 were successfully changed. An error in one application, however, stopped the job so 2820 applications are still in the draft state. We want to be able to run that job again manually so that all other applications transition state successfully.

## Changes proposed in this pull request

Just a quick fix
- add a force param so I can force the job to run today
- rescue Invalid record error so it doesn't stop the job.

I will make more robust changes to the job so that it is in better condition next year, but this is just a quick fix so we can get all the applications in the right state for this point in the cycle.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
