### PR TITLE
Revert grouping dependabots

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,6 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
-    groups:
-      ruby-dependencies:
-        applies-to: version-updates
-        update-types:
-          - minor
-          - patch
     ignore:
       - dependency-name: audited
       - dependency-name: faker
@@ -18,15 +12,8 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: weekly
-      day: sunday
+      interval: daily
     open-pull-requests-limit: 10
-    groups:
-      javascript-dependencies:
-        applies-to: version-updates
-        update-types:
-          - minor
-          - patch
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
## Context

We thought grouping dependabots would make managing them easier, but it makes it harder to determine which ones are breaking the tests without individual commits. 

## Changes proposed in this pull request

Let's go back to the way it was!

## Guidance to review

NA

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
