### PR TITLE
Set maxlength and inputmode html attribute for all year inputs

### DIFF
--- a/app/views/candidate_interface/degrees/degree/new_award_year.erb
+++ b/app/views/candidate_interface/degrees/degree/new_award_year.erb
@@ -4,7 +4,7 @@
   <% content_for :before_content, govuk_back_link_to(@wizard.award_year_back_link) %>
   <%= form_with model: @wizard, url: candidate_interface_degree_award_year_path do |f| %>
     <%= f.govuk_error_summary %>
-    <%= f.govuk_text_field :award_year, label: { text: t('application_form.degree.award_year.label', did_or_will: (@wizard.completed? ? 'did' : 'will').to_s), size: 'l' }, hint: { text: t('application_form.degree.award_year.hint') }, width: 4, maxlength: 4 %>
+    <%= f.govuk_text_field :award_year, label: { text: t('application_form.degree.award_year.label', did_or_will: (@wizard.completed? ? 'did' : 'will').to_s), size: 'l' }, hint: { text: t('application_form.degree.award_year.hint') }, width: 4, maxlength: 4, inputmode: 'numeric' %>
     <%= f.govuk_submit t('save_and_continue') %>
   <% end %>
   </div>

--- a/app/views/candidate_interface/degrees/degree/new_award_year.erb
+++ b/app/views/candidate_interface/degrees/degree/new_award_year.erb
@@ -1,10 +1,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-  <% content_for :title, title_with_error_prefix(t("application_form.degree.award_year.label", did_or_will: "#{@wizard.completed? ? 'did' : 'will' }"), @wizard.errors.any?) %>
+  <% content_for :title, title_with_error_prefix(t('application_form.degree.award_year.label', did_or_will: (@wizard.completed? ? 'did' : 'will').to_s), @wizard.errors.any?) %>
   <% content_for :before_content, govuk_back_link_to(@wizard.award_year_back_link) %>
   <%= form_with model: @wizard, url: candidate_interface_degree_award_year_path do |f| %>
     <%= f.govuk_error_summary %>
-    <%= f.govuk_text_field :award_year, label: { text: t("application_form.degree.award_year.label", did_or_will: "#{@wizard.completed? ? 'did' : 'will' }"), size: 'l'}, hint: { text: t("application_form.degree.award_year.hint") }, width: 4  %>
+    <%= f.govuk_text_field :award_year, label: { text: t('application_form.degree.award_year.label', did_or_will: (@wizard.completed? ? 'did' : 'will').to_s), size: 'l' }, hint: { text: t('application_form.degree.award_year.hint') }, width: 4, maxlength: 4 %>
     <%= f.govuk_submit t('save_and_continue') %>
   <% end %>
   </div>

--- a/app/views/candidate_interface/degrees/degree/new_start_year.html.erb
+++ b/app/views/candidate_interface/degrees/degree/new_start_year.html.erb
@@ -4,7 +4,7 @@
   <% content_for :before_content, govuk_back_link_to(@wizard.start_year_back_link) %>
   <%= form_with model: @wizard, url: candidate_interface_degree_start_year_path do |f| %>
     <%= f.govuk_error_summary %>
-    <%= f.govuk_text_field :start_year, label: { text: t('page_titles.what_year_did_you_start_your_degree'), size: 'l' }, hint: { text: 'For example, 1999' }, width: 4, maxlength: 4 %>
+    <%= f.govuk_text_field :start_year, label: { text: t('page_titles.what_year_did_you_start_your_degree'), size: 'l' }, hint: { text: 'For example, 1999' }, width: 4, maxlength: 4, inputmode: 'numeric' %>
     <%= f.govuk_submit t('save_and_continue') %>
   <% end %>
   </div>

--- a/app/views/candidate_interface/degrees/degree/new_start_year.html.erb
+++ b/app/views/candidate_interface/degrees/degree/new_start_year.html.erb
@@ -4,7 +4,7 @@
   <% content_for :before_content, govuk_back_link_to(@wizard.start_year_back_link) %>
   <%= form_with model: @wizard, url: candidate_interface_degree_start_year_path do |f| %>
     <%= f.govuk_error_summary %>
