### PR TITLE
[506] update provider report to reflect new withdrawal reasons

### DIFF
--- a/app/components/candidate_interface/withdrawal_reasons/level_two_reasons_review_component.rb
+++ b/app/components/candidate_interface/withdrawal_reasons/level_two_reasons_review_component.rb
@@ -27,7 +27,7 @@ module CandidateInterface
     private
 
       def withdrawal_reasons
-        @withdrawal_reasons ||= @application_choice.draft_withdrawal_reasons.by_level_one_reason(@level_one_reason)
+        @withdrawal_reasons ||= @application_choice.draft_withdrawal_reasons.by_level(@level_one_reason)
       end
 
       def reason_without_further_detail(reason, comment = nil)

--- a/app/controllers/provider_interface/reports/withdrawal_reasons_reports_controller.rb
+++ b/app/controllers/provider_interface/reports/withdrawal_reasons_reports_controller.rb
@@ -5,6 +5,7 @@ module ProviderInterface
 
       def show
         @provider = current_user.providers.find(provider_id)
+        @withdrawal_reason_report = ProviderInterface::CandidateWithdrawalReasonsDataByProvider.new(@provider)
       end
 
     private

--- a/app/controllers/provider_interface/reports/withdrawal_reasons_reports_controller.rb
+++ b/app/controllers/provider_interface/reports/withdrawal_reasons_reports_controller.rb
@@ -1,0 +1,17 @@
+module ProviderInterface
+  module Reports
+    class WithdrawalReasonsReportsController < ProviderInterfaceController
+      attr_reader :provider
+
+      def show
+        @provider = current_user.providers.find(provider_id)
+      end
+
+    private
+
+      def provider_id
+        params.permit(:provider_id)[:provider_id]
+      end
+    end
+  end
+end

--- a/app/controllers/provider_interface/reports/withdrawal_reports_controller.rb
+++ b/app/controllers/provider_interface/reports/withdrawal_reports_controller.rb
@@ -3,6 +3,10 @@ module ProviderInterface
     class WithdrawalReportsController < ProviderInterfaceController
       attr_reader :provider
 
+      def index
+        @providers = current_user.providers
+      end
+
       def show
         @provider = current_user.providers.find(provider_id)
         @withdrawal_report_data = CandidateWithdrawalDataByProvider.new(provider: provider)

--- a/app/forms/candidate_interface/withdrawal_reasons/level_two_reasons_builder.rb
+++ b/app/forms/candidate_interface/withdrawal_reasons/level_two_reasons_builder.rb
@@ -19,7 +19,7 @@ module CandidateInterface
       end
 
       def withdrawal_reasons
-        @withdrawal_reasons ||= @application_choice.draft_withdrawal_reasons.by_level_one_reason(@level_one_reason)
+        @withdrawal_reasons ||= @application_choice.draft_withdrawal_reasons.by_level(@level_one_reason)
       end
 
     private

--- a/app/frontend/styles/provider/_all.scss
+++ b/app/frontend/styles/provider/_all.scss
@@ -16,3 +16,4 @@
 @import "user-card";
 @import "email-preview";
 @import "recruitment_performance_report";
+@import "withdrawal_reasons_report";

--- a/app/frontend/styles/provider/_withdrawal_reasons_report.scss
+++ b/app/frontend/styles/provider/_withdrawal_reasons_report.scss
@@ -1,0 +1,34 @@
+.withdrawal-reasons-report-table {
+  &__wrapper {
+    overflow-x: auto;
+  }
+
+  &__heading {
+    border-bottom: none;
+  }
+
+  &__cell--main-reason {
+    font-weight: $govuk-font-weight-bold;
+
+    background: govuk-colour("light-grey");
+    border-top: 2px solid  $govuk-input-border-colour;
+  }
+
+  &__cell--second-level-reason {
+    padding-left: govuk-spacing(3);
+  }
+
+  &__cell--third-level-reason {
+    padding-left: govuk-spacing(5);
+  }
+
+  &__cell--second-level-with-nested-reasons {
+    padding-left: govuk-spacing(3);
+
+    background: govuk-tint(govuk-colour('light-grey'), 50);
+  }
+
+  &__cell--light-grey-background {
+    background: govuk-tint(govuk-colour('light-grey'), 50);
+  }
+}

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -77,7 +77,7 @@ class NavigationItems
       if current_provider_user && !performing_setup
         items << NavigationItem.new('Applications', provider_interface_applications_path, active?(current_controller, %w[application_choices decisions offer_changes notes interviews offers feedback conditions reconfirm_deferred_offers]), [])
         items << NavigationItem.new('Interview schedule', provider_interface_interview_schedule_path, active?(current_controller, %w[interview_schedules]), [])
