### PR TITLE
1427 changing a science gcse grade on support console doesnt always work

### DIFF
--- a/app/forms/concerns/science_gcse_helper.rb
+++ b/app/forms/concerns/science_gcse_helper.rb
@@ -12,9 +12,7 @@ module ScienceGcseHelper
 
   def grade_format
     return if
-      qualification.qualification_type.nil? ||
-      qualification.qualification_type == 'other_uk' ||
-      qualification.qualification_type == 'non_uk' ||
+      not_uk_gcse? ||
       grade.nil? ||
       triple_award?
 
@@ -117,6 +115,8 @@ module ScienceGcseHelper
   end
 
   def sanitize(grade)
+    return grade if not_uk_gcse?
+
     if ALL_GCSE_GRADES.exclude?(grade) && grade_contains_two_numbers?(grade)
       remove_special_characters_and_add_dash_between_numbers(grade)
     elsif DOUBLE_GCSE_GRADES.exclude?(grade)
@@ -124,6 +124,12 @@ module ScienceGcseHelper
     else
       grade
     end
+  end
+
+  def not_uk_gcse?
+    qualification.qualification_type.nil? ||
+      qualification.qualification_type == 'other_uk' ||
+      qualification.qualification_type == 'non_uk'
   end
 
   def new_record?

--- a/app/forms/concerns/science_gcse_helper.rb
+++ b/app/forms/concerns/science_gcse_helper.rb
@@ -1,5 +1,7 @@
 module ScienceGcseHelper
   def grade_from(params)
+    return params[:grade] if not_uk_gcse?
+
     case params[:gcse_science]
     when ApplicationQualification::SCIENCE_SINGLE_AWARD
       params[:single_award_grade]
@@ -8,6 +10,12 @@ module ScienceGcseHelper
     else
       params[:grade]
     end
+  end
+
+  def subject_from(params)
+    return ApplicationQualification::SCIENCE if not_uk_gcse?
+
+    params[:gcse_science] || ApplicationQualification::SCIENCE
   end
 
   def grade_format

--- a/app/forms/support_interface/science_gcse_form.rb
+++ b/app/forms/support_interface/science_gcse_form.rb
@@ -115,7 +115,7 @@ module SupportInterface
       @chemistry_grade = params[:chemistry_grade]
       @physics_grade = params[:physics_grade]
       @grade = grade_from(params)
-      @subject = params[:gcse_science] || ApplicationQualification::SCIENCE
+      @subject = subject_from(params)
       @gcse_science = params[:gcse_science]
       @single_award_grade = params[:single_award_grade]
       @double_award_grade = params[:double_award_grade]

--- a/spec/factories/application_qualification.rb
+++ b/spec/factories/application_qualification.rb
@@ -32,6 +32,8 @@ FactoryBot.define do
       subject { %w[maths english science].sample }
       grade { %w[A B C].sample }
       predicted_grade { false }
+      institution_name { nil }
+      institution_country { nil }
       award_year { Faker::Date.between(from: 10.years.ago, to: 8.years.ago).year }
 
       trait :non_uk do

--- a/spec/forms/candidate_interface/science_gcse_grade_form_spec.rb
+++ b/spec/forms/candidate_interface/science_gcse_grade_form_spec.rb
@@ -263,6 +263,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
         qualification = ApplicationQualification.create(
           level: 'gcse',
           application_form:,
+          qualification_type: 'gcse',
         )
 
         details_form = described_class.build_from_qualification(qualification)
@@ -338,6 +339,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
         qualification = ApplicationQualification.create(
           level: 'gcse',
           application_form:,
+          qualification_type: 'gcse',
         )
 
         details_form = described_class.build_from_qualification(qualification)
@@ -354,6 +356,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
       it 'stores sanitized grades when it is a triple award' do
         application_form = build(:application_form)
         qualification = ApplicationQualification.create(
+          qualification_type: 'gcse',
           level: 'gcse',
           application_form:,
         )
@@ -451,6 +454,14 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
 
           expect(gcse_details_form.grade).to eq 'other'
           expect(gcse_details_form.other_grade).to eq 'D'
+        end
+
+        it 'does not sanitize the grade' do
+          qualification = build_stubbed(:gcse_qualification, qualification_type: 'non_uk', grade: 'High pass')
+          gcse_details_form = described_class.build_from_qualification(qualification)
+
+          expect(gcse_details_form.grade).to eq 'other'
+          expect(gcse_details_form.other_grade).to eq 'High pass'
         end
       end
     end

--- a/spec/system/support_interface/change_science_gcse_spec.rb
+++ b/spec/system/support_interface/change_science_gcse_spec.rb
@@ -60,6 +60,11 @@ RSpec.describe 'Change science GCSE' do
     and_i_click_update
     then_it_has_saved_non_uk_gcse_into_the_application_form
 
