### PR TITLE
[290] Prevent the inactive email being sent to candidates who cannot act on them

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -314,6 +314,10 @@ class ApplicationForm < ApplicationRecord
   #
   ##########################################
 
+  def maximum_number_of_choices_reached?
+    application_limit_reached? || cannot_add_more_choices?
+  end
+
   def application_limit_reached?
     application_choices.count(&:application_unsuccessful?) >= MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS
   end

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -8,6 +8,9 @@ class Candidate < ApplicationRecord
   devise :timeoutable
   audited last_signed_in_at: true
 
+  scope :for_transaction_emails, -> { where({ submission_blocked: false, account_locked: false }) }
+  scope :for_marketing_or_nudge_emails, -> { for_transaction_emails.where(unsubscribed_from_emails: false) }
+
   before_validation :downcase_email
   validates :email_address, presence: true, length: { maximum: 100 }, valid_for_notify: true
 

--- a/app/queries/get_applications_to_send_deadline_reminders_to.rb
+++ b/app/queries/get_applications_to_send_deadline_reminders_to.rb
@@ -5,11 +5,9 @@ class GetApplicationsToSendDeadlineRemindersTo
 
   def self.deadline_reminder_query
     ApplicationForm
-      .joins(:candidate)
+      .joins(:candidate).merge(Candidate.for_marketing_or_nudge_emails)
       .current_cycle
       .unsubmitted
-      # Filter out candidates who should not be receiving emails about their accounts
-      .where(candidates: { submission_blocked: false, account_locked: false, unsubscribed_from_emails: false })
   end
 
   def self.need_to_send_deadline_reminder?

--- a/app/queries/get_inactive_applications_from_past_day.rb
+++ b/app/queries/get_inactive_applications_from_past_day.rb
@@ -1,7 +1,7 @@
 class GetInactiveApplicationsFromPastDay
   def self.call(single: true)
     ApplicationForm.current_cycle.joins(:application_choices)
-      .joins(:candidate).where(candidates: { submission_blocked: false, account_locked: false })
+      .joins(:candidate).merge(Candidate.for_transaction_emails)
       .select('application_forms.id')
       .group('application_forms.id')
       .having(single ? 'COUNT(application_choices) = 1' : 'COUNT(application_choices) > 1')

--- a/app/queries/get_inactive_applications_from_past_day.rb
+++ b/app/queries/get_inactive_applications_from_past_day.rb
@@ -1,6 +1,7 @@
 class GetInactiveApplicationsFromPastDay
   def self.call(single: true)
     ApplicationForm.current_cycle.joins(:application_choices)
+      .joins(:candidate).where(candidates: { submission_blocked: false, account_locked: false })
       .select('application_forms.id')
       .group('application_forms.id')
       .having(single ? 'COUNT(application_choices) = 1' : 'COUNT(application_choices) > 1')

--- a/app/queries/get_incomplete_course_choice_applications_ready_to_nudge.rb
+++ b/app/queries/get_incomplete_course_choice_applications_ready_to_nudge.rb
@@ -12,7 +12,7 @@ class GetIncompleteCourseChoiceApplicationsReadyToNudge
   def call
     ApplicationForm
       # Filter out candidates who should not receive emails about their accounts
-      .joins(:candidate).where(candidates: { submission_blocked: false, account_locked: false, unsubscribed_from_emails: false })
+      .joins(:candidate).merge(Candidate.for_marketing_or_nudge_emails)
       .current_cycle
       .inactive_since(7.days.ago)
       # They have completed their references and the personal statement

--- a/app/queries/get_incomplete_personal_statement_applications_ready_to_nudge.rb
+++ b/app/queries/get_incomplete_personal_statement_applications_ready_to_nudge.rb
@@ -17,7 +17,7 @@ class GetIncompletePersonalStatementApplicationsReadyToNudge
       # Only candidates with unsubmitted application_choices
       .joins(:application_choices).where('application_choices.status': 'unsubmitted')
       # Filter out candidates who should not receive emails about their accounts
