### PR TITLE
Format worker logs in production 

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,6 +76,12 @@ Rails.application.configure do
   config.log_format = :json                               # For parsing in Logit
   config.rails_semantic_logger.add_file_appender = false  # Don't log to file
   config.active_record.logger = nil                       # Don't log SQL
+  config.rails_semantic_logger.format = :json
+  config.semantic_logger.add_appender(
+    io: $stdout,
+    level: config.log_level,
+    formatter: config.rails_semantic_logger.format,
+  )
 
   # Use a different cache store in production.
   config.cache_store = :redis_cache_store, { url: ENV.fetch("REDIS_CACHE_URL") }
@@ -124,7 +130,7 @@ Rails.application.configure do
   #   ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.select_value("select '2024-01-01'::date") #=> Date
   #
   # This query will return a `String` if postgresql_adapter_decode_dates is set to false.
-  
+
   config.active_record.postgresql_adapter_decode_dates = false
 
   class FixAzureXForwardedForMiddleware


### PR DESCRIPTION
## Context

We use SemanticLogger to format our logs so that they can be queried in Logit.io. The web pod logs are formatted correctly but the sidekiq worker pods are not, specifically the `message` value, it's not decoded

This commit fixes this so that we can query logs in Logit 

## Changes proposed in this pull request

Changed production env. This is inspired by [teacher vacancies production config](https://github.com/DFE-Digital/teaching-vacancies/blob/main/config/environments/production.rb#L80-L83) their logs are in the correct format

## Guidance to review

Visit [logit](https://kibana-uk1.logit.io/s/b2876053-0173-44fc-983d-99567292ba31/app/data-explorer/discover#?_a=(discover:(columns:!(app.message),isDirty:!t,sort:!()),metadata:(indexPattern:'filebeat-*',view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-5h,to:now))&_q=(filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:kubernetes.deployment.name,negate:!f,params:(query:apply-review-9947-worker),type:phrase),query:(match_phrase:(kubernetes.deployment.name:apply-review-9947-worker)))),query:(language:kuery,query:''))) and check the app.message content, it should be correctly formatted

| Before | After |
| ------ | ------ |
| ![Screenshot from 2024-10-18 15-14-01](https://github.com/user-attachments/assets/95938248-730c-4bda-b37b-d3f67e07b5d4) | ![Screenshot from 2024-10-18 15-13-27](https://github.com/user-attachments/assets/a8224bdd-fbdf-4c99-a37f-85fd1dbd17e1) |

Message format

| Before | After |
| ------ | ------ |
| ![Screenshot from 2024-10-18 15-14-15](https://github.com/user-attachments/assets/18b4f635-4d04-4ecf-9357-64b97ac283a5) | ![Screenshot from 2024-10-18 15-00-43](https://github.com/user-attachments/assets/ab5326a6-4f8a-49c4-8efd-44d6bb7910d5) |

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
