### PR TITLE
Updated all params to only consider current cycle details

### DIFF
--- a/app/services/candidate_courses_recommender.rb
+++ b/app/services/candidate_courses_recommender.rb
@@ -137,14 +137,14 @@ private
     # What Course subjects has the Candidate applied for?
     # subject codes
     candidate.application_choices
-             .joins(:application_form)
-             .where(application_form: { recruitment_cycle_year: CycleTimetable.current_year  })
-             .where(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
-                          .joins(course_option: { course: :subjects })
-                          .pluck('subjects.code')
-                          .compact_blank
-                          .uniq
-                          .sort
+      .joins(:application_form)
+      .where(application_form: { recruitment_cycle_year: CycleTimetable.current_year })
+      .where(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
+      .joins(course_option: { course: :subjects })
+      .pluck('subjects.code')
+      .compact_blank
+      .uniq
+      .sort
   end
 
   def location_params

--- a/app/services/candidate_courses_recommender.rb
+++ b/app/services/candidate_courses_recommender.rb
@@ -51,25 +51,25 @@ private
 
   def can_sponsor_visa
     return unless candidate.application_forms
-                           .where(recruitment_cycle_year: 2025)
+                           .where(recruitment_cycle_year: CycleTimetable.current_year)
                            .exists?(personal_details_completed: true)
 
     # Does the Candidate require Courses to sponsor their visa?
     # Returns true if the Candidate does not have the right to work or study in the UK
     requires_visa = candidate.application_forms
-                             .where(recruitment_cycle_year: 2025)
+                             .where(recruitment_cycle_year: CycleTimetable.current_year)
                              .exists?(right_to_work_or_study: 'no')
     requires_visa.to_s # 'true' or 'false'
   end
 
   def degree_required
     return unless candidate.application_forms
-                           .where(recruitment_cycle_year: 2025)
+                           .where(recruitment_cycle_year: CycleTimetable.current_year)
                            .exists?(degrees_completed: true)
 
     candidate_degree_grades = candidate.degree_qualifications
                                        .joins(:application_form)
-                                       .where(application_form: { recruitment_cycle_year: 2025 })
+                                       .where(application_form: { recruitment_cycle_year: CycleTimetable.current_year })
                                        .pluck(:grade)
 
     return 'not_required' if candidate_degree_grades.empty?
@@ -88,13 +88,13 @@ private
     # Does the Candidate have any submitted Applications?
     return unless candidate.application_choices
                            .joins(:application_form)
-                           .where(application_form: { recruitment_cycle_year: 2025 })
+                           .where(application_form: { recruitment_cycle_year: CycleTimetable.current_year })
                            .exists?(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
 
     # What Course funding types has the Candidate applied for?
     funding_types = candidate.application_choices
                       .joins(:application_form)
-                      .where(application_form: { recruitment_cycle_year: 2025 })
+                      .where(application_form: { recruitment_cycle_year: CycleTimetable.current_year })
                              .where(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
                              .joins(course_option: :course)
                              .pluck('courses.funding_type')
@@ -110,13 +110,13 @@ private
     # Does the Candidate have any submitted Applications?
     return unless candidate.application_choices
                            .joins(:application_form)
-                           .where(application_form: { recruitment_cycle_year: 2025 })
+                           .where(application_form: { recruitment_cycle_year: CycleTimetable.current_year })
                            .exists?(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
 
     # What Course study types has the Candidate applied for?
     study_modes = candidate.application_choices
                            .joins(:application_form)
-                           .where(application_form: { recruitment_cycle_year: 2025 })
+                           .where(application_form: { recruitment_cycle_year: CycleTimetable.current_year })
                            .where(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
                            .joins(course_option: :course)
                            .pluck('course_options.study_mode')
@@ -131,14 +131,14 @@ private
     # Does the Candidate have any submitted Applications?
     return unless candidate.application_choices
                            .joins(:application_form)
-                           .where(application_form: { recruitment_cycle_year: 2025 })
+                           .where(application_form: { recruitment_cycle_year: CycleTimetable.current_year })
                            .exists?(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
 
     # What Course subjects has the Candidate applied for?
     # subject codes
     candidate.application_choices
              .joins(:application_form)
-             .where(application_form: { recruitment_cycle_year: 2025 })
+             .where(application_form: { recruitment_cycle_year: CycleTimetable.current_year  })
              .where(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
                           .joins(course_option: { course: :subjects })
                           .pluck('subjects.code')

--- a/app/services/candidate_courses_recommender.rb
+++ b/app/services/candidate_courses_recommender.rb
@@ -50,18 +50,27 @@ private
   end
 
   def can_sponsor_visa
-    return unless candidate.application_forms.exists?(personal_details_completed: true)
+    return unless candidate.application_forms
+                           .where(recruitment_cycle_year: 2025)
+                           .exists?(personal_details_completed: true)
 
     # Does the Candidate require Courses to sponsor their visa?
     # Returns true if the Candidate does not have the right to work or study in the UK
-    requires_visa = candidate.application_forms.exists?(right_to_work_or_study: 'no')
+    requires_visa = candidate.application_forms
+                             .where(recruitment_cycle_year: 2025)
+                             .exists?(right_to_work_or_study: 'no')
     requires_visa.to_s # 'true' or 'false'
   end
 
   def degree_required
-    return unless candidate.application_forms.exists?(degrees_completed: true)
+    return unless candidate.application_forms
+                           .where(recruitment_cycle_year: 2025)
+                           .exists?(degrees_completed: true)
 
-    candidate_degree_grades = candidate.degree_qualifications.pluck(:grade)
+    candidate_degree_grades = candidate.degree_qualifications
+                                       .joins(:application_form)
+                                       .where(application_form: { recruitment_cycle_year: 2025 })
+                                       .pluck(:grade)
 
     return 'not_required' if candidate_degree_grades.empty?
 
@@ -77,10 +86,15 @@ private
 
   def funding_type
     # Does the Candidate have any submitted Applications?
-    return unless candidate.application_choices.exists?(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
+    return unless candidate.application_choices
+                           .joins(:application_form)
+                           .where(application_form: { recruitment_cycle_year: 2025 })
+                           .exists?(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
 
     # What Course funding types has the Candidate applied for?
     funding_types = candidate.application_choices
+                      .joins(:application_form)
+                      .where(application_form: { recruitment_cycle_year: 2025 })
                              .where(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
                              .joins(course_option: :course)
                              .pluck('courses.funding_type')
@@ -94,10 +108,16 @@ private
 
   def study_type
     # Does the Candidate have any submitted Applications?
-    return unless candidate.application_choices.exists?(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
+    return unless candidate.application_choices
+                           .joins(:application_form)
+                           .where(application_form: { recruitment_cycle_year: 2025 })
+                           .exists?(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
 
     # What Course study types has the Candidate applied for?
-    study_modes = candidate.application_choices.where(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
+    study_modes = candidate.application_choices
+                           .joins(:application_form)
+                           .where(application_form: { recruitment_cycle_year: 2025 })
+                           .where(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
                            .joins(course_option: :course)
                            .pluck('course_options.study_mode')
                            .compact_blank
@@ -109,11 +129,17 @@ private
 
   def subjects
     # Does the Candidate have any submitted Applications?
-    return unless candidate.application_choices.exists?(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
+    return unless candidate.application_choices
+                           .joins(:application_form)
+                           .where(application_form: { recruitment_cycle_year: 2025 })
+                           .exists?(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
 
     # What Course subjects has the Candidate applied for?
     # subject codes
-    candidate.application_choices.where(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
+    candidate.application_choices
+             .joins(:application_form)
+             .where(application_form: { recruitment_cycle_year: 2025 })
+             .where(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
                           .joins(course_option: { course: :subjects })
                           .pluck('subjects.code')
                           .compact_blank


### PR DESCRIPTION
## Context

The previous implementation considered all Application Form details attached to the Candidate. 
We only want to use the most recent/most relevant details

## Changes proposed in this pull request

Updated param methods to only consider details from the current cycle (2025)
- Joins have been deliberately used rather than the `current_application_form` method as we don't want to create Application Forms if they don't exist

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