-      .joins(:candidate).where(candidates: { submission_blocked: false, account_locked: false, unsubscribed_from_emails: false })
+      .joins(:candidate).merge(Candidate.for_marketing_or_nudge_emails)
       # Only include candidates who have not submitted ANY applications. unsubmitted == NEVER submitted.
       # Candidates can't submit an application choice without a personal statement, so this is just here to be explicit, it won't practically change anything.
       .unsubmitted

--- a/app/queries/get_unsubmitted_applications_ready_to_nudge.rb
+++ b/app/queries/get_unsubmitted_applications_ready_to_nudge.rb
@@ -17,7 +17,7 @@ class GetUnsubmittedApplicationsReadyToNudge
       # Only candidates with unsubmitted application_choices
       .joins(:application_choices).where('application_choices.status': 'unsubmitted')
       # Filter out candidates who should not receive emails about their accounts
-      .joins(:candidate).where(candidates: { submission_blocked: false, account_locked: false, unsubscribed_from_emails: false })
+      .joins(:candidate).merge(Candidate.for_marketing_or_nudge_emails)
       .joins('LEFT OUTER JOIN application_choices ac_primary ON ac_primary.application_form_id = application_forms.id')
       .joins('LEFT OUTER JOIN course_options ON course_options.id = ac_primary.course_option_id')
       .joins("LEFT OUTER JOIN courses courses_primary ON courses_primary.id = course_options.course_id AND LOWER(courses_primary.level) = 'primary'")

--- a/app/queries/get_unsuccessful_and_unsubmitted_candidates.rb
+++ b/app/queries/get_unsuccessful_and_unsubmitted_candidates.rb
@@ -4,13 +4,7 @@ class GetUnsuccessfulAndUnsubmittedCandidates
     # Candidates who didn't have successful applications last year
     Candidate
       .left_outer_joins(:application_forms)
-      .where(
-        {
-          submission_blocked: false,
-          account_locked: false,
-          unsubscribed_from_emails: false,
-        },
-      )
+      .for_marketing_or_nudge_emails
       .where(
         '(application_forms.recruitment_cycle_year = (:previous_recruitment_year) AND NOT EXISTS (:successful))',
         previous_recruitment_year:,
@@ -22,17 +16,11 @@ class GetUnsuccessfulAndUnsubmittedCandidates
       .or(
         # Candidates who have started working on applications this year, but not submitted.
         Candidate
+          .for_marketing_or_nudge_emails
           .where(application_forms: {
             recruitment_cycle_year: RecruitmentCycle.current_year,
             submitted_at: nil,
-          })
-          .where(
-            {
-              submission_blocked: false,
-              account_locked: false,
-              unsubscribed_from_emails: false,
-            },
-          ),
+          }),
       )
       .distinct
   end

--- a/app/services/send_apply_to_another_course_when_inactive_email_to_candidate.rb
+++ b/app/services/send_apply_to_another_course_when_inactive_email_to_candidate.rb
@@ -1,5 +1,6 @@
 class SendApplyToAnotherCourseWhenInactiveEmailToCandidate
   def self.call(application_form)
+    return if application_form.maximum_number_of_choices_reached?
     return if already_sent_to?(application_form)
 
     CandidateMailer.apply_to_another_course_after_30_working_days(application_form).deliver_later

--- a/app/services/send_apply_to_multiple_courses_when_inactive_email_to_candidate.rb
+++ b/app/services/send_apply_to_multiple_courses_when_inactive_email_to_candidate.rb
@@ -1,5 +1,6 @@
 class SendApplyToMultipleCoursesWhenInactiveEmailToCandidate
   def self.call(application_form)
+    return if application_form.maximum_number_of_choices_reached?
     return if already_sent_to?(application_form)
 
     CandidateMailer.apply_to_multiple_courses_after_30_working_days(application_form).deliver_later

--- a/app/workers/end_of_cycle/send_application_deadline_has_passed_email_to_candidates_worker.rb
+++ b/app/workers/end_of_cycle/send_application_deadline_has_passed_email_to_candidates_worker.rb
@@ -14,9 +14,8 @@ module EndOfCycle
 
     def relation
       ApplicationForm
