### PR TITLE
Fix Makefile target conflict

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ shell: get-cluster-credentials ## Open a shell on the app instance on AKS, eg: m
 	kubectl -n ${NAMESPACE} -ti exec "deployment/${APP_NAME}" -- /bin/sh
 
 .PHONY: console
-shell: get-cluster-credentials ## Open a Rails console on the app instance on AKS, eg: make qa console
+console: get-cluster-credentials ## Open a Rails console on the app instance on AKS, eg: make qa console
 	$(eval NAMESPACE=$(shell jq -r '.namespace' terraform/$(PLATFORM)/workspace_variables/$(APP_ENV).tfvars.json))
 	$(eval APP_ENV=$(shell jq -r '.app_environment' terraform/$(PLATFORM)/workspace_variables/$(APP_ENV).tfvars.json))
 	$(if ${APP_NAME_SUFFIX}, $(eval APP_NAME=apply-${APP_NAME_SUFFIX}-clock-worker), $(eval APP_NAME=apply-${APP_ENV}-clock-worker))


### PR DESCRIPTION
## Context

Resolve conflict where `shell` target was defined twice to ensure that both targets work independently without warnings.

<img width="508" alt="image" src="https://github.com/user-attachments/assets/a251b165-9432-4ff5-9d05-d98ef341475d">


## Changes proposed in this pull request

- Rename the second `shell` target to `console` to accurately reflect its purpose of opening a Rails console.

## Guidance to review

You could try it out locally or on the review app.