### PR TITLE
Handle BigqueryV2 when it returns empty rows

### DIFF
--- a/app/lib/dfe/bigquery/relation.rb
+++ b/app/lib/dfe/bigquery/relation.rb
@@ -23,6 +23,10 @@ module DfE
           query_object,
         )
 
+        # If there are no results we should return early
+        # BigqueryV2 client sets rows to nil if there are no results
+        return [] if result.rows.blank?
+
         unless result.job_complete?
           raise JobIncompleteError, 'the query job did not complete for some reason'
         end

--- a/spec/lib/dfe/bigquery/application_metrics_by_provider_spec.rb
+++ b/spec/lib/dfe/bigquery/application_metrics_by_provider_spec.rb
@@ -289,6 +289,24 @@ RSpec.describe DfE::Bigquery::ApplicationMetricsByProvider do
     end
   end
 
+  describe 'when the query returns nil for rows' do
+    subject(:national_statistics) do
+      described_class.new(cycle_week: 18).national_data
+    end
+
+    let(:stub_bigquery_response) do
+      stub_bigquery_application_metrics_by_provider_request(result: false)
+    end
+
+    before do
+      stub_bigquery_response
+    end
+
+    it 'fails silently' do
+      national_statistics
+    end
+  end
+
   describe 'when there is an error' do
     subject(:provider_statistics) do
       described_class.new(cycle_week: 7).provider_data

--- a/spec/lib/dfe/bigquery/application_metrics_spec.rb
+++ b/spec/lib/dfe/bigquery/application_metrics_spec.rb
@@ -1,16 +1,19 @@
 require 'rails_helper'
 
-RSpec.describe DfE::Bigquery::ApplicationMetrics do
+RSpec.describe DfE::Bigquery::ApplicationMetrics, time: Time.zone.local(2023, 11, 20) do
   include DfE::Bigquery::TestHelper
 
-  before do
-    set_time(Time.zone.local(2023, 11, 20))
+  let(:stub_bigquery_response) do
     stub_bigquery_application_metrics_request(rows: [[
       { name: 'cycle_week', type: 'INTEGER', value: '7' },
       { name: 'number_of_candidates_submitted_to_date', type: 'INTEGER', value: '100' },
       { name: 'first_date_in_week', type: 'DATE', value: '2024-03-18' },
       { name: 'subject_filter', type: 'INTEGER', value: nil },
     ]])
+  end
+
+  before do
+    stub_bigquery_response
   end
 
   describe '.candidate_headline_statistics' do
@@ -67,12 +70,16 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
       ]
     end
 
-    before do
+    let(:stub_bigquery_response) do
       stub_bigquery_application_metrics_request(rows: [[
         { name: 'cycle_week', type: 'INTEGER', value: '7' },
         { name: 'nonsubject_filter', type: 'STRING', value: '25 to 29' },
         { name: 'number_of_candidates_submitted_to_date', type: 'INTEGER', value: '100' },
       ]])
+    end
+
+    before do
+      stub_bigquery_response
     end
 
     it 'provides the correct SQL' do
@@ -133,7 +140,7 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
       ]
     end
 
-    before do
+    let(:stub_bigquery_response) do
       stub_bigquery_application_metrics_request(rows: [
         [
           { name: 'nonsubject_filter', type: 'STRING', value: 'Male' },
@@ -152,6 +159,10 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
           { name: 'cycle_week', type: 'INTEGER', value: '7' },
         ],
       ])
+    end
+
+    before do
+      stub_bigquery_response
     end
 
     it 'returns the correct results' do
@@ -203,7 +214,7 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
       ]
     end
 
-    before do
+    let(:stub_bigquery_response) do
       stub_bigquery_application_metrics_request(rows: [
         [
           { name: 'nonsubject_filter', type: 'STRING', value: 'London' },
@@ -214,6 +225,10 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
           { name: 'cycle_week', type: 'INTEGER', value: '7' },
         ],
       ])
+    end
+
+    before do
+      stub_bigquery_response
     end
 
     it 'returns the correct results' do
@@ -265,7 +280,7 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
       ]
     end
 
-    before do
+    let(:stub_bigquery_response) do
       stub_bigquery_application_metrics_request(rows: [
         [
           { name: 'subject_filter', type: 'STRING', value: 'Primary' },
@@ -276,6 +291,10 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
           { name: 'cycle_week', type: 'INTEGER', value: '7' },
         ],
       ])
+    end
+
+    before do
+      stub_bigquery_response
     end
 
     it 'returns the correct results' do
@@ -329,7 +348,7 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
       ]
     end
 
-    before do
+    let(:stub_bigquery_response) do
       stub_bigquery_application_metrics_request(rows: [
         [
           { name: 'nonsubject_filter', type: 'STRING', value: 'Postgraduate teaching apprenticeship' },
@@ -340,6 +359,10 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
           { name: 'cycle_week', type: 'INTEGER', value: '7' },
         ],
       ])
+    end
+
+    before do
+      stub_bigquery_response
     end
 
     it 'returns the correct results' do
@@ -392,7 +415,7 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
       ]
     end
 