-    <%= f.govuk_text_field :start_year, label: { text: t('page_titles.what_year_did_you_start_your_degree'), size: 'l' }, hint: { text: 'For example, 1999' }, width: 4 %>
+    <%= f.govuk_text_field :start_year, label: { text: t('page_titles.what_year_did_you_start_your_degree'), size: 'l' }, hint: { text: 'For example, 1999' }, width: 4, maxlength: 4 %>
     <%= f.govuk_submit t('save_and_continue') %>
   <% end %>
   </div>

--- a/app/views/candidate_interface/english_foreign_language/ielts/_form_fields.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/ielts/_form_fields.html.erb
@@ -19,6 +19,7 @@
   hint: { text: 'Give the year, for example: ‘2020’' },
   inputmode: 'numeric',
   width: 4,
+  maxlength: 4,
 ) %>
 
 <%= f.govuk_submit t('save_and_continue') %>

--- a/app/views/candidate_interface/english_foreign_language/other_efl_qualification/_form_fields.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/other_efl_qualification/_form_fields.html.erb
@@ -16,6 +16,7 @@
   hint: { text: 'Give the year, for example: ‘2020’' },
   inputmode: 'numeric',
   width: 4,
+  maxlength: 4,
 ) %>
 
 <%= f.govuk_submit t('save_and_continue') %>

--- a/app/views/candidate_interface/english_foreign_language/toefl/_form_fields.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/toefl/_form_fields.html.erb
@@ -20,6 +20,7 @@
   hint: { text: 'Give the year, for example: ‘2020’' },
   inputmode: 'numeric',
   width: 4,
+  maxlength: 4,
 ) %>
 
 <%= f.govuk_submit t('save_and_continue') %>

--- a/app/views/candidate_interface/gcse/year/_form.html.erb
+++ b/app/views/candidate_interface/gcse/year/_form.html.erb
@@ -2,9 +2,9 @@
 <h1 class="govuk-heading-xl"><%= year_step_title(@subject, @year_form.qualification_type) %></h1>
 
 <% if @year_form.qualification_type == 'gce_o_level' %>
-  <%= f.govuk_text_field :award_year, label: { text: t('application_form.gcse.award_year.label'), size: 'm' }, hint: { text: t('application_form.gcse.award_year.gce_o_level_hint_text') }, width: 4, maxlength: 4 %>
+  <%= f.govuk_text_field :award_year, label: { text: t('application_form.gcse.award_year.label'), size: 'm' }, hint: { text: t('application_form.gcse.award_year.gce_o_level_hint_text') }, width: 4, maxlength: 4, inputmode: 'numeric' %>
 <% else %>
-  <%= f.govuk_text_field :award_year, label: { text: t('application_form.gcse.award_year.label'), size: 'm' }, hint: { text: t('application_form.gcse.award_year.hint_text') }, width: 4, maxlength: 4 %>
+  <%= f.govuk_text_field :award_year, label: { text: t('application_form.gcse.award_year.label'), size: 'm' }, hint: { text: t('application_form.gcse.award_year.hint_text') }, width: 4, maxlength: 4, inputmode: 'numeric' %>
 <% end %>
 
 <%= f.govuk_submit t('save_and_continue') %>

--- a/app/views/candidate_interface/gcse/year/_form.html.erb
+++ b/app/views/candidate_interface/gcse/year/_form.html.erb
@@ -2,9 +2,9 @@
 <h1 class="govuk-heading-xl"><%= year_step_title(@subject, @year_form.qualification_type) %></h1>
 
 <% if @year_form.qualification_type == 'gce_o_level' %>
-  <%= f.govuk_text_field :award_year, label: { text: t('application_form.gcse.award_year.label'), size: 'm' }, hint: { text: t('application_form.gcse.award_year.gce_o_level_hint_text') }, type: :number, width: 4 %>
+  <%= f.govuk_text_field :award_year, label: { text: t('application_form.gcse.award_year.label'), size: 'm' }, hint: { text: t('application_form.gcse.award_year.gce_o_level_hint_text') }, width: 4, maxlength: 4 %>
 <% else %>
-  <%= f.govuk_text_field :award_year, label: { text: t('application_form.gcse.award_year.label'), size: 'm' }, hint: { text: t('application_form.gcse.award_year.hint_text') }, type: :number, width: 4 %>
+  <%= f.govuk_text_field :award_year, label: { text: t('application_form.gcse.award_year.label'), size: 'm' }, hint: { text: t('application_form.gcse.award_year.hint_text') }, width: 4, maxlength: 4 %>
 <% end %>
 
 <%= f.govuk_submit t('save_and_continue') %>

