### PR TITLE
[426] candidate withdrawal reasons list refinement and mandatory

### DIFF
--- a/app/components/candidate_interface/application_review_component.html.erb
+++ b/app/components/candidate_interface/application_review_component.html.erb
@@ -31,7 +31,7 @@
 
 <% if show_withdraw? %>
   <h2 class="govuk-heading-m">Withdraw your application</h2>
-  <p class="govuk-body">You can <%= govuk_link_to 'withdraw this application', candidate_interface_withdraw_path(application_choice) %> if you no longer wish to be considered for this course.</p>
+  <p class="govuk-body">You can <%= govuk_link_to 'withdraw this application', path_for_withdrawals %> if you no longer wish to be considered for this course.</p>
 <% end %>
 
 <% if show_provider_contact_component? %>

--- a/app/components/candidate_interface/application_review_component.rb
+++ b/app/components/candidate_interface/application_review_component.rb
@@ -168,5 +168,13 @@ module CandidateInterface
     def provider
       application_choice.current_provider
     end
+
+    def path_for_withdrawals
+      if FeatureFlag.active?(:new_candidate_withdrawal_reasons)
+        candidate_interface_withdrawal_reasons_level_one_reason_new_path(application_choice)
+      else
+        candidate_interface_withdraw_path(application_choice)
+      end
+    end
   end
 end

--- a/app/components/candidate_interface/course_choices_review_component.html.erb
+++ b/app/components/candidate_interface/course_choices_review_component.html.erb
@@ -9,7 +9,7 @@
               <span class="govuk-visually-hidden"> <%= application_choice.current_course.name_and_code %></span>
             <% end %>
           <% elsif withdrawable?(application_choice) %>
-            <%= govuk_link_to candidate_interface_withdraw_path(application_choice.id), data: { action: :withdraw } do %>
+            <%= govuk_link_to path_for_withdrawals(application_choice), data: { action: :withdraw } do %>
               <%= t('application_form.courses.withdraw') %>
               <span class="govuk-visually-hidden"> <%= application_choice.current_course.name_and_code %></span>
             <% end %>

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -74,6 +74,14 @@ module CandidateInterface
                                end
     end
 
+    def path_for_withdrawals(application_choice)
+      if FeatureFlag.active? :new_candidate_withdrawal_reasons
+        candidate_interface_withdrawal_reasons_level_one_reason_new_path(application_choice)
+      else
+        candidate_interface_withdraw_path(application_choice)
+      end
+    end
+
   private
 
     attr_reader :application_form

--- a/app/components/candidate_interface/course_choices_summary_card_action_component.html.erb
+++ b/app/components/candidate_interface/course_choices_summary_card_action_component.html.erb
@@ -1,6 +1,6 @@
 <% if action == :withdraw %>
   <p class="govuk-body">
-    <%= govuk_link_to 'Withdraw this application', candidate_interface_withdraw_path(application_choice.id) %>
+    <%= govuk_link_to 'Withdraw this application', path_for_withdrawals %>
   </p>
 <% elsif action == :respond_to_offer %>
   <p class="govuk-body">

--- a/app/components/candidate_interface/course_choices_summary_card_action_component.rb
+++ b/app/components/candidate_interface/course_choices_summary_card_action_component.rb
@@ -6,5 +6,13 @@ module CandidateInterface
       @action = action
       @application_choice = application_choice
     end
+
+    def path_for_withdrawals
+      if FeatureFlag.active? :new_candidate_withdrawal_reasons
+        candidate_interface_withdrawal_reasons_level_one_reason_new_path(application_choice.id)
+      else
+        candidate_interface_withdraw_path(application_choice.id)
+      end
+    end
   end
 end

--- a/app/components/candidate_interface/withdrawal_reasons/level_one_reason_review_component.html.erb
+++ b/app/components/candidate_interface/withdrawal_reasons/level_one_reason_review_component.html.erb
@@ -1,0 +1,35 @@
+<h1 class="govuk-heading-l"><%= t('page_titles.decisions.withdraw') %></h1>
+<%= govuk_summary_list do |summary_list| %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t('withdrawal_reasons.level_one_reason_review_component.provider')) %>
+    <% row.with_value(text: @application_choice.current_course.provider.name) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t('withdrawal_reasons.level_one_reason_review_component.course')) %>
+    <% row.with_value(text: @application_choice.current_course.name_and_code) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t('withdrawal_reasons.level_one_reason_review_component.reason')) %>
+    <% row.with_value(text: level_one_reason_text) %>
+    <% row.with_action(
+       text: t('withdrawal_reasons.level_one_reason_review_component.change'),
+       href: candidate_interface_withdrawal_reasons_level_one_reason_edit_path,
+       visually_hidden_text: t('withdrawal_reasons.level_one_reason_review_component.visually_hidden_change_text'),
+     ) %>
+  <% end %>
+<% end %>
+
+<%= form_with(
+    url: candidate_interface_withdrawal_create_path(@application_choice),
+    method: :post,
+  ) do |f| %>
+
+  <%= f.govuk_submit t('withdrawal_reasons.level_one_reason_review_component.submit'), warning: true %>
+<% end %>
+
+<p class="govuk-body">
+  <%= govuk_link_to(
+    t('cancel'),
+    candidate_interface_application_choices_path,
+  ) %>
+</p>

--- a/app/components/candidate_interface/withdrawal_reasons/level_one_reason_review_component.rb
+++ b/app/components/candidate_interface/withdrawal_reasons/level_one_reason_review_component.rb
@@ -1,0 +1,23 @@
+module CandidateInterface
+  module WithdrawalReasons
+    class LevelOneReasonReviewComponent < ViewComponent::Base
+      def initialize(application_choice:, withdrawal_reason:)
+        @application_choice = application_choice
+        @withdrawal_reason = withdrawal_reason
+      end
+
+      def level_one_reason_text
+        [translate("#{withdrawal_reason.reason}.label"), withdrawal_reason.comment].join(': ')
+      end
+
+    private
+
+      attr_reader :application_choice, :withdrawal_reason
+
+      def translate(string)
+        string.gsub!('-', '_')
+        I18n.t("candidate_interface.withdrawal_reasons.reasons.#{string}")
+      end
+    end
+  end
+end

--- a/app/components/candidate_interface/withdrawal_reasons/level_two_reasons_review_component.html.erb
+++ b/app/components/candidate_interface/withdrawal_reasons/level_two_reasons_review_component.html.erb
@@ -1,0 +1,45 @@
+<%= govuk_summary_list do |summary_list| %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t('withdrawal_reasons.level_two_reasons_review_component.provider')) %>
+    <% row.with_value(text: @application_choice.current_course.provider.name) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t('withdrawal_reasons.level_two_reasons_review_component.course')) %>
+    <% row.with_value(text: @application_choice.current_course.name_and_code) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t('withdrawal_reasons.level_two_reasons_review_component.reason')) %>
+    <% row.with_value(text: level_one_reason_text) %>
+    <% row.with_action(
+       text: t('withdrawal_reasons.level_two_reasons_review_component.change'),
+       href: candidate_interface_withdrawal_reasons_level_one_reason_edit_path(withdrawal_reason_id: redirect_id),
+       visually_hidden_text: t('withdrawal_reasons.level_two_reasons_review_component.level_one_reason_visually_hidden_change_text'),
+     ) %>
+  <% end %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key(text: t('withdrawal_reasons.level_two_reasons_review_component.reason_details')) %>
+    <% row.with_value do %>
+      <%= govuk_list(reason_details) %>
+    <% end %>
+    <% row.with_action(
+       text: t('withdrawal_reasons.level_two_reasons_review_component.change'),
+       href: candidate_interface_withdrawal_reasons_level_two_reasons_new_path(level_one_reason: @level_one_reason),
+       visually_hidden_text: t('withdrawal_reasons.level_two_reasons_review_component.level_two_reasons_visually_hidden_change_text'),
+     ) %>
+  <% end %>
+<% end %>
+
+<%= form_with(
+    url: candidate_interface_withdrawal_create_path(@application_choice),
+    method: :post,
+  ) do |f| %>
+
+  <%= f.govuk_submit 'Yes I’m sure – withdraw this application', warning: true %>
+<% end %>
+
+<p class="govuk-body">
+  <%= govuk_link_to(
+    t('cancel'),
+    candidate_interface_application_choices_path,
+  ) %>
+</p>

--- a/app/components/candidate_interface/withdrawal_reasons/level_two_reasons_review_component.rb
+++ b/app/components/candidate_interface/withdrawal_reasons/level_two_reasons_review_component.rb
@@ -1,0 +1,59 @@
+module CandidateInterface
+  module WithdrawalReasons
+    class LevelTwoReasonsReviewComponent < ViewComponent::Base
+      def initialize(level_one_reason, application_choice:)
+        @application_choice = application_choice
+        @level_one_reason = level_one_reason
+      end
+
+      def level_one_reason_text
+        translate("#{@level_one_reason}.label")
+      end
+
+      def reason_details
+        withdrawal_reasons.pluck(:reason, :comment).map do |reason, comment|
+          if reason.include?(personal_circumstances_key)
+            reasons_with_further_detail(reason, comment)
+          else
+            reason_without_further_detail(reason, comment)
+          end
+        end
+      end
+
+      def redirect_id
+        withdrawal_reasons.first.id
+      end
+
+    private
+
+      def withdrawal_reasons
+        @withdrawal_reasons ||= @application_choice.draft_withdrawal_reasons.by_level_one_reason(@level_one_reason)
+      end
+
+      def reason_without_further_detail(reason, comment = nil)
+        label = translate("#{reason}.label")
+
+        comment.present? ? "#{label}: #{comment}" : label
+      end
+
+      def reasons_with_further_detail(reason, comment = nil)
+        personal_circumstances_label = translate("#{@level_one_reason}.#{personal_circumstances_key}.label")
+        label = translate("#{reason}.label")
+
+        if comment.present?
+          "#{personal_circumstances_label} (#{label}): #{comment}"
+        else
+          "#{personal_circumstances_label}: #{label}"
+        end
+      end
+
+      def translate(string)
+        I18n.t("candidate_interface.withdrawal_reasons.reasons.#{string}".gsub!('-', '_'))
+      end
+
+      def personal_circumstances_key
+        WithdrawalReason::PERSONAL_CIRCUMSTANCES_KEY
+      end
+    end
+  end
+end

