### PR TITLE
Add one login feature flag

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -23,6 +23,7 @@ class FeatureFlag
     [:draft_vendor_api_specification, 'The specification for upcoming vendor API releases', 'Abeer Salameh'],
     [:adviser_sign_up, 'Allow candidates to sign up for a teacher training adviser', 'Ross Oliver'],
     [:monthly_statistics_redirected, 'Redirect requests for Publications Monthly Statistics to temporarily unavailable', 'Iain McNulty'],
+    [:one_login_candidate_sign_in, 'Use one login to authenticate candidates. When turned off we will default to magic link authentification', 'Apply team'],
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = [


### PR DESCRIPTION
## Context

This adds a feature flag for one login. This should act as a switch between one login and magic-link as an authentication method for our candidates. 

## Changes proposed in this pull request

One login feature flag

## Guidance to review

![Screenshot from 2024-12-06 11-49-22](https://github.com/user-attachments/assets/f9040f92-7b06-4b90-a506-b7d9a6e9da54)


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [x] Make sure all information from the Trello card is in here
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Add PR link to Trello card
