### PR TITLE
Delay transactional mailers related to application submission

### DIFF
--- a/app/services/candidate_interface/submit_application_choice.rb
+++ b/app/services/candidate_interface/submit_application_choice.rb
@@ -23,13 +23,18 @@ module CandidateInterface
         ApplicationStateChange.new(application_choice).send_to_provider!
 
         SendNewApplicationEmailToProvider.new(application_choice:).call
-        CandidateMailer.application_choice_submitted(application_choice).deliver_later
+        CandidateMailer.application_choice_submitted(application_choice).deliver_later(wait: wait_time)
       end
     end
 
     def current_time
       Time.zone.now
     end
+
+    def wait_time
+      rand(1..15).minutes
+    end
+
     alias effective_date current_time
     alias submitted_at current_time
     alias sent_to_provider_at current_time

--- a/app/services/send_new_application_email_to_provider.rb
+++ b/app/services/send_new_application_email_to_provider.rb
@@ -10,10 +10,16 @@ class SendNewApplicationEmailToProvider
 
     NotificationsList.for(application_choice, event: :application_submitted, include_ratifying_provider: true).each do |provider_user|
       if application_choice.application_form.has_safeguarding_issues_to_declare?
-        ProviderMailer.application_submitted_with_safeguarding_issues(provider_user, application_choice).deliver_later
+        ProviderMailer.application_submitted_with_safeguarding_issues(provider_user, application_choice).deliver_later(wait: wait_time)
       else
-        ProviderMailer.application_submitted(provider_user, application_choice).deliver_later
+        ProviderMailer.application_submitted(provider_user, application_choice).deliver_later(wait: wait_time)
       end
     end
+  end
+
+private
+
+  def wait_time
+    @wait_time ||= rand(1..15).minutes
   end
 end


### PR DESCRIPTION
## Context

We know that we will hit our rate limit with Notify when Apply opens. One of the consequences is that the Candidate magic link emails will be delayed. By the time the candidate gets it, it might be expired. And then before that happens, the candidate might have requested one or two more logins, further clogging up the email queue.

There will be lots of support requests if this happens.

We can spread out the transactional emails (notifications to candidate and provider that a choice has been submitted) by adding a wait time to the `deliver_later` method. So rather than trying to send potentially around 10k emails in the first 30 seconds, we'll delay the emails from anywhere from 1 minute to 15 minutes. 

We don't want to delay everyone the same amount of time, or we'll just push the same bottle neck to 15 minutes later. 

## Changes proposed in this pull request

Adding a random wait time of 1-15 minutes to the emails that are sent to providers and candidates.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
