### PR TITLE
Remove teacher degree apprenticeship feature flag code

### DIFF
--- a/app/components/candidate_interface/degree_empty_component.html.erb
+++ b/app/components/candidate_interface/degree_empty_component.html.erb
@@ -1,18 +1,13 @@
-<% if @application_form.teacher_degree_apprenticeship_feature_active? %>
-  <h2 class="govuk-heading-s"><%= t('.postgraduate.name') %></h2>
+<h2 class="govuk-heading-s"><%= t('.postgraduate.name') %></h2>
 
-  <p class="govuk-body"><%= t('.postgraduate.bachelor_degree') %></p>
-  <p class="govuk-body"><%= t('.postgraduate.add_bachelor_degree') %></p>
+<p class="govuk-body"><%= t('.postgraduate.bachelor_degree') %></p>
+<p class="govuk-body"><%= t('.postgraduate.add_bachelor_degree') %></p>
 
-  <h2 class="govuk-heading-s"><%= t('.undergraduate.name') %></h2>
+<h2 class="govuk-heading-s"><%= t('.undergraduate.name') %></h2>
 
-  <p class="govuk-body">
-    <%= t('.undergraduate.bachelor_degree_html', link: govuk_link_to(t('.undergraduate.teacher_degree_apprenticeship'), t('get_into_teaching.url_teacher_degree_apprenticeship'))) %>
-  </p>
-<% else %>
-  <p class="govuk-body"><%= t('.postgraduate.bachelor_degree') %></p>
-  <p class="govuk-body"><%= t('.postgraduate.add_bachelor_degree') %></p>
-<% end %>
+<p class="govuk-body">
+  <%= t('.undergraduate.bachelor_degree_html', link: govuk_link_to(t('.undergraduate.teacher_degree_apprenticeship'), t('get_into_teaching.url_teacher_degree_apprenticeship'))) %>
+</p>
 
 <% unless @application_form.no_degree_and_degree_completed? %>
   <%= govuk_button_link_to degrees.empty? ? t('application_form.degree.add.button') : t('application_form.degree.another.button'), candidate_interface_degree_country_path, primary: true %>

--- a/app/components/candidate_interface/other_qualifications_review_component.html.erb
+++ b/app/components/candidate_interface/other_qualifications_review_component.html.erb
@@ -38,13 +38,8 @@
   <% else %>
     <% if @editable %>
       <%= govuk_inset_text(classes: 'govuk-!-width-two-thirds govuk-!-margin-top-0') do %>
-        <% if application_form.teacher_degree_apprenticeship_feature_active? %>
-          <p class="govuk-body"><%= t('.a_levels_are_required') %></p>
-          <p class="govuk-body"><%= t('.a_levels_postgraduate_or_undergraduate') %></p>
-        <% else %>
-          <p class="govuk-body"><%= t('.a_levels_postgraduate') %></p>
-          <p class="govuk-body"><%= t('.training_providers') %></p>
-        <% end %>
+        <p class="govuk-body"><%= t('.a_levels_are_required') %></p>
+        <p class="govuk-body"><%= t('.a_levels_postgraduate_or_undergraduate') %></p>
 
         <%= govuk_button_link_to t('application_form.other_qualification.first.button'),
           candidate_interface_other_qualification_type_path,

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -27,9 +27,6 @@ module CandidateInterface
       end
     end
 
-    delegate :teacher_degree_apprenticeship_feature_active?, to: :current_application
-    helper_method :teacher_degree_apprenticeship_feature_active?
-
     def choices_controller?
       ChoicesControllerMatcher.choices_controller?(current_application: current_application, controller_path: controller_path, request: request)
     end

--- a/app/controllers/candidate_interface/degrees/destroy_controller.rb
+++ b/app/controllers/candidate_interface/degrees/destroy_controller.rb
@@ -16,7 +16,7 @@ module CandidateInterface
           current_application.update!(degrees_completed: nil)
           @wizard.clear_state!
 
-          return redirect_to candidate_interface_details_path if teacher_degree_apprenticeship_feature_active?
+          return redirect_to candidate_interface_details_path
         end
         redirect_to candidate_interface_degree_review_path
       end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -633,10 +633,6 @@ class ApplicationForm < ApplicationRecord
     module_function :by_column, :by_section
   end
 
-  def teacher_degree_apprenticeship_feature_active?
-    FeatureFlag.active?(:teacher_degree_apprenticeship) && recruitment_cycle_year >= 2025
-  end
-
   def no_degree_and_degree_not_completed?
     no_degrees? && !degrees_completed?
   end

--- a/app/models/provider_interface/provider_applications_filter.rb
+++ b/app/models/provider_interface/provider_applications_filter.rb
@@ -105,8 +105,6 @@ module ProviderInterface
     end
 
     def course_type_filter
-      return unless FeatureFlag.active?(:teacher_degree_apprenticeship)
-
       {
         type: :checkboxes,
         heading: I18n.t('provider_interface.filters.course_type.heading'),

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -16,7 +16,6 @@ module CandidateInterface
              :phase,
              :personal_details_completed,
              :no_degree_and_degree_not_completed?,
-             :teacher_degree_apprenticeship_feature_active?,
              :support_reference, to: :application_form
 
     def initialize(application_form)
@@ -199,7 +198,7 @@ module CandidateInterface
     end
 
     def degrees_path
-      if no_degree_and_degree_not_completed? && teacher_degree_apprenticeship_feature_active?
+      if no_degree_and_degree_not_completed?
         Rails.application.routes.url_helpers.candidate_interface_degree_university_degree_path
       else
         Rails.application.routes.url_helpers.candidate_interface_degree_review_path

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -33,7 +33,6 @@ class FeatureFlag
     [:sample_applications_factory, 'An alternate generator for test/sample applications, uses `SampleApplicationsFactory` in place of `TestApplications.new`', 'Elliot Crosby-McCullough + Tomas Destefi'],
     [:structured_reference_condition, 'Structured reference condition that can be added as a condition to an offer', 'Tomas Destefi'],
     [:continuous_applications, 'The new continuous applications flow', 'James Glenn'],
-    [:teacher_degree_apprenticeship, 'The degree apprenticeship program', 'Tomas Destefi'],
     [:block_provider_activity_log, 'Block provider activity log if causing problems', 'Lori Bailey'],
     [:block_candidate_sign_in, 'Blocking candidate sign in, used if we are reaching rate limits in Notify', 'Lori Bailey'],
   ].freeze

--- a/app/services/sample_applications_factory.rb
+++ b/app/services/sample_applications_factory.rb
@@ -24,7 +24,7 @@ class SampleApplicationsFactory
       form_options[:references_completed] = true if states.include?(:unsubmitted_with_completed_references)
       form_options[:submitted_at] = nil if states.uniq.difference(%i[unsubmitted unsubmitted_with_completed_references]).blank?
 
