### PR TITLE
[356] Render the correct dates between cycles in withdrawal emails

### DIFF
--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -54,4 +54,30 @@ module RecruitmentCycle
   def self.verbose_cycle_name(year = current_year)
     "October #{year - 1} to September #{year}"
   end
+
+  def self.next_courses_starting_range
+    # if it's cycle year 2025 before apply opens (after find opens, eg 2 October 2024)
+    # 2025 - 26 (current_year - next year )
+    # if it's cycle year 2024 after apply closes (before find closes, eg 29 Sept 2024)
+    # 2025 - 26 (next_year - next_year + 1)
+
+    if CycleTimetable.before_apply_opens?
+      cycle_name(next_year)
+    else
+      cycle_name(next_year + 1)
+    end
+  end
+
+  def self.next_apply_opening_date
+    # if it's cycle year 2025 before apply opens (after find opens)
+    # October 2024, (apply opens in the current recruitment year, ie apply_opens)
+    # if it's cycle year 2024 after apply closes (before find closes)
+    # October 2024, (apply opens in the next recruitment year, ie apply reopens)
+
+    if CycleTimetable.before_apply_opens?
+      CycleTimetable.apply_opens
+    else
+      CycleTimetable.apply_reopens
+    end
+  end
 end

--- a/app/views/candidate_mailer/_still_interested_content.text.erb
+++ b/app/views/candidate_mailer/_still_interested_content.text.erb
@@ -1,11 +1,10 @@
 <% if CycleTimetable.between_cycles? %>
-
-You can apply again for courses starting in the <%= "#{RecruitmentCycle.next_year} to #{RecruitmentCycle.next_year + 1}" %> academic year.
+You can apply again for courses starting in the <%= RecruitmentCycle.next_courses_starting_range %> academic year.
 
 All you need to do is:
 
 - check your details are still correct
-- submit from <%= CycleTimetable.apply_reopens.to_fs(:govuk_time) %> on <%= CycleTimetable.apply_reopens.to_fs(:govuk_date) %>
+- submit from <%= RecruitmentCycle.next_apply_opening_date.to_fs(:govuk_time) %> on <%= RecruitmentCycle.next_apply_opening_date.to_fs(:govuk_date) %>
 
 <% else %>
 

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -196,14 +196,37 @@ RSpec.describe CandidateMailer do
     context 'when a candidate has 1 course choice that was withdrawn' do
       let(:application_choices) { [create(:application_choice, status: 'withdrawn')] }
 
-      it_behaves_like(
-        'a mail with subject and content',
-        'You have withdrawn your application',
-        'heading' => 'Hello Fred',
-        'application_withdrawn' => 'You have withdrawn your application',
-        'realistic job preview' => 'Try the realistic job preview tool',
-        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
-      )
+      context 'mid cycle', time: mid_cycle do
+        it_behaves_like(
+          'a mail with subject and content',
+          'You have withdrawn your application',
+          'heading' => 'Hello Fred',
+          'still interested' => 'If now’s the right time for you, you can still apply for teacher training again this year.',
+          'application_withdrawn' => 'You have withdrawn your application',
+          'realistic job preview' => 'Try the realistic job preview tool',
+          'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
+        )
+      end
+
+      context 'between cycles, before find opens', time: after_apply_deadline(2024) do
+        it_behaves_like(
+          'a mail with subject and content',
+          'You have withdrawn your application',
+          'heading' => 'Hello Fred',
+          'still interested' => 'You can apply again for courses starting in the 2025 to 2026 academic year.',
+          'when to apply again' => 'submit from 9am on 8 October 2024',
+        )
+      end
+
+      context 'between cycles, before apply reopens', time: after_find_opens(2025) do
+        it_behaves_like(
+          'a mail with subject and content',
+          'You have withdrawn your application',
+          'heading' => 'Hello Fred',
+          'still interested' => 'You can apply again for courses starting in the 2025 to 2026 academic year.',
+          'when to apply again' => 'submit from 9am on 8 October 2024',
+        )
+      end
     end
 
     context 'when new reference flow is active' do
@@ -233,14 +256,37 @@ RSpec.describe CandidateMailer do
     let(:email) { described_class.decline_last_application_choice(application_form.application_choices.first) }
     let(:application_choices) { [build_stubbed(:application_choice, status: :declined)] }
 
