### PR TITLE
Fix back link for references interruptions

### DIFF
--- a/app/controllers/candidate_interface/references/interruptions_controller.rb
+++ b/app/controllers/candidate_interface/references/interruptions_controller.rb
@@ -9,7 +9,11 @@ module CandidateInterface
         @next_step = return_to_path || candidate_interface_references_relationship_path
 
         return_to_params = return_to_review? ? { return_to: 'review' } : nil
-        @back_link = candidate_interface_references_edit_email_address_path(@reference.id, params: return_to_params)
+        @back_link = if @reference.nil?
+                       candidate_interface_references_review_path
+                     else
+                       candidate_interface_references_edit_email_address_path(@reference.id, params: return_to_params)
+                     end
       end
     end
   end


### PR DESCRIPTION
## Context

When filling up a reference, we show the candidate an interruption page when inputting a personal email address. The back link on this page can break if the reference is not in DB anymore. This can happen if the user deleted the reference in another tab.

This PR changes this to redirect the user to the review/index page if the reference in not present anymore.

https://dfe-teacher-services.sentry.io/issues/6104915581/?environment=production&project=1765973&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&statsPeriod=24h&stream_index=0
## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Go to review or pull locally
Add new reference with personal email
Stop on the interruption page, where we warn the candidate against using a personal email
Delete the reference in a new tab or console.
Click the back link

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Add PR link to Trello card
