### PR TITLE
Add rejection reasons for providers

### DIFF
--- a/app/presenters/rejection_reasons/rejection_reasons_presenter.rb
+++ b/app/presenters/rejection_reasons/rejection_reasons_presenter.rb
@@ -9,7 +9,16 @@ class RejectionReasons
     CLASS_ROOM_EXPERIENCE_REASON_CODES = %w[teaching_demonstration teaching_knowledge_other teaching_method_knowledge safeguarding_knowledge teaching_role_knowledge].freeze
     COMMUNICATION_OTHER_REASON_CODES = %w[could_not_arrange_interview did_not_reply communication_and_scheduling_other].freeze
     VALID_HIGH_LEVEL_ADVICE_REASON_CODES = %w[qualifications personal_statement teaching_knowledge communication_and_scheduling safeguarding visa_sponsorship course_full other].freeze
-    NO_TAILORED_ADVICE_CODES = %w[unsuitable_a_levels].freeze
+    NO_TAILORED_ADVICE_CODES = %w[
+      unsuitable_a_levels
+      unsuitable_degree_subject
+      unverified_equivalency_qualifications
+      already_qualified
+      english_below_standard
+      no_placements
+      no_suitable_placements
+      placements_other
+    ].freeze
 
     def rejection_reasons
       return {} unless structured_rejection_reasons&.any?

--- a/config/rejection_reason_codes.yml
+++ b/config/rejection_reason_codes.yml
@@ -58,3 +58,11 @@ R09:
     :id: other_details
     :label: Details
     :text: We were unable to offer you a place on the chosen course. Please contact us for details.
+R10:
+  :id: school_placement
+  :label: School placement
+  :details:
+    :id: school_placement_details
+    :label: Details
+    :text: We are unable to offer you a place because we could not find a suitable placement
+

--- a/config/rejection_reasons.yml
+++ b/config/rejection_reasons.yml
@@ -19,17 +19,35 @@
       :label: Details
       :visually_hidden: about why their A levels do not meet course requirements
   - :id: unsuitable_degree
-    :label: Degree does not meet course requirements
+    :label: Degree grade does not meet course requirements
     :details:
       :id: unsuitable_degree_details
       :label: Details
-      :visually_hidden: about why their qualifications do not meet course requirements
+      :visually_hidden: about why their qualifications does not meet course requirements
+  - :id: unsuitable_degree_subject
+    :label: Degree subject does not meet course requirements
+    :details:
+      :id: unsuitable_degree_subject_details
+      :label: Details
+      :visually_hidden: about why their subject does not meet course requirements
   - :id: unverified_qualifications
     :label: Could not verify qualifications
     :details:
       :id: unverified_qualifications_details
       :label: Details
       :visually_hidden: about why you could not verify qualifications
+  - :id: unverified_equivalency_qualifications
+    :label: Could not verify equivalency of qualifications
+    :details:
+      :id: unverified_equivalency_qualifications_details
+      :label: Details
+      :visually_hidden: about why you could not verify equivalency qualifications
+  - :id: already_qualified
+    :label: Already has a teaching qualification
+    :details:
+      :id: already_qualified_details
+      :label: Details
+      :visually_hidden: about their rejection due to having a qualification already
   - :id: qualifications_other
     :label: Other
     :details:
@@ -114,6 +132,12 @@
       :id: could_not_arrange_interview_details
       :label: Details
       :visually_hidden: about not being able to arrange an interview
+  - :id: english_below_standard
+    :label: English language ability below expected standard
+    :details:
+      :id: english_below_standard_details
+      :label: Details
+      :visually_hidden: about the english ability being below expected standard
   - :id: communication_and_scheduling_other
     :label: Other
     :details:
@@ -145,6 +169,28 @@
     :label: Details (optional)
     :optional: true
     :visually_hidden: about the course being full
+- :id: school_placement
+  :label: School placement
+  :reasons_visually_hidden: for rejecting due to school placement
+  :reasons:
+  - :id: no_placements
+    :label: No available placements
+    :details:
+      :id: no_placements_details
+      :label: Details
+      :visually_hidden: of why there are no placements
+  - :id: no_suitable_placements
+    :label: No placements that are suitable
+    :details:
+      :id: no_suitable_placements_details
+      :label: Details
+      :visually_hidden: of why there are no suitable placements
+  - :id: placements_other
+    :label: Other
+    :details:
+      :id: placements_other_details
+      :label: Details
+      :visually_hidden: of other rejection reasons regarding placements
 - :id: other
   :label: Other
   :details:

--- a/config/vendor_api/v1.2.yml
+++ b/config/vendor_api/v1.2.yml
@@ -116,6 +116,7 @@ components:
             - R07
             - R08
             - R09
+            - R10
         details:
           type: string
           description: Optional details about why the application was rejected for the given reason.

--- a/spec/forms/provider_interface/rejections_wizard_spec.rb
+++ b/spec/forms/provider_interface/rejections_wizard_spec.rb
@@ -30,7 +30,17 @@ RSpec.describe ProviderInterface::RejectionsWizard do
 
   describe '.selectable_reasons' do
     it 'includes non-deprecated reasons' do
