### PR TITLE
Stop lazying loading choices in worker

### DIFF
--- a/app/workers/end_of_cycle/decline_by_default_worker.rb
+++ b/app/workers/end_of_cycle/decline_by_default_worker.rb
@@ -15,7 +15,7 @@ module EndOfCycle
     def relation
       ApplicationForm
         .current_cycle
-        .includes(:application_choices).where('application_choices.status': 'offer')
+        .joins(:application_choices).where('application_choices.status': 'offer')
         .distinct
     end
   end

--- a/app/workers/end_of_cycle/reject_by_default_worker.rb
+++ b/app/workers/end_of_cycle/reject_by_default_worker.rb
@@ -15,7 +15,7 @@ module EndOfCycle
     def relation
       ApplicationForm
         .current_cycle
-        .includes(:application_choices).where('application_choices.status': EndOfCycle::RejectByDefaultService::REJECTABLE_STATUSES)
+        .joins(:application_choices).where('application_choices.status': EndOfCycle::RejectByDefaultService::REJECTABLE_STATUSES)
         .distinct
     end
   end


### PR DESCRIPTION
## Context

We were originally lazy loading the associations so that we could iterate over them faster, but now we are delegating these in batches to a secondary worker, so makes the job run slower. 

## Changes proposed in this pull request

replace `includes` with `joins` in two jobs. 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