-        .joins(:candidate)
-        .where(candidates: { submission_blocked: false, account_locked: false })
         .current_cycle
+        .joins(:candidate).merge(Candidate.for_transaction_emails)
         .unsubmitted
         .distinct
     end

--- a/app/workers/end_of_cycle/send_reject_by_default_explainer_email_to_candidates_worker.rb
+++ b/app/workers/end_of_cycle/send_reject_by_default_explainer_email_to_candidates_worker.rb
@@ -15,7 +15,7 @@ module EndOfCycle
     def relation
       ApplicationForm
         .current_cycle
-        .joins(:candidate).where(candidates: { submission_blocked: false, account_locked: false })
+        .joins(:candidate).merge(Candidate.for_transaction_emails)
         .joins(:application_choices).where('application_choices.rejected_by_default': true)
         .distinct
     end

--- a/app/workers/send_apply_to_another_course_when_inactive_email_to_candidates_worker.rb
+++ b/app/workers/send_apply_to_another_course_when_inactive_email_to_candidates_worker.rb
@@ -5,11 +5,19 @@ class SendApplyToAnotherCourseWhenInactiveEmailToCandidatesWorker
   BATCH_SIZE = 150
 
   def perform
+    return if after_apply_deadline?
+
     GroupedRelationBatchDelivery.new(relation: GetInactiveApplicationsFromPastDay.call, stagger_over: STAGGER_OVER, batch_size: BATCH_SIZE).each do |batch_time, records|
       SendApplyToAnotherCourseWhenInactiveEmailToCandidatesBatchWorker.perform_at(
         batch_time,
         records.pluck(:id),
       )
     end
+  end
+
+private
+
+  def after_apply_deadline?
+    CycleTimetable.current_date.after? CycleTimetable.apply_deadline
   end
 end

--- a/app/workers/send_new_cycle_has_started_email_to_candidates_worker.rb
+++ b/app/workers/send_new_cycle_has_started_email_to_candidates_worker.rb
@@ -23,7 +23,7 @@ class SendNewCycleHasStartedEmailToCandidatesWorker
     current_recruitment_year = RecruitmentCycle.current_year
     # Candidates who didn't have successful applications last year and haven't started working on their 2025 application
     Candidate
