### PR TITLE
[2367] Scale pods for start of cycle MERGE ON 4 OCT

### DIFF
--- a/terraform/aks/workspace_variables/production_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/production_aks.tfvars.json
@@ -13,7 +13,7 @@
   "worker_memory_max": "2Gi",
   "secondary_worker_memory_max": "2Gi",
   "clock_worker_memory_max": "1Gi",
-  "webapp_replicas": 4,
+  "webapp_replicas": 8,
   "worker_replicas": 2,
   "secondary_worker_replicas": 2,
   "clock_worker_replicas": 1,

--- a/terraform/aks/workspace_variables/production_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/production_aks.tfvars.json
@@ -17,7 +17,7 @@
   "worker_replicas": 2,
   "secondary_worker_replicas": 2,
   "clock_worker_replicas": 1,
-  "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
+  "postgres_flexible_server_sku": "GP_Standard_D4ds_v4",
   "redis_queue_family": "P",
   "redis_queue_capacity": 1,
   "redis_queue_sku_name": "Premium",


### PR DESCRIPTION
## Context

We know that a large proportion of the total number of applications are made within the first week of apply opening (8 October). We want to have the capacity to handle the increased amount of traffic on the site.

## Changes proposed in this pull request

Increases the number of web replicas. We will revert this change after apply has been open for a week (15 October).

## Guidance to review

We are not increasing the workers at this point, but can do it on the fly if required.

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
