### PR TITLE
Updated Application Choice Item component to optionally display the Site Name

### DIFF
--- a/app/components/candidate_interface/application_choice_item_component.html.erb
+++ b/app/components/candidate_interface/application_choice_item_component.html.erb
@@ -11,7 +11,7 @@
           </h2>
           <p class="govuk-body-s"><%= application_id %></p>
         </div>
-        <p class="govuk-body-s"><%= course_name %> - <%= study_mode %> at <%= site_name %></p>
+        <p class="govuk-body-s"><%= course_option_summary %></p>
       </div>
     </div>
   <% end %>

--- a/app/components/candidate_interface/application_choice_item_component.rb
+++ b/app/components/candidate_interface/application_choice_item_component.rb
@@ -3,7 +3,7 @@ class CandidateInterface::ApplicationChoiceItemComponent < ViewComponent::Base
     @application_choice = application_choice
   end
   attr_reader :application_choice
-  delegate :status, to: :application_choice
+  delegate :status, :school_placement_auto_selected, to: :application_choice
 
   def provider_name
     application_choice.current_course.provider.name
@@ -23,6 +23,14 @@ class CandidateInterface::ApplicationChoiceItemComponent < ViewComponent::Base
 
   def site_name
     application_choice.site.name
+  end
+
+  def course_option_summary
+    if school_placement_auto_selected
+      "#{course_name} - #{study_mode}"
+    else
+      "#{course_name} - #{study_mode} at #{site_name}"
+    end
   end
 
   def view_application_path

--- a/spec/components/candidate_interface/application_choice_item_component_spec.rb
+++ b/spec/components/candidate_interface/application_choice_item_component_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe CandidateInterface::ApplicationChoiceItemComponent do
       expect(rendered.text).to include(application_choice.current_course.provider.name)
       expect(rendered.text).to include(application_choice.id.to_s)
       expect(rendered.text).to include(application_choice.current_course.name_and_code)
-      expect(rendered.text).to include(application_choice.site.name)
     end
   end
 
@@ -28,4 +27,20 @@ RSpec.describe CandidateInterface::ApplicationChoiceItemComponent do
   it_behaves_like('application choice item') { let(:status) { :rejected } }
   it_behaves_like('application choice item') { let(:status) { :declined } }
   it_behaves_like('application choice item') { let(:status) { :inactive } }
+
+  context 'when the Candidate has chosen the School Placement' do
+    let(:application_choice) { create(:application_choice, school_placement_auto_selected: false) }
+
+    it 'displays with the Site name' do
+      expect(rendered.text).to include(application_choice.site.name)
+    end
+  end
+
+  context 'when the Candidate has not chosen the School Placement' do
+    let(:application_choice) { create(:application_choice, school_placement_auto_selected: true) }
+
+    it 'displays with the Site name' do
+      expect(rendered.text).not_to include(application_choice.site.name)
+    end
+  end
 end


### PR DESCRIPTION
## Context

The Site Name is only displayed if the , `school_placement_auto_selected` was not auto selected

## Changes proposed in this pull request

| Candidate selected | Auto selected |
|--------|-------|
|   ![Screenshot 2024-10-14 at 16 17 48](https://github.com/user-attachments/assets/3c39b12e-940d-45e7-96c8-b1a05c8fc589)  | ![Screenshot 2024-10-14 at 16 17 19](https://github.com/user-attachments/assets/de4ef0a3-accf-4de7-9f32-bbcfabb3d17b) |

## Guidance to review

UI
