### PR TITLE
[543] only warn on onsaved changes for large text fields

### DIFF
--- a/app/frontend/packs/warn-on-unsaved-changes.js
+++ b/app/frontend/packs/warn-on-unsaved-changes.js
@@ -6,7 +6,9 @@ const getCompleteSectionCheckbox = () => {
 }
 
 const getTextArea = () => {
-  return document.querySelector('.govuk-textarea')
+  const $textAreas = document.querySelectorAll('.govuk-textarea')
+
+  return [].filter.call($textAreas, ($textArea) => $textArea.rows > 5)[0]
 }
 
 const getFirstEnhanceableForm = () => {


### PR DESCRIPTION
## Context

We were interrupting people whenever there was a text box on the page -- when the text box is small and optional this is jarring. It was flagged when testing the review app for withdrawal reasons. 

## Changes proposed in this pull request
When clicking the back navigation on a form where there is a small text box used to show this warning. Now the user will just go back. 

| Before|
| ------ |
| <img width="882" alt="image" src="https://github.com/user-attachments/assets/a676a253-0518-414a-ba94-318510b1e307" /> | 

The user will still see the warning when navigating away from text boxes larger than 5 lines long, eg the personal statement.
<img width="769" alt="image" src="https://github.com/user-attachments/assets/ea1bb72e-704e-45a3-8e38-c2ade3ffe046" />


## Guidance to review


## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card https://trello.com/c/96SunAJO
