### PR TITLE
Ability to temporarily block provider activity log

### DIFF
--- a/app/controllers/provider_interface/activity_log_controller.rb
+++ b/app/controllers/provider_interface/activity_log_controller.rb
@@ -5,11 +5,13 @@ module ProviderInterface
     PAGY_PER_PAGE = 50
 
     def index
-      application_choices = GetApplicationChoicesForProviders.call(
-        providers: current_provider_user.providers,
-      )
-      events = GetActivityLogEvents.call(application_choices:)
-      @pagy, @events = pagy(events, limit: PAGY_PER_PAGE)
+      unless FeatureFlag.active?(:block_provider_activity_log)
+        application_choices = GetApplicationChoicesForProviders.call(
+          providers: current_provider_user.providers,
+        )
+        events = GetActivityLogEvents.call(application_choices:)
+        @pagy, @events = pagy(events, limit: PAGY_PER_PAGE)
+      end
     end
   end
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -34,6 +34,7 @@ class FeatureFlag
     [:structured_reference_condition, 'Structured reference condition that can be added as a condition to an offer', 'Tomas Destefi'],
     [:continuous_applications, 'The new continuous applications flow', 'James Glenn'],
     [:teacher_degree_apprenticeship, 'The degree apprenticeship program', 'Tomas Destefi'],
+    [:block_provider_activity_log, 'Block provider activity log if causing problems', 'Lori Bailey'],
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day

--- a/app/views/provider_interface/activity_log/index.html.erb
+++ b/app/views/provider_interface/activity_log/index.html.erb
@@ -2,29 +2,37 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <% if FeatureFlag.active?(:block_provider_activity_log) %>
+    <%= govuk_notification_banner(
+          title_text: 'Temporarily unavailable',
+          text: 'The activity log is currently unavailable. We estimate it will be available by 10 October 2024.',
+        ) %>
+    <% else %>
     <h1 class="govuk-heading-l">Activity log</h1>
+      <div class="govuk-!-margin-top-0">
+        <% previous_date = '' %>
+        <% @events.each do |event| %>
+          <% current_date = event.created_at.to_fs(:govuk_date) %>
+          <% if current_date != previous_date %>
+            </div>
 
-    <div class="govuk-!-margin-top-0">
-      <% previous_date = '' %>
-      <% @events.each do |event| %>
-        <% current_date = event.created_at.to_fs(:govuk_date) %>
-        <% if current_date != previous_date %>
-          </div>
+            <h2 class="govuk-heading-m govuk-!-margin-top-9">
+              <%= current_date %>
+            </h2>
+            <% previous_date = current_date %>
 
-          <h2 class="govuk-heading-m govuk-!-margin-top-9">
-            <%= current_date %>
-          </h2>
-          <% previous_date = current_date %>
+            <div class="app-timeline">
+          <% end %>
 
-          <div class="app-timeline">
+          <%= render ProviderInterface::ActivityLogEventComponent.new(activity_log_event: ActivityLogEvent.new(audit: event)) %>
         <% end %>
-
-        <%= render ProviderInterface::ActivityLogEventComponent.new(activity_log_event: ActivityLogEvent.new(audit: event)) %>
-      <% end %>
-    </div>
+      </div>
+    <% end %>
   </div>
 </div>
 
-<div class="govuk-grid-row govuk-!-margin-top-4">
-  <%= govuk_pagination(pagy: @pagy) %>
-</div>
+<% unless FeatureFlag.active?(:block_provider_activity_log) %>
+  <div class="govuk-grid-row govuk-!-margin-top-4">
+    <%= govuk_pagination(pagy: @pagy) %>
+  </div>
+<% end %>


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request


https://github.com/user-attachments/assets/7cd02179-744f-4723-b5d7-11e86ad086c4



<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
