### PR TITLE
One login account recovery test helpers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -121,6 +121,7 @@ gem 'rouge'
 gem 'ruby-graphviz'
 
 gem 'pagy'
+gem 'bcrypt'
 
 # Adviser sign up integration
 gem 'get_into_teaching_api_client_faraday', github: 'DFE-Digital/get-into-teaching-api-ruby-client', require: 'api/client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -852,6 +852,7 @@ DEPENDENCIES
   archive-zip
   audited
   azure-blob
+  bcrypt
   blazer
   brakeman
   bullet

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -29,6 +29,7 @@ SANITIZED_REQUEST_PARAMS = %i[
   certificate
   otp
   ssn
+  code
 ].freeze
 
 MAILER_SANITIZED_PARAMS = %w[

--- a/spec/factories/account_recovery_request.rb
+++ b/spec/factories/account_recovery_request.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :account_recovery_request do
+    candidate { association(:candidate) }
+  end
+end

--- a/spec/factories/account_recovery_request_code.rb
+++ b/spec/factories/account_recovery_request_code.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :account_recovery_request_code do
+    account_recovery_request { association(:account_recovery_request) }
+    code { Array.new(6) { rand(0..9) }.join }
+  end
+end

--- a/spec/factories/candidate.rb
+++ b/spec/factories/candidate.rb
@@ -13,5 +13,12 @@ FactoryBot.define do
         candidate.update(candidate_api_updated_at: nil)
       end
     end
+
+    trait :with_live_session do
+      after(:create) do |candidate, _|
+        create(:session, candidate:)
+        create(:one_login_auth, candidate:)
+      end
+    end
   end
 end

--- a/spec/factories/sesssion.rb
+++ b/spec/factories/sesssion.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :session do
+    candidate { association(:candidate) }
+    id_token_hint { SecureRandom.hex }
+  end
+end

--- a/spec/support/test_helpers/one_login_helper.rb
+++ b/spec/support/test_helpers/one_login_helper.rb
@@ -13,4 +13,14 @@ module OneLoginHelper
       },
     )
   end
+
+  def sign_in_with_one_login(email_address)
+    if FeatureFlag.active?(:one_login_candidate_sign_in)
+      user_exists_in_one_login(email_address:)
+      visit candidate_interface_create_account_or_sign_in_path
+      click_link_or_button 'Continue'
+    else
+      raise 'One login feature flag needs to be active'
+    end
+  end
 end


### PR DESCRIPTION
## Context

The One login account recovery PR is getting too big https://github.com/DFE-Digital/apply-for-teacher-training/pull/10215. So I want to merge some test helpers before, to make it easier to review the feature PR.

This just adds factories, test helpers and bcrypt gem to facilitate the development of the account recovery feature.

## Changes proposed in this pull request

Test helpers and bcrypt gem

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
