### PR TITLE
Allow Support Users to change Course to previous Recruitment Cycles

### DIFF
--- a/app/controllers/support_interface/application_forms/courses_controller.rb
+++ b/app/controllers/support_interface/application_forms/courses_controller.rb
@@ -67,7 +67,7 @@ module SupportInterface
 
       def change_course_choice_params
         params.require(:support_interface_application_forms_change_course_choice_form)
-              .permit(:application_choice_id, :provider_code, :course_code, :study_mode, :site_code, :audit_comment_ticket, :accept_guidance, :confirm_course_change, :checkbox_rendered)
+              .permit(:application_choice_id, :provider_code, :course_code, :study_mode, :site_code, :recruitment_cycle_year, :audit_comment_ticket, :accept_guidance, :confirm_course_change, :checkbox_rendered)
       end
 
       def application_form_id

--- a/app/forms/support_interface/application_forms/change_course_choice_form.rb
+++ b/app/forms/support_interface/application_forms/change_course_choice_form.rb
@@ -37,7 +37,7 @@ module SupportInterface
           site_code:,
           audit_comment: audit_comment_ticket,
           confirm_course_change:,
-          recruitment_cycle_year: ,
+          recruitment_cycle_year:,
         ).call
       rescue ActiveRecord::RecordNotFound
         raise CourseChoiceError, 'This is not a valid course option'

--- a/app/forms/support_interface/application_forms/change_course_choice_form.rb
+++ b/app/forms/support_interface/application_forms/change_course_choice_form.rb
@@ -3,7 +3,17 @@ module SupportInterface
     class ChangeCourseChoiceForm
       include ActiveModel::Model
 
-      attr_accessor :application_choice_id, :application_choice, :provider_code, :course_code, :study_mode, :site_code, :accept_guidance, :audit_comment_ticket, :confirm_course_change, :checkbox_rendered
+      attr_accessor :application_choice_id,
+                    :application_choice,
+                    :provider_code,
+                    :course_code,
+                    :study_mode,
+                    :site_code,
+                    :accept_guidance,
+                    :audit_comment_ticket,
+                    :confirm_course_change,
+                    :checkbox_rendered
+      attr_writer :recruitment_cycle_year
 
       validates :provider_code, :course_code, :study_mode, :site_code, :accept_guidance, :audit_comment_ticket, presence: true
       validates :confirm_course_change, presence: true, if: :checkbox_rendered?
@@ -27,6 +37,7 @@ module SupportInterface
           site_code:,
           audit_comment: audit_comment_ticket,
           confirm_course_change:,
+          recruitment_cycle_year: ,
         ).call
       rescue ActiveRecord::RecordNotFound
         raise CourseChoiceError, 'This is not a valid course option'
@@ -56,6 +67,10 @@ module SupportInterface
 
       def remove_ske_conditions!
         RemoveSkeConditionsFromOffer.new(offer: application_choice_with_offer).call
+      end
+
+      def recruitment_cycle_year
+        @recruitment_cycle_year || RecruitmentCycle.current_year
       end
     end
   end

--- a/app/services/support_interface/change_application_choice_course_option.rb
+++ b/app/services/support_interface/change_application_choice_course_option.rb
@@ -4,7 +4,7 @@ module SupportInterface
   class ChangeApplicationChoiceCourseOption
     VALID_STATES = ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER
 
-    attr_reader :application_choice, :provider_id, :course_code, :study_mode, :site_code, :audit_comment
+    attr_reader :application_choice, :provider_id, :course_code, :study_mode, :site_code, :audit_comment, :recruitment_cycle_year
     attr_accessor :confirm_course_change
 
     def initialize(application_choice_id:,
@@ -13,7 +13,8 @@ module SupportInterface
                    study_mode:,
                    site_code:,
                    audit_comment:,
-                   confirm_course_change: false)
+                   confirm_course_change: false,
+                   recruitment_cycle_year: RecruitmentCycle.current_year)
       @application_choice = ApplicationChoice.find(application_choice_id)
       @provider_id = provider_id
       @course_code = course_code
