### PR TITLE
[528] Ensure undergraduate courses have been created before generating test data

### DIFF
--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -33,12 +33,14 @@ task setup_local_dev_data: %i[environment copy_feature_flags_from_production syn
   puts 'Generating fake API requests for the Vendor API Monitor...'
   CreateVendorAPIMonitorDummyData.call
 
+  puts 'Creating undergraduate courses...'
+  Rake::Task['create_undergraduate_courses'].invoke
+
+  puts 'Generating test applications...'
   Rake::Task['generate_test_applications'].invoke
 
   puts 'Finding duplicate applications'
   UpdateDuplicateMatchesWorker.new.perform
-
-  Rake::Task['create_undergraduate_courses'].invoke
 end
 
 desc 'Create undergraduate courses'


### PR DESCRIPTION
## Context

Trello card: https://trello.com/c/nrFYWTBO

We are getting intermittent errors when creating test data for review apps. 

The error happens at line 94 of the test application script, which is when undergraduate applications are being created. 

<img width="1122" alt="image" src="https://github.com/user-attachments/assets/f34e46df-1be2-4470-8abc-f7ae938f9b86" />

The test application script only generates more undergraduate courses if the are `zero`. The Factory will fail if there are more states than there are courses. So in this case, there were three states, but not three courses. Possibly, there were one or two courses from the TTAPI sync -- more than zero, so we didn't generate more, and less than the number of states.

## Changes proposed in this pull request

- Change the order of the local dev job to ensure plenty of undergraduate courses are created before the test application job is called. 

## Guidance to review

- I could change the test application script to generate undergraduate courses, but I'm hesitant to do that as this is the script that is used when we generate test data for providers in sandbox and it might have unintended consequences. If you think we should do it another way, happy to hear ideas.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
