### PR TITLE
Change updated at of application choices

### DIFF
--- a/app/services/data_migrations/revert_application_choices_updated_at.rb
+++ b/app/services/data_migrations/revert_application_choices_updated_at.rb
@@ -1,0 +1,26 @@
+module DataMigrations
+  class RevertApplicationChoicesUpdatedAt
+    TIMESTAMP = 20240923111225
+    MANUAL_RUN = true
+
+    def change(limit: nil, provider_ids: [], stagger_over: 5)
+      BatchDelivery.new(relation: choices(limit, provider_ids), stagger_over: stagger_over.hours, batch_size: 1000).each do |next_batch_time, choices|
+        RevertApplicationChoicesUpdatedAtWorker.perform_at(next_batch_time, choices.pluck(:id))
+      end
+    end
+
+    def choices(limit, provider_ids)
+      choices = ApplicationChoice
+        .where(updated_at: Date.new(2024, 9, 3).all_day)
+        .where.not(created_at: Date.new(2024, 9, 3).all_day)
+        .where(current_recruitment_cycle_year: [2024, 2023])
+        .where(status: ApplicationStateChange.states_visible_to_provider)
+
+      if provider_ids.present?
+        choices = choices.where(provider_ids:)
+      end
+
+      choices.limit(limit)
+    end
+  end
+end

--- a/app/workers/revert_application_choices_updated_at_worker.rb
+++ b/app/workers/revert_application_choices_updated_at_worker.rb
@@ -1,0 +1,49 @@
+class RevertApplicationChoicesUpdatedAtWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :low_priority
+
+  def perform(choice_ids)
+    choices_to_update = {}
+    timestamps = {}
+
+    ApplicationChoice.where(id: choice_ids).find_each(batch_size: 100) do |choice|
+      audits = choice.own_and_associated_audits.order(:created_at)
+      touch_audits, user_audits = audits.partition do |audit|
+        audit.created_at.between?(Time.zone.parse('2024-9-3 10:00'), Time.zone.parse('2024-9-3 20:00')) &&
+          audit.user_type.nil? &&
+          audit.user_id.nil? &&
+          audit.action == 'create' &&
+          audit.username == '(Automated process)' &&
+          %w[ApplicationExperience ApplicationWorkHistoryBreak].include?(audit.auditable_type) &&
+          audit.associated_type = 'ApplicationChoice'
+      end
+
+      next if touch_audits.blank?
+
+      last_created_user_audit = user_audits.first.created_at
+      last_created_touch_audit = touch_audits.first.created_at
+
+      if last_created_user_audit.before?(last_created_touch_audit) && choice.updated_at < last_created_touch_audit + 10.seconds
+        choices_to_update[choice.id] = choice
+        timestamps[choice.id] = last_created_user_audit
+      end
+    end
+
+    ActiveRecord::Base.transaction do
+      choices_to_update.each do |id, choice|
+        choice.update_columns(updated_at: timestamps[id])
+      end
+    end
+
+    log("Updated choice ids: #{choices_to_update.keys}")
+  end
+
+private
+
+  def log(message)
+    Rails.logger.tagged('Big Touch Fix') do
+      Rails.logger.info(message)
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RevertApplicationChoicesUpdatedAt',
   'DataMigrations::BackfillApplicationChoicesWithWorkExperiences',
   'DataMigrations::MarkUnsubmittedApplicationsWithoutEnglishProficiencyAsElfIncomplete',
   'DataMigrations::BackfillEnglishProficiencyRecordsForCarriedOverApplications',

