### PR TITLE
One login db session

### DIFF
--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -1,9 +1,10 @@
 module CandidateInterface
   class CandidateInterfaceController < ApplicationController
     include BackLinks
+    include Authentication
 
     before_action :protect_with_basic_auth
-    before_action :authenticate_candidate!
+    before_action :authenticate_candidate!, unless: -> { one_login_enabled? }
     before_action :set_user_context
     before_action :check_cookie_preferences
     before_action :check_account_locked
@@ -11,6 +12,10 @@ module CandidateInterface
     layout 'application'
     alias audit_user current_candidate
     alias current_user current_candidate
+
+    def current_candidate
+      super || Current.session&.candidate
+    end
 
     def set_user_context(candidate_id = current_candidate&.id)
       Sentry.set_user(id: "candidate_#{candidate_id}")

--- a/app/controllers/candidate_interface/start_page_controller.rb
+++ b/app/controllers/candidate_interface/start_page_controller.rb
@@ -3,6 +3,7 @@ module CandidateInterface
     before_action :redirect_to_application_if_signed_in
     before_action :redirect_to_post_offer_dashboard_if_accepted_deferred_or_recruited, if: :candidate_signed_in?
     skip_before_action :authenticate_candidate!
+    allow_unauthenticated_access only: %i[create_account_or_sign_in create_account_or_sign_in_handler]
 
     def create_account_or_sign_in
       @create_account_or_sign_in_form = CreateAccountOrSignInForm.new

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -1,0 +1,63 @@
+module Authentication
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :require_authentication, if: -> { one_login_enabled? }
+    helper_method :authenticated?
+  end
+
+  class_methods do
+    def allow_unauthenticated_access(**options)
+      skip_before_action :require_authentication, **options
+    end
+  end
+
+private
+
+  def authenticated?
+    resume_session
+  end
+
+  def require_authentication
+    current_candidate || resume_session || request_authentication
+  end
+
+  def resume_session
+    Current.session ||= find_session_by_cookie
+  end
+
+  def find_session_by_cookie
+    Session.find_by(id: cookies.signed[:session_id]) if cookies.signed[:session_id]
+  end
+
+  def request_authentication
+    redirect_to candidate_interface_create_account_or_sign_in_path
+  end
+
+  def start_new_session_for(candidate:, id_token_hint: nil)
+    ActiveRecord::Base.transaction do
+      unless authenticated?
+        candidate.sessions.create!(
+          user_agent: request.user_agent,
+          ip_address: request.remote_ip,
+          id_token_hint:,
+        ).tap do |session|
+          Current.session = session
+          cookies.signed.permanent[:session_id] = { value: session.id, httponly: true, same_site: :lax }
+        end
+
+        candidate.update!(last_signed_in_at: Time.zone.now)
+      end
+    end
+  end
+
+  def terminate_session
+    Current.session&.destroy
+    cookies.delete(:session_id)
+    reset_session
+  end
+
+  def one_login_enabled?
+    FeatureFlag.active?(:one_login_candidate_sign_in)
+  end
+end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,4 @@
+class Current < ActiveSupport::CurrentAttributes
+  attribute :session
+  delegate :candidate, to: :session, allow_nil: true
+end

--- a/app/models/one_login_user.rb
+++ b/app/models/one_login_user.rb
@@ -21,6 +21,14 @@ class OneLoginUser
     create_candidate!
   end
 
+  def self.find_candidate(omniauth_auth)
+    new(omniauth_auth).find_candidate
+  end
+
+  def find_candidate
+    OneLoginAuth.find_by(token:)&.candidate || Candidate.find_by(email_address:)
+  end
+
 private
 
   def candidate_with_one_login(one_login_auth)

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -116,6 +116,29 @@
       "note": ""
     },
     {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "783f66b9e6119c7b65c794a57f29b291e256d49267c511bff375d031ef83ea96",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/one_login_controller.rb",
+      "line": 71,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(logout_one_login((Current.session.id_token_hint or SessionError.find_by(:id => session[:session_error_id]).id_token_hint)), :allow_other_host => true)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "OneLoginController",
+        "method": "sign_out"
+      },
+      "user_input": "Current.session.id_token_hint",
+      "confidence": "Weak",
+      "cwe_id": [
+        601
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "7ebec2ba1f928826a941998c744411d55731a6eeb19dc1b1a406b3fb3a19b330",
@@ -277,6 +300,29 @@
       "note": ""
     },
     {
+      "warning_type": "Unscoped Find",
+      "warning_code": 82,
+      "fingerprint": "bb99c47602bf4e5e8c658f10645d3d0af3f1ac7e78e590db5e66d8986ba1642a",
+      "check_name": "UnscopedFind",
+      "message": "Unscoped call to `Session#find_by`",
+      "file": "app/controllers/concerns/authentication.rb",
+      "line": 32,
+      "link": "https://brakemanscanner.org/docs/warning_types/unscoped_find/",
+      "code": "Session.find_by(:id => cookies.signed[:session_id])",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Authentication",
+        "method": "find_session_by_cookie"
+      },
+      "user_input": "cookies.signed[:session_id]",
+      "confidence": "Weak",
+      "cwe_id": [
+        285
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "c70b946ccbfabd084091ad425893a7647560431761faa0f86bf80e95ffa007e1",
@@ -346,6 +392,6 @@
       "note": ""
     }
   ],
-  "updated": "2024-08-27 15:35:00 +0100",
-  "brakeman_version": "6.1.2"
+  "updated": "2025-01-02 12:10:42 +0000",
+  "brakeman_version": "6.2.2"
 }


### PR DESCRIPTION
## Context

In testing the one login integration, we discovered that having session backed
login is not ideal. There is a risk that the session gets too big, over 5000
bytes. To fix this, we are switching to Database backed sessions.

This is inspired by the rails 8 new [db backed sessions](https://dev.to/jetthoughts/rails-8-introducing-the-built-in-authentication-generator-1l77).
Most of the logic is in this concern `Authentication` using this and before
filters in controllers we control the one login mechanism.

We will use DB backed session for the normal candidate flow. Impersonation will
still use cookie session.

This means that deleting the session from the DB logs out the user.

Switching between one login and magic link auth system will be seamless as we
always check `current_candidate`.

We will still save some data in the session but it will be very little,
just ids rather than big tokens.

The session size decreased from roughly 3224 to 600

https://github.com/user-attachments/assets/7754de91-f283-4bef-8648-47c3d0583451

## Changes proposed in this pull request

Migrations, models and controllers

## Guidance to review

Go on QA and test the integration. It should work like before.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
