### PR TITLE
Removes db-query-matchers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -184,7 +184,6 @@ end
 group :development, :test do
   gem 'brakeman'
   gem 'bullet', require: false
-  gem 'db-query-matchers'
   gem 'dotenv-rails', require: false
   gem 'parallel_tests'
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,9 +223,6 @@ GEM
     crass (1.0.6)
     csv (3.3.0)
     date (3.3.4)
-    db-query-matchers (0.14.0)
-      activesupport (>= 4.0, < 8.1)
-      rspec (>= 3.0)
     declarative (0.0.20)
     deepsort (0.5.0)
     devise (4.9.4)
@@ -864,7 +861,6 @@ DEPENDENCIES
   clockwork
   clockwork-test
   colorize
-  db-query-matchers
   deepsort
   devise
   dfe-analytics!

--- a/spec/system/candidate_interface/carry_over/candidate_carries_over_different_application_states_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_carries_over_different_application_states_spec.rb
@@ -172,9 +172,10 @@ RSpec.describe 'Carry over application to a new cycle in different states', time
   end
 
   def then_i_am_on_the_pages_that_is_possible_to_carry_over_an_application
-    expect(page).to have_current_path(
-      candidate_interface_start_carry_over_path,
-    ).or(have_current_path(candidate_interface_application_complete_path))
+    # rubocop:disable Capybara/CurrentPathExpectation
+    expect(page.current_path).to eq(candidate_interface_start_carry_over_path)
+                                   .or(eq(candidate_interface_application_complete_path))
+    # rubocop:enable Capybara/CurrentPathExpectation
   end
 
   def when_i_carry_over


### PR DESCRIPTION
## Context

This is no longer being used

## Changes proposed in this pull request

- Removed db-query-matchers hem

Closes #10064 
