### PR TITLE
[454] Expose `confidential` from `Reference` on the Vendor API `V1.6pre`

### DIFF
--- a/app/controllers/api_docs/vendor_api_docs/reference_controller.rb
+++ b/app/controllers/api_docs/vendor_api_docs/reference_controller.rb
@@ -44,6 +44,8 @@ module APIDocs
           api_docs_spec_1_4_url
         when '1.5'
           api_docs_spec_1_5_url
+        when '1.6'
+          api_docs_spec_1_6_url
         end
       end
       helper_method :spec_url_for_current_version

--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -7,6 +7,7 @@ module VendorAPI
   VERSION_1_3 = '1.3'.freeze
   VERSION_1_4 = '1.4'.freeze
   VERSION_1_5 = '1.5'.freeze
+  VERSION_1_6 = '1.6pre'.freeze
   VERSION = VERSION_1_5
 
   VERSIONS = {
@@ -65,5 +66,6 @@ module VendorAPI
       Changes::V15::AddApplicationSentToProviderDatetime,
       Changes::V15::AddReferenceFeedbackProvidedAtDatetime,
     ],
+    '1.6pre' => [Changes::V16::AddConfidentialToReference],
   }.freeze
 end

--- a/app/lib/vendor_api/changes/v16/add_confidential_to_reference.rb
+++ b/app/lib/vendor_api/changes/v16/add_confidential_to_reference.rb
@@ -1,0 +1,11 @@
+module VendorAPI
+  module Changes
+    module V16
+      class AddConfidentialToReference < VersionChange
+        description 'Add the confidentiality status selected by the referee for the reference.'
+
+        resource ReferencePresenter, [ReferencePresenter::AddConfidential]
+      end
+    end
+  end
+end

--- a/app/presenters/vendor_api/reference_presenter/add_confidential.rb
+++ b/app/presenters/vendor_api/reference_presenter/add_confidential.rb
@@ -1,0 +1,7 @@
+module VendorAPI::ReferencePresenter::AddConfidential
+  def schema
+    super.deep_merge!({
+      confidential: reference.confidential,
+    })
+  end
+end

--- a/app/views/api_docs/vendor_api_docs/reference/_v1_6_changes.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/_v1_6_changes.html.erb
@@ -1,0 +1,10 @@
+<h2 class="govuk-heading-l" id="important">Version 1.6 changes</h2>
+
+<p class="govuk-heading-s">Add the confidentiality status, selected by the referee for the reference</p>
+
+<p class="govuk-body">
+  The following field has been added to the <%= govuk_link_to 'reference', '#reference-object' %> object:
+
+<ul class="govuk-list govuk-list--bullet">
+  <li><code>confidential</code> (boolean, required)</li>
+</ul>

--- a/app/views/api_docs/vendor_api_docs/reference/draft.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/draft.html.erb
@@ -10,7 +10,7 @@
 <ol class="app-contents-list__list">
   <li class="app-contents-list__list-item app-contents-list__list-item--parent"><%= govuk_link_to 'API Versions', '#versions', class: 'app-contents-list__link' %></li>
   <li class="app-contents-list__list-item app-contents-list__list-item--parent"><%= govuk_link_to 'Testing draft changes', '#testing-draft', class: 'app-contents-list__link' %></li>
-  <li class="app-contents-list__list-item app-contents-list__list-item--parent"><%= govuk_link_to 'Version 1.4 changes', '#changes', class: 'app-contents-list__link' %></li>
+  <li class="app-contents-list__list-item app-contents-list__list-item--parent"><%= govuk_link_to 'Version 1.6 changes', '#changes', class: 'app-contents-list__link' %></li>
   <li class="app-contents-list__list-item app-contents-list__list-item--parent"><%= govuk_link_to 'Developing on the API', '#developing', class: 'app-contents-list__link' %></li>
   <li class="app-contents-list__list-item app-contents-list__list-item--parent">
     <%= govuk_link_to 'Endpoints', '#endpoints', class: 'app-contents-list__link' %>
@@ -52,39 +52,33 @@
   <li>using the correct version of the API</li>
 </ul>
 
-<h3 class="govuk-heading-l" id="testing-draft">Testing draft version 1.4</h3>
+<h3 class="govuk-heading-l" id="testing-draft">Testing draft version 1.6</h3>
 
 <p class="govuk-body">
   When an API version is in draft, you can test it using our sandbox test environment.
 </p>
 
 <p class="govuk-body">
-  You can test draft version <code>1.4</code> by using:
+  You can test draft version <code>1.6</code> by using:
 </p>
 <ul class="govuk-list govuk-list--bullet">
-  <li>the sandbox URL for the version, which is <%= govuk_link_to 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.4', 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.4' %></li>
+  <li>the sandbox URL for the version, which is <%= govuk_link_to 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.6', 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.6' %></li>
   <li>your sandbox API token - email <%= govuk_mail_to 'becomingateacher@digital.education.gov.uk' %> if you do not have one</li>
 </ul>
 
 <p class="govuk-body">
-  After version <code>1.4</code> has been released it will also be available in the sandbox on <%= govuk_link_to 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1', 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1' %>.
+  After version <code>1.6</code> has been released it will also be available in the sandbox on <%= govuk_link_to 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1', 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1' %>.
 </p>
 
-<h2 class="govuk-heading-l" id="changes">Version 1.4 changes</h2>
+<h2 class="govuk-heading-l" id="changes">Version 1.6 changes</h2>
 
-<p class="govuk-heading-s">Add GCSE qualifications data</p>
+<p class="govuk-heading-s">Expose the confidentiality status selected by the referee for the reference object</p>
 
 <p class="govuk-body">
