### PR TITLE
Updated wording for "QTS with PGDE" qualifications

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -187,7 +187,7 @@ class Course < ApplicationRecord
 
     case qualifications.sort
     in ['pgce', 'qts'] then 'QTS with PGCE'
-    in ['pgde', 'qts'] then 'PGDE with QTS'
+    in ['pgde', 'qts'] then 'QTS with PGDE'
     in ['qts', 'undergraduate_degree'] then description
     else
       qualifications.first.upcase
@@ -197,7 +197,7 @@ class Course < ApplicationRecord
   def description_to_s
     # This terminology comes directly from Publish API inside the description
     # and we need to invert when we show in Apply.
-    @description_to_s ||= description.to_s.gsub('PGCE with QTS', 'QTS with PGCE')
+    @description_to_s ||= description.to_s.gsub('PGCE with QTS', 'QTS with PGCE').gsub('PGDE with QTS', 'QTS with PGDE')
   end
 
   def undergraduate?

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe Course do
     context 'when contains pgde with qts' do
       let(:description) { 'PGDE with QTS, full time or part time' }
 
-      it { is_expected.to eq(course.description) }
+      it { is_expected.to eq('QTS with PGDE, full time or part time') }
     end
   end
 
@@ -268,7 +268,7 @@ RSpec.describe Course do
     context 'when [qts pgde]' do
       let(:qualifications) { %w[qts pgde] }
 
-      it { is_expected.to eq('PGDE with QTS') }
+      it { is_expected.to eq('QTS with PGDE') }
     end
 
     context 'when [qts]' do


### PR DESCRIPTION
## Context

The text "PGDE with QTS" does not match up with other services and should be reworded to "QTS with PGDE". 
This is inline with the Find & Publish services and the GiT website. 

## Changes proposed in this pull request

We are using `gsub` in the description to ensure previous Courses receive the updated wording without migrating. This matches the implementation of the "QTS with PGCE" rewording.

Both `description_to_s` and `qualifications_to_s` methods are used only for displaying text.

## Guidance to review

- Check usages 