+    when_i_click_to_change_my_science_gcse
+    and_i_change_the_grade
+    and_i_click_update
+    then_it_has_saved_the_new_grade
+
     and_i_click_to_change_my_science_gcse
     and_i_choose_another_uk_qualification
     and_i_click_update
@@ -104,6 +109,8 @@ RSpec.describe 'Change science GCSE' do
     then_it_has_saved_the_triple_award_gcses_into_the_application_form
   end
 
+  private
+
   def given_i_am_a_support_user
     sign_in_as_support_user
   end
@@ -135,6 +142,7 @@ RSpec.describe 'Change science GCSE' do
       click_link_or_button 'Change'
     end
   end
+  alias_method :when_i_click_to_change_my_science_gcse, :and_i_click_to_change_my_science_gcse
 
   def and_i_click_update
     click_link_or_button 'Update details'
@@ -259,6 +267,12 @@ RSpec.describe 'Change science GCSE' do
     select 'Brazil', from: 'support_interface_gcse_form[institution_country]'
     fill_in 'UK ENIC reference number', with: '4000228363'
     choose 'GCE Advanced (A) level'
+    fill_in 'support_interface_gcse_form[grade]', with: '67%'
+    and_i_add_the_zendesk_ticket_url
+  end
+
+  def and_i_change_the_grade
+    fill_in 'support_interface_gcse_form[grade]', with: 'High pass'
     and_i_add_the_zendesk_ticket_url
   end
 
@@ -334,8 +348,22 @@ RSpec.describe 'Change science GCSE' do
       comparable_uk_qualification: 'GCE Advanced (A) level',
       enic_reference: '4000228363',
       institution_country: 'BR',
+      grade: '67%',
     )
   end
+
+  def then_it_has_saved_the_new_grade
+    and_it_should_update_the_attributes(
+      qualification_type: 'non_uk',
+      non_uk_qualification_type: 'Higher Secondary School Certificate',
+      comparable_uk_qualification: 'GCE Advanced (A) level',
+      enic_reference: '4000228363',
+      institution_country: 'BR',
+      grade: 'High pass',
+      )
+  end
+
+
 
   def then_it_has_saved_another_uk_qualification_into_the_application_form
     and_it_should_update_the_attributes(

--- a/spec/system/support_interface/change_science_gcse_spec.rb
+++ b/spec/system/support_interface/change_science_gcse_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe 'Change science GCSE' do
     then_it_has_saved_the_triple_award_gcses_into_the_application_form
   end
 
-  private
+private
 
   def given_i_am_a_support_user
     sign_in_as_support_user
@@ -349,6 +349,7 @@ RSpec.describe 'Change science GCSE' do
       enic_reference: '4000228363',
       institution_country: 'BR',
       grade: '67%',
+      subject: 'science',
     )
   end
 
@@ -360,10 +361,9 @@ RSpec.describe 'Change science GCSE' do
       enic_reference: '4000228363',
       institution_country: 'BR',
       grade: 'High pass',
-      )
+      subject: 'science',
+    )
   end
