### PR TITLE
[339] update rejection emails to include advice for new reasons

### DIFF
--- a/app/presenters/rejection_reasons/rejection_reasons_presenter.rb
+++ b/app/presenters/rejection_reasons/rejection_reasons_presenter.rb
@@ -20,7 +20,7 @@ class RejectionReasons
       course_full
       other
     ].freeze
-    NO_TAILORED_ADVICE_CODES = %w[unsuitable_a_levels unsuitable_degree_subject unverified_equivalency_qualifications].freeze
+    NO_TAILORED_ADVICE_CODES = %w[unsuitable_a_levels unverified_equivalency_qualifications].freeze
 
     def rejection_reasons
       return {} unless structured_rejection_reasons&.any?

--- a/app/presenters/rejection_reasons/rejection_reasons_presenter.rb
+++ b/app/presenters/rejection_reasons/rejection_reasons_presenter.rb
@@ -20,12 +20,7 @@ class RejectionReasons
       course_full
       other
     ].freeze
-    NO_TAILORED_ADVICE_CODES = %w[
-      unsuitable_a_levels
-      unsuitable_degree_subject
-      unverified_equivalency_qualifications
-      already_qualified
-    ].freeze
+    NO_TAILORED_ADVICE_CODES = %w[unsuitable_a_levels unsuitable_degree_subject unverified_equivalency_qualifications].freeze
 
     def rejection_reasons
       return {} unless structured_rejection_reasons&.any?

--- a/app/presenters/rejection_reasons/rejection_reasons_presenter.rb
+++ b/app/presenters/rejection_reasons/rejection_reasons_presenter.rb
@@ -25,7 +25,6 @@ class RejectionReasons
       unsuitable_degree_subject
       unverified_equivalency_qualifications
       already_qualified
-      english_below_standard
     ].freeze
 
     def rejection_reasons

--- a/app/presenters/rejection_reasons/rejection_reasons_presenter.rb
+++ b/app/presenters/rejection_reasons/rejection_reasons_presenter.rb
@@ -9,6 +9,7 @@ class RejectionReasons
     CLASS_ROOM_EXPERIENCE_REASON_CODES = %w[teaching_demonstration teaching_knowledge_other teaching_method_knowledge safeguarding_knowledge teaching_role_knowledge].freeze
     COMMUNICATION_OTHER_REASON_CODES = %w[could_not_arrange_interview did_not_reply communication_and_scheduling_other].freeze
     PLACEMENTS_REASON_CODES = %w[no_placements no_suitable_placements placements_other].freeze
+    UNVERIFIED_QUALIFICATION_CODES = %w[unverified_equivalency_qualifications unverified_qualifications].freeze
     VALID_HIGH_LEVEL_ADVICE_REASON_CODES = %w[
       school_placement
       qualifications
@@ -20,7 +21,7 @@ class RejectionReasons
       course_full
       other
     ].freeze
-    NO_TAILORED_ADVICE_CODES = %w[unsuitable_a_levels unverified_equivalency_qualifications].freeze
+    NO_TAILORED_ADVICE_CODES = %w[unsuitable_a_levels].freeze
 
     def rejection_reasons
       return {} unless structured_rejection_reasons&.any?
@@ -102,6 +103,8 @@ class RejectionReasons
         'communication_and_scheduling_other'
       elsif reason_id.in? PLACEMENTS_REASON_CODES
         'placements_other'
+      elsif reason_id.in? UNVERIFIED_QUALIFICATION_CODES
+        'unverified_qualifications'
       else
         reason_id
       end

--- a/app/presenters/rejection_reasons/rejection_reasons_presenter.rb
+++ b/app/presenters/rejection_reasons/rejection_reasons_presenter.rb
@@ -8,16 +8,24 @@ class RejectionReasons
     PERSONAL_STATEMENT_REJECTION_REASON_CODES = %w[quality_of_writing personal_statement_other].freeze
     CLASS_ROOM_EXPERIENCE_REASON_CODES = %w[teaching_demonstration teaching_knowledge_other teaching_method_knowledge safeguarding_knowledge teaching_role_knowledge].freeze
     COMMUNICATION_OTHER_REASON_CODES = %w[could_not_arrange_interview did_not_reply communication_and_scheduling_other].freeze
