### PR TITLE
Remove hidden country field on degree#coutry

### DIFF
--- a/app/views/candidate_interface/degrees/degree/new_country.html.erb
+++ b/app/views/candidate_interface/degrees/degree/new_country.html.erb
@@ -7,9 +7,7 @@
   <%= form_with model: @wizard, url: candidate_interface_degree_country_path do |f| %>
     <%= f.govuk_error_summary %>
     <%= f.govuk_radio_buttons_fieldset :uk_or_non_uk, legend: { text: 'Which country was the degree from?', size: 'l' } do %>
-      <%= f.govuk_radio_button :uk_or_non_uk, 'uk', label: { text: 'United Kingdom' }, link_errors: true do %>
-          <%= f.hidden_field :country, value: 'GB' %>
-        <% end %>
+      <%= f.govuk_radio_button :uk_or_non_uk, 'uk', label: { text: 'United Kingdom' }, link_errors: true %>
 
       <%= f.govuk_radio_button :uk_or_non_uk, 'non_uk', label: { text: 'Another country' } do %>
         <%= f.govuk_collection_select :country, select_degree_country_options, :id,


### PR DESCRIPTION
## Context

The hidden `country` field is not actually used. We use `the uk_or_non_uk` radio button field for the country value. This hidden field would add too much padding between the options on the form, making the styling inconsistent to the other pages we have.

Removing it fixes this.

This field has been added here https://github.com/DFE-Digital/apply-for-teacher-training/pull/8956 But we are no longer using it, so we can remove it. We use the `uk_or_non_uk` field https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/app/controllers/candidate_interface/degrees/degree_controller.rb#L74-L76

## Changes proposed in this pull request

Removed hidden field

## Guidance to review

Go on review or local and play with the country radio buttons when adding a degree. Before, the gap between the two radio buttons was too big.

| Before | After |
| ------ | ----- |
| ![Screenshot from 2024-10-25 13-37-26](https://github.com/user-attachments/assets/418252a7-12a8-4f36-a6f2-f1a9e86e3d98) | ![Screenshot from 2024-10-25 13-37-18](https://github.com/user-attachments/assets/9283dbb4-86fc-4261-b5b2-ad8ed0ee981e) |

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
