### PR TITLE
[343] steps toward updating notifications ruby client dependancy

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -15,7 +15,16 @@ class ApplicationMailer < Mail::Notify::Mailer
   end
 
   def notify_email(headers)
-    headers = headers.merge(rails_mailer: mailer_name, rails_mail_template: action_name)
+    set_mailer_details
     view_mail(GENERIC_NOTIFY_TEMPLATE, headers)
+  end
+
+private
+
+  def set_mailer_details
+    message.instance_variable_set(:@rails_mailer, mailer_name)
+    message.instance_variable_set(:@rails_mail_template, action_name)
+    message.class.send(:attr_reader, :rails_mailer)
+    message.class.send(:attr_reader, :rails_mail_template)
   end
 end

--- a/lib/email_log_interceptor.rb
+++ b/lib/email_log_interceptor.rb
@@ -13,8 +13,8 @@ class EmailLogInterceptor
       body: mail.body.encoded,
       notify_reference:,
       application_form_id: mail.header['application_form_id']&.value,
-      mailer: mail.header['rails_mailer'].value,
-      mail_template: mail.header['rails_mail_template'].value,
+      mailer: mail.rails_mailer,
+      mail_template: mail.rails_mail_template,
       delivery_status: mail.perform_deliveries ? 'pending' : 'skipped',
     )
 

--- a/lib/sandbox_interceptor.rb
+++ b/lib/sandbox_interceptor.rb
@@ -1,11 +1,10 @@
 class SandboxInterceptor
-  PROVIDER_EMAIL_ALLOWLIST = %w[fallback_sign_in_email permissions_granted].freeze
+  PROVIDER_EMAIL_ALLOW_LIST = %w[fallback_sign_in_email permissions_granted].freeze
 
   def self.delivering_email(message)
     return unless HostingEnvironment.sandbox_mode?
 
-    if message.header['rails_mailer'].value == 'provider_mailer' &&
-       PROVIDER_EMAIL_ALLOWLIST.exclude?(message.header['rails_mail_template'].value)
+    if message.rails_mailer == 'provider_mailer' && PROVIDER_EMAIL_ALLOW_LIST.exclude?(message.rails_mail_template)
       message.perform_deliveries = false
     end
   end

--- a/spec/lib/email_log_interceptor_spec.rb
+++ b/spec/lib/email_log_interceptor_spec.rb
@@ -21,7 +21,12 @@ RSpec.describe EmailLogInterceptor do
     end
 
     def generate_email
-      Mail::Message.new(to: ['test@example.com'], subject: 'Foo', headers: { rails_mailer: 'foo', rails_mail_template: 'bar' })
+      Mail::Message.new(to: ['test@example.com'], subject: 'Foo') do |message|
+        message.instance_variable_set(:@rails_mailer, 'test-mailer')
+        message.instance_variable_set(:@rails_mail_template, 'test-template')
+        message.class.send(:attr_reader, :rails_mailer)
+        message.class.send(:attr_reader, :rails_mail_template)
+      end
     end
   end
 end

--- a/spec/lib/sandbox_interceptor_spec.rb
+++ b/spec/lib/sandbox_interceptor_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SandboxInterceptor do
   context 'In sandbox mode', :sandbox do
     context 'when rails_mailer is set to provider_mailer' do
       it 'aborts delivery by default' do
-        message = email_with_mailer_and_template_headers('provider_mailer', 'anything')
+        message = email_with_mailer_and_template('provider_mailer', 'anything')
 
         described_class.delivering_email(message)
 
@@ -12,7 +12,7 @@ RSpec.describe SandboxInterceptor do
       end
 
       it 'still permits fallback_sign_in_email' do
-        message = email_with_mailer_and_template_headers('provider_mailer', 'fallback_sign_in_email')
+        message = email_with_mailer_and_template('provider_mailer', 'fallback_sign_in_email')
 
         described_class.delivering_email(message)
 
@@ -20,7 +20,7 @@ RSpec.describe SandboxInterceptor do
       end
 
       it 'still permits permissions granted' do
-        message = email_with_mailer_and_template_headers('provider_mailer', 'permissions_granted')
+        message = email_with_mailer_and_template('provider_mailer', 'permissions_granted')
 
         described_class.delivering_email(message)
 
