### PR TITLE
Add spec to guarantee empty degrees is returned from TDA courses

### DIFF
--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -228,6 +228,21 @@ module CandidateHelper
     create(:course_option, site:, course: course4) unless CourseOption.find_by(site:, course: course4, study_mode: :full_time)
   end
 
+  def given_undergraduate_courses_exist
+    @provider = create(:provider, name: 'Gorse SCITT', code: '1N1', provider_type: 'scitt')
+    site = create(:site, name: 'Main site', code: '-', provider: @provider)
+    @course = create(
+      :course,
+      :teacher_degree_apprenticeship,
+      :open,
+      :secondary,
+      name: 'Mathematics',
+      code: 'VTDR',
+      provider: @provider,
+    )
+    create(:course_option, site:, course: @course)
+  end
+
   def candidate_fills_in_apply_again_course_choice
     visit candidate_interface_application_choices_path
     click_link_or_button 'Add application'
@@ -243,6 +258,32 @@ module CandidateHelper
 
     choose t('application_form.completed_radio')
     click_link_or_button t('continue')
+  end
+
+  def candidate_does_not_have_a_degree
+    @application.application_qualifications.degrees.delete_all
+    @application.update!(degrees_completed: false)
+    visit candidate_interface_details_path
+    click_link_or_button 'Degree'
+    choose 'No, I do not have a degree'
+    click_link_or_button 'Continue'
+  end
+
+  def candidate_submits_undergraduate_application
+    visit candidate_interface_application_choices_path
+    click_link_or_button 'Add application'
+    choose 'Yes, I know where I want to apply'
+    click_link_or_button t('continue')
+
+    select 'Gorse SCITT (1N1)'
+    click_link_or_button t('continue')
+
+    choose 'Mathematics (VTDR)'
+    click_link_or_button t('continue')
+
+    click_link_or_button 'Review application'
+    click_link_or_button 'Continue without editing'
+    click_link_or_button 'Confirm and submit application'
   end
 
   def candidate_fills_in_apply_again_with_four_course_choices

--- a/spec/system/register_api/register_receives_application_spec.rb
+++ b/spec/system/register_api/register_receives_application_spec.rb
@@ -2,16 +2,23 @@ require 'rails_helper'
 
 # This is an end-to-end test for the API response. To test complex logic in
 # the presenter, see spec/presenters/register_api/single_application_presenter_spec.rb.
-RSpec.describe 'Register receives an application data', time: CycleTimetableHelper.mid_cycle(2024) do
+RSpec.describe 'Register receives an application data', time: CycleTimetableHelper.mid_cycle(2025) do
   include CandidateHelper
 
-  it 'A candidate is recruited' do
-    given_a_provider_recruited_a_candidate
+  scenario 'A candidate is recruited in a postgraduate course' do
+    given_a_provider_recruited_a_candidate_that_applied_to_a_postgraduate_course
     when_i_retrieve_the_application_over_the_api
     then_it_includes_the_data_from_the_application_form
   end
 
-  def given_a_provider_recruited_a_candidate
+  scenario 'A candidate is recruited in an undergraduate course' do
+    given_teacher_degree_apprenticeship_feature_flag_is_on
+    and_a_provider_recruited_a_candidate_that_applied_to_an_undergraduate_course
+    when_i_retrieve_the_application_over_the_api
+    then_it_includes_the_empty_degrees_data_from_application
+  end
+
+  def given_a_provider_recruited_a_candidate_that_applied_to_a_postgraduate_course
     candidate_completes_application_form
     candidate_submits_application
     equality_and_diversity_data = {
@@ -25,10 +32,27 @@ RSpec.describe 'Register receives an application data', time: CycleTimetableHelp
     }
     @application.update!(equality_and_diversity: equality_and_diversity_data)
     @provider.courses.first.update!(uuid: SecureRandom.uuid)
+
+    and_application_is_recruited
+  end
+
+  def and_application_is_recruited
     @application.application_choices.first.update!(
       status: :recruited,
       recruited_at: Time.zone.now,
     )
+  end
+
+  def and_a_provider_recruited_a_candidate_that_applied_to_an_undergraduate_course
+    given_undergraduate_courses_exist
+    candidate_completes_application_form
+    candidate_does_not_have_a_degree
+    candidate_submits_undergraduate_application
+    and_application_is_recruited
+  end
+
+  def given_teacher_degree_apprenticeship_feature_flag_is_on
+    FeatureFlag.activate(:teacher_degree_apprenticeship)
   end
 
   def when_i_retrieve_the_application_over_the_api
@@ -195,7 +219,14 @@ RSpec.describe 'Register receives an application data', time: CycleTimetableHelp
       },
     }
 
-    received_attributes = @api_response['data'].first.deep_symbolize_keys
-    expect(received_attributes.deep_sort).to eq expected_attributes.deep_sort
+    expect(api_received_data.deep_sort).to eq expected_attributes.deep_sort
+  end
+
+  def then_it_includes_the_empty_degrees_data_from_application
+    expect(api_received_data[:attributes][:qualifications][:degrees]).to eq([])
+  end
+
+  def api_received_data
+    @api_response['data'].first.deep_symbolize_keys
   end
 end

--- a/spec/system/register_api/register_receives_application_spec.rb
+++ b/spec/system/register_api/register_receives_application_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Register receives an application data', time: CycleTimetableHelp
     given_teacher_degree_apprenticeship_feature_flag_is_on
     and_a_provider_recruited_a_candidate_that_applied_to_an_undergraduate_course
     when_i_retrieve_the_application_over_the_api