-      form = Satisfactory.root.add(:application_form, **form_options).which_is(:completed)
+      form = Satisfactory.root.add(:application_form, **form_options).which_is(:completed).which_is(:with_bachelor_degree)
       form = form.which_is(:apply_again) if apply_again
       form = form.which_is(:carry_over) if carry_over
 

--- a/app/validators/incomplete_postgraduate_course_details_validator.rb
+++ b/app/validators/incomplete_postgraduate_course_details_validator.rb
@@ -4,7 +4,6 @@ class IncompletePostgraduateCourseDetailsValidator < ActiveModel::EachValidator
   include GovukVisuallyHiddenHelper
 
   def validate_each(record, attribute, application_choice)
-    return unless application_choice.application_form.teacher_degree_apprenticeship_feature_active?
     return if application_choice.course.undergraduate?
 
     if application_choice.application_form.no_degree_and_degree_completed?

--- a/app/views/candidate_interface/degrees/degree/new_country.html.erb
+++ b/app/views/candidate_interface/degrees/degree/new_country.html.erb
@@ -2,11 +2,7 @@
   <div class="govuk-grid-column-two-thirds">
   <% content_for :title, title_with_error_prefix(t('page_titles.degree_country'), @wizard.errors.any?) %>
 
-  <% if teacher_degree_apprenticeship_feature_active? %>
-    <% content_for :before_content, govuk_back_link_to(candidate_interface_degree_university_degree_path) %>
-  <% else %>
-    <% content_for :before_content, govuk_back_link_to(candidate_interface_degree_review_path) %>
-  <% end %>
+  <% content_for :before_content, govuk_back_link_to(candidate_interface_degree_university_degree_path) %>
 
   <%= form_with model: @wizard, url: candidate_interface_degree_country_path do |f| %>
     <%= f.govuk_error_summary %>

--- a/app/views/candidate_interface/degrees/review/show.html.erb
+++ b/app/views/candidate_interface/degrees/review/show.html.erb
@@ -31,7 +31,7 @@
     <%= render CandidateInterface::CompleteSectionComponent.new(
       section_policy: @section_policy,
       form: f,
-      hint_text: (teacher_degree_apprenticeship_feature_active? ? t('application_form.degree.review.teacher_degree_apprenticeship_feature_flag_on.complete_hint_text') : t('application_form.degree.review.complete_hint_text')).html_safe,
+      hint_text: t('application_form.degree.review.complete_hint_text_html'),
     ) %>
   <% end %>
 <% end %>

--- a/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
@@ -21,7 +21,7 @@
     <%= f.govuk_radio_button :qualification_type,
       'no_other_qualifications',
       label: { text: current_application.international_applicant? ? 'I do not want to add any other qualifications' : 'I do not want to add any A levels and other qualifications' },
-      hint: -> { teacher_degree_apprenticeship_feature_active? ? t('application_form.other_qualification.qualification_type.no_other_qualifications.tda_hint_text') : t('application_form.other_qualification.qualification_type.no_other_qualifications.hint_text') } %>
+      hint: -> { t('application_form.other_qualification.qualification_type.no_other_qualifications.tda_hint_text') } %>
   <% end %>
 <% end %>
 

--- a/app/views/candidate_mailer/tailored_rejection_advice/_no_degree_tailored_advice.text.erb
+++ b/app/views/candidate_mailer/tailored_rejection_advice/_no_degree_tailored_advice.text.erb
@@ -2,8 +2,6 @@ You could consider a different route into teaching.
 
 [Find out how to train to teach if you do not have a degree](<%= t('get_into_teaching.url_train_without_a_degree') %>).
 
-<% if FeatureFlag.active?(:teacher_degree_apprenticeship) %>
-  You may also be eligible to apply for a teacher degree apprenticeship (TDA). This new course will allow you work in a school and earn a salary while getting a bachelor’s degree and Qualified Teacher Status (QTS). So you will not have to pay tuition fees.
+You may also be eligible to apply for a teacher degree apprenticeship (TDA). This new course will allow you work in a school and earn a salary while getting a bachelor’s degree and Qualified Teacher Status (QTS). So you will not have to pay tuition fees.
 
-  [Find out more about teacher degree apprenticeships (TDAs)](<%= t('get_into_teaching.url_teacher_degree_apprenticeship') %>).
-<% end %>
+[Find out more about teacher degree apprenticeships (TDAs)](<%= t('get_into_teaching.url_teacher_degree_apprenticeship') %>).

--- a/config/locales/candidate_interface/degree.yml
+++ b/config/locales/candidate_interface/degree.yml
@@ -83,9 +83,7 @@ en:
         label: What year %{did_or_will} you graduate?
         hint: For example, 2019
       review:
-        complete_hint_text: Check the entry requirements for your chosen course. Providers usually ask for a degree at 2:2 or above. Contact the training provider if you do not have the right degree level.
-        teacher_degree_apprenticeship_feature_flag_on:
-          complete_hint_text: Check the entry requirements for your chosen course. Postgraduate courses usually require a bachelor’s degree at 2:2 or above. Contact the training provider if you do not have the right degree level. <p class=\"govuk-block\">Teacher degree apprenticeships do not require a degree.</p>
+        complete_hint_text_html: Check the entry requirements for your chosen course. Postgraduate courses usually require a bachelor’s degree at 2:2 or above. Contact the training provider if you do not have the right degree level. <p class=\"govuk-block\">Teacher degree apprenticeships do not require a degree.</p>
         not_specified: Not entered
       another:
         button: Add another degree

--- a/spec/components/candidate_interface/degree_empty_component_spec.rb
+++ b/spec/components/candidate_interface/degree_empty_component_spec.rb
@@ -28,34 +28,11 @@ RSpec.describe CandidateInterface::DegreeEmptyComponent, type: :component do
     end
   end
 
-  describe 'when teacher degree apprenticeship feature is on' do
-    subject(:result) { render_inline(described_class.new(application_form:)).text }
+  it 'renders degree types headers' do
+    result = render_inline(described_class.new(application_form: build(:application_form)))
 
-    let(:application_form) { create(:application_form, recruitment_cycle_year: 2025) }
-
-    before do
-      FeatureFlag.activate(:teacher_degree_apprenticeship)
-    end
-
-    it 'renders degree types headers' do
-      expect(result).to include('Postgraduate teacher training courses')
-      expect(result).to include('Teacher degree apprenticeships')
-    end
-  end
-
-  describe 'when teacher degree apprenticeship feature is off' do
-    subject(:result) { render_inline(described_class.new(application_form:)).text }
-
-    let(:application_form) { create(:application_form, recruitment_cycle_year: 2024) }
-
-    before do
-      FeatureFlag.deactivate(:teacher_degree_apprenticeship)
-    end
-
-    it 'does not render degree types headers' do
-      expect(result).not_to include('Postgraduate teacher training courses')
-      expect(result).not_to include('Teacher degree apprenticeships')
-    end
+    expect(result.text).to include('Postgraduate teacher training courses')
+    expect(result.text).to include('Teacher degree apprenticeships')
   end
 
   describe 'button text' do

