### PR TITLE
[140] Add unsubscribe message to relevant emails

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -4,6 +4,7 @@ class CandidateMailer < ApplicationMailer
   layout(
     'candidate_email_with_support_footer',
     except: %i[
+      find_has_opened
       nudge_unsubmitted
       nudge_unsubmitted_with_incomplete_courses
       nudge_unsubmitted_with_incomplete_personal_statement

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -1,21 +1,5 @@
 class CandidateMailer < ApplicationMailer
   helper UtmLinkHelper
-
-  layout(
-    'candidate_email_with_support_footer',
-    except: %i[
-      find_has_opened
-      nudge_unsubmitted
-      nudge_unsubmitted_with_incomplete_courses
-      nudge_unsubmitted_with_incomplete_personal_statement
-      nudge_unsubmitted_with_incomplete_references
-      duplicate_match_email
-      application_rejected
-      application_deadline_has_passed
-      respond_to_offer_before_deadline
-      reject_by_default_explainer
-    ],
-  )
   include QualificationValueHelper
 
   def application_choice_submitted(application_choice)

--- a/app/queries/offers_to_chase_query.rb
+++ b/app/queries/offers_to_chase_query.rb
@@ -4,9 +4,12 @@
 class OffersToChaseQuery
   def self.call(chaser_type:, date_range:)
     ApplicationChoice
+      .joins(:candidate)
+      .merge(Candidate.for_marketing_or_nudge_emails) # Filter out candidates who should not receive nudge-like emails
       .offer
       .where.not(id: ChaserSent.send(chaser_type).select(:chased_id).where(chased_type: 'ApplicationChoice'))
       .where(current_recruitment_cycle_year: CycleTimetable.current_year)
       .where('application_choices.offered_at': date_range)
+      .distinct
   end
 end

--- a/app/views/candidate_mailer/_get_help_teacher_training_adviser.text.erb
+++ b/app/views/candidate_mailer/_get_help_teacher_training_adviser.text.erb
@@ -1,0 +1,6 @@
+
+# Get help
+
+If you need support with your application, you can speak to a teacher training adviser. Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'support_footer_on_all_emails', @application_form.phase %>).
+
+<%= t('get_into_teaching.opening_times') %>.

--- a/app/views/candidate_mailer/_unsubscribe_from_emails_like_this.text.erb
+++ b/app/views/candidate_mailer/_unsubscribe_from_emails_like_this.text.erb
@@ -1,0 +1,3 @@
+---
+
+[Unsubscribe from reminder emails like this one](<%= candidate_unsubscribe_link(@application_form.candidate) %>). You will still receive essential updates about your application. You cannot undo this.

--- a/app/views/candidate_mailer/application_choice_submitted.text.erb
+++ b/app/views/candidate_mailer/application_choice_submitted.text.erb
@@ -5,5 +5,4 @@ Hello <%= @application_form.first_name %>
 
 [Sign in to your account to check the progress of your application](<%= @candidate_magic_link %>).
 
-
-  Your training provider will contact you if they would like to organise an interview.
+<%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/application_choice_submitted.text.erb
+++ b/app/views/candidate_mailer/application_choice_submitted.text.erb
@@ -1,8 +1,9 @@
 Hello <%= @application_form.first_name %>
 
-
-  You have submitted an application for <%= @application_choice.course_option.course.name_and_code %> at <%= @application_choice.course_option.course.provider.name %>.
+You have submitted an application for <%= @application_choice.course_option.course.name_and_code %> at <%= @application_choice.course_option.course.provider.name %>.
 
 [Sign in to your account to check the progress of your application](<%= @candidate_magic_link %>).
+
+Your training provider will contact you if they would like to organise an interview.
 
 <%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/apply_to_another_course_after_30_working_days.text.erb
+++ b/app/views/candidate_mailer/apply_to_another_course_after_30_working_days.text.erb
@@ -7,3 +7,5 @@ Candidates who apply for 4 or more courses are more likely to receive an offer.
 [Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>) to apply for another course.
 
 You can also contact <%= @provider_name %> to check on your application.
+
+<%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/apply_to_multiple_courses_after_30_working_days.text.erb
+++ b/app/views/candidate_mailer/apply_to_multiple_courses_after_30_working_days.text.erb
@@ -11,3 +11,5 @@ While you wait for a response on these applications, you can apply to <%= @choic
 Candidates who apply for 4 or more courses are more likely to receive an offer.
 
 [Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>) to apply for another course.
+
+<%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/change_course.text.erb
+++ b/app/views/candidate_mailer/change_course.text.erb
@@ -13,3 +13,5 @@ The new details are:
 ^ Qualification: <%= @qualification %>
 
 If you were not expecting this change, contact <%= @current_course_option.course.provider.name %> to find out more.
+
+<%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/changed_offer.text.erb
+++ b/app/views/candidate_mailer/changed_offer.text.erb
@@ -24,3 +24,5 @@ The new offer is:
 [Sign in to your account to respond to your offer](<%= candidate_magic_link(@application_choice.application_form.candidate) %>).
 
 Contact <%= @current_course_option.course.provider.name %> directly if you have any questions about this.
+
+<%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/chase_reference.text.erb
+++ b/app/views/candidate_mailer/chase_reference.text.erb
@@ -12,3 +12,5 @@ You can sign into your account to:
 [Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>).
 
 <%= @provider_name %> must check your references before they can confirm your place on the course. Contact them if you need help getting references or choosing who to ask.
+
+<%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/chase_reference_again.text.erb
+++ b/app/views/candidate_mailer/chase_reference_again.text.erb
@@ -14,3 +14,5 @@ You can sign into your account to:
 [Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>).
 
 Contact <%= @provider_name %> if you need help getting references or choosing who to ask.
+
+<%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/conditions_met.text.erb
+++ b/app/views/candidate_mailer/conditions_met.text.erb
@@ -1,19 +1,21 @@
 Dear <%= @application_form.first_name %>
 
-  <%= @course.provider.name %> has confirmed that you have met the conditions of your offer.
+<%= @course.provider.name %> has confirmed that you have met the conditions of your offer.
 
-  They’ll let you know if they need further information before you can start training. Contact them if you have any questions.
+They’ll let you know if they need further information before you can start training. Contact them if you have any questions.
 
-  You can sign into your account if you need to check the progress of your reference requests.
+You can sign into your account if you need to check the progress of your reference requests.
 
-  <% if RecruitedWithPendingConditions.new(application_choice: @application_choice).call %>
-  Remember to complete your subject knowledge enhancement (SKE) course to meet the conditions of this offer.
-  <% end %>
+<% if RecruitedWithPendingConditions.new(application_choice: @application_choice).call %>
+Remember to complete your subject knowledge enhancement (SKE) course to meet the conditions of this offer.
+<% end %>
 
-  [Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>).
+[Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>).
 
-  #If you are unable to start training in <%= @start_date %>
+#If you are unable to start training in <%= @start_date %>
 
-  Contact <%= @course.provider.name %> to find out if they’ll allow you to defer your offer. This means that you could start your course a year later.
+Contact <%= @course.provider.name %> to find out if they’ll allow you to defer your offer. This means that you could start your course a year later.
 
-  Asking if it is possible will not affect your existing offer.
+Asking if it is possible will not affect your existing offer.
+
+<%= render'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/conditions_not_met.text.erb
+++ b/app/views/candidate_mailer/conditions_not_met.text.erb
@@ -19,3 +19,5 @@ All you need to do is:
 - find a course and submit another application
 
 [Sign in to apply again](<%= candidate_magic_link(@application_form.candidate) %>).
+
+<%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/conditions_statuses_changed.text.erb
+++ b/app/views/candidate_mailer/conditions_statuses_changed.text.erb
@@ -22,3 +22,5 @@ The following <%= 'condition'.pluralize(@pending_conditions.count) %> still <%= 
 - <%= condition.text %>
 <% end %>
 <% end %>
+
+<%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/decline_last_application_choice.text.erb
+++ b/app/views/candidate_mailer/decline_last_application_choice.text.erb
@@ -3,3 +3,5 @@ Hello <%= @application_form.first_name %>
 You have declined your offer to study <%= @declined_course_name %>.
 
 <%= render 'still_interested_content' %>
+
+<%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/deferred_offer.text.erb
+++ b/app/views/candidate_mailer/deferred_offer.text.erb
@@ -7,3 +7,5 @@ Any conditions for this offer will be confirmed closer to the start date of the 
 <%= @course.provider.name %> will send you an email shortly after October <%= @course.recruitment_cycle_year %>, to confirm the offer.
 
 Contact us if you do not receive a message from <%= @course.provider.name %>.
+
+<%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/deferred_offer_reminder.text.erb
+++ b/app/views/candidate_mailer/deferred_offer_reminder.text.erb
@@ -5,3 +5,5 @@ On <%= @application_choice.offer_deferred_at.to_fs(:govuk_date) %>, <%= @course_
 You will shortly receive an email to confirm the offer. If you do not receive this, you should contact <%= @course_option.course.provider.name %>.
 
 [Sign in to your account to see your deferred offer](<%= candidate_magic_link(@application_choice.application_form.candidate) %>).
+
+<%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/eoc_first_deadline_reminder.text.erb
+++ b/app/views/candidate_mailer/eoc_first_deadline_reminder.text.erb
@@ -14,6 +14,4 @@ If you have questions about your application, you can [get in touch with us on t
 
 You can also [get a teacher training adviser](<%= email_link_with_utm_params I18n.t('get_into_teaching.url_get_an_adviser_start'), 'eoc_deadline_reminder', @application_form.phase %>) for free, one-to-one support to help you write a strong application.
 
----
-
-[Unsubscribe from these emails](<%= candidate_unsubscribe_link(@application_form.candidate) %>). You will still receive essential updates about your application.
+<%= render "unsubscribe_from_emails_like_this" %>

--- a/app/views/candidate_mailer/eoc_second_deadline_reminder.text.erb
+++ b/app/views/candidate_mailer/eoc_second_deadline_reminder.text.erb
@@ -16,6 +16,4 @@ If you’re not ready to apply now, you can continue preparing your application.
 
 <%= "Call #{t("get_into_teaching.tel")}" %> or [chat online](<%= email_link_with_utm_params I18n.t('get_into_teaching.url_online_chat'), 'eoc_deadline_reminder', @application_form.phase %>).
 
----
-
-[Unsubscribe from these emails](<%= candidate_unsubscribe_link(@application_form.candidate) %>). You will still receive essential updates about your application.
+<%= render "unsubscribe_from_emails_like_this" %>

--- a/app/views/candidate_mailer/feedback_received_for_application_rejected_by_default.text.erb
+++ b/app/views/candidate_mailer/feedback_received_for_application_rejected_by_default.text.erb
@@ -11,3 +11,5 @@ They’ve now given you the following feedback:
 <% if @show_apply_again_guidance %>
   If this was useful, [use your feedback to strengthen your application and apply again](<%= @candidate_magic_link %>).
 <% end %>
+
+<%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/find_has_opened.text.erb
+++ b/app/views/candidate_mailer/find_has_opened.text.erb
@@ -22,6 +22,4 @@ Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_
 
 <%= t('get_into_teaching.opening_times') %>.
 
-<% render 'still_interested_content' %>
-
 <%= render 'unsubscribe_from_emails_like_this' %>

--- a/app/views/candidate_mailer/find_has_opened.text.erb
+++ b/app/views/candidate_mailer/find_has_opened.text.erb
@@ -21,3 +21,7 @@ Training providers offer places on courses as people apply throughout the year. 
 Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'find_has_opened', @application_form.phase %>).
 
 <%= t('get_into_teaching.opening_times') %>.
+
+<% render 'still_interested_content' %>
+
+<%= render 'unsubscribe_from_emails_like_this' %>

--- a/app/views/candidate_mailer/interview_cancelled.text.erb
+++ b/app/views/candidate_mailer/interview_cancelled.text.erb
@@ -7,3 +7,5 @@ They’ve given the following reason for cancelling the interview:
 ^ <%= @reason %>
 
 Contact <%= @provider_name %> if you have any questions.
+
+<%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/interview_updated.text.erb
+++ b/app/views/candidate_mailer/interview_updated.text.erb
@@ -21,3 +21,5 @@ Address or online meeting details:
 <% end %>
 
 Contact <%= @provider_name %> if you have any questions. Let them know if you cannot attend the interview.
+
+<%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/new_cycle_has_started.text.erb
+++ b/app/views/candidate_mailer/new_cycle_has_started.text.erb
@@ -20,6 +20,4 @@ All our advisers are experienced former teachers who provide free, one-to-one su
 
 Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'find_has_opened', @application_form.phase %>).
 