-    before do
+    let(:stub_bigquery_response) do
       stub_bigquery_application_metrics_request(rows: [
         [
           { name: 'subject_filter', type: 'STRING', value: 'Primary with English' },
@@ -403,6 +426,10 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
           { name: 'cycle_week', type: 'INTEGER', value: '7' },
         ],
       ])
+    end
+
+    before do
+      stub_bigquery_response
     end
 
     it 'returns the correct results' do
@@ -455,7 +482,7 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
       ]
     end
 
-    before do
+    let(:stub_bigquery_response) do
       stub_bigquery_application_metrics_request(rows: [
         [
           { name: 'subject_filter', type: 'STRING', value: 'Magic tricks' },
@@ -466,6 +493,10 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
           { name: 'cycle_week', type: 'INTEGER', value: '7' },
         ],
       ])
+    end
+
+    before do
+      stub_bigquery_response
     end
 
     it 'returns the correct results' do
@@ -518,7 +549,7 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
       ]
     end
 
-    before do
+    let(:stub_bigquery_response) do
       stub_bigquery_application_metrics_request(rows: [
         [
           { name: 'nonsubject_filter', type: 'STRING', value: 'Gondor' },
@@ -529,6 +560,10 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
           { name: 'cycle_week', type: 'INTEGER', value: '7' },
         ],
       ])
+    end
+
+    before do
+      stub_bigquery_response
     end
 
     it 'returns the correct results' do
@@ -560,6 +595,24 @@ RSpec.describe DfE::Bigquery::ApplicationMetrics do
       expect(application_metrics.first.cycle_week).to eq 7
       expect(application_metrics.first.nonsubject_filter).to eq('Gondor')
       expect(application_metrics.last.nonsubject_filter).to eq('Mordor')
+    end
+  end
+
+  describe 'when the query returns nil for rows' do
+    let(:stub_bigquery_response) do
+      stub_bigquery_application_metrics_request(result: false)
+    end
+
+    before do
+      stub_bigquery_response
+    end
+
+    subject(:application_metrics) do
+      described_class.new(cycle_week: 7).candidate_headline_statistics
+    end
+
+    it 'fails silently' do
+      application_metrics
     end
   end
 

