### PR TITLE
[537] Ensure production logs are in JSON format

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,5 @@
 require "active_support/core_ext/integer/time"
+require Rails.root.join('app/lib/custom_log_formatter')
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -61,6 +62,13 @@ Rails.application.configure do
                                        .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
   config.log_format = :json                               # For parsing in Logit
   config.rails_semantic_logger.add_file_appender = false  # Don't log to file
+  config.rails_semantic_logger.format = CustomLogFormatter.new
+  config.semantic_logger.add_appender(
+    io: $stdout,
+    level: config.log_level,
+    formatter: CustomLogFormatter.new
+  )
+  
   config.active_record.logger = nil                       # Don't log SQL
 
   # Change to "debug" to log everything (including potentially personally-identifiable information!)

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -2,16 +2,8 @@
 
 return unless defined? SemanticLogger
 
-require_dependency Rails.root.join('app/lib/custom_log_formatter')
-
 unless Rails.env.local?
   Clockwork.configure { |config| config[:logger] = SemanticLogger[Clockwork] if defined?(Clockwork) }
-  SemanticLogger.add_appender(
-    io: STDOUT,
-    level: Rails.application.config.log_level,
-    formatter: CustomLogFormatter.new,
-  )
-  Rails.logger.info('Application logging to STDOUT')
 end
 
 ## To avoid logging sensitive data on "subjects" and "to":


### PR DESCRIPTION
## Context

The formatting of the logs mean that it's more difficult to get the information you need quickly, this PR ensures that the production logs are formatted correctly in JSON.

## Changes proposed in this pull request

Update production logs to JSON format

## Screenshots

### Worker

#### Before (full)

<img width="2560" alt="review app worker before fix (full)" src="https://github.com/user-attachments/assets/c8f18bfe-8cc8-420a-80ff-db49723a9d45" />


#### Before

<img width="1649" alt="worker before fix" src="https://github.com/user-attachments/assets/3e794fbf-c499-408d-959a-3c9270da336a" />

#### After (change)

<img width="1656" alt="worker after fix" src="https://github.com/user-attachments/assets/0bf59fe0-6ef7-4f5e-a11d-d59ee0fb231f" />

### App

#### Before

<img width="1650" alt="app before fix" src="https://github.com/user-attachments/assets/da723537-85c8-4089-bd36-c7e1d7965e3f" />

#### After (no change)

<img width="1656" alt="app after fix" src="https://github.com/user-attachments/assets/7406241c-ed66-4c11-8823-13b67a7a8b97" />

### Clock

#### Before

<img width="1657" alt="clock before fix" src="https://github.com/user-attachments/assets/fc059000-494a-4cce-9dcb-f7a26628111f" />

#### After (no change)

<img width="1657" alt="clock after fix" src="https://github.com/user-attachments/assets/8aaa0330-d7fe-4724-b19e-4303e7e17cd7" />

## Link to Trello card (Trello - Github integration is broken)

https://trello.com/c/YUDlHGjf


## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [x] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
