### PR TITLE
Add data migration to remove tda feature flag

### DIFF
--- a/app/services/data_migrations/remove_teacher_degree_apprenticeship_feature_flag.rb
+++ b/app/services/data_migrations/remove_teacher_degree_apprenticeship_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class RemoveTeacherDegreeApprenticeshipFeatureFlag
+    TIMESTAMP = 20241011094842
+    MANUAL_RUN = false
+
+    def change
+      Feature.where(name: :teacher_degree_aprenticeship).first&.destroy
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveTeacherDegreeApprenticeshipFeatureFlag',
   'DataMigrations::RevertApplicationChoicesUpdatedAt',
   'DataMigrations::BackfillApplicationChoicesWithWorkExperiences',
   'DataMigrations::MarkUnsubmittedApplicationsWithoutEnglishProficiencyAsElfIncomplete',

--- a/spec/services/data_migrations/remove_teacher_degree_apprenticeship_feature_flag_spec.rb
+++ b/spec/services/data_migrations/remove_teacher_degree_apprenticeship_feature_flag_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveTeacherDegreeApprenticeshipFeatureFlag do
+  context 'when the feature flags exist' do
+    before do
+      create(:feature, name: 'teacher_degree_aprenticeship')
+      create(:feature, name: 'some_other_feature_flag')
+    end
+
+    it 'removes the relevant feature flags' do
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: 'teacher_degree_aprenticeship')).to be_none
+      expect(Feature.where(name: 'some_other_feature_flag')).to be_any
+    end
+  end
+
+  context 'when the feature flags have already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end


### PR DESCRIPTION
## Context

With the start of 2025 we don't need the teacher degree apprenticeship feature flag anymore.
Remove of the teacher degree apprenticeship feature flag.

https://github.com/DFE-Digital/apply-for-teacher-training/pull/9913

