### PR TITLE
Add new redacted email service for support

### DIFF
--- a/app/services/redact_candidate_email.rb
+++ b/app/services/redact_candidate_email.rb
@@ -1,0 +1,26 @@
+class RedactCandidateEmail
+  def initialize(candidate, audit_comment:)
+    @candidate = candidate
+    @audit_comment = build_audit_comment(audit_comment)
+  end
+
+  def call
+    redacted_email = "redacted.email.address#{@candidate.id}@example.com"
+
+    @candidate.update!(
+      email_address: redacted_email,
+      audit_comment: @audit_comment,
+    )
+  end
+
+private
+
+  def build_audit_comment(audit_comment)
+    <<~COMMENT
+      User email replaced following request to stop automatic email reminders and communications.
+      User advised that this will prevent access to their account and may also prevent
+      communications from providers they have applied to. Reversion to original email address
+      permitted if requested to grant access to account. Extra information: #{audit_comment}
+    COMMENT
+  end
+end

--- a/app/services/redact_candidate_email.rb
+++ b/app/services/redact_candidate_email.rb
@@ -5,7 +5,7 @@ class RedactCandidateEmail
   end
 
   def call
-    redacted_email = "redacted.email.address#{@candidate.id}@example.com"
+    redacted_email = "redacted-email-address-#{@candidate.id}@example.com"
 
     @candidate.update!(
       email_address: redacted_email,

--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -729,6 +729,35 @@ Candidate.transaction do
 end
 ```
 
+## Redact email address
+
+A candidate decides they no longer want to receive communication and does not
+want to use the service anymore.
+
+This service is called to redact their email and add an audit log documenting
+the change. The email address is replaced in the format:
+
+```
+redacted.email.address{candidate.id}@example.com
+```
+
+The service requires a candidate and an audit_comment:
+
+```ruby
+candidate = Candidate.find(ID_OF_THE_CANDIDATE)
+service = RedactCandidateEmail.new(candidate, audit_comment: "some audit comment")
+service.candidate # to check the candidate
+service.audit_comment # to check the audit message
+service.call
+```
+
+If you want to check the candidate and the audit created above:
+
+```ruby
+  candidate.reload.email_address
+  candidate.reload.audits.last
+```
+
 ## Old recruitment cycles
 
 When an `ApplicationForm` is updated, we ususally want those changes to be available in the API so Providers and Vendors can consume the updates. This is done by `touch`ing the `ApplicationChoice` records. This updates the `updated_at` value on the ApplicationChoice so it is made priority for the providers to consume.

--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -737,8 +737,8 @@ want to use the service anymore.
 This service is called to redact their email and add an audit log documenting
 the change. The email address is replaced in the format:
 
-```
-redacted.email.address{candidate.id}@example.com
+```ruby
+"redacted-email-address-#{candidate.id}@example.com"
 ```
 
 The service requires a candidate and an audit_comment:

--- a/spec/services/redact_candidate_email_spec.rb
+++ b/spec/services/redact_candidate_email_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe RedactCandidateEmail, :with_audited do
+  describe '#call' do
+    let(:candidate) { create(:candidate) }
+    let(:custom_audit_comment) { 'Candidate requested email removal.' }
+    let(:expected_comment) do
+      <<~COMMENT
+        User email replaced following request to stop automatic email reminders and communications.
+        User advised that this will prevent access to their account and may also prevent
+        communications from providers they have applied to. Reversion to original email address
+        permitted if requested to grant access to account. Extra information: #{custom_audit_comment}
+      COMMENT
+    end
+
+    subject(:service) { described_class.new(candidate, audit_comment: custom_audit_comment) }
+
+    it 'updates the email_address to the redacted format' do
+      service.call
+
+      expect(candidate.reload.email_address).to eq("redacted.email.address#{candidate.id}@example.com")
+    end
+
+    it 'adds the correct audit comment' do
+      service.call
+
+      expect(candidate.reload.audits.last.comment).to eq(expected_comment)
+    end
+
+    it 'raises an error if the candidate update fails' do
+      allow(candidate).to receive(:update!).and_raise(ActiveRecord::RecordInvalid)
+
+      expect { service.call }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+end

--- a/spec/services/redact_candidate_email_spec.rb
+++ b/spec/services/redact_candidate_email_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe RedactCandidateEmail, :with_audited do
     it 'updates the email_address to the redacted format' do
       service.call
 
-      expect(candidate.reload.email_address).to eq("redacted.email.address#{candidate.id}@example.com")
+      expect(candidate.reload.email_address).to eq("redacted-email-address-#{candidate.id}@example.com")
     end
 
     it 'adds the correct audit comment' do


### PR DESCRIPTION
## Context

We’ve begun receiving support requests to redact candidates' email addresses without deleting their data to stop receiving any emails within the service. 

To handle these requests more effectively and consistently, we need a clear and structured approach that makes the reasons for the changes explicit.

By implementing this, we will also be able to easily track candidates whose email addresses were changed, which will help when implementing a long-term solution in the future. This avoids the need to sift through individual audit comments to identify these changes retrospectively.