### PR TITLE
Fix incorrect candidate bachelor degree equivalency

### DIFF
--- a/app/components/candidate_interface/degree_review_component.rb
+++ b/app/components/candidate_interface/degree_review_component.rb
@@ -282,7 +282,7 @@ module CandidateInterface
       if degree.qualification_level.present?
         DegreeWizard::QUALIFICATION_LEVEL[degree.qualification_level]
       else
-        reference_data = DfE::ReferenceData::Degrees::TYPES.some_by_field(:name).keys.select { |type| degree.qualification_type == type }
+        reference_data = DfE::ReferenceData::Degrees::TYPES.some_by_field(:name).keys.select { |type| degree.qualification_type.downcase == type.downcase }
         degree.qualification_type.split.first if reference_data.present?
       end
     end

--- a/app/components/candidate_interface/degree_review_component.rb
+++ b/app/components/candidate_interface/degree_review_component.rb
@@ -282,7 +282,7 @@ module CandidateInterface
       if degree.qualification_level.present?
         DegreeWizard::QUALIFICATION_LEVEL[degree.qualification_level]
       else
-        reference_data = DfE::ReferenceData::Degrees::TYPES.some_by_field(:name).keys.select { |type| degree.qualification_type.include?(type) }
+        reference_data = DfE::ReferenceData::Degrees::TYPES.some_by_field(:name).keys.select { |type| degree.qualification_type == type }
         degree.qualification_type.split.first if reference_data.present?
       end
     end

--- a/app/lib/hesa/degree_type.rb
+++ b/app/lib/hesa/degree_type.rb
@@ -52,7 +52,9 @@ module Hesa
       end
 
       def find_by_name(name)
-        all.find { |type| type.name == name }
+        return if name.blank?
+
+        all.find { |type| type.name.downcase == name.downcase }
       end
 
       def find_by_abbreviation_or_name(value)

--- a/spec/components/candidate_interface/degree_review_component_spec.rb
+++ b/spec/components/candidate_interface/degree_review_component_spec.rb
@@ -87,6 +87,77 @@ RSpec.describe CandidateInterface::DegreeReviewComponent, type: :component do
       )
     end
 
+    context "when selection 'Another qualification equivalent to a degree' for uk degree which is a bachelor degree" do
+      let(:qualification_type) { 'Bachelor of Arts in Architecture' }
+      let(:degree1) do
+        build_stubbed(
+          :degree_qualification,
+          qualification_type:,
+          qualification_level: nil,
+          subject: 'Woof',
+          institution_name: 'University of Doge',
+          grade: 'Upper second',
+          predicted_grade: false,
+          start_year: '2005',
+          award_year: '2008',
+        )
+      end
+
+      it 'renders component as a bachelor degree when equivalent is a bachelor' do
+        allow(application_form).to receive(:application_qualifications).and_return(
+          ActiveRecordRelationStub.new(ApplicationQualification, [degree1], scopes: [:degrees]),
+        )
+
+        component = render_inline(described_class.new(application_form:))
+        expect(component).to summarise(
+          key: 'Type of bachelor degree',
+          value: 'Bachelor of Arts in Architecture',
+          action: {
+            text: "Change #{t('application_form.degree.type_of_degree.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
+            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :type),
+          },
+        )
+
+        expect(component).to summarise(
+          key: 'Degree type',
+          value: 'Bachelor',
+          action: {
+            text: "Change #{t('application_form.degree.qualification.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
+            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :degree_level),
+          },
+        )
+      end
+
+      context 'with case insensitive' do
+        let(:qualification_type) { 'Bachelor of arts in architecture' }
+
+        it 'renders component as a bachelor degree when equivalent is a bachelor' do
+          allow(application_form).to receive(:application_qualifications).and_return(
+            ActiveRecordRelationStub.new(ApplicationQualification, [degree1], scopes: [:degrees]),
+          )
+
+          component = render_inline(described_class.new(application_form:))
+          expect(component).to summarise(
+            key: 'Type of bachelor degree',
+            value: 'Bachelor of arts in architecture',
+            action: {
+              text: "Change #{t('application_form.degree.type_of_degree.change_action')} for Bachelor of arts in architecture, Woof, University of Doge, 2008",
+              href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :type),
+            },
+          )
+
+          expect(component).to summarise(
+            key: 'Degree type',
+            value: 'Bachelor',
+            action: {
+              text: "Change #{t('application_form.degree.qualification.change_action')} for Bachelor of arts in architecture, Woof, University of Doge, 2008",
+              href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :degree_level),
+            },
+          )
+        end
+      end
+    end
+
     context "when selection 'Another qualification equivalent to a degree' for uk degree is a bachelor degree" do
       let(:degree1) do
         build_stubbed(

--- a/spec/components/candidate_interface/degree_review_component_spec.rb
+++ b/spec/components/candidate_interface/degree_review_component_spec.rb
@@ -87,7 +87,80 @@ RSpec.describe CandidateInterface::DegreeReviewComponent, type: :component do
       )
     end
 
