### PR TITLE
Show the right data when seeing undergraduate courses in provider interface

### DIFF
--- a/app/helpers/qualification_value_helper.rb
+++ b/app/helpers/qualification_value_helper.rb
@@ -2,6 +2,10 @@ module QualificationValueHelper
   def qualification_text(course_option)
     return if course_option.course.qualifications.nil?
 
-    course_option.course.qualifications.map(&:upcase).join(' with ')
+    if course_option.course.undergraduate?
+      course_option.course.description
+    else
+      course_option.course.qualifications.map(&:upcase).join(' with ')
+    end
   end
 end

--- a/spec/components/provider_interface/application_course_summary_component_spec.rb
+++ b/spec/components/provider_interface/application_course_summary_component_spec.rb
@@ -133,4 +133,23 @@ RSpec.describe ProviderInterface::ApplicationCourseSummaryComponent do
     expect(render_text).to include('Funding type')
     expect(render_text).to include('Fee')
   end
+
+  context 'when undergraduate application' do
+    let(:course) do
+      build(
+        :course,
+        :teacher_degree_apprenticeship,
+        name: 'Geograpghy',
+        code: 'H234',
+        provider:,
+      )
+    end
+
+    it 'renders the undergraduate course qualification' do
+      render_text = row_text_selector(:qualification, render)
+
+      expect(render_text).to include('Qualification')
+      expect(render_text).to include('Teacher degree apprenticeship with QTS')
+    end
+  end
 end


### PR DESCRIPTION
## Context

We are showing wrong data on provider interface for undergraduate applications

 
### BUG

<img width="533" alt="Screenshot 2024-10-10 at 17 03 50" src="https://github.com/user-attachments/assets/23819726-95f0-42e6-ae4c-9c143a1ff311">

### After

<img width="551" alt="Screenshot 2024-10-10 at 17 10 00" src="https://github.com/user-attachments/assets/eb8aee82-2b79-47a6-b623-a1531b2bf629">

### Guidance to review

1. Apply for a undergraduate course (run `rake create_undergraduate_courses`)
2. See application on provider interface
3. check for the Qualification row