### PR TITLE
[500] Add reference confidentiality to support interface

### DIFF
--- a/app/components/support_interface/reference_with_feedback_component.html.erb
+++ b/app/components/support_interface/reference_with_feedback_component.html.erb
@@ -1,5 +1,5 @@
 <div data-qa="reference">
-  <%= render SummaryCardComponent.new(rows: rows, editable: true) do %>
+  <%= render SummaryCardComponent.new(rows: rows, editable: true, warning_text: warning_text) do %>
     <%= render(SummaryCardHeaderComponent.new(title: title, heading_level: 3)) do %>
       <div class="app-summary-card__actions">
         <ul class="app-summary-card__actions-list">

--- a/app/components/support_interface/reference_with_feedback_component.html.erb
+++ b/app/components/support_interface/reference_with_feedback_component.html.erb
@@ -1,5 +1,5 @@
 <div data-qa="reference">
-  <%= render SummaryCardComponent.new(rows: rows, editable: true, warning_text: warning_text) do %>
+  <%= render SummaryCardComponent.new(rows:, editable: true, warning_text:) do %>
     <%= render(SummaryCardHeaderComponent.new(title: title, heading_level: 3)) do %>
       <div class="app-summary-card__actions">
         <ul class="app-summary-card__actions-list">

--- a/app/components/support_interface/reference_with_feedback_component.rb
+++ b/app/components/support_interface/reference_with_feedback_component.rb
@@ -272,7 +272,7 @@ module SupportInterface
     end
 
     def confidentiality_value
-      reference.confidential ? 'No, this reference is confidential. Do not share it.' : 'Yes, if they request it.'
+      t("support_interface.references.confidential_warning.#{reference.confidential}")
     end
 
     attr_reader :reference

--- a/app/components/support_interface/reference_with_feedback_component.rb
+++ b/app/components/support_interface/reference_with_feedback_component.rb
@@ -44,6 +44,14 @@ module SupportInterface
       reference.name
     end
 
+    def warning_text
+      return unless FeatureFlag.active?(:show_reference_confidentiality_status)
+      return unless reference&.confidential == true
+      return unless reference&.feedback_provided?
+
+      t('support_interface.confidential_warning')
+    end
+
   private
 
     def status_row

--- a/app/components/support_interface/reference_with_feedback_component.rb
+++ b/app/components/support_interface/reference_with_feedback_component.rb
@@ -21,7 +21,7 @@ module SupportInterface
     end
 
     def rows
-      [
+      base_rows = [
         status_row,
         type_of_reference_row,
         name_row,
@@ -34,6 +34,10 @@ module SupportInterface
         consent_row,
 
       ].flatten.compact
+
+      base_rows.insert(6, confidentiality_row) if feature_active_and_feedback_provided?
+
+      base_rows
     end
 
     def title
@@ -215,6 +219,13 @@ module SupportInterface
       end
     end
 
+    def confidentiality_row
+      {
+        key: 'Can this reference be shared with the candidate?',
+        value: confidentiality_value,
+      }
+    end
+
     def history_row
       return if reference.not_requested_yet?
 
@@ -252,6 +263,14 @@ module SupportInterface
       when 'feedback_refused', 'email_bounced'
         'red'
       end
+    end
+
+    def feature_active_and_feedback_provided?
+      FeatureFlag.active?(:show_reference_confidentiality_status) && reference.feedback_provided?
+    end
+
+    def confidentiality_value
+      reference.confidential ? 'No, this reference is confidential. Do not share it.' : 'Yes, if they request it.'
     end
 
     attr_reader :reference

--- a/app/components/support_interface/reference_with_feedback_component.rb
+++ b/app/components/support_interface/reference_with_feedback_component.rb
@@ -35,7 +35,7 @@ module SupportInterface
 
       ].flatten.compact
 
-      base_rows.insert(6, confidentiality_row) if feature_active_and_feedback_provided?
+      base_rows.insert(6, confidentiality_row) if FeatureFlag.active?(:show_reference_confidentiality_status) && reference.feedback_provided?
 
       base_rows
     end
@@ -271,10 +271,6 @@ module SupportInterface
       when 'feedback_refused', 'email_bounced'
         'red'
       end
-    end
-
-    def feature_active_and_feedback_provided?
-      FeatureFlag.active?(:show_reference_confidentiality_status) && reference.feedback_provided?
     end
 
     def confidentiality_value

--- a/app/components/support_interface/reference_with_feedback_component.rb
+++ b/app/components/support_interface/reference_with_feedback_component.rb
@@ -21,23 +21,20 @@ module SupportInterface
     end
 
     def rows
