### PR TITLE
Make sure you can't offer SKE to undergraduate candidates

### DIFF
--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -151,7 +151,11 @@ module ProviderInterface
     end
 
     def ske_required?
-      language_course? || ske_standard_course? || Array(ske_conditions).any?
+      !undergraduate_course? && (language_course? || ske_standard_course? || Array(ske_conditions).any?)
+    end
+
+    def undergraduate_course?
+      course_option&.course&.undergraduate?
     end
 
     def language_course?

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -329,6 +329,26 @@ RSpec.describe ProviderInterface::OfferWizard do
         end
       end
 
+      context 'when course is undergraduate and current step is :select_option' do
+        let(:current_step) { :select_option }
+        let(:course) do
+          create(
+            :course,
+            :teacher_degree_apprenticeship,
+            subjects: [build(:subject, code: '15', name: 'Portuguese')],
+          )
+        end
+        let(:application_choice) do
+          create(:application_choice, course_option: create(:course_option, course:))
+        end
+        let(:application_choice_id) { application_choice.id }
+        let(:course_option_id) { application_choice.course_option.id }
+
+        it 'returns :conditions' do
+          expect(wizard.next_step).to eq(:conditions)
+        end
+      end
+
       context 'when a ske condition is required' do
         let(:ske_conditions) { [SkeCondition.new] }
 

--- a/spec/system/provider_interface/make_offer_for_undergraduate_application_spec.rb
+++ b/spec/system/provider_interface/make_offer_for_undergraduate_application_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Provider makes an offer with SKE enabled in standard courses' do
+RSpec.describe 'Provider makes an offer on undergraduate applications' do
   include DfESignInHelpers
   include ProviderUserPermissionsHelper
   include OfferStepsHelper

--- a/spec/system/provider_interface/make_offer_for_undergraduate_application_spec.rb
+++ b/spec/system/provider_interface/make_offer_for_undergraduate_application_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe 'Provider makes an offer with SKE enabled in standard courses' do
+  include DfESignInHelpers
+  include ProviderUserPermissionsHelper
+  include OfferStepsHelper
+  let(:provider) { @provider }
+  let(:ratifying_provider) { @provider }
+  let(:provider_user) { @provider_user }
+  let(:application_choice) { @application_choice }
+
+  scenario 'Making an offer for the requested course option' do
+    given_there_is_an_undergraduate_application
+    and_the_course_subject_requires_ske
+    and_i_am_a_provider_user
+    and_i_am_permitted_to_make_decisions_for_my_provider
+    and_i_sign_in_to_the_provider_interface
+
+    and_the_provider_user_can_offer_multiple_provider_courses
+    when_i_visit_the_provider_interface
+    and_i_click_an_application_choice_awaiting_decision
+    and_i_click_on_make_decision
+    then_i_see_the_decision_page
+
+    when_i_choose_to_make_an_offer
+    then_the_ske_questions_are_skipped
+    then_the_conditions_page_is_loaded
+    and_the_default_conditions_are_checked
+
+    when_i_add_further_conditions
+    and_i_add_and_remove_another_condition
+    and_i_click_continue
+    then_the_review_page_is_loaded
+    and_i_can_confirm_my_answers
+
+    when_i_send_the_offer
+    then_i_see_that_the_offer_was_successfuly_made
+  end
+
+  def given_there_is_an_undergraduate_application
+    @provider_user = create(:provider_user, :with_dfe_sign_in)
+    @provider = @provider_user.providers.first
+    @ratifying_provider = create(:provider)
+    course = build(:course, :teacher_degree_apprenticeship, provider: @provider, accredited_provider: @ratifying_provider)
+    course_option = build(:course_option, course:)
+    @application_choice = create(:application_choice, :awaiting_provider_decision, course_option:)
+  end
+
+  def and_the_course_subject_requires_ske
+    @application_choice.course_option.course.subjects.delete_all
+    @application_choice.course_option.course.subjects << build(
+      :subject, code: 'F1', name: 'Chemistry'
+    )
+  end
+
+  def and_i_am_a_provider_user
+    user_exists_in_dfe_sign_in(email_address: @provider_user.email_address)
+  end
+
+  def and_the_provider_user_can_offer_multiple_provider_courses
+    create(
+      :provider_relationship_permissions,
+      training_provider: @provider,
+      ratifying_provider: @ratifying_provider,
+      ratifying_provider_can_make_decisions: true,
+    )
+  end
+
+  def then_the_ske_questions_are_skipped
+    expect(page).to have_no_content('SKE')
+  end
+end


### PR DESCRIPTION
## Context

When candidates applying for a undergraduate courses, the provider should not have the option to make a offer with SKE.

The Make Offer - SKE condition page shouldn’t be shown to Manage User when making an offer for an undergraduate course.

## Changes proposed in this pull request

SKE condition page isn’t shown to Providers when making an offer for Undergraduate course.
Page still does appear for Postgraduate courses.

## Guidance to review

There is [one application to an undergraduate course in review app that has one a subject that shows SKE - only when is postgraduate](https://apply-review-9849.test.teacherservices.cloud/support/applications/49)

1. Login via support
2. [Sign in on provider interface](https://apply-review-9849.test.teacherservices.cloud/support/providers/16/users)
3. [Enter the application on provider interface](https://apply-review-9849.test.teacherservices.cloud/provider/applications/89)
4. [Make an offer](https://apply-review-9849.test.teacherservices.cloud/provider/applications/89/decision/new)
5. SKE should not be shown