----
-
-[Unsubscribe from these emails](<%= candidate_unsubscribe_link(@application_form.candidate) %>). You will still receive essential updates about your application.
+<%= render "unsubscribe_from_emails_like_this" %>

--- a/app/views/candidate_mailer/new_interview.text.erb
+++ b/app/views/candidate_mailer/new_interview.text.erb
@@ -4,7 +4,7 @@ Dear <%= @application_form.first_name %>
 
 The interview is on <%= @interview.date %> at <%= @interview.time %>.
 
-Address or online meeting details: 
+Address or online meeting details:
 
 ^ <%= @interview.location %>
 
@@ -21,3 +21,5 @@ Do you have a teacher training adviser yet? They can help you prepare for your i
 As former teachers, they can also offer insight into teacher training and teaching as a career.
 
 [Get a teacher training adviser](<%= email_link_with_utm_params t('get_into_teaching.url_get_an_adviser_start'), 'new_interview_offered', @application_form.phase %>)
+
+<%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/new_offer_made.text.erb
+++ b/app/views/candidate_mailer/new_offer_made.text.erb
@@ -23,3 +23,5 @@ The training provider will usually pay for the criminal records checks.
 Contact <%= @provider_name %> if you have any questions about this.
 
 [Sign into your account to respond to your offer](<%= candidate_magic_link(@application_form.candidate) %>).
