### PR TITLE
[2241] Change max input size for gcse not_competed_explanation field

### DIFF
--- a/app/forms/candidate_interface/gcse_missing_form.rb
+++ b/app/forms/candidate_interface/gcse_missing_form.rb
@@ -7,6 +7,7 @@ module CandidateInterface
 
     validates :missing_explanation, word_count: { maximum: 50 }
     validate :missing_explanation_presence
+    validates :not_completed_explanation, length: { maximum: 256 }
 
     def self.build_from_qualification(qualification)
       new(

--- a/app/forms/candidate_interface/gcse_not_completed_form.rb
+++ b/app/forms/candidate_interface/gcse_not_completed_form.rb
@@ -9,7 +9,7 @@ module CandidateInterface
 
     validates :not_completed_explanation, presence: true, if: -> { currently_completing_qualification }
 
-    validates :not_completed_explanation, word_count: { maximum: 200 }
+    validates :not_completed_explanation, length: { maximum: 256 }
     validate :validates_currently_completing_qualification
 
     def self.build_from_qualification(qualification)

--- a/app/forms/support_interface/english_gcse_form.rb
+++ b/app/forms/support_interface/english_gcse_form.rb
@@ -63,7 +63,7 @@ module SupportInterface
     validates :institution_country, presence: true, inclusion: { in: COUNTRIES_AND_TERRITORIES }, if: :non_uk_qualification?
 
     validates :not_completed_explanation, presence: true, if: ->(record) { record.missing_qualification? && record.currently_completing_qualification? }
-    validates :not_completed_explanation, word_count: { maximum: 200 }
+    validates :not_completed_explanation, length: { maximum: 256 }
     validate :validates_currently_completing_qualification, if: :missing_qualification?
 
     def self.build_from_qualification(qualification)

--- a/app/forms/support_interface/math_gcse_form.rb
+++ b/app/forms/support_interface/math_gcse_form.rb
@@ -39,7 +39,7 @@ module SupportInterface
     validates :institution_country, presence: true, inclusion: { in: COUNTRIES_AND_TERRITORIES }, if: :non_uk_qualification?
 
     validates :not_completed_explanation, presence: true, if: ->(record) { record.missing_qualification? && record.currently_completing_qualification? }
-    validates :not_completed_explanation, word_count: { maximum: 200 }
+    validates :not_completed_explanation, length: { maximum: 256 }
     validate :validates_currently_completing_qualification, if: :missing_qualification?
 
     def self.build_from_qualification(qualification)

--- a/app/forms/support_interface/science_gcse_form.rb
+++ b/app/forms/support_interface/science_gcse_form.rb
@@ -47,7 +47,7 @@ module SupportInterface
     validates :institution_country, presence: true, inclusion: { in: COUNTRIES_AND_TERRITORIES }, if: :non_uk_qualification?
 
     validates :not_completed_explanation, presence: true, if: ->(record) { record.missing_qualification? && record.currently_completing_qualification? }
-    validates :not_completed_explanation, word_count: { maximum: 200 }
+    validates :not_completed_explanation, length: { maximum: 256 }
     validate :validates_currently_completing_qualification, if: :missing_qualification?
 
     validate :grade_length, if: :gcse?

--- a/app/views/candidate_interface/gcse/not_completed_qualification/_form.html.erb
+++ b/app/views/candidate_interface/gcse/not_completed_qualification/_form.html.erb
@@ -5,7 +5,7 @@
 
         <%= f.govuk_radio_buttons_fieldset :not_yet_completed, legend: { size: 'l', text: "Are you currently studying for a GCSE in #{capitalize_english(@subject)}, or equivalent?" } do %>
           <%= f.govuk_radio_button :currently_completing_qualification, true, label: { text: 'Yes' }, link_errors: true do %>
-                <%= f.govuk_text_area :not_completed_explanation, label: { text: 'Details of the qualification you are studying for', size: 's' }, rows: 12, max_words: 200, threshold: 90 do %>
+                <%= f.govuk_text_area :not_completed_explanation, label: { text: 'Details of the qualification you are studying for', size: 's' }, rows: 6, max_chars: 256, threshold: 90 do %>
                 <% end %>
           <% end %>
           <%= f.govuk_radio_button :currently_completing_qualification, false, label: { text: 'No' } %>

--- a/app/views/support_interface/english_gcse_forms/_english_gcse_form.html.erb
+++ b/app/views/support_interface/english_gcse_forms/_english_gcse_form.html.erb
@@ -67,7 +67,7 @@
   <%= f.govuk_radio_button :qualification_type, :missing, label: { text: t('application_form.gcse.qualification_types.missing', subject: capitalize_english(f.object.subject)) } do %>
       <%= f.govuk_radio_buttons_fieldset :not_yet_completed, legend: { text: "Are you currently studying for a GCSE in #{capitalize_english(f.object.subject)}, or equivalent?" } do %>
         <%= f.govuk_radio_button :currently_completing_qualification, true, label: { text: 'Yes' }, link_errors: true do %>
-              <%= f.govuk_text_area :not_completed_explanation, label: { text: 'Details of the qualification you are studying for', size: 's' }, rows: 12, max_words: 200, threshold: 90 do %>
+              <%= f.govuk_text_area :not_completed_explanation, label: { text: 'Details of the qualification you are studying for', size: 's' }, rows: 6, max_chars: 256, threshold: 90 do %>
               <% end %>
         <% end %>
         <%= f.govuk_radio_button :currently_completing_qualification, false, label: { text: 'No' } do %>

--- a/app/views/support_interface/math_gcse_forms/_math_gcse_form.html.erb
+++ b/app/views/support_interface/math_gcse_forms/_math_gcse_form.html.erb
@@ -40,7 +40,7 @@
     <%= f.govuk_radio_button :qualification_type, :missing, label: { text: t('application_form.gcse.qualification_types.missing', subject: capitalize_english(f.object.subject)) } do %>
       <%= f.govuk_radio_buttons_fieldset :not_yet_completed, legend: { text: "Are you currently studying for a GCSE in #{capitalize_english(f.object.subject)}, or equivalent?" } do %>
         <%= f.govuk_radio_button :currently_completing_qualification, true, label: { text: 'Yes' }, link_errors: true do %>
-              <%= f.govuk_text_area :not_completed_explanation, label: { text: 'Details of the qualification you are studying for', size: 's' }, rows: 12, max_words: 200, threshold: 90 do %>
+              <%= f.govuk_text_area :not_completed_explanation, label: { text: 'Details of the qualification you are studying for', size: 's' }, rows: 6, max_chars: 256, threshold: 90 do %>
               <% end %>
         <% end %>
         <%= f.govuk_radio_button :currently_completing_qualification, false, label: { text: 'No' } do %>

--- a/app/views/support_interface/science_gcse_forms/_science_gcse_form.html.erb
+++ b/app/views/support_interface/science_gcse_forms/_science_gcse_form.html.erb
@@ -52,7 +52,7 @@
     <%= f.govuk_radio_button :qualification_type, :missing, label: { text: t('application_form.gcse.qualification_types.missing', subject: 'science') } do %>
       <%= f.govuk_radio_buttons_fieldset :not_yet_completed, legend: { text: "Are you currently studying for a GCSE in #{capitalize_english(f.object.subject)}, or equivalent?" } do %>
         <%= f.govuk_radio_button :currently_completing_qualification, true, label: { text: 'Yes' }, link_errors: true do %>
-              <%= f.govuk_text_area :not_completed_explanation, label: { text: 'Details of the qualification you are studying for', size: 's' }, rows: 12, max_words: 200, threshold: 90 do %>
+              <%= f.govuk_text_area :not_completed_explanation, label: { text: 'Details of the qualification you are studying for', size: 's' }, rows: 6, max_chars: 256, threshold: 90 do %>
               <% end %>
         <% end %>
         <%= f.govuk_radio_button :currently_completing_qualification, false, label: { text: 'No' } do %>

--- a/config/locales/candidate_interface/gcse.yml
+++ b/config/locales/candidate_interface/gcse.yml
@@ -154,7 +154,7 @@ en:
               inclusion: Select yes if you are currently studying for a GCSE in %{subject}, or equivalent
             not_completed_explanation:
               blank: Enter details of the qualification you are studying for
-              too_many_words: Qualification details must be %{maximum} words or less
+              too_long: Qualification details must be %{count} characters or fewer
         candidate_interface/gcse_grade_explanation_form:
           attributes:
             currently_completing_qualification:

--- a/config/locales/support_interface/gcse.yml
+++ b/config/locales/support_interface/gcse.yml
@@ -66,7 +66,7 @@ en:
               inclusion: Select yes if you are currently studying for a GCSE in %{subject}, or equivalent
             not_completed_explanation:
               blank: Enter details of the qualification you are studying for
-              too_many_words: Qualification details must be %{maximum} words or less
+              too_long: Qualification details must be %{count} characters or fewer
             currently_completing_qualification:
               blank: Select yes if you are currently studying for a GCSE in %{subject}, or equivalent
             missing_explanation:
@@ -86,7 +86,7 @@ en:
               too_long: Type of degree must be %{count} characters or fewer
             not_completed_explanation:
               blank: Enter details of the qualification you are studying for
-              too_many_words: Qualification details must be %{maximum} words or less
+              too_long: Qualification details must be %{count} characters or fewer
             audit_comment:
               blank: You must provide an audit comment
             non_uk_qualification_type:
@@ -151,7 +151,7 @@ en:
               inclusion: Select yes if you are currently studying for a GCSE in %{subject}, or equivalent
             not_completed_explanation:
               blank: Enter details of the qualification you are studying for
-              too_many_words: Qualification details must be %{maximum} words or less
+              too_long: Qualification details must be %{count} characters or fewer
             currently_completing_qualification:
               blank: Select yes if you are currently studying for a GCSE in %{subject}, or equivalent
             missing_explanation:

--- a/spec/forms/candidate_interface/gcse_missing_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_missing_form_spec.rb
@@ -4,10 +4,20 @@ RSpec.describe CandidateInterface::GcseMissingForm, type: :model do
   describe 'validations' do
     let(:valid_text) { Faker::Lorem.sentence(word_count: 50) }
     let(:long_text) { Faker::Lorem.sentence(word_count: 51) }
+    let(:valid_char_count) { Faker::Lorem.characters(number: 256) }
+    let(:too_long_char_count) { Faker::Lorem.characters(number: 257) }
     let(:form) { described_class.new(missing_explanation: nil, subject: 'english') }
 
     it { is_expected.to allow_value(valid_text).for(:missing_explanation) }
     it { is_expected.not_to allow_value(long_text).for(:missing_explanation) }
+
+    it { is_expected.to allow_value(valid_char_count).for(:not_completed_explanation) }
+
+    it 'validates not_completed_explanation' do
+      form.not_completed_explanation = too_long_char_count
+      form.valid?
+      expect(form.errors[:not_completed_explanation]).to include 'Not completed explanation must be 256 characters or fewer'
+    end
 
     it 'validates presence of missing explanation with the subject in the error message' do
       form.valid?

--- a/spec/forms/candidate_interface/gcse_not_completed_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_not_completed_form_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::GcseNotCompletedForm, type: :model do
   describe 'validations' do
-    valid_text = Faker::Lorem.sentence(word_count: 200)
-    long_text = Faker::Lorem.sentence(word_count: 201)
+    valid_text = Faker::Lorem.characters(number: 256)
+    long_text = Faker::Lorem.characters(number: 257)
 
     it { is_expected.to allow_value(valid_text).for(:not_completed_explanation) }
     it { is_expected.not_to allow_value(long_text).for(:not_completed_explanation) }

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_with_missing_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_with_missing_qualification_spec.rb
@@ -22,6 +22,11 @@ RSpec.describe 'Candidate entering GCSE details' do
 
     when_i_change_if_i_am_currently_studying
     and_i_select_yes
+
+    when_i_provide_invalid_details
+    and_i_click_save_and_continue
+    then_i_see_the_error_message
+
     and_i_provide_my_details
     and_i_click_save_and_continue
     then_i_see_the_review_page_with_the_updated_details
@@ -61,6 +66,11 @@ RSpec.describe 'Candidate entering GCSE details' do
     expect(page).to have_content 'You need a GCSE in English at grade 4 (C) or above, or equivalent'
   end
 
+  def then_i_see_the_error_message
+    expect(page).to have_content 'There is a problem'
+    expect(page).to have_content('Qualification details must be 256 characters or fewer').twice
+  end
+
   def when_i_enter_the_missing_explanation
     fill_in 'candidate-interface-gcse-missing-form-missing-explanation-field', with: 'I’ve completed a course'
   end
@@ -83,7 +93,12 @@ RSpec.describe 'Candidate entering GCSE details' do
   end
 
   def and_i_provide_my_details
-    fill_in 'candidate-interface-gcse-not-completed-form-not-completed-explanation-field', with: 'This is in progress'
+    fill_in 'Details of the qualification you are studying for', with: 'This is in progress'
+  end
+
+  def when_i_provide_invalid_details
+    too_long = 'Not completed ' * 19
+    fill_in 'Details of the qualification you are studying for', with: too_long
   end
 
   def then_i_see_the_review_page_with_the_updated_details


### PR DESCRIPTION
## Context
A provider has complained that if a candidate uses more the 256 characters on the not-yet-completed field, the data is not included in the API. Right now there is no char limit, only a word limit. 

We've done some research and only 3% of entries on this column are over 256 chars. So it makes basically no difference to start limiting this to 256 chars. 

## Changes proposed in this pull request

- Changes the word limit to a char limit
- Reduces the size of the text box to reflect the change
- Adds a spec for the error messaging

| Before | After |
| ------- | -------|
| <img width="940" alt="image" src="https://github.com/user-attachments/assets/0a4c422b-7006-4615-960a-c7d78744574b"> |<img width="917" alt="image" src="https://github.com/user-attachments/assets/210d1bc0-4e74-4d1c-bb75-317215bb9323"> |

## Guidance to review

Note: We are not backfilling data or making any changes to the database. We're just limiting input. 

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