--- a/spec/support/bigquery_stubs.rb
+++ b/spec/support/bigquery_stubs.rb
@@ -2,7 +2,7 @@ module BigqueryStubs
   def stub_response(rows: nil, job_complete: true, page_token: nil)
     default_rows = [
       [
-        { name: 'cycle_week', type: 'INTEGER', value: '7' },
+        { name: 'cycle_week',                             type: 'INTEGER', value: '7' },
         { name: 'number_of_candidates_submitted_to_date', type: 'INTEGER', value: '100' },
         { name: 'nonsubject_filter_category',             type: 'STRING',  value: 'Provider name' },
         { name: 'first_date_in_week',                     type: 'DATE',    value: '2024-03-18' },

--- a/spec/support/bigquery_stubs.rb
+++ b/spec/support/bigquery_stubs.rb
@@ -1,5 +1,8 @@
 module BigqueryStubs
-  def stub_response(rows: nil, job_complete: true, page_token: nil)
+  # Makes #instance_double available to module method
+  extend RSpec::Mocks::ExampleMethods
+
+  def stub_response(rows: nil, job_complete: true, page_token: nil, result: true)
     default_rows = [
       [
         { name: 'cycle_week',                             type: 'INTEGER', value: '7' },
@@ -16,13 +19,15 @@ module BigqueryStubs
       Google::Apis::BigqueryV2::TableFieldSchema.new(name: cell[:name], type: cell[:type], mode: 'NULLABLE')
     end
 
-    processed_rows = rows.map do |row|
-      processed_row = row.map do |cell|
-        Google::Apis::BigqueryV2::TableCell.new(v: cell[:value])
-      end
+    processed_rows = if result
+                       rows.map do |row|
+                         processed_row = row.map do |cell|
+                           Google::Apis::BigqueryV2::TableCell.new(v: cell[:value])
+                         end
 
-      Google::Apis::BigqueryV2::TableRow.new(f: processed_row)
-    end
+                         Google::Apis::BigqueryV2::TableRow.new(f: processed_row)
+                       end
+                     end
 
     schema = Google::Apis::BigqueryV2::TableSchema.new(fields:)
 

--- a/spec/support/bigquery_stubs.rb
+++ b/spec/support/bigquery_stubs.rb
@@ -2,7 +2,7 @@ module BigqueryStubs
   # Makes #instance_double available to module method
   extend RSpec::Mocks::ExampleMethods
 
-  def stub_response(rows: nil, job_complete: true, page_token: nil, result: true)
+  def self.stub_response(rows: nil, job_complete: true, page_token: nil, result: true)
     default_rows = [
       [
         { name: 'cycle_week',                             type: 'INTEGER', value: '7' },

--- a/spec/support/test_helper.rb
+++ b/spec/support/test_helper.rb
@@ -1,24 +1,32 @@
 module DfE
   module Bigquery
     module TestHelper
-      include ::BigqueryStubs
-
-      def stub_bigquery_application_metrics_request(rows: nil, job_complete: true, page_token: nil)
+      def stub_bigquery_application_metrics_request(rows: nil, job_complete: true, page_token: nil, result: true)
         bigquery_client = instance_double(Google::Apis::BigqueryV2::BigqueryService)
         allow(DfE::Bigquery).to receive(:client).and_return(bigquery_client)
-        allow(bigquery_client).to receive(:query_job).and_return(stubbed_bigquery_application_metrics_response(rows:, job_complete:, page_token:))
+        allow(bigquery_client).to receive(:query_job).and_return(stubbed_bigquery_application_metrics_response(rows:, job_complete:, page_token:, result:))
       end
 
-      def stub_bigquery_application_metrics_by_provider_request(rows: nil, job_complete: true, page_token: nil)
+      def stub_bigquery_application_metrics_by_provider_request(rows: nil, job_complete: true, page_token: nil, result: true)
         bigquery_client = instance_double(Google::Apis::BigqueryV2::BigqueryService)
         allow(DfE::Bigquery).to receive(:client).and_return(bigquery_client)
-        allow(bigquery_client).to receive(:query_job).and_return(stubbed_bigquery_application_metrics_by_provider_response(rows:, job_complete:, page_token:))
+        allow(bigquery_client).to receive(:query_job).and_return(stubbed_bigquery_application_metrics_by_provider_response(rows:, job_complete:, page_token:, result:))
       end
 
-      def stubbed_bigquery_application_metrics_response(rows: nil, job_complete: nil, page_token: nil)
-        return stub_response(rows:, job_complete:, page_token:) if rows
+      # @param row [nil|Row|'nil']
+      #   When nil, it returns a default response
+      #   When Row it returns the values defined in the Row
+      #   When 'nil' it returns literal nil
+      # @param job_complete [Boolean] Is the response populated with the query result?
+      # @param page_token [String] If present, there is a next page that must be fetched
+      # @param result [Boolean] Does the response return values?
+      #
+      def stubbed_bigquery_application_metrics_response(rows: nil, job_complete: nil, page_token: nil, result: true)
+        return BigqueryStubs.stub_response(rows:, job_complete:, page_token:, result:) unless result
 
-        stub_response(rows: [[
+        return BigqueryStubs.stub_response(rows:, job_complete:, page_token:, result:) if rows
+
+        BigqueryStubs.stub_response(rows: [[
           { name: 'cycle_week', type: 'INTEGER', value: '7' },
           { name: 'first_date_in_week', type: 'DATE', value: '2023-11-13' },
           { name: 'last_date_in_week', type: 'DATE', value: '2023-11-19' },
@@ -39,13 +47,13 @@ module DfE
           { name: 'number_of_candidates_with_reconfirmed_offers_deferred_from_previous_cycle_to_same_date_previous_cycle', type: 'INTEGER', value: '213' },
           { name: 'number_of_candidates_accepted_to_date', type: 'INTEGER', value: '20' },
           { name: 'number_of_candidates_accepted_to_same_date_previous_cycle', type: 'INTEGER', value: '10' },
-        ]], job_complete:, page_token:)
+        ]], job_complete:, page_token:, result:)
       end
 
-      def stubbed_bigquery_application_metrics_by_provider_response(rows: nil, job_complete: nil, page_token: nil)
-        return stub_response(rows:) if rows
+      def stubbed_bigquery_application_metrics_by_provider_response(rows: nil, job_complete: nil, page_token: nil, result: true)
+        return BigqueryStubs.stub_response(rows:, result:) if rows
 
-        stub_response(rows: [[
+        BigqueryStubs.stub_response(rows: [[
           { name: 'id', type: 'INTEGER', value: '1337' },
           { name: 'cycle_week', type: 'INTEGER', value: '18' },
           { name: 'recruitment_cycle_year', type: 'INTEGER', value: '2024' },
@@ -70,7 +78,7 @@ module DfE
           { name: 'number_of_candidates_who_had_all_applications_rejected_this_cycle_to_date_as_proportion_of_last_cycle', type: 'INTEGER', value: '0' },
           { name: 'number_of_candidates_who_had_an_inactive_application_this_cycle_to_date', type: 'INTEGER', value: '12' },
           { name: 'number_of_candidates_who_had_an_inactive_application_this_cycle_to_date_as_proportion_of_submitted_candidates', type: 'INTEGER', value: '12' },
-        ]], job_complete:, page_token:)
+        ]], job_complete:, page_token:, result:)
       end
     end
   end


### PR DESCRIPTION
## Context

1. We need to handle the case where a request to Bigquery V2 returns nil for the rows property.
2. On QA, we will make a lot of calls to create reports for provider whose ids do not appear in BigQuery. We should also disable the report generation on QA for this reason.
3. A final recommendation is that we make changes to the BigQuery implementation so that we fetch by provider code rather than provider id. This would make the report generation work in all environments.


## Changes proposed in this pull request

Return an empty array to represent the rows of a BigqueryV2 response when there are no rows returned by the client. This is done because the client `#rows` is nil otherwise and we want to be able to iterate over the `rows` value.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
