### PR TITLE
Update the offer email to include "mandatory checks" information

### DIFF
--- a/app/views/candidate_mailer/new_offer_made.text.erb
+++ b/app/views/candidate_mailer/new_offer_made.text.erb
@@ -8,10 +8,18 @@ Congratulations! You have an offer from <%= @provider_name %> to study <%= @cour
  - <%= condition.text %>
 <% end %>
 
-Contact <%= @provider_name %> if you have any questions about this.
-
 <% if @show_deadline_reminder %>
   If you want to accept this offer, you must do so by <%= I18n.l(CycleTimetable.decline_by_default_date.to_date, format: :no_year) %>. If you have not responded by then, the offer will be automatically declined on your behalf.
 <% end %>
+
+You will have to pass essential checks before you can start your training.
+
+These are:
+  - An enhanced disclosure and barring service (DBS) check. This is a criminal records check to make sure it is safe for you to work with children. If you are from outside of the UK and Ireland then the training provider will request a criminal records check from your home country.
+  - A fitness to train to teach check. These are questions to check your ability to meet teaching standards, both physically and mentally.
+
+The training provider will usually pay for the criminal records checks.
+
+Contact <%= @provider_name %> if you have any questions about this.
 
 [Sign into your account to respond to your offer](<%= candidate_magic_link(@application_form.candidate) %>).

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -670,7 +670,9 @@ RSpec.describe CandidateMailer do
       )]
     end
 
-    it 'renders deadline reminder text' do
+    it 'renders essential checks and deadline reminder text' do
+      expect(email.body).to include 'An enhanced disclosure and barring service (DBS) check. This is a criminal records check to make sure it is safe for you to work with children. If you are from outside of the UK and Ireland then the training provider will request a criminal records check from your home country.'
+      expect(email.body).to include 'A fitness to train to teach check. These are questions to check your ability to meet teaching standards, both physically and mentally.'
       expect(email.body).to include "If you want to accept this offer, you must do so by #{I18n.l(CycleTimetable.decline_by_default_date.to_date, format: :no_year)}. If you have not responded by then, the offer will be automatically declined on your behalf."
     end
   end


### PR DESCRIPTION
## Context

We have removed the ‘other requirements’ field from Publish and Find but we still need to tell candidates about the mandatory checks that they need to pass before they can accept an offer.

One place we can include this information is the email a candidate receives when they receive an offer.

## Changes proposed in this pull request

Update content for the `/rails/mailers/candidate_mailer/new_offer_made` email

## Guidance to review

Review screenshot below
![Screenshot 2024-09-23 at 07 40 57](https://github.com/user-attachments/assets/903c76d6-ea77-414b-b8ec-468b606b4653)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
