### PR TITLE
[112 pt 2] Migration for updating the withdrawal reasons

### DIFF
--- a/app/services/data_migrations/backfill_withdrawal_reasons.rb
+++ b/app/services/data_migrations/backfill_withdrawal_reasons.rb
@@ -1,0 +1,48 @@
+module DataMigrations
+  class BackfillWithdrawalReasons
+    TIMESTAMP = 20241023160952
+    MANUAL_RUN = true
+
+    WITHDRAWAL_REASONS_MAPPING = {
+      'application_unsuccessful' => 'asked_to_withdraw',
+      'change_of_course_option' => 'applying_to_different_course_same_provider',
+      'change_of_training_provider' => 'applying_to_different_provider',
+      'circumstances_changed' => 'no_longer_want_to_train_to_teach',
+      'costs' => 'concerns_about_cost',
+      'course_location' => 'training_location_too_far_away',
+      'course_unavailable' => 'course_not_available_anymore',
+      'deferred' => 'applying_to_teacher_training_next_year',
+      # Yes, flexible is spelled incorrectly
+      'flexibile_itt_study_intensity' => 'concerns_about_time_to_train',
+      'flexible_itt_course_date' => 'wait_to_start_course_too_long',
+      'flexible_itt_disabilities' => 'concerns_about_training_with_disability_or_health_condition',
+      'provider_behaviour' => 'training_provider_has_not_responded',
+    }.freeze
+
+    def change
+      choices.in_batches(of: 5_000) do |choices_batch|
+        choices_attributes = choices_batch.as_json.map do |attributes|
+          { **attributes, structured_withdrawal_reasons: mapped_reasons(attributes['structured_withdrawal_reasons']) }
+        end
+        ApplicationChoice.upsert_all(
+          choices_attributes,
+          record_timestamps: false,
+          returning: false,
+          update_only: [:structured_withdrawal_reasons],
+        )
+      end
+    end
+
+  private
+
+    def choices
+      ApplicationChoice.where.not(structured_withdrawal_reasons: [])
+    end
+
+    def mapped_reasons(original_reasons)
+      Array.wrap(original_reasons).map do |original_reason|
+        WITHDRAWAL_REASONS_MAPPING.fetch(original_reason, nil)
+      end.compact
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,6 +1,7 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
   'DataMigrations::CorrectHesaEthnicity',
+  'DataMigrations::BackfillWithdrawalReasons',
   'DataMigrations::RemoveTeacherDegreeApprenticeshipFeatureFlag',
   'DataMigrations::RevertApplicationChoicesUpdatedAt',
   'DataMigrations::BackfillApplicationChoicesWithWorkExperiences',

--- a/spec/services/data_migrations/backfill_withdrawal_reasons_spec.rb
+++ b/spec/services/data_migrations/backfill_withdrawal_reasons_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::BackfillWithdrawalReasons do
+  context 'where choice has multiple valid withdrawal reasons' do
+    it 'maps the old reasons to the new reasons' do
+      application_choice = create(:application_choice, :withdrawn, structured_withdrawal_reasons: all_old_reasons)
+      described_class.new.change
+      expect(application_choice.reload.structured_withdrawal_reasons).to eq(all_new_reasons)
+    end
+
+    it 'does not update any other fields' do
+      application_choice = create(:application_choice, :withdrawn, structured_withdrawal_reasons: all_old_reasons)
+      old_attributes = application_choice.attributes
+      old_attributes.delete('structured_withdrawal_reasons')
+
+      described_class.new.change
+      new_attributes = application_choice.reload.attributes
+      new_attributes.delete('structured_withdrawal_reasons')
+
+      expect(old_attributes).to match(new_attributes)
+    end
+
+    it 'does not create new records' do
+      create_list(:application_choice, 3)
+      create_list(:application_choice, 3,
+                  :withdrawn,
+                  structured_withdrawal_reasons: %w[flexibile_itt_study_intensity flexible_itt_course_date])
+      described_class.new.change
+
+      expect(ApplicationChoice.count).to eq(6)
+    end
+  end
+
+  context 'where choice has some invalid withdrawal reasons' do
+    it 'discards to the invalid reason, and maps the valid ones to the new choices' do
+      application_choice = create(:application_choice, :withdrawn, structured_withdrawal_reasons: %w[costs something_else])
+      described_class.new.change
+      expect(application_choice.reload.structured_withdrawal_reasons).to eq(['concerns_about_cost'])
+    end
+  end
+
+  context 'where choice does not have any withdrawal reasons' do
+    it 'does not change the structured withdrawal reasons' do
+      application_choice = create(:application_choice, :withdrawn, structured_withdrawal_reasons: [])
+      described_class.new.change
+      expect(application_choice.reload.structured_withdrawal_reasons).to eq([])
+    end
+
+    it 'does not change records where reasons are nil' do
+      application_choice = create(:application_choice, :withdrawn, structured_withdrawal_reasons: nil)
+      described_class.new.change
+      expect(application_choice.reload.structured_withdrawal_reasons).to be_nil
+    end
+  end
+
+  def all_old_reasons
+    # Yes, flexible is spelled incorrectly in one of the old reasons, flexibile_itt_study_intensity
+    %w[application_unsuccessful change_of_course_option change_of_training_provider circumstances_changed costs
+       course_location course_unavailable deferred flexibile_itt_study_intensity flexible_itt_course_date
+       flexible_itt_disabilities provider_behaviour]
+  end
+
+  def all_new_reasons
+    %w[asked_to_withdraw applying_to_different_course_same_provider applying_to_different_provider
+       no_longer_want_to_train_to_teach concerns_about_cost training_location_too_far_away course_not_available_anymore
+       applying_to_teacher_training_next_year concerns_about_time_to_train wait_to_start_course_too_long
+       concerns_about_training_with_disability_or_health_condition training_provider_has_not_responded]
+  end
+end


### PR DESCRIPTION
## Context

To be rebased on main and merged AFTER [part 1](https://github.com/DFE-Digital/apply-for-teacher-training/pull/9999) is deployed.

This is a migration to backfill the withdrawal reason values that we changed in part 1. This change has been requested by the data insights team. 

## Changes proposed in this pull request

Migration to update the data.

## Guidance to review

- Any chance this is going to cause a BigTouch? 
- I've set this to run automatically `MANUAL_RUN = false`, any thoughts on this? Should we do it manually in the wee hours? There are 35,711 records to update. Doing it batches should keep the table from being locked too long for each upsert. But 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [x] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