-    then_it_includes_the_empty_degrees_data_from_application
+    then_it_includes_the_empty_degrees_data_from_the_application
   end
 
   def given_a_provider_recruited_a_candidate_that_applied_to_a_postgraduate_course
@@ -222,7 +222,7 @@ RSpec.describe 'Register receives an application data', time: CycleTimetableHelp
     expect(api_received_data.deep_sort).to eq expected_attributes.deep_sort
   end
 
-  def then_it_includes_the_empty_degrees_data_from_application
+  def then_it_includes_the_empty_degrees_data_from_the_application
     expect(api_received_data[:attributes][:qualifications][:degrees]).to eq([])
   end
 

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Vendor receives the application', time: CycleTimetableHelper.mid
     and_candidate_sign_in
     and_a_candidate_has_submitted_an_undergraduate_application
     when_i_retrieve_the_application_over_the_api
-    then_it_includes_the_empty_degrees_data_from_application
+    then_it_includes_the_empty_degrees_data_from_the_application
   end
 
   def given_teacher_degree_apprenticeship_feature_flag_is_on
@@ -336,7 +336,7 @@ RSpec.describe 'Vendor receives the application', time: CycleTimetableHelper.mid
     @api_response['data'].first.deep_symbolize_keys
   end
 
-  def then_it_includes_the_empty_degrees_data_from_application
+  def then_it_includes_the_empty_degrees_data_from_the_application
     expect(api_received_data[:attributes][:qualifications][:degrees]).to eq([])
   end
 end

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 
 # This is an end-to-end test for the API response. To test complex logic in
 # the presenter, see spec/presenters/vendor_api/single_application_presenter_spec.rb.
-RSpec.describe 'Vendor receives the application', time: CycleTimetableHelper.mid_cycle(2024) do
+RSpec.describe 'Vendor receives the application', time: CycleTimetableHelper.mid_cycle(2025) do
   include CandidateHelper
 
-  scenario 'A completed application is submitted with references' do
-    given_a_candidate_has_submitted_their_application
+  scenario 'A completed postgraduate application is submitted with references' do
+    given_a_candidate_has_submitted_their_postgraduate_application
     when_i_retrieve_the_application_over_the_api
     then_it_includes_the_data_from_the_application_form
     when_an_offer_is_made_and_accepted
@@ -14,10 +14,33 @@ RSpec.describe 'Vendor receives the application', time: CycleTimetableHelper.mid
     then_it_includes_their_references
   end
 
-  def given_a_candidate_has_submitted_their_application
+  scenario 'A completed undergraduate application is submitted' do
+    given_teacher_degree_apprenticeship_feature_flag_is_on
+    and_candidate_sign_in
+    and_a_candidate_has_submitted_an_undergraduate_application
+    when_i_retrieve_the_application_over_the_api
+    then_it_includes_the_empty_degrees_data_from_application
+  end
+
+  def given_teacher_degree_apprenticeship_feature_flag_is_on
+    FeatureFlag.activate(:teacher_degree_apprenticeship)
+  end
+
+  def and_candidate_sign_in
+    create_and_sign_in_candidate
+  end
+
+  def given_a_candidate_has_submitted_their_postgraduate_application
     candidate_completes_application_form
     and_the_candidate_add_more_degrees
     candidate_submits_application
+  end
+
+  def and_a_candidate_has_submitted_an_undergraduate_application
+    given_undergraduate_courses_exist
+    candidate_completes_application_form
+    candidate_does_not_have_a_degree
+    candidate_submits_undergraduate_application
   end
 
   def and_the_candidate_add_more_degrees
@@ -286,9 +309,8 @@ RSpec.describe 'Vendor receives the application', time: CycleTimetableHelper.mid
   end
 
   def then_it_includes_their_references
-    received_attributes = @api_response['data'].first.deep_symbolize_keys
-    expect(received_attributes.dig(:attributes, :references)).to be_present
-    expect(received_attributes.dig(:attributes, :references)).to contain_exactly(
+    expect(api_received_data.dig(:attributes, :references)).to be_present
+    expect(api_received_data.dig(:attributes, :references)).to contain_exactly(
       {
         id: @application.application_references.creation_order.first.id,
         name: 'Terri Tudor',
@@ -308,5 +330,13 @@ RSpec.describe 'Vendor receives the application', time: CycleTimetableHelper.mid
         safeguarding_concerns: false,
       },
     )
+  end
+
+  def api_received_data
+    @api_response['data'].first.deep_symbolize_keys
+  end
+
+  def then_it_includes_the_empty_degrees_data_from_application
+    expect(api_received_data[:attributes][:qualifications][:degrees]).to eq([])
   end
 end


### PR DESCRIPTION
## Context

Empty degrees will come automatically from Vendor API and Register API for TDA courses but we need to add automated tests on Vendor API to guarantee behaviour is properly tested.

## Guidance to review

1. Run the rake task `rake create_undergraduate_courses`
2. Set the cycle switcher to mid cycle
3. Login as a candidate
4. Submit an undergraduate course
5. Check on Vendor API the application via `/api/v1/applications/id-of-the-application-choice` (you probably need to create a vendor API token for the provider that you submit on step 3).
6. The degrees on qualifications should be an empty array
7. Recruit this candidate via Manage
8. Check on Register API the application via  `/register-api/applications` 
9. The degrees on qualifications should be an empty array