### PR TITLE
Update personal statement section

### DIFF
--- a/app/views/candidate_interface/personal_statement/_form.html.erb
+++ b/app/views/candidate_interface/personal_statement/_form.html.erb
@@ -7,11 +7,11 @@
 <%= render 'guidance' %>
 
 <% if adviser_sign_up.available? %>
-  <p class="govuk-body">If you have a bachelor's degree, you can get support with your personal statement by speaking to our <%= govuk_link_to('teacher training advisers', new_candidate_interface_adviser_sign_up_path) %>.</p>
+  <p class="govuk-body">If you have a bachelor’s degree, you can get support with your personal statement by speaking to our <%= govuk_link_to('teacher training advisers', new_candidate_interface_adviser_sign_up_path) %>.</p>
 <% elsif adviser_sign_up.waiting_to_be_assigned_to_an_adviser? || adviser_sign_up.already_assigned_to_an_adviser? %>
   <p class="govuk-body">Ask your teacher training adviser for help with your personal statement.</p>
 <% else %>
-  <p class="govuk-body">If you have a bachelor's degree, you can get support with your personal statement by speaking to our <%= govuk_link_to_with_utm_params('teacher training advisers', t('get_into_teaching.url_get_an_adviser_start'), utm_campaign(params), current_application.phase) %>.</p>
+  <p class="govuk-body">If you have a bachelor’s degree, you can get support with your personal statement by speaking to our <%= govuk_link_to_with_utm_params('teacher training advisers', t('get_into_teaching.url_get_an_adviser_start'), utm_campaign(params), current_application.phase) %>.</p>
 <% end %>
 
 <%= f.govuk_text_area :becoming_a_teacher, label: { text: 'Your personal statement', size: 'm' }, rows: 25, max_words: 1000 %>


### PR DESCRIPTION
## Context

This ticket is to display a variation of the personal statement page for TDA courses, by altering the text.

## Changes proposed in this pull request

- Update the text on the personal details edit page

## Guidance to review

- Log in as a candidate
- Edit your personal statement
- You should see the updated content
- 
<img width="942" alt="Screenshot 2024-09-24 at 15 50 11" src="https://github.com/user-attachments/assets/368c6227-2c39-4d98-8f79-e648067eaefe">

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
