### PR TITLE
[2315] Add migration to set decline by default

### DIFF
--- a/app/services/data_migrations/set_decline_by_default_at_and_decline_by_default_days_to_nil.rb
+++ b/app/services/data_migrations/set_decline_by_default_at_and_decline_by_default_days_to_nil.rb
@@ -1,0 +1,28 @@
+module DataMigrations
+  class SetDeclineByDefaultAtAndDeclineByDefaultDaysToNil
+    TIMESTAMP = 20240925092609
+    MANUAL_RUN = false
+
+    def change
+      application_choices.in_batches(of: 4000) do |batch|
+        batch.update_all(decline_by_default_at: nil, decline_by_default_days: nil)
+      end
+    end
+
+  private
+
+    def application_choices
+      choices_from_2024
+        .where.not(decline_by_default_at: nil)
+        .or(choices_from_2024.where.not(decline_by_default_days: nil))
+        .distinct
+    end
+
+    def choices_from_2024
+      @choices_from_2024 ||= ApplicationChoice
+                               .joins(:application_form)
+                               .where('application_form.recruitment_cycle_year': 2024)
+                               .distinct
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::SetDeclineByDefaultAtAndDeclineByDefaultDaysToNil',
   'DataMigrations::BackfillApplicationChoicesWithWorkExperiences',
   'DataMigrations::MarkUnsubmittedApplicationsWithoutEnglishProficiencyAsElfIncomplete',
   'DataMigrations::BackfillEnglishProficiencyRecordsForCarriedOverApplications',
@@ -19,8 +20,6 @@ DATA_MIGRATION_SERVICES = [
   'DataMigrations::RemoveFeedbackHelpfulFeatureFlag',
   'DataMigrations::RemoveOnePersonalStatementFeatureFlag',
   'DataMigrations::SetMissingWorkHistoryStatusValues',
-  'DataMigrations::UpdateDeclineByDefaultAtFromCurrentCycle',
-  'DataMigrations::RemoveDbdFromCurrentCycle',
   'DataMigrations::RemoveRecruitWithPendingConditionsFeatureFlag',
   'DataMigrations::BackfillFeedbackFormComplete',
   'DataMigrations::RemoveMidCycleReportFeatureFlag',

--- a/spec/services/data_migrations/set_decline_by_default_at_and_decline_by_default_days_to_nil_spec.rb
+++ b/spec/services/data_migrations/set_decline_by_default_at_and_decline_by_default_days_to_nil_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::SetDeclineByDefaultAtAndDeclineByDefaultDaysToNil do
+  it 'updates choices where decline_by_default_at is not null' do
+    application_choice = create(:application_choice,
+                                decline_by_default_at: DateTime.now,
+                                decline_by_default_days: nil,
+                                application_form: build(:application_form, recruitment_cycle_year: 2024))
+
+    described_class.new.change
+    expect(application_choice.reload.decline_by_default_at).to be_nil
+  end
+
+  it 'updates choices where decline_by_default_days is not null' do
+    application_choice = create(:application_choice,
+                                decline_by_default_at: nil,
+                                decline_by_default_days: 10,
+                                application_form: build(:application_form, recruitment_cycle_year: 2024))
+
+    described_class.new.change
+
+    expect(application_choice.reload.decline_by_default_days).to be_nil
+  end
+
+  it 'updates choices where both days and at are not null' do
+    application_choice = create(:application_choice,
+                                decline_by_default_at: DateTime.now,
+                                decline_by_default_days: 10,
+                                application_form: build(:application_form, recruitment_cycle_year: 2024))
+
+    described_class.new.change
+
+    application_choice.reload
+    expect(application_choice.decline_by_default_days).to be_nil
+    expect(application_choice.decline_by_default_at).to be_nil
+  end
+
+  it 'updates only 2024 application choices' do
+    application_2024 = create(:application_choice, decline_by_default_at: Time.zone.now,
+                                                   application_form: build(:application_form, recruitment_cycle_year: 2024))
+    application_2023 = create(:application_choice, decline_by_default_at: Time.zone.now,
+                                                   application_form: build(:application_form, recruitment_cycle_year: 2023))
+
+    described_class.new.change
+
+    expect(application_2024.reload.decline_by_default_at).to be_nil
+    expect(application_2023.reload.decline_by_default_at).not_to be_nil
+  end
+end


### PR DESCRIPTION
## Context

This is the second of three PRs to correct this bug related to decline_by_default. See the [first PR here](https://github.com/DFE-Digital/apply-for-teacher-training/pull/9861) for context and to see what has been done already.

## Changes proposed in this pull request
Job will set data to nil for about 40,109 applications. See [blazer query](https://www.apply-for-teacher-training.service.gov.uk/support/blazer/queries/987-2024-application-choices-with-non-null-decline_by_default_at-values).

I've tested it locally with 4000 application choices and it took 6.506ms, so I think this update will only take 65ms, no time at all. 

## Guidance to review
Will this touch 40,000 records? Am going to cause another BIG TOUCH incident? I don't think so because it doesn't execute active record callbacks, but if someone knows better, please speak up!

https://apidock.com/rails/ActiveRecord/Relation/update_all
## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
