### PR TITLE
Change content on placement locations page

### DIFF
--- a/app/views/candidate_interface/course_choices/course_site/_form_fields.html.erb
+++ b/app/views/candidate_interface/course_choices/course_site/_form_fields.html.erb
@@ -9,10 +9,10 @@
   </p>
 <% end %>
 
-<h1 class="govuk-heading-xl govuk-!-margin-top-3">School placement location</h1>
+<h1 class="govuk-heading-xl govuk-!-margin-top-3"><%= t('course_choices.course_site.school_placement_location') %></h1>
 
-<p class="govuk-body">During your training, you will be placed in at least 2 different schools to give you experience of teaching in a real classroom.</p>
-<p class="govuk-body">You can choose which location you are most interested in. Your training provider will do their best to place you at a location you prefer and can travel to.</p>
+<p class="govuk-body"><%= t('course_choices.course_site.select_preferred_placement') %></p>
+<p class="govuk-body"><%= t('course_choices.course_site.training_provider_will_contact_you') %></p>
 
 <%= f.govuk_radio_buttons_fieldset :course_option_id, legend: { text: t('page_titles.which_location'), size: 'l', tag: 'h1' } do %>
   <% @wizard.current_step.available_sites.each_with_index do |option, i| %>

--- a/config/locales/candidate_interface/course_choices/course_site.yml
+++ b/config/locales/candidate_interface/course_choices/course_site.yml
@@ -1,0 +1,9 @@
+en:
+  course_choices:
+    course_site:
+      school_placement_location: School placement location
+      select_preferred_placement: >
+        You can select a preferred placement location, but there is no guarantee you will be placed in the school you
+        choose.
+      training_provider_will_contact_you: >
+        The training provider will contact you to discuss your choice to help them select a location that suits you.


### PR DESCRIPTION
## Context

Now that the ‘select a location’ page in Apply is only shown to candidates when a provider has toggled selectable_school ON - we should update the content to reflect that candidates can select a preference.

## Changes proposed in this pull request

| Before | After |
| ------ | ------ |
| <img width="956" alt="image" src="https://github.com/user-attachments/assets/b44078a2-a8da-4c24-adc1-e40c7970615f"> | <img width="950" alt="image" src="https://github.com/user-attachments/assets/f304577f-04a8-49e2-8c9c-79ce80d03ef3"> | 

## Guidance to review

Locally or on the review app, 
- Chose a course that has selectable schools and multiple sites* 
- Click continue
- You should see the new content

*provider: GORSE SCITT (Leeds, Bradford, Hull and East Yorkshire) has all courses with multiple sites on the review app.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
