### PR TITLE
Added a chaser email to the Inactive state

### DIFF
--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -133,6 +133,9 @@ en:
       name: Inactive
       description: |
         The provider takes too long to make a decision (2024 recruitment cycle onwards)
+      emails: # Chaser emails
+        - candidate_mailer-apply_to_another_course_after_30_working_days
+        - candidate_mailer-apply_to_multiple_courses_after_30_working_days
 
     interviewing:
       name: Interviewing

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -67,8 +67,6 @@ RSpec.describe 'Docs' do
       provider_mailer-reference_received
       candidate_mailer-application_rejected
       candidate_mailer-application_choice_submitted
-      candidate_mailer-apply_to_another_course_after_30_working_days
-      candidate_mailer-apply_to_multiple_courses_after_30_working_days
       candidate_mailer-offer_10_day
       candidate_mailer-offer_20_day
       candidate_mailer-offer_30_day


### PR DESCRIPTION
## Context

We identified some missing documentation around when emails are sent

## Changes proposed in this pull request

- Added a reference to the Inactive applications email chaser being sent

## Guidance to review

- visible at `/support/docs/when-emails-are-sent#inactive`

![d54f9c115fc74b4ecd27c0ca304fed2f](https://github.com/user-attachments/assets/9a5379d6-465a-4eef-afd3-a460ca42cfb0)

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