-        items << NavigationItem.new('Reports', provider_interface_reports_path, active?(current_controller, %w[reports application_data_export hesa_export recruitment_performance_reports]))
+        items << NavigationItem.new('Reports', provider_interface_reports_path, active?(current_controller, %w[reports application_data_export hesa_exports recruitment_performance_reports withdrawal_reports withdrawal_reasons_reports status_of_active_applications diversity_reports]))
         items << NavigationItem.new('Activity log', provider_interface_activity_log_path, active?(current_controller, %w[activity_log]), [])
       end
 

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -28,6 +28,7 @@ class ApplicationChoice < ApplicationRecord
   has_many :interviews, dependent: :destroy
   has_many :withdrawal_reasons, dependent: :destroy
   has_many :draft_withdrawal_reasons, -> { draft }, class_name: 'WithdrawalReason', dependent: :destroy
+  has_many :published_withdrawal_reasons, -> { published }, class_name: 'WithdrawalReason', dependent: :destroy
 
   has_many :work_experiences, as: :experienceable, class_name: 'ApplicationWorkExperience'
   has_many :volunteering_experiences, as: :experienceable, class_name: 'ApplicationVolunteeringExperience'

--- a/app/services/provider_interface/candidate_withdrawal_reasons_data_by_provider.rb
+++ b/app/services/provider_interface/candidate_withdrawal_reasons_data_by_provider.rb
@@ -1,0 +1,135 @@
+module ProviderInterface
+  class CandidateWithdrawalReasonsDataByProvider
+    def initialize(provider)
+      @provider = provider
+    end
+
+    ReasonRow = Data.define(:reason, :before_accepting, :after_accepting, :total)
+
+    def show_report?
+      all_rows.any?
+    end
+
+    def all_rows
+      return [] if application_form_count < ProviderReports::MINIMUM_DATA_SIZE_REQUIRED
+
+      rows = []
+      nested_reasons.each_key do |level_one_reason|
+        rows << build_reason_row(level_one_reason, 'level_one')
+
+        nested_reasons[level_one_reason].each_key do |level_two_reason|
+          full_level_two_reason = [level_one_reason, level_two_reason].join('.')
+
+          if nested_reasons[level_one_reason][level_two_reason].present?
+            rows << build_reason_row(full_level_two_reason, 'level_two_with_nested_reasons')
+            nested_reasons[level_one_reason][level_two_reason].each_key do |level_three_reason|
+              full_level_three_reason = [level_one_reason, level_two_reason, level_three_reason].join('.')
+              rows << build_reason_row(full_level_three_reason, 'level_three')
+            end
+          else
+            rows << build_reason_row(full_level_two_reason, 'level_two')
+          end
+        end
+      end
+      rows
+    end
+
+  private
+
+    def build_reason_row(reason, level)
+      ReasonRow.new(
+        reason: {
+          text: translate(reason),
+          html_attributes: text_cell_attributes_for(level),
+        },
+        before_accepting: {
+          text: before_accepting_count(reason),
+          numeric: true,
+          html_attributes: numeric_cell_attributes_for(level),
+        },
+        after_accepting: {
+          text: after_accepting_count(reason),
+          numeric: true,
+          html_attributes: numeric_cell_attributes_for(level),
+        },
+        total: {
+          text: before_accepting_count(reason) + after_accepting_count(reason),
+          numeric: true,
+          html_attributes: numeric_cell_attributes_for(level),
+        },
+      )
+    end
+
+    def text_cell_attributes_for(level)
+      case level
+      when 'level_one'
+        { class: 'withdrawal-reasons-report-table__cell--main-reason' }
+      when 'level_two'
+        { class: 'withdrawal-reasons-report-table__cell--second-level-reason' }
+      when 'level_two_with_nested_reasons'
+        { class: 'withdrawal-reasons-report-table__cell--second-level-with-nested-reasons' }
+      when 'level_three'
+        { class: 'withdrawal-reasons-report-table__cell--third-level-reason' }
+      else
+        {}
+      end
+    end
+
+    def numeric_cell_attributes_for(level)
+      case level
+      when 'level_one'
+        { class: 'withdrawal-reasons-report-table__cell--main-reason' }
+      when 'level_two_with_nested_reasons'
+        { class: 'withdrawal-reasons-report-table__cell--light-grey-background' }
+      else
+        {}
+      end
+    end
+
+    def translate(string)
+      translation_string = string.dup.gsub('-', '_')
+      I18n.t("candidate_interface.withdrawal_reasons.reasons.#{translation_string}.label")
+    end
+
+    def before_accepting_count(reason)
+      withdrawal_reasons_before_acceptance.filter { |r| r.starts_with?(reason) }.length
+    end
+
+    def after_accepting_count(reason)
+      withdrawal_reasons_after_acceptance.filter { |r| r.starts_with?(reason) }.length
+    end
+
+    def nested_reasons
+      @nested_reasons ||= WithdrawalReason.selectable_reasons
+    end
+
+    def withdrawal_reasons_before_acceptance
+      @withdrawal_reasons_before_acceptance ||=
+        withdrawal_reasons
+        .where(application_choices: { accepted_at: nil })
+        .uniq
+        .pluck(:reason)
+    end
+
+    def withdrawal_reasons_after_acceptance
+      @withdrawal_reasons_after_acceptance ||=
+        withdrawal_reasons
+          .where.not(application_choices: { accepted_at: nil })
+          .uniq
+          .pluck(:reason)
+    end
+
+    def withdrawal_reasons
+      @withdrawal_reasons ||=
+        WithdrawalReason
+          .joins(:application_choice)
+          .published
+          .where('application_choices.provider_ids @> ARRAY[?]::bigint[]', @provider.id)
+          .where(application_choices: { current_recruitment_cycle_year: RecruitmentCycle.current_year })
+    end
+
+    def application_form_count
+      withdrawal_reasons.select('application_choices.application_form_id').distinct.count
+    end
+  end
+end

