### PR TITLE
Fixing github env typo for delete review workflop

### DIFF
--- a/.github/workflows/delete-v2-review-app.yml
+++ b/.github/workflows/delete-v2-review-app.yml
@@ -37,7 +37,7 @@ jobs:
 
           source global_config/review_aks.sh
 
-          echo "STORAGE_ACCOUNT_RG=${RESOURCE_NAME_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-rg >> $GITHUB_ENV
+          echo "STORAGE_ACCOUNT_RG=${RESOURCE_NAME_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-rg" >> $GITHUB_ENV
           echo "STORAGE_ACCOUNT_NAME=${RESOURCE_NAME_PREFIX}${SERVICE_SHORT}tfstate${CONFIG_SHORT}sa" >> $GITHUB_ENV
 
       - uses: azure/login@v2


### PR DESCRIPTION
## Context

Fixing github env typo for delete review workflop

## Changes proposed in this pull request

Fixing github env typo for delete review workflop

## Guidance to review

https://github.com/DFE-Digital/apply-for-teacher-training/actions/runs/12068284996/job/33653058146

## Things to check

- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
