### PR TITLE
[556] Update confidential form to handle `nil` values

### DIFF
--- a/app/forms/referee_interface/confidentiality_form.rb
+++ b/app/forms/referee_interface/confidentiality_form.rb
@@ -7,7 +7,7 @@ module RefereeInterface
     validates :confidential, presence: true
 
     def self.build_from_reference(reference:)
-      confidential = reference.confidential?
+      confidential = reference.confidential
       new(confidential: confidential)
     end
 

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -9,7 +9,7 @@ class ApplicationReference < ApplicationRecord
   has_many :reference_tokens, dependent: :destroy
   has_one :candidate, through: :application_form
 
-  attribute :confidential, :boolean, default: true
+  attribute :confidential, :boolean, default: -> { FeatureFlag.active?(:show_reference_confidentiality_status) ? nil : true }
 
   scope :selected, -> { feedback_provided.where(selected: true) }
   scope :creation_order, -> { order(:id) }

--- a/spec/forms/referee_interface/confidentiality_form_spec.rb
+++ b/spec/forms/referee_interface/confidentiality_form_spec.rb
@@ -5,6 +5,32 @@ RSpec.describe RefereeInterface::ConfidentialityForm do
     it { is_expected.to validate_presence_of(:confidential) }
 
     describe '.build_from_reference' do
+      context 'when the reference confidentiality is not set and confidentiality feature flag is on' do
+        before do
+          FeatureFlag.activate(:show_reference_confidentiality_status)
+        end
+
+        it 'initialises a form with confidential set to nil' do
+          reference = build(:reference)
+          form = described_class.build_from_reference(reference: reference)
+
+          expect(form.confidential).to be_nil
+        end
+      end
+
+      context 'when the reference confidentiality is not set and confidentiality feature flag is off' do
+        before do
+          FeatureFlag.deactivate(:show_reference_confidentiality_status)
+        end
+
+        it 'initialises a form with confidential set to true' do
+          reference = build(:reference)
+          form = described_class.build_from_reference(reference: reference)
+
+          expect(form.confidential).to be(true)
+        end
+      end
+
       context 'when the reference is confidential' do
         it 'initialises a form with confidential set to true' do
           reference = build(:reference, confidential: true)

--- a/spec/models/application_reference_spec.rb
+++ b/spec/models/application_reference_spec.rb
@@ -194,16 +194,16 @@ RSpec.describe ApplicationReference do
   end
 
   describe 'confidential' do
-    # context 'when the `show_reference_confidentiality_status` feature flag is active' do
-    #   before do
-    #     FeatureFlag.activate(:show_reference_confidentiality_status)
-    #   end
+    context 'when the `show_reference_confidentiality_status` feature flag is active' do
+      before do
+        FeatureFlag.activate(:show_reference_confidentiality_status)
+      end
 
-    #   it 'sets the default to nil' do
-    #     reference = build(:reference)
-    #     expect(reference.confidential).to be_nil
-    #   end
-    # end
+      it 'sets the default to nil' do
+        reference = build(:reference)
+        expect(reference.confidential).to be_nil
+      end
+    end
 
     context 'when the `show_reference_confidentiality_status` feature flag is inactive' do
       before do


### PR DESCRIPTION
## Context

Now that references will be created with nil values, we need to handle the third case on the form where no confidentiality selection has been made.

The default will be nil once the feature flag is active, then users will explicitly make a selection.

## Changes proposed in this pull request

Stop pre selecting radios before a value has been added to the database.

<img width="625" alt="image" src="https://github.com/user-attachments/assets/bdd648d1-9fdc-4786-bd8d-66cad904fa62" />


## Guidance to review

- Send a reference off
- Receive the reference and go through the multi step form
- Check that the value for the confidentiality question is not pre-selected

## Things to check

- [x] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [x] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [x] API release notes have been updated if necessary
- [x] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