-    VALID_HIGH_LEVEL_ADVICE_REASON_CODES = %w[qualifications personal_statement teaching_knowledge communication_and_scheduling safeguarding visa_sponsorship course_full other].freeze
+    PLACEMENTS_REASON_CODES = %w[no_placements no_suitable_placements placements_other].freeze
+    VALID_HIGH_LEVEL_ADVICE_REASON_CODES = %w[
+      school_placement
+      qualifications
+      personal_statement
+      teaching_knowledge
+      communication_and_scheduling
+      safeguarding
+      visa_sponsorship
+      course_full
+      other
+    ].freeze
     NO_TAILORED_ADVICE_CODES = %w[
       unsuitable_a_levels
       unsuitable_degree_subject
       unverified_equivalency_qualifications
       already_qualified
       english_below_standard
-      no_placements
-      no_suitable_placements
-      placements_other
     ].freeze
 
     def rejection_reasons
@@ -98,6 +106,8 @@ class RejectionReasons
         'teaching_knowledge_other'
       elsif reason_id.in? COMMUNICATION_OTHER_REASON_CODES
         'communication_and_scheduling_other'
+      elsif reason_id.in? PLACEMENTS_REASON_CODES
+        'placements_other'
       else
         reason_id
       end

--- a/app/views/candidate_mailer/_application_rejected_get_help.text.erb
+++ b/app/views/candidate_mailer/_application_rejected_get_help.text.erb
@@ -1,11 +1,11 @@
 # Get help
-A teacher training adviser can provide free support to help you improve your application.
-They can support you with:
+A teacher training adviser can provide free support to help you improve your application. They can support you with:
 
 * acting on any feedback
 * making your application stronger
 
 All our advisers have years of teaching experience and know the application process inside and out.
+
 [Learn more about teacher training advisers](<%= t('get_into_teaching.url_get_an_adviser_start') %>).
 
 Call <%= t('get_into_teaching.tel') %> or [chat online](<%= email_link_with_utm_params t('get_into_teaching.url_online_chat'), 'support_footer_on_all_emails', @application_form.phase %>).

--- a/app/views/candidate_mailer/tailored_rejection_advice/_already_qualified_tailored_advice.text.erb
+++ b/app/views/candidate_mailer/tailored_rejection_advice/_already_qualified_tailored_advice.text.erb
@@ -1,0 +1,5 @@
+If you already hold qualified teacher status (QTS) you can [search for teaching vacancies](<%= t('teaching_vacancies.url_home') %>) or [find out more about returning to teach](<%= t('teaching_vacancies.url_return_to_teaching') %>).
+
+You may also be eligible for [assessment only routes into teaching](<%= t('get_into_teaching.url_assessment_only_route_to_qts') %>).
+
+If you qualified as a teacher outside of the UK find out about [teaching in England if you trained overseas](<%= t('get_into_teaching.url_teach_in_england_if_you_trained_overseas') %>).

--- a/app/views/candidate_mailer/tailored_rejection_advice/_english_below_standard_tailored_advice.text.erb
+++ b/app/views/candidate_mailer/tailored_rejection_advice/_english_below_standard_tailored_advice.text.erb
@@ -1,0 +1,5 @@
+## Make sure your English meets the criteria
+
+You can take an English language proficiency test or an equivalency test to show that you meet the standard of a grade 4 General Certificate of Secondary Education (GCSE) in English.
+
+[Find out about the qualifications you need to train to teach in England](<%= t('get_into_teaching.url_non_uk_qualifications') %>)

--- a/app/views/candidate_mailer/tailored_rejection_advice/_placements_other_tailored_advice.text.erb
+++ b/app/views/candidate_mailer/tailored_rejection_advice/_placements_other_tailored_advice.text.erb
@@ -1,0 +1,6 @@
+<% unless CycleTimetable.between_cycles? %>
+<%# Do not be tempted to indent this title. Have a look at the preview if you do. It will no longer be a heading. %>
+## There are still courses with placements available
+
+If the course you applied to has no placements, [you can search again](<%= t('find_teacher_training.production_url') %>). You can try increasing the search radius or location to see more options.
+<% end %>

--- a/app/views/candidate_mailer/tailored_rejection_advice/_school_placement_tailored_advice.text.erb
+++ b/app/views/candidate_mailer/tailored_rejection_advice/_school_placement_tailored_advice.text.erb
@@ -1,0 +1,4 @@
+<% @application_choice.tailored_advice_reasons['school_placement'].each do |advice_reason_id| %>
+<%# Do not be tempted to indent this render. Have a look at the preview if you do. These sections will lose their formatting. %>
+<%= render "candidate_mailer/tailored_rejection_advice/#{advice_reason_id}_tailored_advice" %>
+<% end %>