--- a/app/controllers/candidate_interface/withdrawal_reasons/level_one_reasons_controller.rb
+++ b/app/controllers/candidate_interface/withdrawal_reasons/level_one_reasons_controller.rb
@@ -1,0 +1,62 @@
+module CandidateInterface
+  module WithdrawalReasons
+    class LevelOneReasonsController < WithdrawalsController
+      before_action :set_draft_reason, only: %i[show edit create]
+      before_action :clear_earlier_drafts, only: %i[show]
+
+      def show
+        @level_one_reasons_form = LevelOneReasonsForm.build_from_reason(@level_one_reason)
+      end
+
+      def new
+        @level_one_reasons_form = LevelOneReasonsForm.new({ level_one_reason: level_one_reason_params[:level_one_reason] })
+      end
+
+      def edit
+        @level_one_reasons_form = LevelOneReasonsForm.build_from_reason(@level_one_reason)
+      end
+
+      def create
+        attributes = @level_one_reason.present? ? form_params.merge(id: @level_one_reason.id) : form_params
+        @level_one_reasons_form = LevelOneReasonsForm.new(attributes, application_choice: @application_choice)
+
+        if @level_one_reasons_form.invalid?
+          render :new
+        elsif @level_one_reasons_form.ready_for_review?
+          draft_withdrawal_reason = @level_one_reasons_form.persist!
+          redirect_to candidate_interface_withdrawal_reasons_level_one_reason_show_path(
+            withdrawal_reason_id: draft_withdrawal_reason.id,
+          )
+        else
+          redirect_to candidate_interface_withdrawal_reasons_level_two_reasons_new_path(
+            level_one_reason: @level_one_reasons_form.level_one_reason,
+          )
+        end
+      end
+
+    private
+
+      def form_params
+        params.require(:candidate_interface_withdrawal_reasons_level_one_reasons_form).permit(:level_one_reason, :comment)
+      end
+
+      def set_draft_reason
+        if withdrawal_reason_id.positive?
+          @level_one_reason = @application_choice.draft_withdrawal_reasons.find(withdrawal_reason_id)
+        end
+      end
+
+      def clear_earlier_drafts
+        @application_choice.draft_withdrawal_reasons.where.not(id: withdrawal_reason_id).destroy_all
+      end
+
+      def withdrawal_reason_id
+        params[:withdrawal_reason_id].to_i
+      end
+
+      def level_one_reason_params
+        params.permit(:level_one_reason)
+      end
+    end
+  end
+end

--- a/app/controllers/candidate_interface/withdrawal_reasons/level_two_reasons_controller.rb
+++ b/app/controllers/candidate_interface/withdrawal_reasons/level_two_reasons_controller.rb
@@ -1,0 +1,35 @@
+module CandidateInterface
+  module WithdrawalReasons
+    class LevelTwoReasonsController < WithdrawalsController
+      def show
+        @level_one_reason = level_one_reason
+      end
+
+      def new
+        @level_two_reasons_form = LevelTwoReasonsForm.build_from_application_choice(level_one_reason, @application_choice)
+      end
+
+      def create
+        @level_two_reasons_form = LevelTwoReasonsForm.new(form_params, application_choice: @application_choice)
+        if @level_two_reasons_form.valid?
+          @level_two_reasons_form.persist!
+          redirect_to candidate_interface_withdrawal_reasons_level_two_reasons_show_path
+        else
+          render :new
+        end
+      end
+
+    private
+
+      def form_params
+        params.require(:candidate_interface_withdrawal_reasons_level_two_reasons_form)
+              .permit(:comment, :personal_circumstances_reasons_comment, level_two_reasons: [], personal_circumstances_reasons: [])
+              .merge({ level_one_reason: })
+      end
+
+      def level_one_reason
+        params[:level_one_reason]
+      end
+    end
+  end
+end

--- a/app/controllers/candidate_interface/withdrawal_reasons/withdrawals_controller.rb
+++ b/app/controllers/candidate_interface/withdrawal_reasons/withdrawals_controller.rb
@@ -1,0 +1,29 @@
+module CandidateInterface
+  module WithdrawalReasons
+    class WithdrawalsController < CandidateInterfaceController
+      before_action :set_application_choice
+      before_action :check_that_candidate_can_withdraw
+
+      def create
+        WithdrawApplication.new(application_choice: @application_choice).save!
+        flash[:success] = I18n.t(
+          'candidate_interface.withdrawal_reasons.success_message',
+          provider_name: @application_choice.current_course_option.provider.name,
+        )
+        redirect_to candidate_interface_application_choices_path
+      end
+
+    private
+
+      def set_application_choice
+        @application_choice = @current_application.application_choices.find(params[:id])
+      end
+
+      def check_that_candidate_can_withdraw
+        unless ApplicationStateChange.new(@application_choice).can_withdraw?
+          render_404
+        end
+      end
+    end
+  end
+end

--- a/app/forms/candidate_interface/withdrawal_reasons/level_one_reasons_form.rb
+++ b/app/forms/candidate_interface/withdrawal_reasons/level_one_reasons_form.rb
@@ -1,0 +1,68 @@
+module CandidateInterface
+  module WithdrawalReasons
+    class LevelOneReasonsForm
+      include ActiveModel::Model
+
+      attr_accessor :level_one_reason, :comment, :id
+
+      validates :level_one_reason, presence: true
+      validates :comment, presence: true, if: :other?
+      validates :comment, word_count: { maximum: 200 }
+
+      def self.build_from_reason(withdraw_reason)
+        new(
+          {
+            level_one_reason: withdraw_reason.reason.split('.').first,
+            comment: withdraw_reason.comment,
+            id: withdraw_reason.id,
+          },
+          application_choice: withdraw_reason.application_choice,
+        )
+      end
+
+      def initialize(attributes = {}, application_choice: nil)
+        @application_choice = application_choice
+        super(attributes)
+      end
+
+      def ready_for_review?
+        valid? && other?
+      end
+
+      def persist!
+        ActiveRecord::Base.transaction do
+          @application_choice.withdrawal_reasons.where.not(id:).destroy_all
+          if id.present?
+            withdrawal_reason = @application_choice.withdrawal_reasons.find(id)
+            withdrawal_reason.update!(reason: level_one_reason, comment:)
+            withdrawal_reason
+          else
+            @application_choice.draft_withdrawal_reasons.create!(reason: level_one_reason, comment:)
+          end
+        end
+      end
+
+      def reason_options
+        option = Struct.new(:id, :name, :other_reason)
+        WithdrawalReason.get_reason_options.keys.map do |reason|
+          option.new(
+            id: reason,
+            name: translate("#{reason}.label"),
+            other_reason: reason == 'other' ? translate("#{reason}.comment.label") : nil,
+          )
+        end
+      end
+
+    private
+
+      def other?
+        level_one_reason == 'other'
+      end
+
+      def translate(string)
+        string.gsub!('-', '_')
+        I18n.t("candidate_interface.withdrawal_reasons.reasons.#{string}")
+      end
+    end
+  end
+end

--- a/app/forms/candidate_interface/withdrawal_reasons/level_two_reasons_builder.rb
+++ b/app/forms/candidate_interface/withdrawal_reasons/level_two_reasons_builder.rb
@@ -1,0 +1,66 @@
+module CandidateInterface
+  module WithdrawalReasons
+    class LevelTwoReasonsBuilder
+      PERSONAL_CIRCUMSTANCES_KEY = WithdrawalReason::PERSONAL_CIRCUMSTANCES_KEY
+
+      def initialize(level_one_reason, application_choice)
+        @level_one_reason = level_one_reason
+        @application_choice = application_choice
+      end
+
+      def form_attributes
+        {
+          level_one_reason: @level_one_reason,
+          level_two_reasons:,
+          personal_circumstances_reasons:,
+          comment:,
+          personal_circumstances_reasons_comment:,
+        }
+      end
+
+      def withdrawal_reasons
+        @withdrawal_reasons ||= @application_choice.draft_withdrawal_reasons.by_level_one_reason(@level_one_reason)
+      end
+
+    private
+
+      def level_two_reasons
+        @level_two_reasons ||= build_level_two_reasons
+      end
+
+      def personal_circumstances_reasons
+        @personal_circumstances_reasons ||= build_personal_circumstances_reasons
+      end
+
+      def personal_circumstances_reasons_comment
+        @personal_circumstances_reasons_comment ||= withdrawal_reasons.find do |withdrawal_reason|
+          withdrawal_reason.reason.include?("#{PERSONAL_CIRCUMSTANCES_KEY}.other")
+        end&.comment
+      end
+
+      def comment
+        @comment ||= withdrawal_reasons.find do |withdrawal_reason|
+          withdrawal_reason.reason.include?("#{@level_one_reason}.other")
+        end&.comment
+      end
+
+      def build_level_two_reasons
+        level_two_reasons = withdrawal_reasons.map do |withdrawal_reason|
+          next if withdrawal_reason.reason.include?("#{PERSONAL_CIRCUMSTANCES_KEY}.")
+
+          (withdrawal_reason.reason.split('.') - [@level_one_reason]).join('.')
+        end&.compact
+        level_two_reasons << PERSONAL_CIRCUMSTANCES_KEY if personal_circumstances_reasons.present?
+        level_two_reasons
+      end
+
+      def build_personal_circumstances_reasons
+        withdrawal_reasons.map do |withdrawal_reason|
+          next if withdrawal_reason.reason.exclude?("#{PERSONAL_CIRCUMSTANCES_KEY}.")
+
+          (withdrawal_reason.reason.split('.') - [@level_one_reason]).join('.')
+        end&.compact
+      end
+    end
+  end
+end