@@ -29,7 +29,7 @@ RSpec.describe SandboxInterceptor do
     end
 
     it 'allows delivery when rails_mailer is not set to provider_mailer' do
-      message = email_with_mailer_and_template_headers('authentication_mailer', 'sign_in_email')
+      message = email_with_mailer_and_template('authentication_mailer', 'sign_in_email')
 
       described_class.delivering_email(message)
 
@@ -38,7 +38,7 @@ RSpec.describe SandboxInterceptor do
   end
 
   it 'does nothing outside sandbox mode' do
-    message = email_with_mailer_and_template_headers('provider_mailer', 'anything')
+    message = email_with_mailer_and_template('provider_mailer', 'anything')
 
     described_class.delivering_email(message)
 
@@ -46,7 +46,12 @@ RSpec.describe SandboxInterceptor do
   end
 
   # this reflects the standard format emitted by ApplicationMailer
-  def email_with_mailer_and_template_headers(mailer, template)
-    Mail::Message.new(to: ['test@example.com'], subject: 'Foo', headers: { rails_mailer: mailer, rails_mail_template: template })
+  def email_with_mailer_and_template(mailer, template)
+    Mail::Message.new(to: ['test@example.com'], subject: 'Foo') do |message|
+      message.instance_variable_set(:@rails_mailer, mailer)
+      message.instance_variable_set(:@rails_mail_template, template)
+      message.class.send(:attr_reader, :rails_mailer)
+      message.class.send(:attr_reader, :rails_mail_template)
+    end
   end
 end

--- a/spec/services/cancel_interview_spec.rb
+++ b/spec/services/cancel_interview_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe CancelInterview do
       expect(associated_audit.audited_changes.keys).to eq(%w[cancelled_at cancellation_reason])
       expect(associated_audit.audited_changes['cancellation_reason']).to eq([nil, 'There is a global pandemic going on'])
 
-      expect(ActionMailer::Base.deliveries.first['rails-mail-template'].value).to eq('interview_cancelled')
+      expect(ActionMailer::Base.deliveries.first.rails_mail_template).to eq('interview_cancelled')
     end
 
     it 'touches the application choice' do
@@ -93,7 +93,7 @@ RSpec.describe CancelInterview do
       expect { described_class.new(**service_params).save! }
         .to raise_error(ValidationException)
 
-      expect(ActionMailer::Base.deliveries.map { |d| d['rails-mail-template'].value }).not_to include('interview_cancelled')
+      expect(ActionMailer::Base.deliveries.map(&:rails_mail_template)).not_to include('interview_cancelled')
     end
   end
 
@@ -112,7 +112,7 @@ RSpec.describe CancelInterview do
       expect { described_class.new(**service_params).save! }
         .to raise_error(InterviewWorkflowConstraints::WorkflowError)
 
-      expect(ActionMailer::Base.deliveries.map { |d| d['rails-mail-template'].value }).not_to include('interview_cancelled')
+      expect(ActionMailer::Base.deliveries.map(&:rails_mail_template)).not_to include('interview_cancelled')
     end
   end
 end

--- a/spec/services/create_interview_spec.rb
+++ b/spec/services/create_interview_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe CreateInterview do
       )
       expect(associated_audit.audited_changes['location']).to eq('Zoom call')
 
-      expect(ActionMailer::Base.deliveries.first['rails-mail-template'].value).to eq('new_interview')
+      expect(ActionMailer::Base.deliveries.first.rails_mail_template).to eq('new_interview')
     end
 
     it 'touches the application choice' do
@@ -96,7 +96,7 @@ RSpec.describe CreateInterview do
       expect { described_class.new(**service_params).save! }
         .to raise_error(ValidationException)
 
-      expect(ActionMailer::Base.deliveries.map { |d| d['rails-mail-template'].value }).not_to include('new_interview')
+      expect(ActionMailer::Base.deliveries.map(&:rails_mail_template)).not_to include('new_interview')
     end
   end
 
@@ -117,7 +117,7 @@ RSpec.describe CreateInterview do
       expect { described_class.new(**service_params).save! }
         .to raise_error(InterviewWorkflowConstraints::WorkflowError)
 
-      expect(ActionMailer::Base.deliveries.map { |d| d['rails-mail-template'].value }).not_to include('new_interview')
+      expect(ActionMailer::Base.deliveries.map(&:rails_mail_template)).not_to include('new_interview')
     end
   end
 end

