### PR TITLE
Set attachments in monkey patch

### DIFF
--- a/config/initializers/mailer_previews.rb
+++ b/config/initializers/mailer_previews.rb
@@ -2,9 +2,16 @@ ActiveSupport.on_load(:action_controller, run_once: true) do
   Rails::MailersController.class_eval do
     include Rails.application.routes.url_helpers
 
+    before_action :set_attachments
+
     around_action :rollback_changes, only: :preview
 
   private
+
+    def set_attachments
+      @attachments = []
+      @inline_attachments = []
+    end
 
     def rollback_changes
       exception_during_preview = nil


### PR DESCRIPTION
## Context

Our email previews have stopped working with the upgrade to rails 7.2.1 because of a change in the email.html.erb template used for previews.

Here is why: https://github.com/rails/rails/commit/ff2e38ccc53c202dbc4b16956dd1adc30c94b450#diff-6ef9a11b479045afc41cc65c9877a1da41172535b8261a49920182b03fbff9fe

## Changes proposed in this pull request

In the previous version, attachments could be nil, but alas no longer. So I've set attachments in our monkey patch.

I did attempt to [re-instate this fix](https://github.com/DFE-Digital/apply-for-teacher-training/pull/9386) from the previews being broken in the past, but I'm afraid it didn't work.  

## Guidance to review

Go [here](https://apply-review-9850.test.teacherservices.cloud/rails/mailers) and make sure mailers render.

I don't love this solution, so if anyone has any other ideas to test out, glad to hear suggestions. 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