-    it_behaves_like(
-      'a mail with subject and content',
-      'You have declined an offer: next steps',
-      'greeting' => 'Hello Fred',
-      'content' => 'declined your offer to study',
-      'realistic job preview' => 'Try the realistic job preview tool',
-      'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
-    )
+    context 'mid cycle', time: mid_cycle do
+      it_behaves_like(
+        'a mail with subject and content',
+        'You have declined an offer: next steps',
+        'greeting' => 'Hello Fred',
+        'still interested' => 'If now’s the right time for you, you can still apply for teacher training again this year.',
+        'content' => 'declined your offer to study',
+        'realistic job preview' => 'Try the realistic job preview tool',
+        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
+      )
+    end
+
+    context 'between cycles, before find opens', time: after_apply_deadline(2024) do
+      it_behaves_like(
+        'a mail with subject and content',
+        'You have declined an offer: next steps',
+        'greeting' => 'Hello Fred',
+        'still interested' => 'You can apply again for courses starting in the 2025 to 2026 academic year.',
+        'when to apply again' => 'submit from 9am on 8 October 2024',
+      )
+    end
+
+    context 'between cycles, before find opens', time: after_find_opens(2025) do
+      it_behaves_like(
+        'a mail with subject and content',
+        'You have declined an offer: next steps',
+        'greeting' => 'Hello Fred',
+        'still interested' => 'You can apply again for courses starting in the 2025 to 2026 academic year.',
+        'when to apply again' => 'submit from 9am on 8 October 2024',
+      )
+    end
   end
 
   describe '.chase_reference_again' do
@@ -284,15 +330,36 @@ RSpec.describe CandidateMailer do
       )]
     end
 
-    it_behaves_like(
-      'a mail with subject and content',
-      'Offer withdrawn by Arachnid College',
-      'greeting' => 'Dear Fred',
-      'offer details' => 'Arachnid College has withdrawn their offer for you to study Mathematics (M101)',
-      'withdrawal reason' => 'You lied to us about secretly being Spiderman',
-      'realistic job preview' => 'Try the realistic job preview tool',
-      'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
-    )
+    context 'between cycles, before find opens', time: after_apply_deadline(2024) do
+      it_behaves_like(
+        'a mail with subject and content',
+        'Offer withdrawn by Arachnid College',
+        'still interested' => 'You can apply again for courses starting in the 2025 to 2026 academic year.',
+        'when to apply again' => 'submit from 9am on 8 October 2024',
+      )
+    end
+
+    context 'between cycles, after find opens, before apply reopens', time: after_find_opens(2025) do
+      it_behaves_like(
+        'a mail with subject and content',
+        'Offer withdrawn by Arachnid College',
+        'still interested' => 'You can apply again for courses starting in the 2025 to 2026 academic year.',
+        'when to apply again' => 'submit from 9am on 8 October 2024',
+      )
+    end
+
+    context 'mid cycle', time: mid_cycle do
+      it_behaves_like(
+        'a mail with subject and content',
+        'Offer withdrawn by Arachnid College',
+        'greeting' => 'Dear Fred',
+        'still interested' => 'If now’s the right time for you, you can still apply for teacher training again this year.',
+        'offer details' => 'Arachnid College has withdrawn their offer for you to study Mathematics (M101)',
+        'withdrawal reason' => 'You lied to us about secretly being Spiderman',
+        'realistic job preview' => 'Try the realistic job preview tool',
+        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
+      )
+    end
   end
 
   describe '.offer_accepted' do
@@ -761,15 +828,38 @@ RSpec.describe CandidateMailer do
     context 'when the candidate has withdrawn or asked to be withdrawn from an application choice' do
       let(:email) { mailer.application_withdrawn_on_request(application_form.application_choices.first) }
 
