### PR TITLE
Add A level reasons for rejection for undergraduate applications *only*

### DIFF
--- a/app/components/candidate_interface/rejection_reasons/rejection_reasons_component.html.erb
+++ b/app/components/candidate_interface/rejection_reasons/rejection_reasons_component.html.erb
@@ -9,11 +9,11 @@
           <% reason.selected_reasons.each do |nested_reason| %>
             <% if nested_reason.details %>
               <li>
-                <p><%= nested_reason.label %>:</p>
+                <p><%= nested_reason.label_text %>:</p>
                 <%= simple_format(nested_reason.details.text) %>
               </li>
             <% else %>
-              <li><%= nested_reason.label %></li>
+              <li><%= nested_reason.label_text %></li>
             <% end %>
           <% end %>
         </ul>

--- a/app/components/shared/rejection_reasons/rejection_reasons_component.html.erb
+++ b/app/components/shared/rejection_reasons/rejection_reasons_component.html.erb
@@ -10,7 +10,7 @@
             <% reason.selected_reasons.each do |nested_reason| %>
               <% if nested_reason.details %>
                 <li>
-                  <p><%= nested_reason.label %>:</p>
+                  <p><%= nested_reason.label_text %>:</p>
                   <%= simple_format(nested_reason.details.text) %>
                 </li>
               <% else %>

--- a/app/forms/provider_interface/rejections_wizard.rb
+++ b/app/forms/provider_interface/rejections_wizard.rb
@@ -26,6 +26,17 @@ module ProviderInterface
       reset_deselected_attrs(attrs)
     end
 
+    def selectable_reasons(application_choice)
+      self.class.selectable_reasons.dup.map do |reason|
+        if reason.id == 'qualifications' && !application_choice.undergraduate?
+          filtered_reasons = reason.reasons.reject { |sub_reason| sub_reason.id == 'unsuitable_a_levels' }
+          reason.dup.tap { |r| r.reasons = filtered_reasons }
+        else
+          reason
+        end
+      end
+    end
+
     def initialize_extra(_attrs)
       @checking_answers = true if current_step == 'check'
     end

--- a/app/models/rejection_reasons/reason.rb
+++ b/app/models/rejection_reasons/reason.rb
@@ -70,5 +70,9 @@ class RejectionReasons
 
       super
     end
+
+    def label_text
+      I18n.t("rejection_reasons.label_text.#{id}", default: @label)
+    end
   end
 end

--- a/app/presenters/rejection_reasons/rejection_reasons_presenter.rb
+++ b/app/presenters/rejection_reasons/rejection_reasons_presenter.rb
@@ -9,6 +9,7 @@ class RejectionReasons
     CLASS_ROOM_EXPERIENCE_REASON_CODES = %w[teaching_demonstration teaching_knowledge_other teaching_method_knowledge safeguarding_knowledge teaching_role_knowledge].freeze
     COMMUNICATION_OTHER_REASON_CODES = %w[could_not_arrange_interview did_not_reply communication_and_scheduling_other].freeze
     VALID_HIGH_LEVEL_ADVICE_REASON_CODES = %w[qualifications personal_statement teaching_knowledge communication_and_scheduling safeguarding visa_sponsorship course_full other].freeze
+    NO_TAILORED_ADVICE_CODES = %w[unsuitable_a_levels]
 
     def rejection_reasons
       return {} unless structured_rejection_reasons&.any?
@@ -77,6 +78,8 @@ class RejectionReasons
     end
 
     def valid_tailored_advice_reason_id(reason_id)
+      return if reason_id.in? NO_TAILORED_ADVICE_CODES
+
       # We consolidate some nested reasons so we don't repeat the same advice.
       if reason_id.in? NO_GCSE_REJECTION_REASON_CODES
         'no_gcse'

--- a/app/presenters/rejection_reasons/rejection_reasons_presenter.rb
+++ b/app/presenters/rejection_reasons/rejection_reasons_presenter.rb
@@ -9,7 +9,7 @@ class RejectionReasons
     CLASS_ROOM_EXPERIENCE_REASON_CODES = %w[teaching_demonstration teaching_knowledge_other teaching_method_knowledge safeguarding_knowledge teaching_role_knowledge].freeze
     COMMUNICATION_OTHER_REASON_CODES = %w[could_not_arrange_interview did_not_reply communication_and_scheduling_other].freeze
     VALID_HIGH_LEVEL_ADVICE_REASON_CODES = %w[qualifications personal_statement teaching_knowledge communication_and_scheduling safeguarding visa_sponsorship course_full other].freeze