--- a/app/forms/candidate_interface/withdrawal_reasons/level_two_reasons_form.rb
+++ b/app/forms/candidate_interface/withdrawal_reasons/level_two_reasons_form.rb
@@ -1,0 +1,131 @@
+module CandidateInterface
+  module WithdrawalReasons
+    class LevelTwoReasonsForm
+      include ActiveModel::Model
+      include ActiveModel::Validations::Callbacks
+      include Rails.application.routes.url_helpers
+
+      attr_accessor :level_one_reason,
+                    :level_two_reasons,
+                    :personal_circumstances_reasons,
+                    :personal_circumstances_reasons_comment,
+                    :comment
+
+      validate :level_two_reasons_presence
+      validates :personal_circumstances_reasons,
+                presence: true,
+                if: :personal_circumstances_reasons_required?
+      validates :personal_circumstances_reasons_comment,
+                presence: true,
+                if: :personal_circumstances_reasons_comment_required?
+      validates :personal_circumstances_reasons_comment, word_count: { maximum: 200 }
+      validates :comment, presence: true, if: :other?
+      validates :comment, word_count: { maximum: 200 }
+
+      before_validation :sanitize_reasons
+
+      PERSONAL_CIRCUMSTANCES_KEY = WithdrawalReason::PERSONAL_CIRCUMSTANCES_KEY
+
+      def self.build_from_application_choice(level_one_reason, application_choice)
+        form_builder = LevelTwoReasonsBuilder.new(level_one_reason, application_choice)
+        new(
+          { **form_builder.form_attributes },
+          application_choice:,
+          withdrawal_reasons: form_builder.withdrawal_reasons,
+        )
+      end
+
+      def initialize(attributes = {}, application_choice: nil, withdrawal_reasons: nil)
+        @application_choice = application_choice
+        @withdrawal_reasons = withdrawal_reasons
+        super(attributes)
+      end
+
+      def persist!
+        # Reasons can be orphaned if the user abandons the withdrawal form before confirming or cancelling.
+        # So we want to destroy any existing drafts; and only save for review what is in the current form.
+        ActiveRecord::Base.transaction do
+          @application_choice.draft_withdrawal_reasons.destroy_all
+
+          # Then create from valid form attributes
+          [level_two_reasons, personal_circumstances_reasons].flatten.compact.each do |reason|
+            next if reason == PERSONAL_CIRCUMSTANCES_KEY
+
+            other_comment = if reason == 'other'
+                              comment
+                            elsif reason == "#{PERSONAL_CIRCUMSTANCES_KEY}.other"
+                              personal_circumstances_reasons_comment
+                            end
+
+            @application_choice.draft_withdrawal_reasons.create!(
+              reason: "#{level_one_reason}.#{reason}",
+              comment: other_comment,
+            )
+          end
+        end
+      end
+
+      def reason_options
+        option = Struct.new(:id, :name, :other_reason, :personal_circumstances_reasons)
+        WithdrawalReason.get_reason_options(level_one_reason).map do |reason_id, nested_reasons|
+          personal_circumstances_reasons = nested_reasons.map do |supporting_reason_id, _options|
+            option.new(
+              id: "#{reason_id}.#{supporting_reason_id}",
+              name: translate("#{reason_id}.#{supporting_reason_id}.label"),
+              other_reason: supporting_reason_id == 'other' ? translate("#{reason_id}.#{supporting_reason_id}.comment.label") : nil,
+            )
+          end
+
+          option.new(
+            id: reason_id,
+            name: translate("#{reason_id}.label"),
+            other_reason: reason_id == 'other' ? translate("#{reason_id}.comment.label") : nil,
+            personal_circumstances_reasons: reason_id == 'other' ? nil : personal_circumstances_reasons,
+          )
+        end
+      end
+
+      def form_title
+        translate('level_two_reasons_title')
+      end
+
+      def return_to_level_one_reasons_path
+        if @withdrawal_reasons.present?
+          candidate_interface_withdrawal_reasons_level_one_reason_edit_path(@application_choice, withdrawal_reason_id: @withdrawal_reasons.first.id)
+        else
+          candidate_interface_withdrawal_reasons_level_one_reason_new_path(@application_choice, params: { level_one_reason: })
+        end
+      end
+
+    private
+
+      def other?
+        level_two_reasons.present? && level_two_reasons.include?('other')
+      end
+
+      def personal_circumstances_reasons_comment_required?
+        personal_circumstances_reasons.present? && personal_circumstances_reasons.include?("#{PERSONAL_CIRCUMSTANCES_KEY}.other")
+      end
+
+      def personal_circumstances_reasons_required?
+        level_two_reasons.present? && level_two_reasons.include?(PERSONAL_CIRCUMSTANCES_KEY)
+      end
+
+      def level_two_reasons_presence
+        return if level_two_reasons.present?
+
+        error_type = "blank_#{level_one_reason}".gsub('-', '_').to_sym
+        errors.add(:level_two_reasons, error_type)
+      end
+
+      def sanitize_reasons
+        level_two_reasons.reject!(&:blank?)
+        personal_circumstances_reasons.reject!(&:blank?) if personal_circumstances_reasons.present?
+      end
+
+      def translate(string)
+        I18n.t("candidate_interface.withdrawal_reasons.reasons.#{level_one_reason}.#{string}".gsub!('-', '_'))
+      end
+    end
+  end
+end

--- a/app/models/withdrawal_reason.rb
+++ b/app/models/withdrawal_reason.rb
@@ -5,6 +5,20 @@ class WithdrawalReason < ApplicationRecord
   PERSONAL_CIRCUMSTANCES_KEY = 'personal-circumstances-have-changed'.freeze
   CONFIG_PATH = 'config/candidate_withdrawal_reasons.yml'.freeze
 
+  scope :by_level_one_reason, lambda { |level|
+    keys = get_reason_options(level).map do |key, value|
+      if value == {}
+        key
+      else
+        value.map { |val_key, _| "#{key}.#{val_key}" }
+      end
+    end&.flatten
+
+    where('reason LIKE ?', "#{level}%").sort do |a, b|
+      keys.index(a.reason.gsub("#{level}.", '')) <=> keys.index(b.reason.gsub("#{level}.", ''))
+    end
+  }
+
   enum :status, {
     draft: 'draft',
     published: 'published',
@@ -18,7 +32,7 @@ class WithdrawalReason < ApplicationRecord
     YAML.load_file(CONFIG_PATH).fetch('candidate-withdrawal-reasons')
   end
 
-  def self.find_reason_options(reason = '')
+  def self.get_reason_options(reason = '')
     if reason.empty?
       selectable_reasons
     else

--- a/app/services/candidate_interface/choices_controller_matcher.rb
+++ b/app/services/candidate_interface/choices_controller_matcher.rb
@@ -4,7 +4,8 @@ class CandidateInterface::ChoicesControllerMatcher
   APPLICATION_CHOICE_CONTROLLER_PATHS = [
     'candidate_interface/course_choices', # the course choice wizard
     'candidate_interface/application_choices', # controller for Your applications & deleting an application choice
-    'candidate_interface/decisions', # withdrawing from a course offer
+    'candidate_interface/decisions', # withdrawing from a course offer, the old way
+    'candidate_interface/withdrawal_reasons', # Withdrawing the new way
     'candidate_interface/apply_from_find',
   ].freeze
 

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -29,6 +29,7 @@ class FeatureFlag
   TEMPORARY_FEATURE_FLAGS = [
     [:block_provider_activity_log, 'Block provider activity log if causing problems', 'Lori Bailey'],
     [:show_reference_confidentiality_status, 'Control whether the confidentiality status of references is explicitly communicated to candidates, referees and providers', 'Avin Hurry'],
+    [:new_candidate_withdrawal_reasons, 'Turn on new withdrawal reasons', 'Lori Bailey'],
   ].freeze
 
   CACHE_EXPIRES_IN = 1.day

--- a/app/services/withdraw_application.rb
+++ b/app/services/withdraw_application.rb
@@ -10,6 +10,7 @@ class WithdrawApplication
         withdrawn_at: Time.zone.now,
         withdrawn_or_declined_for_candidate_by_provider: false,
       )
+      application_choice.draft_withdrawal_reasons.each(&:publish!)
     end
 
     CancelUpcomingInterviews.new(

--- a/app/views/candidate_interface/offer_dashboard/_sidebar.html.erb
+++ b/app/views/candidate_interface/offer_dashboard/_sidebar.html.erb
@@ -1,4 +1,8 @@
   <div class="govuk-grid-column-third">
     <p class="govuk-body-s"><%= govuk_link_to 'View application', candidate_interface_application_review_submitted_path %></p>
-    <p class="govuk-body-s"><%= govuk_link_to 'Withdraw from the course', candidate_interface_withdraw_path(@application_choice) %></p>
+    <% if FeatureFlag.active? :new_candidate_withdrawal_reasons %>
+      <p class="govuk-body-s"><%= govuk_link_to 'Withdraw from the course', candidate_interface_withdrawal_reasons_level_one_reason_new_path(@application_choice) %></p>
+    <% else %>
+      <p class="govuk-body-s"><%= govuk_link_to 'Withdraw from the course', candidate_interface_withdraw_path(@application_choice) %></p>
+    <% end %>
   </div>

--- a/app/views/candidate_interface/withdrawal_reasons/level_one_reasons/_form.html.erb
+++ b/app/views/candidate_interface/withdrawal_reasons/level_one_reasons/_form.html.erb
@@ -1,0 +1,36 @@
+<%= form_with(
+      model: @level_one_reasons_form,
+      url: candidate_interface_withdrawal_reasons_level_one_reason_create_path(withdrawal_reason_id: @level_one_reasons_form.id),
+    ) do |f| %>
+  <%= f.govuk_error_summary %>
+  <%= f.govuk_radio_buttons_fieldset(
+    :level_one_reason,
+    legend: { text: t('candidate_interface.withdrawal_reasons.level_one_reason_title'), tag: 'h1', size: 'l' },
+  ) do %>
+    <% @level_one_reasons_form.reason_options.each_with_index do |reason, index| %>
+      <% if reason.other_reason.blank? %>
+        <%= f.govuk_radio_button(
+              :level_one_reason,
+              reason.id,
+              link_errors: index.zero?,
+              label: { text: reason.name },
+            ) %>
+      <% else %>
+        <%= f.govuk_radio_button(
+          :level_one_reason,
+          reason.id,
+          label: { text: reason.name },
+        )  do %>
+          <%= f.govuk_text_area(
+                :comment,
+                label: { text: reason.other_reason, size: 's' },
+                max_words: 200,
+                rows: 5,
+                link_errors: true,
+              ) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+  <%= f.govuk_submit t('continue') %>
+<% end %>

--- a/app/views/candidate_interface/withdrawal_reasons/level_one_reasons/edit.html.erb
+++ b/app/views/candidate_interface/withdrawal_reasons/level_one_reasons/edit.html.erb
@@ -1,0 +1,8 @@
+<% content_for :title, t('candidate_interface.withdrawal_reasons.level_one_reason_title') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_course_choices_course_review_path(@application_choice), back_link_text, force_text: true) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render 'form' %>
+  </div>
+</div>

