### PR TITLE
Make sure degree requirements row doesn't appear for undergraduate

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -158,8 +158,7 @@ module CandidateInterface
     end
 
     def degree_required_row(application_choice)
-      return if application_choice.current_course.undergraduate?
-      return unless application_choice.current_course.degree_grade?
+      return if application_choice.current_course.does_not_require_degree?
 
       {
         key: 'Degree requirements',

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -158,6 +158,7 @@ module CandidateInterface
     end
 
     def degree_required_row(application_choice)
+      return if application_choice.current_course.undergraduate?
       return unless application_choice.current_course.degree_grade?
 
       {

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -210,6 +210,10 @@ class Course < ApplicationRecord
     I18n.t('course_types.postgraduate')
   end
 
+  def does_not_require_degree?
+    undergraduate? || !degree_grade?
+  end
+
 private
 
   def touch_application_choices_and_forms

--- a/spec/components/candidate_interface/course_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_review_component_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe CandidateInterface::CourseReviewComponent do
         create(
           :course,
           :teacher_degree_apprenticeship,
-          degree_grade: 'two_one', # forcing a bad data coming from Publish
+          degree_grade: 'two_one',
         )
       end
 

--- a/spec/components/candidate_interface/course_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_review_component_spec.rb
@@ -60,4 +60,41 @@ RSpec.describe CandidateInterface::CourseReviewComponent do
       end
     end
   end
+
+  describe 'degree requirements' do
+    let(:application_choice) { create(:application_choice, course_option: create(:course_option, course:)) }
+
+    context 'when course is undergraduate' do
+      let(:course) do
+        create(
+          :course,
+          :teacher_degree_apprenticeship,
+          degree_grade: 'two_one', # forcing a bad data coming from Publish
+        )
+      end
+
+      it 'does not render row' do
+        result = render_inline(described_class.new(application_choice:))
+        expect(result.text).not_to include('Degree requirements')
+      end
+    end
+
+    context 'when course is postgraduate and degree grade is present' do
+      let(:course) { create(:course, degree_grade: 'two_one') }
+
+      it 'does render row' do
+        result = render_inline(described_class.new(application_choice:))
+        expect(result.text).to include('Degree requirements')
+      end
+    end
+
+    context 'when course is postgraduate and degree grade is blank' do
+      let(:course) { create(:course, degree_grade: nil) }
+
+      it 'does not render row' do
+        result = render_inline(described_class.new(application_choice:))
+        expect(result.text).not_to include('Degree requirements')
+      end
+    end
+  end
 end

--- a/spec/components/candidate_interface/course_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_review_component_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe CandidateInterface::CourseReviewComponent do
   describe 'degree requirements' do
     let(:application_choice) { create(:application_choice, course_option: create(:course_option, course:)) }
 
-    context 'when course is undergraduate' do
+    context 'when course is undergraduate but incorrectly has a degree_grade' do
       let(:course) do
         create(
           :course,

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -349,4 +349,35 @@ RSpec.describe Course do
       end
     end
   end
+
+  describe '#does_not_require_degree?' do
+    let(:course) { build(:course, program_type:, degree_grade:) }
+
+    context 'when the course is undergraduate' do
+      let(:program_type) { 'teacher_degree_apprenticeship' }
+      let(:degree_grade) { nil }
+
+      it 'returns true' do
+        expect(course.does_not_require_degree?).to be(true)
+      end
+    end
+
+    context 'when the course is postgraduate and does not require a degree grade' do
+      let(:program_type) { 'higher_education_programme' }
+      let(:degree_grade) { nil }
+
+      it 'returns true' do
+        expect(course.does_not_require_degree?).to be(true)
+      end
+    end
+
+    context 'when the course is postgraduate and requires a degree grade' do
+      let(:program_type) { 'higher_education_programme' }
+      let(:degree_grade) { 'two_one' }
+
+      it 'returns false' do
+        expect(course.does_not_require_degree?).to be(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

If candidate is applying for undergraduate they should not see the degree requirements row no matter how bad the data is on the course.

## Changes proposed in this pull request

<img width="586" alt="Screenshot 2024-09-18 at 15 05 28" src="https://github.com/user-attachments/assets/236a029c-27c4-4586-a19f-ddb741392a07">

## Guidance to review

1. Setup the cycle switcher to be on 2025 cycle
2. Setup. a 2025 undergraduate course (wrongly) with degree grade 
3. Apply for this course