-    NO_TAILORED_ADVICE_CODES = %w[unsuitable_a_levels]
+    NO_TAILORED_ADVICE_CODES = %w[unsuitable_a_levels].freeze
 
     def rejection_reasons
       return {} unless structured_rejection_reasons&.any?
@@ -32,10 +32,10 @@ class RejectionReasons
     def nested_reasons(reason)
       reason.selected_reasons.each_with_object([]) do |nested_reason, ary|
         if nested_reason.details
-          ary << "#{nested_reason.label}:" if render_label?(nested_reason.label, reason.selected_reasons)
+          ary << "#{nested_reason.label_text}:" if render_label?(nested_reason.label, reason.selected_reasons)
           ary << nested_reason.details.text
         else
-          ary << "#{nested_reason.label}."
+          ary << "#{nested_reason.label_text}."
         end
       end
     end

--- a/app/views/candidate_mailer/application_rejected.text.erb
+++ b/app/views/candidate_mailer/application_rejected.text.erb
@@ -16,7 +16,7 @@ This year, more people than ever are choosing to apply again.
 <% end %>
 
 <% @application_choice.tailored_advice_reasons.keys.each do |advice_reason_id| %>
-<%= render "candidate_mailer/tailored_rejection_advice/#{advice_reason_id}_tailored_advice" %>
+  <%= render "candidate_mailer/tailored_rejection_advice/#{advice_reason_id}_tailored_advice" %>
 <% end %>
 
 [Try the realistic job preview tool](<%= candidate_realistic_job_preview_link(@application_form.candidate) %>) to get insights into life in the classroom. Respond to video scenarios and get instant feedback on your suitability for a career in teaching.

--- a/app/views/provider_interface/rejections/check.html.erb
+++ b/app/views/provider_interface/rejections/check.html.erb
@@ -41,13 +41,13 @@
                 <% reason[:selected_reasons].each do |reason| %>
                   <% if reason.details.present? %>
                     <% if reason.details.text.empty? %>
-                      <p class="govuk-body"><%= reason.label %></p>
+                      <p class="govuk-body"><%= reason.label_text %></p>
                     <% else %>
-                      <p class="govuk-body"><%= reason.label %>:</p>
+                      <p class="govuk-body"><%= reason.label_text %>:</p>
                       <p class="govuk-body"><%= reason.details.text %></p>
                     <% end %>
                   <% else %>
-                    <p class="govuk-body"><%= reason.label %></p>
+                    <p class="govuk-body"><%= reason.label_text %></p>
                   <% end %>
                 <% end %>
               <% end %>

--- a/app/views/provider_interface/rejections/new.html.erb
+++ b/app/views/provider_interface/rejections/new.html.erb
@@ -17,7 +17,7 @@
       <% end %>
 
       <%= f.govuk_check_boxes_fieldset :selected_reasons, legend: -> { content_for(:fieldset_legend) }, form_group: { classes: 'govuk-!-margin-bottom-2' } do %>
-        <% @wizard.class.selectable_reasons.each do |reason| %>
+        <% @wizard.selectable_reasons(@application_choice).each do |reason| %>
           <%= f.govuk_check_box :selected_reasons, reason.id, label: { text: reason.label }, link_errors: true do %>
             <% if reason.details.present? %>
               <%= f.govuk_text_area reason.details.id.to_sym,

--- a/config/locales/provider_interface/rejections.yml
+++ b/config/locales/provider_interface/rejections.yml
@@ -59,6 +59,9 @@ en:
             communication_and_scheduling_other_details:
               blank: Enter details about communication, interview attendance and scheduling
               size: Details about communication, interview attendance and scheduling must be 100 words or fewer
+            unsuitable_a_levels_details:
+              blank: Enter details about why their A levels do not meet course requirements
+              size: Details about why their A levels do not meet course requirements must be 100 words or fewer
             references_details:
               blank: Enter details about references
               size: Details about references must be 100 words or fewer

--- a/config/locales/provider_interface/rejections.yml
+++ b/config/locales/provider_interface/rejections.yml
@@ -1,5 +1,7 @@
 en:
   rejection_reasons:
+    label_text:
+      unsuitable_a_levels: A levels do not meet course requirements
     course_full:
       description: The course is full.
   activemodel:

--- a/config/rejection_reasons.yml
+++ b/config/rejection_reasons.yml
@@ -12,6 +12,12 @@
     :label: No science GCSE at minimum grade 4 or C, or equivalent
   - :id: no_degree
     :label: No bachelor’s degree or equivalent
