### PR TITLE
[403] Add realistic job preview text to relevant emails

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -455,10 +455,7 @@ class CandidateMailer < ApplicationMailer
     @application_form = application_form
     email_for_candidate(
       application_form,
-      subject: I18n.t!('candidate_mailer.nudge_unsubmitted_with_incomplete_references.no_references.subject'),
-      layout: false,
-      template_path: 'candidate_mailer/nudge_unsubmitted_with_incomplete_references',
-      template_name: :no_references,
+      subject: I18n.t!('candidate_mailer.nudge_unsubmitted_with_incomplete_references.subject'),
     )
   end
 

--- a/app/views/candidate_mailer/_gain_insights_into_life_as_a_teacher.text.erb
+++ b/app/views/candidate_mailer/_gain_insights_into_life_as_a_teacher.text.erb
@@ -1,4 +1,4 @@
-## Gain insights into life as a teacher
+# Gain insights into life as a teacher
 
 Respond to realistic video scenarios to understand what life in the classroom is like. Get real-time feedback from experienced teachers on your strengths as a potential teacher.
 

--- a/app/views/candidate_mailer/_gain_insights_into_life_as_a_teacher.text.erb
+++ b/app/views/candidate_mailer/_gain_insights_into_life_as_a_teacher.text.erb
@@ -1,0 +1,5 @@
+## Gain insights into life as a teacher
+
+Respond to realistic video scenarios to understand what life in the classroom is like. Get real-time feedback from experienced teachers on your strengths as a potential teacher.
+
+[Try the realistic job preview tool](<%= candidate_realistic_job_preview_link(@application_form.candidate) %>)

--- a/app/views/candidate_mailer/_get_help_teacher_training_adviser.text.erb
+++ b/app/views/candidate_mailer/_get_help_teacher_training_adviser.text.erb
@@ -1,6 +1,2 @@
 
-# Get help
-
-If you need support with your application, you can speak to a teacher training adviser. Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'support_footer_on_all_emails', @application_form.phase %>).
-
-<%= t('get_into_teaching.opening_times') %>.
+<%= render 'candidate_mailer/get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/_get_help_teacher_training_adviser.text.erb
+++ b/app/views/candidate_mailer/_get_help_teacher_training_adviser.text.erb
@@ -1,2 +1,6 @@
 
-<%= render 'candidate_mailer/get_help_teacher_training_adviser' %>
+# Get help
+
+If you need support with your application, you can speak to a teacher training adviser. Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'support_footer_on_all_emails', @application_form.phase %>).
+
+<%= t('get_into_teaching.opening_times') %>.

--- a/app/views/candidate_mailer/_understand_your_professional_strengths.text.erb
+++ b/app/views/candidate_mailer/_understand_your_professional_strengths.text.erb
@@ -1,0 +1,5 @@
+## Understand your professional strengths
+
+Use the realistic job preview tool to respond to video classroom scenarios and receive real-time feedback from experienced teachers.
+
+[Try the realistic job preview tool](<%= candidate_realistic_job_preview_link(@application_form.candidate) %>)

--- a/app/views/candidate_mailer/_understand_your_professional_strengths.text.erb
+++ b/app/views/candidate_mailer/_understand_your_professional_strengths.text.erb
@@ -1,4 +1,4 @@
-## Understand your professional strengths
+# Understand your professional strengths
 
 Use the realistic job preview tool to respond to video classroom scenarios and receive real-time feedback from experienced teachers.
 

--- a/app/views/candidate_mailer/application_rejected.text.erb
+++ b/app/views/candidate_mailer/application_rejected.text.erb
@@ -19,7 +19,7 @@ This year, more people than ever are choosing to apply again.
   <%= render "candidate_mailer/tailored_rejection_advice/#{advice_reason_id}_tailored_advice" %>
 <% end %>
 
