### PR TITLE
[460] migration remove unused feature flags

### DIFF
--- a/app/services/data_migrations/remove_unused_feature_flags.rb
+++ b/app/services/data_migrations/remove_unused_feature_flags.rb
@@ -1,0 +1,20 @@
+module DataMigrations
+  class RemoveUnusedFeatureFlags
+    TIMESTAMP = 20241122140221
+    MANUAL_RUN = false
+
+    def change
+      feature_flags = %i[
+        deadline_notices
+        lock_external_report_to_january_2022
+        monthly_statistics_preview
+        reference_nudges
+        sample_applications_factory
+        structured_reference_condition
+        continuous_applications
+        block_candidate_sign_in
+      ]
+      Feature.where(name: feature_flags).delete_all
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveUnusedFeatureFlags',
   'DataMigrations::RemoveTdaFlag',
   'DataMigrations::DeleteAllOldAudits',
   'DataMigrations::CorrectHesaEthnicity',

--- a/spec/services/data_migrations/remove_unused_feature_flags_spec.rb
+++ b/spec/services/data_migrations/remove_unused_feature_flags_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveUnusedFeatureFlags do
+  context 'when the feature flags exist' do
+    let(:feature_flags) do
+      %i[
+        deadline_notices
+        lock_external_report_to_january_2022
+        monthly_statistics_preview
+        reference_nudges
+        sample_applications_factory
+        structured_reference_condition
+        continuous_applications
+        block_candidate_sign_in
+      ]
+    end
+
+    before do
+      feature_flags.each {   |name| create(:feature, name:) }
+
+      create(:feature, name: 'some_other_feature_flag')
+    end
+
+    it 'removes the relevant feature flags' do
+      expect { described_class.new.change }.to change { Feature.count }.by(feature_flags.length * -1)
+      feature_flags.each { |name| expect(Feature.where(name:)).to be_none }
+
+      expect(Feature.where(name: 'some_other_feature_flag')).to be_any
+    end
+  end
+
+  context 'when the feature flags have already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end


### PR DESCRIPTION
## Context

This is the second PR, migration removing unused feature flags. The [first PR is here](https://github.com/DFE-Digital/apply-for-teacher-training/pull/10088). 

## Changes proposed in this pull request

Data migration to remove unused feature flags. It will be rebased and merged after the first one is merged

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
