### PR TITLE
[2413] Amend the new cycle has started email

### DIFF
--- a/app/services/email_timetable.rb
+++ b/app/services/email_timetable.rb
@@ -16,7 +16,7 @@ class EmailTimetable < CycleTimetable
   end
 
   def self.send_new_cycle_has_started_email?
-    current_date.to_date == apply_opens.to_date
+    current_date.to_date == (apply_opens + 2.days).to_date
   end
 
   def self.send_application_deadline_has_passed_email_to_candidates?

--- a/app/workers/send_new_cycle_has_started_email_to_candidates_worker.rb
+++ b/app/workers/send_new_cycle_has_started_email_to_candidates_worker.rb
@@ -7,7 +7,7 @@ class SendNewCycleHasStartedEmailToCandidatesWorker
     return unless EmailTimetable.send_new_cycle_has_started_email?
 
     BatchDelivery.new(
-      relation: GetUnsuccessfulAndUnsubmittedCandidates.call,
+      relation:,
       stagger_over: 12.hours,
       batch_size: BATCH_SIZE,
     ).each do |batch_time, records|
@@ -16,5 +16,28 @@ class SendNewCycleHasStartedEmailToCandidatesWorker
         records.pluck(:id),
       )
     end
+  end
+
+  def relation
+    previous_recruitment_year = RecruitmentCycle.previous_year
+    current_recruitment_year = RecruitmentCycle.current_year
+    # Candidates who didn't have successful applications last year and haven't started working on their 2025 application
+    Candidate
+      .where({ submission_blocked: false, account_locked: false, unsubscribed_from_emails: false })
+      .joins(:application_forms)
+      # Has not started a new application form
+      .where.not(id: Candidate.joins(:application_forms).where(
+        application_forms: { recruitment_cycle_year: current_recruitment_year },
+      ))
+      # The previous year's application form did not have any successful choices.
+      .where(
+        '(application_forms.recruitment_cycle_year = (:previous_recruitment_year) AND NOT EXISTS (:successful))',
+        previous_recruitment_year:,
+        successful: ApplicationChoice
+                      .select(1)
+                      .where(status: ApplicationStateChange::SUCCESSFUL_STATES)
+                      .where('application_choices.application_form_id = application_forms.id'),
+      )
+      .distinct
   end
 end

--- a/spec/services/email_timetable_spec.rb
+++ b/spec/services/email_timetable_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe EmailTimetable do
 
     context 'it is after apply reopens' do
       it 'returns true' do
-        travel_temporarily_to(described_class.apply_opens) do
+        travel_temporarily_to(described_class.apply_opens + 2.days) do
           expect(described_class.send_new_cycle_has_started_email?).to be(true)
         end
       end


### PR DESCRIPTION
## Context

We have re-thought the email we are sending announcing the Apply has opened, in the context of the pressure it puts on the workers and database on the busiest day of the year.

## Changes proposed in this pull request

- only sending this to people who had an unsuccessful 2024 application and haven't started a 2025 application form (people who have started a 2025 application will start receiving nudges if they don't act on it anyway)
- Send it on the 3rd day of the cycle (10 October 2024) instead of the first day.
- No content changes

## Guidance to review



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