--- a/spec/services/decline_offer_spec.rb
+++ b/spec/services/decline_offer_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe DeclineOffer do
     training_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == training_provider_user.email_address }
     ratifying_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == ratifying_provider_user.email_address }
 
-    expect(training_provider_email['rails-mail-template'].value).to eq('declined')
-    expect(ratifying_provider_email['rails-mail-template'].value).to eq('declined')
+    expect(training_provider_email.rails_mail_template).to eq('declined')
+    expect(ratifying_provider_email.rails_mail_template).to eq('declined')
   end
 end

--- a/spec/services/provider_interface/save_condition_statuses_spec.rb
+++ b/spec/services/provider_interface/save_condition_statuses_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ProviderInterface::SaveConditionStatuses do
 
         it 'sends an email to the candidate', :sidekiq do
           service.save!
-          expect(ActionMailer::Base.deliveries.first['rails-mail-template'].value).to eq('conditions_met')
+          expect(ActionMailer::Base.deliveries.first.rails_mail_template).to eq('conditions_met')
         end
 
         # rubocop:disable RSpec/NestedGroups
@@ -117,7 +117,7 @@ RSpec.describe ProviderInterface::SaveConditionStatuses do
 
       it 'sends an email to the candidate', :sidekiq do
         service.save!
-        expect(ActionMailer::Base.deliveries.first['rails-mail-template'].value).to eq('conditions_not_met')
+        expect(ActionMailer::Base.deliveries.first.rails_mail_template).to eq('conditions_not_met')
       end
 
       context 'when the application is not in the pending_conditions state' do

--- a/spec/services/send_new_application_email_to_provider_spec.rb
+++ b/spec/services/send_new_application_email_to_provider_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe SendNewApplicationEmailToProvider, :sidekiq do
     training_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == training_provider_user.email_address }
     ratifying_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == ratifying_provider_user.email_address }
 
-    expect(training_provider_email['rails-mail-template'].value).to eq('application_submitted')
-    expect(ratifying_provider_email['rails-mail-template'].value).to eq('application_submitted')
+    expect(training_provider_email.rails_mail_template).to eq('application_submitted')
+    expect(ratifying_provider_email.rails_mail_template).to eq('application_submitted')
   end
 
   it 'sends a different email when the candidate supplied safeguarding information' do
@@ -32,7 +32,7 @@ RSpec.describe SendNewApplicationEmailToProvider, :sidekiq do
 
     described_class.new(application_choice: choice).call
 
-    email = ActionMailer::Base.deliveries.find { |e| e.header['rails_mail_template'].value == 'application_submitted_with_safeguarding_issues' }
+    email = ActionMailer::Base.deliveries.find { |e| e.rails_mail_template == 'application_submitted_with_safeguarding_issues' }
 
     expect(email).to be_present
   end

--- a/spec/services/update_interview_spec.rb
+++ b/spec/services/update_interview_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe UpdateInterview do
       expect(associated_audit.audited_changes['location'].last).to eq('Zoom call')
       expect(associated_audit.audited_changes['additional_details'].last).to eq('Business casual')
 
-      expect(ActionMailer::Base.deliveries.first['rails-mail-template'].value).to eq('interview_updated')
+      expect(ActionMailer::Base.deliveries.first.rails_mail_template).to eq('interview_updated')
     end
 
     it 'touches the application choice' do
@@ -99,7 +99,7 @@ RSpec.describe UpdateInterview do
       expect { described_class.new(**service_params).save! }
         .to raise_error(ValidationException)
 
-      expect(ActionMailer::Base.deliveries.map { |d| d['rails-mail-template'].value }).not_to include('interview_updated')
+      expect(ActionMailer::Base.deliveries.map(&:rails_mail_template)).not_to include('interview_updated')
     end
   end
 
@@ -120,7 +120,7 @@ RSpec.describe UpdateInterview do
       expect { described_class.new(**service_params).save! }
         .to raise_error(InterviewWorkflowConstraints::WorkflowError)
 
-      expect(ActionMailer::Base.deliveries.map { |d| d['rails-mail-template'].value }).not_to include('interview_updated')
+      expect(ActionMailer::Base.deliveries.map(&:rails_mail_template)).not_to include('interview_updated')
     end
   end
 