--- a/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
+++ b/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
@@ -258,36 +258,10 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
         ).text.gsub(/\r?\n/, ' ').squeeze(' ').strip
       end
 
-      context 'when teacher degree apprenticeship feature is on' do
-        before { FeatureFlag.activate(:teacher_degree_apprenticeship) }
-
-        it 'shows postgraduate and undergraduate content' do
-          expect(result).to include(
-            'A levels are required for teacher degree apprenticeships. If you are applying to postgraduate courses, adding A levels and other qualifications will make your application stronger. They demonstrate subject knowledge not covered in your degree or work history.',
-          )
-        end
-      end
-
-      context 'when teacher degree apprenticeship feature is on but is an application prior to 2025' do
-        let(:application_form) { create(:application_form, recruitment_cycle_year: 2024) }
-
-        before { FeatureFlag.activate(:teacher_degree_apprenticeship) }
-
-        it 'shows postgraduate content' do
-          expect(result).to include(
-            'Adding A levels and other qualifications makes your application stronger. They demonstrate subject knowledge not covered in your degree or work experience. Training providers usually ask you for them later in the process. Add a qualification',
-          )
-        end
-      end
-
-      context 'when teacher degree apprenticeship feature is off' do
-        before { FeatureFlag.deactivate(:teacher_degree_apprenticeship) }
-
-        it 'shows postgraduate content' do
-          expect(result).to include(
-            'Adding A levels and other qualifications makes your application stronger. They demonstrate subject knowledge not covered in your degree or work experience. Training providers usually ask you for them later in the process. Add a qualification',
-          )
-        end
+      it 'shows postgraduate and undergraduate content' do
+        expect(result).to include(
+          'A levels are required for teacher degree apprenticeships. If you are applying to postgraduate courses, adding A levels and other qualifications will make your application stronger. They demonstrate subject knowledge not covered in your degree or work history.',
+        )
       end
     end
   end

--- a/spec/factories/application_form.rb
+++ b/spec/factories/application_form.rb
@@ -63,12 +63,14 @@ FactoryBot.define do
     end
 
     trait :with_bachelor_degree do
+      university_degree { true }
       after(:create) do |application_form, _|
         create(:degree_qualification, :bachelor, application_form:)
       end
     end
 
     trait :with_degree do
+      university_degree { true }
       after(:create) do |application_form, _|
         create(:degree_qualification, application_form:)
       end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -1220,44 +1220,4 @@ RSpec.describe ApplicationForm do
       end
     end
   end
-
-  describe '#teacher_degree_apprenticeship_feature_active?' do
-    let(:application_form) { build(:application_form) }
-
-    context 'when the teacher degree apprenticeship feature flag is active and recruitment cycle year is 2025 or later' do
-      it 'returns true' do
-        FeatureFlag.activate(:teacher_degree_apprenticeship)
-        application_form.recruitment_cycle_year = 2025
-
-        expect(application_form.teacher_degree_apprenticeship_feature_active?).to be true
-      end
-    end
-
-    context 'when the teacher degree apprenticeship feature flag is active but recruitment cycle year is before 2025' do
-      it 'returns false' do
-        FeatureFlag.activate(:teacher_degree_apprenticeship)
-        application_form.recruitment_cycle_year = 2024
-
-        expect(application_form.teacher_degree_apprenticeship_feature_active?).to be false
-      end
-    end
-
-    context 'when the teacher degree apprenticeship feature flag is not active but recruitment cycle year is 2025 or later' do
-      it 'returns false' do
-        FeatureFlag.deactivate(:teacher_degree_apprenticeship)
-        application_form.recruitment_cycle_year = 2025
-
-        expect(application_form.teacher_degree_apprenticeship_feature_active?).to be false
-      end
-    end
-
-    context 'when the teacher degree apprenticeship feature flag is not active and recruitment cycle year is before 2025' do
-      it 'returns false' do
-        FeatureFlag.deactivate(:teacher_degree_apprenticeship)
-        application_form.recruitment_cycle_year = 2024
-
-        expect(application_form.teacher_degree_apprenticeship_feature_active?).to be false
-      end
-    end
-  end
 end

--- a/spec/models/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/models/provider_interface/provider_applications_filter_spec.rb
@@ -27,15 +27,17 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
     StateStores::RedisStore.new(key: "#{described_class::STATE_STORE_KEY}_#{provider_user.id}")
   end
 
-  before do
-    FeatureFlag.deactivate(:teacher_degree_apprenticeship)
-  end
-
   describe '#filters' do
     let(:headings) { filter.filters.map { |f| f[:heading] } }
     let(:params) { ActionController::Parameters.new }
 
     context 'default filters' do