-    it 'renders component with correct values for a uk degree type' do
+    context "when selection 'Another qualification equivalent to a degree' for uk degree is a bachelor degree" do
+      let(:degree1) do
+        build_stubbed(
+          :degree_qualification,
+          qualification_type: 'Bachelor of Arts in Architecture',
+          qualification_level: nil,
+          subject: 'Woof',
+          institution_name: 'University of Doge',
+          grade: 'Upper second',
+          predicted_grade: false,
+          start_year: '2005',
+          award_year: '2008',
+        )
+      end
+
+      it 'renders component as a bachelor degree when equivalent is a bachelor' do
+        allow(application_form).to receive(:application_qualifications).and_return(
+          ActiveRecordRelationStub.new(ApplicationQualification, [degree1], scopes: [:degrees]),
+        )
+
+        component = render_inline(described_class.new(application_form:))
+        expect(component).to summarise(
+          key: 'Type of bachelor degree',
+          value: 'Bachelor of Arts in Architecture',
+          action: {
+            text: "Change #{t('application_form.degree.type_of_degree.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
+            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :type),
+          },
+        )
+
+        expect(component).to summarise(
+          key: 'Degree type',
+          value: 'Bachelor',
+          action: {
+            text: "Change #{t('application_form.degree.qualification.change_action')} for Bachelor of Arts in Architecture, Woof, University of Doge, 2008",
+            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :degree_level),
+          },
+        )
+      end
+    end
+
+    context "when selection 'Another qualification equivalent to a degree' for uk degree is not a bachelor degree" do
+      let(:degree1) do
+        build_stubbed(
+          :degree_qualification,
+          qualification_type: 'Bachelor of Arts in Architecture and Potion making',
+          qualification_level: nil,
+          subject: 'Woof',
+          institution_name: 'University of Doge',
+          grade: 'Upper second',
+          predicted_grade: false,
+          start_year: '2005',
+          award_year: '2008',
+        )
+      end
+
+      it 'renders component as a bachelor degree when equivalent is a bachelor' do
+        allow(application_form).to receive(:application_qualifications).and_return(
+          ActiveRecordRelationStub.new(ApplicationQualification, [degree1], scopes: [:degrees]),
+        )
+
+        component = render_inline(described_class.new(application_form:))
+        expect(component).to summarise(
+          key: 'Degree type',
+          value: 'Bachelor of Arts in Architecture and Potion making',
+          action: {
+            text: "Change #{t('application_form.degree.qualification.change_action')} for Bachelor of Arts in Architecture and Potion making, Woof, University of Doge, 2008",
+            href: Rails.application.routes.url_helpers.candidate_interface_degree_edit_path(degree1, :degree_level),
+          },
+        )
+      end
+    end
+
+    it 'renders component with correct values for a uk degree with equivalent bachelor degree' do
       component = render_inline(described_class.new(application_form:))
       expect(component).to summarise(
         key: 'Type of bachelor degree',

--- a/spec/lib/hesa/degree_type_spec.rb
+++ b/spec/lib/hesa/degree_type_spec.rb
@@ -100,6 +100,23 @@ RSpec.describe Hesa::DegreeType do
       end
     end
 
+    context 'given a valid name with case insensitive' do
+      it 'returns the matching struct' do
+        result = described_class.find_by_name('Bachelor of divinity')
+
+        expect(result.abbreviation).to eq 'BD'
+        expect(result.name).to eq 'Bachelor of Divinity'
+      end
+    end
+
+    context 'with name blank' do
+      it 'returns nil' do
+        result = described_class.find_by_name(nil)
+
+        expect(result).to be_nil
+      end
+    end
+
     context 'given an unrecognised name' do
       it 'returns nil' do
         result = described_class.find_by_name('Master of Conjuration')


### PR DESCRIPTION
## Context

When a candidate inputs their degrees, they can chose an option called 'Another qualification equivalent to a degree'. This free text field will try to figure out if the value imputed is a bachelor degree or not.

Previously we would just check if the free text search value is in our list of Bachelor degrees by checking if the string is included in the list. We didn't match the strings exactly.

So if you have the correct keywords, like Bachelor of Medicine and Pixie hunting we would classify this degree as a bachelor degree because there is a valid bachelor degree called `Bachelor of Medicine`.

This caused the form to break as there is no valid degree for Pixie hunting in the reference data gem.

This commit checks the strings exactly to avoid this issue. Fixing this [sentry error](https://dfe-teacher-services.sentry.io/issues/5809526550/?notification_uuid=820b4a63-536c-4ff7-a6d5-c359bf2a4844&project=1765973&referrer=regression_activity-slack) 

## Changes proposed in this pull request

The `Type of bachelor degree` should only be there for valid bachelor degrees

| Before | After |
| ------ | ----- |
| ![Screenshot from 2024-10-21 14-45-15](https://github.com/user-attachments/assets/2fb94eb3-b20b-4460-938c-be9e4ba08d29) | ![Screenshot from 2024-10-21 15-37-11](https://github.com/user-attachments/assets/17814b3d-f2ff-4341-b706-2ea1f56ebda0) |


## Guidance to review

Go on review app and add a `Another qualification equivalent to a degree` with the keywords of a actual bachelor degree like `Bachelor of Medicine`

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