+
+<%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/new_referee_request.text.erb
+++ b/app/views/candidate_mailer/new_referee_request.text.erb
@@ -43,3 +43,5 @@ You can sign into your account to:
 [Sign into your account](<%= candidate_magic_link(@candidate) %>).
 
 <%= @provider_name %> must check your references before they can confirm your place on the course. Contact them if you need help getting references or choosing who to ask.
+
+<%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/nudge_unsubmitted.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted.text.erb
@@ -11,3 +11,5 @@ A teacher training adviser could help with your application, if something is hol
 Alternatively, call 0800 389 2500 or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted', @application_form.phase %>).
 
 Monday to Friday, 8:30am to 5:30pm (except public holidays).
+
+<%= render 'unsubscribe_from_emails_like_this' %>

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_courses.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_courses.text.erb
@@ -17,3 +17,5 @@ If you are training to teach certain secondary subjects (or primary mathematics)
 Alternatively, call 0800 389 2500 or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_with_incomplete_courses', @application_form.phase %>).
 
 Monday to Friday, 8:30am to 5:30pm (except public holidays).
+
+<%= render 'unsubscribe_from_emails_like_this' %>

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_personal_statement.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_personal_statement.text.erb
@@ -11,3 +11,5 @@ A teacher training adviser can help you understand what to put in your personal 
 Alternatively, call 0800 389 2500 or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_with_incomplete_personal_statement', @application_form.phase %>).
 
 Monday to Friday, 8:30am to 5:30pm (except public holidays).