+      let(:filter) do
+        described_class.new(params:,
+                            provider_user:,
+                            state_store:)
+      end
+
       context 'for a user belonging to multiple providers' do
         let(:filter) do
           described_class.new(params:,
@@ -44,7 +46,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
         end
 
         it 'does not include the Locations filter' do
-          expected_number_of_filters = 6
+          expected_number_of_filters = 7
           recruitment_cycle_index = 1
           providers_array_index = 3
           number_of_courses = 2
@@ -65,28 +67,16 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
         end
 
         it 'does not include the Providers filter' do
-          expected_number_of_filters = 6
+          expected_number_of_filters = 7
 
           expect(filter.filters.size).to eq(expected_number_of_filters)
           expect(headings).not_to include('Provider')
         end
       end
 
-      context 'when teacher degree apprenticeship feature flag active' do
-        let(:filter) do
-          described_class.new(params:,
-                              provider_user:,
-                              state_store:)
-        end
-
-        before do
-          FeatureFlag.activate(:teacher_degree_apprenticeship)
-        end
-
-        it 'does include the course type filter' do
-          expect(filter.filters.size).to be(7)
-          expect(headings).to include('Course type')
-        end
+      it 'does include the course type filter' do
+        expect(filter.filters.size).to be(7)
+        expect(headings).to include('Course type')
       end
     end
 
@@ -103,11 +93,11 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
           relevant_provider_labels = [provider1.sites.first.name_and_code, provider1.sites.last.name_and_code]
 
           expect(headings).to include("Locations for #{provider1.name}")
-          expect(relevant_provider_name_and_code).to include(filter.filters[5][:options][0][:value])
-          expect(relevant_provider_name_and_code).to include(filter.filters[5][:options][1][:value])
+          expect(relevant_provider_name_and_code).to include(filter.filters[6][:options][0][:value])
+          expect(relevant_provider_name_and_code).to include(filter.filters[6][:options][1][:value])
 
-          expect(relevant_provider_labels).to include(filter.filters[5][:options][0][:label])
-          expect(relevant_provider_labels).to include(filter.filters[5][:options][1][:label])
+          expect(relevant_provider_labels).to include(filter.filters[6][:options][0][:label])
+          expect(relevant_provider_labels).to include(filter.filters[6][:options][1][:label])
         end
       end
 
@@ -125,8 +115,8 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
           old_site_label = old_site.name_and_code
 
           expect(headings).to include("Locations for #{provider1.name}")
-          expect(old_site_name_and_code).not_to include(filter.filters[5][:options][0][:value])
-          expect(old_site_label).not_to include(filter.filters[5][:options][0][:label])
+          expect(old_site_name_and_code).not_to include(filter.filters[6][:options][0][:value])
+          expect(old_site_label).not_to include(filter.filters[6][:options][0][:label])
         end
       end
     end
@@ -145,11 +135,11 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
 
         expect(headings).to include("Locations for #{provider1.name}")
 
-        expect(relevant_provider_name_and_code).to include(filter.filters[6][:options][0][:value])
-        expect(relevant_provider_name_and_code).to include(filter.filters[6][:options][1][:value])
+        expect(relevant_provider_name_and_code).to include(filter.filters[7][:options][0][:value])
+        expect(relevant_provider_name_and_code).to include(filter.filters[7][:options][1][:value])
 
-        expect(relevant_provider_labels).to include(filter.filters[6][:options][0][:label])
-        expect(relevant_provider_labels).to include(filter.filters[6][:options][1][:label])
+        expect(relevant_provider_labels).to include(filter.filters[7][:options][0][:label])
+        expect(relevant_provider_labels).to include(filter.filters[7][:options][1][:label])
       end
     end
 

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   describe '#degrees_path' do
     let(:presenter) { described_class.new(application_form) }
 
-    context 'when there are no degrees and the degree is not completed, and the teacher degree apprenticeship feature is active' do
+    context 'when there are no degrees and the degree is not completed' do
       let(:application_form) do
         create(
           :application_form,
@@ -37,31 +37,8 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
         )
       end
 
-      before do
-        FeatureFlag.activate(:teacher_degree_apprenticeship)
-      end
-
       it 'returns the university degree path' do
         expect(presenter.degrees_path).to eq(Rails.application.routes.url_helpers.candidate_interface_degree_university_degree_path)
-      end
-    end
-
-    context 'when there are no degrees and the degree is not completed, but the teacher degree apprenticeship feature is not active' do
-      let(:application_form) do
-        create(
-          :application_form,
-          application_qualifications: [],
-          degrees_completed: false,
-          recruitment_cycle_year: 2024,
-        )
-      end
-
-      before do
-        FeatureFlag.deactivate(:teacher_degree_apprenticeship)
-      end
-
-      it 'returns the degree review path' do
-        expect(presenter.degrees_path).to eq(Rails.application.routes.url_helpers.candidate_interface_degree_review_path)
       end
     end
 
@@ -72,10 +49,6 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
           :with_degree,
           recruitment_cycle_year: 2025,
         )
-      end
-
-      before do
-        FeatureFlag.activate(:teacher_degree_apprenticeship)
       end
 
       it 'returns the degree review path' do

--- a/spec/services/candidate_interface/application_choice_submission_spec.rb
+++ b/spec/services/candidate_interface/application_choice_submission_spec.rb
@@ -21,10 +21,6 @@ RSpec.describe CandidateInterface::ApplicationChoiceSubmission do
         create(:application_choice, :unsubmitted, course_option: create(:course_option, course:), application_form:)
       end
 
-      before do
-        FeatureFlag.activate(:teacher_degree_apprenticeship)
-      end
-
       context 'when all postgraduate course details are complete' do
         let(:application_form) { create(:application_form, :completed, :with_degree) }
 
@@ -48,33 +44,6 @@ RSpec.describe CandidateInterface::ApplicationChoiceSubmission do
             application_qualifications: [],
             university_degree: false,
           )
-        end
-
-        before do
-          FeatureFlag.activate(:teacher_degree_apprenticeship)
-        end
-
-        it 'does not add an error to the application choice' do
-          application_choice_submission.valid?
-
-          expect(
-            application_choice_submission.errors.of_kind?(:application_choice, :incomplete_postgraduate_course_details),
-          ).to be false
-        end
-      end
-
-      context 'when teacher degree apprenticeship feature is off' do
-        let(:application_form) do
-          create(
-            :application_form,
-            :completed,
-            application_qualifications: [],
-            university_degree: false,
-          )
-        end
-
-        before do
-          FeatureFlag.deactivate(:teacher_degree_apprenticeship)
         end
 
         it 'does not add an error to the application choice' do

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -517,6 +517,11 @@ module CandidateHelper
     )
   end
 
+  def and_i_answer_that_i_have_a_university_degree
+    choose 'Yes, I have a degree or am studying for one'
+    click_link_or_button 'Continue'
+  end
+
   def and_the_candidate_add_the_degree(degree_level:, degree_type:, degree_subject:, university:, grade:)
     visit candidate_interface_degree_review_path
 

--- a/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_no_qualification_option_choice_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_no_qualification_option_choice_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe 'Entering their other qualifications' do
 
   scenario 'Candidate submits their other qualifications after choosing not to provide any' do
     given_i_am_signed_in
-    and_teacher_degree_apprenticeship_feature_flag_is_off
     and_i_visit_the_site
     then_i_see_the_other_qualifications_section_is_incomplete
 
@@ -48,10 +47,6 @@ RSpec.describe 'Entering their other qualifications' do
     create_and_sign_in_candidate
   end
 
-  def and_teacher_degree_apprenticeship_feature_flag_is_off
-    FeatureFlag.deactivate(:teacher_degree_apprenticeship)
-  end
-
   def and_i_visit_the_site
     visit candidate_interface_details_path
   end
@@ -74,7 +69,7 @@ RSpec.describe 'Entering their other qualifications' do
   alias_method :and_i_select_i_do_not_want_to_add_any_a_levels, :when_i_select_i_do_not_want_to_add_any_a_levels
 
   def then_i_see_a_level_advice
-    expect(page).to have_content('Adding A levels and other qualifications makes your application stronger.')
+    expect(page).to have_content('A levels are required for teacher degree apprenticeships. If you are applying to postgraduate courses, adding A levels and other qualifications will make your application stronger. They demonstrate subject knowledge not covered in your degree or work history.')
   end
 
   def and_i_see_my_no_other_qualification_selection

--- a/spec/system/candidate_interface/entering_details/degrees/backlinks_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/backlinks_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe 'Degrees' do
   scenario 'Candidate editing degree' do
     given_i_am_signed_in
     and_i_have_completed_the_degree_section
-    and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
     when_i_view_the_degree_section
     and_i_click_to_change_my_undergraduate_degree_type
     and_i_click_the_back_link
@@ -41,6 +40,8 @@ RSpec.describe 'Degrees' do
     and_i_click_the_back_link
     then_i_am_taken_back_to_the_country_page
     and_i_click_the_back_link