+  - :id: unsuitable_a_levels
+    :label: A levels do not meet course requirements (Teacher Degree Apprenticeship courses only)
+    :details:
+      :id: unsuitable_a_levels_details
+      :label: Details
+      :visually_hidden: about why their A levels do not meet course requirements
   - :id: unsuitable_degree
     :label: Degree does not meet course requirements
     :details:

--- a/spec/components/candidate_interface/rejection_reasons/rejection_reasons_component_spec.rb
+++ b/spec/components/candidate_interface/rejection_reasons/rejection_reasons_component_spec.rb
@@ -11,6 +11,15 @@ RSpec.describe CandidateInterface::RejectionReasons::RejectionReasonsComponent d
           { id: 'no_english_gcse', label: 'No English GCSE at minimum grade 4 or C, or equivalent.' },
           { id: 'no_science_gcse', label: 'No science GCSE at minimum grade 4 or C, or equivalent.' },
           {
+            id: 'unsuitable_a_levels',
+            label: 'A levels do not meet course requirements (Teacher Degree Apprenticeship courses only)',
+            details: {
+              id: 'unsuitable_a_levels_details',
+              label: 'Details',
+              text: 'Some description about A level.',
+            },
+          },
+          {
             id: 'unsuitable_degree',
             label: 'Degree does not meet course requirements',
             details: {
@@ -59,6 +68,8 @@ RSpec.describe CandidateInterface::RejectionReasons::RejectionReasonsComponent d
         'No science GCSE at minimum grade 4 or C, or equivalent.',
       )
       expect(result.css('.app-rejection__body ul li p').map(&:text).map(&:strip)).to eq([
+        'A levels do not meet course requirements:',
+        'Some description about A level.',
         'Degree does not meet course requirements:',
         'A degree in falconry is no use.',
       ])

--- a/spec/components/shared/rejection_reasons/rejection_reasons_component_spec.rb
+++ b/spec/components/shared/rejection_reasons/rejection_reasons_component_spec.rb
@@ -11,6 +11,15 @@ RSpec.describe RejectionReasons::RejectionReasonsComponent do
           { id: 'no_english_gcse', label: 'No English GCSE at minimum grade 4 or C, or equivalent.' },
           { id: 'no_science_gcse', label: 'No science GCSE at minimum grade 4 or C, or equivalent.' },
           {
+            id: 'unsuitable_a_levels',
+            label: 'A levels do not meet course requirements (Teacher Degree Apprenticeship courses only)',
+            details: {
+              id: 'unsuitable_a_levels_details',
+              label: 'Details',
+              text: 'Some description about A level.',
+            },
+          },
+          {
             id: 'unsuitable_degree',
             label: 'Degree does not meet course requirements',
             details: {
@@ -57,9 +66,12 @@ RSpec.describe RejectionReasons::RejectionReasonsComponent do
         'No maths GCSE at minimum grade 4 or C, or equivalent.',
         'No English GCSE at minimum grade 4 or C, or equivalent.',
         'No science GCSE at minimum grade 4 or C, or equivalent.',
+        'A levels do not meet course requirements: Some description about A level.',
         'Degree does not meet course requirements: A degree in falconry is no use.',
       ])
       expect(result.css('.govuk-summary-list__value p').map(&:text).map(&:strip)).to eq([
+        'A levels do not meet course requirements:',
+        'Some description about A level.',
         'Degree does not meet course requirements:',
         'A degree in falconry is no use.',
         'A close family member, suchas your mother, cannot give a reference.',

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -313,6 +313,32 @@ FactoryBot.define do
       end
     end
 
+    trait :insufficient_a_levels_rejection_reasons do
+      rejected
+      rejection_reason { nil }
+      rejection_reasons_type { 'rejection_reasons' }
+      structured_rejection_reasons do
+        {
+          selected_reasons: [
+            {
+              id: 'qualifications',
+              label: 'Qualifications',
+              selected_reasons: [
+                {
+                  id: 'unsuitable_a_levels',
+                  label: 'A levels do not meet course requirements (Teacher Degree Apprenticeship courses only)',
+                  details: {
+                    id: 'unsuitable_a_levels_details',
+                    text: 'No sufficient grade',
+                  },
+                },
+              ],
+            },
+          ],
+        }
+      end
+    end
+
     trait :reasons_for_rejection do
       rejected
       rejection_reason { nil }

--- a/spec/forms/provider_interface/rejections_wizard_spec.rb
+++ b/spec/forms/provider_interface/rejections_wizard_spec.rb
@@ -38,6 +38,41 @@ RSpec.describe ProviderInterface::RejectionsWizard do
     end
   end
 
+  describe '#selectable_reasons' do
+    subject(:selectable_reasons) do
+      instance.selectable_reasons(application_choice)
+    end
+
+    let(:application_choice) { create(:application_choice, course_option: create(:course_option, course:)) }
+    let(:qualification_reasons) do
+      selectable_reasons.find { |reason| reason.id == 'qualifications' }.reasons
+    end
+
+    context 'when undergraduate application' do
+      let(:course) { create(:course, :teacher_degree_apprenticeship) }
+
+      it 'includes the A level rejection reason' do
+        expect(qualification_reasons.map(&:id)).to include('unsuitable_a_levels')
+      end
+
+      it 'includes other qualification-related reasons' do
+        expect(qualification_reasons.map(&:id)).to include('no_maths_gcse', 'no_english_gcse', 'no_science_gcse', 'no_degree')
+      end
+    end
+
+    context 'when postgraduate application' do
+      let(:course) { create(:course, program_type: 'scitt_programme') }
+
+      it 'does not include the A level rejection reason' do
+        expect(qualification_reasons.map(&:id)).not_to include('unsuitable_a_levels')
+      end
+
+      it 'still includes other qualification-related reasons' do
+        expect(qualification_reasons.map(&:id)).to include('no_maths_gcse', 'no_english_gcse', 'no_science_gcse', 'no_degree')
+      end
+    end
+  end
+
   describe 'dynamic attributes' do
     it 'defines accessors for all attributes' do
       described_class.attribute_names.each do |attr_name|

--- a/spec/mailers/candidate_mailer_application_rejected_tailored_advice_spec.rb
+++ b/spec/mailers/candidate_mailer_application_rejected_tailored_advice_spec.rb
@@ -3,6 +3,16 @@ require 'rails_helper'
 RSpec.describe 'Tailored advice for rejected applications' do
   include TestHelpers::MailerSetupHelper
 
+  context 'when A level reason is given' do
+    it 'does not show qualifications heading neither any tailored advice' do
+      application_choice = create(:application_choice, :insufficient_a_levels_rejection_reasons)
+      email = CandidateMailer.application_rejected(application_choice)
+
+      expect(email.body).to have_no_text('Make sure you meet the qualifications criteria')
+      expect(email.body).to have_text('^ # Qualifications ^ A levels do not meet course requirements: ^ ^ No sufficient grade')
+    end
+  end
+
   context 'when one reason is given' do
     it 'does not show qualifications heading, but shows other relevant content' do
       structured_rejection_reasons = {

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -96,6 +96,18 @@ RSpec.describe CandidateMailer do
         'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
       )
     end
+
+    context 'when the candidate that submitted to an undergraduate application is rejected' do
+      let(:application_choice) do
+        build_stubbed(:application_choice, :insufficient_a_levels_rejection_reasons)
+      end
+
+      it_behaves_like(
+        'a mail with subject and content',
+        I18n.t!('candidate_mailer.application_rejected.subject'),
+        'rejection reasons' => "Qualifications\r\n\r\n        ^ A levels do not meet course requirements:\r\n        ^\r\n        ^ No sufficient grade",
+      )
+    end
   end
 
   describe 'Offer X day mailers' do

--- a/spec/models/rejection_reasons/reason_spec.rb
+++ b/spec/models/rejection_reasons/reason_spec.rb
@@ -89,6 +89,34 @@ RSpec.describe RejectionReasons::Reason do
     end
   end
 
+  describe '#label_text' do
+    let(:reason) do
+      described_class.new(
+        id: label_id,
+        label:,
+        details: { id: 'ddd', label: 'DDD', text: 'DeeDeeDee' },
+      )
+    end
+
+    context 'when translation exists' do
+      let(:label_id) { 'unsuitable_a_levels' }
+      let(:label) { 'Some label from config' }
+
+      it 'returns the translated label' do
+        expect(reason.label_text).to eq('A levels do not meet course requirements')
+      end
+    end
+
+    context 'when translation does not exist' do
+      let(:label_id) { 'qualifications' }
+      let(:label) { 'Qualifications' }
+
+      it 'returns the fallback label from configuration' do
+        expect(reason.label_text).to eq('Qualifications')
+      end
+    end
+  end
+
   describe 'validations' do
     before do
       allow(I18n).to receive(:t).and_return('Invalid!')

--- a/spec/presenters/rejection_reasons/rejection_reasons_presenter_spec.rb
+++ b/spec/presenters/rejection_reasons/rejection_reasons_presenter_spec.rb
@@ -243,6 +243,19 @@ RSpec.describe RejectionReasons::RejectionReasonsPresenter do
         end
       end
 
+      context 'when there is no need of tailored advice' do
+        let(:application_choice) do
+          build_stubbed(
+            :application_choice,
+            :insufficient_a_levels_rejection_reasons,
+          )
+        end
+
+        it 'ignores tailored advice' do
+          expect(rejected_application_choice.tailored_advice_reasons).to eq('qualifications' => [])
+        end
+      end
+
       context 'only safeguarding is a reason' do
         let(:reasons) do
           { selected_reasons: [

--- a/spec/system/provider_interface/reject_an_application_spec.rb
+++ b/spec/system/provider_interface/reject_an_application_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Reject an application' do
   include ProviderUserPermissionsHelper
   include CourseOptionHelpers
 
-  scenario 'giving rejection reasons using rejection form', :with_audited do
+  scenario 'giving rejection reasons to a postgraduate application', :with_audited do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_permitted_to_see_applications_for_my_provider
     and_i_am_permitted_to_make_decisions_on_applications_for_my_provider
@@ -26,6 +26,27 @@ RSpec.describe 'Reject an application' do
     then_i_can_see_the_rejected_application_feedback
   end
 
+  scenario 'giving rejection reasons to an undergraduate application', :with_audited do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_am_permitted_to_see_applications_for_my_provider
+    and_i_am_permitted_to_make_decisions_on_applications_for_my_provider
+    and_my_organisation_has_received_an_undergraduate_application
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_choose_to_reject_an_application
+
+    then_i_can_navigate_back_to_the_make_decision_form
+    and_i_give_a_level_reasons_why_i_am_rejecting_the_application
+    and_i_click_continue
+    and_i_check_the_a_level_reasons_for_rejection
+    and_i_click_back
+    then_i_can_see_the_rejection_reasons_form
+
+    when_i_click_continue
+    and_i_reject_the_application
+    then_i_can_see_the_rejected_undergraduate_application_feedback
+  end
+
   def given_i_am_a_provider_user_with_dfe_sign_in
     provider_exists_in_dfe_sign_in
   end
@@ -41,6 +62,18 @@ RSpec.describe 'Reject an application' do
   def and_my_organisation_has_received_an_application
     course_option = course_option_for_provider_code(provider_code: 'ABC')
     @application_choice = create(:application_choice, :with_completed_application_form, :awaiting_provider_decision, course_option:)
+  end
+
+  def and_my_organisation_has_received_an_undergraduate_application
+    provider = Provider.find_by(code: 'ABC') || create(:provider, code: 'ABC')
+    course = create(:course, :teacher_degree_apprenticeship, provider:)
+    course_option = create(:course_option, course:)
+    @application_choice = create(
+      :application_choice,
+      :with_completed_application_form,
+      :awaiting_provider_decision,
+      course_option:,
+    )
   end
 
   def when_i_choose_to_reject_an_application
@@ -61,6 +94,7 @@ RSpec.describe 'Reject an application' do
 
   def and_i_give_reasons_why_i_am_rejecting_the_application
     check 'Qualifications'
+    and_the_a_levels_rejection_reason_is_not_visible_for_postgraduate_application
 
     within_fieldset 'Reasons for rejecting due to qualifications' do
       check 'No maths GCSE at minimum grade 4 or C, or equivalent'
@@ -85,27 +119,42 @@ RSpec.describe 'Reject an application' do
     fill_in 'Details of other reasons', with: 'There are so many other reasons why your application was rejected...'
   end
 
+  def and_i_give_a_level_reasons_why_i_am_rejecting_the_application
+    check 'Qualifications'
+    check 'A levels do not meet course requirements (Teacher Degree Apprenticeship courses only)'
+    fill_in 'Details about why their A levels do not meet course requirements', with: 'A level below expected grade'
+  end
+
+  def and_i_check_the_a_level_reasons_for_rejection
+    expect(page).to have_content('Check details and reject application')
+    expect(email_preview[4..6]).to eq(
+      [
+        'Qualifications',
+        'A levels do not meet course requirements:',
+        'A level below expected grade',
+      ],
+    )
+  end
+
   def and_i_check_the_reasons_for_rejection
     expect(page).to have_content('Check details and reject application')
     expect(page).to have_content('The candidate will be sent this email:')
 
-    email = page.all('.app-email-preview').first.text.split("\n")
-
-    expect(email[0..3]).to eq([
+    expect(email_preview[0..3]).to eq([
       "Dear #{@application_choice.application_form.first_name},",
       "Thank you for your application to study #{@application_choice.current_course_option.course.name_and_code} at #{@application_choice.current_course_option.provider.name}.",
       'On this occasion, the provider is not offering you a place on this course.',
       'They’ve given the following feedback to explain their decision:',
     ])
 
-    expect(email[4..7]).to eq([
+    expect(email_preview[4..7]).to eq([
       'Qualifications',
       'No maths GCSE at minimum grade 4 or C, or equivalent',
       'Could not verify qualifications:',
       'We can find no evidence of your GCSEs',
     ])
 
-    expect(email[8..12]).to eq([
+    expect(email_preview[8..12]).to eq([
       'Personal statement',
       'Quality of writing:',
       'We do not accept applications written in morse code',
@@ -113,19 +162,19 @@ RSpec.describe 'Reject an application' do
       'This was wayyyyy too personal',
     ])
 
-    expect(email[13..15]).to eq([
+    expect(email_preview[13..15]).to eq([
       'Course full',
       'Course full:',
       'Other courses exist',
     ])
 
-    expect(email[16..18]).to eq([
+    expect(email_preview[16..18]).to eq([
       'Other',
       'Other:',
       'There are so many other reasons why your application was rejected...',
     ])
 
-    expect(email.last).to eq(
+    expect(email_preview.last).to eq(
       "Contact #{@application_choice.current_course_option.provider.name} if you would like to talk about their feedback.",
     )
 
@@ -169,5 +218,21 @@ RSpec.describe 'Reject an application' do
 
     expect(page).to have_content('Other')
     expect(page).to have_content('There are so many other reasons why your application was rejected...')
+  end
+
+  def then_i_can_see_the_rejected_undergraduate_application_feedback
+    expect(page).to have_content(
+      'The following feedback was sent to the candidate. Qualifications A levels do not meet course requirements: A level below expected grade',
+    )
+  end
+
+  def and_the_a_levels_rejection_reason_is_not_visible_for_postgraduate_application
+    expect(page).to have_no_content('A levels do not meet course requirements')
+  end
+
+private
+
+  def email_preview
+    page.all('.app-email-preview').first.text.split("\n")
   end
 end


### PR DESCRIPTION
## Context

With TDA courses, Providers will be looking at Candidate’s A-Level qualifications to see if they meet the requirements. This PR adds a new reason for rejection for undergraduate courses.
Note: This isn’t relevant to non-TDA (Postgraduate) courses so it does not appear for postgraduate courses.

## Changes

![screencapture-localhost-3000-provider-applications-3001-rejections-new-2024-10-10-16_53_39](https://github.com/user-attachments/assets/043cf0a3-4cb5-4abb-9507-3a78b69bb4dd)
![screencapture-localhost-3000-provider-applications-3001-rejections-check-2024-10-10-16_53_52](https://github.com/user-attachments/assets/19bf0356-106c-478f-825b-df1a4f381dbf)
![screencapture-localhost-3000-provider-applications-3001-feedback-2024-10-10-16_54_01](https://github.com/user-attachments/assets/6686bad0-0a75-480e-9647-e934f8dcfe6b)
![screencapture-localhost-3000-candidate-application-course-choices-3001-review-2024-10-10-16_56_14](https://github.com/user-attachments/assets/6139fbfe-1862-4e1e-8d03-cb94305de401)

## Guidance to review

1. Apply to a teacher degree apprenticeship course (run `rake create_undergraduate_courses`) - [this candidate](https://apply-review-9903.test.teacherservices.cloud/support/applications/73) or [this candidate](https://apply-review-9903.test.teacherservices.cloud/support/applications/72) for example on the review app
2. Reject this application giving A level rejection reason
3. See the pages posted on the screenshots above (feedback for example)
4. Check the email on support interface (given the workers are running to simulate the email be sending) - you can also check your own email if the candidate has your email
5. Check the candidate interface


You can see one example of on the review app here: https://apply-review-9903.test.teacherservices.cloud/provider/applications/95/ (you need to be logged in as the provider [here](https://apply-review-9903.test.teacherservices.cloud/support/users/provider/2))