-[Try the realistic job preview tool](<%= candidate_realistic_job_preview_link(@application_form.candidate) %>) to get insights into life in the classroom. Respond to video scenarios and get instant feedback on your suitability for a career in teaching.
+<%= render 'understand_your_professional_strengths' %>
 
 [Sign in to apply again](<%= @candidate_magic_link %>).
 

--- a/app/views/candidate_mailer/apply_to_another_course_after_30_working_days.text.erb
+++ b/app/views/candidate_mailer/apply_to_another_course_after_30_working_days.text.erb
@@ -8,4 +8,6 @@ Candidates who apply for 4 or more courses are more likely to receive an offer.
 
 You can also contact <%= @provider_name %> to check on your application.
 
+<%= render 'understand_your_professional_strengths' %>
+
 <%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/apply_to_multiple_courses_after_30_working_days.text.erb
+++ b/app/views/candidate_mailer/apply_to_multiple_courses_after_30_working_days.text.erb
@@ -12,4 +12,6 @@ Candidates who apply for 4 or more courses are more likely to receive an offer.
 
 [Sign into your account](<%= candidate_magic_link(@application_form.candidate) %>) to apply for another course.
 
+<%= render 'understand_your_professional_strengths' %>
+
 <%= render 'get_help_teacher_training_adviser' %>

--- a/app/views/candidate_mailer/eoc_first_deadline_reminder.text.erb
+++ b/app/views/candidate_mailer/eoc_first_deadline_reminder.text.erb
@@ -8,6 +8,8 @@ Dear <%= @application_form.first_name %>
 
 Courses fill up quickly at this time of year.
 
+<%= render 'gain_insights_into_life_as_a_teacher' %>
+
 # Get help
 
 If you have questions about your application, you can [get in touch with us on the phone or through live chat](<%= email_link_with_utm_params I18n.t('get_into_teaching.url_online_chat'), 'eoc_deadline_reminder', @application_form.phase %>).

--- a/app/views/candidate_mailer/eoc_second_deadline_reminder.text.erb
+++ b/app/views/candidate_mailer/eoc_second_deadline_reminder.text.erb
@@ -8,13 +8,13 @@ Dear <%= @application_form.first_name %>
 
 Need help writing a strong application? You can [get a teacher training adviser](<%= email_link_with_utm_params I18n.t('get_into_teaching.url_get_an_adviser_start'), 'eoc_deadline_reminder', @application_form.phase %>) for free, one-to-one support.
 
-## If you’re not ready to submit your application
+# If you’re not ready to submit your application
 
 If you’re not ready to apply now, you can continue preparing your application. <%= "From #{l(CycleTimetable.apply_reopens.to_date, format: :no_year)} you’ll be able to apply for courses starting in the #{RecruitmentCycle.cycle_name(RecruitmentCycle.next_year)} academic year." %>
 
 <%= render 'gain_insights_into_life_as_a_teacher' %>
 
-## Get help
+# Get help
 
 <%= "Call #{t("get_into_teaching.tel")}" %> or [chat online](<%= email_link_with_utm_params I18n.t('get_into_teaching.url_online_chat'), 'eoc_deadline_reminder', @application_form.phase %>).
 

--- a/app/views/candidate_mailer/eoc_second_deadline_reminder.text.erb
+++ b/app/views/candidate_mailer/eoc_second_deadline_reminder.text.erb
@@ -12,6 +12,8 @@ Need help writing a strong application? You can [get a teacher training adviser]
 
 If you’re not ready to apply now, you can continue preparing your application. <%= "From #{l(CycleTimetable.apply_reopens.to_date, format: :no_year)} you’ll be able to apply for courses starting in the #{RecruitmentCycle.cycle_name(RecruitmentCycle.next_year)} academic year." %>
 
+<%= render 'gain_insights_into_life_as_a_teacher' %>
+
 ## Get help
 
 <%= "Call #{t("get_into_teaching.tel")}" %> or [chat online](<%= email_link_with_utm_params I18n.t('get_into_teaching.url_online_chat'), 'eoc_deadline_reminder', @application_form.phase %>).