-      expect(described_class.selectable_reasons.find { |r| r.id == 'personal_statement' }).to be_present
+      expect(described_class.selectable_reasons.map(&:id)).to include(
+        'qualifications',
+        'personal_statement',
+        'teaching_knowledge',
+        'communication_and_scheduling',
+        'safeguarding',
+        'visa_sponsorship',
+        'course_full',
+        'school_placement',
+        'other',
+      )
     end
 
     it 'does not include deprecated reasons' do
@@ -56,7 +66,19 @@ RSpec.describe ProviderInterface::RejectionsWizard do
       end
 
       it 'includes other qualification-related reasons' do
-        expect(qualification_reasons.map(&:id)).to include('no_maths_gcse', 'no_english_gcse', 'no_science_gcse', 'no_degree')
+        expect(qualification_reasons.map(&:id)).to include(
+          'no_maths_gcse',
+          'no_english_gcse',
+          'no_science_gcse',
+          'no_degree',
+          'unsuitable_a_levels',
+          'unsuitable_degree',
+          'unsuitable_degree_subject',
+          'unverified_qualifications',
+          'unverified_equivalency_qualifications',
+          'already_qualified',
+          'qualifications_other',
+        )
       end
     end
 
@@ -68,7 +90,18 @@ RSpec.describe ProviderInterface::RejectionsWizard do
       end
 
       it 'still includes other qualification-related reasons' do
-        expect(qualification_reasons.map(&:id)).to include('no_maths_gcse', 'no_english_gcse', 'no_science_gcse', 'no_degree')
+        expect(qualification_reasons.map(&:id)).to include(
+          'no_maths_gcse',
+          'no_english_gcse',
+          'no_science_gcse',
+          'no_degree',
+          'unsuitable_degree',
+          'unsuitable_degree_subject',
+          'unverified_qualifications',
+          'unverified_equivalency_qualifications',
+          'already_qualified',
+          'qualifications_other',
+        )
       end
     end
   end

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -642,10 +642,43 @@ private
           { id: 'no_english_gcse', label: 'No English GCSE at minimum grade 4 or C, or equivalent' },
           { id: 'no_science_gcse', label: 'No science GCSE at minimum grade 4 or C, or equivalent' },
           { id: 'no_degree', label: 'No bachelor’s degree or equivalent' },
-          { id: 'unverified_qualifications',
+          {
+            id: 'unsuitable_degree',
+            label: 'Degree grade does not meet course requirements',
+            details: { id: 'unsuitable_degree_details', text: 'Your degree does not meet course requirements.' },
+          },
+          {
+            id: 'unsuitable_degree_subject',
+            label: 'Degree subject does not meet course requirements',
+            details: { id: 'unsuitable_degree_subject_details', text: 'Your degree subject does not match.' },
+          },
+          {
+            id: 'unverified_qualifications',
             label: 'Could not verify qualifications',
-            details: { id: 'unverified_qualifications_details', text: 'We could find no record of your GCSEs.' } },
+            details: { id: 'unverified_qualifications_details', text: 'We could find no record of your GCSEs.' },
+          },
+          {
+            id: 'unverified_equivalency_qualifications',
+            label: 'Could not verify equivalency of qualifications',
+            details: { id: 'unverified_equivalency_qualifications_details', text: 'We could verify the equivalency of your qualifications.' },
+          },
+          {
+            id: 'already_qualified',
+            label: 'Already has a teaching qualification',
+            details: { id: 'already_qualified_details', text: 'You are already a qualified teacher.' },
+          },
         ] },
+        {
+          id: 'communication_and_scheduling',
+          label: 'Communication, interview attendance and scheduling',
+          selected_reasons: [
+            {
+              id: 'english_below_standard',
+              label: 'English language ability below expected standard',
+              details: { id: 'english_below_standard_details', text: 'English language ability below the expected standard.' },
+            },
+          ],
+        },
         { id: 'personal_statement',
           label: 'Personal statement',
           selected_reasons: [
@@ -653,7 +686,28 @@ private
               label: 'Quality of writing',
               details: { id: 'quality_of_writing_details', text: 'We do not accept applications written in Old Norse.' } },
           ] },
-        { id: 'course_full',  label: 'Course full' },
+        { id: 'course_full', label: 'Course full' },
+        {
+          id: 'school_placement',
+          label: 'School placement',
+          selected_reasons: [
+            {
+              id: 'no_placements',
+              label: 'No available placements',
+              details: { id: 'no_placements_details', text: 'We filled all our placements.' },
+            },
+            {
+              id: 'no_suitable_placements',
+              label: 'No placements that are suitable',
+              details: { id: 'no_suitable_placements_details', text: 'We do not have a suitable place for you.' },
+            },
+            {
+              id: 'placements_other',
+              label: 'Other',
+              details: { id: 'no_placements_details', text: 'We have funding issues.' },
+            },
+          ],
+        },
         { id: 'other', label: 'Other', details: { id: 'other_details', text: 'So many other things were wrong...' } },
       ],
     }

