### PR TITLE
Revert "Delay transactional mailers related to application submission"

### DIFF
--- a/app/services/candidate_interface/submit_application_choice.rb
+++ b/app/services/candidate_interface/submit_application_choice.rb
@@ -23,18 +23,13 @@ module CandidateInterface
         ApplicationStateChange.new(application_choice).send_to_provider!
 
         SendNewApplicationEmailToProvider.new(application_choice:).call
-        CandidateMailer.application_choice_submitted(application_choice).deliver_later(wait: wait_time)
+        CandidateMailer.application_choice_submitted(application_choice).deliver_later
       end
     end
 
     def current_time
       Time.zone.now
     end
-
-    def wait_time
-      rand(1..15).minutes
-    end
-
     alias effective_date current_time
     alias submitted_at current_time
     alias sent_to_provider_at current_time

--- a/app/services/send_new_application_email_to_provider.rb
+++ b/app/services/send_new_application_email_to_provider.rb
@@ -10,16 +10,10 @@ class SendNewApplicationEmailToProvider
 
     NotificationsList.for(application_choice, event: :application_submitted, include_ratifying_provider: true).each do |provider_user|
       if application_choice.application_form.has_safeguarding_issues_to_declare?
-        ProviderMailer.application_submitted_with_safeguarding_issues(provider_user, application_choice).deliver_later(wait: wait_time)
+        ProviderMailer.application_submitted_with_safeguarding_issues(provider_user, application_choice).deliver_later
       else
-        ProviderMailer.application_submitted(provider_user, application_choice).deliver_later(wait: wait_time)
+        ProviderMailer.application_submitted(provider_user, application_choice).deliver_later
       end
     end
-  end
-
-private
-
-  def wait_time
-    @wait_time ||= rand(1..15).minutes
   end
 end


### PR DESCRIPTION
Reverts DFE-Digital/apply-for-teacher-training#9897
We added these delays to ensure we wouldn't hit our notify limits, anticipating a sharp increase in submitted applications in the first few minutes / hours of apply opening. 

Now that we have resumed normal traffic, we can resume sending these messages promptly. 