+    then_i_am_taken_back_to_the_university_degree_page
+    and_i_click_the_back_link
     then_i_am_taken_back_to_the_degree_review_page
 
     given_that_i_have_a_completed_international_degree
@@ -63,10 +64,6 @@ RSpec.describe 'Degrees' do
   def given_i_am_signed_in
     @candidate = create(:candidate)
     login_as(@candidate)
-  end
-
-  def and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
-    FeatureFlag.deactivate(:teacher_degree_apprenticeship)
   end
 
   def and_i_have_completed_the_degree_section
@@ -197,6 +194,10 @@ RSpec.describe 'Degrees' do
 
   def then_i_am_taken_to_the_degree_complete_page
     expect(page).to have_content 'Have you completed your degree?'
+  end
+
+  def then_i_am_taken_back_to_the_university_degree_page
+    expect(page).to have_current_path(candidate_interface_degree_university_degree_path)
   end
 
   def when_i_visit_the_application_review_page

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_adding_unknown_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_adding_unknown_degrees_spec.rb
@@ -2,16 +2,12 @@ require 'rails_helper'
 
 RSpec.describe 'Adding an unknown degree', :js do
   include CandidateHelper
-  before do
-    given_teacher_degree_apprenticeship_redirect_feature_flag_is_off
-  end
 
   scenario 'Candidate enters their degree' do
     given_i_am_signed_in
     when_i_view_the_degree_section
 
-    # Add degree
-    and_i_click_add_degree
+    and_i_answer_that_i_have_a_university_degree
 
     # Add country
     then_i_can_see_the_country_page
@@ -77,16 +73,11 @@ RSpec.describe 'Adding an unknown degree', :js do
     then_the_custom_subject_remains_filled_in
   end
 
-  def given_teacher_degree_apprenticeship_redirect_feature_flag_is_off
-    FeatureFlag.deactivate(:teacher_degree_apprenticeship)
-  end
-
   def given_i_am_at_the_degree_subject_page
     given_i_am_signed_in
     when_i_view_the_degree_section
 
-    # Add degree
-    and_i_click_add_degree
+    and_i_answer_that_i_have_a_university_degree
 
     # Add country
     then_i_can_see_the_country_page
@@ -120,10 +111,6 @@ RSpec.describe 'Adding an unknown degree', :js do
 
   def when_i_click_on_degree
     click_link_or_button 'Degree'
-  end
-
-  def and_i_click_add_degree
-    click_link_or_button 'Add a degree'
   end
 
   def then_i_can_see_the_country_page

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_delete_and_replace_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_delete_and_replace_degrees_spec.rb
@@ -5,18 +5,17 @@ RSpec.describe 'Deleting and replacing a degree' do
 
   scenario 'Candidate deletes and replaces their degree' do
     given_i_am_signed_in
-    and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
     and_i_have_completed_the_degree_section
     when_i_view_the_degree_section
     and_i_click_on_change_country
     and_i_click_the_back_link
+    and_i_click_the_back_link
+    and_i_click_on_degree
     and_i_click_on_delete_degree
     and_i_confirm_that_i_want_to_delete_my_degree
-    then_i_see_the_undergraduate_degree_form
-    and_when_i_click_back_on_the_browser
-    then_i_am_redirected_to_degrees_review_page_as_degree_no_longer_exists
+    then_i_am_redirected_to_candidate_details_as_degree_no_longer_exists
 
-    when_i_click_add_degree
+    when_i_click_on_degree
     and_i_add_my_degree_back_in
     and_i_mark_the_section_as_incomplete
     and_i_click_on_continue
@@ -42,10 +41,6 @@ RSpec.describe 'Deleting and replacing a degree' do
     login_as(@candidate)
   end
 
-  def and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
-    FeatureFlag.deactivate(:teacher_degree_apprenticeship)
-  end
-
   def when_i_view_the_degree_section
     visit candidate_interface_details_path
     when_i_click_on_degree
@@ -54,6 +49,7 @@ RSpec.describe 'Deleting and replacing a degree' do
   def when_i_click_on_degree
     click_link_or_button 'Degree'
   end
+  alias_method :and_i_click_on_degree, :when_i_click_on_degree
 
   def and_i_click_on_change_country
     click_change_link('country')
@@ -150,6 +146,8 @@ RSpec.describe 'Deleting and replacing a degree' do
   end
 
   def and_i_add_my_degree_back_in
+    and_i_answer_that_i_have_a_university_degree
+
     when_i_choose_united_kingdom
     and_i_click_on_save_and_continue
 
@@ -224,7 +222,7 @@ RSpec.describe 'Deleting and replacing a degree' do
   end
 
   def and_i_have_completed_the_degree_section
-    @application_form = create(:application_form, candidate: @candidate)
+    @application_form = create(:application_form, candidate: @candidate, university_degree: true)
     create(:application_qualification, level: 'degree', application_form: @application_form)
     @application_form.update!(degrees_completed: true)
     @degree_id = @application_form.application_qualifications.first.id
@@ -254,7 +252,7 @@ RSpec.describe 'Deleting and replacing a degree' do
     visit candidate_interface_confirm_degree_destroy_path(@degree_id)
   end
 
-  def then_i_am_redirected_to_degrees_review_page_as_degree_no_longer_exists
-    expect(page).to have_current_path(candidate_interface_degree_review_path)
+  def then_i_am_redirected_to_candidate_details_as_degree_no_longer_exists
+    expect(page).to have_current_path(candidate_interface_details_path)
   end
 end

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_editing_international_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_editing_international_degrees_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe 'Editing a degree' do
 
   before do
     given_i_am_signed_in
-    and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
     when_i_view_the_degree_section
     and_i_create_an_international_degree
   end
@@ -23,10 +22,6 @@ RSpec.describe 'Editing a degree' do
     and_i_choose_uk
     and_i_click_on_save_and_continue
     then_i_start_the_add_degree_flow_from_the_beginning
-  end
-
-  def and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
-    FeatureFlag.deactivate(:teacher_degree_apprenticeship)
   end
 
   def then_i_start_the_add_degree_flow_from_the_beginning
@@ -56,7 +51,7 @@ RSpec.describe 'Editing a degree' do
   end
 
   def and_i_create_an_international_degree
-    and_i_click_add_degree
+    and_i_answer_that_i_have_a_university_degree
     when_i_select_another_country
     and_i_click_on_save_and_continue
     when_i_fill_in_the_subject
@@ -86,10 +81,6 @@ RSpec.describe 'Editing a degree' do
 
   def then_i_can_check_an_additional_degree_is_not_created
     expect(page.all('.app-summary-card__header').count).to eq(1)
-  end
-
-  def and_i_click_add_degree
-    click_link_or_button 'Add a degree'
   end
 
   def when_i_select_another_country

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_degrees_spec.rb
@@ -5,11 +5,9 @@ RSpec.describe 'Entering a degree' do
 
   scenario 'Candidate enters their degree' do
     given_i_am_signed_in
