### PR TITLE
Automatically selected location is appearing to candidate on a submitted application

### DIFF
--- a/app/components/candidate_interface/offer_review_component.rb
+++ b/app/components/candidate_interface/offer_review_component.rb
@@ -11,7 +11,7 @@ module CandidateInterface
         course_row,
         (salary_row if @course_choice.current_course.salary_details),
         (fee_row if @course_choice.current_course.fee?),
-        (location_row if @course_choice.school_placement_auto_selected?),
+        (location_row unless @course_choice.school_placement_auto_selected?),
         (ske_conditions_row if @course_choice.offer.ske_conditions.any?),
         (reference_condition_row if @course_choice.offer.reference_condition.present?),
         (conditions_row if @course_choice.offer.conditions.any?),

--- a/app/components/provider_interface/offer_summary_component.rb
+++ b/app/components/provider_interface/offer_summary_component.rb
@@ -7,6 +7,7 @@ module ProviderInterface
 
     def initialize(application_choice:, course:, course_option:, conditions:, available_providers: [], available_courses: [], available_course_options: [], border: true, editable: true, show_conditions_link: false, ske_conditions: [], show_recruit_pending_button: false)
       @application_choice = application_choice
+      @school_placement_auto_selected = application_choice.school_placement_auto_selected
       @course_option = course_option
       @conditions = conditions
       @available_providers = available_providers

--- a/app/controllers/candidate_interface/decisions_controller.rb
+++ b/app/controllers/candidate_interface/decisions_controller.rb
@@ -113,7 +113,7 @@ module CandidateInterface
       [].tap do |collection|
         collection << { key: 'Provider', value: @application_choice.current_course.provider.name }
         collection << { key: 'Course', value: @application_choice.current_course.name_and_code }
-        if @application_choice.school_placement_auto_selected?
+        if !@application_choice.school_placement_auto_selected?
           collection << { key: 'Location', value: @application_choice.current_course_option.site.name }
         end
       end

--- a/app/helpers/summary_list_rows_helper.rb
+++ b/app/helpers/summary_list_rows_helper.rb
@@ -8,14 +8,11 @@ module SummaryListRowsHelper
                      t('school_placements.selected_by_candidate')
                    end
 
-    summary_list_rows = [
+    [
       { key: 'Full name', value: application_choice.application_form.full_name },
       { key: 'Course', value: application_choice.course.name_and_code },
       { key: 'Starting', value: application_choice.course.recruitment_cycle_year },
+      { key: location_key, value: application_choice.current_course_option.site.name },
     ]
-    if application_choice.different_offer?
-      summary_list_rows << { key: location_key, value: application_choice.site.name }
-    end
-    summary_list_rows
   end
 end

--- a/spec/components/candidate_interface/offer_review_component_spec.rb
+++ b/spec/components/candidate_interface/offer_review_component_spec.rb
@@ -82,9 +82,7 @@ RSpec.describe CandidateInterface::OfferReviewComponent do
       it 'renders component with correct values for the location' do
         render_inline(described_class.new(course_choice: application_choice))
 
-        within('.govuk-summary-list__value') do
-          expect(page).to have_content(course_option.site.name)
-        end
+        expect(page).to have_content(course_option.site.name)
       end
     end
 
@@ -94,9 +92,7 @@ RSpec.describe CandidateInterface::OfferReviewComponent do
       it 'does not render the location row' do
         render_inline(described_class.new(course_choice: application_choice))
 
-        within('.govuk-summary-list__value') do
-          expect(page).to have_no_content(course_option.site.name)
-        end
+        expect(page).to have_no_content(course_option.site.name)
       end
     end
   end

--- a/spec/components/provider_interface/offer_summary_component_spec.rb
+++ b/spec/components/provider_interface/offer_summary_component_spec.rb
@@ -6,8 +6,10 @@ RSpec.describe ProviderInterface::OfferSummaryComponent do
   let(:application_choice) do
     create(:application_choice,
            :offered,
-           offer: build(:offer, conditions:, ske_conditions:))
+           offer: build(:offer, conditions:, ske_conditions:),
+           school_placement_auto_selected:)
   end
+  let(:school_placement_auto_selected) { false }
   let(:conditions) { [build(:text_condition, description: 'condition 1')] }
   let(:ske_conditions) { [] }
   let(:course_option) { build(:course_option, course:) }
@@ -124,6 +126,23 @@ RSpec.describe ProviderInterface::OfferSummaryComponent do
 
     it 'renders no change link' do
       expect(row_link_selector(2)).to be_nil
+    end
+  end
+
+  context 'when school placement is auto selected' do
+    let(:course) { build_stubbed(:course, study_mode: :full_time) }
+    let(:school_placement_auto_selected) { true }
+
+    it 'renders no change link' do
+      expect(render).to have_content('(not selected by candidate)')
+    end
+  end
+
+  context 'when school placement is candidate selected' do
+    let(:course) { build_stubbed(:course, study_mode: :full_time) }
+
+    it 'renders no change link' do
+      expect(render).to have_content('(selected by candidate)')
     end
   end
 


### PR DESCRIPTION
## Context

We made some mistakes when implementing the conditional location information in the Candidate & Provider Interfaces.



## Changes proposed in this pull request

### Apply

|Page|Auto Selected|User Selected|
|---|---|---|
|Details of Offer|![image](https://github.com/user-attachments/assets/1b3164a5-2803-4a7e-9fd8-3df73289173d)|![image](https://github.com/user-attachments/assets/26035b54-41a9-4488-a12f-b396f54621e4)|
|Are you sure you want to decline this offer?|![image](https://github.com/user-attachments/assets/fac18a62-f9c2-415d-8cb4-3eec39a2fcf8)|![image](https://github.com/user-attachments/assets/3434340f-d92c-43eb-b67b-632b60f077ac)|

### Manage

|Page|Auto Selected|User Selected|
|---|---|---|
|"Offer"|![image](https://github.com/user-attachments/assets/2e34107a-2c43-4972-9b51-5f30caa8b146)|![image](https://github.com/user-attachments/assets/46ac0686-9046-40f8-bd43-3074c4b7373c)|


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
