### PR TITLE
[474] Refactor `next_step`

### DIFF
--- a/app/forms/candidate_interface/degree_wizard.rb
+++ b/app/forms/candidate_interface/degree_wizard.rb
@@ -98,7 +98,7 @@ module CandidateInterface
     end
 
     def next_step(step = current_step)
-      if !reviewing? || (reviewing? && country_changed?)
+      if !reviewing? || country_changed?
         if step == :country && uk?
           :degree_level
         elsif (step == :type && international?) || step == :degree_level
@@ -117,11 +117,9 @@ module CandidateInterface
           :award_year
         elsif step == :award_year && international? && completed?
           :enic
-        elsif step == :enic && international? && enic_reason != HAS_STATEMENT
-          :review
-        elsif step == :enic && international?
+        elsif step == :enic && international? && enic_reason == HAS_STATEMENT
           :enic_reference
-        elsif %i[award_year enic enic_reference].include?(step) # rubocop:disable Lint/DuplicateBranch
+        elsif %i[award_year enic enic_reference].include?(step)
           :review
         else
           Sentry.capture_exception(


### PR DESCRIPTION
## Context

The degree flow is prone to bugs and is in need of a refactor, this PR attempts to try and tidy up the `next_step` method for now to attempt to reduce the number of bugs, make it easier to understand and maintain. 

## Changes proposed in this pull request

- Consolidate duplicate `:review` branches into a single one.
- Stop disabling the linter.

## Guidance to review

- Does the flow still work as it did before? 
- Is the refactored version easier to understand?