### PR TITLE
Fix deferred course start date on offer deferred

### DIFF
--- a/app/components/candidate_interface/application_status_tag_component.html.erb
+++ b/app/components/candidate_interface/application_status_tag_component.html.erb
@@ -40,7 +40,7 @@
     </p>
   <% elsif  @application_choice.offer_deferred? %>
     <p class="govuk-body govuk-!-margin-top-2">
-      Your training will now start in <%= (@application_choice.current_course_option.course.start_date + 1.year).to_fs(:month_and_year) %>.
+      Your training will now start in <%= @application_choice.current_course.deferred_start_date.to_fs(:month_and_year) %>.
     </p>
   <% elsif @application_choice.pending_conditions? || @application_choice.recruited? || @application_choice.offer? %>
     <%= govuk_details(

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -214,6 +214,10 @@ class Course < ApplicationRecord
     undergraduate? || !degree_grade?
   end
 
+  def deferred_start_date
+    start_date + 1.year
+  end
+
 private
 
   def touch_application_choices_and_forms

--- a/app/views/candidate_interface/offer_dashboard/_offer_deferred.html.erb
+++ b/app/views/candidate_interface/offer_dashboard/_offer_deferred.html.erb
@@ -2,7 +2,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">You have chosen to defer your offer from <%= @provider.name %> to study <%= @course_name_and_code %>.</p>
-    <p class="govuk-body">Your training will now start in <%= @application_choice.course.deferred_start_date.to_fs(:month_and_year) %>.</p>
+    <p class="govuk-body">Your training will now start in <%= @application_choice.current_course.deferred_start_date.to_fs(:month_and_year) %>.</p>
     <p class="govuk-body">Your place will be confirmed once they have:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>received your references</li>

--- a/app/views/candidate_interface/offer_dashboard/_offer_deferred.html.erb
+++ b/app/views/candidate_interface/offer_dashboard/_offer_deferred.html.erb
@@ -2,7 +2,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">You have chosen to defer your offer from <%= @provider.name %> to study <%= @course_name_and_code %>.</p>
-    <p class="govuk-body">Your training will now start in <%= @application_choice.course.start_date.to_fs(:month_and_year) %>.</p>
+    <p class="govuk-body">Your training will now start in <%= @application_choice.course.deferred_start_date.to_fs(:month_and_year) %>.</p>
     <p class="govuk-body">Your place will be confirmed once they have:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>received your references</li>

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -380,4 +380,12 @@ RSpec.describe Course do
       end
     end
   end
+
+  describe '#deferred_start_date' do
+    it 'returns the deferred start date' do
+      course = build(:course)
+
+      expect(course.deferred_start_date).to eq(course.start_date + 1.year)
+    end
+  end
 end


### PR DESCRIPTION
## Context

Previously, it didn't show the actual date of the course start when it's deferred.

It was showing the date of the current cycle, not the next. So 2024 not 2025 for example

## Changes proposed in this pull request

Added deferred_start_date

## Guidance to review

Is the logic of the method correct?
Go on the review app and sign in as a candidate with a deferred offer and check the start date of your course is correct, in the next cycle, should be 2025 for a deferred offer in 2024 cycle 



https://github.com/user-attachments/assets/6358bd57-0458-40da-8e4f-0617fda191f3



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