--- a/app/views/provider_interface/reports/index.html.erb
+++ b/app/views/provider_interface/reports/index.html.erb
@@ -35,7 +35,7 @@
           <%= govuk_link_to t('page_titles.provider.diversity_report'), provider_interface_reports_provider_diversity_report_path(provider_id: provider) %>
         </li>
         <li>
-          <%= govuk_link_to t('page_titles.provider.withdrawal_report'), provider_interface_reports_provider_withdrawal_report_path(provider_id: provider) %>
+          <%= govuk_link_to t('page_titles.provider.withdrawal_report'), provider_interface_reports_withdrawal_reports_path %>
         </li>
       </ul>
     <% end %>

--- a/app/views/provider_interface/reports/index.html.erb
+++ b/app/views/provider_interface/reports/index.html.erb
@@ -35,7 +35,11 @@
           <%= govuk_link_to t('page_titles.provider.diversity_report'), provider_interface_reports_provider_diversity_report_path(provider_id: provider) %>
         </li>
         <li>
-          <%= govuk_link_to t('page_titles.provider.withdrawal_report'), provider_interface_reports_withdrawal_reports_path %>
+          <% if FeatureFlag.active? :new_candidate_withdrawal_reasons %>
+            <%= govuk_link_to t('page_titles.provider.withdrawal_report'), provider_interface_reports_withdrawal_reports_path %>
+          <% else %>
+            <%= govuk_link_to t('page_titles.provider.withdrawal_report'), provider_interface_reports_provider_withdrawal_report_path(provider_id: provider) %>
+          <% end %>
         </li>
       </ul>
     <% end %>

--- a/app/views/provider_interface/reports/withdrawal_reasons_reports/show.html.erb
+++ b/app/views/provider_interface/reports/withdrawal_reasons_reports/show.html.erb
@@ -8,5 +8,47 @@
       <span class="govuk-caption-l"> <%= @provider.name %></span>
       <%= t('page_titles.provider.withdrawal_reasons_report') %>
     </h1>
