### PR TITLE
Shorten the PR template checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,14 +15,8 @@
 - [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
 - [ ] This code does not rely on migrations in the same Pull Request
 - [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
-- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
+- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
 - [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
 - [ ] API release notes have been updated if necessary
 - [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
-- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
-- [ ] Inform data insights team due to database changes
-- [ ] Make sure all information from the Trello card is in here
-- [ ] Rebased main
-- [ ] Cleaned commit history
-- [ ] Tested by running locally
-- [ ] Add PR link to Trello card
+- [ ] Attach the PR to the Trello card


### PR DESCRIPTION
## Context

This checklist has grown quite long over time. Some items are basic and considered good practice, while others are duplicated. As a result, we shouldn't need to read through the current entire list every time we open a PR.

If the list is too long:

- Developers may skip reading the checklist due to its length.
- Important items could be overlooked in favour of less critical ones.

By streamlining the list, we aim to focus on the most essential checks and encourage adherence to best practices.