+
+<%= render 'unsubscribe_from_emails_like_this' %>

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references/no_references.text.erb
@@ -27,3 +27,5 @@ A teacher training adviser can give advice on references:
 Alternatively, call 0800 389 2500 or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_no_references', @application_form.phase %>).
 
 Monday to Friday, 8:30am to 5:30pm (except public holidays).
+
+<%= render 'unsubscribe_from_emails_like_this' %>

--- a/app/views/candidate_mailer/offer_10_day.text.erb
+++ b/app/views/candidate_mailer/offer_10_day.text.erb
@@ -10,4 +10,6 @@ Accepting your offer is your first step to becoming an amazing teacher and makin
 
 If you have any questions about your training, you can contact the training provider.
 
+<%= render 'get_help_teacher_training_adviser' %>
+
 <%= render 'unsubscribe_from_emails_like_this' %>

--- a/app/views/candidate_mailer/offer_10_day.text.erb
+++ b/app/views/candidate_mailer/offer_10_day.text.erb
@@ -9,3 +9,5 @@ You should respond to your offer as soon as you can. Most candidates respond to 
 Accepting your offer is your first step to becoming an amazing teacher and making a positive difference.
 
 If you have any questions about your training, you can contact the training provider.
+
+<%= render 'unsubscribe_from_emails_like_this' %>

