### PR TITLE
[21] Monthly Statistics Pause the monthly generation & publication for October 2024

### DIFF
--- a/app/services/monthly_statistics_timetable.rb
+++ b/app/services/monthly_statistics_timetable.rb
@@ -4,7 +4,11 @@ module MonthlyStatisticsTimetable
   end
 
   def self.current_generation_date
-    third_monday_of_the_month(Date.current.beginning_of_month)
+    if month_without_reports?(Date.current)
+      third_monday_of_the_month(Date.current.beginning_of_month + 1.month)
+    else
+      third_monday_of_the_month(Date.current.beginning_of_month)
+    end
   end
 
   def self.current_publication_date
@@ -12,7 +16,13 @@ module MonthlyStatisticsTimetable
   end
 
   def self.last_generation_date
-    third_monday_of_the_month(Date.current.beginning_of_month - 1.month)
+    months_ago = if month_without_reports?(Date.current - 1.month)
+                   2.months
+                 else
+                   1.month
+                 end
+
+    third_monday_of_the_month(Date.current.beginning_of_month - months_ago)
   end
 
   def self.last_publication_date
@@ -22,7 +32,12 @@ module MonthlyStatisticsTimetable
   end
 
   def self.next_generation_date
-    third_monday_of_the_month(Date.current.beginning_of_month + 1.month)
+    months_from_now = if month_without_reports?(Date.current.beginning_of_month + 1.month)
+                        2.months
+                      else
+                        1.month
+                      end
+    third_monday_of_the_month(Date.current.beginning_of_month + months_from_now)
   end
 
   def self.next_publication_date
@@ -34,5 +49,9 @@ module MonthlyStatisticsTimetable
   def self.third_monday_of_the_month(start_date)
     first_monday = start_date.upto(start_date.next_week).find(&:monday?)
     first_monday + 2.weeks
+  end
+
+  def self.month_without_reports?(date)
+    date.month == CycleTimetable.find_opens.to_date.month
   end
 end

--- a/spec/factories/monthly_statistics_reports.rb
+++ b/spec/factories/monthly_statistics_reports.rb
@@ -12,6 +12,8 @@ FactoryBot.define do
 
     trait :v2 do
       statistics { Publications::MonthlyStatistics::StubbedReport.new.to_h }
+      publication_date { 1.day.ago }
+      generation_date { 8.days.ago }
     end
   end
 end

--- a/spec/services/monthly_statistics_timetable_spec.rb
+++ b/spec/services/monthly_statistics_timetable_spec.rb
@@ -2,16 +2,25 @@ require 'rails_helper'
 
 RSpec.describe MonthlyStatisticsTimetable do
   describe '#generate_monthly_statistics?' do
+    let(:report_months) { (1..12).to_a - [CycleTimetable.find_opens.to_date.month] }
+
     it 'returns true if the monthly report is scheduled to run on the current date' do
-      1.upto(12).each do |month|
+      report_months.each do |month|
         travel_temporarily_to(described_class.third_monday_of_the_month(Date.new(RecruitmentCycle.current_year, month, 1))) do
           expect(described_class.generate_monthly_statistics?).to be true
         end
       end
     end
 
+    it 'returns false if within the first month of the cycle opening' do
+      find_opens_month = CycleTimetable.find_opens.to_date.month
+      travel_temporarily_to(described_class.third_monday_of_the_month(Date.new(RecruitmentCycle.current_year, find_opens_month, 1))) do
+        expect(described_class.generate_monthly_statistics?).to be false
+      end
+    end
+
     it 'returns false if the monthly report is not scheduled to run on the current date' do
-      1.upto(12).each do |month|
+      report_months.each do |month|
         travel_temporarily_to(RecruitmentCycle.current_year, month, 1) do
           expect(described_class.generate_monthly_statistics?).to be false
         end
@@ -20,13 +29,6 @@ RSpec.describe MonthlyStatisticsTimetable do
   end
 
   describe '.next_publication_date' do
-    let!(:current_report) do
-      create(:monthly_statistics_report, :v1, month: '2021-12')
-    end
-    let!(:previous_report) do
-      create(:monthly_statistics_report, :v1, month: '2021-11')
-    end
-
     context 'when today is before the publishing date in the current month' do
       it 'returns the date of this month’s report' do
         travel_temporarily_to(Date.new(2021, 12, 21)) do
@@ -39,6 +41,32 @@ RSpec.describe MonthlyStatisticsTimetable do
       it 'returns the date of next month’s report' do
         travel_temporarily_to(Date.new(2021, 12, 28)) do
           expect(described_class.next_publication_date).to eq(Date.new(2022, 1, 24))
+        end
+      end
+    end
+
+    context 'when today is before find opens' do
+      it 'returns 4th monday in the month after find opens' do
+        travel_temporarily_to(Date.new(2024, 9, 28)) do
+          expect(described_class.next_publication_date).to eq(Date.new(2024, 11, 25))
+        end
+      end
+    end
+  end
+
+  describe '#last_generation_date' do
+    context 'when it in the month after find opens' do
+      it 'returns date two months ago' do
+        travel_temporarily_to(Date.new(2024, 11, 1)) do
+          expect(described_class.last_generation_date).to eq(Date.new(2024, 9, 16))
+        end
+      end
+    end
+
+    context 'when it is three months after find_opens' do
+      it 'returns date one month ago' do
+        travel_temporarily_to(Date.new(2024, 12, 1)) do
+          expect(described_class.last_generation_date).to eq(Date.new(2024, 11, 18))
         end
       end
     end

--- a/spec/workers/generate_monthly_statistics_spec.rb
+++ b/spec/workers/generate_monthly_statistics_spec.rb
@@ -4,6 +4,17 @@ RSpec.describe GenerateMonthlyStatistics, :sidekiq do
   include DfE::Bigquery::TestHelper
   before { stub_bigquery_application_metrics_request }
 
+  context 'when third Monday, but within the first month of the cycle' do
+    before do
+      TestSuiteTimeMachine.travel_permanently_to(Time.zone.local(2024, 10, 21))
+    end
+
+    it 'returns false' do
+      expect(described_class.new.perform).to be false
+      expect(Publications::MonthlyStatistics::MonthlyStatisticsReport.count).to be_zero
+    end
+  end
+
   context 'when second Monday of the month' do
     before do
       TestSuiteTimeMachine.travel_permanently_to(Time.zone.local(2023, 11, 13))


### PR DESCRIPTION
## Context

We do not want to generate the monthly statistics publication during the first month of the new cycle -- there just isn't enough data

## Changes proposed in this pull request

Changes to the monthly statistics timetable module to exclude generation dates for the month the cycle starts. 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [x] Add PR link to Trello card