--- a/spec/services/data_migrations/revert_application_choices_updated_at_spec.rb
+++ b/spec/services/data_migrations/revert_application_choices_updated_at_spec.rb
@@ -1,0 +1,194 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RevertApplicationChoicesUpdatedAt do
+  describe '#change' do
+    it 'enques jobs to RevertApplicationChoicesUpdatedAtWorker' do
+      create(
+        :application_choice,
+        updated_at: Time.zone.parse('2024-9-3 13:00'),
+        created_at: Time.zone.parse('2024-8-1'),
+        status: :awaiting_provider_decision,
+        current_recruitment_cycle_year: 2024,
+      )
+
+      expect { described_class.new.change }.to change(
+        RevertApplicationChoicesUpdatedAtWorker.jobs, :size
+      ).by(1)
+    end
+
+    context 'with limit' do
+      it 'enques jobs to RevertApplicationChoicesUpdatedAtWorker' do
+        create(
+          :application_choice,
+          updated_at: Time.zone.parse('2024-9-3 13:00'),
+          created_at: Time.zone.parse('2024-8-1'),
+          status: :awaiting_provider_decision,
+          current_recruitment_cycle_year: 2024,
+        )
+
+        expect { described_class.new.change(limit: 20) }.to change(
+          RevertApplicationChoicesUpdatedAtWorker.jobs, :size
+        ).by(1)
+      end
+    end
+
+    context 'with limit and provider_ids' do
+      it 'enques jobs to RevertApplicationChoicesUpdatedAtWorker' do
+        choice = create(
+          :application_choice,
+          updated_at: Time.zone.parse('2024-9-3 13:00'),
+          created_at: Time.zone.parse('2024-8-1'),
+          status: :awaiting_provider_decision,
+          current_recruitment_cycle_year: 2024,
+        )
+
+        expect { described_class.new.change(limit: 20, provider_ids: choice.provider_ids) }.to change(
+          RevertApplicationChoicesUpdatedAtWorker.jobs, :size
+        ).by(1)
+      end
+    end
+
+    context 'with limit, provider_ids and stagger_over' do
+      it 'enques jobs to RevertApplicationChoicesUpdatedAtWorker' do
+        choice = create(
+          :application_choice,
+          updated_at: Time.zone.parse('2024-9-3 13:00'),
+          created_at: Time.zone.parse('2024-8-1'),
+          status: :awaiting_provider_decision,
+          current_recruitment_cycle_year: 2024,
+        )
+
+        expect { described_class.new.change(limit: 20, provider_ids: choice.provider_ids, stagger_over: 2) }.to change(
+          RevertApplicationChoicesUpdatedAtWorker.jobs, :size
+        ).by(1)
+      end
+    end
+  end
+
+  describe '#choices' do
+    it 'returns the application choices that need updating' do
+      provider = create(:provider)
+      correct_choice_2024 = create(
+        :application_choice,
+        updated_at: Time.zone.parse('2024-9-3 13:00'),
+        created_at: Time.zone.parse('2024-8-1'),
+        status: :awaiting_provider_decision,
+        current_recruitment_cycle_year: 2024,
+        provider_ids: [provider.id],
+      )
+      correct_choice_2023 = create(
+        :application_choice,
+        updated_at: Time.zone.parse('2024-9-3 13:00'),
+        created_at: Time.zone.parse('2024-8-1'),
+        status: :awaiting_provider_decision,
+        current_recruitment_cycle_year: 2023,
+        provider_ids: [provider.id],
+      )
+      choice_with_wrong_updated_at = create(
+        :application_choice,
+        updated_at: Time.zone.parse('2024-9-4 13:00'),
+        created_at: Time.zone.parse('2024-8-1'),
+        status: :awaiting_provider_decision,
+        current_recruitment_cycle_year: 2024,
+        provider_ids: [provider.id],
+      )
+      choice_with_wrong_created_at = create(
+        :application_choice,
+        updated_at: Time.zone.parse('2024-9-3 13:00'),
+        created_at: Time.zone.parse('2024-9-3 13:00'),
+        status: :awaiting_provider_decision,
+        current_recruitment_cycle_year: 2024,
+        provider_ids: [provider.id],
+      )
+      choice_with_wrong_status = create(
+        :application_choice,
+        updated_at: Time.zone.parse('2024-9-3 13:00'),
+        created_at: Time.zone.parse('2024-8-1'),
+        status: :unsubmitted,
+        current_recruitment_cycle_year: 2024,
+        provider_ids: [provider.id],
+      )
+      choice_with_wrong_recruitment_cycle = create(
+        :application_choice,
+        updated_at: Time.zone.parse('2024-9-3 13:00'),
+        created_at: Time.zone.parse('2024-8-1'),
+        status: :awaiting_provider_decision,
+        current_recruitment_cycle_year: 2022,
+        provider_ids: [provider.id],
+      )
+
+      choices = described_class.new.choices(100, [provider.id])
+
+      expect(choices).to include(
+        correct_choice_2024,
+        correct_choice_2023,
+      )
+
+      expect(choices).not_to include(
+        choice_with_wrong_updated_at,
+        choice_with_wrong_created_at,
+        choice_with_wrong_status,
+        choice_with_wrong_recruitment_cycle,
+      )
+    end
+
+    it 'returns the application choices with limit' do
+      provider = create(:provider)
+      choice_2024 = create(
+        :application_choice,
+        updated_at: Time.zone.parse('2024-9-3 13:00'),
+        created_at: Time.zone.parse('2024-8-1'),
+        status: :awaiting_provider_decision,
+        current_recruitment_cycle_year: 2024,
+        provider_ids: [provider.id],
+      )
+      choice_2023 = create(
+        :application_choice,
+        updated_at: Time.zone.parse('2024-9-3 13:00'),
+        created_at: Time.zone.parse('2024-8-1'),
+        status: :awaiting_provider_decision,
+        current_recruitment_cycle_year: 2023,
+        provider_ids: [provider.id],
+      )
+
+      choices = described_class.new.choices(1, [provider.id])
+
+      expect(choices).to include(choice_2024)
+      expect(choices).not_to include(choice_2023)
+    end
+
+    it 'returns the application choices with specific providers' do
+      provider_1 = create(:provider)
+      provider_2 = create(:provider)
+      choice_2024 = create(
+        :application_choice,
+        updated_at: Time.zone.parse('2024-9-3 13:00'),
+        created_at: Time.zone.parse('2024-8-1'),
+        status: :awaiting_provider_decision,
+        current_recruitment_cycle_year: 2024,
+        provider_ids: [provider_1.id, provider_2.id],
+      )
+      choice_2023 = create(
+        :application_choice,
+        updated_at: Time.zone.parse('2024-9-3 13:00'),
+        created_at: Time.zone.parse('2024-8-1'),
+        status: :awaiting_provider_decision,
+        current_recruitment_cycle_year: 2023,
+        provider_ids: [provider_1.id, provider_2.id],
+      )
+      choice_with_wrong_provider_combination = create(
+        :application_choice,
+        updated_at: Time.zone.parse('2024-9-3 13:00'),
+        created_at: Time.zone.parse('2024-8-1'),
+        status: :awaiting_provider_decision,
+        current_recruitment_cycle_year: 2023,
+        provider_ids: [provider_1],
+      )
+
+      choices = described_class.new.choices(100, [provider_1.id, provider_2.id])
+
+      expect(choices).to include(choice_2024, choice_2023)
+      expect(choices).not_to include(choice_with_wrong_provider_combination)
+    end
+  end
+end

