### PR TITLE
Add new Event to track PDF-export functionality utilised by users in Manage

### DIFF
--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -8,6 +8,8 @@ module ProviderInterface
     before_action :set_application_choice, :set_workflow_flags, except: %i[index]
     before_action :redirect_if_application_changed_provider, only: %i[timeline]
 
+    after_action :track_if_pdf_download, only: %i[show]
+
     def index
       @filter = ProviderApplicationsFilter.new(
         params:,

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -52,6 +52,21 @@ module ProviderInterface
       DfESignInUser.load_from_session(session)
     end
 
+    def track_if_pdf_download
+      return unless request.original_url.end_with?('.pdf')
+
+      tracking = ProviderInterface::Tracking.new(current_user, request)
+
+      path_action_map = {
+        provider_interface_application_choice_path(@application_choice) => :provider_download_application,
+        provider_interface_application_choice_references_path(@application_choice) => :provider_download_references,
+      }
+
+      action = path_action_map[request.path]
+
+      tracking.send(action) if action
+    end
+
     def authenticate_provider_user!
       return if current_provider_user
 

--- a/app/controllers/provider_interface/references_controller.rb
+++ b/app/controllers/provider_interface/references_controller.rb
@@ -2,6 +2,10 @@ module ProviderInterface
   class ReferencesController < ProviderInterfaceController
     before_action :set_application_choice, :redirect_if_unsuccessful, :set_references, :set_workflow_flags, :redirect_if_application_changed_provider
 
+    after_action :track_if_pdf_download, only: %i[index]
+
+    def index; end
+
   private
 
     def redirect_if_unsuccessful

--- a/app/services/provider_interface/tracking.rb
+++ b/app/services/provider_interface/tracking.rb
@@ -1,0 +1,26 @@
+class ProviderInterface::Tracking
+  attr_reader :current_user, :request
+
+  def initialize(current_user, request)
+    @current_user = current_user
+    @request = request
+  end
+
+  def provider_download_application
+    event = DfE::Analytics::Event.new
+      .with_type(:provider_download_application)
+      .with_user(current_user)
+      .with_request_details(request)
+
+    DfE::Analytics::SendEvents.do([event])
+  end
+
+  def provider_download_references
+    event = DfE::Analytics::Event.new
+      .with_type(:provider_download_references)
+      .with_user(current_user)
+      .with_request_details(request)
+
+    DfE::Analytics::SendEvents.do([event])
+  end
+end

--- a/config/analytics_custom_events.yml
+++ b/config/analytics_custom_events.yml
@@ -1,3 +1,5 @@
 shared:
   - candidate_offered_adviser
   - candidate_signed_up_for_adviser
+  - provider_download_application
+  - provider_download_references

--- a/spec/services/provider_interface/tracking_spec.rb
+++ b/spec/services/provider_interface/tracking_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::Tracking do
+  let(:current_user_double) { instance_double(Candidate, id: 1) }
+  let(:request_double) do
+    instance_double(ActionDispatch::Request,
+                    uuid: SecureRandom.uuid,
+                    user_agent: 'Chrome',
+                    method: :get,
+                    original_fullpath: '/path',
+                    query_string: nil,
+                    referer: nil,
+                    remote_ip: '1.2.3.4')
+  end
+
+  subject(:tracker) { described_class.new(current_user_double, request_double) }
+
+  before { allow(DfE::Analytics).to receive(:enabled?).and_return(true) }
+
+  describe '.provider_download_application' do
+    before { tracker.provider_download_application }
+
+    it 'enqueues a provider_download_application event' do
+      expect(:provider_download_application).to have_been_enqueued_as_analytics_events
+    end
+  end
+
+  describe '.provider_download_references' do
+    before { tracker.provider_download_references }
+
+    it 'enqueues a provider_download_references event' do
+      expect(:provider_download_references).to have_been_enqueued_as_analytics_events
+    end
+  end
+end


### PR DESCRIPTION
## Context

We have persistent performance issues and errors with the component/library we utilise to allow users to generate PDFs. Furthermore, currently this activity is not being tracked. We want to be able to track every time a user downloads the PDF.

## Changes proposed in this pull request

Add DfE::Analytics tracking to these PDF download buttons

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
