### PR TITLE
Only get invariant application choices for the current year

### DIFF
--- a/app/workers/detect_invariants_daily_check.rb
+++ b/app/workers/detect_invariants_daily_check.rb
@@ -94,6 +94,7 @@ class DetectInvariantsDailyCheck
       ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS +
       ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES - 1
     applications_with_too_many_unsuccessful_choices = ApplicationForm
+      .current_cycle
       .joins(:application_choices)
       .where(application_choices: { status: (ApplicationStateChange::UNSUCCESSFUL_STATES - %i[inactive]) })
       .group('application_forms.id')


### PR DESCRIPTION
## Context

We know that there were application forms in 2024 that were able to submit more than the expected number of application choices due to a change in the limit taking place partway through the year. 

## Changes proposed in this pull request

This change ensures we are only look at the current cycle -- so far, no one has been able to submit more than the expected number of applications. 

Assuming this is still the case in a couple of months, I think we should get rid of this check altgether.

## Guidance to review


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