--- a/app/views/candidate_mailer/tailored_rejection_advice/_unsuitable_degree_subject_tailored_advice.text.erb
+++ b/app/views/candidate_mailer/tailored_rejection_advice/_unsuitable_degree_subject_tailored_advice.text.erb
@@ -1,0 +1,5 @@
+<% unless CycleTimetable.between_cycles? %>
+  You can [search again](<%= t('find_teacher_training.production_url') %>) but make sure you check the degree subject requirements on the course you want to apply for.
+
+  You can try searching for a course that matches the subject of your degree more closely.
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,7 @@ en:
     url_qualifications_you_need_to_teach: https://getintoteaching.education.gov.uk/is-teaching-right-for-me/qualifications-you-need-to-teach
     url_if_you_dont_have_a_degree: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/if-you-dont-have-a-degree
     url_international_candidates: https://getintoteaching.education.gov.uk/non-uk-teachers
+    url_non_uk_qualifications: https://getintoteaching.education.gov.uk/non-uk-teachers/non-uk-qualifications
     url_online_chat: https://getintoteaching.education.gov.uk/help-and-support
     url_references: https://getintoteaching.education.gov.uk/how-to-apply-for-teacher-training/teacher-training-references
     url_subject_knowledge_enhancement: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/subject-knowledge-enhancement

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,9 @@ en:
     production_url: https://find-teacher-training-courses.service.gov.uk/
     sandbox_url: https://sandbox.find-teacher-training-courses.service.gov.uk/
     qa_url: https://qa.find-teacher-training-courses.service.gov.uk/
+  teaching_vacancies:
+    url_home: https://teaching-vacancies.service.gov.uk/
+    url_return_to_teaching: https://teaching-vacancies.service.gov.uk/jobseeker-guides/return-to-teaching-in-england/return-to-teaching/
   get_into_teaching:
     tel: 0800 389 2500
     opening_times: "Monday to Friday, 8:30am to 5:30pm (except public\u00A0holidays)"
@@ -63,6 +66,8 @@ en:
     url_ways_to_train: https://getintoteaching.education.gov.uk/train-to-be-a-teacher
     url_train_without_a_degree: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/if-you-dont-have-a-degree
     url_teacher_degree_apprenticeship: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/teacher-degree-apprenticeships
+    url_assessment_only_route_to_qts: https://getintoteaching.education.gov.uk/train-to-be-a-teacher/assessment-only-route-to-qts
+    url_teach_in_england_if_you_trained_overseas: https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas
   train_to_teach_in_england:
     url: https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration
   register_of_sponsor_licences:

--- a/spec/mailers/candidate_mailer/candidate_mailer_application_rejected_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_application_rejected_spec.rb
@@ -215,6 +215,7 @@ RSpec.describe CandidateMailer do
             { id: 'did_not_reply', label: 'Did not reply to messages' },
             { id: 'did_not_attend_interview', label: 'Did not attend interview' },
             { id: 'could_not_arrange_interview', label: 'Could not arrange interview' },
+            { id: 'english_below_standard', label: 'English language ability below expected standard' },
             { id: 'communication_and_scheduling_other', label: 'Other' },
           ] },
         ],
@@ -232,6 +233,12 @@ RSpec.describe CandidateMailer do
       # Could not arrange interview advice AND Did not reply advice AND Communication and scheduling other advice are the same, only rendered once
       expect(email.body).to have_text('If you are ready to apply again, check your contact details are correct before you submit any more applications.').once
       expect(email.body).to have_text('If you change your mind about a course, you can withdraw your application.').once
+
+      # English below standard advice
+      expect(email.body).to have_text 'Make sure your English meets the criteria'
+      expect(email.body).to have_text 'You can take an English language proficiency test or an equivalency test to show that you meet the standard of a grade 4 General Certificate of Secondary Education (GCSE) in English.'
+      expect(email.body).to have_text 'Find out about the qualifications you need to train to teach in England'
+      expect(email.body).to have_text 'https://getintoteaching.education.gov.uk/non-uk-teachers/non-uk-qualifications'
     end
   end
 

--- a/spec/mailers/candidate_mailer/candidate_mailer_application_rejected_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_application_rejected_spec.rb
@@ -323,6 +323,7 @@ RSpec.describe CandidateMailer do
       selected_reasons: [
         { id: 'qualifications', label: 'Qualifications', selected_reasons: [
           { id: 'unverified_qualifications', label: 'Cant verify' },
+          { id: 'unverified_equivalency_qualifications', label: 'Could not verify equivalency of qualifications' },
         ] },
       ],
     }