+    <% if @withdrawal_reason_report.show_report? %>
+      <p class="govuk-body">
+        <%= t('.report_description') %>
+      </p>
+    <% else %>
+      <%= t('.report_not_visible_html', link: govuk_link_to(t('.withdrawal_report_link_text'), provider_interface_reports_provider_withdrawal_report_path(@provider))) %>
+    <% end %>
+  </div>
+
+  <% if @withdrawal_reason_report.show_report? %>
+    <div class="govuk-grid-column-full">
+      <div class="withdrawal-reasons-report-table__wrapper">
+        <%= govuk_table do |table| %>
+          <%= table.with_caption(text: t('.table_caption'), html_attributes: { class: 'govuk-visually-hidden' }) %>
+          <%= table.with_head do |head| %>
+            <%= head.with_row do |row| %>
+              <%= row.with_cell(
+                    text: t('.withdrawal_reason'),
+                    html_attributes: { class: 'withdrawal-reasons-report-table__heading' },
+                  ) %>
+              <% %w[before_accepting after_accepting total].each do |heading| %>
+               <%= row.with_cell(
+                    text: t(".#{heading}"),
+                    numeric: true,
+                    html_attributes: { class: 'withdrawal-reasons-report-table__heading' },
+                  ) %>
+              <% end %>
+            <% end %>
+          <% end %>
+          <%= table.with_body do |body| %>
+            <% @withdrawal_reason_report.all_rows.each do |reason_row| %>
+              <%= body.with_row do |row| %>
+                <%= row.with_cell(**reason_row.reason) %>
+                <%= row.with_cell(**reason_row.before_accepting) %>
+                <%= row.with_cell(**reason_row.after_accepting) %>
+                <%= row.with_cell(**reason_row.total) %>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/provider_interface/reports/withdrawal_reasons_reports/show.html.erb
+++ b/app/views/provider_interface/reports/withdrawal_reasons_reports/show.html.erb
@@ -1,0 +1,12 @@
+<%= content_for :title, t('page_titles.provider.withdrawal_reasons_report') %>
+<%= content_for :before_content, breadcrumbs(t('page_titles.provider.reports') => provider_interface_reports_path,
+                                             t('page_titles.provider.withdrawal_reasons_report') => nil) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l"> <%= @provider.name %></span>
+      <%= t('page_titles.provider.withdrawal_reasons_report') %>
+    </h1>
+  </div>
+</div>

--- a/app/views/provider_interface/reports/withdrawal_reports/index.html.erb
+++ b/app/views/provider_interface/reports/withdrawal_reports/index.html.erb
@@ -2,14 +2,11 @@
 <%= content_for :before_content, breadcrumbs(t('page_titles.provider.reports') => provider_interface_reports_path,
                                              t('page_titles.provider.withdrawal_reports') => nil) %>
 
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t('page_titles.provider.withdrawal_reports') %></h1>
 
-    <p class="govuk-body">
-      TBD, some text about why there are two different reports
-    </p>
+    <%= t('.description_html') %>
 
     <% @providers.each do |provider| %>
       <% if @providers.many? %>
@@ -18,23 +15,19 @@
       <ul class="govuk-list govuk-list--spaced">
         <li>
           <%= govuk_link_to(
-                t('page_titles.provider.legacy_withdrawal_report'),
+                t('.legacy_withdrawal_report'),
                 provider_interface_reports_provider_withdrawal_report_path(provider),
                 no_visited_state: true,
               ) %>
         </li>
         <li>
           <%= govuk_link_to(
-                t('page_titles.provider.withdrawal_reasons_report'),
+                t('.withdrawal_reasons_report'),
                 provider_interface_reports_provider_withdrawal_reasons_report_path(provider),
-                no_visited_state: true
+                no_visited_state: true,
               ) %>
         </li>
       </ul>
-
     <% end %>
-
-
-
   </div>
 </div>

--- a/app/views/provider_interface/reports/withdrawal_reports/index.html.erb
+++ b/app/views/provider_interface/reports/withdrawal_reports/index.html.erb
@@ -1,0 +1,40 @@
+<%= content_for :title, t('page_titles.provider.withdrawal_reports') %>
+<%= content_for :before_content, breadcrumbs(t('page_titles.provider.reports') => provider_interface_reports_path,
+                                             t('page_titles.provider.withdrawal_reports') => nil) %>
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t('page_titles.provider.withdrawal_reports') %></h1>
+
+    <p class="govuk-body">
+      TBD, some text about why there are two different reports
+    </p>
+
+    <% @providers.each do |provider| %>
+      <% if @providers.many? %>
+        <h2 class="govuk-heading-s"><%= provider.name %></h2>
+      <% end %>
+      <ul class="govuk-list govuk-list--spaced">
+        <li>
+          <%= govuk_link_to(
+                t('page_titles.provider.legacy_withdrawal_report'),
+                provider_interface_reports_provider_withdrawal_report_path(provider),
+                no_visited_state: true,
+              ) %>
+        </li>
+        <li>
+          <%= govuk_link_to(
+                t('page_titles.provider.withdrawal_reasons_report'),
+                provider_interface_reports_provider_withdrawal_reasons_report_path(provider),
+                no_visited_state: true
+              ) %>
+        </li>
+      </ul>
+
+    <% end %>
+
+
+
+  </div>
+</div>

--- a/app/views/provider_interface/reports/withdrawal_reports/show.html.erb
+++ b/app/views/provider_interface/reports/withdrawal_reports/show.html.erb
@@ -6,38 +6,15 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
       <span class="govuk-caption-l"> <%= @provider.name %></span>
-      <%= t('page_titles.provider.withdrawal_report') %>
+      <%= t('.heading') %>
     </h1>
