### PR TITLE
Rename Account Recovery Request Code

### DIFF
--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -239,7 +239,7 @@
   - decline_by_default_at
   - decline_by_default_days
   :account_recovery_request_codes:
-  - hashed_code
+  - code_digest
   :account_recovery_requests:
   - previous_account_email_address
   :site_settings:

--- a/db/migrate/20250108120414_rename_account_recovery_request_code_column.rb
+++ b/db/migrate/20250108120414_rename_account_recovery_request_code_column.rb
@@ -1,0 +1,8 @@
+class RenameAccountRecoveryRequestCodeColumn < ActiveRecord::Migration[8.0]
+  def change
+    safety_assured do
+      add_column :account_recovery_request_codes, :code_digest, :string, null: false
+      remove_column :account_recovery_request_codes, :hashed_code, :string, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_03_094646) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_08_120414) do
   create_sequence "qualifications_public_id_seq", start: 120000
 
   # These are extensions that must be enabled in order to support this database
@@ -19,10 +19,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_03_094646) do
   enable_extension "unaccent"
 
   create_table "account_recovery_request_codes", force: :cascade do |t|
-    t.string "hashed_code", null: false
     t.bigint "account_recovery_request_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "code_digest", null: false
     t.index ["account_recovery_request_id"], name: "idx_on_account_recovery_request_id_c1c0af72cc"
   end
 


### PR DESCRIPTION
## Context

We need to use has_secure_password for the code on the Account Recovery Request Code. To use this helper, you need to have a xxx_digest column in DB.

This commit creates this column. There are no records in any environment for this table, using safety assured should be enough.

## Changes proposed in this pull request

Migration to create `code_digest` column on AccountRecoveryRequestCode

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