@@ -335,6 +336,26 @@ RSpec.describe CandidateMailer do
 
     expect(email.body).to have_text('Showing providers how your qualifications compare to UK ones with a statement of comparability makes you around 30% more likely to receive an offer.').once
     expect(email.body).not_to have_text('You should also be able to request a copy of your degree certificate from the organisation where you studied in the UK.').once
+  end
+
+  it 'shows content for domestic candidates for unverified qualifications reasons' do
+    structured_rejection_reasons = {
+      selected_reasons: [
+        { id: 'qualifications', label: 'Qualifications', selected_reasons: [
+          { id: 'unverified_qualifications', label: 'Cant verify' },
+          { id: 'unverified_equivalency_qualifications', label: 'Could not verify equivalency of qualifications' },
+        ] },
+      ],
+    }
+
+    application_form = create(:application_form, :minimum_info)
+    application_choice = create(:application_choice, :rejected_reasons, structured_rejection_reasons:, application_form: application_form)
+
+    email = described_class.application_rejected(application_choice)
+
+    expect(email.body).to have_text('get a certified statement of your exam results').once
+    expect(email.body).to have_text('You should also be able to request a copy of your degree certificate from the organisation where you studied in the UK.').once
+    expect(email.body).not_to have_text('Showing providers how your qualifications compare to UK ones with a statement of comparability makes you around 30% more likely to receive an offer.').once
   end
 
   describe 'tailored rejection reason for placements' do

--- a/spec/mailers/candidate_mailer/candidate_mailer_application_rejected_spec.rb
+++ b/spec/mailers/candidate_mailer/candidate_mailer_application_rejected_spec.rb
@@ -100,6 +100,7 @@ RSpec.describe CandidateMailer do
             { id: 'no_english_gcse', label: 'No maths GCSE at minimum grade 4 or C, or equivalent' },
             { id: 'no_science_gcse', label: 'No maths GCSE at minimum grade 4 or C, or equivalent' },
             { id: 'no_degree', label: 'No bachelor’s degree or equivalent' },
+            { id: 'already_qualified', label: 'Already has a teaching qualification' },
           ] },
         ],
       }
@@ -113,6 +114,12 @@ RSpec.describe CandidateMailer do
       expect(email.body).to have_text('take your GCSE exams if you do not have them or,').once
       expect(email.body).to have_text('retake them to improve your grades.').once
       expect(email.body).to have_text('You could consider a different route into teaching.').once
+      expect(email.body).to have_text 'If you already hold qualified teacher status (QTS)'
+      expect(email.body).to have_text 'search for teaching vacancies'
+      expect(email.body).to have_text 'https://teaching-vacancies.service.gov.uk/'
+      expect(email.body).to have_text 'https://teaching-vacancies.service.gov.uk/jobseeker-guides/return-to-teaching-in-england/return-to-teaching/'
+      expect(email.body).to have_text 'https://getintoteaching.education.gov.uk/train-to-be-a-teacher/assessment-only-route-to-qts'
+      expect(email.body).to have_text 'https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas'
     end
   end
 

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -670,7 +670,7 @@ private
             {
               id: 'english_below_standard',
               label: 'English language ability below expected standard',
-              details: { id: 'english_below_standard_details', text: 'English language ability below the expected standard.' },
+              details: { id: 'english_below_standard_details', text: 'Consider taking steps to improve your spoken English.' },
             },
             {
               id: 'did_not_attend_interview',

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -147,6 +147,23 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.application_rejected(application_choice)
   end
 
+  def application_rejected_international_unverified
+    application_choice = FactoryBot.create(
+      :application_choice,
+      status: :rejected,
+      structured_rejection_reasons: international_qualifications_rejection_reasons,
+      rejection_reasons_type: 'rejection_reasons',
+    )
+
+    FactoryBot.create(
+      :degree_qualification,
+      enic_reference: nil,
+      institution_country: 'FR',
+      application_form: application_choice.application_form,
+    )
+    CandidateMailer.application_rejected(application_choice)
+  end
+
   def application_rejected_via_api
     application_rejected(:vendor_api_rejection_reasons)
   end
@@ -607,6 +624,25 @@ private
                      application_form:,
                      course_option:,
                      sent_to_provider_at: 1.day.ago)
