### PR TITLE
Run decline by default job more quickly

### DIFF
--- a/app/workers/end_of_cycle/decline_by_default_worker.rb
+++ b/app/workers/end_of_cycle/decline_by_default_worker.rb
@@ -3,11 +3,12 @@ module EndOfCycle
     include Sidekiq::Worker
 
     BATCH_SIZE = 120
+    STAGGER_OVER = 1.minute
 
     def perform(force: false)
       return unless CycleTimetable.run_decline_by_default? || force
 
-      BatchDelivery.new(relation:, batch_size: BATCH_SIZE).each do |batch_time, applications|
+      BatchDelivery.new(relation:, stagger_over: STAGGER_OVER, batch_size: BATCH_SIZE).each do |batch_time, applications|
         DeclineByDefaultSecondaryWorker.perform_at(batch_time, applications.pluck(:id))
       end
     end


### PR DESCRIPTION
## Context

As we approach the decline by default date, it looks like there will be less than 300 applications with declineable choices. [See blazer](https://www.apply-for-teacher-training.service.gov.uk/support/blazer/queries/994-2024-decline-by-default-application-form-count).

So just spreading it out over 1 minutes rather than the default 5 hours.

## Changes proposed in this pull request

Add a stagger_over time to the batch worker responsible for declining applications.

## Guidance to review

I realise this probably doesn't need to be batched all, but I don't want to make major changes right before it is set to run. 

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ NA] Add PR link to Trello card