--- a/spec/support/audited.rb
+++ b/spec/support/audited.rb
@@ -1,9 +1,18 @@
 Audited.auditing_enabled = false
+AUDIT_USER_NAME = '(Automated process)'.freeze
 
 RSpec.configure do |config|
   config.around(:each, :with_audited) do |example|
     Audited.auditing_enabled = true
-    example.run
+
+    if example.metadata.keys.include?(:audited_automatic_process)
+      Audited.audit_class.as_user(AUDIT_USER_NAME) do
+        example.run
+      end
+    else
+      example.run
+    end
+
     Audited.auditing_enabled = false
   end
 end

--- a/spec/workers/revert_application_choices_updated_at_worker_spec.rb
+++ b/spec/workers/revert_application_choices_updated_at_worker_spec.rb
@@ -1,0 +1,169 @@
+require 'rails_helper'
+
+RSpec.describe RevertApplicationChoicesUpdatedAtWorker, :audited_automatic_process do
+  before do
+    TestSuiteTimeMachine.unfreeze!
+  end
+
+  describe '#perform' do
+    it 'updates the application_choices that have been touched by the big touch', :with_audited do
+      correct_choice = nil
+      choice_with_wrong_audit = nil
+      august = Time.zone.parse('2024-8-1')
+
+      TestSuiteTimeMachine.travel_temporarily_to(august) do
+        application_form = create(:completed_application_form)
+        correct_choice = create(:application_choice, application_form:)
+        choice_with_wrong_audit = create(:application_choice, application_form:)
+      end
+
+      september = Time.zone.parse('2024-9-3 16:00')
+      TestSuiteTimeMachine.travel_temporarily_to(september) do
+        create(
+          :application_work_experience,
+          experienceable: correct_choice,
+        )
+      end
+      create(
+        :application_work_experience,
+        experienceable: choice_with_wrong_audit,
+      )
+      choices = [correct_choice.id, choice_with_wrong_audit.id]
+
+      allow(Rails.logger).to receive(:info)
+
+      expect {
+        described_class.new.perform(choices)
+      }.to not_change(choice_with_wrong_audit.reload, :updated_at)
+      .and not_change(correct_choice.reload.own_and_associated_audits, :count)
+      .and not_change(correct_choice.application_form.reload, :updated_at)
+      .and not_change(correct_choice.application_form.candidate, :updated_at)
+
+      expect(correct_choice.reload.updated_at).to eq(august)
+
+      expect(Rails.logger).to have_received(:info).with(
+        "Updated choice ids: #{[correct_choice.id]}",
+      )
+    end
+
+    it 'does update choice when there is a user audit before touch', :with_audited do
+      application_choice = nil
+
+      TestSuiteTimeMachine.travel_temporarily_to(Time.zone.parse('2024-8-1')) do
+        application_choice = create(:application_choice, :with_submitted_application_form)
+      end
+
+      user_audit = Time.zone.parse('2024-9-3 11:00')
+      TestSuiteTimeMachine.travel_temporarily_to(user_audit) do
+        create(
+          :interview,
+          application_choice:,
+        )
+      end
+
+      the_touch = Time.zone.parse('2024-9-3 16:00')
+      TestSuiteTimeMachine.travel_temporarily_to(the_touch) do
+        create(
+          :application_work_experience,
+          experienceable: application_choice,
+        )
+      end
+      # replicates the updated at of the choice being before the audit in terms of timestamp
+      application_choice.update_column(:updated_at, application_choice.updated_at - 0.01.seconds)
+
+      choices = [application_choice.id]
+
+      described_class.new.perform(choices)
+
+      expect(application_choice.reload.updated_at).to be_within(0.5).of(user_audit)
+    end
+
+    it 'does not update choice when there is a user audit after touch', :with_audited do
+      application_choice = nil
+
+      TestSuiteTimeMachine.travel_temporarily_to(Time.zone.parse('2024-8-1')) do
+        application_choice = create(:application_choice, :with_submitted_application_form)
+      end
+
+      the_touch = Time.zone.parse('2024-9-3 16:00')
+      TestSuiteTimeMachine.travel_temporarily_to(the_touch) do
+        create(
+          :application_work_experience,
+          experienceable: application_choice,
+        )
+      end
+
+      user_audit = Time.zone.parse('2024-9-3 17:00')
+      TestSuiteTimeMachine.travel_temporarily_to(user_audit) do
+        create(
+          :interview,
+          application_choice:,
+        )
+      end
+      # replicates the updated at of the choice being before the audit in terms of timestamp
+      application_choice.update_column(:updated_at, application_choice.updated_at - 0.01.seconds)
+
+      choices = [application_choice.id]
+
+      expect {
+        described_class.new.perform(choices)
+      }.to not_change(application_choice.reload, :updated_at)
+
+      expect(application_choice.updated_at).to be_within(0.5).of(user_audit)
+    end
+
+    it 'does not update choices with user created audits after the big touch', :with_audited do
+      application_choice = nil
+
+      august = Time.zone.parse('2024-8-1')
+      TestSuiteTimeMachine.travel_temporarily_to(august) do
+        application_choice = create(:application_choice, :with_submitted_application_form)
+      end
+
+      the_touch = Time.zone.parse('2024-9-3 16:00')
+      TestSuiteTimeMachine.travel_temporarily_to(the_touch) do
+        create(
+          :application_work_experience,
+          experienceable: application_choice,
+        )
+      end
+      create(
+        :interview,
+        application_choice:,
+        created_at: Time.zone.parse('2024-9-10'),
+      )
+      choices = [application_choice.id]
+
+      expect {
+        described_class.new.perform(choices)
+      }.to not_change(application_choice.reload, :updated_at)
+
+      expect(application_choice.updated_at).not_to be_within(0.5).of(the_touch)
+    end
+
+    it 'does not update choices that have updated_at passed touch audit', :with_audited do
+      application_choice = nil
+
+      august = Time.zone.parse('2024-8-1')
+      TestSuiteTimeMachine.travel_temporarily_to(august) do
+        application_choice = create(:application_choice, :with_submitted_application_form)
+      end
+
+      the_touch = Time.zone.parse('2024-9-3 16:00')
+      TestSuiteTimeMachine.travel_temporarily_to(the_touch) do
+        create(
+          :application_work_experience,
+          experienceable: application_choice,
+        )
+      end
+      application_choice.update_columns(updated_at: Time.zone.now)
+      choices = [application_choice.id]
+
+      expect {
+        described_class.new.perform(choices)
+      }.to not_change(application_choice.reload, :updated_at)
+
+      expect(application_choice.updated_at).not_to be_within(0.5).of(the_touch)
+    end
+  end
+end


