### PR TITLE
[17] Revert start-of-cycle scaling

### DIFF
--- a/terraform/aks/workspace_variables/production_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/production_aks.tfvars.json
@@ -13,7 +13,7 @@
   "worker_memory_max": "2Gi",
   "secondary_worker_memory_max": "2Gi",
   "clock_worker_memory_max": "1Gi",
-  "webapp_replicas": 8,
+  "webapp_replicas": 4,
   "worker_replicas": 2,
   "secondary_worker_replicas": 2,
   "clock_worker_replicas": 1,


### PR DESCRIPTION
## Context

To handle increased activity on Apply on the first few days of the start of cycle, we increased the number of web replicas and the database CPU. 

## Changes proposed in this pull request

We have decided to maintain the database CPU levels for now, go back to 4 web replicas. 

## Guidance to review

There will not be any downtime with just the change to the web replicas. 

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