--- a/app/views/candidate_mailer/find_has_opened.text.erb
+++ b/app/views/candidate_mailer/find_has_opened.text.erb
@@ -22,4 +22,6 @@ Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_
 
 <%= t('get_into_teaching.opening_times') %>.
 
+<% render 'still_interested_content' %>
+
 <%= render 'unsubscribe_from_emails_like_this' %>

--- a/app/views/candidate_mailer/find_has_opened.text.erb
+++ b/app/views/candidate_mailer/find_has_opened.text.erb
@@ -22,6 +22,4 @@ Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_
 
 <%= t('get_into_teaching.opening_times') %>.
 
-<% render 'still_interested_content' %>
-
 <%= render 'unsubscribe_from_emails_like_this' %>

--- a/app/views/candidate_mailer/find_has_opened.text.erb
+++ b/app/views/candidate_mailer/find_has_opened.text.erb
@@ -16,6 +16,8 @@ Training providers offer places on courses as people apply throughout the year. 
 
 [Read how the application process works](<%= candidate_interface_guidance_url %>).
 
+<%= render 'gain_insights_into_life_as_a_teacher' %>
+
 # Get help
 
 Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'find_has_opened', @application_form.phase %>).

--- a/app/views/candidate_mailer/nudge_unsubmitted.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted.text.erb
@@ -12,4 +12,6 @@ Alternatively, call 0800 389 2500 or [chat online](<%= email_link_with_utm_param
 
 Monday to Friday, 8:30am to 5:30pm (except public holidays).
 
+<%= render 'gain_insights_into_life_as_a_teacher' %>
+
 <%= render 'unsubscribe_from_emails_like_this' %>

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_courses.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_courses.text.erb
@@ -18,6 +18,6 @@ Alternatively, call 0800 389 2500 or [chat online](<%= email_link_with_utm_param
 
 Monday to Friday, 8:30am to 5:30pm (except public holidays).
 
-<%= render 'understand_your_professional_strengths' %>
+<%= render 'gain_insights_into_life_as_a_teacher' %>
 
 <%= render 'unsubscribe_from_emails_like_this' %>

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_courses.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_courses.text.erb
@@ -18,4 +18,6 @@ Alternatively, call 0800 389 2500 or [chat online](<%= email_link_with_utm_param
 
 Monday to Friday, 8:30am to 5:30pm (except public holidays).
 
+<%= render 'understand_your_professional_strengths' %>
+
 <%= render 'unsubscribe_from_emails_like_this' %>

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_personal_statement.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_personal_statement.text.erb
@@ -12,4 +12,6 @@ Alternatively, call 0800 389 2500 or [chat online](<%= email_link_with_utm_param
 
 Monday to Friday, 8:30am to 5:30pm (except public holidays).
 
+<%= render 'understand_your_professional_strengths' %>
+
 <%= render 'unsubscribe_from_emails_like_this' %>

--- a/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references.text.erb
+++ b/app/views/candidate_mailer/nudge_unsubmitted_with_incomplete_references.text.erb
@@ -14,9 +14,9 @@ You could choose someone like a manager, a university tutor or a client.
 
 In their reference, they will be asked to:
 
-  - confirm how they know you and how long they’ve known you for
-  - say if they know any reason why you should not work with children
-  - give factual information which can be used to check your application
+- confirm how they know you and how long they’ve known you for
+- say if they know any reason why you should not work with children
+- give factual information which can be used to check your application
 
 # Get help
 
@@ -27,5 +27,7 @@ A teacher training adviser can give advice on references:
 Alternatively, call 0800 389 2500 or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'nudge_unsubmitted_no_references', @application_form.phase %>).
 
 Monday to Friday, 8:30am to 5:30pm (except public holidays).
+
+<%= render 'understand_your_professional_strengths' %>
 
 <%= render 'unsubscribe_from_emails_like_this' %>

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -88,14 +88,7 @@ en:
     nudge_unsubmitted:
       subject: Get last-minute advice about your teacher training application
     nudge_unsubmitted_with_incomplete_references:
-      no_references:
-        subject: Give details of 2 people who can give references
-      one_requested_reference:
-        subject: Request another reference for your teacher training application
-      one_received_reference:
-        subject: Request another reference for your teacher training application
-      two_references:
-        subject: ????
+      subject: Give details of 2 people who can give references
     nudge_unsubmitted_with_incomplete_courses:
       subject: Get help choosing a teacher training course
     nudge_unsubmitted_with_incomplete_personal_statement:

--- a/spec/mailers/candidate_mailer/candidate_mailer_application_rejected_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_application_rejected_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe CandidateMailer do
         'Update on your application',
         'intro' => 'Thank you for your application to study Mathematics at Arithmetic College',
         'rejection reasons' => 'Missing your English GCSE',
+        'realistic job preview heading' => 'Understand your professional strengths',
         'realistic job preview' => 'Try the realistic job preview tool',
         'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
       )

--- a/spec/mailers/candidate_mailer/candidate_mailer_apply_to_another_course_after_30_working_days_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_apply_to_another_course_after_30_working_days_spec.rb
@@ -19,6 +19,9 @@ RSpec.describe CandidateMailer do
       'Increase your chances of receiving an offer for teacher training',
       'greeting' => 'Hello Fred',
       'content' => 'To give yourself the best chance of success, you can apply to another training provider',
+      'realistic job preview heading' => 'Understand your professional strengths',
+      'realistic job preview' => 'Try the realistic job preview tool',
+      'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
     )
   end
 end

--- a/spec/mailers/candidate_mailer/candidate_mailer_apply_to_multiple_courses_after_30_working_days_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_apply_to_multiple_courses_after_30_working_days_spec.rb
@@ -24,6 +24,9 @@ RSpec.describe CandidateMailer do
       'Increase your chances of receiving an offer for teacher training',
       'greeting' => 'Hello Fred',
       'content' => 'While you wait for a response on these applications, you can apply to 4 more courses at different training providers',
+      'realistic job preview heading' => 'Understand your professional strengths',
+      'realistic job preview' => 'Try the realistic job preview tool',
+      'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
     )
   end
 end

