### PR TITLE
Redirect to sign_in page for magic link pages if one-login enabled

### DIFF
--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -2,6 +2,7 @@ module CandidateInterface
   class SignInController < CandidateInterfaceController
     skip_before_action :authenticate_candidate!
     before_action :redirect_to_application_if_signed_in, except: %i[confirm_authentication authenticate]
+    before_action :redirect_to_sign_in_if_one_login_enabled
 
     def new
       candidate = Candidate.new
@@ -101,6 +102,12 @@ module CandidateInterface
 
     def candidate_params
       params.require(:candidate).permit(:email_address)
+    end
+
+    def redirect_to_sign_in_if_one_login_enabled
+      if FeatureFlag.active?(:one_login_candidate_sign_in)
+        redirect_to candidate_interface_create_account_or_sign_in_path
+      end
     end
   end
 end

--- a/app/controllers/candidate_interface/sign_up_controller.rb
+++ b/app/controllers/candidate_interface/sign_up_controller.rb
@@ -2,6 +2,7 @@ module CandidateInterface
   class SignUpController < CandidateInterfaceController
     skip_before_action :authenticate_candidate!
     before_action :redirect_to_application_if_signed_in, except: :external_sign_up_forbidden
+    before_action :redirect_if_one_login_enabled
 
     def show; end
 
@@ -56,6 +57,12 @@ module CandidateInterface
       @provider = Provider.find_by(code: params[:providerCode])
       @course = @provider.courses.current_cycle.find_by(code: params[:courseCode]) if @provider.present?
       @course.id if @course.present?
+    end
+
+    def redirect_if_one_login_enabled
+      if FeatureFlag.active?(:one_login_candidate_sign_in)
+        redirect_to candidate_interface_create_account_or_sign_in_path
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

When the one login feature flag is activated, we should not let the user to go to any magic links urls

## Changes proposed in this pull request

before check in magic links controllers

## Guidance to review

Go on review app and try these URLs, you should be redirected back to sign in page

```
/candidate/sign-up
/candidate/sign-in
```

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
