### PR TITLE
[422] Bug error handling when selecting a provider

### DIFF
--- a/app/forms/candidate_interface/course_choices/provider_selection_step.rb
+++ b/app/forms/candidate_interface/course_choices/provider_selection_step.rb
@@ -8,13 +8,6 @@ module CandidateInterface
         [:provider_id]
       end
 
-      def provider_cache_key
-        @provider_cache_key ||= begin
-          max_date = [Provider.maximum(:updated_at), Course.current_cycle.exposed_in_find.maximum(:updated_at)].compact.max
-          "provider-list-#{max_date}"
-        end
-      end
-
       def available_providers
         GetAvailableProviders.call
       end

--- a/app/views/candidate_interface/course_choices/provider_selection/new.html.erb
+++ b/app/views/candidate_interface/course_choices/provider_selection/new.html.erb
@@ -6,15 +6,13 @@
     <%= form_with model: @wizard.current_step, url: @wizard.current_step_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <% cache @wizard.current_step.provider_cache_key do %>
-        <%= f.govuk_collection_select(
-              :provider_id,
-              select_provider_options(@wizard.current_step.available_providers),
-              :id,
-              :name,
-              label: { text: t('page_titles.which_provider'), size: 'xl', tag: 'h1' },
-            ) %>
-      <% end %>
+      <%= f.govuk_collection_select(
+            :provider_id,
+            select_provider_options(@wizard.current_step.available_providers),
+            :id,
+            :name,
+            label: { text: t('page_titles.which_provider'), size: 'xl', tag: 'h1' },
+          ) %>
 
       <%= f.govuk_submit t('continue') %>
     <% end %>


### PR DESCRIPTION
## Context

I noticed that the error handling when selecting a provider did not work as expected in production-like environments. The link the the error box did not go anywhere and the input was not formatted for an error. (qa on the left, local development on the right).
<img width="958" alt="image (5)" src="https://github.com/user-attachments/assets/d60c9e88-933c-4477-97c8-5f7f897cc466">

## Changes proposed in this pull request

The reason this wasn't working in production is because we were caching this element client side in production-like environments, but we don't do that in development. 

Because we were caching it, we weren't adding the error wrapper and error id when rendering the page with the error.

I've removed the caching -- tested locally with 800+ providers (there are about 600 in production at the moment) and there is no noticeable performance issue. I don't think caching this drop down is necessary. 

## Guidance to review

Compare the error handling in QA vs the review app -- it should work correctly in the review app. 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