-
-    <% if @submitted_withdrawal_reason_count < ProviderReports::MINIMUM_DATA_SIZE_REQUIRED %>
-      <p class="govuk-body">
-        You will be able to see this report once it contains data from at least <%= ProviderReports::MINIMUM_DATA_SIZE_REQUIRED %> candidates. This is to protect the privacy of candidates.
-      </p>
-      <p class="govuk-body">
-        The report shows data from candidates who withdrew their application and selected their reason from a set list. This is an optional question. Data for this report has only been collected from 11 April 2023.
-      </p>
-    <% else %>
-      <p class="govuk-body">Candidates who withdraw their application are asked to select their reasons for withdrawing. This is an optional question.</p>
-      <p class="govuk-body">Candidates are asked this question when they withdraw:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>before a decision on their application is made</li>
-        <li>after accepting an offer</li>
-      </ul>
-      <p class="govuk-body">
-        Candidates who have received an offer are not able to withdraw – they have to either accept or decline instead.
-      </p>
-      <h2 class="govuk-heading-m">Applications withdrawn in the <%= RecruitmentCycle.cycle_name %> recruitment cycle</h2>
-      <p class="govuk-body">
-        Candidates can select multiple reasons, so the numbers in each column may not match the ‘Total’ number.
-      </p>
-      <p class="govuk-body">
-        This data has only been collected from 11 April 2023.
-      </p>
+    <%= t('.description_html', link: govuk_link_to(t('.withdrawal_reasons_report_link_text'), provider_interface_reports_provider_withdrawal_reasons_report_path(@provider))) %>
     </div>
   </div>