@@ -21,6 +22,7 @@ module SupportInterface
       @study_mode = study_mode
       @audit_comment = audit_comment
       @confirm_course_change = confirm_course_change
+      @recruitment_cycle_year = recruitment_cycle_year
     end
 
     def call
@@ -61,7 +63,7 @@ module SupportInterface
     def course
       Course.find_by!(code: course_code,
                       provider_id:,
-                      recruitment_cycle_year: RecruitmentCycle.current_year)
+                      recruitment_cycle_year: recruitment_cycle_year)
     end
 
     def other_fields

--- a/app/views/support_interface/application_forms/courses/edit.html.erb
+++ b/app/views/support_interface/application_forms/courses/edit.html.erb
@@ -32,7 +32,11 @@
         <%= f.govuk_radio_button :study_mode, :part_time, label: { text: 'Part time' } %>
       <% end %>
       <%= f.govuk_text_field :site_code, label: { text: 'Site code', size: 's' }, width: 5 %>
-      <%= f.govuk_text_field :recruitment_cycle_year, label: { text: 'Recruitment cycle year', size: 's' }, width: 5 %>
+
+      <%= f.govuk_radio_buttons_fieldset :recruitment_cycle_year, legend: { text: 'Recruitment cycle year', size: 's' } do %>
+        <%= f.govuk_radio_button :recruitment_cycle_year, RecruitmentCycle.current_year, label: { text: RecruitmentCycle.current_year } %>
+        <%= f.govuk_radio_button :recruitment_cycle_year, RecruitmentCycle.previous_year, label: { text: RecruitmentCycle.previous_year } %>
+      <% end %>
 
       <%= f.govuk_text_field(
         :audit_comment_ticket,

--- a/app/views/support_interface/application_forms/courses/edit.html.erb
+++ b/app/views/support_interface/application_forms/courses/edit.html.erb
@@ -32,6 +32,7 @@
         <%= f.govuk_radio_button :study_mode, :part_time, label: { text: 'Part time' } %>
       <% end %>
       <%= f.govuk_text_field :site_code, label: { text: 'Site code', size: 's' }, width: 5 %>
+      <%= f.govuk_text_field :recruitment_cycle_year, label: { text: 'Recruitment cycle year', size: 's' }, width: 5 %>
 
       <%= f.govuk_text_field(
         :audit_comment_ticket,

--- a/spec/forms/support_interface/application_forms/change_course_choice_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/change_course_choice_form_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe SupportInterface::ApplicationForms::ChangeCourseChoiceForm, :with
           recruitment_cycle_year: 2024,
           audit_comment_ticket: zendesk_ticket,
           accept_guidance: true,
-          )
+        )
 
         expect(form.save(application_choice.id)).to be(true)
 

--- a/spec/forms/support_interface/application_forms/change_course_choice_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/change_course_choice_form_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe SupportInterface::ApplicationForms::ChangeCourseChoiceForm, :with
         original_course_option = create(:course_option)
         application_choice = create(:application_choice, :awaiting_provider_decision, course_option: original_course_option)
 
-        course_option = create(:course_option, study_mode: :full_time, course: create(:course, funding_type: 'fee'))
+        course_option = create(:course_option)
         zendesk_ticket = 'https://becomingateacher.zendesk.com/agent/tickets/12345'
 
         form = described_class.new(
@@ -132,6 +132,33 @@ RSpec.describe SupportInterface::ApplicationForms::ChangeCourseChoiceForm, :with
           audit_comment_ticket: zendesk_ticket,
           accept_guidance: true,
         )