--- a/spec/mailers/candidate_mailer/candidate_mailer_eoc_first_deadline_reminder_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_eoc_first_deadline_reminder_spec.rb
@@ -13,6 +13,9 @@ RSpec.describe CandidateMailer do
         'heading' => 'Dear Fred',
         'cycle_details' => "as soon as you can to get on a course starting in the #{RecruitmentCycle.current_year} to #{RecruitmentCycle.next_year} academic year.",
         'details' => "The deadline to submit your application is 6pm on #{CycleTimetable.apply_deadline.to_fs(:govuk_date)}",
+        'realistic job preview heading' => 'Gain insights into life as a teacher',
+        'realistic job preview' => 'Try the realistic job preview tool',
+        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
       )
 
       it_behaves_like 'an email with unsubscribe option'

--- a/spec/mailers/candidate_mailer/candidate_mailer_eoc_second_deadline_reminder_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_eoc_second_deadline_reminder_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe CandidateMailer do
       'heading' => 'Dear Fred',
       'cycle_details' => "you’ll be able to apply for courses starting in the #{RecruitmentCycle.cycle_name(RecruitmentCycle.next_year)} academic year.",
       'details' => "You must submit your application by #{I18n.l(CycleTimetable.apply_deadline.to_date, format: :no_year)} if you want to start teacher training this year.",
+      'realistic job preview heading' => 'Gain insights into life as a teacher',
+      'realistic job preview' => 'Try the realistic job preview tool',
+      'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
     )
 
     it_behaves_like 'an email with unsubscribe option'

