### PR TITLE
Bug Fix: clicking on option divs always selected first option when e

### DIFF
--- a/app/views/candidate_interface/decisions/withdrawal_feedback.html.erb
+++ b/app/views/candidate_interface/decisions/withdrawal_feedback.html.erb
@@ -15,8 +15,8 @@
     <p class="govuk-body">The reasons you select may be shared with <%= @provider.name %>. They will receive these reasons as anonymous feedback so they will not know it was you.</p>
 
     <%= f.govuk_check_boxes_fieldset :selected_reasons, legend: { text: 'Why are you withdrawing this application? (optional)', size: 'm' }, hint: { text: 'Select all that apply.' }, form_group: { classes: 'govuk-!-margin-bottom-4' } do %>
-      <% @withdrawal_feedback_form.selectable_reasons.each do |reason| %>
-        <%= f.govuk_check_box :selected_reasons, reason[:id], label: { text: reason[:label] }, link_errors: true %>
+      <% @withdrawal_feedback_form.selectable_reasons.each_with_index do |reason, index| %>
+        <%= f.govuk_check_box :selected_reasons, reason[:id], label: { text: reason[:label] }, link_errors: index.zero? %>
       <% end %>
     <% end %>
 

--- a/app/views/candidate_interface/degrees/degree/new_enic.html.erb
+++ b/app/views/candidate_interface/degrees/degree/new_enic.html.erb
@@ -14,12 +14,12 @@
     <p class="govuk-body"> <%= t('application_form.degree.enic_statement.enic_cost') %></p>
 
     <%= f.govuk_radio_buttons_fieldset :enic_details, legend: { text: t('application_form.degree.enic_statement.label'), size: 'm' } do %>
-      <% ApplicationQualification.enic_reasons.keys.each do |enic_reason| %>
+      <% ApplicationQualification.enic_reasons.keys.each_with_index do |enic_reason, index| %>
         <%= f.govuk_radio_button(
           :enic_reason,
           enic_reason,
           label: { text: t("application_form.degree.enic_statement.#{enic_reason}") },
-          link_errors: true,
+          link_errors: index.zero?,
         ) %>
       <% end %>
     <% end %>

--- a/app/views/candidate_interface/gcse/enic/_form.html.erb
+++ b/app/views/candidate_interface/gcse/enic/_form.html.erb
@@ -10,12 +10,12 @@
 <p class="govuk-body"> <%= t('gcse_edit_enic.enic_cost') %></p>
 
 <%= f.govuk_radio_buttons_fieldset :enic_details, legend: { text: t('application_form.gcse.enic_statement.label'), size: 'm' } do %>
-  <% ApplicationQualification.enic_reasons.keys.each do |enic_reason| %>
+  <% ApplicationQualification.enic_reasons.keys.each_with_index do |enic_reason, index| %>
     <%= f.govuk_radio_button(
       :enic_reason,
       enic_reason,
       label: { text: t("application_form.degree.enic_statement.#{enic_reason}") },
-      link_errors: true,
+      link_errors: index.zero?,
     ) %>
   <% end %>
 <% end %>

--- a/app/views/provider_interface/application_data_export/new.html.erb
+++ b/app/views/provider_interface/application_data_export/new.html.erb
@@ -17,8 +17,8 @@
       </h1>
 
       <%= f.govuk_check_boxes_fieldset :recruitment_cycle_years, legend: { text: 'Recruitment cycle', size: 'm' } do %>
-        <% RecruitmentCycle.years_visible_to_providers.each do |year| %>
-          <%= f.govuk_check_box :recruitment_cycle_years, year.to_s, label: { text: RecruitmentCycle.cycle_string(year) }, link_errors: true %>
+        <% RecruitmentCycle.years_visible_to_providers.each_with_index do |year, index| %>
+          <%= f.govuk_check_box :recruitment_cycle_years, year.to_s, label: { text: RecruitmentCycle.cycle_string(year) }, link_errors: index.zero? %>
         <% end %>
       <% end %>
 

