### PR TITLE
[349] Make cycle dates dynamic in performance report page

### DIFF
--- a/app/views/provider_interface/reports/recruitment_performance_reports/_about_this_data_section.html.erb
+++ b/app/views/provider_interface/reports/recruitment_performance_reports/_about_this_data_section.html.erb
@@ -5,7 +5,7 @@
   </h2>
 
   <h3 class="govuk-heading-s">
-    <%= t('about_this_data_section.subsection_heading_one') %>
+    <%= t('about_this_data_section.subsection_heading_one', cycle_range: RecruitmentCycle.cycle_name) %>
   </h3>
   <p class="govuk-body">
     <%= t('about_this_data_section.subsection_one_paragraph_one') %>
@@ -55,7 +55,11 @@
     <%= t('about_this_data_section.subsection_four_paragraph_one') %>
   </p>
   <p class="govuk-body">
-    <%= t('about_this_data_section.subsection_four_paragraph_two') %>
+    <%= t(
+          'about_this_data_section.subsection_four_paragraph_two',
+          last_cycle_start_date: CycleTimetable.find_opens(CycleTimetable.current_year - 1).to_fs(:govuk_date),
+          this_cycle_start_date: CycleTimetable.find_opens.to_fs(:govuk_date),
+        ) %>
   </p>
   <p class="govuk-body">
     <%= t('about_this_data_section.subsection_four_paragraph_three') %>

--- a/app/views/provider_interface/reports/recruitment_performance_reports/_report_description.html.erb
+++ b/app/views/provider_interface/reports/recruitment_performance_reports/_report_description.html.erb
@@ -5,7 +5,7 @@
           date: l(CycleTimetable.find_opens.to_date, format: :long)) %>
   </p>
   <p class="govuk-body">
-    <%= t('show.this_report_will_update', date: l(Date.new(2024, 5, 20), format: :long)) %>
+    <%= t('show.this_report_will_update', date: CycleTimetable.start_of_cycle_week(34).to_fs(:govuk_date)) %>
   </p>
   <p class="govuk-body"><%= t('show.this_report_compares') %></p>
   <h2 class="govuk-heading-m"><%= t('show.contents') %></h2>

--- a/app/views/provider_interface/reports/recruitment_performance_reports/show.html.erb
+++ b/app/views/provider_interface/reports/recruitment_performance_reports/show.html.erb
@@ -1,9 +1,9 @@
-<%= content_for :title, t('show.title') %>
+<%= content_for :title, t('show.title', cycle_year_range: RecruitmentCycle.cycle_name) %>
 <%= content_for :before_content,
-                breadcrumbs(t('page_titles.provider.reports') => provider_interface_reports_path, t('show.heading') => nil) %>
+                breadcrumbs(t('page_titles.provider.reports') => provider_interface_reports_path, t('show.heading', cycle_year_range: RecruitmentCycle.cycle_name) => nil) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= t('show.heading') %></h1>
+    <h1 class="govuk-heading-l"><%= t('show.heading', cycle_year_range: RecruitmentCycle.cycle_name) %></h1>
   </div>
 
   <% if @national_data.present? && @provider_data.present? %>

--- a/config/locales/provider_interface/recruitment_performance_reports.yml
+++ b/config/locales/provider_interface/recruitment_performance_reports.yml
@@ -1,8 +1,8 @@
 en:
   show:
-    title: Recruitment performance weekly report 2023 to 2024 - Apply for teacher training - GOV.UK
+    title: Recruitment performance weekly report %{cycle_year_range} - Apply for teacher training - GOV.UK
     contents: Contents
-    heading: Recruitment performance weekly report 2023 to 2024
+    heading: Recruitment performance weekly report %{cycle_year_range}
     last_updated: 'Last updated: %{date}'
     not_ready_to_view: This report is not ready to view.
     this_report_shows: >
@@ -25,7 +25,7 @@ en:
       Proportion of candidates who have waited more than 30 days for a response
   about_this_data_section:
     section_heading: 1. About this data
-    subsection_heading_one: Changes for the 2023 to 2024 recruitment cycle
+    subsection_heading_one: Changes for the %{cycle_range} recruitment cycle
     subsection_one_paragraph_one: >
       These statistics cover applications in the 2023 to 2024 recruitment cycle for courses in England starting in the
       2024 to 2025 academic year. To allow for comparison, statistics covering the 2022 to 2023 recruitment cycle 2023
@@ -69,7 +69,7 @@ en:
       the publication date is from the first day of the current cycle.
     subsection_four_paragraph_two: >
       This means days in last cycle will not be the same calendar date as days in this cycle. For example, day one of
-      last cycle was on 4 October 2022, but day one of the current cycle was 3 October 2023.
+      last cycle was on %{last_cycle_start_date}, but day one of the current cycle was %{this_cycle_start_date}.
     subsection_four_paragraph_three: >
       These statistics collect data up to and including the day before they were published. The report is published
       weekly on a Monday.

--- a/spec/system/provider_interface/reports/view_provider_recruitment_performance_report_spec.rb
+++ b/spec/system/provider_interface/reports/view_provider_recruitment_performance_report_spec.rb
@@ -109,7 +109,8 @@ private
   end
 
   def then_i_see_no_report_message
-    expect(page).to have_content('Recruitment performance weekly report 2023 to 2024')
+    year_range = RecruitmentCycle.cycle_name(CycleTimetable.current_year)
+    expect(page).to have_content("Recruitment performance weekly report #{year_range}")
     expect(page).to have_content('This report is not ready to view.')
   end
 


### PR DESCRIPTION
## Context

Some of the performance report text has cycle years / dates hard coded. This PR makes those dynamic. 

It does NOT make changes to the content of the 'Changes for the {cycle_range} recruitment cycle' section because presumably we will want to re-write this entirely for changes to the 2024 to 2025 recruitment cycle.

## Changes proposed in this pull request

| Before | After |
| ------- | -------| 
| <img width="612" alt="image" src="https://github.com/user-attachments/assets/aa37d415-74b7-4132-a402-9d4eca168143"> | <img width="606" alt="image" src="https://github.com/user-attachments/assets/ad7d33b3-0d13-496b-8f49-47d1c724fc5f"> |
| <img width="625" alt="image" src="https://github.com/user-attachments/assets/35242339-494f-498a-a2e3-d749df8183e9"> | <img width="618" alt="image" src="https://github.com/user-attachments/assets/6e579d41-5d0d-4e14-b21f-34b5ae2e38bd"> |
| <img width="639" alt="image" src="https://github.com/user-attachments/assets/c5f3f180-b85d-44cc-b9d2-709acde4ba05"> | <img width="621" alt="image" src="https://github.com/user-attachments/assets/475c70f4-9404-4dce-8c57-5d0ea34455b5"> |
| <img width="621" alt="image" src="https://github.com/user-attachments/assets/972faa62-61dc-4f4f-84fa-01d9fc058441"> | <img width="648" alt="image" src="https://github.com/user-attachments/assets/1b412f1e-0470-47a4-a771-c4461aa9d749"> |


## Guidance to review

If you sign in as Cameron Carrot, you can see a report here: https://apply-review-10042.test.teacherservices.cloud/provider/reports/1/recruitment-performance-report (the generation date, cycle week isn't right, but you get the idea)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
