### PR TITLE
Remove date and time from maintenance page.

### DIFF
--- a/maintenance_page/html/index.html
+++ b/maintenance_page/html/index.html
@@ -56,7 +56,7 @@
             <h1 class="govuk-heading-l">This service is currently unavailable</h1>
             <p class="govuk-body">Sorry, this service is not available right now</p>
             <p class="govuk-body">You cannot use the service at the moment because we are carrying out essential maintenance.</p>
-            <p class="govuk-body">Please try again later. We estimate that the service will be back online by 8am on Tuesday 29 October 2024.</p>
+            <p class="govuk-body">Please try again later.</p>
             <p class="govuk-body">If you entered information recently it may not have been saved. Please check your information once the service is back online.</p>
             <p class="govuk-body">If you have any questions, email us at<br>
               <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.


### PR DESCRIPTION
## Context

We want to avoid having outdated information on our maintenance page

## Changes proposed in this pull request

- Removes the date and time that the service is expected to be back online

## Guidance to review

- n/a