### PR TITLE
Improve activity page monitoring

### DIFF
--- a/app/controllers/provider_interface/activity_log_controller.rb
+++ b/app/controllers/provider_interface/activity_log_controller.rb
@@ -15,12 +15,13 @@ module ProviderInterface
         end
       end
 
-      provider_ids = current_provider_user.providers.ids.join(', ')
-      if benchmark.real.between?(30, 115)
-        Rails.logger.info "Activity page slow for providers [#{provider_ids}] took #{benchmark.real.to_i} seconds"
-      end
-      if benchmark.real > 115
-        Rails.logger.info "Activity page timed out for providers [#{provider_ids}] took #{benchmark.real.to_i} seconds"
+      if benchmark.real > 5
+        Rails.logger.info(
+          'Activity page slow for providers',
+          activity_page_response: benchmark.real.round(2),
+          activity_page_timeout: benchmark.real > 115,
+          activity_page_providers: current_provider_user.providers.ids,
+        )
       end
     end
   end


### PR DESCRIPTION
## Context

The previous [PR](https://github.com/DFE-Digital/apply-for-teacher-training/pull/10053) I did to monitor this page was not enough. This PR adds more information to be able to create a dashboard.

`activity_page_response` - response time
`activity_page_timeout` - if the page timed out, this is not an exact metric, it's based on previous response times that experienced time outs, over 115 seconds
`activity_page_providers` - the provider_ids, the activity log can show logs for multiple providers
 

## Changes proposed in this pull request

Added more columns to query in logit

## Guidance to review

I created a dummy dashboard using review data. Is there any other helpful information missing?

![Screenshot from 2024-11-12 10-37-36](https://github.com/user-attachments/assets/0c1f40ca-9dda-4dac-8a76-964d001f7907)



[Dashboard](https://kibana-uk1.logit.io/s/b2876053-0173-44fc-983d-99567292ba31/app/dashboards#/view/c41f3930-a0da-11ef-886b-455689d97b15?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-2h,to:now))&_a=(description:'',filters:!(),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),query:(language:kuery,query:''),timeRestore:!f,title:'Provider%20Activity%20page',viewMode:view))

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