--- a/app/views/candidate_interface/other_qualifications/details/_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/_form.html.erb
@@ -2,7 +2,7 @@
     <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.optional_label'), size: 'm' } %>
     <%= f.govuk_collection_select :institution_country, select_country_options, :id, :name, label: { text: t('application_form.other_qualification.institution_country.label'), size: 'm' } %>
     <%= f.govuk_text_field :grade, label: { text: t('application_form.other_qualification.grade.optional_label'), size: 'm' }, width: 10 %>
-    <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint: { text: t('application_form.other_qualification.award_year.hint_text') }, inputmode: 'numeric', width: 4 %>
+    <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint: { text: t('application_form.other_qualification.award_year.hint_text') }, inputmode: 'numeric', width: 4, maxlength: 4 %>
   <% elsif @form.btec? %>
     <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label'), size: 'm' } %>
     <%= tag.div(id: 'subject-autosuggest-data', data: { source: subjects }) if subjects %>
@@ -11,7 +11,7 @@
         <%= f.govuk_radio_button :grade, grade, label: { text: grade.to_s }, link_errors: i.zero? %>
       <% end %>
     <% end %>
-    <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint: { text: t('application_form.other_qualification.award_year.hint_text') }, type: :number, width: 4 %>
+    <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint: { text: t('application_form.other_qualification.award_year.hint_text') }, width: 4, maxlength: 4 %>
   <% else %>
     <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label'), size: 'm' } %>
     <%= tag.div(id: 'subject-autosuggest-data', data: { source: subjects }) if subjects %>
@@ -20,5 +20,6 @@
                            width: ['A level', 'AS level', 'GCSE'].include?(@form.qualification_type) ? 4 : 10,
                            hint: @form.grade_hint %>
     <%= tag.div(id: 'grade-autosuggest-data', data: { source: grades }) if grades %>
-    <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint: { text: t('application_form.other_qualification.award_year.hint_text') }, inputmode: 'numeric', width: 4 %>
+    <%= f.govuk_text_field :award_year,
+                           label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint: { text: t('application_form.other_qualification.award_year.hint_text') }, inputmode: 'numeric', width: 4, maxlength: 4 %>
   <% end %>

--- a/app/views/candidate_interface/other_qualifications/details/_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/_form.html.erb
@@ -11,7 +11,7 @@
         <%= f.govuk_radio_button :grade, grade, label: { text: grade.to_s }, link_errors: i.zero? %>
       <% end %>
     <% end %>
-    <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint: { text: t('application_form.other_qualification.award_year.hint_text') }, width: 4, maxlength: 4 %>
+    <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint: { text: t('application_form.other_qualification.award_year.hint_text') }, width: 4, maxlength: 4, inputmode: 'numeric' %>
   <% else %>
     <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label'), size: 'm' } %>
     <%= tag.div(id: 'subject-autosuggest-data', data: { source: subjects }) if subjects %>

--- a/app/views/support_interface/application_forms/degrees/edit.html.erb
+++ b/app/views/support_interface/application_forms/degrees/edit.html.erb
@@ -7,8 +7,8 @@
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_fieldset legend: { text: "Edit #{@degree_form.subject.capitalize} degree details", size: 'l' } do %>
-        <%= f.govuk_text_field :start_year, label: { text: 'Start year', size: 'm' }, maxlength: 4 %>
-        <%= f.govuk_text_field :award_year, label: { text: 'Award year', size: 'm' }, maxlength: 4 %>
+        <%= f.govuk_text_field :start_year, label: { text: 'Start year', size: 'm' }, maxlength: 4, inputmode: 'numeric' %>
+        <%= f.govuk_text_field :award_year, label: { text: 'Award year', size: 'm' }, maxlength: 4, inputmode: 'numeric' %>
       <% end %>
 
         <%= f.govuk_text_field :audit_comment, label: { text: t('support_interface.edit_address_details_form.audit_comment.label'), size: 'm' }, hint: { text: t('support_interface.edit_address_details_form.audit_comment.hint') } %>

