### PR TITLE
[112] Update values for structured reasons for withdrawal

### DIFF
--- a/config/withdrawal_reasons.yml
+++ b/config/withdrawal_reasons.yml
@@ -1,24 +1,24 @@
-- :id: change_of_training_provider
+- :id: applying_to_different_provider
   :label: I’m going to apply (or have applied) to a different training provider
-- :id: change_of_course_option
+- :id: applying_to_different_course_same_provider
   :label: I’m going to apply (or have applied) to a different course at the same training provider
-- :id: costs
+- :id: concerns_about_cost
   :label: I have concerns about the cost of doing the course
-- :id: course_unavailable
+- :id: course_not_available_anymore
   :label: The course is not available anymore
-- :id: flexible_itt_course_date
+- :id: wait_to_start_course_too_long
   :label: The wait to start the course is too long
-- :id: deferred
+- :id: applying_to_teacher_training_next_year
   :label: I’ve decided to apply for teacher training next year
-- :id: application_unsuccessful
+- :id: asked_to_withdraw
   :label: The training provider has asked me to withdraw
-- :id: provider_behaviour
+- :id: training_provider_has_not_responded
   :label: The training provider has not responded to me
-- :id: course_location
+- :id: training_location_too_far_away
   :label: The location I’m expected to train at is too far away
-- :id: flexibile_itt_study_intensity
+- :id: concerns_about_time_to_train
   :label: I have concerns that I will not have time to train
-- :id: flexible_itt_disabilities
+- :id: concerns_about_training_with_disability_or_health_condition
   :label: I have concerns about training with a disability or health condition
-- :id: circumstances_changed
+- :id: no_longer_want_to_train_to_teach
   :label: I do not want to train to be a teacher anymore

--- a/spec/factories/application_choice.rb
+++ b/spec/factories/application_choice.rb
@@ -201,7 +201,7 @@ FactoryBot.define do
 
     trait :with_structured_withdrawal_reasons do
       withdrawn
-      structured_withdrawal_reasons { %w[costs course_unavailable circumstances_changed] }
+      structured_withdrawal_reasons { %w[concerns_about_cost course_not_available_anymore no_longer_want_to_train_to_teach] }
     end
 
     trait :withdrawn_at_candidates_request do

--- a/spec/services/provider_interface/candidate_withdrawal_data_by_provider_spec.rb
+++ b/spec/services/provider_interface/candidate_withdrawal_data_by_provider_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ProviderInterface::CandidateWithdrawalDataByProvider do
   describe '#withdrawal_data' do
     let(:config_path) { Rails.root.join('config/withdrawal_reasons.yml') }
     let(:selectable_reasons) { YAML.load_file(config_path) }
-    let!(:application_choice_with_accepted_offer) { create(:application_choice, :withdrawn, accepted_at: 3.days.ago, structured_withdrawal_reasons: ['provider_behaviour'], provider_ids: [provider.id]) }
+    let!(:application_choice_with_accepted_offer) { create(:application_choice, :withdrawn, accepted_at: 3.days.ago, structured_withdrawal_reasons: ['training_provider_has_not_responded'], provider_ids: [provider.id]) }
 
     before do
       create_list(:application_choice, 2, :with_structured_withdrawal_reasons, provider_ids: [provider.id])


### PR DESCRIPTION
## Context

We've been asked by the data insights team to update the values for reasons for withdrawal to better reflect the statements selected by the candidate.

No changes to the UI.

This is the first of two PRs.

We'll do the migration after this is merged. [PR for the migration](https://github.com/DFE-Digital/apply-for-teacher-training/pull/9970).

I've checked that we do not include these values on the API
- See [api docs](https://www.apply-for-teacher-training.service.gov.uk/api-docs/v1.0/reference#withdrawal-object)
- And in the codebase, `VendorAPI::ApplicationPresenter` and `DecisionsAPIData`

The only place these values are used is in the withdrawal report (`provider/reports/:provider_id/withdrawal-report`). This report will be temporarily all zeros until after the migration. It shouldn't be a problem though because it is so early in the cycle and most providers haven't had enough withdrawals yet to even see the report (you have to have had at least 10). 

## Changes proposed in this pull request

In this first PR, it is just swapping out the old values for the new ones. You can have a look at the trello ticket for the mapping.

## Guidance to review

Can you think of anywhere else this is used that might be a problem?

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