-    and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
     when_i_view_the_degree_section
 
-    # Add degree
-    and_i_click_add_degree
+    and_i_answer_that_i_have_a_university_degree
 
     # Add country
     then_i_can_see_the_country_page
@@ -72,10 +70,6 @@ RSpec.describe 'Entering a degree' do
     create_and_sign_in_candidate
   end
 
-  def and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
-    FeatureFlag.deactivate(:teacher_degree_apprenticeship)
-  end
-
   def when_i_view_the_degree_section
     visit candidate_interface_details_path
     when_i_click_on_degree
@@ -83,10 +77,6 @@ RSpec.describe 'Entering a degree' do
 
   def when_i_click_on_degree
     click_link_or_button 'Degree'
-  end
-
-  def and_i_click_add_degree
-    click_link_or_button 'Add a degree'
   end
 
   def then_i_can_see_the_country_page

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degree_without_a_grade_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degree_without_a_grade_spec.rb
@@ -5,10 +5,8 @@ RSpec.describe 'Entering an international doctorate degree' do
 
   scenario 'Candidate enters their degree' do
     given_i_am_signed_in
-    and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
     when_i_view_the_degree_section
-
-    and_i_click_add_degree
+    and_i_answer_that_i_have_a_university_degree
     and_i_select_another_country
     and_i_fill_in_the_subject
     and_i_fill_in_the_type_of_degree
@@ -36,10 +34,6 @@ private
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
-  end
-
-  def and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
-    FeatureFlag.deactivate(:teacher_degree_apprenticeship)
   end
 
   def when_i_view_the_degree_section

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degree_without_an_enic_reason_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degree_without_an_enic_reason_spec.rb
@@ -5,10 +5,9 @@ RSpec.describe 'Entering an international doctorate degree' do
 
   scenario 'Candidate enters their degree without an enic reason' do
     given_i_am_signed_in
-    and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
     when_i_view_the_degree_section
 
-    and_i_click_add_degree
+    and_i_answer_that_i_have_a_university_degree
     and_i_select_another_country
     and_i_fill_in_the_subject
     and_i_fill_in_the_type_of_degree
@@ -24,10 +23,6 @@ private
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
-  end
-
-  def and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
-    FeatureFlag.deactivate(:teacher_degree_apprenticeship)
   end
 
   def when_i_view_the_degree_section

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degrees_spec.rb
@@ -5,11 +5,9 @@ RSpec.describe 'Entering an international degree' do
 
   scenario 'Candidate enters their degree' do
     given_i_am_signed_in
-    and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
     when_i_view_the_degree_section
 
-    # Add degree
-    and_i_click_add_degree
+    and_i_answer_that_i_have_a_university_degree
 
     # Add country
     then_i_can_see_the_country_page
@@ -72,10 +70,6 @@ RSpec.describe 'Entering an international degree' do
     then_i_can_check_my_answers
   end
 
-  def and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
-    FeatureFlag.deactivate(:teacher_degree_apprenticeship)
-  end
-
   def given_i_am_signed_in
     create_and_sign_in_candidate
   end
@@ -87,10 +81,6 @@ RSpec.describe 'Entering an international degree' do
 
   def when_i_click_on_degree
     click_link_or_button 'Degree'
-  end
-
-  def and_i_click_add_degree
-    click_link_or_button 'Add a degree'
   end
 
   def then_i_can_see_the_country_page

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_masters_degree_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_masters_degree_spec.rb
@@ -5,11 +5,9 @@ RSpec.describe 'Entering a Masters degree' do
 
   scenario 'Candidate enters their Masters degree' do
     given_i_am_signed_in
-    and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
     when_i_view_the_degree_section
 
-    # Add degree
-    and_i_click_add_degree
+    and_i_answer_that_i_have_a_university_degree
 
     # Add country
     then_i_can_see_the_country_page
@@ -20,52 +18,10 @@ RSpec.describe 'Entering a Masters degree' do
     then_i_can_see_the_level_page
     when_i_choose_the_masters_level
     and_i_click_on_save_and_continue
-
-    # Add subject
-    then_i_can_see_the_subject_page
-    when_i_fill_in_the_subject
-    and_i_click_on_save_and_continue
-
-    # Add degree type
-    then_i_can_see_the_type_page
-    when_i_choose_the_type_of_degree
-    and_i_click_on_save_and_continue
-
-    # Add university
-    then_i_can_see_the_university_page
-    when_i_fill_in_the_university
-    and_i_click_on_save_and_continue
-
-    # Add completion
-    then_i_can_see_the_completion_page
-    when_i_choose_whether_degree_is_completed
-    and_i_click_on_save_and_continue
-
-    # Add grade
-    then_i_can_see_the_grade_page_with_masters_grade_options
-    when_i_select_the_grade
-    and_i_click_on_save_and_continue
-
-    # Add start year
-    then_i_can_see_the_start_year_page
-    when_i_fill_in_the_start_year
-    and_i_click_on_save_and_continue
-
-    # Add award year
-    then_i_can_see_the_award_year_page
-    when_i_fill_in_the_award_year
-    and_i_click_on_save_and_continue
-
-    # Review
-    then_i_can_check_my_undergraduate_degree
   end
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
-  end
-
-  def and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
-    FeatureFlag.deactivate(:teacher_degree_apprenticeship)
   end
 
   def when_i_view_the_degree_section
@@ -75,10 +31,6 @@ RSpec.describe 'Entering a Masters degree' do
 
   def when_i_click_on_degree
     click_link_or_button 'Degree'
-  end
-
-  def and_i_click_add_degree
-    click_link_or_button 'Add a degree'
   end
 
   def then_i_can_see_the_country_page

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_phd_degree_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_phd_degree_spec.rb
@@ -5,11 +5,9 @@ RSpec.describe 'Entering a PhD' do
 
   scenario 'Candidate enters their PhD' do
     given_i_am_signed_in
-    and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
     when_i_view_the_degree_section
 
-    # Add degree
-    and_i_click_add_degree
+    and_i_answer_that_i_have_a_university_degree
 
     # Add country
     then_i_can_see_the_country_page
@@ -58,10 +56,6 @@ RSpec.describe 'Entering a PhD' do
 
     # Review
     then_i_can_check_my_phd
-  end
-
-  def and_teacher_degree_apprenticeship_redirect_feature_flag_is_off
-    FeatureFlag.deactivate(:teacher_degree_apprenticeship)
   end
 
   def given_i_am_signed_in

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_university_degree_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_university_degree_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe 'Entering a degree' do
 
   before do
     given_i_am_on_the_cycle_when_candidates_can_enter_details_for_undergraduate_course
-    and_teacher_degree_apprenticeship_feature_flag_is_on
   end
 
   scenario 'Candidate does not have a degree' do
@@ -72,10 +71,6 @@ RSpec.describe 'Entering a degree' do
     TestSuiteTimeMachine.travel_permanently_to(
       CycleTimetableHelper.after_apply_deadline(2024),
     )
