### PR TITLE
Revert "Updates the Redis cache to C3 (6G)"

### DIFF
--- a/terraform/aks/workspace_variables/production_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/production_aks.tfvars.json
@@ -21,7 +21,7 @@
   "redis_queue_family": "P",
   "redis_queue_capacity": 1,
   "redis_queue_sku_name": "Premium",
-  "redis_cache_capacity": 3,
+  "redis_cache_capacity": 2,
   "postgres_enable_high_availability": true,
   "postgres_flexible_server_storage_mb": 131072,
   "enable_alerting": true,


### PR DESCRIPTION
Reverts DFE-Digital/apply-for-teacher-training#9800

Our memory usage has stabilised below 500mb since we introduced changes to our caching mechanism in #9805 
<img width="916" alt="Screenshot 2024-09-23 at 10 12 56" src="https://github.com/user-attachments/assets/08b0669d-f564-4b73-99b5-41bcedc79110">
