### PR TITLE
Implement ability to block sign in

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -35,6 +35,7 @@ class FeatureFlag
     [:continuous_applications, 'The new continuous applications flow', 'James Glenn'],
     [:teacher_degree_apprenticeship, 'The degree apprenticeship program', 'Tomas Destefi'],
     [:block_provider_activity_log, 'Block provider activity log if causing problems', 'Lori Bailey'],
+    [:block_candidate_sign_in, 'Blocking candidate sign in, used if we are reaching rate limits in Notify', 'Lori Bailey'],
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day

--- a/app/views/candidate_interface/sign_in/new.html.erb
+++ b/app/views/candidate_interface/sign_in/new.html.erb
@@ -3,18 +3,29 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: candidate, url: candidate_interface_sign_in_path(providerCode: params[:providerCode], courseCode: params[:courseCode]), html: { novalidate: true } do |f| %>
-      <%= f.govuk_error_summary %>
+    <% if FeatureFlag.inactive? :block_candidate_sign_in %>
+      <%= form_with model: candidate, url: candidate_interface_sign_in_path(providerCode: params[:providerCode], courseCode: params[:courseCode]), html: { novalidate: true } do |f| %>
+        <%= f.govuk_error_summary %>
 
+        <h1 class="govuk-heading-xl">
+          <%= t('page_titles.sign_in') %>
+        </h1>
+
+        <p class="govuk-body-l">Enter the email address you used to register with, and we will send you a link to sign in.</p>
+
+        <%= f.govuk_email_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, width: 'two-thirds', autocomplete: 'email', spellcheck: false %>
+
+        <%= f.govuk_submit t('continue') %>
+      <% end %>
+    <% else %>
       <h1 class="govuk-heading-xl">
         <%= t('page_titles.sign_in') %>
       </h1>
-
-      <p class="govuk-body-l">Enter the email address you used to register with, and we will send you a link to sign in.</p>
-
-      <%= f.govuk_email_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, width: 'two-thirds', autocomplete: 'email', spellcheck: false %>
-
-      <%= f.govuk_submit t('continue') %>
+      <%= govuk_notification_banner(
+            title_text: 'Sign in temporarily unavailable',
+            text: 'We are experiencing a high number of requests.
+                   The service will be available again shortly.',
+          ) %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/sign_up/new.html.erb
+++ b/app/views/candidate_interface/sign_up/new.html.erb
@@ -3,19 +3,30 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <% if FeatureFlag.inactive? :block_candidate_sign_in %>
 
-    <%= form_with model: @sign_up_form, url: candidate_interface_sign_up_path(providerCode: params[:providerCode], courseCode: params[:courseCode]), html: { novalidate: true } do |f| %>
-      <%= f.govuk_error_summary %>
+      <%= form_with model: @sign_up_form, url: candidate_interface_sign_up_path(providerCode: params[:providerCode], courseCode: params[:courseCode]), html: { novalidate: true } do |f| %>
+        <%= f.govuk_error_summary %>
 
+        <h1 class="govuk-heading-xl">
+          <%= t('authentication.sign_up.heading') %>
+        </h1>
+
+        <%= f.govuk_email_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, hint: { text: t('authentication.sign_up.email_address.hint_label') }, width: 'two-thirds', autocomplete: 'email', spellcheck: false %>
+
+        <p class="govuk-body govuk-!-margin-bottom-6">By continuing, you agree to our <%= govuk_link_to 'terms and conditions', candidate_interface_terms_path %> and <%= govuk_link_to 'privacy notice', t('personal_information_charter.url') %>.</p>
+
+        <%= f.govuk_submit t('continue') %>
+      <% end %>
+    <% else %>
       <h1 class="govuk-heading-xl">
         <%= t('authentication.sign_up.heading') %>
       </h1>
