### PR TITLE
[556] Set model level default for `confidential` on `Reference`

### DIFF
--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -9,6 +9,8 @@ class ApplicationReference < ApplicationRecord
   has_many :reference_tokens, dependent: :destroy
   has_one :candidate, through: :application_form
 
+  attribute :confidential, :boolean, default: true
+
   scope :selected, -> { feedback_provided.where(selected: true) }
   scope :creation_order, -> { order(:id) }
 

--- a/spec/models/application_reference_spec.rb
+++ b/spec/models/application_reference_spec.rb
@@ -192,4 +192,28 @@ RSpec.describe ApplicationReference do
       end
     end
   end
+
+  describe 'confidential' do
+    # context 'when the `show_reference_confidentiality_status` feature flag is active' do
+    #   before do
+    #     FeatureFlag.activate(:show_reference_confidentiality_status)
+    #   end
+
+    #   it 'sets the default to nil' do
+    #     reference = build(:reference)
+    #     expect(reference.confidential).to be_nil
+    #   end
+    # end
+
+    context 'when the `show_reference_confidentiality_status` feature flag is inactive' do
+      before do
+        FeatureFlag.deactivate(:show_reference_confidentiality_status)
+      end
+
+      it 'sets the default to true' do
+        reference = build(:reference)
+        expect(reference.confidential).to be(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

We will be removing the default from the database as we do not want pre-selected radios. 

Adding a model level default will negate the need for us to run a backfill. This is an issue because the confidential feature is not live yet but references are continuously being created with a confidential value under the hood.


## Changes proposed in this pull request

Set model level default (of `true`) for `confidential` on `Reference`.


## Guidance to review

This code sets the value of confidential to `true`, which is currently what the database does. 

I will update update it to set the confidential value to `nil` if the feature flag is enabled once the migration in #10235 has been run. 

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [x] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