--- a/app/views/candidate_mailer/offer_20_day.text.erb
+++ b/app/views/candidate_mailer/offer_20_day.text.erb
@@ -8,4 +8,6 @@ You must respond to your offer as soon as you can. Most candidates respond to th
 
 If you have any questions about your training, you can contact the training provider.
 
+<%= render 'get_help_teacher_training_adviser' %>
+
 <%= render 'unsubscribe_from_emails_like_this' %>

--- a/app/views/candidate_mailer/offer_20_day.text.erb
+++ b/app/views/candidate_mailer/offer_20_day.text.erb
@@ -7,3 +7,5 @@ You must respond to your offer as soon as you can. Most candidates respond to th
 [Sign in to your account to respond to your offer](<%= candidate_magic_link(@candidate) %>).
 
 If you have any questions about your training, you can contact the training provider.
+
+<%= render 'unsubscribe_from_emails_like_this' %>

--- a/app/views/candidate_mailer/offer_30_day.text.erb
+++ b/app/views/candidate_mailer/offer_30_day.text.erb
@@ -15,3 +15,5 @@ You can defer your offer and start your course a year later.
 Contact <%= @provider_name %> to ask if it is possible to defer, this will not affect your existing offer.
 
 If your training provider agrees, you will need to accept the offer first.
+
+<%= render 'unsubscribe_from_emails_like_this' %>

--- a/app/views/candidate_mailer/offer_30_day.text.erb
+++ b/app/views/candidate_mailer/offer_30_day.text.erb
@@ -16,4 +16,6 @@ Contact <%= @provider_name %> to ask if it is possible to defer, this will not a
 
 If your training provider agrees, you will need to accept the offer first.
 
+<%= render 'get_help_teacher_training_adviser' %>
+
 <%= render 'unsubscribe_from_emails_like_this' %>

--- a/app/views/candidate_mailer/offer_40_day.text.erb
+++ b/app/views/candidate_mailer/offer_40_day.text.erb
@@ -15,3 +15,5 @@ You can defer your offer and start your course a year later.
 Contact <%= @provider_name %> to ask if it is possible to defer, this will not affect your existing offer.
 
 If your training provider agrees, you will need to accept the offer first.
+
+<%= render 'unsubscribe_from_emails_like_this' %>

--- a/app/views/candidate_mailer/offer_40_day.text.erb
+++ b/app/views/candidate_mailer/offer_40_day.text.erb
@@ -16,4 +16,6 @@ Contact <%= @provider_name %> to ask if it is possible to defer, this will not a
 
 If your training provider agrees, you will need to accept the offer first.
 
