### PR TITLE
Dev environment updates

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -2,4 +2,4 @@ web: SERVICE_TYPE=web bundle exec puma -C config/puma.rb
 worker: SERVICE_TYPE=worker bundle exec sidekiq -c 5 -C config/sidekiq-main.yml
 worker_secondary: SERVICE_TYPE=worker bundle exec sidekiq -c 5 -C config/sidekiq-secondary.yml
 clock: SERVICE_TYPE=clock bundle exec clockwork config/clock.rb
-caddy: caddy run -c Caddyfile.dev
+caddy: caddy run -c Caddyfile.dev -a caddyfile

--- a/bin/setup
+++ b/bin/setup
@@ -28,12 +28,20 @@ FileUtils.chdir APP_ROOT do
   puts "\n== Preparing database =="
   system! "bin/rails db:prepare"
 
-  puts "\n== Sync some provider data =="
-  system! "bundle exec rake setup_local_dev_data"
+  unless ARGV.include?("--skip-dev-data")
+    puts "\n== Sync some provider data =="
+    system! "bundle exec rake setup_local_dev_data"
+  end
 
   puts "\n== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"
 
   puts "\n== Restarting application server =="
   system! "bin/rails restart"
+
+  unless ARGV.include?("--skip-server")
+    puts "\n== Starting development server =="
+    STDOUT.flush # flush the output before exec(2) so that it displays
+    exec "bin/dev"
+  end
 end

--- a/docs/development/developer-setup.md
+++ b/docs/development/developer-setup.md
@@ -65,7 +65,7 @@ docker compose up
 
 ## Initial setup
 
-`bin/setup` will install local dependencies and set up your database with seed data.
+`bin/setup` will install local dependencies, set up your database with seed data and [run the application](#running-the-application).
 
 ```bash
 bin/setup


### PR DESCRIPTION
## Context

Setup has been updated to align with Rails 8 defaults.
Caddy updated to support latest version of Caddy

## Changes proposed in this pull request

- add `bin/dev` to the `bin/setup` script. Allows developers to get up and running with only `bin/setup`
- Adds flag to help Caddy determine that the `Caddyfile.dev` is a Caddy configuration file

## Guidance to review

- Try `bin/setup` locally, options include `--skip-dev-data` and `--skip-server`