### PR TITLE
Fix degree form when changing countries and backing off

### DIFF
--- a/app/forms/candidate_interface/degree_wizard.rb
+++ b/app/forms/candidate_interface/degree_wizard.rb
@@ -271,7 +271,7 @@ module CandidateInterface
 
     def persist!
       existing_degree = ApplicationQualification.find_by(id:)
-      if existing_degree.present?
+      if existing_degree.present? && all_attributes_for_persistence_present?
         existing_degree.update(attributes_for_persistence)
         clear_state!
       elsif all_attributes_for_persistence_present?

--- a/spec/forms/candidate_interface/degree_wizard_spec.rb
+++ b/spec/forms/candidate_interface/degree_wizard_spec.rb
@@ -1077,13 +1077,25 @@ RSpec.describe CandidateInterface::DegreeWizard do
   describe '#persist' do
     let(:application_form) { create(:application_form) }
     let!(:application_qualification) { create(:degree_qualification, award_year: '2014') }
-    let(:degree_params) { { id: application_qualification.id, award_year: '2011', application_form_id: application_form.id } }
+    let(:degree_params) do
+      {
+        id: application_qualification.id,
+        application_form_id: application_form.id,
+        uk_or_non_uk: 'uk',
+        subject: 'History',
+        start_year: '2007',
+        award_year: '2011',
+        type: 'Bachelor of Arts',
+        university: 'Manchester',
+        grade: 'Pass',
+      }
+    end
 
     before do
       allow(store).to receive(:delete)
     end
 
-    context 'updates degree if it exists' do
+    context 'updates degree if it exists and all necessary fields are present' do
       it 'attribute is changed' do
         expect { wizard.persist! }.not_to(change { ApplicationQualification.count })
         application_qualification.reload


### PR DESCRIPTION
## Context

There's an edge case when editing a candidate edits a degree

If they edit the country and click the back link and select the old country they already have and save. The form would have cleared the degree type, subject and university information.

Asking for the user to input this information again is valid as the degree types, etc don't match when you change the countries.

But if you go back through the form and select the country you originally have, the form should not erase your degree type, subject and university choices.

This commit fixes this. By validating that the data is there before saving it to the ApplicationQualification record.

## Changes proposed in this pull request

Change logic when saving to DB

## Guidance to review

Go on review app or local, on a candidate with a UK degree.
Change the country of that degree and click the back button until you get to select the country again.
Select UK.
You should still have your degree type, subject and university saved on the degree.

## Before

https://github.com/user-attachments/assets/dfedd3c0-a12e-4528-87bc-8f45a9eb1066



## After

https://github.com/user-attachments/assets/9f5ee32a-f8e7-4c06-bf17-d9ab1b4423d0





## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