--- a/spec/mailers/candidate_mailer/candidate_mailer_find_has_opened_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_find_has_opened_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe CandidateMailer do
       'greeting' => 'Dear Fred',
       'academic_year' => "#{CycleTimetable.current_year} to #{CycleTimetable.next_year}",
       'details' => 'Find your courses',
+      'realistic job preview heading' => 'Gain insights into life as a teacher',
+      'realistic job preview' => 'Try the realistic job preview tool',
+      'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
     )
 
     it_behaves_like 'an email with unsubscribe option'

--- a/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_spec.rb
@@ -10,6 +10,9 @@ RSpec.describe CandidateMailer do
       'a mail with subject and content',
       'Get last-minute advice about your teacher training application',
       'greeting' => 'Dear Fred',
+      'realistic job preview heading' => 'Gain insights into life as a teacher',
+      'realistic job preview' => 'Try the realistic job preview tool',
+      'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
     )
 
     it_behaves_like 'an email with unsubscribe option'

--- a/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_with_incomplete_courses_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_with_incomplete_courses_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CandidateMailer do
       'a mail with subject and content',
       'Get help choosing a teacher training course',
       'greeting' => 'Hello Fred',
-      'realistic job preview heading' => 'Understand your professional strengths',
+      'realistic job preview heading' => 'Gain insights into life as a teacher',
       'realistic job preview' => 'Try the realistic job preview tool',
       'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
     )

--- a/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_with_incomplete_courses_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_with_incomplete_courses_spec.rb
@@ -10,6 +10,9 @@ RSpec.describe CandidateMailer do
       'a mail with subject and content',
       'Get help choosing a teacher training course',
       'greeting' => 'Hello Fred',
+      'realistic job preview heading' => 'Understand your professional strengths',
+      'realistic job preview' => 'Try the realistic job preview tool',
+      'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
     )
 
     it_behaves_like 'an email with unsubscribe option'

--- a/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_with_incomplete_references_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_nudge_unsubmitted_with_incomplete_references_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe CandidateMailer do
         'Give details of 2 people who can give references',
         'greeting' => 'Hello Fred',
         'content' => 'You have not completed the references section of your teacher training application yet',
+        'realistic job preview heading' => 'Understand your professional strengths',
+        'realistic job preview' => 'Try the realistic job preview tool',
+        'realistic job preview link' => /https:\/\/platform\.teachersuccess\.co\.uk\/p\/.*\?id=\w{64}&utm_source/,
       )
 
       it_behaves_like 'an email with unsubscribe option'

--- a/spec/workers/nudge_candidates_worker_spec.rb
+++ b/spec/workers/nudge_candidates_worker_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe NudgeCandidatesWorker, :sidekiq do
 
       described_class.new.perform
       email = email_for_candidate(application_form_without_references.candidate)
-      expect(email.subject).to include(I18n.t!('candidate_mailer.nudge_unsubmitted_with_incomplete_references.no_references.subject'))
+      expect(email.subject).to include(I18n.t!('candidate_mailer.nudge_unsubmitted_with_incomplete_references.subject'))
     end
   end
 


### PR DESCRIPTION
## Context

We want to add the realistic job preview link to some emails. We have two possible paragraphs for this. 

## Changes proposed in this pull request

Added the 'Understand your professional strengths' paragraph to:

- application_rejected
- apply_to_another_course_after_30_working_days
- apply_to_multiple_courses_after_30_working_days
- nudge_unsubmitted_with_incomplete_personal_statement
- nudge_unsubmitted_with_incomplete_references

Added the 'Gain insights...' paragraph to:

- eoc_first_deadline_reminder
- eoc_second_deadline_reminder
- find_has_opened
- nudge_unsubmitted
- nudge_unsubmitted_with_incomplete_courses


## Guidance to review

Have a look at the previews for the above mentioned emails, either in the review app or locally and make sure everything is as expected.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