### PR DESCRIPTION
## Context

This PR attempts to fix some of the issues caused by `The Big Touch`https://github.com/DFE-Digital/apply-for-teacher-training/pull/9741

It will revert all the application choices that have been touched to the previous updated_at they had. We do this using their audits.

We get all the choices on the `3rd of September 2024` and get the touch audits for each of these choices and if there is an audit before the touch moment we revert the choice to the created_at of that audit.

If the choice has user created audits after the touch, we don't update that choice.

The data migration allow us to pass a limit or an array of provider ids to target a provider choices or to run the migration on a limited amount of choices. These params are optional. 

Co-authored by @inulty-dfe 

## Changes proposed in this pull request

Migration using `Batch Delivery` over 5 hours
Worker that figures out what choices need to be updated. Updates them in a loop using SQL with no callbacks


## Guidance to review

Does the logic look OK?
- We have tested this migration on a copy of QA and Production DB. The sample of ids we checked were correct, including choices that shouldn't be updated.


### How the Migration works
1. We select `id`s of all the `ApplicationChoices` whose `updated_at` is on the day of the big touch.
	1. Those `Choices` must be from the 2023 or 2024 Recruitment Cycles
	2. And be visible to providers ("`submitted`")
2. We pass those applications to the `BatchDelivery` service.
	1. The service chunks the applications for processing into batches of 1000
	2. It schedule the batches to be run over a 5 hours period.
	3. That's about 350 batches
	4. A batch every 51 seconds [(60 * 60 * 5) / 350 = 51]
3. **Processing each batch**
	1. Each 1000 batch is chunked into groups of 100
	2. We get all the `Audit`s that exist for a `Choice`
	3. Partition the audits into "`touch_audits`" and "`user_audits`"
4. If there are no `touch_audits` - we skip this Choice
5. We compare the latest user audit to the latest touch audit
	1. If the latest `user_audit` is more recent than the latest `touch_audit`, we can assume we don't need to change the `updated_at` on the choice, it has been updated 'naturally' already.
	2. If the latest `touch_audit` is after the last `user_audit` then we set the `updated_at` to the latest `user_audit.created_at`
	3. If the `choice.updated_at` is more than 10 seconds after the last `touch_audit` we can assume that it was not the `touch_audit` that  set the `updated_at`. It must be some operation that changes the `updated_at` but does not create an audit.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