-  end
-
-  def and_teacher_degree_apprenticeship_feature_flag_is_on
-    FeatureFlag.activate(:teacher_degree_apprenticeship)
   end
 
   def given_i_am_signed_in

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_and_prefills_application_in_sandbox_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_and_prefills_application_in_sandbox_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe 'Candidate signs in and prefills application in Sandbox', :sandbo
     given_sign_in_is_not_blocked
     and_a_course_is_available
     and_i_am_a_candidate_with_a_blank_application
-    and_teacher_degree_apprenticeship_feature_is_off
 
     when_i_fill_in_the_sign_in_form
     and_i_click_on_the_link_in_my_email_and_sign_in
@@ -25,10 +24,6 @@ RSpec.describe 'Candidate signs in and prefills application in Sandbox', :sandbo
 
   def and_a_course_is_available
     @course_option = create(:course_option, course: create(:course, :open, recruitment_cycle_year: RecruitmentCycle.current_year))
-  end
-
-  def and_teacher_degree_apprenticeship_feature_is_off
-    FeatureFlag.deactivate(:teacher_degree_apprenticeship)
   end
 
   def and_i_am_a_candidate_with_a_blank_application

--- a/spec/system/candidate_interface/submitting/candidate_tries_submit_to_undergraduate_course_without_a_levels_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_tries_submit_to_undergraduate_course_without_a_levels_spec.rb
@@ -3,9 +3,8 @@ require 'rails_helper'
 RSpec.describe 'Candidate tries to submit undergraduate courses with no A levels' do
   include CandidateHelper
 
-  scenario 'when teacher degree apprenticeship is live' do
+  scenario 'when candidate tries to submit undergraduate course with no A level' do
     given_i_am_on_the_cycle_when_candidates_can_enter_details_for_undergraduate_course
-    and_teacher_degree_apprenticeship_feature_flag_is_on
     and_there_is_undergraduate_courses
     and_i_am_signed_in
     when_i_view_the_a_levels_section
@@ -19,18 +18,6 @@ RSpec.describe 'Candidate tries to submit undergraduate courses with no A levels
     then_i_see_that_i_need_a_levels_to_apply_for_an_undergraduate_course
   end
 
-  scenario 'when teacher degree apprenticeship is not live' do
-    given_i_am_on_the_cycle_when_candidates_can_not_enter_details_for_undergraduate_course
-    and_i_am_signed_in
-    when_i_view_the_a_levels_section
-    then_i_see_the_content_for_postgraduate
-
-    when_i_choose_no_a_levels
-    and_i_click_continue
-    then_i_am_on_a_levels_review_page
-    and_i_see_the_postgraduate_content_for_no_a_levels
-  end
-
   def given_i_am_on_the_cycle_when_candidates_can_enter_details_for_undergraduate_course
     TestSuiteTimeMachine.travel_permanently_to(
       CycleTimetableHelper.mid_cycle(2025),
@@ -41,10 +28,6 @@ RSpec.describe 'Candidate tries to submit undergraduate courses with no A levels
     TestSuiteTimeMachine.travel_permanently_to(
       CycleTimetableHelper.mid_cycle(2024),
     )
-  end
-
-  def and_teacher_degree_apprenticeship_feature_flag_is_on
-    FeatureFlag.activate(:teacher_degree_apprenticeship)
   end
 
   def and_there_is_undergraduate_courses
@@ -76,12 +59,6 @@ RSpec.describe 'Candidate tries to submit undergraduate courses with no A levels
     )
   end
 
-  def then_i_see_the_content_for_postgraduate
-    expect(no_a_levels_hint).to have_content(
-      'Providers look at A levels and other qualifications for evidence of subject knowledge not covered in your degree or work history.',
-    )
-  end
-
   def when_i_choose_no_a_levels
     choose 'I do not want to add any A levels and other qualifications'
   end
@@ -99,12 +76,6 @@ RSpec.describe 'Candidate tries to submit undergraduate courses with no A levels
   def and_i_see_the_postgraduate_and_undergraduate_content_for_no_a_levels
     expect(page).to have_content(
       'A levels are required for teacher degree apprenticeships. If you are applying to postgraduate courses, adding A levels and other qualifications will make your application stronger. They demonstrate subject knowledge not covered in your degree or work history.',
-    )
-  end
-
-  def and_i_see_the_postgraduate_content_for_no_a_levels
-    expect(page).to have_content(
-      'Adding A levels and other qualifications makes your application stronger. They demonstrate subject knowledge not covered in your degree or work experience. Training providers usually ask you for them later in the process. Add a qualification',
     )
   end
 

--- a/spec/system/candidate_interface/submitting/candidate_tries_to_submit_postgraduate_course_without_degrees_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_tries_to_submit_postgraduate_course_without_degrees_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe 'Submitting a postgraduate course' do
 
   before do
     given_i_am_on_the_cycle_when_candidates_can_enter_details_for_undergraduate_course
-    and_teacher_degree_apprenticeship_feature_flag_is_on
     given_i_am_signed_in
   end
 
@@ -28,10 +27,6 @@ RSpec.describe 'Submitting a postgraduate course' do
     TestSuiteTimeMachine.travel_permanently_to(
       CycleTimetableHelper.mid_cycle(2025),
     )
-  end
-
-  def and_teacher_degree_apprenticeship_feature_flag_is_on
-    FeatureFlag.activate(:teacher_degree_apprenticeship)
   end
 
   def given_i_am_signed_in

--- a/spec/system/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/system/provider_interface/provider_applications_filter_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe 'Providers should be able to filter applications' do
     and_i_am_permitted_to_see_applications_from_multiple_providers
     and_my_organisation_has_courses_with_applications
     and_i_sign_in_to_the_provider_interface
-    and_teacher_degree_apprenticeship_feature_flag_is_inactive
 
     when_i_visit_the_provider_page
 
@@ -30,8 +29,6 @@ RSpec.describe 'Providers should be able to filter applications' do
     then_location_filters_are_not_visible
 
     then_i_can_see_applications_from_the_previous_year_too
-
-    and_teacher_degree_apprenticeship_filter_is_not_visible
 
     when_i_filter_for_rejected_applications
     then_only_rejected_applications_are_visible
@@ -119,9 +116,8 @@ RSpec.describe 'Providers should be able to filter applications' do
     and_i_click_the_sign_out_button
   end
 
-  scenario 'when the teacher degree apprenticeship feature flag is active' do
+  scenario 'when filtering by course type' do
     given_i_am_a_provider_user_with_dfe_sign_in
-    and_teacher_degree_apprenticeship_feature_flag_is_active
     and_i_am_permitted_to_see_applications_from_multiple_providers
     and_my_organisation_has_courses_with_applications_without_accredited_providers
     and_my_organisation_has_courses_that_awards_a_degree
