### PR TITLE
Don't send request to one login when signing out after impersonation

### DIFF
--- a/app/controllers/one_login_controller.rb
+++ b/app/controllers/one_login_controller.rb
@@ -36,7 +36,7 @@ class OneLoginController < ApplicationController
     reset_session
 
     session[:one_login_error] = one_login_error
-    if OneLogin.bypass?
+    if OneLogin.bypass? || id_token.nil?
       redirect_to candidate_interface_create_account_or_sign_in_path
     else
       # Go back to one login to sign out the user on their end as well

--- a/spec/requests/one_login_controller_spec.rb
+++ b/spec/requests/one_login_controller_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe 'OneLoginController' do
     end
   end
 
-  describe 'GET /auth/one-login/sign_out' do
+  describe 'GET /auth/one-login/sign-out' do
     it 'redirects to one_login logout url' do
       create(:candidate, email_address: 'test@email.com')
 
@@ -162,9 +162,16 @@ RSpec.describe 'OneLoginController' do
         expect(response).to redirect_to candidate_interface_create_account_or_sign_in_path
       end
     end
+
+    context 'session id_token is nil' do
+      it 'redirects to sign_in page' do
+        get auth_one_login_sign_out_path
+        expect(response).to redirect_to candidate_interface_create_account_or_sign_in_path
+      end
+    end
   end
 
-  describe 'GET /auth/one-login/sign_out_complete' do
+  describe 'GET /auth/one-login/sign-out-complete' do
     context 'when candidate has a different one login token than the one returned by one login' do
       it 'redirects to logout_one_login_path and persists the session error message' do
         candidate = create(:candidate, email_address: 'test@email.com')


### PR DESCRIPTION
## Context

There is a small bug when login out the candidate using one login. If you logout as a candidate after impersonating the candidate we are sending request to one login to log out.

This is wrong as we didn't log in as a candidate through one login.

This PR fixes this by just redirecting to candidate sign in page if the `id_token` is nill, the `id_token` is set in the session only when one login sign in is successfull. 

## Changes proposed in this pull request

## Guidance to review

Go on review app and impersonate a candidate user.
Sign out as a candidate user.
You should be redirected to the candidate sign in page.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
