### PR TITLE
Ignore international column on ApplicationQualifications 

### DIFF
--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -1,6 +1,7 @@
 class ApplicationQualification < ApplicationRecord
   include TouchApplicationChoices
   include TouchApplicationFormState
+  self.ignored_columns += [:international]
 
   EXPECTED_DEGREE_DATA = %i[
     qualification_type

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -168,7 +168,6 @@ shared:
     - institution_country
     - institution_hesa_code
     - institution_name
-    - international
     - level
     - not_completed_explanation
     - non_uk_qualification_type

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -16,28 +16,6 @@
   - remote_address
   - request_uuid
   - created_at
-  :active_storage_variant_records:
-  - id
-  - blob_id
-  - variation_digest
-  - created_at
-  :active_storage_blobs:
-  - id
-  - key
-  - filename
-  - content_type
-  - metadata
-  - service_name
-  - byte_size
-  - checksum
-  - created_at
-  :active_storage_attachments:
-  - id
-  - name
-  - record_type
-  - record_id
-  - blob_id
-  - created_at
   :blazer_queries:
   - id
   - creator_id
@@ -80,6 +58,28 @@
   - query_id
   - statement
   - data_source
+  - created_at
+  :active_storage_variant_records:
+  - id
+  - blob_id
+  - variation_digest
+  - created_at
+  :active_storage_attachments:
+  - id
+  - name
+  - record_type
+  - record_id
+  - blob_id
+  - created_at
+  :active_storage_blobs:
+  - id
+  - key
+  - filename
+  - content_type
+  - metadata
+  - service_name
+  - byte_size
+  - checksum
   - created_at
   :monthly_statistics_reports:
   - id
@@ -175,7 +175,6 @@
   :data_exports:
   - id
   - name
-  - data
   - completed_at
   - initiator_type
   - initiator_id
@@ -216,8 +215,6 @@
   :application_choices:
   - provider_ids
   - current_recruitment_cycle_year
-  - decline_by_default_at
-  - decline_by_default_days
   :site_settings:
   - id
   - name


### PR DESCRIPTION
## Context

The field international in the applications_qualifications table is no longer used. it is false for all qualifications after 2022. We do not update it when someone creates a non uk qualification. Instead we use the presence of non_uk_qualification_type (string) as a proxy for the qualification being from another country.

Having an unused field like this is noisy and causes confusion when collecting and analysing data.

## Changes proposed in this pull request

Ignore the `international` column
Regenerate the analytics blocklist

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [x] Add PR link to Trello card