--- a/app/views/support_interface/application_forms/degrees/edit.html.erb
+++ b/app/views/support_interface/application_forms/degrees/edit.html.erb
@@ -7,8 +7,8 @@
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_fieldset legend: { text: "Edit #{@degree_form.subject.capitalize} degree details", size: 'l' } do %>
-        <%= f.govuk_text_field :start_year, label: { text: 'Start year', size: 'm' } %>
-        <%= f.govuk_text_field :award_year, label: { text: 'Award year', size: 'm' } %>
+        <%= f.govuk_text_field :start_year, label: { text: 'Start year', size: 'm' }, maxlength: 4 %>
+        <%= f.govuk_text_field :award_year, label: { text: 'Award year', size: 'm' }, maxlength: 4 %>
       <% end %>
 
         <%= f.govuk_text_field :audit_comment, label: { text: t('support_interface.edit_address_details_form.audit_comment.label'), size: 'm' }, hint: { text: t('support_interface.edit_address_details_form.audit_comment.hint') } %>

--- a/app/views/support_interface/application_forms/other_qualifications/edit.html.erb
+++ b/app/views/support_interface/application_forms/other_qualifications/edit.html.erb
@@ -32,7 +32,8 @@
       <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' },
                                           hint: { text: t('application_form.other_qualification.award_year.hint_text') },
                                           inputmode: 'numeric',
-                                          width: 4 %>
+                                          width: 4,
+                                          maxlength: 4 %>
 
   <%= f.govuk_text_field :audit_comment, label: { text: t('support_interface.audit_comment_ticket.label'), size: 'm' }, hint: { text: t('support_interface.audit_comment_ticket.hint') } %>
 

--- a/app/views/support_interface/english_gcse_forms/_english_gcse_form.html.erb
+++ b/app/views/support_interface/english_gcse_forms/_english_gcse_form.html.erb
@@ -78,7 +78,7 @@
 <% end %>
 
 <%= f.govuk_text_field :grade, label: { text: t('application_form.gcse.grade.label'), size: 'm' }, hint: { text: t('gcse_edit_grade.hint.other.non_gcse') }, width: 4 %>
-<%= f.govuk_text_field :award_year, label: { text: 'Award year', size: 'm' }, width: 4 %>
+<%= f.govuk_text_field :award_year, label: { text: 'Award year', size: 'm' }, width: 4, maxlength: 4 %>
 
 <%= f.govuk_text_field :audit_comment, label: { text: t('support_interface.audit_comment_ticket.label'), size: 'm' }, hint: { text: t('support_interface.audit_comment_ticket.hint') } %>
 

--- a/app/views/support_interface/english_gcse_forms/_english_gcse_form.html.erb
+++ b/app/views/support_interface/english_gcse_forms/_english_gcse_form.html.erb
@@ -78,7 +78,7 @@
 <% end %>
 
 <%= f.govuk_text_field :grade, label: { text: t('application_form.gcse.grade.label'), size: 'm' }, hint: { text: t('gcse_edit_grade.hint.other.non_gcse') }, width: 4 %>
-<%= f.govuk_text_field :award_year, label: { text: 'Award year', size: 'm' }, width: 4, maxlength: 4 %>
+<%= f.govuk_text_field :award_year, label: { text: 'Award year', size: 'm' }, width: 4, maxlength: 4, inputmode: 'numeric' %>
 
 <%= f.govuk_text_field :audit_comment, label: { text: t('support_interface.audit_comment_ticket.label'), size: 'm' }, hint: { text: t('support_interface.audit_comment_ticket.hint') } %>
 

--- a/app/views/support_interface/math_gcse_forms/_math_gcse_form.html.erb
+++ b/app/views/support_interface/math_gcse_forms/_math_gcse_form.html.erb
@@ -51,7 +51,7 @@
   <% end %>
 
 <%= f.govuk_text_field :grade, label: { text: t('application_form.gcse.grade.label'), size: 'm' }, hint: { text: t('gcse_edit_grade.hint.other.non_gcse') }, width: 4 %>
-<%= f.govuk_text_field :award_year, label: { text: 'Award year', size: 'm' }, width: 4 %>
+<%= f.govuk_text_field :award_year, label: { text: 'Award year', size: 'm' }, width: 4, maxlength: 4 %>
 
 <%= f.govuk_text_field :audit_comment, label: { text: t('support_interface.audit_comment_ticket.label'), size: 'm' }, hint: { text: t('support_interface.audit_comment_ticket.hint') } %>
 

