### PR TITLE
Bring the journey uk and non uk degree in line

### DIFF
--- a/app/forms/candidate_interface/degree_wizard.rb
+++ b/app/forms/candidate_interface/degree_wizard.rb
@@ -101,11 +101,11 @@ module CandidateInterface
       if !reviewing? || (reviewing? && country_changed?)
         if step == :country && uk?
           :degree_level
-        elsif (step == :country && international? && country.present?) || step == :degree_level
+        elsif (step == :type && international?) || step == :degree_level
           :subject
-        elsif (step == :subject && uk? && !degree_has_type?) || step == :type
+        elsif (step == :subject && uk? && !degree_has_type?) || (step == :type && uk?) || (step == :subject && international?)
           :university
-        elsif step == :subject
+        elsif (step == :country && international? && country.present?) || (step == :subject && uk?)
           :type
         elsif step == :university
           :completed
@@ -177,7 +177,7 @@ module CandidateInterface
       if reviewing_and_unchanged_country?
         back_to_review
       elsif international?
-        Rails.application.routes.url_helpers.candidate_interface_degree_country_path
+        Rails.application.routes.url_helpers.candidate_interface_degree_type_path
       else
         Rails.application.routes.url_helpers.candidate_interface_degree_degree_level_path
       end
@@ -186,10 +186,12 @@ module CandidateInterface
     def types_page_back_link
       if reviewing_and_from_wizard_page
         if international?
-          Rails.application.routes.url_helpers.candidate_interface_degree_subject_path
+          Rails.application.routes.url_helpers.candidate_interface_degree_country_path
         else
           Rails.application.routes.url_helpers.candidate_interface_degree_degree_level_path
         end
+      elsif !reviewing? && international?
+        Rails.application.routes.url_helpers.candidate_interface_degree_country_path
       elsif !reviewing? || (reviewing? && country_changed?)
         Rails.application.routes.url_helpers.candidate_interface_degree_subject_path
       else
@@ -200,7 +202,7 @@ module CandidateInterface
     def university_back_link
       if reviewing_and_unchanged_country?
         back_to_review
-      elsif degree_has_type?
+      elsif degree_has_type? && uk?
         Rails.application.routes.url_helpers.candidate_interface_degree_type_path
       else
         Rails.application.routes.url_helpers.candidate_interface_degree_subject_path

--- a/spec/forms/candidate_interface/degree_wizard_spec.rb
+++ b/spec/forms/candidate_interface/degree_wizard_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe CandidateInterface::DegreeWizard do
         let(:degree_params) { { uk_or_non_uk: 'non_uk', country: 'FR', current_step: :country } }
 
         it 'redirects to the subject step' do
-          expect(wizard.next_step).to be(:subject)
+          expect(wizard.next_step).to be(:type)
         end
       end
 
@@ -193,8 +193,8 @@ RSpec.describe CandidateInterface::DegreeWizard do
         end
       end
 
-      context 'when either uk or non_uk degree and any other degree_level' do
-        let(:degree_params) { { current_step: :subject, uk_or_non_uk: %w[uk non_uk].sample } }
+      context 'when uk degree and any other degree_level' do
+        let(:degree_params) { { current_step: :subject, uk_or_non_uk: 'uk' } }
 
         it 'redirects to the type page' do
           expect(wizard.next_step).to be(:type)
@@ -203,7 +203,7 @@ RSpec.describe CandidateInterface::DegreeWizard do
     end
 
     context 'type step' do
-      let(:degree_params) { { current_step: :type } }
+      let(:degree_params) { { current_step: :type, uk_or_non_uk: 'uk' } }
 
       it 'redirects to university page' do
         expect(wizard.next_step).to be(:university)
@@ -372,12 +372,12 @@ RSpec.describe CandidateInterface::DegreeWizard do
       end
 
       context 'when a uk degree is changed to international' do
-        it 'redirects to subject step' do
+        it 'redirects to type step' do
           wizard.current_step = :country
           wizard.uk_or_non_uk = 'non_uk'
           wizard.country = 'France'
 
-          expect(wizard.next_step).to eq(:subject)
+          expect(wizard.next_step).to eq(:type)
         end
       end
 

--- a/spec/system/candidate_interface/entering_details/degrees/backlinks_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/backlinks_spec.rb
@@ -33,10 +33,14 @@ RSpec.describe 'Degrees' do
     when_i_click_to_change_my_country
     and_i_choose_another_country
     and_i_click_on_save_and_continue
+    and_i_fill_the_type_of_degree
+    and_i_click_on_save_and_continue
     and_i_fill_in_a_subject
     and_i_click_on_save_and_continue
     and_i_click_the_back_link
     then_i_am_taken_back_to_the_subject_page
+    and_i_click_the_back_link
+    then_i_am_taken_back_to_the_type_page
     and_i_click_the_back_link
     then_i_am_taken_back_to_the_country_page
     and_i_click_the_back_link
@@ -141,12 +145,20 @@ RSpec.describe 'Degrees' do
     select 'France'
   end
 