+<%= render 'get_help_teacher_training_adviser' %>
+
 <%= render 'unsubscribe_from_emails_like_this' %>

--- a/app/views/candidate_mailer/offer_50_day.text.erb
+++ b/app/views/candidate_mailer/offer_50_day.text.erb
@@ -15,3 +15,5 @@ You can defer your offer and start your course a year later.
 Contact <%= @provider_name %> to ask if it is possible to defer, this will not affect your existing offer.
 
 If your training provider agrees, you will need to accept the offer first.
+
+<%= render 'unsubscribe_from_emails_like_this' %>

--- a/app/views/candidate_mailer/offer_50_day.text.erb
+++ b/app/views/candidate_mailer/offer_50_day.text.erb
@@ -16,4 +16,6 @@ Contact <%= @provider_name %> to ask if it is possible to defer, this will not a
 
 If your training provider agrees, you will need to accept the offer first.
 
+<%= render 'get_help_teacher_training_adviser' %>
+
 <%= render 'unsubscribe_from_emails_like_this' %>

--- a/app/views/candidate_mailer/offer_accepted.text.erb
+++ b/app/views/candidate_mailer/offer_accepted.text.erb
@@ -9,3 +9,4 @@ Your place will be confirmed when:
 
 [Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>) to check the progress of your reference requests and offer conditions.
 
+<%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/offer_withdrawn.text.erb
+++ b/app/views/candidate_mailer/offer_withdrawn.text.erb
@@ -10,3 +10,5 @@ Contact <%= @provider_name %> directly if you have questions about this.
 # You can apply again
 
 <%= render 'still_interested_content' %>
+
+<%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/reference_received.text.erb
+++ b/app/views/candidate_mailer/reference_received.text.erb
@@ -11,3 +11,5 @@ You can sign into your account to check the progress of your reference requests 
 <% end %>
 
 [Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>).
+
+<%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/reinstated_offer.text.erb
+++ b/app/views/candidate_mailer/reinstated_offer.text.erb
@@ -13,3 +13,5 @@ The course starts in <%= @course_option.course.start_date.to_fs(:month_and_year)
 
   [Sign into your account](<%= candidate_magic_link(@application_choice.application_form.candidate) %>).
 <% end %>
+
+<%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/unconditional_offer_accepted.text.erb
+++ b/app/views/candidate_mailer/unconditional_offer_accepted.text.erb
@@ -7,3 +7,5 @@ You have accepted <%= @provider_name %>’s offer to study <%= @course_name_and_
 They’ll let you know if they need further information before you can start training.
 
 [Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>) to check the progress of your reference requests.
+
+<%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/withdraw_last_application_choice.text.erb
+++ b/app/views/candidate_mailer/withdraw_last_application_choice.text.erb
@@ -3,3 +3,5 @@ Hello <%= @application_form.first_name %>
 You have withdrawn your <%= 'application'.pluralize(@withdrawn_course_names.size) %> for <%= @withdrawn_course_names.to_sentence %>.
 
 <%= render 'still_interested_content' %>
+
+<%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/layouts/candidate_email_with_support_footer.text.erb
+++ b/app/views/layouts/candidate_email_with_support_footer.text.erb
@@ -1,7 +1,3 @@
 <%= yield %>
 
-# Get help
-
-If you need support with your application, you can speak to a teacher training adviser. Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'support_footer_on_all_emails', @application_form.phase %>).
-
-<%= t('get_into_teaching.opening_times') %>.
+<%= render 'candidate_mailer/get_help_teacher_training_adviser' %>

--- a/app/views/layouts/candidate_email_with_support_footer.text.erb
+++ b/app/views/layouts/candidate_email_with_support_footer.text.erb
@@ -1,3 +1,0 @@
-<%= yield %>
-
-<%= render 'candidate_mailer/get_help_teacher_training_adviser' %>

