### PR TITLE
[545] part 2 remove feature flag from database

### DIFF
--- a/app/services/data_migrations/remove_new_withdrawal_reasons_feature_flag.rb
+++ b/app/services/data_migrations/remove_new_withdrawal_reasons_feature_flag.rb
@@ -1,0 +1,10 @@
+module DataMigrations
+  class RemoveNewWithdrawalReasonsFeatureFlag
+    TIMESTAMP = 20250109170301
+    MANUAL_RUN = false
+
+    def change
+      Feature.where(name: :new_candidate_withdrawal_reasons).delete_all
+    end
+  end
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
 DATA_MIGRATION_SERVICES = [
   # do not delete or edit this line - services added below by generator
+  'DataMigrations::RemoveNewWithdrawalReasonsFeatureFlag',
   'DataMigrations::RemoveUnusedFeatureFlags',
   'DataMigrations::RemoveTdaFlag',
   'DataMigrations::DeleteAllOldAudits',

--- a/spec/services/data_migrations/remove_new_withdrawal_reasons_feature_flag_spec.rb
+++ b/spec/services/data_migrations/remove_new_withdrawal_reasons_feature_flag_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::RemoveNewWithdrawalReasonsFeatureFlag do
+  context 'when the feature flag exist' do
+    it 'removes the relevant feature flags' do
+      create(:feature, name: 'new_candidate_withdrawal_reasons')
+      create(:feature, name: 'some_other_feature_flag')
+
+      expect { described_class.new.change }.to change { Feature.count }.by(-1)
+      expect(Feature.where(name: 'new_candidate_withdrawal_reasons')).to be_none
+      expect(Feature.where(name: 'some_other_feature_flag')).to be_any
+    end
+  end
+
+  context 'when the feature flags have already been dropped' do
+    it 'does nothing' do
+      expect { described_class.new.change }.not_to(change { Feature.count })
+    end
+  end
+end


### PR DESCRIPTION
## Context
Trello: https://trello.com/c/0ZWcB3K9

This is the second PR to remove the withdrawal reasons feature flag. See the [first PR](https://github.com/DFE-Digital/apply-for-teacher-training/pull/10232) for more context

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
