### PR TITLE
Add safe validator for support edit on application

### DIFF
--- a/app/forms/support_interface/application_forms/delete_reference_form.rb
+++ b/app/forms/support_interface/application_forms/delete_reference_form.rb
@@ -3,14 +3,16 @@ module SupportInterface
     class DeleteReferenceForm
       include ActiveModel::Model
 
-      attr_accessor :reference, :accept_guidance, :audit_comment_ticket
+      attr_accessor :reference, :accept_guidance, :audit_comment_ticket, :application_form
 
       validates :accept_guidance, presence: true
       validates :audit_comment_ticket, presence: true
       validates_with ZendeskUrlValidator
+      validates_with SafeChoiceUpdateValidator
 
       def save(actor:, reference:)
         @reference = reference
+        @application_form = reference.application_form
 
         return false unless valid?
 

--- a/app/forms/support_interface/application_forms/edit_applicant_details_form.rb
+++ b/app/forms/support_interface/application_forms/edit_applicant_details_form.rb
@@ -14,6 +14,7 @@ module SupportInterface
       validates :date_of_birth, date: { presence: true, date_of_birth: true }
       validates :phone_number, presence: true, phone_number: true
       validates :audit_comment, presence: true
+      validates_with SafeChoiceUpdateValidator
 
       def initialize(application_form)
         @application_form = application_form

--- a/app/forms/support_interface/application_forms/edit_becoming_a_teacher_form.rb
+++ b/app/forms/support_interface/application_forms/edit_becoming_a_teacher_form.rb
@@ -3,13 +3,14 @@ module SupportInterface
     class EditBecomingATeacherForm
       include ActiveModel::Model
 
-      attr_accessor :becoming_a_teacher, :audit_comment
+      attr_accessor :becoming_a_teacher, :audit_comment, :application_form
 
       validates :becoming_a_teacher,
                 word_count: { maximum: 600 },
                 presence: true
 
       validates :audit_comment, presence: true
