### PR TITLE
Don't pass nil email address to EmailChecker

### DIFF
--- a/app/components/candidate_interface/application_review_and_submit_component.rb
+++ b/app/components/candidate_interface/application_review_and_submit_component.rb
@@ -44,7 +44,7 @@ module CandidateInterface
       application_form.unsubmitted? &&
         # One or more of the professional references has a personal email address
         application_form.application_references.pluck(:referee_type, :email_address).any? do |referee_type, email_address|
-          referee_type != 'character' && EmailChecker.new(email_address).personal?
+          referee_type != 'character' && email_address.present? && EmailChecker.new(email_address).personal?
         end
     end
 


### PR DESCRIPTION
## Context

In production we have over 12k application references with nil email addresses.

The EmailChecker class expects an email and not a nil value. This creates a few exceptions when a candidate inputs a reference.
 
The form is saved to DB once the candidate adds a name to the reference, if the candidate moves on, the reference is saved in DB, without a email. So this might be a way we got 12k references without an email.

This commit tries to make sure this class doesn't receive a nil parameter.

https://dfe-teacher-services.sentry.io/issues/6047049953/events/ce842c5fdcad4b9d91787920e1098f91/?environment=production&project=1765973&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=previous-event&statsPeriod=24h&stream_index=2

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
