### PR TITLE
Add missing translations for new rejection errors

### DIFF
--- a/config/locales/provider_interface/rejections.yml
+++ b/config/locales/provider_interface/rejections.yml
@@ -17,9 +17,18 @@ en:
             unsuitable_degree_details:
               blank: Enter details about how the degree does not meet course requirements
               size: Details about how the degree does not meet course requirements must be 200 words or fewer
+            unsuitable_degree_subject_details:
+              blank: Enter details about the degree subject not meeting the course requirements
+              size: Details about the degree subject not meeting the course requirements must be 200 words or fewer
             unverified_qualifications_details:
               blank: Enter details about qualifications which could not be verified
               size: Details about unverified qualifications must be 200 words or fewer
+            unverified_equivalency_qualifications_details:
+              blank: Enter details about being unable to verify the equivalency of qualifications
+              size: Details about being unable to verify the equivalency of qualifications must be 200 words or fewer
+            already_qualified_details:
+              blank: Enter details about the candidate already being qualified
+              size: Details about the candidate already being qualified must be 200 words or fewer
             qualifications_other_details:
               blank: Enter details about reasons related to qualifications
               size: Details about reasons related to qualifications must be 200 words or fewer
@@ -56,6 +65,9 @@ en:
             could_not_arrange_interview_details:
               blank: Enter details about not being able to arrange interview
               size: Details about not being able to arrange interview must be 200 words or fewer
+            english_below_standard_details:
+              blank: Enter details about the English level being below the expected standard
+              size: Details about the English level being below the expected standard must be 200 words or fewer
             communication_and_scheduling_other_details:
               blank: Enter details about communication, interview attendance and scheduling
               size: Details about communication, interview attendance and scheduling must be 200 words or fewer
@@ -71,6 +83,16 @@ en:
             visa_sponsorship_details:
               blank: Enter details about visa sponsorship
               size: Details about visa sponsorship must be 200 words or fewer
+            no_placements_details:
+              blank: Enter details about there being no placements available
+              size: Details about there being no placements available must be 200 words or fewer
+            no_suitable_placements_details:
+              blank: Enter details about there being no suitable placements available
+              size: Details about there being no suitable placements available must be 200 words or fewer
+            placements_other_details:
+              blank: Enter details about other placement reasons for rejection
+              size: Details about other placement reasons for rejection must be 200 words or fewer
             other_details:
               blank: Enter details about reasons for rejecting the application
               size: Details about reasons for rejecting the application must be 200 words or fewer
+


### PR DESCRIPTION
## Context

In adding new rejection reasons, the error translations were missed for the new rejection reasons https://github.com/DFE-Digital/apply-for-teacher-training/pull/9933.

When a provider would input more than 200 characters the form would break. This commit fixes this. 

## Changes proposed in this pull request

Added error translations for the new rejection reasons

## Guidance to review

Go on review app and input over 200 words for all the new rejection reasons



https://github.com/user-attachments/assets/5fc0c9a1-a941-4d9f-8ad6-0706333e0d52




## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in hereitt-mentor-services/pulls
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
