### PR TITLE
Added a `make <environment> console` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ shell: get-cluster-credentials ## Actually opens a Rails Console: Open a shell o
 	$(eval NAMESPACE=$(shell jq -r '.namespace' terraform/$(PLATFORM)/workspace_variables/$(APP_ENV).tfvars.json))
 	$(eval APP_ENV=$(shell jq -r '.app_environment' terraform/$(PLATFORM)/workspace_variables/$(APP_ENV).tfvars.json))
 	$(if ${APP_NAME_SUFFIX}, $(eval APP_NAME=apply-${APP_NAME_SUFFIX}-clock-worker), $(eval APP_NAME=apply-${APP_ENV}-clock-worker))
-	kubectl -n ${NAMESPACE} -ti exec "deployment/${APP_NAME}" -- sh -c "cd /app && /usr/local/bin/bundle exec rails console -- --noautocomplete"
+	kubectl -n ${NAMESPACE} -ti exec "deployment/${APP_NAME}" -- /bin/sh
 
 .PHONY: console
 shell: get-cluster-credentials ## Open a Rails console on the app instance on AKS, eg: make qa console

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ edit-infra-secrets: read-keyvault-config install-fetch-config set-azure-account 
 		-e -d azure-key-vault-secret:${KEY_VAULT_NAME}/${KEY_VAULT_INFRA_SECRET_NAME} -f yaml -c
 
 .PHONY: shell
-shell: get-cluster-credentials ## Actually opens a Rails Console: Open a shell on the app instance on AKS, eg: make qa shell
+shell: get-cluster-credentials ## Open a shell on the app instance on AKS, eg: make qa shell
 	$(eval NAMESPACE=$(shell jq -r '.namespace' terraform/$(PLATFORM)/workspace_variables/$(APP_ENV).tfvars.json))
 	$(eval APP_ENV=$(shell jq -r '.app_environment' terraform/$(PLATFORM)/workspace_variables/$(APP_ENV).tfvars.json))
 	$(if ${APP_NAME_SUFFIX}, $(eval APP_NAME=apply-${APP_NAME_SUFFIX}-clock-worker), $(eval APP_NAME=apply-${APP_ENV}-clock-worker))

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,14 @@ edit-infra-secrets: read-keyvault-config install-fetch-config set-azure-account 
 		-e -d azure-key-vault-secret:${KEY_VAULT_NAME}/${KEY_VAULT_INFRA_SECRET_NAME} -f yaml -c
 
 .PHONY: shell
-shell: get-cluster-credentials ## Open a shell on the app instance on AKS, eg: make qa shell
+shell: get-cluster-credentials ## Actually opens a Rails Console: Open a shell on the app instance on AKS, eg: make qa shell
+	$(eval NAMESPACE=$(shell jq -r '.namespace' terraform/$(PLATFORM)/workspace_variables/$(APP_ENV).tfvars.json))
+	$(eval APP_ENV=$(shell jq -r '.app_environment' terraform/$(PLATFORM)/workspace_variables/$(APP_ENV).tfvars.json))
+	$(if ${APP_NAME_SUFFIX}, $(eval APP_NAME=apply-${APP_NAME_SUFFIX}-clock-worker), $(eval APP_NAME=apply-${APP_ENV}-clock-worker))
+	kubectl -n ${NAMESPACE} -ti exec "deployment/${APP_NAME}" -- sh -c "cd /app && /usr/local/bin/bundle exec rails console -- --noautocomplete"
+
+.PHONY: console
+shell: get-cluster-credentials ## Open a Rails console on the app instance on AKS, eg: make qa console
 	$(eval NAMESPACE=$(shell jq -r '.namespace' terraform/$(PLATFORM)/workspace_variables/$(APP_ENV).tfvars.json))
 	$(eval APP_ENV=$(shell jq -r '.app_environment' terraform/$(PLATFORM)/workspace_variables/$(APP_ENV).tfvars.json))
 	$(if ${APP_NAME_SUFFIX}, $(eval APP_NAME=apply-${APP_NAME_SUFFIX}-clock-worker), $(eval APP_NAME=apply-${APP_ENV}-clock-worker))


### PR DESCRIPTION
## Context

Calling `make qa shell` currently creates a Rails console rather than a `shell`

The `shell` command still opens a `console`, this should be updated separately

## Changes proposed in this pull request

This commit adds the `console` command.

## Guidance to review

- Pull branch
- run `make qa console` 
- expect to access a Rails console on the QA environment
- run `make qa shell`
- expect to access a Rails console on the QA environment (no change to current behaviour)