--- a/app/views/candidate_interface/withdrawal_reasons/level_one_reasons/new.html.erb
+++ b/app/views/candidate_interface/withdrawal_reasons/level_one_reasons/new.html.erb
@@ -1,0 +1,7 @@
+<% content_for :title, title_with_error_prefix(t('candidate_interface.withdrawal_reasons.level_one_reason_title'), @level_one_reasons_form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_course_choices_course_review_path(@application_choice), back_link_text, force_text: true) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render 'form' %>
+  </div>
+</div>

--- a/app/views/candidate_interface/withdrawal_reasons/level_one_reasons/show.html.erb
+++ b/app/views/candidate_interface/withdrawal_reasons/level_one_reasons/show.html.erb
@@ -1,0 +1,11 @@
+<% content_for :title, t('page_titles.decisions.withdraw') %>
+<% content_for(:before_content, govuk_back_link_to(candidate_interface_withdrawal_reasons_level_one_reason_edit_path)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render CandidateInterface::WithdrawalReasons::LevelOneReasonReviewComponent.new(
+      application_choice: @application_choice,
+      withdrawal_reason: @level_one_reason,
+    ) %>
+  </div>
+</div>

--- a/app/views/candidate_interface/withdrawal_reasons/level_two_reasons/_form.html.erb
+++ b/app/views/candidate_interface/withdrawal_reasons/level_two_reasons/_form.html.erb
@@ -1,0 +1,24 @@
+<%= form_with(model: @level_two_reasons_form, url: candidate_interface_withdrawal_reasons_level_two_reasons_create_path) do |f| %>
+  <%= f.govuk_error_summary %>
+  <%= f.govuk_check_boxes_fieldset(:level_two_reasons, legend: { text: @level_two_reasons_form.form_title, tag: 'h1', size: 'l' }, hint: { text: t('candidate_interface.withdrawal_reasons.select_all_that_apply') }) do %>
+    <% @level_two_reasons_form.reason_options.each_with_index do |reason, index| %>
+      <%= f.govuk_check_box(:level_two_reasons, reason.id, link_errors: index.zero?, label: { text: reason.name })  do %>
+        <% if reason.other_reason.present? %>
+          <%= f.govuk_text_area(:comment, label: { text: reason.other_reason, size: 's' }, max_words: 200, rows: 5, link_errors: true) %>
+        <% end %>
+        <% if reason.personal_circumstances_reasons.present? %>
+          <%= f.govuk_check_boxes_fieldset :personal_circumstances_reasons, legend: { text: t('candidate_interface.withdrawal_reasons.personal_circumstances_legend'), size: 's' } do %>
+            <% reason.personal_circumstances_reasons.each_with_index do |supporting_reason, index| %>
+              <%= f.govuk_check_box(:personal_circumstances_reasons, supporting_reason.id, link_errors: index.zero?, label: { text: supporting_reason.name }) do %>
+                <% if supporting_reason.other_reason.present? %>
+                  <%= f.govuk_text_area(:personal_circumstances_reasons_comment, label: { text: supporting_reason.other_reason, size: 's' }, max_words: 200, rows: 5, link_errors: true) %>
+                <% end %>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+  <%= f.govuk_submit t('continue') %>
+<% end %>

--- a/app/views/candidate_interface/withdrawal_reasons/level_two_reasons/new.html.erb
+++ b/app/views/candidate_interface/withdrawal_reasons/level_two_reasons/new.html.erb
@@ -1,0 +1,7 @@
+<% content_for :title, title_with_error_prefix(@level_two_reasons_form.form_title, @level_two_reasons_form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(@level_two_reasons_form.return_to_level_one_reasons_path) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render 'form' %>
+  </div>
+</div>

--- a/app/views/candidate_interface/withdrawal_reasons/level_two_reasons/show.html.erb
+++ b/app/views/candidate_interface/withdrawal_reasons/level_two_reasons/show.html.erb
@@ -1,0 +1,11 @@
+<% content_for :title, t('page_titles.decisions.withdraw') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_withdrawal_reasons_level_two_reasons_new_path, 'Back', force_text: true) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t('page_titles.decisions.withdraw') %></h1>
+      <%= render CandidateInterface::WithdrawalReasons::LevelTwoReasonsReviewComponent.new(
+        @level_one_reason, application_choice: @application_choice
+      ) %>
+  </div>
+</div>

--- a/config/locales/candidate_interface/withdrawal_reasons.yml
+++ b/config/locales/candidate_interface/withdrawal_reasons.yml
@@ -1,0 +1,124 @@
+en:
+  activemodel:
+    errors:
+      models:
+        candidate_interface/withdrawal_reasons/level_one_reasons_form:
+          attributes:
+            level_one_reason:
+              blank: Select a reason for withdrawing this application
+            comment:
+              blank: Enter details to explain the reason for withdrawing
+              too_many_words: Details must be %{maximum} words or fewer
+        candidate_interface/withdrawal_reasons/level_two_reasons_form:
+          attributes:
+            personal_circumstances_reasons_comment:
+              blank: Enter details about the change to your personal circumstances
+              too_many_words: Details must be %{maximum} words or fewer
+            personal_circumstances_reasons:
+              blank: Select a reason why your personal circumstances have changed
+            level_two_reasons:
+              blank_applying_to_another_provider: Select a reason for applying to another training provider
+              blank_change_or_update_application_with_this_provider: Select a reason for changing or updating your application with this training provider
+              blank_apply_in_the_future: Select a reason for applying for teacher training in the future
+              blank_do_not_want_to_train_anymore: Select a reason for not wanting to train to teach anymore
+            comment:
+              blank: Enter details to explain the reason for withdrawing
+              too_many_words: Details must be %{maximum} words or fewer
+
+  candidate_interface:
+    withdrawal_reasons:
+      success_message: You have withdrawn your application to %{provider_name}
+      level_one_reason_title: Why are you withdrawing this application?
+      select_all_that_apply: Select all that apply
+      personal_circumstances_legend: Details about the change to your personal circumstances
+      reasons:
+        applying_to_another_provider:
+          level_two_reasons_title: Why are you applying to another training provider?
+          label: I am going to apply (or have applied) to a different training provider
+          accepted_another_offer:
+            label: I have accepted another offer
+          seen_a_course_that_suits_me_better:
+            label: I have seen a course that suits me better
+          provider_has_not_replied_to_me:
+            label: The training provider has not replied to me
+          location_is_too_far_away:
+            label: The location I’m expected to train at is too far away
+          personal_circumstances_have_changed:
+            label: My personal circumstances have changed
+            concerns_about_cost_of_doing_course:
+              label: I have concerns about the cost of doing the course
+            concerns_about_having_enough_time_to_train:
+              label: I have concerns that I will not have time to train
+            concerns_about_training_with_a_disability_or_health_condition:
+              label: I have concerns about training with a disability or health condition
+            other:
+              label: Other
+              comment:
+                label: Details
+          course_no_longer_available:
+            label: The course is not available anymore
+          other:
+            label: Other
+            comment:
+              label: Details
+        change_or_update_application_with_this_provider:
+          label: I am going to change or update my application with this training provider
+          level_two_reasons_title: Why are you changing or updating your application with this training provider?
+          update_my_application_correct_an_error_or_add_information:
+            label: I want to update my application, for example correct an error or add information
+          change_study_pattern:
+            label: I want to change my study pattern, for example from full time to part time
+          apply_for_a_different_subject_with_the_same_provider:
+            label: I want to apply for a different subject with the same provider
+          other:
+            label: Other
+            comment:
+              label: Details
+        apply_in_the_future:
+          label: I plan to apply for teacher training in the future
+          level_two_reasons_title: Why are you planning to apply for teacher training in the future?
+          personal_circumstances_have_changed:
+            label: My personal circumstances have changed
+            concerns_about_cost_of_doing_course:
+              label: I have concerns about the cost of doing the course
+            concerns_about_having_enough_time_to_train:
+              label: I have concerns that I will not have time to train
+            concerns_about_training_with_a_disability_or_health_condition:
+              label: I have concerns about training with a disability or health condition
+            other:
+              label: Other
+              comment:
+                label: Details
+          gain_more_experience:
+            label: I want to get more experience before I apply again
+          improve_qualifications:
+            label: I want to improve my qualifications before I apply again
+          other:
+            label: Other
+            comment:
+              label: Details
+        do_not_want_to_train_anymore:
+          label: I do not want to train to teach anymore
+          level_two_reasons_title: Why do you not want to train to teach anymore?
+          personal_circumstances_have_changed:
+            label: My personal circumstances have changed
+            concerns_about_cost_of_doing_course:
+              label: I have concerns about the cost of doing the course
+            concerns_about_having_enough_time_to_train:
+              label: I have concerns that I will not have time to train
+            concerns_about_training_with_a_disability_or_health_condition:
+              label: I have concerns about training with a disability or health condition
+            other:
+              label: Other
+              comment:
+                label: Details
+          another_career_path_or_accepted_a_job_offer:
+            label: I have decided on another career path or I have accepted a job offer
+          other:
+            label: Other
+            comment:
+              label: Details
+        other:
+          label: Other
+          comment:
+            label: Details

--- a/config/locales/components/candidate_interface/withdrawal_reasons/level_one_reason_review_component.yml
+++ b/config/locales/components/candidate_interface/withdrawal_reasons/level_one_reason_review_component.yml
@@ -1,0 +1,10 @@
+en:
+  withdrawal_reasons:
+    level_one_reason_review_component:
+      submit: Yes I’m sure – withdraw this application
+      provider: Provider
+      course: Course
+      reason: Reason
+      change: Change
+      cancel: Cancel
+      visually_hidden_change_text: reason for withdrawal

--- a/config/locales/components/candidate_interface/withdrawal_reasons/secondary_reasons_review_component.yml
+++ b/config/locales/components/candidate_interface/withdrawal_reasons/secondary_reasons_review_component.yml
@@ -1,0 +1,12 @@
+en:
+  withdrawal_reasons:
+    level_two_reasons_review_component:
+      submit: Yes I’m sure – withdraw this application
+      provider: Provider
+      course: Course
+      reason: Reason
+      reason_details: Reason details
+      change: Change
+      cancel: Cancel
+      level_two_reasons_visually_hidden_change_text: additional details for withdrawal
+      level_one_reason_visually_hidden_change_text: main reason for withdrawal

--- a/config/routes/candidate.rb
+++ b/config/routes/candidate.rb
@@ -407,6 +407,18 @@ namespace :candidate_interface, path: '/candidate' do
 
       get '/withdraw/feedback' => 'decisions#withdrawal_feedback', as: :withdrawal_feedback
       post '/withdraw/confirm-feedback' => 'decisions#confirm_withdrawal_feedback', as: :confirm_withdrawal_feedback
+
+      get '/withdrawal-reasons/level-one-reason/new' => 'withdrawal_reasons/level_one_reasons#new', as: :withdrawal_reasons_level_one_reason_new
+      post '/withdrawal-reasons/level-one-reason(/:withdrawal_reason_id)/create' => 'withdrawal_reasons/level_one_reasons#create', as: :withdrawal_reasons_level_one_reason_create
+      get '/withdrawal-reasons/level-one-reason/:withdrawal_reason_id/show' => 'withdrawal_reasons/level_one_reasons#show', as: :withdrawal_reasons_level_one_reason_show
+      get '/withdrawal-reasons/level-one-reason/:withdrawal_reason_id/edit' => 'withdrawal_reasons/level_one_reasons#edit', as: :withdrawal_reasons_level_one_reason_edit
+
+      get '/withdrawal-reasons/:level_one_reason/new' => 'withdrawal_reasons/level_two_reasons#new', as: :withdrawal_reasons_level_two_reasons_new
+      post '/withdrawal-reasons/:level_one_reason/create' => 'withdrawal_reasons/level_two_reasons#create', as: :withdrawal_reasons_level_two_reasons_create
+      get '/withdrawal-reasons/:level_one_reason/show' => 'withdrawal_reasons/level_two_reasons#show', as: :withdrawal_reasons_level_two_reasons_show
+      get '/withdrawal-reasons/:level_one_reason/edit' => 'withdrawal_reasons/level_two_reasons#edit', as: :withdrawal_reasons_level_two_reasons_edit
+
+      post '/withdrawal-reasons/create' => 'withdrawal_reasons/withdrawals#create', as: :withdrawal_create
     end
 
     scope '/other-qualifications' do

--- a/db/scripts/sanitise.sql
+++ b/db/scripts/sanitise.sql
@@ -158,3 +158,11 @@ UPDATE "vendor_api_users"
 SET
     full_name = concat('Api User', id),
     email_address = concat('application_reference_', id, '@example.com');
+
+-- WithdrawalReason
+UPDATE "withdrawal_reasons"
+SET
+    comment = CASE
+    WHEN comment IS NULL THEN NULL
+    ELSE generate_lorem_ipsum('short')
+    END;

--- a/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
+++ b/spec/components/candidate_interface/application_dashboard_course_choices_component_spec.rb
@@ -238,6 +238,10 @@ RSpec.describe CandidateInterface::ApplicationDashboardCourseChoicesComponent, t
   end
 
   context 'when an offer has been accepted i.e. pending conditions to a course choice' do
+    before do
+      FeatureFlag.deactivate(:new_candidate_withdrawal_reasons)
+    end
+
     let(:application_choice) { create(:application_choice, :accepted) }
     let(:application_form) { application_choice.application_form }
 

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -153,6 +153,7 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, :mid_cycle, typ
     end
 
     it 'renders component with a withdraw link' do
+      FeatureFlag.deactivate :new_candidate_withdrawal_reasons
       result = render_inline(described_class.new(application_form:, show_status: true))
 
       expect(result.css('.app-summary-card__actions').text).to include(t('application_form.courses.withdraw'))
@@ -199,6 +200,10 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent, :mid_cycle, typ
   end
 
   context 'when an offer has been accepted i.e. pending conditions to a course choice' do
+    before do
+      FeatureFlag.deactivate :new_candidate_withdrawal_reasons
+    end
+
     let(:application_form) { create_application_form_with_course_choices(statuses: %w[pending_conditions]) }
 
     it 'renders component with the status as accepted' do

--- a/spec/factories/withdrawal_reason.rb
+++ b/spec/factories/withdrawal_reason.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :withdrawal_reason, class: 'WithdrawalReason' do
+    reason { 'applying-to-another-provider.accepted_another-offer' }
+  end
+end

--- a/spec/forms/candidate_interface/withdrawal_reasons/level_one_reasons_form_spec.rb
+++ b/spec/forms/candidate_interface/withdrawal_reasons/level_one_reasons_form_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::WithdrawalReasons::LevelOneReasonsForm do
+  describe '#persist!' do
+    let(:application_choice) { create(:application_choice) }
+    let(:form) { described_class.new({ level_one_reason: 'other', comment: 'hi' }, application_choice:) }
+
+    it 'clears old drafts' do
+      old_draft = create(:withdrawal_reason, application_choice:)
+      form.persist!
+      expect { old_draft.reload }.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    it 'creates a new draft withdrawal reason' do
+      expect { form.persist! }.to change { WithdrawalReason.count }.by(1)
+    end
+
+    it 'updates existing withdrawal reason' do
+      draft = create(:withdrawal_reason, reason: 'other', comment: 'old comment', application_choice:)
+      form = described_class.new({ level_one_reason: 'other', comment: 'new comment', id: draft.id }, application_choice:)
+      expect { form.persist! }.to change { draft.reload.comment }.from('old comment').to('new comment')
+    end
+  end
+
+  describe '#ready_for_review?' do
+    it 'only returns true if valid no supporting detail is required' do
+      application_choice = create(:application_choice)
+
+      # Not valid, no comment for 'other'
+      form = described_class.new({ level_one_reason: 'other' }, application_choice:)
+      expect(form.ready_for_review?).to be false
+
+      # Needs to proceed to second step to get more detail
+      form = described_class.new({ level_one_reason: 'apply-in-the-future' }, application_choice:)
+      expect(form.ready_for_review?).to be false
+
+      # Valid and does not need to go to second step
+      form = described_class.new({ level_one_reason: 'other', comment: 'words' }, application_choice:)
+      expect(form.ready_for_review?).to be true
+    end
+  end
+end

--- a/spec/forms/candidate_interface/withdrawal_reasons/level_two_reasons_builder_spec.rb
+++ b/spec/forms/candidate_interface/withdrawal_reasons/level_two_reasons_builder_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::WithdrawalReasons::LevelTwoReasonsBuilder do
+  describe '#form_attributes' do
+    let(:application_choice) { create(:application_choice) }
+
+    context 'when no draft withdrawal reasons exist' do
+      it 'returns empty / nil values for all attributes other than level_one_reason' do
+        builder = described_class.new('change-or-update-application-with-this-provider', application_choice)
+        expect(builder.form_attributes)
+          .to eq({
+            level_one_reason: 'change-or-update-application-with-this-provider',
+            level_two_reasons: [],
+            personal_circumstances_reasons: [],
+            comment: nil,
+            personal_circumstances_reasons_comment: nil,
+          })
+      end
+    end
+
+    context 'when reasons exist but with a different level one reason' do
+      it 'returns empty / nil values for all attributes other than level_one_reason' do
+        create(:withdrawal_reason, reason: 'other', application_choice:)
+        builder = described_class.new('change-or-update-application-with-this-provider', application_choice)
+        expect(builder.form_attributes)
+          .to eq({
+            level_one_reason: 'change-or-update-application-with-this-provider',
+            level_two_reasons: [],
+            personal_circumstances_reasons: [],
+            comment: nil,
+            personal_circumstances_reasons_comment: nil,
+          })
+      end
+    end
+
+    context 'when there are existing reasons with matching level_one_reasons' do
+      it 'returns the correct level one and level two reasons' do
+        create(
+          :withdrawal_reason,
+          reason: 'change-or-update-application-with-this-provider.change-study-pattern',
+          application_choice:,
+        )
+
+        create(
+          :withdrawal_reason,
+          reason: 'change-or-update-application-with-this-provider.other',
+          comment: 'This is a comment about updating my application',
+          application_choice:,
+        )
+
+        builder = described_class.new('change-or-update-application-with-this-provider', application_choice)
+        expect(builder.form_attributes).to eq(
+          {
+            level_one_reason: 'change-or-update-application-with-this-provider',
+            level_two_reasons: %w[change-study-pattern other],
+            personal_circumstances_reasons: [],
+            comment: 'This is a comment about updating my application',
+            personal_circumstances_reasons_comment: nil,
+          },
+        )
+      end
+    end
+
+    context 'when there are existing, relevant personal circumstances related reasons' do
+      it 'returns the correct personal circumstances reasons' do
+        create(
+          :withdrawal_reason,
+          reason: 'apply-in-the-future.personal-circumstances-have-changed.other',
+          comment: 'My personal circumstances have changed, this is a comment about them.',
+          application_choice:,
+        )
+        create(
+          :withdrawal_reason,
+          reason: 'apply-in-the-future.personal-circumstances-have-changed.concerns-about-cost-of-doing-course',
+          application_choice:,
+        )
+        builder = described_class.new('apply-in-the-future', application_choice)
+        expect(builder.form_attributes).to eq(
+          {
+            level_one_reason: 'apply-in-the-future',
+            level_two_reasons: %w[personal-circumstances-have-changed],
+            personal_circumstances_reasons: %w[personal-circumstances-have-changed.concerns-about-cost-of-doing-course personal-circumstances-have-changed.other],
+            comment: nil,
+            personal_circumstances_reasons_comment: 'My personal circumstances have changed, this is a comment about them.',
+          },
+        )
+      end
+    end
+  end
+end

--- a/spec/forms/candidate_interface/withdrawal_reasons/level_two_reasons_form_spec.rb
+++ b/spec/forms/candidate_interface/withdrawal_reasons/level_two_reasons_form_spec.rb
@@ -1,0 +1,105 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::WithdrawalReasons::LevelTwoReasonsForm do
+  describe '#persist!' do
+    let(:application_choice) { create(:application_choice) }
+
+    it 'destroys old drafts' do
+      draft = create(:withdrawal_reason, application_choice:)
+      form = described_class.new(
+        {
+          level_one_reason: 'change-or-update-application-with-this-provider',
+          level_two_reasons: %w[update-my-application-correct-an-error-or-add-information change-study-pattern],
+        },
+        application_choice:,
+      )
+      form.persist!
+      expect { draft.reload }.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    it 'creates multiple new drafts' do
+      form = described_class.new(
+        {
+          level_one_reason: 'change-or-update-application-with-this-provider',
+          level_two_reasons: %w[update-my-application-correct-an-error-or-add-information change-study-pattern],
+        },
+        application_choice:,
+      )
+      form.persist!
+      expect(application_choice.withdrawal_reasons.pluck(:reason)).to contain_exactly(
+        'change-or-update-application-with-this-provider.update-my-application-correct-an-error-or-add-information',
+        'change-or-update-application-with-this-provider.change-study-pattern',
+      )
+    end
+  end
+
+  describe 'validations' do
+    let(:application_choice) { create(:application_choice) }
+
+    context 'when personal circumstances are selected' do
+      it 'requires personal circumstances details' do
+        form = described_class.new(
+          {
+            level_one_reason: 'do-not-want-to-train-anymore',
+            level_two_reasons: %w[personal-circumstances-have-changed],
+          },
+          application_choice:,
+        )
+        expect(form).not_to be_valid
+        expect(form.errors[:personal_circumstances_reasons]).to contain_exactly('Select a reason why your personal circumstances have changed')
+      end
+
+      it 'requires a personal circumstances comment when personal circumstances other is selected' do
+        form = described_class.new(
+          {
+            level_one_reason: 'do-not-want-to-train-anymore',
+            level_two_reasons: %w[personal-circumstances-have-changed],
+            personal_circumstances_reasons: %w[personal-circumstances-have-changed.other],
+
+          }, application_choice:
+        )
+        expect(form).not_to be_valid
+        expect(form.errors[:personal_circumstances_reasons_comment]).to contain_exactly('Enter details about the change to your personal circumstances')
+      end
+    end
+
+    context 'when other is selected' do
+      it 'requires comment for other reason' do
+        form = described_class.new(
+          {
+            level_one_reason: 'do-not-want-to-train-anymore',
+            level_two_reasons: %w[other],
+          }, application_choice:
+        )
+        expect(form).not_to be_valid
+        expect(form.errors[:comment]).to contain_exactly('Enter details to explain the reason for withdrawing')
+      end
+    end
+
+    context 'provides different presence errors depending on the first level reason' do
+      it 'applying-to-another-provider' do
+        form = described_class.new({ level_one_reason: 'applying-to-another-provider', level_two_reasons: [] }, application_choice:)
+        expect(form).not_to be_valid
+        expect(form.errors[:level_two_reasons]).to contain_exactly('Select a reason for applying to another training provider')
+      end
+
+      it 'change-or-update-application-with-this-provider' do
+        form = described_class.new({ level_one_reason: 'change-or-update-application-with-this-provider', level_two_reasons: [] }, application_choice:)
+        expect(form).not_to be_valid
+        expect(form.errors[:level_two_reasons]).to contain_exactly('Select a reason for changing or updating your application with this training provider')
+      end
+
+      it 'apply-in-the-future' do
+        form = described_class.new({ level_one_reason: 'apply-in-the-future', level_two_reasons: [] }, application_choice:)
+        expect(form).not_to be_valid
+        expect(form.errors[:level_two_reasons]).to contain_exactly('Select a reason for applying for teacher training in the future')
+      end
+
+      it 'do-not-want-to-train-anymore' do
+        form = described_class.new({ level_one_reason: 'do-not-want-to-train-anymore', level_two_reasons: [] }, application_choice:)
+        expect(form).not_to be_valid
+        expect(form.errors[:level_two_reasons]).to contain_exactly('Select a reason for not wanting to train to teach anymore')
+      end
+    end
+  end
+end

--- a/spec/models/withdrawal_reason_spec.rb
+++ b/spec/models/withdrawal_reason_spec.rb
@@ -9,31 +9,69 @@ RSpec.describe WithdrawalReason do
     it { is_expected.to belong_to(:application_choice) }
   end
 
+  describe 'scopes' do
+    describe '#by_level_one_reason' do
+      let(:application_choice) { create(:application_choice) }
+
+      it 'returns all records where the level one reason matches in the correct order' do
+        %w[applying-to-another-provider.provider-has-not-replied-to-me
+           other
+           applying-to-another-provider.accepted-another-offer
+           applying-to-another-provider.seen-a-course-that-suits-me-better
+           applying-to-another-provider.other
+           do-not-want-to-train-anymore.other
+           do-not-want-to-train-anymore.personal-circumstances-have-changed.other
+           applying-to-another-provider.personal-circumstances-have-changed.concerns-about-having-enough-time-to-train
+           applying-to-another-provider.location-is-too-far-away
+           applying-to-another-provider.course-no-longer-available
+           applying-to-another-provider.personal-circumstances-have-changed.concerns-about-cost-of-doing-course
+           applying-to-another-provider.personal-circumstances-have-changed.concerns-about-training-with-a-disability-or-health-condition
+           applying-to-another-provider.personal-circumstances-have-changed.other].each do |reason|
+          create(:withdrawal_reason, application_choice:, reason:)
+        end
+
+        result = described_class.by_level_one_reason('applying-to-another-provider')
+        expect(result.pluck(:reason)).to eq %w[
+          applying-to-another-provider.accepted-another-offer
+          applying-to-another-provider.seen-a-course-that-suits-me-better
+          applying-to-another-provider.provider-has-not-replied-to-me
+          applying-to-another-provider.location-is-too-far-away
+          applying-to-another-provider.personal-circumstances-have-changed.concerns-about-cost-of-doing-course
+          applying-to-another-provider.personal-circumstances-have-changed.concerns-about-having-enough-time-to-train
+          applying-to-another-provider.personal-circumstances-have-changed.concerns-about-training-with-a-disability-or-health-condition
+          applying-to-another-provider.personal-circumstances-have-changed.other
+          applying-to-another-provider.course-no-longer-available
+          applying-to-another-provider.other
+        ]
+      end
+    end
+  end
+
   describe '#selectable_reasons' do
     it 'returns a hash of selectable reasons' do
       expect(described_class.selectable_reasons).to eq(selectable_reasons)
     end
   end
 
-  describe '#find_reason_options' do
+  describe '#get_reason_options' do
     context 'without a reason_id' do
       it 'returns all selectable reasons' do
-        expect(described_class.find_reason_options).to eq(selectable_reasons)
+        expect(described_class.get_reason_options).to eq(selectable_reasons)
       end
     end
 
-    context 'with primary reason id' do
+    context 'with level-one reason id' do
       it 'returns all the reasons under that id' do
         expect(
-          described_class.find_reason_options('applying-to-another-provider'),
+          described_class.get_reason_options('applying-to-another-provider'),
         ).to eq(selectable_reasons['applying-to-another-provider'])
       end
     end
 
     context 'with nested reason id' do
-      it 'returns all secondary reasons when there are any' do
+      it 'returns all level-two reasons if there are any' do
         expect(
-          described_class.find_reason_options('applying-to-another-provider.personal-circumstances-have-changed'),
+          described_class.get_reason_options('applying-to-another-provider.personal-circumstances-have-changed'),
         ).to eq({ 'concerns-about-cost-of-doing-course' => {},
                   'concerns-about-having-enough-time-to-train' => {},
                   'concerns-about-training-with-a-disability-or-health-condition' => {},
@@ -42,7 +80,7 @@ RSpec.describe WithdrawalReason do
 
       it 'returns an empty hash when there are none' do
         expect(
-          described_class.find_reason_options('applying-to-another-provider.location-is-too-far-away'),
+          described_class.get_reason_options('applying-to-another-provider.location-is-too-far-away'),
         ).to eq({})
       end
     end

--- a/spec/support/test_helpers/withdrawal_reasons_test_helpers.rb
+++ b/spec/support/test_helpers/withdrawal_reasons_test_helpers.rb
@@ -1,0 +1,89 @@
+module WithdrawalReasonsTestHelpers
+  def and_i_click_on(*args)
+    Array(args).each do |text|
+      click_on text
+    end
+  end
+  alias when_i_click_on and_i_click_on
+
+  def and_i_check(*args)
+    Array(args).each do |text|
+      check text
+    end
+  end
+
+  def given_i_have_submitted_an_application
+    @application_choice = create(
+      :application_choice,
+      status: 'awaiting_provider_decision',
+      application_form: @application_form,
+    )
+  end
+
+  def when_i_view_the_application
+    click_on 'Your applications'
+    click_on @application_choice.current_course_option.provider.name
+  end
+
+  def and_i_am_signed_in
+    login_as(@candidate)
+    visit root_path
+  end
+
+  def then_i_see_the_success_message
+    expect(page).to have_content "You have withdrawn your application to #{@application_choice.current_course_option.provider.name}"
+  end
+
+  def then_i_am_on_the_review_page
+    expect(page).to have_content 'Are you sure you want to withdraw this application?'
+  end
+
+  def when_i_select_the_level_one_reason(level_one_reason)
+    choose level_one_reason
+    click_on 'Continue'
+  end
+
+  def then_i_see_the_error_message(error_message)
+    expect(page).to have_content('There is a problem')
+    expect(page).to have_content(error_message).twice
+  end
+
+  def when_i_enter_details_for_main_other_option(error: false)
+    id = 'candidate-interface-withdrawal-reasons-level-two-reasons-form-comment-field'
+    id += '-error' if error
+    other_details_field = find_by_id(id)
+    other_details_field.set('Here is some more detail that does not quite match the options above.')
+  end
+  alias enter_details_for_main_other_option when_i_enter_details_for_main_other_option
+
+  def and_i_select_the_main_other_option
+    find('input[type="checkbox"][value="other"]').check
+  end
+  alias select_the_main_other_option and_i_select_the_main_other_option
+  alias when_i_select_the_main_other_option and_i_select_the_main_other_option
+
+  def and_i_select_the_personal_circumstances_other_option
+    find('input[type="checkbox"][value="personal-circumstances-have-changed.other"]').check
+  end
+  alias select_the_personal_circumstances_other_option and_i_select_the_personal_circumstances_other_option
+  alias when_i_select_the_personal_circumstances_other_option and_i_select_the_personal_circumstances_other_option
+
+  def level_one_reasons
+    [
+      'I am going to apply (or have applied) to a different training provider',
+      'I am going to change or update my application with this training provider',
+      'I plan to apply for teacher training in the future',
+      'I do not want to train to teach anymore',
+      'Other',
+    ]
+  end
+
+  def reason_key_mapping
+    {
+      'I am going to apply (or have applied) to a different training provider' => 'applying-to-another-provider',
+      'I am going to change or update my application with this training provider' => 'change-or-update-application-with-this-provider',
+      'I plan to apply for teacher training in the future' => 'apply-in-the-future',
+      'I do not want to train to teach anymore' => 'do-not-want-to-train-anymore',
+    }
+  end
+end

--- a/spec/system/candidate_interface/carry_over/candidate_views_and_withdraws_after_apply_deadline_spec.rb
+++ b/spec/system/candidate_interface/carry_over/candidate_views_and_withdraws_after_apply_deadline_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe 'Views offer and withdraws before carrying over', time: CycleTimetableHelper.mid_cycle do
   include CandidateHelper
 
+  before do
+    FeatureFlag.deactivate(:new_candidate_withdrawal_reasons)
+  end
+
   scenario 'candidate is awaiting provider decision' do
     given_i_am_waiting_provider_decision
     and_the_apply_deadline_passes

--- a/spec/system/candidate_interface/withdrawal_reasons/candidate_selects_level_one_reason_only_spec.rb
+++ b/spec/system/candidate_interface/withdrawal_reasons/candidate_selects_level_one_reason_only_spec.rb
@@ -1,0 +1,127 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidate selects level-one reasons for withdrawal' do
+  include CandidateHelper
+  include WithdrawalReasonsTestHelpers
+
+  before do
+    FeatureFlag.activate(:new_candidate_withdrawal_reasons)
+    @candidate = create(:candidate)
+    @application_form = create(:completed_application_form, submitted_at: Time.zone.now, candidate: @candidate)
+  end
+
+  scenario 'Candidate can navigate around the page', time: mid_cycle do
+    given_i_have_submitted_an_application
+    and_i_am_signed_in
+    when_i_view_the_application
+    and_i_click_on('withdraw this application')
+    then_i_see_all_the_expected_elements_on_the_page
+    when_i_click_on('Back to application')
+    then_i_see_the_application_choice
+
+    when_i_click_on('withdraw this application')
+    and_i_select_other
+    and_i_add_details
+    and_i_click_on('Continue', 'Change reason for withdrawal')
+    then_i_am_on_the_level_one_reason_select_edit_page
+    when_i_click_on('Continue', 'Back')
+    then_i_am_on_the_level_one_reason_select_edit_page
+    when_i_click_on('Continue', 'Cancel')
+    then_i_see_my_application_choices
+  end
+
+  scenario 'Candidate sees error messages if they do not select a reason', time: mid_cycle do
+    given_i_have_submitted_an_application
+    and_i_am_signed_in
+    when_i_view_the_application
+    and_i_click_on('withdraw this application', 'Continue')
+    then_i_see_an_error_message_telling_me_to_select_an_option
+
+    when_i_select_other
+    and_i_click_on('Continue')
+    then_i_see_an_error_message_telling_me_to_add_details
+
+    when_i_enter_more_than_256_characters
+    and_i_click_on('Continue')
+    then_i_see_an_error_message_telling_me_to_be_more_concise
+  end
+
+  scenario 'Candidate can save other reason and withdrawal' do
+    given_i_have_submitted_an_application
+    and_i_am_signed_in
+    when_i_view_the_application
+    and_i_click_on('withdraw this application')
+    and_i_select_other
+    and_i_add_details
+    and_i_click_on('Continue')
+    then_i_see_the_review_page
+    when_i_click_on('Yes I’m sure – withdraw this application')
+    then_i_see_the_success_message
+    and_my_application_is_withdrawn_with_the_other_reason
+  end
+
+private
+
+  def then_i_am_on_the_level_one_reason_select_edit_page
+    withdrawal_reason = @application_choice.withdrawal_reasons.last
+    expect(page).to have_current_path(candidate_interface_withdrawal_reasons_level_one_reason_edit_path(@application_choice, withdrawal_reason), ignore_query: true)
+    expect(page.find_field('Other')).to be_checked
+    expect(find_field('Details').value).to eq 'Some details'
+  end
+
+  def then_i_see_an_error_message_telling_me_to_select_an_option
+    expect(page).to have_content('Select a reason for withdrawing this application').twice
+  end
+
+  def when_i_select_other
+    choose 'Other'
+  end
+  alias_method :and_i_select_other, :when_i_select_other
+
+  def and_i_add_details
+    fill_in 'Details', with: 'Some details'
+  end
+
+  def then_i_see_the_review_page
+    expect(page).to have_content 'Are you sure you want to withdraw this application?'
+    expect(page).to have_title 'Are you sure you want to withdraw this application?'
+    expect(page).to have_content 'Other: Some details'
+    expect(page).to have_css('.govuk-link.app-primary-navigation__link[aria-current=page]', text: 'Your applications')
+  end
+
+  def and_my_application_is_withdrawn_with_the_other_reason
+    expect(@application_choice.reload.status).to eq 'withdrawn'
+    expect(@application_choice.withdrawal_reasons.count).to eq 1
+    expect(
+      @application_choice.withdrawal_reasons.first,
+    ).to have_attributes(comment: 'Some details', reason: 'other', status: 'published')
+  end
+
+  def then_i_see_an_error_message_telling_me_to_add_details
+    expect(page).to have_content('Enter details to explain the reason for withdrawing').twice
+  end
+
+  def when_i_enter_more_than_256_characters
+    fill_in 'Details', with: 'a ' * 201
+  end
+
+  def then_i_see_an_error_message_telling_me_to_be_more_concise
+    expect(page).to have_content('Details must be 200 words or fewer').twice
+  end
+
+  def then_i_see_all_the_expected_elements_on_the_page
+    expect(page).to have_title 'Why are you withdrawing this application?'
+    expect(page).to have_content 'Why are you withdrawing this application?'
+    level_one_reasons.each { |reason| expect(page).to have_content reason }
+    expect(page).to have_css('.govuk-link.app-primary-navigation__link[aria-current=page]', text: 'Your applications')
+  end
+
+  def then_i_see_the_application_choice
+    expect(page).to have_current_path(candidate_interface_course_choices_course_review_path(@application_choice))
+    expect(page).to have_text("Your application to #{@application_choice.current_course_option.provider.name}")
+  end
+
+  def then_i_see_my_application_choices
+    expect(page).to have_current_path(candidate_interface_application_choices_path)
+  end
+end

--- a/spec/system/candidate_interface/withdrawal_reasons/candidate_selects_level_two_withdrawal_reasons_spec.rb
+++ b/spec/system/candidate_interface/withdrawal_reasons/candidate_selects_level_two_withdrawal_reasons_spec.rb
@@ -1,0 +1,150 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidate selects level-two withdrawal reasons' do
+  include CandidateHelper
+  include WithdrawalReasonsTestHelpers
+
+  before do
+    FeatureFlag.activate(:new_candidate_withdrawal_reasons)
+    @candidate = create(:candidate)
+    @application_form = create(:completed_application_form, submitted_at: Time.zone.now, candidate: @candidate)
+  end
+
+  shared_examples_for 'Candidate selects a level-one reason and views level-two reasons' do |level_one_reason|
+    scenario 'Candidate can navigate around the page after selecting', time: mid_cycle do
+      given_i_have_submitted_an_application
+      and_i_am_signed_in
+      when_i_view_the_application
+      and_i_click_on('withdraw this application')
+      when_i_select_the_level_one_reason(level_one_reason)
+      then_i_see_the_correct_level_two_options_page(level_one_reason)
+
+      when_i_click_on('Back')
+      then_i_am_on_the_start_page
+      and_the_level_one_reason_is_selected(level_one_reason)
+
+      when_i_click_on('Continue')
+      and_i_select_the_main_other_option
+      when_i_enter_details_for_main_other_option
+      and_i_click_on('Continue')
+      then_i_am_on_the_review_page
+
+      when_i_click_on('Change main reason for withdrawal')
+      then_i_am_on_the_edit_page
+      and_the_level_one_reason_is_selected(level_one_reason)
+
+      when_i_click_on('Continue')
+      and_other_is_selected
+      when_i_click_on('Continue')
+      then_i_am_on_the_review_page
+
+      when_i_click_on('Change additional details for withdrawal')
+      then_i_see_the_correct_level_two_options_page(level_one_reason)
+      and_other_is_selected
+
+      when_i_click_on('Continue')
+      then_i_am_on_the_review_page
+      and_i_click_on('Cancel')
+      then_i_am_on_the_applications_choice_page
+    end
+  end
+
+  it_behaves_like(
+    'Candidate selects a level-one reason and views level-two reasons',
+    'I am going to apply (or have applied) to a different training provider',
+  )
+
+  it_behaves_like(
+    'Candidate selects a level-one reason and views level-two reasons',
+    'I am going to change or update my application with this training provider',
+  )
+
+  it_behaves_like(
+    'Candidate selects a level-one reason and views level-two reasons',
+    'I plan to apply for teacher training in the future',
+  )
+
+  it_behaves_like(
+    'Candidate selects a level-one reason and views level-two reasons',
+    'I do not want to train to teach anymore',
+  )
+  def then_i_am_on_the_start_page
+    expect(page).to have_current_path(
+      candidate_interface_withdrawal_reasons_level_one_reason_new_path(id: @application_choice.id),
+      ignore_query: true,
+    )
+  end
+
+  def then_i_am_on_the_edit_page
+    expect(page).to have_content 'Why are you withdrawing this application?'
+  end
+
+  def and_other_is_selected
+    other_field = find('input[type="checkbox"][value="other"]')
+    expect(other_field.checked?).to be true
+  end
+
+  def then_i_am_on_the_applications_choice_page
+    expect(page).to have_current_path(candidate_interface_application_choices_path)
+  end
+
+  def and_the_level_one_reason_is_selected(level_one_reason)
+    expect(find_field(level_one_reason).checked?).to be true
+  end
+
+  def then_i_see_the_correct_level_two_options_page(level_one_reason)
+    key = reason_key_mapping[level_one_reason]
+    expect(page).to have_current_path(
+      candidate_interface_withdrawal_reasons_level_two_reasons_new_path(id: @application_choice.id, level_one_reason: key),
+    )
+    case key
+    when 'applying-to-another-provider'
+      [
+        'I have accepted another offer',
+        'I have seen a course that suits me better',
+        'The training provider has not replied to me',
+        'The location I’m expected to train at is too far away',
+        'My personal circumstances have changed',
+        'The course is not available anymore',
+        'Other',
+      ].each do |supporting_reason|
+        expect(page).to have_content(supporting_reason)
+      end
+      expect(page).to have_title 'Why are you applying to another training provider?'
+      expect(page).to have_content 'Why are you applying to another training provider?'
+    when 'change-or-update-application-with-this-provider'
+      [
+        'I want to update my application, for example correct an error or add information',
+        'I want to change my study pattern, for example from full time to part time',
+        'I want to apply for a different subject with the same provider',
+        'Other',
+      ].each do |supporting_reason|
+        expect(page).to have_content(supporting_reason)
+      end
+      expect(page).to have_title 'Why are you changing or updating your application with this training provider?'
+      expect(page).to have_content 'Why are you changing or updating your application with this training provider?'
+    when 'apply-in-the-future'
+      [
+        'My personal circumstances have changed',
+        'I want to get more experience before I apply again',
+        'I want to improve my qualifications before I apply again',
+        'Other',
+      ].each do |supporting_reason|
+        expect(page).to have_content(supporting_reason)
+      end
+      expect(page).to have_title 'Why are you planning to apply for teacher training in the future?'
+      expect(page).to have_content 'Why are you planning to apply for teacher training in the future?'
+    when 'do-not-want-to-train-anymore'
+
+      [
+        'My personal circumstances have changed',
+        'I have decided on another career path or I have accepted a job offer',
+        'Other',
+      ].each do |supporting_reason|
+        expect(page).to have_content(supporting_reason)
+      end
+      expect(page).to have_title 'Why do you not want to train to teach anymore?'
+      expect(page).to have_content 'Why do you not want to train to teach anymore?'
+    end
+  end
+end

--- a/spec/system/candidate_interface/withdrawal_reasons/candidate_withdraws_application_choice_spec.rb
+++ b/spec/system/candidate_interface/withdrawal_reasons/candidate_withdraws_application_choice_spec.rb
@@ -1,0 +1,131 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidate selects level-two withdrawal reasons' do
+  include CandidateHelper
+  include WithdrawalReasonsTestHelpers
+
+  before do
+    FeatureFlag.activate(:new_candidate_withdrawal_reasons)
+    @candidate = create(:candidate)
+    @application_form = create(:completed_application_form, submitted_at: Time.zone.now, candidate: @candidate)
+  end
+
+  scenario 'Candidate sees error messages unless all required data has been entered' do
+    given_i_have_submitted_an_application
+    and_i_am_signed_in
+    when_i_view_the_application
+    and_i_click_on('withdraw this application')
+    when_i_select_the_level_one_reason('I am going to apply (or have applied) to a different training provider')
+    and_i_click_on('Continue')
+    then_i_see_the_error_message('Select a reason for applying to another training provider')
+
+    when_i_select_the_main_other_option
+    and_i_click_on('Continue')
+    then_i_see_the_error_message('Enter details to explain the reason for withdrawing')
+
+    when_i_enter_details_for_main_other_option(error: true)
+    and_i_check('My personal circumstances have changed')
+    and_i_click_on('Continue')
+    then_i_see_the_error_message('Select a reason why your personal circumstances have changed')
+
+    when_i_select_the_personal_circumstances_other_option
+    and_i_click_on('Continue')
+    then_i_see_the_error_message('Enter details about the change to your personal circumstances')
+
+    when_i_enter_details_for_personal_circumstances_other_option(error: true)
+    and_i_click_on('Continue')
+    then_i_am_on_the_review_page
+
+    when_i_click_on('Yes I’m sure – withdraw this application')
+    then_i_have_withdrawn_from_the_course
+  end
+
+  scenario 'Candidate selects all level-two reasons and withdraws' do
+    given_i_have_submitted_an_application
+    and_i_am_signed_in
+    when_i_view_the_application
+    and_i_click_on('withdraw this application')
+    when_i_select_the_level_one_reason('I am going to apply (or have applied) to a different training provider')
+    and_i_select_all_the_level_two_reasons
+    and_fill_in_required_details
+    and_i_click_on('Continue')
+    then_i_see_the_review_page
+
+    when_i_click_on('Yes I’m sure – withdraw this application')
+    then_i_have_withdrawn_from_the_course
+    and_the_reasons_have_been_saved
+  end
+
+  def and_fill_in_required_details
+    enter_details_for_personal_circumstances_other_option
+    enter_details_for_main_other_option
+  end
+
+  def when_i_enter_details_for_personal_circumstances_other_option(error: false)
+    id = 'candidate-interface-withdrawal-reasons-level-two-reasons-form-personal-circumstances-reasons-comment-field'
+    id += '-error' if error
+    personal_circumstances_other_field = find_by_id(id)
+    personal_circumstances_other_field.set('Here are more details about my personal circumstances.')
+  end
+  alias_method :enter_details_for_personal_circumstances_other_option, :when_i_enter_details_for_personal_circumstances_other_option
+
+  def and_i_select_all_the_level_two_reasons
+    [
+      'I have accepted another offer',
+      'I have seen a course that suits me better',
+      'The training provider has not replied to me',
+      'The location I’m expected to train at is too far away',
+      'My personal circumstances have changed',
+      'I have concerns about the cost of doing the course',
+      'I have concerns that I will not have time to train',
+      'I have concerns about training with a disability or health condition',
+      'The course is not available anymore',
+    ].each do |reason|
+      check reason
+    end
+    select_the_main_other_option
+    select_the_personal_circumstances_other_option
+  end
+
+  def then_i_see_the_review_page
+    expect(page).to have_content 'I am going to apply (or have applied) to a different training provider'
+    [
+      'I have accepted another offer',
+      'I have seen a course that suits me better',
+      'The training provider has not replied to me',
+      'The location I’m expected to train at is too far away',
+      'My personal circumstances have changed (Other): Here are more details about my personal circumstances.',
+      'My personal circumstances have changed: I have concerns that I will not have time to train',
+      'My personal circumstances have changed: I have concerns about training with a disability or health condition',
+      'My personal circumstances have changed: I have concerns about the cost of doing the course',
+      'The course is not available anymore',
+      'Other: Here is some more detail that does not quite match the options above',
+    ].each do |review_reason|
+      expect(page).to have_content review_reason
+    end
+  end
+
+  def then_i_have_withdrawn_from_the_course
+    expect(page).to have_content "You have withdrawn your application to #{@application_choice.current_course.provider.name}"
+    expect(@application_choice.reload.status).to eq 'withdrawn'
+  end
+
+  def and_the_reasons_have_been_saved
+    expect(@application_choice.withdrawal_reasons.count).to eq 10
+    expect(@application_choice.withdrawal_reasons.pluck(:reason)).to match(
+      %w[
+        applying-to-another-provider.accepted-another-offer
+        applying-to-another-provider.seen-a-course-that-suits-me-better
+        applying-to-another-provider.provider-has-not-replied-to-me
+        applying-to-another-provider.location-is-too-far-away
+        applying-to-another-provider.course-no-longer-available
+        applying-to-another-provider.other
+        applying-to-another-provider.personal-circumstances-have-changed.concerns-about-cost-of-doing-course
+        applying-to-another-provider.personal-circumstances-have-changed.concerns-about-having-enough-time-to-train
+        applying-to-another-provider.personal-circumstances-have-changed.concerns-about-training-with-a-disability-or-health-condition
+        applying-to-another-provider.personal-circumstances-have-changed.other
+      ],
+    )
+    expect(@application_choice.withdrawal_reasons.pluck(:status).uniq).to eq ['published']
+  end
+end

--- a/spec/system/candidate_interface/withdraws/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/withdraws/candidate_withdraws_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'A candidate withdraws their application', :bullet do
   # Our mailer previews are reliant on build_stubbed so we need to exclude this test.
 
   before do
+    FeatureFlag.deactivate :new_candidate_withdrawal_reasons
     Bullet.raise = false
   end
 

--- a/spec/system/candidate_interface/withdraws/candidate_withdraws_with_upcoming_interviews_spec.rb
+++ b/spec/system/candidate_interface/withdraws/candidate_withdraws_with_upcoming_interviews_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe 'A candidate withdraws with upcoming interviews' do
   include CandidateHelper
 
+  before do
+    FeatureFlag.deactivate :new_candidate_withdrawal_reasons
+  end
+
   scenario 'successful withdrawal' do
     given_i_am_signed_in_as_a_candidate
     and_i_have_an_application_choice_with_an_upcoming_interview


### PR DESCRIPTION
## Context

Candidates can give optional reasons why they withdraw. Making the giving of a reason mandatory would help us and providers understand why candidates are ending an application.

Providers only get a summary of selected structured reasons so any more sensitive feedback can be given via the free text option.

## Changes proposed in this pull request

https://github.com/user-attachments/assets/c810a160-8f3e-43cd-8852-665f16bc4369

Instead of shoving all the reasons into a jsonb column as a single `withdrawal_reasons` field on the `application_choice`, we have a has many association between the application choice and the withdrawal reasons. Each reason follows a pattern that described in the yml file `candidate-withdrawal-reasons`, the pattern is `level-one-reason.level-two-reason.details`.  

## Guidance to review

There is a lot to review here and test here, very sorry about the big PR! 
It it would be helpful for me to chat through it before review, let me know.

But in general, the way to test is to create some applications and then withdraw them. Use the back buttons and the change buttons, abandon your journey half way through, click lots of different reasons, etc etc. 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [NA - we've decided not to backfill] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [x] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