-      .where({ submission_blocked: false, account_locked: false, unsubscribed_from_emails: false })
+      .for_marketing_or_nudge_emails
       .joins(:application_forms)
       # Has not started a new application form
       .where.not(id: Candidate.joins(:application_forms).where(

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -260,4 +260,28 @@ RSpec.describe Candidate do
       expect(candidate.pseudonymised_id).to eq '5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9'
     end
   end
+
+  context 'scopes' do
+    describe '#for_transaction_emails' do
+      let!(:unsubscribed_from_emails) { create(:candidate, unsubscribed_from_emails: true) }
+      let!(:submission_blocked) { create(:candidate, submission_blocked: true) }
+      let!(:account_locked) { create(:candidate, account_locked: true) }
+      let!(:free_to_email) { create(:candidate, account_locked: false, unsubscribed_from_emails: false, submission_blocked: false) }
+
+      it 'excludes candidates whose accounts are blocked or locked' do
+        expect(described_class.for_transaction_emails).to contain_exactly(unsubscribed_from_emails, free_to_email)
+      end
+    end
+
+    describe '#for_marketing_or_nudge_emails' do
+      let!(:unsubscribed_from_emails) { create(:candidate, unsubscribed_from_emails: true) }
+      let!(:submission_blocked) { create(:candidate, submission_blocked: true) }
+      let!(:account_locked) { create(:candidate, account_locked: true) }
+      let!(:free_to_email) { create(:candidate, account_locked: false, unsubscribed_from_emails: false, submission_blocked: false) }
+
+      it 'excludes blocked, locked and unsubscribed emails' do
+        expect(described_class.for_marketing_or_nudge_emails).to contain_exactly(free_to_email)
+      end
+    end
+  end
 end

--- a/spec/queries/get_inactive_applications_from_past_day_spec.rb
+++ b/spec/queries/get_inactive_applications_from_past_day_spec.rb
@@ -10,6 +10,20 @@ RSpec.describe GetInactiveApplicationsFromPastDay do
       expect(described_class.call).to be_empty
     end
 
+    context 'when candidate is blocked, locked or unsubscribed' do
+      let(:unsubscribed) { create(:application_form, candidate: build(:candidate, unsubscribed_from_emails: true)) }
+      let(:locked) { create(:application_form, candidate: build(:candidate, account_locked: true)) }
+      let(:blocked) { create(:application_form, candidate: build(:candidate, submission_blocked: true)) }
+
+      it 'only returns unsubscribed candidates' do
+        create(:application_choice, :inactive, application_form: unsubscribed)
+        create(:application_choice, :inactive, application_form: locked)
+        create(:application_choice, :inactive, application_form: blocked)
+
+        expect(described_class.call.pluck(:id)).to eq([unsubscribed.id])
+      end
+    end
+
     context 'when there are inactive applications' do
       let(:application_form) { create(:application_form) }
       let!(:application_choice) { create(:application_choice, :inactive) }

--- a/spec/services/send_apply_to_another_course_when_inactive_email_to_candidate_spec.rb
+++ b/spec/services/send_apply_to_another_course_when_inactive_email_to_candidate_spec.rb
@@ -27,4 +27,54 @@ RSpec.describe SendApplyToAnotherCourseWhenInactiveEmailToCandidate do
       expect(application_form.chasers_sent.apply_to_another_course_after_30_working_days.count).to eq(1)
     end
   end
+
+  describe '#call, candidate has max number of inflight application choices' do
+    let(:application_form) do
+      create(
+        :completed_application_form,
+        application_choices: create_list(:application_choice, 2, :inactive),
+      )
+    end
+
+    before do
+      create_list(:application_choice, ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES, :awaiting_provider_decision, application_form:)
+
+      mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+      allow(CandidateMailer).to receive(:apply_to_multiple_courses_after_30_working_days).and_return(mail)
+
+      described_class.call(application_form)
+    end
+
+    it 'does not send an email to the candidate' do
+      expect(CandidateMailer).not_to have_received(
+        :apply_to_multiple_courses_after_30_working_days,
+      ).with(application_form)
+      expect(application_form.chasers_sent.apply_to_multiple_courses_after_30_working_days.count).to eq(0)
+    end
+  end
+
+  describe '#call, candidate has max number of unsuccessful application choices' do
+    let(:application_form) do
+      create(
+        :completed_application_form,
+        application_choices: create_list(:application_choice, 2, :inactive),
+      )
+    end
+
+    before do
+      create_list(:application_choice, ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS, :withdrawn, application_form:)
+
+      mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+      allow(CandidateMailer).to receive(:apply_to_multiple_courses_after_30_working_days).and_return(mail)
+
+      described_class.call(application_form)
+    end
+
+    it 'does not send an email to the candidate' do
+      expect(CandidateMailer).not_to have_received(
+        :apply_to_multiple_courses_after_30_working_days,
+      ).with(application_form)
+      expect(application_form.chasers_sent.apply_to_multiple_courses_after_30_working_days.count).to eq(0)
+    end
+  end
 end

--- a/spec/services/send_apply_to_multiple_courses_when_inactive_email_to_candidate_spec.rb
+++ b/spec/services/send_apply_to_multiple_courses_when_inactive_email_to_candidate_spec.rb
@@ -34,4 +34,54 @@ RSpec.describe SendApplyToMultipleCoursesWhenInactiveEmailToCandidate do
       expect(application_form.chasers_sent.apply_to_multiple_courses_after_30_working_days.count).to eq(1)
     end
   end
+
+  describe '#call, candidate has max number of inflight application choices' do
+    let(:application_form) do
+      create(
+        :completed_application_form,
+        application_choices: create_list(:application_choice, 2, :inactive),
+      )
+    end
+
+    before do
+      create_list(:application_choice, ApplicationForm::MAXIMUM_NUMBER_OF_COURSE_CHOICES, :awaiting_provider_decision, application_form:)
+
+      mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+      allow(CandidateMailer).to receive(:apply_to_multiple_courses_after_30_working_days).and_return(mail)
+
+      described_class.call(application_form)
+    end
+
+    it 'does not send an email to the candidate' do
+      expect(CandidateMailer).not_to have_received(
+        :apply_to_multiple_courses_after_30_working_days,
+      ).with(application_form)
+      expect(application_form.chasers_sent.apply_to_multiple_courses_after_30_working_days.count).to eq(0)
+    end
+  end
+
+  describe '#call, candidate has max number of unsuccessful application choices' do
+    let(:application_form) do
+      create(
+        :completed_application_form,
+        application_choices: create_list(:application_choice, 2, :inactive),
+      )
+    end
+
+    before do
+      create_list(:application_choice, ApplicationForm::MAXIMUM_NUMBER_OF_UNSUCCESSFUL_APPLICATIONS, :withdrawn, application_form:)
+
+      mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+      allow(CandidateMailer).to receive(:apply_to_multiple_courses_after_30_working_days).and_return(mail)
+
+      described_class.call(application_form)
+    end
+
+    it 'does not send an email to the candidate' do
+      expect(CandidateMailer).not_to have_received(
+        :apply_to_multiple_courses_after_30_working_days,
+      ).with(application_form)
+      expect(application_form.chasers_sent.apply_to_multiple_courses_after_30_working_days.count).to eq(0)
+    end
+  end
 end

--- a/spec/workers/send_apply_to_another_course_when_inactive_email_to_candidates_worker_spec.rb
+++ b/spec/workers/send_apply_to_another_course_when_inactive_email_to_candidates_worker_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe SendApplyToAnotherCourseWhenInactiveEmailToCandidatesWorker, :sidekiq do
-  describe '#perform' do
+  describe '#perform', time: mid_cycle do
     let(:application_forms) { create_list(:completed_application_form, 2) }
 
     subject(:perform) { described_class.new.perform }
@@ -28,6 +28,29 @@ RSpec.describe SendApplyToAnotherCourseWhenInactiveEmailToCandidatesWorker, :sid
       }.to not_change(ActionMailer::Base.deliveries, :count)
      .and not_change(application_forms.first.chasers_sent.apply_to_another_course_after_30_working_days, :count)
      .and not_change(application_forms.second.chasers_sent.apply_to_another_course_after_30_working_days, :count)
+    end
+  end
+
+  describe '#perform after the apply deadline', time: after_apply_deadline do
+    let(:application_forms) { create_list(:completed_application_form, 2) }
+
+    subject(:perform) { described_class.new.perform }
+
+    before do
+      stub_const('SendApplyToAnotherCourseWhenInactiveEmailToCandidatesWorker::BATCH_SIZE', 3) # to make sure it loops through all the applications
+
+      create(:application_choice, :inactive, application_form: application_forms.first)
+      create(:application_choice, :inactive, application_form: application_forms.second)
+      create_list(:application_choice, 5, :inactive)
+      perform
+    end
+
+    it 'does not send any emails' do
+      expect {
+        perform
+      }.to not_change(ActionMailer::Base.deliveries, :count)
+             .and not_change(application_forms.first.chasers_sent.apply_to_another_course_after_30_working_days, :count)
+                    .and not_change(application_forms.second.chasers_sent.apply_to_another_course_after_30_working_days, :count)
     end
   end
 


### PR DESCRIPTION
## Context

When a choice becomes inactive we send an email prompt to the candidate that they now have a ‘free slot’ to submit with again.

We have been sending these emails to people 
- with blocked / locked accounts
- when they don't actually have slots available (have too many inflight applications)
- when they have reached the number of max unsuccessful applications 
- during the between cycles period when candidates can no longer add applications


## Changes proposed in this pull request

- Limit the query to exclude candidates who have submissions blocked / locked accounts
- Prevent sending after the apply deadline
- Prevent sending if the applicant has already reached max (in flight or rejected)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [ ] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
