### PR TITLE
[189] Sort study mode options on the provider interface

### DIFF
--- a/app/queries/get_change_offer_options.rb
+++ b/app/queries/get_change_offer_options.rb
@@ -22,7 +22,7 @@ class GetChangeOfferOptions
     CourseOption
       .where(course: offerable_courses.find_by(id: course.id))
       .group('study_mode')
-      .pluck(:study_mode)
+      .pluck(:study_mode).sort
   end
 
   def available_course_options(course:, study_mode:)

--- a/spec/queries/get_change_offer_options_spec.rb
+++ b/spec/queries/get_change_offer_options_spec.rb
@@ -149,11 +149,11 @@ RSpec.describe GetChangeOfferOptions do
     before { allow(service).to receive(:offerable_courses).and_return(Course.all) }
 
     describe '#available_study_modes' do
-      it 'returns an array of study modes' do
+      it 'returns an array of study modes in the correct order' do
         course_options
 
         expect(service.available_study_modes(course: self_ratified_course))
-          .to contain_exactly('full_time', 'part_time')
+          .to eq(%w[full_time part_time])
       end
 
       it 'returns no study modes if there are no offerable courses' do

--- a/spec/workers/migrate_application_choices_worker_spec.rb
+++ b/spec/workers/migrate_application_choices_worker_spec.rb
@@ -60,8 +60,8 @@ RSpec.describe MigrateApplicationChoicesWorker do
       SQL
       created_work_experiences_commitments = ActiveRecord::Base.connection.execute(sql)
 
-      expect(created_work_experiences_commitments.pluck('commitment')).to eq(
-        # Part time, Full Time
+      expect(created_work_experiences_commitments.pluck('commitment')).to match_array(
+        # Full time, Part Time
         application_form.application_work_experiences.pluck(:commitment).map(&:humanize),
       )
     end


### PR DESCRIPTION
## Context

When choosing a Study mode in the CandidateInterface, Full time is always above Part time.

In the ProviderInterface when making a decision and changing the course of the application, Part time appears above Full time.

## Changes proposed in this pull request

| Before  | After |
| ------- | ------- |
| <img width="596" alt="image" src="https://github.com/user-attachments/assets/3f4c67c9-ba11-453a-b9e1-d417a3b82737"> | <img width="729" alt="image" src="https://github.com/user-attachments/assets/d4ae0a92-88a4-4171-a016-47c907397f8f"> |

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