+
+        expect(form.save(application_choice.id)).to be(true)
+
+        expect(application_choice.reload.course.name).to eq course_option.course.name
+        expect(application_choice.course.id).not_to eq original_course_option.course.id
+        expect(application_choice.audits.last.comment).to include(zendesk_ticket)
+      end
+    end
+
+    context 'if the new course details are for a previous recruitment cycle' do
+      it 'updates the application choice' do
+        original_course_option = create(:course_option, course: create(:course, recruitment_cycle_year: 2024))
+        application_choice = create(:application_choice, :awaiting_provider_decision, course_option: original_course_option)
+
+        course_option = create(:course_option, course: create(:course, recruitment_cycle_year: 2024))
+        zendesk_ticket = 'https://becomingateacher.zendesk.com/agent/tickets/12345'
+
+        form = described_class.new(
+          application_choice_id: application_choice.id,
+          provider_code: course_option.provider.code,
+          course_code: course_option.course.code,
+          study_mode: course_option.course.study_mode,
+          site_code: course_option.site.code,
+          recruitment_cycle_year: 2024,
+          audit_comment_ticket: zendesk_ticket,
+          accept_guidance: true,
+          )
 
         expect(form.save(application_choice.id)).to be(true)
 

--- a/spec/services/support_interface/change_application_choice_course_option_spec.rb
+++ b/spec/services/support_interface/change_application_choice_course_option_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe SupportInterface::ChangeApplicationChoiceCourseOption do
   describe '#call' do
     let!(:application_choice) { create(:application_choice, :awaiting_provider_decision) }
-    let(:fee_paying_course) { create(:course, funding_type: 'fee') }
-    let!(:course_option) { create(:course_option, study_mode: :full_time, course: fee_paying_course) }
+    let(:course) { create(:course) }
+    let!(:course_option) { create(:course_option, study_mode: :full_time, course: course) }
     let(:other_provider) { create(:provider) }
     let(:audit_comment) { 'Zendesk ticket 2 - update course' }
     let(:other_site) { create(:site) }
