### PR TITLE
[415] Restrict provider filter to those with courses in recent cycles

### DIFF
--- a/app/services/provider_interface/provider_options_service.rb
+++ b/app/services/provider_interface/provider_options_service.rb
@@ -57,7 +57,7 @@ module ProviderInterface
   private
 
     def recruitment_cycle_year
-      [CycleTimetable.current_year, CycleTimetable.previous_year]
+      RecruitmentCycle.years_visible_to_providers
     end
   end
 end

--- a/app/services/provider_interface/provider_options_service.rb
+++ b/app/services/provider_interface/provider_options_service.rb
@@ -9,11 +9,11 @@ module ProviderInterface
     def accredited_providers
       Provider
         .joins(:accredited_courses)
-        .where(courses: { provider: provider_user.providers })
+        .where(courses: { provider: provider_user.providers, recruitment_cycle_year: })
         .or(
           Provider
             .joins(:accredited_courses)
-            .where(courses: { accredited_provider: provider_user.providers }),
+            .where(courses: { accredited_provider: provider_user.providers, recruitment_cycle_year: }),
         )
         .distinct
     end
@@ -21,11 +21,11 @@ module ProviderInterface
     def providers
       Provider
         .joins(:courses)
-        .where(courses: { accredited_provider: provider_user.providers })
+        .where(courses: { accredited_provider: provider_user.providers, recruitment_cycle_year: })
         .or(
           Provider
             .joins(:courses)
-            .where(courses: { provider: provider_user.providers }),
+            .where(courses: { provider: provider_user.providers, recruitment_cycle_year: }),
         )
         .distinct
     end
@@ -34,12 +34,12 @@ module ProviderInterface
       Provider
         .joins(:courses)
         .where(id: provider_ids)
-        .where(courses: { accredited_provider: provider_user.providers })
+        .where(courses: { accredited_provider: provider_user.providers, recruitment_cycle_year: })
         .or(
           Provider
             .joins(:courses)
             .where(id: provider_ids)
-            .where(courses: { provider: provider_user.providers }),
+            .where(courses: { provider: provider_user.providers, recruitment_cycle_year: }),
         )
         .includes([:sites]).distinct
     end
@@ -52,6 +52,12 @@ module ProviderInterface
             manage_users: true,
           })
         .order(name: :asc)
+    end
+
+  private
+
+    def recruitment_cycle_year
+      [CycleTimetable.current_year, CycleTimetable.previous_year]
     end
   end
 end

--- a/spec/services/provider_interface/provider_options_service_spec.rb
+++ b/spec/services/provider_interface/provider_options_service_spec.rb
@@ -22,11 +22,22 @@ RSpec.describe ProviderInterface::ProviderOptionsService do
       )
     end
 
+    it 'includes providers where the accredited provider is one the user has access to' do
+      create(:course, provider: build(:provider), accredited_provider: @providers[0])
+      expect(described_class.new(@provider_user).accredited_providers).to include(@providers[0])
+    end
+
     it 'returns de-duplicated list of only the accredited providers that the user can access if they are themselves an accredited provider' do
       accredited_provider_user = create(:provider_user, providers: [@accredited_providers[1]])
       expect(described_class.new(accredited_provider_user).accredited_providers).to contain_exactly(
         @accredited_providers[1],
       )
+    end
+
+    it 'does not return accredited providers with courses from recruitment cycles 2 years ago' do
+      accredited_provider = create(:provider)
+      create(:course, provider: @providers[0], accredited_provider:, recruitment_cycle_year: CycleTimetable.current_year - 2)
+      expect(described_class.new(@provider_user).accredited_providers).not_to include(accredited_provider)
     end
   end
 
@@ -36,6 +47,18 @@ RSpec.describe ProviderInterface::ProviderOptionsService do
         @providers[0],
         @providers[1],
       )
+    end
+
+    it 'includes providers if they have a course accredited by one the user has access to' do
+      provider = create(:provider)
+      create(:course, provider:, accredited_provider: @providers[0])
+      expect(described_class.new(@provider_user).providers).to include(provider)
+    end
+
+    it 'does not return providers with courses from recruitment cycles 2 years ago' do
+      provider = create(:provider)
+      create(:course, provider:, accredited_provider: @providers[0], recruitment_cycle_year: CycleTimetable.current_year - 2)
+      expect(described_class.new(@provider_user).providers).not_to include(provider)
     end
 
     it 'returns de-duplicated list of only the providers that the user can access as an accredited provider' do


### PR DESCRIPTION
## Context

Our provider filters show 'Training providers' that are for all courses, associated with the provider. A provider has raised this as an issue as the list is very long and includes training providers with whom they no longer have a relationship. 

Instead, we should only show providers / accredited providers for courses in the recruitment cycles that are visible to providers. (this one and the previous one.

## Changes proposed in this pull request

- Changed the queries in the provider filter service to only fetch providers for courses in this and last recruitment cycle.

https://github.com/user-attachments/assets/9891443b-5123-4bd7-90ee-3dc8905cb68e


## Guidance to review

As in the video, you can create a course where the accredited provider is a provider for which the user has access. 

If you are on main, the provider that is created with the newly course will show up in the training provider list. But if you switch to this branch it will disappear.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
