### PR TITLE
[503] Refactor `next_step` method

### DIFF
--- a/app/forms/candidate_interface/degree_wizard.rb
+++ b/app/forms/candidate_interface/degree_wizard.rb
@@ -98,9 +98,11 @@ module CandidateInterface
     end
 
     def next_step(step = current_step)
-      return uk? ? uk_steps(step) : international_steps(step) if !reviewing? || country_changed?
-
-      reviewing_or_country_not_changed_steps(step)
+      if !reviewing? || country_changed?
+        uk? ? uk_steps(step) : international_steps(step)
+      else
+        reviewing_or_country_not_changed_steps(step)
+      end
     end
 
     def back_to_review

--- a/app/forms/candidate_interface/degree_wizard.rb
+++ b/app/forms/candidate_interface/degree_wizard.rb
@@ -431,8 +431,8 @@ module CandidateInterface
       when :award_year
         completed? && international? ? :enic : :review
       when :enic
-        if international?
-          enic_reason == HAS_STATEMENT ? :enic_reference : :review
+        if international? && enic_reason == HAS_STATEMENT
+          :enic_reference
         else
           :review
         end

--- a/app/forms/candidate_interface/degree_wizard.rb
+++ b/app/forms/candidate_interface/degree_wizard.rb
@@ -440,44 +440,64 @@ module CandidateInterface
     end
 
     def uk_steps(step)
-      return :type if step == :subject && degree_has_type?
-      return :start_year if step == :completed && phd?
+      case step
+      when :subject
+        return :type if degree_has_type?
 
-      next_step = {
-        country: :degree_level,
-        degree_level: :subject,
-        subject: :university,
-        type: :university,
-        university: :completed,
-        completed: :grade,
-        grade: :start_year,
-        start_year: :award_year,
-        award_year: :review,
-      }
+        :university
+      when :completed
+        return :start_year if phd?
 
-      next_step[step] || handle_invalid_step
+        :grade
+      when :country
+        :degree_level
+      when :degree_level
+        :subject
+      when :type
+        :university
+      when :university
+        :completed
+      when :grade
+        :start_year
+      when :start_year
+        :award_year
+      when :award_year
+        :review
+      else
+        handle_invalid_step
+      end
     end
 
     def international_steps(step)
-      return :type if step == :country && country.present?
-      return :start_year if step == :completed && phd?
-      return :enic if step == :award_year && completed?
-      return :enic_reference if step == :enic && enic_reason == HAS_STATEMENT
+      case step
+      when :country
+        return :type if country.present?
+      when :completed
+        return :start_year if phd?
+      when :award_year
+        return :enic if completed?
+      when :enic
+        return :enic_reference if enic_reason == HAS_STATEMENT
+      end
 
-      next_step = {
-        type: :subject,
-        degree_level: :subject,
-        subject: :university,
-        university: :completed,
-        completed: :grade,
-        grade: :start_year,
-        start_year: :award_year,
-        award_year: :review,
-        enic: :review,
-        enic_reference: :review,
-      }
-
-      next_step[step] || handle_invalid_step
+      case step
+      when :type, :degree_level
+        :subject
+      when :subject
+        :university
+      when :university
+        :completed
+      when :completed
+        :grade
+      when :grade
+        :start_year
+      when :start_year
+        :award_year
+      when :award_year, :enic, :enic_reference
+        :review
+      else
+        handle_invalid_step
+      end
     end
 
     def handle_invalid_step


### PR DESCRIPTION
## Context

While investigating a bug with degrees it became apparent that the degree wizard and the `next_step` method is prone to bugs and is in need of a refactor. 

This is a first stab at that.

## Changes proposed in this pull request

- Refactor the `next_step` method.
- Stop disabling Rubocop
- Convert the giant if else statement into more digestible hash maps and case statements
- Create smaller private methods

## Guidance to review

- Do you prefer the refactored version of the original?
- Do you prefer the [hash map](https://github.com/DFE-Digital/apply-for-teacher-training/pull/10142/commits/254429b75a9dd6be17fe8139cc3fe214e4630e01) or the [case statements](https://github.com/DFE-Digital/apply-for-teacher-training/pull/10142/commits/b4adc79c822db6353555dd91c68cdc386aab3651)?
- Does everything still work