+  end
+
+  def international_qualifications_rejection_reasons
+    {
+      selected_reasons: [
+        { id: 'qualifications', label: 'Qualifications', selected_reasons: [
+          {
+            id: 'unverified_qualifications',
+            label: 'Could not verify qualifications',
+            details: { id: 'unverified_qualifications_details', text: 'We could not verify your degree.' },
+          },
+          {
+            id: 'unverified_equivalency_qualifications',
+            label: 'Could not verify equivalency of qualifications',
+            details: { id: 'unverified_equivalency_qualifications_details', text: 'We could verify the equivalency of your GCSEs because they are not from the UK.' },
+          },
+        ] },
+      ],
+    }
   end
 
   def rejection_reasons

--- a/spec/presenters/rejection_reasons/rejection_reasons_presenter_spec.rb
+++ b/spec/presenters/rejection_reasons/rejection_reasons_presenter_spec.rb
@@ -108,6 +108,38 @@ RSpec.describe RejectionReasons::RejectionReasonsPresenter do
       end
     end
 
+    describe 'when placement related reasons are selected' do
+      let(:reasons) do
+        {
+          selected_reasons: [
+            {
+              id: 'school_placement',
+              label: 'School placement',
+              selected_reasons: [
+                {
+                  id: 'no_placements',
+                  label: 'No available placements',
+                  details: { id: 'no_placements_details', text: 'No placements reason' },
+                }, {
+                  id: 'no_suitable_placements',
+                  label: 'No placements that are suitable',
+                  details: { id: 'no_suitable_placements_details', text: 'No suitable placements' },
+                }, {
+                  id: 'placements_other',
+                  label: 'Other',
+                  details: { id: 'placements_other_details', text: 'Other placements reason' },
+                }
+              ],
+            },
+          ],
+        }
+      end
+
+      it 'returns no_suitable_placements only' do
+        expect(rejected_application_choice.tailored_advice_reasons).to match({ 'school_placement' => ['placements_other'] })
+      end
+    end
+
     describe 'with multiple gcse rejection reasons' do
       let(:reasons) do
         { selected_reasons: [

--- a/spec/presenters/rejection_reasons/rejection_reasons_presenter_spec.rb
+++ b/spec/presenters/rejection_reasons/rejection_reasons_presenter_spec.rb
@@ -147,12 +147,13 @@ RSpec.describe RejectionReasons::RejectionReasonsPresenter do
             selected_reasons: [{ id: 'no_maths_gcse', label: 'No maths GCSE at minimum grade 4 or C, or equivalent' },
                                { id: 'no_english_gcse', label: 'No english GCSE at minimum grade 4 or C, or equivalent' },
                                { id: 'no_science_gcse', label: 'No english GCSE at minimum grade 4 or C, or equivalent' },
-                               { id: 'already_qualified', label: 'Already has a teaching qualification' }] },
+                               { id: 'already_qualified', label: 'Already has a teaching qualification' },
+                               { id: 'unsuitable_degree_subject', label: 'Degree subject does not meet course requirements' }] },
         ] }
       end
 
       it 'only returns a single "no_gcse" reason code for all gcses,' do
-        expect(rejected_application_choice.tailored_advice_reasons).to eq({ 'qualifications' => %w[no_gcse already_qualified] })
+        expect(rejected_application_choice.tailored_advice_reasons).to eq({ 'qualifications' => %w[no_gcse already_qualified unsuitable_degree_subject] })
       end
     end
 

--- a/spec/presenters/rejection_reasons/rejection_reasons_presenter_spec.rb
+++ b/spec/presenters/rejection_reasons/rejection_reasons_presenter_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe RejectionReasons::RejectionReasonsPresenter do
       end
     end
 
-    describe 'with multiple gcse rejection reasons' do
+    describe 'with multiple qualification rejection reasons' do
       let(:reasons) do
         { selected_reasons: [
           { id: 'qualifications', label: 'Qualifications',
@@ -148,12 +148,16 @@ RSpec.describe RejectionReasons::RejectionReasonsPresenter do
                                { id: 'no_english_gcse', label: 'No english GCSE at minimum grade 4 or C, or equivalent' },
                                { id: 'no_science_gcse', label: 'No english GCSE at minimum grade 4 or C, or equivalent' },
                                { id: 'already_qualified', label: 'Already has a teaching qualification' },
-                               { id: 'unsuitable_degree_subject', label: 'Degree subject does not meet course requirements' }] },
+                               { id: 'unsuitable_degree_subject', label: 'Degree subject does not meet course requirements' },
+                               { id: 'unverified_equivalency_qualifications', label: 'Could not verify equivalency of qualifications' },
+                               { id: 'unverified_qualifications', label: 'Could not verify qualifications' }] },
         ] }
       end
 