--- a/spec/system/provider_interface/reject_an_application_spec.rb
+++ b/spec/system/provider_interface/reject_an_application_spec.rb
@@ -99,8 +99,17 @@ RSpec.describe 'Reject an application' do
     within_fieldset 'Reasons for rejecting due to qualifications' do
       check 'No maths GCSE at minimum grade 4 or C, or equivalent'
 
+      check 'Degree grade does not meet course requirements'
+      fill_in 'Details about why their qualifications does not meet course requirements', with: 'Your grade does not match the course requirement'
+
+      check 'Degree subject does not meet course requirements'
+      fill_in 'Details about why their subject does not meet course requirements', with: 'Your subject does not match the course requirement'
+
       check 'Could not verify qualifications'
       fill_in 'Details about why you could not verify qualifications', with: 'We can find no evidence of your GCSEs'
+
+      check 'Could not verify equivalency of qualifications'
+      fill_in 'Details about why you could not verify equivalency qualifications', with: 'We can find no evidence of your GCSEs'
     end
 
     check 'Personal statement'
@@ -112,11 +121,31 @@ RSpec.describe 'Reject an application' do
       fill_in 'Details of other issues with their personal statement', with: 'This was wayyyyy too personal'
     end
 
+    check 'Communication, interview attendance and scheduling'
+
+    within_fieldset 'Reasons for rejecting due to communication, interview attendance or scheduling' do
+      check 'English language ability below expected standard'
+      fill_in 'Details about the english ability being below expected standard', with: 'Your english level is below expected standard'
+    end
+
     check 'Course full'
     fill_in 'Details (optional) about the course being full', with: 'Other courses exist'
 
     check 'provider-interface-rejections-wizard-selected-reasons-other-field'
     fill_in 'Details of other reasons', with: 'There are so many other reasons why your application was rejected...'
+
+    check 'School placement'
+
+    within_fieldset 'Reasons for rejecting due to school placement' do
+      check 'No available placements'
+      fill_in 'Details of why there are no placements', with: 'We are full'
+
+      check 'No placements that are suitable'
+      fill_in 'Details of why there are no suitable placements', with: 'Funding issues'
+
+      check 'Other'
+      fill_in 'Details of other rejection reasons regarding placements', with: 'Other issues'
+    end
   end
 
   def and_i_give_a_level_reasons_why_i_am_rejecting_the_application
@@ -147,14 +176,20 @@ RSpec.describe 'Reject an application' do
       'They’ve given the following feedback to explain their decision:',
     ])
 
-    expect(email_preview[4..7]).to eq([
+    expect(email_preview[4..13]).to eq([
       'Qualifications',
       'No maths GCSE at minimum grade 4 or C, or equivalent',
+      'Degree grade does not meet course requirements:',
+      'Your grade does not match the course requirement',
+      'Degree subject does not meet course requirements:',
+      'Your subject does not match the course requirement',
       'Could not verify qualifications:',
+      'We can find no evidence of your GCSEs',
+      'Could not verify equivalency of qualifications:',
       'We can find no evidence of your GCSEs',
     ])
 
-    expect(email_preview[8..12]).to eq([
+    expect(email_preview[14..18]).to eq([
       'Personal statement',
       'Quality of writing:',
       'We do not accept applications written in morse code',
@@ -162,13 +197,29 @@ RSpec.describe 'Reject an application' do
       'This was wayyyyy too personal',
     ])
 
-    expect(email_preview[13..15]).to eq([
+    expect(email_preview[19..21]).to eq([
+      'Communication, interview attendance and scheduling',
+      'English language ability below expected standard:',
+      'Your english level is below expected standard',
+    ])
+
+    expect(email_preview[22..24]).to eq([
       'Course full',
       'Course full:',
       'Other courses exist',
     ])
 
-    expect(email_preview[16..18]).to eq([
+    expect(email_preview[25..31]).to eq([
+      'School placement',
+      'No available placements:',
+      'We are full',
+      'No placements that are suitable:',
+      'Funding issues',
+      'Other:',
+      'Other issues',
+    ])
+
+    expect(email_preview[32..34]).to eq([
       'Other',
       'Other:',
       'There are so many other reasons why your application was rejected...',


### PR DESCRIPTION
## Context

We want to better understand why a provider rejects a candidate. Offering the provider more options of rejection will help us.

This commit adds rejection reasons and the email that the candidate will receive, containing these new emails. We won't be adding any advice to the email yet.

## Changes proposed in this pull request
The reasons checked are new, except for `Degree grade does not meet course requirements` which is reworded 

![screenshot](https://github.com/user-attachments/assets/2396fbb1-d5ba-4591-8d15-f27451fc807f)

Vendor API change: 
New reason code. this reason code can also be used for rejecting via the post `reject-by-code` endpoint. Both get and post endpoints have been tested on local
```
{
    "code": "R10",
    "label": "School placement",
    "default_details": "We are unable to offer you a place because we could not find a suitable placement"
}
```


## Guidance to review

Go on the review app and reject a candidate with the new rejection reasons

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [x] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