@@ -68,6 +68,24 @@ RSpec.describe SupportInterface::ChangeApplicationChoiceCourseOption do
       }.to raise_error(ActiveRecord::RecordNotFound, /Couldn't find CourseOption/)
     end
 
+    context 'course is in a previous cycle' do
+      let(:course) { create(:course, recruitment_cycle_year: 2024) }
+
+      it 'sets the course_option of the specified site of a course' do
+        expect {
+          described_class.new(application_choice_id: application_choice.id,
+                              provider_id: course_option.course.provider_id,
+                              course_code: course_option.course.code,
+                              study_mode: course_option.study_mode,
+                              site_code: course_option.site.code,
+                              recruitment_cycle_year: 2024,
+                              audit_comment: '').call
+        }.to(change { application_choice.reload.course_option })
+
+        expect(application_choice.course_option).to eq(course_option)
+      end
+    end
+
     context 'application is not in a state visible to providers' do
       let!(:application_choice) { create(:application_choice, :cancelled) }
 
@@ -115,7 +133,7 @@ RSpec.describe SupportInterface::ChangeApplicationChoiceCourseOption do
 
     context 'course full check' do
       it 'raises a CourseFullError if the new course has no vacancies' do
-        course_option = create(:course_option, :no_vacancies, course: fee_paying_course)
+        course_option = create(:course_option, :no_vacancies, course: course)
         error_message = I18n.t('support_interface.errors.messages.course_full_error')
 
         expect {
@@ -129,7 +147,7 @@ RSpec.describe SupportInterface::ChangeApplicationChoiceCourseOption do
       end
 
       it 'does not raise a CourseFullError if confirm_course_change is true' do
-        course_option =  create(:course_option, :no_vacancies, course: fee_paying_course)
+        course_option =  create(:course_option, :no_vacancies, course: course)
 
         expect {
           described_class.new(application_choice_id: application_choice.id,

--- a/spec/system/support_interface/change_course_to_different_year_spec.rb
+++ b/spec/system/support_interface/change_course_to_different_year_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+RSpec.describe 'Change course choice to a different year' do
+  include DfESignInHelpers
+
+  before do
+    given_i_am_a_support_user
+    and_there_is_a_submitted_application_in_the_system_with_a_deferred_offer
+    and_i_visit_the_support_page
+    when_i_click_on_an_application
+  end
+
+  scenario 'Support user changes offered course for a submitted application' do
+    when_i_click_on_change_offered_course
+    then_i_see_the_change_course_page
+    and_i_complete_the_form_for_a_course
+    and_i_provide_a_valid_zendesk_ticket
+    and_i_confirm_changing_the_offer
+    and_i_click_change
+
+    then_i_am_redirected_to_the_application_form_page
+    and_i_see_new_course_has_been_offered
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_is_a_submitted_application_in_the_system_with_a_deferred_offer
+    @application_form = create(:completed_application_form, first_name: 'Alice', last_name: 'Wunder')
+    @application_choice = create(:application_choice, :offer_deferred, application_form: @application_form)
+  end
+
+  def and_i_visit_the_support_page
+    visit support_interface_path
+  end
+
+  def when_i_click_on_an_application
+    click_link_or_button 'Alice Wunder'
+  end
+
+  def when_i_click_on_change_offered_course
+    click_link_or_button 'Change course choice'
+  end
+
+  def then_i_see_the_change_course_page
+    expect(page).to have_current_path support_interface_application_form_change_course_choice_path(
+      application_form_id: @application_form.id,
+      application_choice_id: @application_choice.id,
+    )
+  end
+
+  def and_i_complete_the_form_for_a_course
+    course = create(:course, :open, provider: @application_choice.provider, recruitment_cycle_year: 2024)
+    @course_option = create(:course_option, course: course)
+    course_code = @course_option.course.code
+
+    fill_in('Provider code', with: @application_choice.provider.code)
+    fill_in('Course code', with: course_code)
+    fill_in('Site code', with: @course_option.site.code)
+    choose('Full time')
+    fill_in('Recruitment cycle year', with: 2024)
+  end
+
+  def and_i_provide_a_valid_zendesk_ticket
+    fill_in('Zendesk ticket URL', with: 'https://becomingateacher.zendesk.com/agent/tickets/example')
+  end
+
+  def and_i_confirm_changing_the_offer
+    check 'I have read the guidance'
+  end
+
+  def and_i_click_change
+    click_link_or_button 'Change'
+  end
+
+  def then_i_am_redirected_to_the_application_form_page
+    expect(page).to have_current_path support_interface_application_form_path(application_form_id: @application_form.id)
+  end
+
+  def and_i_see_new_course_has_been_offered
+    expect(page).to have_current_path support_interface_application_form_path(application_form_id: @application_form.id)
+    expect(page).to have_content("2024: #{@course_option.course.name} (#{@course_option.course.code})")
+  end
+end

--- a/spec/system/support_interface/change_course_to_different_year_spec.rb
+++ b/spec/system/support_interface/change_course_to_different_year_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Change course choice to a different year' do
   end
 
   def and_i_complete_the_form_for_a_course
-    course = create(:course, :open, provider: @application_choice.provider, recruitment_cycle_year: 2024)
+    course = create(:course, :open, provider: @application_choice.provider, recruitment_cycle_year: RecruitmentCycle.previous_year)
     @course_option = create(:course_option, course: course)
     course_code = @course_option.course.code
 
@@ -59,7 +59,7 @@ RSpec.describe 'Change course choice to a different year' do
     fill_in('Course code', with: course_code)
     fill_in('Site code', with: @course_option.site.code)
     choose('Full time')
-    fill_in('Recruitment cycle year', with: 2024)
+    choose(RecruitmentCycle.previous_year)
   end
 
   def and_i_provide_a_valid_zendesk_ticket


### PR DESCRIPTION
## Context

Developers are often [requested](https://trello.com/c/If5FF45J) to change a Course to one in a previous cycle. 
This functionality is also what is required for Support Users to confirm deferrals in previous cycles when they want to change course. 

## Changes proposed in this pull request

Minor UI change to the change-course-choice UI to add a "Recruitment cycle year" input. This input defaults to the current cycle year. 

| before | after |
|---|---|
| ![image](https://github.com/user-attachments/assets/695662dc-4b4e-4f97-b205-e130a814f9c7) | ![image](https://github.com/user-attachments/assets/26fea630-5eab-43bf-8daf-0eefac38ca84) |

## Guidance to review

- Login to Support console on Review App
- Select an Application Form
- Scroll to Application Choice and click "Change Course"
- Enter course details for a Course in a previous cycle. 
- Submit form
- See the change

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