@@ -133,8 +129,8 @@ RSpec.describe 'Providers should be able to filter applications' do
     when_i_filter_by_postgraduate_courses
     then_i_only_see_postgraduate_applications
 
-    when_i_filter_by_teacher_degree_apprenticeship_courses
-    then_i_only_see_teacher_degree_apprenticeship_applications
+    when_i_filter_by_undergraduate_courses
+    then_i_only_see_undergraduate_applications
 
     when_i_check_both_course_types_filter
     then_i_see_postgraduate_and_teacher_degree_apprenticeship_applications
@@ -142,14 +138,6 @@ RSpec.describe 'Providers should be able to filter applications' do
 
   def and_i_click_the_sign_out_button
     click_link_or_button 'Sign out'
-  end
-
-  def and_teacher_degree_apprenticeship_feature_flag_is_active
-    FeatureFlag.activate(:teacher_degree_apprenticeship)
-  end
-
-  def and_teacher_degree_apprenticeship_feature_flag_is_inactive
-    FeatureFlag.deactivate(:teacher_degree_apprenticeship)
   end
 
   def and_my_organisation_has_courses_with_applications_without_accredited_providers
@@ -188,13 +176,6 @@ RSpec.describe 'Providers should be able to filter applications' do
 
     create(:application_choice, :awaiting_provider_decision, current_course_option: course_option_three, status: 'offer', application_form:
            build(:application_form, first_name: 'Leland', last_name: 'Harris'), updated_at: 4.days.ago)
-  end
-
-  def and_teacher_degree_apprenticeship_filter_is_not_visible
-    expect(page).to have_content('Filter')
-    expect(page).to have_no_content('Course type')
-    expect(page).to have_no_content('Postgraduate courses')
-    expect(page).to have_no_content('Undergraduate courses')
   end
 
   def then_teacher_degree_apprenticeship_filter_is_visible
@@ -251,13 +232,13 @@ RSpec.describe 'Providers should be able to filter applications' do
     expect(page).to have_no_content('Leland Harris')
   end
 
-  def when_i_filter_by_teacher_degree_apprenticeship_courses
+  def when_i_filter_by_undergraduate_courses
     uncheck 'Postgraduate courses'
     check 'Undergraduate courses'
     and_i_apply_the_filters
   end
 
-  def then_i_only_see_teacher_degree_apprenticeship_applications
+  def then_i_only_see_undergraduate_applications
     expect(page).to have_content('Andres Bartell')
     expect(page).to have_content('Quinton Marks')
     expect(page).to have_content('Leland Harris')

--- a/spec/system/provider_interface/provider_views_a_teacher_degree_apprenticeship_application_spec.rb
+++ b/spec/system/provider_interface/provider_views_a_teacher_degree_apprenticeship_application_spec.rb
@@ -6,10 +6,6 @@ RSpec.describe 'A Provider user views a teacher degree apprenticeship applicatio
   let(:provider_user) { create(:provider_user, :with_dfe_sign_in) }
   let(:provider) { provider_user.providers.first }
 
-  before do
-    FeatureFlag.activate(:teacher_degree_apprenticeship)
-  end
-
   scenario 'does not see degrees when application is teacher degree apprenticeship without degrees' do
     given_i_am_a_provider_user
     and_i_sign_in_to_the_provider_interface
@@ -90,10 +86,6 @@ RSpec.describe 'A Provider user views a teacher degree apprenticeship applicatio
 
   def and_i_visit_a_postgraduate_application
     visit provider_interface_application_choice_path(@postgraduate_application)
-  end
-
-  def and_teacher_degree_apprenticeship_feature_flag_is_inactive
-    FeatureFlag.deactivate(:teacher_degree_apprenticeship)
   end
 
   def then_i_see_a_message_on_the_degree_section

--- a/spec/system/register_api/register_receives_application_spec.rb
+++ b/spec/system/register_api/register_receives_application_spec.rb
@@ -12,8 +12,7 @@ RSpec.describe 'Register receives an application data', time: CycleTimetableHelp
   end
 
   scenario 'A candidate is recruited in an undergraduate course' do
-    given_teacher_degree_apprenticeship_feature_flag_is_on
-    and_a_provider_recruited_a_candidate_that_applied_to_an_undergraduate_course
+    given_a_provider_recruited_a_candidate_that_applied_to_an_undergraduate_course
     when_i_retrieve_the_application_over_the_api
     then_it_includes_the_empty_degrees_data_from_the_application
   end
@@ -43,16 +42,12 @@ RSpec.describe 'Register receives an application data', time: CycleTimetableHelp
     )
   end
 
-  def and_a_provider_recruited_a_candidate_that_applied_to_an_undergraduate_course
+  def given_a_provider_recruited_a_candidate_that_applied_to_an_undergraduate_course
     given_undergraduate_courses_exist
     candidate_completes_application_form
     candidate_does_not_have_a_degree
     candidate_submits_undergraduate_application
     and_application_is_recruited
-  end
-
-  def given_teacher_degree_apprenticeship_feature_flag_is_on
-    FeatureFlag.activate(:teacher_degree_apprenticeship)
   end
 
   def when_i_retrieve_the_application_over_the_api

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -15,18 +15,13 @@ RSpec.describe 'Vendor receives the application', time: CycleTimetableHelper.mid
   end
 
   scenario 'A completed undergraduate application is submitted' do
-    given_teacher_degree_apprenticeship_feature_flag_is_on
-    and_candidate_sign_in
+    given_candidate_sign_in
     and_a_candidate_has_submitted_an_undergraduate_application
     when_i_retrieve_the_application_over_the_api
     then_it_includes_the_empty_degrees_data_from_the_application
   end
 
-  def given_teacher_degree_apprenticeship_feature_flag_is_on
-    FeatureFlag.activate(:teacher_degree_apprenticeship)
-  end
-
-  def and_candidate_sign_in
+  def given_candidate_sign_in
     create_and_sign_in_candidate
   end
 

--- a/spec/views/degrees/show.html.erb_spec.rb
+++ b/spec/views/degrees/show.html.erb_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe 'candidate_interface/degrees/review/show' do
     # rubocop:disable RSpec/AnyInstance
     without_partial_double_verification do
       allow_any_instance_of(ActionView::Base).to receive(:current_application).and_return(application_form)
-      allow_any_instance_of(ActionView::Base).to receive(:teacher_degree_apprenticeship_feature_active?).and_return(false)
     end
     # rubocop:enable RSpec/AnyInstance
 


### PR DESCRIPTION
## Context

With the start of 2025 we don't need the teacher degree apprenticeship feature flag anymore.
Remove of the teacher degree apprenticeship feature flag code checks and making the TDA the default behaviour.

## Guidance to review

1. Is there anything feature flag related checks left in the code that it shouldn't be?
2. If you select you have no A levels is the content for postgraduate and undergraduate appears?
3. When you add degrees (or delete all of them), does the new "do you have a degree" question appear?
4. Did you spot any bug when submitting an undergraduate course?