+
+<% if @submitted_withdrawal_reason_count >= ProviderReports::MINIMUM_DATA_SIZE_REQUIRED %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-
       <%= render ProviderInterface::ReportTableComponent.new(headers: ['Reason',
                                                                        'Withdrawn before a decision',
                                                                        'Withdrawn after accepting',
@@ -45,7 +22,6 @@
                                                              rows: @withdrawal_data,
                                                              show_footer: true,
                                                              bold_row_headers: false) %>
-
-    <% end %>
+    </div>
   </div>
-</div>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -320,7 +320,6 @@ en:
       diversity_report: Sex, disability, ethnicity and age of candidates
       withdrawal_report: Withdrawals
       withdrawal_reports: Withdrawal reports
-      legacy_withdrawal_report: Old reasons for withdrawal report
       withdrawal_reasons_report: Withdrawal reasons
     start_apply_again: Do you want to apply again?
     start_carry_over: Continue your application

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -319,6 +319,9 @@ en:
       reports: Reports
       diversity_report: Sex, disability, ethnicity and age of candidates
       withdrawal_report: Withdrawals
+      withdrawal_reports: Withdrawal reports
+      legacy_withdrawal_report: Old reasons for withdrawal report
+      withdrawal_reasons_report: Withdrawal reasons
     start_apply_again: Do you want to apply again?
     start_carry_over: Continue your application
     start_carry_over_between_cycles: The application deadline has passed

--- a/config/locales/provider_interface/reports.yml
+++ b/config/locales/provider_interface/reports.yml
@@ -12,3 +12,32 @@ en:
           info: 'The data will include all candidates who have accepted an offer since %{date}.'
         previous_cycle:
           info: 'The data will include all candidates who have accepted an offer from %{start_date} to %{end_date}.'
+      withdrawal_reports:
+        index:
+          description_html:
+            <p class="govuk-body">This report shows the reasons for withdrawal selected by candidates from a set list.</p>
+            <p class="govuk-body">In January 2025 we made it mandatory for candidates to provide at least one reason for withdrawing. We also added some new reasons for candidates to select from.</p>
+            <p class="govuk-body">Because the new reasons do not map exactly to the old reasons, it is not possible to combine withdrawal data from before January 2025 with withdrawal data from after that date in a single report.</p>
+          legacy_withdrawal_report: 'Withdrawal reasons: up to January 2025'
+          withdrawal_reasons_report: 'Withdrawal reasons: from January 2025'
+        show:
+          heading: 'Withdrawal reasons: October'
+          description_html:
+            <p class="govuk-body">You will be able to see this report if it contains data from at least 10 candidates. This is to protect the privacy of candidates.</p>
+            <p class="govuk-body">The report shows data from candidates who withdrew their application and selected their reason from a set list. This was an optional question, candidates who withdrew their application but did not select a reason are not represented in this report.</p>
+            <p class="govuk-body">Data for this report was collected between October 2024 and January 2025.</p>
+            <p class="govuk-body">Go to the %{link} report to see more recent withdrawal data.</p>
+          withdrawal_reasons_report_link_text: 'withdrawal reasons: from January 2025'
+      withdrawal_reasons_reports:
+        show:
+          report_description: This report shows the reasons for withdrawal selected by candidates from a set list. The question is mandatory and candidates can select more than one reason.
+          report_not_visible_html:
+            <p class="govuk-body">You will be able to see this report when it contains data from at least 10 candidates. This is to protect the privacy of candidates. Candidates can select more than one reason for withdrawing so the number of reasons in this report may not match the number of candidates who have withdrawn.</p>
+            <p class="govuk-body">The report shows data from candidates who withdrew their application and selected their reason from a set list. This question is mandatory.</p>
+            <p class="govuk-body">Data for this report has been collected since 13 January 2025. Go to %{link} to see withdrawal data from before this date.</p>
+          withdrawal_report_link_text: 'withdrawal reasons: up to January 2025'
+          table_caption: Withdrawal reason report data
+          withdrawal_reason: Withdrawal reason
+          before_accepting: Before accepting
+          after_accepting: After accepting
+          total: Total

--- a/config/routes/provider.rb
+++ b/config/routes/provider.rb
@@ -30,10 +30,12 @@ namespace :provider_interface, path: '/provider' do
   namespace :reports do
     resources :hesa_exports, only: :show, path: 'hesa-exports', param: :year, constraints: ValidRecruitmentCycleYear
     resources :hesa_exports, only: :index, path: 'hesa-exports'
+    resources :withdrawal_reports, only: :index, path: 'withdrawal-reports'
     resources :providers, only: [], path: '' do
       resource :status_of_active_applications, only: :show, path: 'status-of-active-applications'
       resource :diversity_report, only: :show, path: 'diversity-report'
       resource :withdrawal_report, only: :show, path: 'withdrawal-report'
+      resource :withdrawal_reasons_report, only: :show, path: 'withdrawal-reasons-report'
       resource :recruitment_performance_report, only: :show, path: 'recruitment-performance-report'
     end
   end

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe ApplicationChoice do
   it { is_expected.to have_many(:work_history_breaks).class_name('ApplicationWorkHistoryBreak') }
   it { is_expected.to have_many(:withdrawal_reasons).dependent(:destroy) }
   it { is_expected.to have_many(:draft_withdrawal_reasons).dependent(:destroy) }
+  it { is_expected.to have_many(:published_withdrawal_reasons).dependent(:destroy) }
 
   describe 'auditing', :with_audited do
     it 'creates audit entries' do

--- a/spec/models/withdrawal_reason_spec.rb
+++ b/spec/models/withdrawal_reason_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe WithdrawalReason do
   end
 
   describe 'scopes' do
-    describe '#by_level_one_reason' do
+    describe '#by_level' do
       let(:application_choice) { create(:application_choice) }
 
-      it 'returns all records where the level one reason matches in the correct order' do
+      before do
         %w[applying-to-another-provider.provider-has-not-replied-to-me
            other
            applying-to-another-provider.accepted-another-offer
@@ -29,8 +29,10 @@ RSpec.describe WithdrawalReason do
            applying-to-another-provider.personal-circumstances-have-changed.other].each do |reason|
           create(:withdrawal_reason, application_choice:, reason:)
         end
+      end
 
-        result = described_class.by_level_one_reason('applying-to-another-provider')
+      it 'returns all records where the level one reason matches in the correct order' do
+        result = described_class.by_level('applying-to-another-provider')
         expect(result.pluck(:reason)).to eq %w[
           applying-to-another-provider.accepted-another-offer
           applying-to-another-provider.seen-a-course-that-suits-me-better
@@ -42,6 +44,17 @@ RSpec.describe WithdrawalReason do
           applying-to-another-provider.personal-circumstances-have-changed.other
           applying-to-another-provider.course-no-longer-available
           applying-to-another-provider.other
+        ]
+      end
+
+      it 'returns all records that match multiple levels' do
+        result = described_class.by_level('applying-to-another-provider.personal-circumstances-have-changed')
+
+        expect(result.pluck(:reason)).to eq %w[
+          applying-to-another-provider.personal-circumstances-have-changed.concerns-about-cost-of-doing-course
+          applying-to-another-provider.personal-circumstances-have-changed.concerns-about-having-enough-time-to-train
+          applying-to-another-provider.personal-circumstances-have-changed.concerns-about-training-with-a-disability-or-health-condition
+          applying-to-another-provider.personal-circumstances-have-changed.other
         ]
       end
     end

--- a/spec/services/provider_interface/candidate_withdrawal_reasons_data_by_provider_spec.rb
+++ b/spec/services/provider_interface/candidate_withdrawal_reasons_data_by_provider_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::CandidateWithdrawalReasonsDataByProvider do
+  let(:provider) { create(:provider) }
+
+  describe '#all_rows' do
+    context 'when there are fewer then 10 withdrawals from unique application forms' do
+      it 'returns an empty array' do
+        application_forms = create_list(:application_form, 9)
+        application_forms.each do |application_form|
+          application_choice = create(:application_choice, :withdrawn, application_form:, provider_ids: [provider.id])
+          create(:withdrawal_reason, status: 'published', application_choice:, reason: WithdrawalReason.all_reasons.sample)
+        end
+
+        expect(described_class.new(provider).all_rows).to eq []
+      end
+    end
+
+    context 'when there are at least 10 withdrawals from unique application forms' do
+      it 'returns data for the report' do
+        create_list(:application_form, 10).each do |application_form|
+          application_choice = create(:application_choice, :withdrawn, application_form:, provider_ids: [provider.id])
+          create(:withdrawal_reason, status: 'published', application_choice:, reason: 'applying-to-another-provider.accepted-another-offer')
+        end
+
+        rows = described_class.new(provider).all_rows
+
+        main_reason_row = rows.find { |row| row.reason[:text] == 'I am going to apply (or have applied) to a different training provider' }
+        expect(main_reason_row.total[:text]).to eq 10
+
+        level_two_reason_row = rows.find { |row| row.reason[:text] == 'I have accepted another offer' }
+        expect(level_two_reason_row.total[:text]).to eq 10
+      end
+    end
+
+    context 'where there is a mix of withdrawals before and after the candidate has accepted an offer' do
+      it 'returns data for the report' do
+        # rubocop:disable Style/CombinableLoops
+        create_list(:application_form, 5).each do |application_form|
+          accepted_application_choice = create(:application_choice, :accepted, application_form:, provider_ids: [provider.id])
+          create(:withdrawal_reason, status: 'published', application_choice: accepted_application_choice, reason: 'applying-to-another-provider.accepted-another-offer')
+        end
+
+        create_list(:application_form, 5).each do |application_form|
+          not_accepted_application_choice = create(:application_choice, application_form: application_form, provider_ids: [provider.id])
+          create(:withdrawal_reason, status: 'published', application_choice: not_accepted_application_choice, reason: 'applying-to-another-provider.accepted-another-offer')
+        end
+        # rubocop:enable Style/CombinableLoops
+
+        rows = described_class.new(provider).all_rows
+        main_reason_row = rows.find { |row| row.reason[:text] == 'I am going to apply (or have applied) to a different training provider' }
+
+        expect(main_reason_row.total[:text]).to eq 10
+        expect(main_reason_row.before_accepting[:text]).to eq 5
+        expect(main_reason_row.after_accepting[:text]).to eq 5
+
+        level_two_reason_row = rows.find { |row| row.reason[:text] == 'I have accepted another offer' }
+        expect(level_two_reason_row.total[:text]).to eq 10
+        expect(level_two_reason_row.before_accepting[:text]).to eq 5
+        expect(level_two_reason_row.after_accepting[:text]).to eq 5
+      end
+    end
+  end
+end

--- a/spec/system/provider_interface/reports/index_provider_user_one_provider_spec.rb
+++ b/spec/system/provider_interface/reports/index_provider_user_one_provider_spec.rb
@@ -2,6 +2,11 @@ require 'rails_helper'
 
 RSpec.describe 'Provider reports index' do
   include DfESignInHelpers
+
+  before do
+    FeatureFlag.deactivate :new_candidate_withdrawal_reasons
+  end
+
   scenario 'when provider user has one provider' do
     given_a_provider_and_provider_user_exists
     and_i_am_signed_in_as_provider_user

--- a/spec/system/provider_interface/reports/index_provider_user_two_providers_spec.rb
+++ b/spec/system/provider_interface/reports/index_provider_user_two_providers_spec.rb
@@ -2,6 +2,11 @@ require 'rails_helper'
 
 RSpec.describe 'Provider with two providers reports index' do
   include DfESignInHelpers
+
+  before do
+    FeatureFlag.deactivate(:new_candidate_withdrawal_reasons)
+  end
+
   scenario 'when a provider user has more than one provider' do
     given_a_provider_user_with_two_providers_exists
     and_i_am_signed_in_as_provider_user

--- a/spec/system/provider_interface/reports/index_provider_user_two_providers_with_performance_report_spec.rb
+++ b/spec/system/provider_interface/reports/index_provider_user_two_providers_with_performance_report_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Provider with two providers reports index' do
 
   scenario 'when provider user has multiple provider with performance report', time: mid_cycle(2024) do
     given_a_provider_user_with_two_providers_exists
-    and_a_provider_has_a_recruitment_peroformance_report
+    and_a_provider_has_a_recruitment_performance_report
     and_i_am_signed_in_as_provider_user
     when_i_visit_the_reports_index
     then_the_page_has_the_right_content
@@ -16,7 +16,7 @@ RSpec.describe 'Provider with two providers reports index' do
     expect(page).to have_current_path('/provider/reports', ignore_query: true)
   end
 
-  def and_a_provider_has_a_recruitment_peroformance_report
+  def and_a_provider_has_a_recruitment_performance_report
     create(:provider_recruitment_performance_report, provider: @provider)
   end
 

--- a/spec/system/provider_interface/reports/index_provider_user_two_providers_with_performance_report_spec.rb
+++ b/spec/system/provider_interface/reports/index_provider_user_two_providers_with_performance_report_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe 'Provider with two providers reports index' do
   include DfESignInHelpers
 
+  before do
+    FeatureFlag.deactivate :new_candidate_withdrawal_reasons
+  end
+
   scenario 'when provider user has multiple provider with performance report', time: mid_cycle(2024) do
     given_a_provider_user_with_two_providers_exists
     and_a_provider_has_a_recruitment_performance_report

--- a/spec/system/provider_interface/reports/provider_views_withdrawal_reasons_report_spec.rb
+++ b/spec/system/provider_interface/reports/provider_views_withdrawal_reasons_report_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe 'Provider views withdrawal reports' do
+  include DfESignInHelpers
+
+  before do
+    FeatureFlag.activate(:new_candidate_withdrawal_reasons)
+  end
+
+  scenario 'Provider navigates to report where fewer than 10 candidates have provided withdrawal reasons' do
+    given_some_candidates_have_withdrawn_applications(9)
+    and_i_sign_in_as_a_provider_user
+    when_i_navigate_to_the_withdrawal_reasons_report
+    then_i_see_the_report_without_data
+  end
+
+  scenario 'Provider navigates to the report where at least 10 candidates have provided withdrawal reasons' do
+    given_some_candidates_have_withdrawn_applications(10)
+    and_i_sign_in_as_a_provider_user
+    when_i_navigate_to_the_withdrawal_reasons_report
+    then_i_see_the_report_with_data
+  end
+
+private
+
+  def given_some_candidates_have_withdrawn_applications(number_of_applications)
+    provider_user = create(:provider_user, :with_dfe_sign_in, email_address: 'email@provider.ac.uk')
+    provider = provider_user.providers.first
+    application_forms = create_list(:application_form, number_of_applications)
+    application_forms.each do |application_form|
+      application_choice = create(:application_choice, :withdrawn, application_form: application_form, provider_ids: [provider.id])
+      create(:withdrawal_reason, status: 'published', application_choice:, reason: WithdrawalReason.all_reasons.sample)
+    end
+  end
+
+  def and_i_sign_in_as_a_provider_user
+    provider_exists_in_dfe_sign_in
+    provider_signs_in_using_dfe_sign_in
+  end
+
+  def when_i_navigate_to_the_withdrawal_reasons_report
+    click_on 'Reports'
+    click_on 'Withdrawals'
+    click_on 'Withdrawal reasons: from January 2025'
+  end
+
+  def then_i_see_the_report_without_data
+    expect(page).to have_content 'You will be able to see this report when it contains data from at least 10 candidates.'
+  end
+
+  def then_i_see_the_report_with_data
+    expect(page).to have_content 'This report shows the reasons for withdrawal selected by candidates from a set list. The question is mandatory and candidates can select more than one reason.'
+  end
+end


### PR DESCRIPTION
## Context
Trello card: https://trello.com/c/5zAe8jNi

We have updated the withdrawal reasons a candidate can give and made them mandatory.

We need to update the provider report on withdrawal reasons to reflect these changes.

Because we have made this change part way through the cycle, we need to keep two reports active for the rest of the cycle. The one reflecting the old style of withdrawal reasons and this new one which reflect the changes. 

## Changes proposed in this pull request

https://github.com/user-attachments/assets/b282d131-0dc2-4db6-9b3a-9331995e65cf

## Guidance to review

Login as support user Susan Upport in the review app. 
Navigate to Reports -> Withdrawal reports
Select the various reports and make sure you see the data as expected. 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