--- a/app/views/provider_interface/rejections/new.html.erb
+++ b/app/views/provider_interface/rejections/new.html.erb
@@ -17,18 +17,18 @@
       <% end %>
 
       <%= f.govuk_check_boxes_fieldset :selected_reasons, legend: -> { content_for(:fieldset_legend) }, form_group: { classes: 'govuk-!-margin-bottom-2' } do %>
-        <% @wizard.selectable_reasons(@application_choice).each do |reason| %>
-          <%= f.govuk_check_box :selected_reasons, reason.id, label: { text: reason.label }, link_errors: true do %>
+        <% @wizard.selectable_reasons(@application_choice).each_with_index do |reason, index| %>
+          <%= f.govuk_check_box :selected_reasons, reason.id, label: { text: reason.label }, link_errors: index.zero? do %>
             <% if reason.details.present? %>
               <%= f.govuk_text_area reason.details.id.to_sym,
                   label: { text: safe_join([reason.details.label, ' ', tag.span(reason.details.visually_hidden, class: 'govuk-visually-hidden')]), size: 's' }, max_words: RejectionReasons::Details::MAX_WORDS %>
             <% elsif reason.reasons&.any? %>
               <%= f.govuk_check_boxes_fieldset reason.selected_reasons_attr_name, legend: { text: safe_join(['Reasons', ' ', tag.span(reason.reasons_visually_hidden, class: 'govuk-visually-hidden')]), size: 's' } do %>
-                <% reason.reasons.each do |nested_reason| %>
+                <% reason.reasons.each_with_index  do |nested_reason, index| %>
                   <%= f.govuk_check_box reason.selected_reasons_attr_name,
                     nested_reason.id,
                     label: { text: nested_reason.label },
