### PR TITLE
Add logit logs for slow provider Activity page request

### DIFF
--- a/app/controllers/provider_interface/activity_log_controller.rb
+++ b/app/controllers/provider_interface/activity_log_controller.rb
@@ -5,12 +5,22 @@ module ProviderInterface
     PAGY_PER_PAGE = 50
 
     def index
-      unless FeatureFlag.active?(:block_provider_activity_log)
-        application_choices = GetApplicationChoicesForProviders.call(
-          providers: current_provider_user.providers,
-        )
-        events = GetActivityLogEvents.call(application_choices:)
-        @pagy, @events = pagy(events, limit: PAGY_PER_PAGE)
+      benchmark = Benchmark.measure do
+        unless FeatureFlag.active?(:block_provider_activity_log)
+          application_choices = GetApplicationChoicesForProviders.call(
+            providers: current_provider_user.providers,
+          )
+          events = GetActivityLogEvents.call(application_choices:)
+          @pagy, @events = pagy(events, limit: PAGY_PER_PAGE)
+        end
+      end
+
+      provider_ids = current_provider_user.providers.ids.join(', ')
+      if benchmark.real.between?(30, 115)
+        Rails.logger.info "Activity page slow for providers [#{provider_ids}] took #{benchmark.real.to_i} seconds"
+      end
+      if benchmark.real > 115
+        Rails.logger.info "Activity page timed out for providers [#{provider_ids}] took #{benchmark.real.to_i} seconds"
       end
     end
   end


### PR DESCRIPTION
## Context

We want to monitor how many providers wait over 115 seconds for the activity page and how many providers wait between 30 seconds and 115 seconds.

We assume provider that wait over 115 seconds are experience time outs. Based on UCL, which times out after about 115 seconds according to logit

## Changes proposed in this pull request

Added benchmark and logs

## Guidance to review

Hard to test this one, I have an example on my local without conditions but with benchmark, it took under 1 seconds 🙃 

![Screenshot from 2024-11-11 12-33-26](https://github.com/user-attachments/assets/0f6b50ea-001e-40cf-aa74-d1683ff37fa6)


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