-      base_rows = [
+      [
         status_row,
         type_of_reference_row,
         name_row,
         email_address_row,
         relationship_row,
         feedback_row,
+        confidentiality_row,
         date_rows,
         sign_in_as_referee_row,
         history_row,
         consent_row,
 
       ].flatten.compact
-
-      base_rows.insert(6, confidentiality_row) if FeatureFlag.active?(:show_reference_confidentiality_status) && reference.feedback_provided?
-
-      base_rows
     end
 
     def title
@@ -228,6 +225,8 @@ module SupportInterface
     end
 
     def confidentiality_row
+      return unless FeatureFlag.active?(:show_reference_confidentiality_status) && reference.feedback_provided?
+
       {
         key: 'Can this reference be shared with the candidate?',
         value: confidentiality_value,

--- a/app/components/support_interface/reference_with_feedback_component.rb
+++ b/app/components/support_interface/reference_with_feedback_component.rb
@@ -42,7 +42,6 @@ module SupportInterface
     end
 
     def warning_text
-      return unless FeatureFlag.active?(:show_reference_confidentiality_status)
       return unless reference&.confidential == true
       return unless reference&.feedback_provided?
 
@@ -225,7 +224,7 @@ module SupportInterface
     end
 
     def confidentiality_row
-      return unless FeatureFlag.active?(:show_reference_confidentiality_status) && reference.feedback_provided?
+      return unless reference.feedback_provided?
 
       {
         key: 'Can this reference be shared with the candidate?',

--- a/config/locales/support_interface/reference_status.yml
+++ b/config/locales/support_interface/reference_status.yml
@@ -8,3 +8,5 @@ en:
       feedback_provided: Feedback provided
       feedback_refused: Reference declined
       email_bounced: Email bounced
+    confidential_warning: 'Confidential: do not share with the candidate'
+      

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -1,5 +1,9 @@
 en:
   support_interface:
+    references:
+      confidential_warning:
+        true: No, this reference is confidential. Do not share it.
+        false: Yes, if they request it.
     page_titles:
       visa_or_immigration_status: Edit applicant visa or immigration status
 

--- a/spec/components/support_interface/reference_with_feedback_component_spec.rb
+++ b/spec/components/support_interface/reference_with_feedback_component_spec.rb
@@ -115,4 +115,67 @@ RSpec.describe SupportInterface::ReferenceWithFeedbackComponent, type: :componen
       expect(rendered_content).to have_css('h3', text: 'Jane Smith')
     end
   end
+
+  describe 'Confidentiality row' do
+    before do
+      FeatureFlag.activate(:show_reference_confidentiality_status)
+    end
+
+    context 'when the reference is confidential' do
+      before do
+        reference.update(confidential: true, feedback_status: 'feedback_provided')
+        render_inline(described_class.new(reference:, reference_number: 1, editable:))
+      end
+
+      it 'shows that the reference is confidential' do
+        expect(rendered_content).to summarise(
+          key: 'Can this reference be shared with the candidate?',
+          value: 'No, this reference is confidential. Do not share it.',
+        )
+      end
+    end
+
+    context 'when the reference is not confidential' do
+      before do
+        reference.update(confidential: false, feedback_status: 'feedback_provided')
+        render_inline(described_class.new(reference:, reference_number: 1, editable:))
+      end
+
+      it 'shows that the reference is not confidential' do
+        expect(rendered_content).to summarise(
+          key: 'Can this reference be shared with the candidate?',
+          value: 'Yes, if they request it.',
+        )
+      end
+    end
+
+    context 'when feedback has not been provided' do
+      before do
+        reference.update(confidential: true, feedback_status: 'feedback_requested')
+        render_inline(described_class.new(reference:, reference_number: 1, editable:))
+      end
+
+      it 'does not show the confidentiality row' do
+        expect(rendered_content).not_to summarise(
+          key: 'Can this reference be shared with the candidate?',
+          value: 'No, this reference is confidential. Do not share it.',
+        )
+      end
+    end
+
+    context 'when the feature flag is inactive' do
+      before do
+        FeatureFlag.deactivate(:show_reference_confidentiality_status)
+        reference.update(confidential: true, feedback_status: 'feedback_provided')
+        render_inline(described_class.new(reference:, reference_number: 1, editable:))
+      end
+
+      it 'does not show the confidentiality row' do
+        expect(rendered_content).not_to summarise(
+          key: 'Can this reference be shared with the candidate?',
+          value: 'No, this reference is confidential. Do not share it.',
+        )
+      end
+    end
+  end
 end

--- a/spec/components/support_interface/reference_with_feedback_component_spec.rb
+++ b/spec/components/support_interface/reference_with_feedback_component_spec.rb
@@ -117,10 +117,6 @@ RSpec.describe SupportInterface::ReferenceWithFeedbackComponent, type: :componen
   end
 
   describe 'Confidentiality row' do
-    before do
-      FeatureFlag.activate(:show_reference_confidentiality_status)
-    end
-
     context 'when the reference is confidential' do
       before do
         reference.update(confidential: true, feedback_status: 'feedback_provided')
@@ -152,21 +148,6 @@ RSpec.describe SupportInterface::ReferenceWithFeedbackComponent, type: :componen
     context 'when feedback has not been provided' do
       before do
         reference.update(confidential: true, feedback_status: 'feedback_requested')
-        render_inline(described_class.new(reference:, reference_number: 1, editable:))
-      end
-
-      it 'does not show the confidentiality row' do
-        expect(rendered_content).not_to summarise(
-          key: 'Can this reference be shared with the candidate?',
-          value: 'No, this reference is confidential. Do not share it.',
-        )
-      end
-    end
-
-    context 'when the feature flag is inactive' do
-      before do
-        FeatureFlag.deactivate(:show_reference_confidentiality_status)
-        reference.update(confidential: true, feedback_status: 'feedback_provided')
         render_inline(described_class.new(reference:, reference_number: 1, editable:))
       end
 


### PR DESCRIPTION
## Context

Following on from #10057, we are surfacing the confidentiality warnings on the support interface so that support are aware when a reference has been marked as confidential.

Failures on CI are unrelated.

## Changes proposed in this pull request

- Add confidentiality row on the support UI
- Add warning text when the reference is confidential
- Put this behind the existing feature flag


## Screenshot
 
<img width="794" alt="image" src="https://github.com/user-attachments/assets/e9921d5c-bf81-4b5d-9fa3-66beae332d10">