-                    link_errors: true do %>
+                    link_errors: index.zero? do %>
                     <% if nested_reason.details.present? %>
                       <%= f.govuk_text_area nested_reason.details.id.to_sym,
                         label: {

--- a/app/views/support_interface/english_gcse_forms/_english_gcse_form.html.erb
+++ b/app/views/support_interface/english_gcse_forms/_english_gcse_form.html.erb
@@ -44,12 +44,12 @@
     <%= f.govuk_text_field :non_uk_qualification_type, label: { text: t('application_form.gcse.non_uk.label'), size: 's' }, hint: { text: t('application_form.gcse.non_uk.hint_text') } %>
     <%= f.govuk_collection_select :institution_country, select_country_options, :id, :name, label: { text: t('gcse_edit_institution_country.page_title', subject: f.object.subject.capitalize) } %>
     <%= f.govuk_radio_buttons_fieldset :enic_details, legend: { text: t('application_form.gcse.enic_statement.label'), size: 's' } do %>
-      <% ApplicationQualification.enic_reasons.keys.each do |enic_reason| %>
+      <% ApplicationQualification.enic_reasons.keys.each_with_index do |enic_reason, index| %>
         <%= f.govuk_radio_button(
           :enic_reason,
           enic_reason,
           label: { text: t("application_form.degree.enic_statement.#{enic_reason}") },
-          link_errors: true,
+          link_errors: index.zero?,
         ) %>
       <% end %>
     <% end %>

--- a/app/views/support_interface/math_gcse_forms/_math_gcse_form.html.erb
+++ b/app/views/support_interface/math_gcse_forms/_math_gcse_form.html.erb
@@ -17,12 +17,12 @@
       <%= f.govuk_text_field :non_uk_qualification_type, label: { text: t('application_form.gcse.non_uk.label'), size: 's' }, hint: { text: t('application_form.gcse.non_uk.hint_text') } %>
       <%= f.govuk_collection_select :institution_country, select_country_options, :id, :name, label: { text: t('gcse_edit_institution_country.page_title', subject: f.object.subject.capitalize), size: 's' } %>
       <%= f.govuk_radio_buttons_fieldset :enic_details, legend: { text: t('application_form.gcse.enic_statement.label'), size: 's' } do %>
-        <% ApplicationQualification.enic_reasons.keys.each do |enic_reason| %>
+        <% ApplicationQualification.enic_reasons.keys.each_with_index do |enic_reason, index| %>
           <%= f.govuk_radio_button(
             :enic_reason,
             enic_reason,
             label: { text: t("application_form.degree.enic_statement.#{enic_reason}") },
-            link_errors: true,
+            link_errors: index.zero?,
           ) %>
         <% end %>
       <% end %>

--- a/app/views/support_interface/science_gcse_forms/_science_gcse_form.html.erb
+++ b/app/views/support_interface/science_gcse_forms/_science_gcse_form.html.erb
@@ -29,12 +29,12 @@
       <%= f.govuk_text_field :non_uk_qualification_type, label: { text: t('application_form.gcse.non_uk.label'), size: 's' }, hint: { text: t('application_form.gcse.non_uk.hint_text') } %>
       <%= f.govuk_collection_select :institution_country, select_country_options, :id, :name, label: { text: t('gcse_edit_institution_country.page_title', subject: f.object.subject.capitalize) } %>
       <%= f.govuk_radio_buttons_fieldset :enic_details, legend: { text: t('application_form.gcse.enic_statement.label'), size: 's' } do %>
-        <% ApplicationQualification.enic_reasons.keys.each do |enic_reason| %>
+        <% ApplicationQualification.enic_reasons.keys.each_with_index do |enic_reason, index| %>
           <%= f.govuk_radio_button(
             :enic_reason,
             enic_reason,
             label: { text: t("application_form.degree.enic_statement.#{enic_reason}") },
-            link_errors: true,
+            link_errors: index.zero?,
           ) %>
         <% end %>
       <% end %>

--- a/config/locales/provider_interface/rejections.yml
+++ b/config/locales/provider_interface/rejections.yml
@@ -14,6 +14,7 @@ en:
             personal_statement_selected_reasons: Select reasons related to personal statement
             teaching_knowledge_selected_reasons: Select reasons related to teaching knowledge, ability and interview performance
             communication_and_scheduling_selected_reasons: Select reasons related to communication, interview attendance and scheduling
+            school_placement_selected_reasons: Select reasons related to school placements
             unsuitable_degree_details:
               blank: Enter details about how the degree does not meet course requirements
               size: Details about how the degree does not meet course requirements must be 200 words or fewer

--- a/spec/models/rejection_reasons_spec.rb
+++ b/spec/models/rejection_reasons_spec.rb
@@ -174,6 +174,7 @@ RSpec.describe RejectionReasons do
   describe '.translated_error' do
     it 'provides the error message for the given key' do
       expect(described_class.translated_error(:qualifications_selected_reasons)).to eq('Select reasons related to qualifications')
+      expect(described_class.translated_error(:school_placement_selected_reasons)).to eq 'Select reasons related to school placements'
     end
 
     it 'provides the error message for the given key and error type' do


### PR DESCRIPTION

## Context

GIVEN I am a provider rejecting a candidate's application
WHEN I select Continue
THEN I see an error
WHEN I select any reason (clicking on the div rather directly on the input)
THEN the *first* reason is selected, regardless of which one I have selected

Note this only happened if you clicked on the text (ie, the surrounding div), rather than the actual checkbox.

## Changes proposed in this pull request

We had `link_error = true` for all of the options, which meant they did not have distinct ids on the input. This PR just inks the first option. 

| Before | After |
| ------ | ------ |
| https://github.com/user-attachments/assets/63b980f8-7391-4f65-a168-3f9eccfaeba3 | https://github.com/user-attachments/assets/109fcee7-a231-4dc8-98cf-fa1f41fb2144 |


## Guidance to review

You can test it locally or on the review app by rejecting a candidate and following the steps in the context above.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