-      it_behaves_like(
-        'a mail with subject and content',
-        'Update on your application',
-        'greeting' => 'Hello Fred',
-        'details' => 'has withdrawn your application for',
-        'content' => 'If now’s the right time for you, you can still apply for teacher training again this year.',
-        'realistic job preview' => 'Try the realistic job preview tool',
-        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
-      )
+      context 'mid cycle', time: mid_cycle do
+        it_behaves_like(
+          'a mail with subject and content',
+          'Update on your application',
+          'greeting' => 'Hello Fred',
+          'details' => 'has withdrawn your application for',
+          'still interested' => 'If now’s the right time for you, you can still apply for teacher training again this year.',
+          'content' => 'If now’s the right time for you, you can still apply for teacher training again this year.',
+          'realistic job preview' => 'Try the realistic job preview tool',
+          'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
+        )
+      end
+
+      context 'between cycles, before find reopens', time: after_apply_deadline(2024) do
+        it_behaves_like(
+          'a mail with subject and content',
+          'Update on your application',
+          'greeting' => 'Hello Fred',
+          'still interested' => 'You can apply again for courses starting in the 2025 to 2026 academic year.',
+          'when to apply again' => 'submit from 9am on 8 October 2024',
+        )
+      end
+
+      context 'between cycles, before find reopens', time: after_find_opens(2025) do
+        it_behaves_like(
+          'a mail with subject and content',
+          'Update on your application',
+          'greeting' => 'Hello Fred',
+          'still interested' => 'You can apply again for courses starting in the 2025 to 2026 academic year.',
+          'when to apply again' => 'submit from 9am on 8 October 2024',
+        )
+      end
     end
   end
 

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -148,4 +148,44 @@ RSpec.describe RecruitmentCycle, time: CycleTimetableHelper.mid_cycle(2023) do
       expect(described_class.verbose_cycle_name(2021)).to eq('October 2020 to September 2021')
     end
   end
+
+  describe '#next_course_starting_range' do
+    context 'after the apply deadline', time: after_apply_deadline(2024) do
+      it 'returns the 2025-26 academic year' do
+        expect(described_class.next_courses_starting_range).to eq '2025 to 2026'
+      end
+    end
+
+    context 'after find opens, before apply opens', time: after_find_opens(2025) do
+      it 'returns the 2025-26 academic year' do
+        expect(described_class.next_courses_starting_range).to eq '2025 to 2026'
+      end
+    end
+
+    context 'mid cycle 2025', time: mid_cycle(2025) do
+      it 'returns the 2026-27 academic year' do
+        expect(described_class.next_courses_starting_range).to eq '2026 to 2027'
+      end
+    end
+  end
+
+  describe '#next_apply_opening_date' do
+    context 'after the apply deadline', time: after_apply_deadline(2024) do
+      it 'returns the apply opening date for recruitment cycle 2025' do
+        expect(described_class.next_apply_opening_date).to eq Time.zone.local(2024, 10, 8, 9)
+      end
+    end
+
+    context 'after find opens, before apply opens', time: after_find_opens(2025) do
+      it 'returns the apply opening date for recruitment cycle 2025' do
+        expect(described_class.next_apply_opening_date).to eq Time.zone.local(2024, 10, 8, 9)
+      end
+    end
+
+    context 'mid cycle', time: mid_cycle(2025) do
+      it 'returns the apply opening date for recruitment cycle 2026' do
+        expect(described_class.next_apply_opening_date).to eq Time.zone.local(2025, 10, 8, 9)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

We have content that we render `between_cycles` on our withdrawal emails. 
Between cycles is from apply_deadline - apply_reopening. 
This means that one week (between find opening and apply reopening) we are in the _next_ cycle year. 
As a result, we weren't rendering the correct academic year and apply opening date to users.

## Changes proposed in this pull request

- I've added methods to the RecruitmentCycle year to handle working out the academic year for the courses and the apply deadlines depending on where we are during the between cycles period. (and unit specs)
- Specs to ensure we are rendering the content in those emails as expected.

The before and after here is rendered by moving forward to after find reopens on the cycle switcher, so the actual opening time and date isn't correct, but you can see that the year is as it should be (2026 - 2027).

| Before | After |
| ------ | ------ |
| <img width="694" alt="image" src="https://github.com/user-attachments/assets/0be03dab-f687-446b-8559-e37ba0703a59"> | <img width="652" alt="image" src="https://github.com/user-attachments/assets/aafabef5-789b-4f80-9db5-2954a20768cb"> |


## Guidance to review


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