@@ -139,7 +139,7 @@ RSpec.describe UpdateInterview do
     it 'does not send emails' do
       described_class.new(**service_params).save!
 
-      expect(ActionMailer::Base.deliveries.map { |d| d['rails-mail-template'].value }).not_to include('interview_updated')
+      expect(ActionMailer::Base.deliveries.map(&:rails_mail_template)).not_to include('interview_updated')
     end
   end
 end

--- a/spec/services/withdraw_application_spec.rb
+++ b/spec/services/withdraw_application_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe WithdrawApplication do
       training_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == training_provider_user.email_address }
       ratifying_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == ratifying_provider_user.email_address }
 
-      expect(training_provider_email['rails-mail-template'].value).to eq('application_withdrawn')
-      expect(ratifying_provider_email['rails-mail-template'].value).to eq('application_withdrawn')
+      expect(training_provider_email.rails_mail_template).to eq('application_withdrawn')
+      expect(ratifying_provider_email.rails_mail_template).to eq('application_withdrawn')
     end
   end
 end

--- a/spec/workers/send_apply_to_another_course_when_inactive_email_to_candidates_batch_worker_spec.rb
+++ b/spec/workers/send_apply_to_another_course_when_inactive_email_to_candidates_batch_worker_spec.rb
@@ -30,6 +30,6 @@ RSpec.describe SendApplyToAnotherCourseWhenInactiveEmailToCandidatesBatchWorker,
 
   def email_template_sent?
     template = 'apply_to_another_course_after_30_working_days'
-    ActionMailer::Base.deliveries.find { |e| e.header['rails_mail_template'].value == template }
+    ActionMailer::Base.deliveries.find { |e| e.rails_mail_template == template }
   end
 end

--- a/spec/workers/send_apply_to_another_course_when_inactive_email_to_candidates_worker_spec.rb
+++ b/spec/workers/send_apply_to_another_course_when_inactive_email_to_candidates_worker_spec.rb
@@ -56,6 +56,6 @@ RSpec.describe SendApplyToAnotherCourseWhenInactiveEmailToCandidatesWorker, :sid
 
   def email_template_sent?
     template = 'apply_to_another_course_after_30_working_days'
-    ActionMailer::Base.deliveries.find { |e| e.header['rails_mail_template'].value == template }
+    ActionMailer::Base.deliveries.find { |e| e.rails_mail_template == template }
   end
 end

--- a/spec/workers/send_apply_to_multiple_courses_when_inactive_email_to_candidates_batch_worker_spec.rb
+++ b/spec/workers/send_apply_to_multiple_courses_when_inactive_email_to_candidates_batch_worker_spec.rb
@@ -31,6 +31,6 @@ RSpec.describe SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesBatchWorke
 
   def email_template_sent?
     template = 'apply_to_multiple_courses_after_30_working_days'
-    ActionMailer::Base.deliveries.find { |e| e.header['rails_mail_template'].value == template }
+    ActionMailer::Base.deliveries.find { |e| e.rails_mail_template == template }
   end
 end

--- a/spec/workers/send_apply_to_multiple_courses_when_inactive_email_to_candidates_worker_spec.rb
+++ b/spec/workers/send_apply_to_multiple_courses_when_inactive_email_to_candidates_worker_spec.rb
@@ -48,6 +48,6 @@ RSpec.describe SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesWorker, :s
 
   def email_template_sent?
     template = 'apply_to_multiple_courses_after_30_working_days'
-    ActionMailer::Base.deliveries.find { |e| e.header['rails_mail_template'].value == template }
+    ActionMailer::Base.deliveries.find { |e| e.rails_mail_template == template }
   end
 end


### PR DESCRIPTION
## Context

Sadly, we cannot actually update to the mail-notify 2.0 for a couple of reasons, but this PR does take us one step closer by removing dependency on an unintended behaviour (headers that are actually options and never get passed to notify api)
- The 'preview' method is no longer available in a the test object without mocking the notify response. 
- We have a [Capybara](https://github.com/dxw/mail-notify/issues/167) dependancy that the update breaks. It's a known issue, when it is fixed, it will go someway toward fixing the first one

Worth noting it's does appear that after this change, it's only the test suite that the update breaks, not the actual functionality.  

We'll probably need to wait until further updates to upgrade.

## Changes proposed in this pull request

- stop storing mail template and mailer as 'headers'

## Guidance to review

NA

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