--- a/spec/mailers/candidate_mailer/candidate_mailer_eoc_first_deadline_reminder_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_eoc_first_deadline_reminder_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe CandidateMailer do
         'cycle_details' => "as soon as you can to get on a course starting in the #{RecruitmentCycle.current_year} to #{RecruitmentCycle.next_year} academic year.",
         'details' => "The deadline to submit your application is 6pm on #{CycleTimetable.apply_deadline.to_fs(:govuk_date)}",
       )
+
+      it_behaves_like 'an email with unsubscribe option'
     end
 
     context 'includes utm parameters' do

--- a/spec/mailers/candidate_mailer/candidate_mailer_eoc_second_deadline_reminder_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_eoc_second_deadline_reminder_spec.rb
@@ -13,5 +13,7 @@ RSpec.describe CandidateMailer do
       'cycle_details' => "you’ll be able to apply for courses starting in the #{RecruitmentCycle.cycle_name(RecruitmentCycle.next_year)} academic year.",
       'details' => "You must submit your application by #{I18n.l(CycleTimetable.apply_deadline.to_date, format: :no_year)} if you want to start teacher training this year.",
     )
+
+    it_behaves_like 'an email with unsubscribe option'
   end
 end

--- a/spec/mailers/candidate_mailer/candidate_mailer_find_has_opened_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_find_has_opened_spec.rb
@@ -13,5 +13,7 @@ RSpec.describe CandidateMailer do
       'academic_year' => "#{CycleTimetable.current_year} to #{CycleTimetable.next_year}",
       'details' => 'Find your courses',
     )
+
+    it_behaves_like 'an email with unsubscribe option'
   end
 end

--- a/spec/mailers/candidate_mailer/candidate_mailer_new_cycle_has_started_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_new_cycle_has_started_spec.rb
@@ -13,5 +13,7 @@ RSpec.describe CandidateMailer do
       'academic_year' => "You can now apply for teacher training courses that start in the #{CycleTimetable.current_year} to #{CycleTimetable.next_year} academic year.",
       'details' => 'Courses can fill up quickly, so apply as soon as you are ready.',
     )
+
+    it_behaves_like 'an email with unsubscribe option'
   end
 end

--- a/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_spec.rb
@@ -11,5 +11,7 @@ RSpec.describe CandidateMailer do
       'Get last-minute advice about your teacher training application',
       'greeting' => 'Dear Fred',
     )
+
+    it_behaves_like 'an email with unsubscribe option'
   end
 end

--- a/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_with_incomplete_courses_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_with_incomplete_courses_spec.rb
@@ -11,5 +11,7 @@ RSpec.describe CandidateMailer do
       'Get help choosing a teacher training course',
       'greeting' => 'Hello Fred',
     )
+
+    it_behaves_like 'an email with unsubscribe option'
   end
 end

--- a/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_with_incomplete_references_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_with_incomplete_references_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe CandidateMailer do
         'greeting' => 'Hello Fred',
         'content' => 'You have not completed the references section of your teacher training application yet',
       )
+
+      it_behaves_like 'an email with unsubscribe option'
     end
   end
 end

--- a/spec/mailers/candidate_mailer/candidate_mailer_offer_x_day_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_offer_x_day_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe CandidateMailer do
         'heading' => 'Hello Fred',
         'provider name' => 'Brighthurst Technical College',
       )
+
+      it_behaves_like 'an email with unsubscribe option'
     end
 
     describe 'Offer 20 day described_class' do
@@ -38,6 +40,8 @@ RSpec.describe CandidateMailer do
         'heading' => 'Hello Fred',
         'provider name' => 'Brighthurst Technical College',
       )
+
+      it_behaves_like 'an email with unsubscribe option'
     end
 
     describe 'Offer 30 day' do
@@ -49,6 +53,8 @@ RSpec.describe CandidateMailer do
         'heading' => 'Hello Fred',
         'provider name' => 'Brighthurst Technical College',
       )
+
+      it_behaves_like 'an email with unsubscribe option'
     end
 
     describe 'Offer 40 day' do
