### PR TITLE
Update the error message to match the text box limit

### DIFF
--- a/config/locales/provider_interface/rejections.yml
+++ b/config/locales/provider_interface/rejections.yml
@@ -16,61 +16,61 @@ en:
             communication_and_scheduling_selected_reasons: Select reasons related to communication, interview attendance and scheduling
             unsuitable_degree_details:
               blank: Enter details about how the degree does not meet course requirements
-              size: Details about how the degree does not meet course requirements must be 100 words or fewer
+              size: Details about how the degree does not meet course requirements must be 200 words or fewer
             unverified_qualifications_details:
               blank: Enter details about qualifications which could not be verified
-              size: Details about unverified qualifications must be 100 words or fewer
+              size: Details about unverified qualifications must be 200 words or fewer
             qualifications_other_details:
               blank: Enter details about reasons related to qualifications
-              size: Details about reasons related to qualifications must be 100 words or fewer
+              size: Details about reasons related to qualifications must be 200 words or fewer
             quality_of_writing_details:
               blank: Enter details about quality of writing
-              size: Details about quality of writing must be 100 words or fewer
+              size: Details about quality of writing must be 200 words or fewer
             personal_statement_other_details:
               blank: Enter details about reasons related to personal statement
-              size: Details about reasons related to personal statement must be 100 words or fewer
+              size: Details about reasons related to personal statement must be 200 words or fewer
             subject_knowledge_details:
               blank: Enter details about subject knowledge
-              size: Details about subject knowledge must be 100 words or fewer
+              size: Details about subject knowledge must be 200 words or fewer
             safeguarding_knowledge_details:
               blank: Enter details about safeguarding knowledge
-              size: Details about safeguarding knowledge must be 100 words or fewer
+              size: Details about safeguarding knowledge must be 200 words or fewer
             teaching_method_knowledge_details:
               blank: Enter details about teaching method knowledge
-              size: Details about teaching method knowledge must be 100 words or fewer
+              size: Details about teaching method knowledge must be 200 words or fewer
             teaching_role_knowledge_details:
               blank: Enter details about teaching role knowledge
-              size: Details about teaching role knowledge must be 100 words or fewer
+              size: Details about teaching role knowledge must be 200 words or fewer
             teaching_demonstration_details:
               blank: Enter details about teaching demonstration knowledge
-              size: Details about teaching demonstration knowledge must be 100 words or fewer
+              size: Details about teaching demonstration knowledge must be 200 words or fewer
             teaching_knowledge_other_details:
               blank: Enter details about teaching knowledge, ability and interview performance
-              size: Details about teaching knowledge, ability and interview performance must be 100 words or fewer
+              size: Details about teaching knowledge, ability and interview performance must be 200 words or fewer
             did_not_reply_details:
               blank: Enter details about the candidate not replying to messages
-              size: Details about the candidate not replying to messages must be 100 words or fewer
+              size: Details about the candidate not replying to messages must be 200 words or fewer
             did_not_attend_interview_details:
               blank: Enter details about the candidate not attending interview
-              size: Details about the candidate not attending interview must be 100 words or fewer
+              size: Details about the candidate not attending interview must be 200 words or fewer
             could_not_arrange_interview_details:
               blank: Enter details about not being able to arrange interview
-              size: Details about not being able to arrange interview must be 100 words or fewer
+              size: Details about not being able to arrange interview must be 200 words or fewer
             communication_and_scheduling_other_details:
               blank: Enter details about communication, interview attendance and scheduling
-              size: Details about communication, interview attendance and scheduling must be 100 words or fewer
+              size: Details about communication, interview attendance and scheduling must be 200 words or fewer
             unsuitable_a_levels_details:
               blank: Enter details about why their A levels do not meet course requirements
-              size: Details about why their A levels do not meet course requirements must be 100 words or fewer
+              size: Details about why their A levels do not meet course requirements must be 200 words or fewer
             references_details:
               blank: Enter details about references
-              size: Details about references must be 100 words or fewer
+              size: Details about references must be 200 words or fewer
             safeguarding_details:
               blank: Enter details about safeguarding
-              size: Details about safeguarding must be 100 words or fewer
+              size: Details about safeguarding must be 200 words or fewer
             visa_sponsorship_details:
               blank: Enter details about visa sponsorship
-              size: Details about visa sponsorship must be 100 words or fewer
+              size: Details about visa sponsorship must be 200 words or fewer
             other_details:
               blank: Enter details about reasons for rejecting the application
-              size: Details about reasons for rejecting the application must be 100 words or fewer
+              size: Details about reasons for rejecting the application must be 200 words or fewer

--- a/spec/models/rejection_reasons_spec.rb
+++ b/spec/models/rejection_reasons_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe RejectionReasons do
 
     it 'provides the error message for the given key and error type' do
       expect(described_class.translated_error(:unsuitable_degree_details, :size)).to eq(
-        'Details about how the degree does not meet course requirements must be 100 words or fewer',
+        'Details about how the degree does not meet course requirements must be 200 words or fewer',
       )
     end
   end


### PR DESCRIPTION
## Context

When rejecting an application, all rejection reasons that opens a textarea to enter details says “200 words remaining” but when this past must be 100 words or fewer”.

## Changes proposed in this pull request

| Before | After |
| ------- | ------- |
| <img width="645" alt="image" src="https://github.com/user-attachments/assets/d71730ed-9472-443a-926e-32f6654e11eb"> | <img width="767" alt="image" src="https://github.com/user-attachments/assets/5687bc9d-7d3f-4ced-aa21-9ee94bcec531"> |

## Guidance to review

- Reject a candidate and provide a free-text reason
- Enter more than 200 words and click the Continue button
- You should see the correct error message

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
