### PR TITLE
Fix hesa ethnicity for 2023/2024 application forms

### DIFF
--- a/app/services/data_migrations/correct_hesa_ethnicity.rb
+++ b/app/services/data_migrations/correct_hesa_ethnicity.rb
@@ -1,0 +1,21 @@
+module DataMigrations
+  class CorrectHesaEthnicity
+    TIMESTAMP = 20241024110710
+    MANUAL_RUN = false
+
+    def change
+      application_forms.update_all(
+        "equality_and_diversity = jsonb_set(equality_and_diversity, '{hesa_ethnicity}', '\"179\"', false)",
+      )
+    end
+
+  private
+
+    def application_forms
+      ApplicationForm
+        .where(recruitment_cycle_year: [2023, 2024])
+        .where("equality_and_diversity->>'hesa_ethnicity' = ?", '160')
+        .where("equality_and_diversity->>'ethnic_background' != ?", 'British, English, Northern Irish, Scottish, or Welsh')
+    end
+  end
+end

--- a/spec/services/data_migrations/correct_hesa_ethnicity_spec.rb
+++ b/spec/services/data_migrations/correct_hesa_ethnicity_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::CorrectHesaEthnicity do
+  describe '#change' do
+    it 'sets the hesa_ethnicity to 179' do
+      form_2023 = create(
+        :application_form,
+        recruitment_cycle_year: 2023,
+        equality_and_diversity: {
+          ethnic_group: 'White',
+          ethnic_background: 'Another White background',
+          hesa_ethnicity: '160',
+        },
+      )
+
+      form_2024 = create(
+        :application_form,
+        recruitment_cycle_year: 2024,
+        equality_and_diversity: {
+          ethnic_group: 'White',
+          ethnic_background: 'European',
+          hesa_ethnicity: '160',
+        },
+      )
+
+      form_2025 = create(
+        :application_form,
+        recruitment_cycle_year: 2025,
+        equality_and_diversity: {
+          ethnic_group: 'White',
+          ethnic_background: 'Another White background',
+          hesa_ethnicity: '160',
+        },
+      )
+
+      correct_hesa_ethnicity = create(
+        :application_form,
+        recruitment_cycle_year: 2024,
+        equality_and_diversity: {
+          ethnic_group: 'White',
+          ethnic_background: 'British, English, Northern Irish, Scottish, or Welsh',
+          hesa_ethnicity: '160',
+        },
+      )
+
+      expect {
+        described_class.new.change
+      }.to change { form_2023.reload.equality_and_diversity['hesa_ethnicity'] }.from('160').to('179')
+        .and change { form_2024.reload.equality_and_diversity['hesa_ethnicity'] }.from('160').to('179')
+        .and not_change { form_2025.reload.equality_and_diversity['hesa_ethnicity'] }.from('160')
+        .and not_change { correct_hesa_ethnicity.reload.equality_and_diversity['hesa_ethnicity'] }.from('160')
+    end
+  end
+end

--- a/spec/services/data_migrations/correct_hesa_ethnicity_spec.rb
+++ b/spec/services/data_migrations/correct_hesa_ethnicity_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe DataMigrations::CorrectHesaEthnicity do
   describe '#change' do
-    it 'sets the hesa_ethnicity to 179' do
+    it 'sets the hesa_ethnicity to 179 without chaning any other keys' do
       form_2023 = create(
         :application_form,
         recruitment_cycle_year: 2023,
@@ -10,6 +10,11 @@ RSpec.describe DataMigrations::CorrectHesaEthnicity do
           ethnic_group: 'White',
           ethnic_background: 'Another White background',
           hesa_ethnicity: '160',
+          sex: 'male',
+          hesa_sex: 11,
+          disabilities: ['I do not have any of these disabilities or health conditions'],
+          free_school_meals: 'Prefer not to say',
+          hesa_disabilities: ['95'],
         },
       )
 
@@ -47,6 +52,11 @@ RSpec.describe DataMigrations::CorrectHesaEthnicity do
         described_class.new.change
       }.to change { form_2023.reload.equality_and_diversity['hesa_ethnicity'] }.from('160').to('179')
         .and change { form_2024.reload.equality_and_diversity['hesa_ethnicity'] }.from('160').to('179')
+        .and not_change { form_2023.reload.equality_and_diversity['sex'] }.from('male')
+        .and not_change { form_2023.reload.equality_and_diversity['hesa_sex'] }.from(11)
+        .and not_change { form_2023.reload.equality_and_diversity['disabilities'] }.from(['I do not have any of these disabilities or health conditions'])
+        .and not_change { form_2023.reload.equality_and_diversity['free_school_meals'] }.from('Prefer not to say')
+        .and not_change { form_2023.reload.equality_and_diversity['hesa_disabilities'] }.from(['95'])
         .and not_change { form_2025.reload.equality_and_diversity['hesa_ethnicity'] }.from('160')
         .and not_change { correct_hesa_ethnicity.reload.equality_and_diversity['hesa_ethnicity'] }.from('160')
     end


### PR DESCRIPTION
## Context

In this commit 05c8752f1f5beee512278f735029036b77eb9479 we have fixed a bug where the `Another White background` option to `ethnic_background` saved the wrong `hesa_ethnicity` code. It saved 160 rather than 179.

We now need to fix this issue for the old application_forms. There are about 5k application_forms in production, only for 2023 and 2024 recruitment cycles. This commit adds a data migration to fix this.

## Changes proposed in this pull request

Data migration

## Guidance to review

Does the query look right? Postgresql Jsonb documentation https://www.postgresql.org/docs/9.5/functions-json.html

`jsonb_set` should only change the specified key, `hesa_ethnicity`.


```
jsonb_set(target jsonb, path text[], new_value jsonb [, create_missing boolean])

Returns target with the section designated by path replaced by new_value, or with new_value
added if create_missing is true (default is true) and the item designated by path does not
exist.
As with the path oriented operators, negative integers that appear in path count from the
end of JSON arrays.
```

Blazer query https://www.apply-for-teacher-training.service.gov.uk/support/blazer/queries/1067-wrong-hesa_ethnicity-for-another-white-background

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