-  Ensure we send the following fields over the API, as part of the "qualifications"."gcses" object:
-</p>
+  The following field has been added to the <%= govuk_link_to 'reference', '#reference-object' %> object:
 
-<p class="govuk-body">
-  The following fields have been added to the <%= govuk_link_to 'qualifications', '#qualifications-object' %> objects, under the <code>gcses</code> array:
-</p>
 <ul class="govuk-list govuk-list--bullet">
-  <li><code>currently_completing_qualification</code> (boolean, optional)</li>
-  <li><code>missing_explanation</code>  (string, optional)</li>
-  <li><code>other_uk_qualification_type</code> (string, optional)</li>
+  <li><code>confidential</code> (boolean, required)</li>
 </ul>
 
 <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-6 govuk-!-margin-bottom-6">
@@ -103,10 +97,10 @@
 
 <p class="govuk-body">
   We have a production environment and a sandbox environment.
-  When version 1.4 is launched initially for testing, it will only be accessible
+  When version 1.6 is launched initially for testing, it will only be accessible
   in the sandbox environment by determining the version in the URL as so:
-  <%= govuk_link_to 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.4',
-                    'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.4' %>.
+  <%= govuk_link_to 'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.6',
+                    'https://sandbox.apply-for-teacher-training.service.gov.uk/api/v1.6' %>.
   Only after testing is complete, the production environment will automatically upgrade
   to the latest minor version without the need to update the URL.
 </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -285,7 +285,7 @@ en:
         release_notes: Release notes
         lifecycle: Lifecycle
         alpha_release_notes: Alpha release notes
-        draft: Draft Version 1.4
+        draft: Draft Version 1.6
       register_api_docs:
         reference: Apply for teacher training - Register API
     provider:

--- a/config/routes/api/docs.rb
+++ b/config/routes/api/docs.rb
@@ -21,6 +21,7 @@ namespace :api_docs, path: nil do
     get '/spec-1.3.yml' => 'openapi#spec_1_3', as: :spec_1_3
     get '/spec-1.4.yml' => 'openapi#spec_1_4', as: :spec_1_4
     get '/spec-1.5.yml' => 'openapi#spec_1_5', as: :spec_1_5
+    get '/spec-1.6.yml' => 'openapi#spec_1_6', as: :spec_1_6
   end
 
   namespace :data_api_docs, path: '/data-api' do

--- a/config/vendor_api/draft.yml
+++ b/config/vendor_api/draft.yml
@@ -1,7 +1,7 @@
 ---
 openapi: 3.0.0
 info:
-  version: v1.5
+  version: v1.6
   title: Apply API
   contact:
     name: DfE
@@ -17,29 +17,12 @@ servers:
     url: https://www.apply-for-teacher-training.service.gov.uk/api/v1.5
 components:
   schemas:
-    ApplicationAttributes:
-      type: object
-      properties:
-        sent_to_provider_at:
-          type: string
-          format: date-time
-          description: The date and time the application was sent to the provider
-          example: "2024-07-10T13:00:00+01:00"
-        submitted_at:
-          type: string
-          format: date-time
-          description: The date and time the Candidate first submitted in this cycle. See `sent_to_provider_at` for the date and time this specific Application was submitted.
-          example: "2019-06-13T10:44:31Z"
-          deprecated: true
-      required:
-        - sent_to_provider_at
     Reference:
       type: object
       properties:
-        feedback_provided_at:
-          type: string
-          format: date-time
-          description: The date and time the reference was provided
-          example: "2024-07-10T13:00:00+01:00"
+        confidential:
+          type: boolean
+          description: The confidentiality status selected by the referee for the reference
+          example: true
       required:
-        - feedback_provided_at
+        - confidential

--- a/spec/presenters/vendor_api/v1.6/reference_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.6/reference_presenter_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe VendorAPI::ReferencePresenter do
+  subject(:reference_schema) { described_class.new(version, reference).schema }
+
+  let(:version) { '1.6' }
+
+  describe 'confidentiality status' do
+    let(:reference) { create(:reference) }
+
+    it 'includes confidential' do
+      expect(reference_schema[:confidential]).to be_present
+    end
+  end
+end

--- a/spec/system/api_docs/api_docs_spec.rb
+++ b/spec/system/api_docs/api_docs_spec.rb
@@ -42,6 +42,6 @@ RSpec.describe 'API docs' do
   end
 
   def then_i_get_redirected_to_the_latest_production_version
-    expect(page).to have_current_path api_docs_versioned_reference_path(api_version: "v#{AllowedCrossNamespaceUsage::VendorAPIInfo.released_version}"), ignore_query: true
+    expect(page).to have_current_path api_docs_versioned_reference_path(api_version: "v#{VendorAPI::VERSION}"), ignore_query: true
   end
 end


### PR DESCRIPTION
## Context

We are beginning the development on the next version of the API (version `1.6`).

This will be passed by the vendors as a way to test the changes on sandbox before we officially release the new version.

Once the vendors have tested and are happy, we will make the release official, at which point we will update the API release notes and official documentation.

## Changes proposed in this pull request

- Expose the confidentiality status, selected by the referee for the reference as `confidential` on `Reference` on the Vendor API

## Guidance to review

- Use the Vendor API on the review app or locally. In particular, check the `confidential` column on references. Alternatively you could inspect the `MultipleApplicationsResponse` on the draft API release document i've linked below.

- Review the [draft release documentation](https://apply-review-10172.test.teacherservices.cloud/api-docs/draft#changes) (vendors will see this on sandbox).

## Things to check

- [x] Add PR link to Trello card