-
-
 
   def then_it_has_saved_another_uk_qualification_into_the_application_form
     and_it_should_update_the_attributes(
@@ -426,6 +426,7 @@ RSpec.describe 'Change science GCSE' do
   def when_i_add_the_double_award_grade
     fill_in 'support_interface_gcse_form[double_award_grade]', with: 'CD'
   end
+  alias_method :and_i_add_the_double_award_grade, :when_i_add_the_double_award_grade
 
   def then_it_has_saved_the_double_award_gcses_into_the_application_form
     and_it_should_update_the_attributes(

--- a/spec/system/support_interface/change_uk_to_not_uk_science_gcse_spec.rb
+++ b/spec/system/support_interface/change_uk_to_not_uk_science_gcse_spec.rb
@@ -1,0 +1,141 @@
+require 'rails_helper'
+
+RSpec.describe 'Change science GCSE' do
+  include DfESignInHelpers
+
+  scenario 'changing from a UK science qualification to an international one', :with_audited do
+    given_i_am_a_support_user
+    and_there_is_an_application_choice_awaiting_provider_decision
+    when_i_visit_the_application_page
+    and_i_click_to_change_my_science_gcse
+    and_i_add_a_double_award
+    and_i_click_update
+    then_it_has_saved_the_double_award_gcses_into_the_application_form
+
+    when_i_click_to_change_my_science_gcse
+    and_i_choose_non_uk_gcse
+    and_i_add_all_details_for_non_uk_gcse
+    and_i_click_update
+    then_it_has_saved_non_uk_gcse_into_the_application_form
+  end
+
+private
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_is_an_application_choice_awaiting_provider_decision
+    @application_form = create(
+      :application_form,
+      submitted_at: Time.zone.now,
+    )
+    @science_gcse = create(:gcse_qualification, :science_triple_award, application_form: @application_form)
+
+    @application_choice = create(
+      :application_choice,
+      :awaiting_provider_decision,
+      application_form: @application_form,
+    )
+  end
+
+  def when_i_visit_the_application_page
+    visit support_interface_application_form_path(@application_choice.application_form_id)
+  end
+
+  def then_i_see_a_change_science_link
+    expect(page).to have_link('Change')
+  end
+
+  def and_i_click_to_change_my_science_gcse
+    within('.app-edit-qualification') do
+      click_link_or_button 'Change'
+    end
+  end
+  alias_method :when_i_click_to_change_my_science_gcse, :and_i_click_to_change_my_science_gcse
+
+  def and_i_click_update
+    click_link_or_button 'Update details'
+  end
+
+  def and_i_add_the_zendesk_ticket_url
+    fill_in 'Zendesk ticket URL', with: 'https://becomingateacher.zendesk.com/agent/tickets/12345'
+  end
+
+  def and_i_choose_non_uk_gcse
+    choose 'Qualification from outside the UK'
+  end
+
+  def and_i_add_a_double_award
+    choose 'GCSE'
+    choose 'Double award'
+    fill_in 'support_interface_gcse_form[double_award_grade]', with: 'CD'
+    and_i_add_the_zendesk_ticket_url
+  end
+
+  def then_it_has_saved_the_double_award_gcses_into_the_application_form
+    and_it_should_update_the_attributes(
+      qualification_type: 'gcse',
+      subject: 'science double award',
+      grade: 'CD',
+      constituent_grades: nil,
+      other_uk_qualification_type: nil,
+      non_uk_qualification_type: nil,
+      comparable_uk_qualification: nil,
+      enic_reference: nil,
+      institution_country: nil,
+    )
+  end
+
+  def and_i_add_all_details_for_non_uk_gcse
+    fill_in 'support_interface_gcse_form[non_uk_qualification_type]', with: 'Higher Secondary School Certificate'
+    select 'Brazil', from: 'support_interface_gcse_form[institution_country]'
+    fill_in 'UK ENIC reference number', with: '4000228363'
+    choose 'GCE Advanced (A) level'
+    fill_in 'support_interface_gcse_form[grade]', with: '67%'
+    and_i_add_the_zendesk_ticket_url
+  end
+
+  def then_it_has_saved_non_uk_gcse_into_the_application_form
+    and_it_should_update_the_attributes(
+      qualification_type: 'non_uk',
+      non_uk_qualification_type: 'Higher Secondary School Certificate',
+      comparable_uk_qualification: 'GCE Advanced (A) level',
+      enic_reference: '4000228363',
+      institution_country: 'BR',
+      grade: '67%',
+      subject: 'science',
+    )
+  end
+
+  def when_i_choose_single_award
+    choose 'Single award'
+  end
+
+  def when_i_add_the_single_award
+    fill_in 'support_interface_gcse_form[single_award_grade]', with: '3'
+  end
+
+  def then_it_has_saved_the_single_award_gcses_into_the_application_form
+    and_it_should_update_the_attributes(
+      qualification_type: 'gcse',
+      subject: 'science single award',
+      grade: '3',
+      constituent_grades: nil,
+      other_uk_qualification_type: nil,
+      non_uk_qualification_type: nil,
+      comparable_uk_qualification: nil,
+      enic_reference: nil,
+      institution_country: nil,
+    )
+  end
+
+  def and_it_should_update_the_attributes(attributes)
+    expect(page).to have_content('GCSE updated')
+
+    expect(page).to have_current_path(support_interface_application_form_path(@application_form))
+
+    @science_gcse.reload
+    expect(@science_gcse.attributes.symbolize_keys).to include(attributes)
+  end
+end


### PR DESCRIPTION
## Context

Bug reported by support. 
GIVEN a candidate has a UK Science GCSE
WHEN I change to an international GCSE
AND I change the grade
THEN the new grade is not saved

## Changes proposed in this pull request

Essentially, the UK GCSE form details are submitted along with the changes and the conditional logic for determining the grade doesn't check of a non-uk qualification has been selected. 

We were also trying to format grades as though they were UK GCSE grades, so 67% would become 6-7. and Pass would become PASS. 

Also, because we were persisting the UK GCSE information, we weren't changing the subject to 'science'. It was the UK specific 'double science' or whatever UK thing had been selected before.

Adding some early returns and some specs. 

## Guidance to review

From the support console, make changes to Science gcse grades and make sure they persist the way they should.

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
