### PR TITLE
[512] Expose `inactive` on `status` via `ApplicationAttribute` on the Vendor API (`V1.6pre`)

### DIFF
--- a/app/lib/vendor_api.rb
+++ b/app/lib/vendor_api.rb
@@ -66,6 +66,9 @@ module VendorAPI
       Changes::V15::AddApplicationSentToProviderDatetime,
       Changes::V15::AddReferenceFeedbackProvidedAtDatetime,
     ],
-    '1.6pre' => [Changes::V16::AddConfidentialToReference],
+    '1.6pre' => [
+      Changes::V16::AddConfidentialToReference,
+      Changes::V16::AddInactiveToApplicationAttributeStatuses,
+    ],
   }.freeze
 end

--- a/app/lib/vendor_api/changes/v16/add_inactive_to_application_attribute_statuses.rb
+++ b/app/lib/vendor_api/changes/v16/add_inactive_to_application_attribute_statuses.rb
@@ -1,0 +1,10 @@
+module VendorAPI
+  module Changes
+    module V16
+      class AddInactiveToApplicationAttributeStatuses < VersionChange
+        description 'Add inactive to the application attributes'
+        resource ApplicationPresenter, [ApplicationPresenter::AddInactiveStatus]
+      end
+    end
+  end
+end

--- a/app/presenters/vendor_api/application_presenter/add_inactive_status.rb
+++ b/app/presenters/vendor_api/application_presenter/add_inactive_status.rb
@@ -1,0 +1,9 @@
+module VendorAPI::ApplicationPresenter::AddInactiveStatus
+  def schema
+    super.deep_merge(
+      attributes: {
+        inactive: @application_choice.inactive?,
+      },
+    )
+  end
+end

--- a/app/views/api_docs/vendor_api_docs/reference/_v1_6_changes.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/_v1_6_changes.html.erb
@@ -8,3 +8,12 @@
 <ul class="govuk-list govuk-list--bullet">
   <li><code>confidential</code> (boolean, required)</li>
 </ul>
+
+<p class="govuk-heading-s">Add inactive to the ApplicationAttribute</p>
+
+<p class="govuk-body">
+  The following field has been added to the <%= govuk_link_to 'application', '#applicationattributes-object' %> object:
+
+<ul class="govuk-list govuk-list--bullet">
+  <li><code>inactive</code> (boolean, required)</li>
+</ul>

--- a/app/views/api_docs/vendor_api_docs/reference/draft.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/draft.html.erb
@@ -81,6 +81,15 @@
   <li><code>confidential</code> (boolean, required)</li>
 </ul>
 
+<p class="govuk-heading-s">Add inactive to the ApplicationAttribute</p>
+
+<p class="govuk-body">
+  The following field has been added to the <%= govuk_link_to 'application', '#applicationattributes-object' %> object:
+
+<ul class="govuk-list govuk-list--bullet">
+  <li><code>inactive</code> (boolean, required)</li>
+</ul>
+
 <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-6 govuk-!-margin-bottom-6">
 
 <h2 class="govuk-heading-l" id="developing">Developing on the API</h2>

--- a/config/vendor_api/draft.yml
+++ b/config/vendor_api/draft.yml
@@ -17,6 +17,11 @@ servers:
     url: https://www.apply-for-teacher-training.service.gov.uk/api/v1.5
 components:
   schemas:
+    ApplicationAttributes:
+      properties:
+        inactive:
+          type: boolean
+          description: Indicates whether the application is inactive, based on time-sensitive criteria. If true, the application is considered inactive; otherwise, it remains active.
     Reference:
       type: object
       properties:

--- a/spec/presenters/vendor_api/v1.6/application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/v1.6/application_presenter_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe VendorAPI::ApplicationPresenter do
+  let(:application_json) { described_class.new(version, application_choice).as_json }
+  let(:version) { '1.6' }
+
+  describe '#inactive' do
+    context 'when the application choice is inactive' do
+      let(:application_choice) { create(:application_choice, :inactive) }
+
+      it 'returns the status as inactive' do
+        expect(application_json.dig(:attributes, :inactive)).to be(true)
+      end
+    end
+  end
+
+  context 'when the application choice is not inactive' do
+    %w[
+      awaiting_provider_decision
+      offer
+      pending_conditions
+      recruited
+      rejected
+      declined
+      withdrawn
+      conditions_not_met
+      offer_deferred
+    ].each do |status|
+      it "returns the correct status #{status}" do
+        application_choice = create(:application_choice, status)
+        application_json = described_class.new('1.6', application_choice).as_json
+        expect(application_json.dig(:attributes, :inactive)).to be(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

We developing the next version of the API (`1.6`).

A draft version (`1.6pre`) will be passed by the vendors as a way to test the changes on sandbox before we officially release the new version.

Once the vendors have tested and are happy, we will make the release official, at which point we will update the API release notes and official documentation.

## Changes proposed in this pull request

- Expose inactive to the `ApplicationAttribute` statuses

## Guidance to review

- I've set application choice `16` to `inactive` on the review app.

- Use the Vendor API on the review app or locally. In particular, check the `status` on `ApplicationAttribute` for an application choice which has a status of `inactive`. 

- Repeat for other statuses and ensure the response accurately reflects the database.

- Alternatively you could inspect the `MultipleApplicationsResponse` on the draft API release document i've linked below.

- Review the [draft release documentation](https://apply-review-10189.test.teacherservices.cloud/api-docs/draft#changes).