-      it 'only returns a single "no_gcse" reason code for all gcses,' do
-        expect(rejected_application_choice.tailored_advice_reasons).to eq({ 'qualifications' => %w[no_gcse already_qualified unsuitable_degree_subject] })
+      it 'only returns a single "no_gcse" reason code for all gcses, and single code for unverified qualifications' do
+        expect(rejected_application_choice.tailored_advice_reasons).to eq(
+          { 'qualifications' => %w[no_gcse already_qualified unsuitable_degree_subject unverified_qualifications] },
+        )
       end
     end
 

--- a/spec/presenters/rejection_reasons/rejection_reasons_presenter_spec.rb
+++ b/spec/presenters/rejection_reasons/rejection_reasons_presenter_spec.rb
@@ -186,6 +186,26 @@ RSpec.describe RejectionReasons::RejectionReasonsPresenter do
       end
     end
 
+    describe 'when communication_and_scheduling_includes english_below_standard' do
+      let(:reasons) do
+        { selected_reasons: [
+          { id: 'communication_and_scheduling', label: 'Communication, interview attendance and scheduling', selected_reasons: [
+            { id: 'could_not_arrange_interview', label: 'Could not arrange interview' },
+            { id: 'communication_and_scheduling_other', label: 'Other' },
+            { id: 'english_below_standard',
+              label: 'English language ability below expected standard',
+              details: { id: 'english_below_standard_details', text: 'details about English language ability' } },
+          ] },
+        ] }
+      end
+
+      it 'includes english_below_standard in nested reasons' do
+        expect(rejected_application_choice.tailored_advice_reasons['communication_and_scheduling']).to match_array(
+          %w[communication_and_scheduling_other english_below_standard],
+        )
+      end
+    end
+
     describe 'when the teaching knowledge selected reasons include classroom experience related reason codes' do
       let(:reasons) do
         { selected_reasons: [

--- a/spec/presenters/rejection_reasons/rejection_reasons_presenter_spec.rb
+++ b/spec/presenters/rejection_reasons/rejection_reasons_presenter_spec.rb
@@ -146,12 +146,13 @@ RSpec.describe RejectionReasons::RejectionReasonsPresenter do
           { id: 'qualifications', label: 'Qualifications',
             selected_reasons: [{ id: 'no_maths_gcse', label: 'No maths GCSE at minimum grade 4 or C, or equivalent' },
                                { id: 'no_english_gcse', label: 'No english GCSE at minimum grade 4 or C, or equivalent' },
-                               { id: 'no_science_gcse', label: 'No english GCSE at minimum grade 4 or C, or equivalent' }] },
+                               { id: 'no_science_gcse', label: 'No english GCSE at minimum grade 4 or C, or equivalent' },
+                               { id: 'already_qualified', label: 'Already has a teaching qualification' }] },
         ] }
       end
 
-      it 'only returns a single "no_gcse" reason code' do
-        expect(rejected_application_choice.tailored_advice_reasons).to eq({ 'qualifications' => ['no_gcse'] })
+      it 'only returns a single "no_gcse" reason code for all gcses,' do
+        expect(rejected_application_choice.tailored_advice_reasons).to eq({ 'qualifications' => %w[no_gcse already_qualified] })
       end
     end
 


### PR DESCRIPTION
## Context

We have recently added some rejection reasons to the UI for providers to select. This PR adds the tailored advice for those selected reasons.

## Changes proposed in this pull request

- Added advice `school_placements` (same for all `no_placements`, `no_suitable_placements`, and `placements_other`)
- Added advice for `english_below_standard`
- Added advice for `already_qualified`
- Added advice for `unsuitable_degree_subject`
- Added advice for `unverified_equivalency_qualifications` (same as `unverified_qualifications`)
- Updated [existing preview](https://apply-review-10069.test.teacherservices.cloud/rails/mailers/candidate_mailer/application_rejected)
- Added [a preview to show the different advice](https://apply-review-10069.test.teacherservices.cloud/rails/mailers/candidate_mailer/application_rejected_international_unverified) that is shown for `unverified_equivalency_qualifications` and `unverified_qualifications` when the candidate has an international qualification.

## Guidance to review

On the [review app](https://apply-review-10069.test.teacherservices.cloud/rails/mailers/candidate_mailer) or locally, have a look at the previews to make sure all the content renders as expected. 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
