### PR TITLE
Change the closed course message

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -192,7 +192,7 @@ en:
     courses: Courses
     course_choices: Course choices
     full_course: Unfortunately, you cannot apply to %{course_name} because it is now full
-    closed_course: Unfortunately, you cannot apply to %{course_name} because it is now closed
+    closed_course: Unfortunately, you cannot apply to %{course_name} because it is closed
     destroy_course_choice: Are you sure you want to delete this draft application?
     do_you_know: Do you know which course you want to apply to?
     find_a_course: Find a course

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_closed_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_closed_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Selecting a course' do
   end
 
   def then_i_be_on_the_application_choice_closed_page
-    expect(page).to have_content('Unfortunately, you cannot apply to Primary (2XT2) because it is now closed')
+    expect(page).to have_content('Unfortunately, you cannot apply to Primary (2XT2) because it is closed')
   end
 
   def and_i_see_that_i_can_apply_to_a_different_provider


### PR DESCRIPTION
## Context

Removed the 'now' word from our closed course message.

This should be a temporary change. Providers want to show their TDA courses before they are published in find, they can do this by having the course closed but this means that the course will be available to apply in apply, though the candidate will get the closed course message.

We want to remove the word 'now' from the closed course message because it indicates the course was available in the past but it's no longer when in fact, for TDA courses is more like they are not available yet.


## Changes proposed in this pull request

| Before | After |
| ---- | --- |
| ![image](https://github.com/user-attachments/assets/c67c51dd-71d9-4172-80e0-9d4dc961485b) | ![Screenshot from 2024-11-19 16-12-27](https://github.com/user-attachments/assets/ae6b2fb5-4cfe-4dbf-95e1-d179a3229aee) |

## Guidance to review

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