+      validates_with SafeChoiceUpdateValidator
 
       def self.build_from_application(application_form)
         new(
@@ -18,6 +19,7 @@ module SupportInterface
       end
 
       def save(application_form)
+        @application_form = application_form
         return false unless valid?
 
         application_form.update!(

--- a/app/forms/support_interface/application_forms/edit_degree_form.rb
+++ b/app/forms/support_interface/application_forms/edit_degree_form.rb
@@ -9,6 +9,7 @@ module SupportInterface
       validates :start_year, presence: true
       validates :award_year, presence: true
       validates :audit_comment, presence: true
+      validates_with SafeChoiceUpdateValidator
 
       delegate :application_form, :subject, to: :degree
 

--- a/app/forms/support_interface/application_forms/edit_other_qualification_form.rb
+++ b/app/forms/support_interface/application_forms/edit_other_qualification_form.rb
@@ -24,6 +24,7 @@ module SupportInterface
       validates :subject, :grade, length: { maximum: 255 }
       validates :other_uk_qualification_type, length: { maximum: 100 }
       validates_with ZendeskUrlValidator
+      validates_with SafeChoiceUpdateValidator
 
       delegate :application_form, to: :qualification
 

--- a/app/forms/support_interface/application_forms/immigration_status_form.rb
+++ b/app/forms/support_interface/application_forms/immigration_status_form.rb
@@ -4,12 +4,13 @@ module SupportInterface
       include ActiveModel::Model
       include CandidateDetailsHelper
 
-      attr_accessor :immigration_status, :right_to_work_or_study_details, :nationalities, :audit_comment
+      attr_accessor :immigration_status, :right_to_work_or_study_details, :nationalities, :audit_comment, :application_form
 
       validates :immigration_status, presence: true
       validates :right_to_work_or_study_details, presence: true, if: :other_immigration_status?
       validates :right_to_work_or_study_details, word_count: { maximum: 7 }
       validates :audit_comment, presence: true
+      validates_with SafeChoiceUpdateValidator
 
       def self.build_from_application(application_form)
         new(
@@ -20,6 +21,7 @@ module SupportInterface
       end
 
       def save(application_form)
+        @application_form = application_form
         @nationalities = application_form.nationalities
 
         return false unless valid?

--- a/app/forms/support_interface/application_forms/nationalities_form.rb
+++ b/app/forms/support_interface/application_forms/nationalities_form.rb
@@ -8,6 +8,7 @@ module SupportInterface
         :other_nationality1, :other_nationality2, :other_nationality3, :nationalities,
         :audit_comment
       )
+      attr_reader :application_form
 
       validates(
         :first_nationality, :second_nationality, :other_nationality1, :other_nationality2, :other_nationality3,
@@ -15,6 +16,7 @@ module SupportInterface
       )
       validates :audit_comment, presence: true
       validate :candidate_provided_nationality
+      validates_with SafeChoiceUpdateValidator
 
       def self.build_from_application(application_form)
         new(
@@ -23,6 +25,7 @@ module SupportInterface
       end
 
       def save(application_form)
+        @application_form = application_form
         return false unless valid?
 
         nationalities = candidates_nationalities

--- a/app/forms/support_interface/english_gcse_form.rb
+++ b/app/forms/support_interface/english_gcse_form.rb
@@ -45,6 +45,7 @@ module SupportInterface
 
     validates :audit_comment, presence: true
     validates_with ZendeskUrlValidator
+    validates_with SafeChoiceUpdateValidator
 
     validates :grade, presence: true, unless: ->(record) { record.multiple_gcse? || record.missing_qualification? }
     validates :grade, length: { maximum: ApplicationQualification::MAX_QUALIFICATION_GRADE_LENGTH }

--- a/app/forms/support_interface/math_gcse_form.rb
+++ b/app/forms/support_interface/math_gcse_form.rb
@@ -25,6 +25,7 @@ module SupportInterface
 
     validates :audit_comment, presence: true
     validates_with ZendeskUrlValidator
+    validates_with SafeChoiceUpdateValidator
 
     validates :grade, presence: true, unless: :missing_qualification?
     validates :grade, length: { maximum: ApplicationQualification::MAX_QUALIFICATION_GRADE_LENGTH }

--- a/app/forms/support_interface/science_gcse_form.rb
+++ b/app/forms/support_interface/science_gcse_form.rb
@@ -33,6 +33,7 @@ module SupportInterface
 
     validates :audit_comment, presence: true
     validates_with ZendeskUrlValidator
+    validates_with SafeChoiceUpdateValidator
 
     validates :grade, presence: true, unless: ->(record) { record.missing_qualification? || record.gcse? }
     validates :grade, length: { maximum: ApplicationQualification::MAX_QUALIFICATION_GRADE_LENGTH }

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -199,11 +199,15 @@ class ApplicationForm < ApplicationRecord
   def touch_choices
     return unless application_choices.any?
 
-    if earlier_cycle? && prevent_unsave_touches? && !deferred?
+    if cannot_touch_choices?
       raise 'Tried to mark an application choice from a previous cycle as changed'
     end
 
     application_choices.touch_all
+  end
+
+  def cannot_touch_choices?
+    earlier_cycle? && prevent_unsave_touches? && !deferred?
   end
 
   def any_qualification_enic_reason_not_needed?

--- a/app/validators/safe_choice_update_validator.rb
+++ b/app/validators/safe_choice_update_validator.rb
@@ -1,0 +1,10 @@
+class SafeChoiceUpdateValidator < ActiveModel::Validator
+  def validate(record)
+    if record.application_form.cannot_touch_choices?
+      record.errors.add(
+        :base,
+        I18n.t('.validators.safe_choice_update_validator.error_message', current_cycle: RecruitmentCycle.current_year),
+      )
+    end
+  end
+end

--- a/app/views/support_interface/references/destroy.html.erb
+++ b/app/views/support_interface/references/destroy.html.erb
@@ -3,30 +3,32 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">
-      Are you sure you want to delete the reference from <%= @reference.name %>?
-    </h1>
-
-    <p class="govuk-body">
-      This operation cannot be undone.
-    </p>
-
-    <%= render(SummaryCardComponent.new(rows: [
-    {
-      key: 'Reference name',
-      value: @reference.name,
-    },
-    {
-      key: 'Reference email address',
-      value: @reference.email_address,
-    },
-    ])) %>
-
     <%= form_with(
       model: @form,
       url: support_interface_destroy_reference_path(@form.reference),
       method: :post,
     ) do |form_builder| %>
+      <%= form_builder.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        Are you sure you want to delete the reference from <%= @reference.name %>?
+      </h1>
+
+      <p class="govuk-body">
+        This operation cannot be undone.
+      </p>
+
+      <%= render(SummaryCardComponent.new(rows: [
+      {
+        key: 'Reference name',
+        value: @reference.name,
+      },
+      {
+        key: 'Reference email address',
+        value: @reference.email_address,
+      },
+      ])) %>
+
       <%= form_builder.govuk_text_field(
         :audit_comment_ticket,
         label: {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,7 @@
 en:
+  validators:
+    safe_choice_update_validator:
+      error_message: The application must be in the current cycle %{current_cycle}
   continue: Continue
   save_and_continue: Save and continue
   save: Save

--- a/spec/forms/support_interface/application_forms/edit_applicant_details_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/edit_applicant_details_form_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe SupportInterface::ApplicationForms::EditApplicantDetailsForm, typ
     it { is_expected.to validate_length_of(:last_name).is_at_most(60) }
     it { is_expected.to validate_length_of(:email_address).is_at_most(100) }
 
+    it 'validates with SafeChoiceUpdateValidator' do
+      expect(model.class.validators.map(&:class)).to include(SafeChoiceUpdateValidator)
+    end
+
     describe '#date_of_birth' do
       let(:application_form) { build(:application_form, :minimum_info, date_of_birth:) }
       let(:date_of_birth) { nil }

--- a/spec/forms/support_interface/application_forms/edit_becoming_a_teacher_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/edit_becoming_a_teacher_form_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe SupportInterface::ApplicationForms::EditBecomingATeacherForm, :with_audited, type: :model do
+  subject(:form) { described_class.new }
+
+  before do
+    form.application_form = build(:application_form, :minimum_info)
+  end
+
   describe 'validations' do
     it { is_expected.to validate_presence_of(:becoming_a_teacher) }
     it { is_expected.to validate_presence_of(:audit_comment) }
@@ -10,6 +16,10 @@ RSpec.describe SupportInterface::ApplicationForms::EditBecomingATeacherForm, :wi
 
     it { is_expected.to allow_value(valid_text).for(:becoming_a_teacher) }
     it { is_expected.not_to allow_value(invalid_text).for(:becoming_a_teacher) }
+
+    it 'validates with SafeChoiceUpdateValidator' do
+      expect(form.class.validators.map(&:class)).to include(SafeChoiceUpdateValidator)
+    end
   end
 
   describe '.build_from_application' do
@@ -25,7 +35,7 @@ RSpec.describe SupportInterface::ApplicationForms::EditBecomingATeacherForm, :wi
 
   describe '#save' do
     it 'returns false if not valid' do
-      application_form = double
+      application_form = create(:application_form)
       form = described_class.new
 
       expect(form.save(application_form)).to be(false)

--- a/spec/forms/support_interface/application_forms/edit_other_qualification_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/edit_other_qualification_form_spec.rb
@@ -191,5 +191,9 @@ RSpec.describe SupportInterface::ApplicationForms::EditOtherQualificationForm, :
         expect(form).to be_valid
       end
     end
+
+    it 'validates with SafeChoiceUpdateValidator' do
+      expect(form.class.validators.map(&:class)).to include(SafeChoiceUpdateValidator)
+    end
   end
 end

--- a/spec/forms/support_interface/application_forms/immigration_status_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/immigration_status_form_spec.rb
@@ -13,12 +13,18 @@ RSpec.describe SupportInterface::ApplicationForms::ImmigrationStatusForm, type: 
 
   describe 'validations' do
     context 'when immigration_status is other' do
-      before { form.immigration_status = 'other' }
+      before {
+        form.immigration_status = 'other'
+        form.application_form = build(:application_form, :minimum_info)
+      }
 
       it { is_expected.to validate_presence_of(:right_to_work_or_study_details) }
 
       context 'right_to_work_or_study_details is 7 words or less' do
-        before { form.right_to_work_or_study_details = 'This is less than seven words' }
+        before {
+          form.right_to_work_or_study_details = 'This is less than seven words'
+          form.application_form = build(:application_form, :minimum_info)
+        }
 
         it 'is valid' do
           expect(form.valid?).to be true
@@ -46,9 +52,20 @@ RSpec.describe SupportInterface::ApplicationForms::ImmigrationStatusForm, type: 
     end
 
     context 'when immigration_status is NOT other' do
-      before { form.immigration_status = 'eu_settled' }
+      before {
+        form.immigration_status = 'eu_settled'
+        form.application_form = build(:application_form, :minimum_info)
+      }
 
       it { is_expected.not_to validate_presence_of(:right_to_work_or_study_details) }
+    end
+
+    context 'with SafeChoiceUpdateValidator' do
+      before { form.application_form = build(:application_form, :minimum_info) }
+
+      it 'validates with SafeChoiceUpdateValidator' do
+        expect(form.class.validators.map(&:class)).to include(SafeChoiceUpdateValidator)
+      end
     end
   end
 

--- a/spec/forms/support_interface/english_gcse_form_spec.rb
+++ b/spec/forms/support_interface/english_gcse_form_spec.rb
@@ -7,5 +7,9 @@ RSpec.describe SupportInterface::EnglishGcseForm do
 
   describe 'validations' do
     it { is_expected.to validate_length_of(:grade).is_at_most(256) }
+
+    it 'validates with SafeChoiceUpdateValidator' do
+      expect(form.class.validators.map(&:class)).to include(SafeChoiceUpdateValidator)
+    end
   end
 end

--- a/spec/forms/support_interface/math_gcse_form_spec.rb
+++ b/spec/forms/support_interface/math_gcse_form_spec.rb
@@ -7,5 +7,9 @@ RSpec.describe SupportInterface::MathGcseForm do
 
   describe 'validations' do
     it { is_expected.to validate_length_of(:grade).is_at_most(256) }
+
+    it 'validates with SafeChoiceUpdateValidator' do
+      expect(form.class.validators.map(&:class)).to include(SafeChoiceUpdateValidator)
+    end
   end
 end

--- a/spec/forms/support_interface/science_gcse_form_spec.rb
+++ b/spec/forms/support_interface/science_gcse_form_spec.rb
@@ -7,5 +7,9 @@ RSpec.describe SupportInterface::ScienceGcseForm do
 
   describe 'validations' do
     it { is_expected.to validate_length_of(:grade).is_at_most(256) }
+
+    it 'validates with SafeChoiceUpdateValidator' do
+      expect(form.class.validators.map(&:class)).to include(SafeChoiceUpdateValidator)
+    end
   end
 end

--- a/spec/validators/safe_choice_update_validator_spec.rb
+++ b/spec/validators/safe_choice_update_validator_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe SafeChoiceUpdateValidator do
+  before do
+    RequestStore.store[:allow_unsafe_application_choice_touches] = false
+
+    stub_const('Record', Class.new).class_eval do
+      include ActiveModel::Model
+      include ActiveModel::Validations
+
+      attr_accessor :application_form
+      # rubocop:disable RSpec/DescribedClass
+      validates_with SafeChoiceUpdateValidator
+      # rubocop:enable RSpec/DescribedClass
+    end
+  end
+
+  context 'when choices are safe to touch' do
+    it 'does not add an error' do
+      record = Record.new
+      record.application_form = create(:application_form)
+
+      described_class.new.validate(record)
+
+      expect(record).to be_valid
+      expect(record.errors).to be_blank
+    end
+  end
+
+  context 'when choices are not safe to touch' do
+    it 'does add an error' do
+      record = Record.new
+      record.application_form = create(
+        :application_form,
+        recruitment_cycle_year: RecruitmentCycle.previous_year,
+      )
+
+      described_class.new.validate(record)
+
+      expect(record).not_to be_valid
+      expect(record.errors[:base]).to contain_exactly(
+        "The application must be in the current cycle #{RecruitmentCycle.current_year}",
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Context

Often when a support user tries to update an application form that is in
the previous cycle, we raise an exception. This exception was not
handled so the page would break

This is because when updating some [specific columns](https://github.com/DFE-Digital/apply-for-teacher-training/blob/cdabfef3685e788fc337e0b1e2df5b8585662716/app/models/application_form.rb#L177-L187) on the application
form, we touch the choices of that form.

If the application_form is in the `previous cycle`, it's not `deferred` or
the global variable `allow_unsafe_application_choice_touches` is not true
we don't allow the support user to update the application form, by
showing an error to the support user

This is because the provider would not get these updates, so we don't
want them to happen.

I have updated all the forms I could find that would trigger this exception.

## Changes proposed in this pull request

New custom validator
Updated forms that trigger this exception to use the validator
specs

## Guidance to review

Go on review app or local and try to update some information on the application form that's in the previous cycle, some information can be updated without issues.

https://github.com/user-attachments/assets/c41c724a-2aa5-4f2c-a435-262fbddb44e2



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