-
-      <%= f.govuk_email_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, hint: { text: t('authentication.sign_up.email_address.hint_label') }, width: 'two-thirds', autocomplete: 'email', spellcheck: false %>
-
-      <p class="govuk-body govuk-!-margin-bottom-6">By continuing, you agree to our <%= govuk_link_to 'terms and conditions', candidate_interface_terms_path %> and <%= govuk_link_to 'privacy notice', t('personal_information_charter.url') %>.</p>
-
-      <%= f.govuk_submit t('continue') %>
+      <%= govuk_notification_banner(
+            title_text: 'Sign in temporarily unavailable',
+            text: 'We are experiencing a high number of requests.
+                   The service will be available again shortly.',
+          ) %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/start_page/create_account_or_sign_in.html.erb
+++ b/app/views/candidate_interface/start_page/create_account_or_sign_in.html.erb
@@ -4,6 +4,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <% if FeatureFlag.inactive? :block_candidate_sign_in %>
+
     <%= form_with(
       model: @create_account_or_sign_in_form,
       url: candidate_interface_create_account_or_sign_in_path(providerCode: params[:providerCode], courseCode: params[:courseCode]),
@@ -30,5 +32,15 @@
       as soon as you can.
       <%= govuk_link_to 'Read how the application process works', candidate_interface_guidance_path %></a>.
     </p>
+    <% else %>
+      <h1 class="govuk-heading-xl">
+        <%= t('page_titles.create_account_or_sign_in') %>
+      </h1>
+      <%= govuk_notification_banner(
+            title_text: 'Sign in temporarily unavailable',
+            text: 'We are experiencing a high number of requests.
+                   The service will be available again shortly.',
+          ) %>
+    <% end %>
   </div>
 </div>

--- a/spec/support/test_helpers/sign_in_helper.rb
+++ b/spec/support/test_helpers/sign_in_helper.rb
@@ -4,6 +4,11 @@ module SignInHelper
     login_as(@current_candidate)
   end
 
+  def given_sign_in_is_not_blocked
+    FeatureFlag.deactivate(:block_candidate_sign_in)
+  end
+  alias and_sign_in_is_not_blocked given_sign_in_is_not_blocked
+
   def and_i_go_to_sign_in(candidate:)
     visit root_path
     choose 'Yes, sign in'

--- a/spec/system/candidate_api/candidate_api_application_state_change_triggers_update_spec.rb
+++ b/spec/system/candidate_api/candidate_api_application_state_change_triggers_update_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'Candidate API application status change' do
 
   before do
     TestSuiteTimeMachine.travel_permanently_to(mid_cycle)
+    given_sign_in_is_not_blocked
   end
 
   it 'candidate_api_updated_at is updated when each state transition occurs' do

--- a/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_not_signed_in_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_not_signed_in_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
 
   scenario 'candidate is not signed in and retains their course selection through the sign in process' do
     # Single site course
+    given_sign_in_is_not_blocked
     given_i_am_an_existing_candidate_on_apply
     and_i_have_less_than_4_application_options
     and_the_course_i_selected_only_has_one_site

--- a/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_with_an_accepted_offer_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_arrives_from_find_with_an_accepted_offer_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'A candidate with an accepted offer arriving from Find' do
   include CandidateHelper
 
   scenario 'candidate is redirected to post offer dashboard' do
+    given_sign_in_is_not_blocked
     given_i_am_an_existing_candidate_on_apply
     and_i_have_an_accepted_offer
     and_the_course_i_selected_only_has_one_site

--- a/spec/system/candidate_interface/entering_details/candidate_account_locking_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_account_locking_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Candidate account locking' do
   include SignInHelper
 
   scenario 'Candidate attempts to continue their application while account is locked' do
+    given_sign_in_is_not_blocked
     given_i_am_signed_in
     and_i_visit_the_site
     and_my_account_is_locked

--- a/spec/system/candidate_interface/signup_and_signin/candidate_account_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_account_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Candidate account' do
 
   scenario 'Candidate signs up, out, and in again' do
     given_i_am_a_candidate_without_an_account
+    and_sign_in_is_not_blocked
 
     when_i_visit_the_signup_page
     and_i_submit_without_entering_an_email

--- a/spec/system/candidate_interface/signup_and_signin/candidate_clicking_on_expired_magic_link_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_clicking_on_expired_magic_link_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe 'Candidate clicks on an expired magic link' do
   include SignInHelper
 
   scenario 'Candidate clicks on a link with an id and expired token link in an email' do
+    given_sign_in_is_not_blocked
     and_i_am_a_candidate_with_an_application
     and_i_received_the_submitted_application_email
 

--- a/spec/system/candidate_interface/signup_and_signin/candidate_email_tracking_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_email_tracking_spec.rb
@@ -12,11 +12,7 @@ RSpec.describe 'Candidate email click tracking' do
 
     when_i_open_the_nudge_email_and_click_on_the_link
 
-    # since we have disabled the nudge_unsubmitted email, this commented out test below is failing.
-    # We can add this test back once we re-enable the email, or we can remove this spec when we decide
-    # to get rid of the email completely.
-
-    # then_an_email_click_is_logged
+    then_an_email_click_is_logged
   end
 
   def given_i_complete_my_application

--- a/spec/system/candidate_interface/signup_and_signin/candidate_sign_in_is_blocked_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_sign_in_is_blocked_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidate sign in is blocked' do
+  scenario 'I do not see the sign in form' do
+    given_candidate_sign_in_is_blocked
+    when_i_visit_the_sign_in_page
+    then_i_see_the_unavailable_message
+    and_i_do_not_see_the_sign_in_form
+  end
+
+  scenario 'I do not see the create an account or sign in page form' do
+    given_candidate_sign_in_is_blocked
+    when_i_visit_the_create_account_or_sign_in_page
+    then_i_see_the_unavailable_message
+    and_i_do_not_see_the_sign_in_or_create_an_account_form
+  end
+
+  scenario 'I do not see the sign up page form' do
+    given_candidate_sign_in_is_blocked
+    when_i_visit_the_sign_up_page
+    then_i_see_the_unavailable_message
+    and_i_do_not_see_the_sign_up_form
+  end
+
+private
+
+  def given_candidate_sign_in_is_blocked
+    FeatureFlag.activate(:block_candidate_sign_in)
+  end
+
+  def when_i_visit_the_sign_in_page
+    visit candidate_interface_sign_up_path
+  end
+
+  def when_i_visit_the_create_account_or_sign_in_page
+    visit candidate_interface_account_path
+  end
+
+  def when_i_visit_the_sign_up_page
+    visit candidate_interface_sign_up_path
+  end
+
+  def and_i_do_not_see_the_sign_in_form
+    expect(page).to have_no_content 'Email address'
+  end
+
+  def then_i_see_the_unavailable_message
+    expect(page).to have_content 'Sign in temporarily unavailable'
+  end
+
+  def and_i_do_not_see_the_sign_in_or_create_an_account_form
+    expect(page).to have_no_content 'Email address'
+  end
+
+  def and_i_do_not_see_the_sign_up_form
+    expect(page).to have_no_content 'Email address'
+  end
+end

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_and_prefills_application_in_sandbox_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_and_prefills_application_in_sandbox_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Candidate signs in and prefills application in Sandbox', :sandbo
   include CandidateHelper
 
   scenario 'User is directed to prefill option page and chooses to prefill the application' do
+    given_sign_in_is_not_blocked
     and_a_course_is_available
     and_i_am_a_candidate_with_a_blank_application
     and_teacher_degree_apprenticeship_feature_is_off

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_and_starts_blank_application_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_and_starts_blank_application_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe 'Candidate signs in and starts blank application in Sandbox', :sa
   include SignInHelper
 
   scenario 'User is directed to prefill option page and chooses to start a blank application' do
+    given_sign_in_is_not_blocked
     and_a_course_is_available
     and_i_am_a_candidate_with_a_blank_application
 

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_using_legacy_email_link_with_u_param_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_using_legacy_email_link_with_u_param_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Candidate account' do
   include SignInHelper
 
   scenario 'Candidate tries to sign in with a legacy email link containing a missing token and `u` param' do
+    given_sign_in_is_not_blocked
     and_i_am_an_existing_candidate
 
     when_i_sign_in_and_out

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_with_an_authentication_token_with_a_path_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_with_an_authentication_token_with_a_path_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Candidates authentication token has the path attribute populated
   include CandidateHelper
 
   it 'Candidate is redirected to the appropriate page' do
+    given_sign_in_is_not_blocked
     and_i_am_a_candidate_with_an_account
     and_i_have_received_a_token_associated_with_the_personal_statement_path
 

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_with_the_penultimate_valid_token_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_with_the_penultimate_valid_token_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe 'Candidate tries to sign up using magic link with an invalid toke
   include SignInHelper
 
   scenario 'Candidate signs in and receives an email inviting them to sign up' do
+    given_sign_in_is_not_blocked
     and_i_am_a_candidate_with_an_account
 
     when_i_go_to_sign_in

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_with_validation_errors_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_with_validation_errors_spec.rb
@@ -1,7 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe 'Candidate tries to sign up' do
+  include SignInHelper
+
   scenario 'Candidate attempts to sign up without filling in an email address' do
+    given_sign_in_is_not_blocked
     when_i_go_to_sign_up
     and_i_submit_the_form_without_entering_an_email
 

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_without_account_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_without_account_spec.rb
@@ -1,9 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe 'Candidate tries to sign in without an account' do
+  include SignInHelper
+
   scenario 'Candidate signs in and receives an email inviting them to sign up' do
     given_i_am_a_candidate_without_an_account
 
+    given_sign_in_is_not_blocked
     when_i_visit_the_signin_page
     and_i_submit_my_email_address
     then_i_receive_an_email_inviting_me_to_sign_up

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_up_to_test_environment_without_dfe_email_address_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_up_to_test_environment_without_dfe_email_address_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'Candidate cannot sign up to a test environment (e.g. qa) without
   end
 
   scenario 'Candidate tries to sign up' do
+    given_sign_in_is_not_blocked
     and_i_am_a_candidate_without_an_account
 
     when_i_go_to_sign_up

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe 'Candidate tries to sign up using magic link with an invalid toke
   include SignInHelper
 
   scenario 'Candidate signs in and receives an email inviting them to sign up' do
+    given_sign_in_is_not_blocked
     given_i_am_a_candidate_without_an_account
 
     when_i_go_to_sign_up

--- a/spec/system/candidate_interface/signup_and_signin/candidate_tries_to_reuse_magic_link_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_tries_to_reuse_magic_link_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Candidate account' do
   include SignInHelper
 
   scenario 'Candidate tries to sign in more than once with same magic link' do
+    given_sign_in_is_not_blocked
     and_i_am_an_existing_candidate
 
     when_i_sign_in_and_out

--- a/spec/system/candidate_interface/signup_and_signin/candidate_views_guidance_from_unsubmitted_application_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_views_guidance_from_unsubmitted_application_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Candidate signs in and starts blank application' do
 
   scenario 'User can start an application and then view the guidance' do
     given_a_course_is_available
+    and_sign_in_is_not_blocked
     and_i_am_a_candidate_with_a_blank_application
 
     when_i_fill_in_the_sign_in_form

--- a/spec/system/candidate_interface/signup_and_signin/candidate_views_guidance_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_views_guidance_spec.rb
@@ -1,7 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe 'Candidate visits the sign-in page and views guidance' do
+  include SignInHelper
+
   scenario 'User can open the guidance page with dates for the current recruitment cycle year' do
+    given_sign_in_is_not_blocked
     and_the_recruitment_cycle_year_is_2024
     and_i_visit_the_sign_in_page
     and_i_click_on_the_guidance_link

--- a/spec/system/candidate_interface/signup_and_signin/two_candidates_sign_in_on_same_machine_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/two_candidates_sign_in_on_same_machine_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe 'Candidate account' do
   include SignInHelper
   scenario 'Two candidates on the same machine sign in one after the other' do
     stub_const('TestUser', Struct.new(:name, :email))
+    given_sign_in_is_not_blocked
 
     given_i_am_the_first_candidate
     then_i_can_sign_up_and_sign_out(@first_user)


### PR DESCRIPTION
## Context
We know that we will hit our rate limit with Notify when Apply opens. One of the consequences is that the Candidate magic link emails will be delayed. By the time the candidate gets it, it might be expired. And then before that happens, the candidate might have requested one or two more logins, further clogging up the email queue. 

There will be lots of support requests if this happens.

## Changes proposed in this pull request

This code implements a feature flag to just temporarily disable the login page. We want this available just as a precaution to use in a situation where we need the email queue to clear before more login requests are made. 

This will not impact users who have already signed in. 
the `sign-in`, `sign-up` and `account` all generate magic links. So this feature flag is around all three. 

https://github.com/user-attachments/assets/79bca20c-7e49-405c-b852-9bcf6ed2121b

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
