### PR TITLE
[341] Update service information banner text and to support interface

### DIFF
--- a/app/views/support_interface/candidates/_candidates_navigation.html.erb
+++ b/app/views/support_interface/candidates/_candidates_navigation.html.erb
@@ -1,5 +1,6 @@
 <% content_for :browser_title, "#{title} - Candidates" %>
 <% content_for :title, 'Candidates' %>
+<%= render ServiceInformationBanner.new(namespace: :support) %>
 
 <%= render TabNavigationComponent.new(items: [
   { name: 'Applications', url: support_interface_applications_path, current: local_assigns[:current] == 'Applications' },

--- a/config/locales/service_information_banner.yml
+++ b/config/locales/service_information_banner.yml
@@ -1,12 +1,17 @@
 en:
   service_information_banner:
     provider:
-      sandbox_header: The sandbox will be unavailable on Tuesday 25 May from 8am to 9am
+      sandbox_header: The sandbox will be unavailable on Wednesday 23 October from 7am to 8am
       sandbox_body: This will affect both the web service and the API. You may lose work if you are using the sandbox when it becomes unavailable.
-      header: The Manage service will be unavailable on Thursday 16 May from 8am to 9am
+      header: The Manage service will be unavailable on Wednesday 23 October from 7am to 8am
       body: This will affect both the web service and the API. You may lose work if you are using Manage when it becomes unavailable.
     candidate:
-      sandbox_header: The sandbox will be unavailable on Tuesday 25 May from 8am to 9am
+      sandbox_header: The sandbox will be unavailable on Wednesday 23 October from 7am to 8am
       sandbox_body: You may lose work if you are using the sandbox when it becomes unavailable.
-      header: The service will be unavailable on Thursday 16 May from 8am to 9am
+      header: The service will be unavailable on Wednesday 23 October from 7am to 8am
+      body: You may lose work if you are using this service when it becomes unavailable.
+    support:
+      sandbox_header: The sandbox will be unavailable on Wednesday 23 October from 7am to 8am
+      sandbox_body: You may lose work if you are using the sandbox when it becomes unavailable.
+      header: The service will be unavailable on Wednesday 23 October from 7am to 8am
       body: You may lose work if you are using this service when it becomes unavailable.


### PR DESCRIPTION
## Context

We are planning some downtime to take place early Wednesday morning to scale down the database.

## Changes proposed in this pull request

- Changed the text of the service banner to reflect the planned downtime
- Added banner to the support landing page so they will also be reminded of the downtime.

## Guidance to review

Locally or on the review app

- In support, activate the Service information banner feature flag
- Login as a candidate / provider / support. You should see the banner. 

https://github.com/user-attachments/assets/0c51c60a-ab0a-48c8-a9ab-55e820c80f12


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [x] Tested by running locally
- [ ] Add PR link to Trello card