--- a/app/views/support_interface/math_gcse_forms/_math_gcse_form.html.erb
+++ b/app/views/support_interface/math_gcse_forms/_math_gcse_form.html.erb
@@ -51,7 +51,7 @@
   <% end %>
 
 <%= f.govuk_text_field :grade, label: { text: t('application_form.gcse.grade.label'), size: 'm' }, hint: { text: t('gcse_edit_grade.hint.other.non_gcse') }, width: 4 %>
-<%= f.govuk_text_field :award_year, label: { text: 'Award year', size: 'm' }, width: 4, maxlength: 4 %>
+<%= f.govuk_text_field :award_year, label: { text: 'Award year', size: 'm' }, width: 4, maxlength: 4, inputmode: 'numeric' %>
 
 <%= f.govuk_text_field :audit_comment, label: { text: t('support_interface.audit_comment_ticket.label'), size: 'm' }, hint: { text: t('support_interface.audit_comment_ticket.hint') } %>
 

--- a/app/views/support_interface/science_gcse_forms/_science_gcse_form.html.erb
+++ b/app/views/support_interface/science_gcse_forms/_science_gcse_form.html.erb
@@ -63,7 +63,7 @@
   <% end %>
 
 <%= f.govuk_text_field :grade, label: { text: t('application_form.gcse.grade.label'), size: 'm' }, hint: { text: t('gcse_edit_grade.hint.other.non_gcse') }, width: 4 %>
-<%= f.govuk_text_field :award_year, label: { text: 'Award year', size: 'm' }, width: 4 %>
+<%= f.govuk_text_field :award_year, label: { text: 'Award year', size: 'm' }, width: 4, maxlength: 4 %>
 
 <%= f.govuk_text_field :audit_comment, label: { text: t('support_interface.audit_comment_ticket.label'), size: 'm' }, hint: { text: t('support_interface.audit_comment_ticket.hint') } %>
 

--- a/app/views/support_interface/science_gcse_forms/_science_gcse_form.html.erb
+++ b/app/views/support_interface/science_gcse_forms/_science_gcse_form.html.erb
@@ -63,7 +63,7 @@
   <% end %>
 
 <%= f.govuk_text_field :grade, label: { text: t('application_form.gcse.grade.label'), size: 'm' }, hint: { text: t('gcse_edit_grade.hint.other.non_gcse') }, width: 4 %>
-<%= f.govuk_text_field :award_year, label: { text: 'Award year', size: 'm' }, width: 4, maxlength: 4 %>
+<%= f.govuk_text_field :award_year, label: { text: 'Award year', size: 'm' }, width: 4, maxlength: 4, inputmode: 'numeric' %>
 
 <%= f.govuk_text_field :audit_comment, label: { text: t('support_interface.audit_comment_ticket.label'), size: 'm' }, hint: { text: t('support_interface.audit_comment_ticket.hint') } %>
 


### PR DESCRIPTION
## Context

Limit the number of characters a user can input to 4, but also set the inputmode to `numeric` in line with gov design system. This is for all year fields

Looking at [gov design](https://design-system.service.gov.uk/components/text-input/) it insists we don't use the `type=number` HTML property. We can still use `maxlength` property and validate the input on the server.

GOV Design guidance
```
Asking for whole numbers
If you’re asking the user to enter a whole number, set the inputmode attribute to numeric
to use the numeric keypad on devices with on-screen keyboards.
```

```
Avoid using inputs with a type of number
Do not use <input type="number"> unless your user research shows that there’s a need
for it. With <input type="number"> there’s a risk of users accidentally incrementing
a number when they’re trying to do something else - for example, scroll up or down the
page. And if the user tries to enter something that’s not a number, there’s no explicit
feedback about what they’re doing wrong.
```

This will allow the user to input values like `abc1` but the server validation will take care of this. 

## Changes proposed in this pull request

Changes to year inputs to limit the maximum characters to 4 and remove the type number 

## Guidance to review

Go on review app or on local and input dates for the whole Qualification section. You should not be able to input more than 4 characters


https://github.com/user-attachments/assets/2d4b4471-8436-4352-aa7a-03c70b14c887



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
