### PR TITLE
Optimise backup workflow diskspace usage

### DIFF
--- a/.github/workflows/backup-db.yml
+++ b/.github/workflows/backup-db.yml
@@ -96,6 +96,20 @@ jobs:
         sudo rm -rf /usr/local/lib/android || true
         sudo rm -rf /usr/share/dotnet || true
         sudo rm -rf /opt/ghc || true
+        sudo rm -rf /usr/local/.ghcup || true
+        sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+        sudo rm -rf /usr/local/share/boost || true
+        sudo docker image prune --all --force || true
+        sudo apt-get remove -y '^aspnetcore-.*' || true
+        sudo apt-get remove -y '^dotnet-.*' --fix-missing || true
+        sudo apt-get remove -y '^llvm-.*' --fix-missing || true
+        sudo apt-get remove -y 'php.*' --fix-missing || true
+        sudo apt-get remove -y '^mongodb-.*' --fix-missing || true
+        sudo apt-get remove -y '^mysql-.*' --fix-missing || true
+        sudo apt-get remove -y google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri --fix-missing || true
+        sudo apt-get remove -y google-cloud-sdk --fix-missing || true
+        sudo apt-get remove -y google-cloud-cli --fix-missing || true
+        sudo apt-get clean
 
     - name: Sanitise dump
       if: github.event_name == 'schedule'


### PR DESCRIPTION
## Context

Backup running out of disk space on the github runner with db sanitise

## Changes proposed in this pull request

Extra delete commands in disk cleanup

old
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        73G   43G   31G  59% /
new
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        73G   26G   47G  36% /

Full backup file is currently 7.7G, sanitised backup will be smaller.
So this should give another 16G for the postgres db.

## Guidance to review

Check workflow looks correct
Some testing here https://github.com/DFE-Digital/apply-for-teacher-training/actions/runs/12142762516

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
