### PR TITLE
Removing `semantic_logger.add_appender` in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,5 @@
 require "active_support/core_ext/integer/time"
+require_dependency Rails.root.join('app/lib/custom_log_formatter')
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -63,11 +64,11 @@ Rails.application.configure do
   config.rails_semantic_logger.add_file_appender = false  # Don't log to file
   config.active_record.logger = nil                       # Don't log SQL
   config.rails_semantic_logger.format = :json
-  # config.semantic_logger.add_appender(
-  #   io: $stdout,
-  #   level: config.log_level,
-  #   formatter: config.rails_semantic_logger.format,
-  #   )
+  config.semantic_logger.add_appender(
+    io: STDOUT,
+    level: config.log_level,
+    formatter: CustomLogFormatter.new,
+  )
 
   # Change to "debug" to log everything (including potentially personally-identifiable information!)
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,11 +63,11 @@ Rails.application.configure do
   config.rails_semantic_logger.add_file_appender = false  # Don't log to file
   config.active_record.logger = nil                       # Don't log SQL
   config.rails_semantic_logger.format = :json
-  config.semantic_logger.add_appender(
-    io: $stdout,
-    level: config.log_level,
-    formatter: config.rails_semantic_logger.format,
-    )
+  # config.semantic_logger.add_appender(
+  #   io: $stdout,
+  #   level: config.log_level,
+  #   formatter: config.rails_semantic_logger.format,
+  #   )
 
   # Change to "debug" to log everything (including potentially personally-identifiable information!)
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")


### PR DESCRIPTION
This will be overriding the SemanticLogger initializer setup

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
- [ ] Inform data insights team due to database changes
- [ ] Make sure all information from the Trello card is in here
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Add PR link to Trello card