@@ -60,6 +66,8 @@ RSpec.describe CandidateMailer do
         'heading' => 'Hello Fred',
         'provider name' => 'Brighthurst Technical College',
       )
+
+      it_behaves_like 'an email with unsubscribe option'
     end
 
     describe 'Offer 50 day' do
@@ -71,6 +79,8 @@ RSpec.describe CandidateMailer do
         'heading' => 'Hello Fred',
         'provider name' => 'Brighthurst Technical College',
       )
+
+      it_behaves_like 'an email with unsubscribe option'
     end
   end
 end

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -555,7 +555,7 @@ private
   end
 
   def reference_at_offer
-    @application_form = FactoryBot.create(:application_form, :minimum_info, recruitment_cycle_year: 2023, application_choices: [application_choice_pending_conditions])
+    @application_form = FactoryBot.create(:application_form, :minimum_info, application_choices: [application_choice_pending_conditions])
     FactoryBot.create(:reference, application_form: @application_form)
   end
 

--- a/spec/queries/offers_to_chase_query_spec.rb
+++ b/spec/queries/offers_to_chase_query_spec.rb
@@ -21,6 +21,24 @@ RSpec.describe OffersToChaseQuery do
     end
   end
 
+  context 'candidate does not want to receive nudges' do
+    let(:chaser_type) { :offer_10_day }
+    let(:days) { 10 }
+
+    let(:date_range) { (travel_to_base - days.days).all_day }
+    let(:inside_range) { date_range.max - 1.hour }
+    let(:offset) { inside_range }
+
+    before do
+      application_choice_without_chaser.candidate.update(unsubscribed_from_emails: true)
+    end
+
+    it 'does not return any application choices for that candidate even though the application choice is in range' do
+      expect(date_range).to cover(application_choice_without_chaser.offered_at)
+      expect(described_class.call(chaser_type:, date_range:)).to be_empty
+    end
+  end
+
   context 'when offers are made 9 days ago for offer_10_day' do
     let(:chaser_type) { :offer_10_day }
     let(:days) { 10 }

--- a/spec/support/shared_examples/mailers.rb
+++ b/spec/support/shared_examples/mailers.rb
@@ -12,3 +12,11 @@ RSpec.shared_examples 'a mail with subject and content' do |email_subject, conte
     end
   end
 end
+
+RSpec.shared_examples 'an email with unsubscribe option' do
+  it 'has the unsubscribe link' do
+    expect(email.body).to have_content 'You will still receive essential updates about your application. You cannot undo this.'
+    expect(email.body).to have_content 'Unsubscribe from reminder emails like this'
+    expect(email.body).to have_content 'http://localhost:3000/candidate/unsubscribe-from-emails/'
+  end
+end


### PR DESCRIPTION
## Context

It became clear in our end-of-cycle planning that we didn’t have a link for unsubscribing to emails. That’s been added to the codebase now ([see this PR](https://github.com/DFE-Digital/apply-for-teacher-training/pull/9534)).

We've identified which emails should have this link

## Changes proposed in this pull request

This pr 
- Adds the unsubscribe link to the emails where it is required
- Stops us sending the `offer_x_day` nudges to people who are unsubscribed and shouldn't otherwise get emails (locked accounts, etc)
- Moves the 'get help' section to a partial rendered selectively rather than as a footer in a layout - it shouldn't always be the last thing, so the exceptions were starting to get bigger than the rule!

## Guidance to review

Have a look at all the changed emails in the review app. Note that the unsubscribe links in the previews won't actually work since we don't persist the candidate in the database.

- find_has_opened
- nudge_unsubmitted
- nudge_unsubmitted_with_incomplete_courses
- nudge_unsubmitted_with_incomplete_personal_statement
- nudge_unsubmitted_with_incomplete_references
- offer_10_day
- offer_20_day
- offer_30_day
- offer_40_day
- offer_50_day

Also worth clicking around and making sure other previews are rendering as expected. 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
