### PR TITLE
Remove tda flag from DB

### DIFF
--- a/app/services/data_migrations/remove_tda_flag.rb
+++ b/app/services/data_migrations/remove_tda_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class RemoveTdaFlag
+    TIMESTAMP = 20241108100246
+    MANUAL_RUN = false
+
+    def change
+      Feature.where(name: 'teacher_degree_apprenticeship')&.destroy_all
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveTdaFlag',
   'DataMigrations::DeleteAllOldAudits',
   'DataMigrations::CorrectHesaEthnicity',
   'DataMigrations::BackfillWithdrawalReasons',

--- a/spec/services/data_migrations/remove_tda_flag_spec.rb
+++ b/spec/services/data_migrations/remove_tda_flag_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveTdaFlag do
+  context 'when the feature flags exist' do
+    it 'removes both feature flags' do
+      create(:feature, name: 'teacher_degree_apprenticeship')
+
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: 'teacher_degree_apprenticeship')).to be_blank
+    end
+  end
+
+  context 'when the feature flags have already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end


### PR DESCRIPTION
## Context

The TDA flag has been removed from FeatureFlag service but not from the features tables. This commit removes the TDA from the table.

## Changes proposed in this pull request

Data migration

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
