### PR TITLE
Fix casting bug when backfilling work histories

### DIFF
--- a/app/workers/migrate_application_choices_worker.rb
+++ b/app/workers/migrate_application_choices_worker.rb
@@ -50,6 +50,10 @@ private
       attributes["#{polymorphic_column}_id"] = choice.id
       attributes['created_at'] = Time.zone.now
       attributes['updated_at'] = Time.zone.now
+      if record.is_a?(ApplicationWorkExperience)
+        # We need to get the DB value 'Full time' not the casted value full_time
+        attributes['commitment'] = ApplicationWorkExperience.commitments[record.commitment]
+      end
       attributes.delete('id')
 
       attributes


### PR DESCRIPTION
## Context

There are two enums on the ApplicationWorkHistory record. part_time and full_time. ActiveRecord returns these enums in the console like so 'part_time' but in the DB it's saved `Part time`.

Previously because we called `record.attributes` it returned 'part_time' and the value in the DB would be saved as 'part_time'. Not 'Part time'.

This would break some views as ActiveRecord expects the value in the DB to be 'Part time'. This commit fixes this issue.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