+  def and_i_fill_the_type_of_degree
+    fill_in 'candidate_interface_degree_wizard[international_type]', with: 'Bachelor'
+  end
+
   def and_i_fill_in_a_subject
     select 'History', from: 'candidate_interface_degree_wizard[subject]'
   end
 
   def then_i_am_taken_back_to_the_subject_page
     expect(page).to have_content('What subject is your degree?')
+  end
+
+  def then_i_am_taken_back_to_the_type_page
+    expect(page).to have_content('What type of degree is it?')
   end
 
   def then_i_am_taken_back_to_the_country_page

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_editing_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_editing_degrees_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'Editing a degree' do
     then_i_see_my_chosen_undergraduate_country
     when_i_change_my_undergraduate_country_to_another_country
     and_i_click_on_save_and_continue
-    then_i_can_check_my_undergraduate_subject_has_been_cleared
+    then_i_can_check_my_undergraduate_degree_type_has_been_cleared
 
     when_i_click_to_change_my_undergraduate_degree_type_again
     and_i_change_my_degree_to_another_masters_degree_type
@@ -244,9 +244,9 @@ RSpec.describe 'Editing a degree' do
     expect(page).to have_content RecruitmentCycle.current_year.to_s
   end
 
-  def then_i_can_check_my_undergraduate_subject_has_been_cleared
-    expect(page).to have_content 'What subject is your degree?'
-    expect(selected_option_for_field('What subject is your degree?')).to be_nil
+  def then_i_can_check_my_undergraduate_degree_type_has_been_cleared
+    expect(page).to have_content('What type of degree is it?')
+    expect(page.find_field('candidate-interface-degree-wizard-international-type-field').value).to be_nil
   end
 
   def and_i_click_on_continue

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_editing_international_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_editing_international_degrees_spec.rb
@@ -54,9 +54,9 @@ RSpec.describe 'Editing a degree' do
     and_i_answer_that_i_have_a_university_degree
     when_i_select_another_country
     and_i_click_on_save_and_continue
-    when_i_fill_in_the_subject
-    and_i_click_on_save_and_continue
     when_i_fill_in_the_type_of_degree
+    and_i_click_on_save_and_continue
+    when_i_fill_in_the_subject
     and_i_click_on_save_and_continue
     when_i_fill_in_the_university
     and_i_click_on_save_and_continue

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degree_without_a_grade_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degree_without_a_grade_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe 'Entering an international doctorate degree' do
     when_i_view_the_degree_section
     and_i_answer_that_i_have_a_university_degree
     and_i_select_another_country
-    and_i_fill_in_the_subject
     and_i_fill_in_the_type_of_degree
+    and_i_fill_in_the_subject
     and_i_fill_in_the_university
     and_i_choose_whether_degree_is_completed
     and_i_select_no_grade_was_given

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degree_without_an_enic_reason_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degree_without_an_enic_reason_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe 'Entering an international doctorate degree' do
 
     and_i_answer_that_i_have_a_university_degree
     and_i_select_another_country
-    and_i_fill_in_the_subject
     and_i_fill_in_the_type_of_degree
+    and_i_fill_in_the_subject
     and_i_fill_in_the_university
     and_i_choose_whether_degree_is_completed
     and_i_select_no_grade_was_given

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degrees_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe 'Entering an international degree' do
     when_i_select_another_country
     and_i_click_on_save_and_continue
 
-    # Add subject
-    then_i_can_see_the_subject_page
-    when_i_fill_in_the_subject
-    and_i_click_on_save_and_continue
-
     # Add degree type
     then_i_can_see_the_type_page
     when_i_fill_in_the_type_of_degree
+    and_i_click_on_save_and_continue
+
+    # Add subject
+    then_i_can_see_the_subject_page
+    when_i_fill_in_the_subject
     and_i_click_on_save_and_continue
 
     # Add university

--- a/spec/system/temporarily_editable_sections_spec.rb
+++ b/spec/system/temporarily_editable_sections_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe 'Unlocking non editable sections temporarily via support' do
     choose 'Another country'
     select 'Brazil', from: 'Country or territory'
     and_i_click_save_and_continue
-    expect(page).to have_current_path(candidate_interface_degree_subject_path)
+    expect(page).to have_current_path(candidate_interface_degree_type_path)
   end
 
   def and_candidate_can_edit_english_gcse


### PR DESCRIPTION
## Context

Currently when adding a UK degree, the first step after choosing the country is the type of degree.

When adding a non UK degree, the first step is the subject of the degree.

This commit changes the non UK degree journey so that the first step is the type of degree. Bringing both journeys steps in line. Swapping subject with type.

## Changes proposed in this pull request

Changes to the insane next_step method for degree wizard

## Guidance to review

Go on review app or local and add a UK and non UK degree. The steps should broadly match. With the expectation of the 'sub-type' of a UK degree, there's no equivalent for a non UK degree. Click the back links too.

```
Country -> Type -> Subject -> University -> Grade -> Year
```


https://github.com/user-attachments/assets/7240e348-de4a-47b8-b559-0706e1c3cc5f



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
