### PR TITLE
Fix typo on A level validation for undergraduate submissions

### DIFF
--- a/app/validators/incomplete_undergraduate_course_details_validator.rb
+++ b/app/validators/incomplete_undergraduate_course_details_validator.rb
@@ -17,7 +17,7 @@ class IncompleteUndergraduateCourseDetailsValidator < ActiveModel::EachValidator
 
   def link_to_a_levels
     govuk_link_to(
-      'Add your A level grade (or equivalent)',
+      'Add an A level (or equivalent)',
       Rails.application.routes.url_helpers.candidate_interface_other_qualification_type_path,
     )
   end

--- a/spec/services/candidate_interface/application_choice_submission_spec.rb
+++ b/spec/services/candidate_interface/application_choice_submission_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe CandidateInterface::ApplicationChoiceSubmission do
 
       def link_to_undergraduate_details_error_message
         govuk_link_to(
-          'Add your A level grade (or equivalent)',
+          'Add an A level (or equivalent)',
           routes.candidate_interface_other_qualification_type_path,
         )
       end

--- a/spec/system/candidate_interface/submitting/candidate_tries_submit_to_undergraduate_course_without_a_levels_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_tries_submit_to_undergraduate_course_without_a_levels_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe 'Candidate tries to submit undergraduate courses with no A levels
 
   def then_i_see_that_i_need_a_levels_to_apply_for_an_undergraduate_course
     expect(page).to have_content(
-      'To apply for this course, you need an A level or equivalent qualification. Add your A level grade (or equivalent) and complete the rest of your details. You can then submit your application. Your application will be saved as a draft while you finish adding your details.',
+      'To apply for this course, you need an A level or equivalent qualification. Add an A level (or equivalent) and complete the rest of your details. You can then submit your application. Your application will be saved as a draft while you finish adding your details.',
     )
   end
 


### PR DESCRIPTION
## Context

Change content on A level validation message

## Changes proposed in this pull request

![a-level](https://github.com/user-attachments/assets/2690cd12-1b3f-41b9-9a28-a466d6f306ec)

## Guidance to review

1. Change cycle switcher to 2025
2. Add no A levels under other qualifications section
3. Try to apply for an undergraduate course
4. See the new message