### PR TITLE
[171] Add feature flag for the reference confidentiality flow

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -35,6 +35,7 @@ class FeatureFlag
     [:continuous_applications, 'The new continuous applications flow', 'James Glenn'],
     [:block_provider_activity_log, 'Block provider activity log if causing problems', 'Lori Bailey'],
     [:block_candidate_sign_in, 'Blocking candidate sign in, used if we are reaching rate limits in Notify', 'Lori Bailey'],
+    [:show_reference_confidentiality_status, 'Control whether the confidentiality status of references is explicitly communicated to candidates, referees and providers', 'Avin Hurry'],
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day


### PR DESCRIPTION
## Context

Adding this feature flag which will allow us to merge PR's relating to this flow without surfacing the changes to the user. This will enable us to switch it all on in one go.

<img width="1132" alt="image" src="https://github.com/user-attachments/assets/bad2336e-354c-4319-a637-2b7340aa2d94">
