### PR TITLE
[564] Support interface - delete withdrawal reasons when reverting withdrawal

### DIFF
--- a/app/forms/support_interface/application_forms/revert_withdrawal_form.rb
+++ b/app/forms/support_interface/application_forms/revert_withdrawal_form.rb
@@ -16,7 +16,10 @@ module SupportInterface
 
         return false if errors.any?
 
-        revert_withdrawal_service.save
+        ActiveRecord::Base.transaction do
+          revert_withdrawal_service.withdrawal_reasons.destroy_all
+          revert_withdrawal_service.save
+        end
       end
 
     private

--- a/app/forms/support_interface/application_forms/revert_withdrawal_form.rb
+++ b/app/forms/support_interface/application_forms/revert_withdrawal_form.rb
@@ -5,9 +5,9 @@ module SupportInterface
 
       attr_accessor :accept_guidance, :audit_comment_ticket, :application_choice
 
-      validates :accept_guidance, presence: true
       validate :valid_service
       validates_with ZendeskUrlValidator
+      validates :accept_guidance, presence: true
 
       def save
         self.accept_guidance = ActiveModel::Type::Boolean.new.cast(accept_guidance)

--- a/spec/forms/support_interface/application_forms/revert_withdrawal_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/revert_withdrawal_form_spec.rb
@@ -38,6 +38,20 @@ RSpec.describe SupportInterface::ApplicationForms::RevertWithdrawalForm, :with_a
 
         expect(application_choice.audits.last.comment).to include(zendesk_ticket)
       end
+
+      it 'deletes associated withdrawal reasons' do
+        application_choice = create(:application_choice, :withdrawn)
+        create(:withdrawal_reason, application_choice:)
+
+        form = described_class.new(
+          application_choice:,
+          audit_comment_ticket: zendesk_ticket,
+          accept_guidance: true,
+        )
+        expect(form.save).to be(true)
+
+        expect(application_choice.withdrawal_reasons).to be_empty
+      end
     end
 
     context 'invalid' do


### PR DESCRIPTION
## Context

Trello card: https://trello.com/c/NhlyzeA9

We have updated the withdrawal reasons model and we creating associated withdrawal reasons. When support reverts a withdrawal, we should delete the withdrawal reasons associated with the application choice.

## Changes proposed in this pull request

- Delete withdrawal reasons when the withdrawal is reverted. 
- Also, I noticed that the order of the errors at the top of the page didn't match the order in the body of the form, so I have fixed that.

| Before | After |
| ------ | ------ |
| <img width="887" alt="image" src="https://github.com/user-attachments/assets/64d8c97b-7947-4ffe-a37d-5b2abbbc7417" /> | <img width="852" alt="image" src="https://github.com/user-attachments/assets/a8b27c4f-ff69-4e8f-83e5-b7d0ad477b87" /> |

## Guidance to review

Locally, or in the review app. 
- Ensure feature flag is on
- Sign in as a candidate and withdrawal an application with the new application withdrawal reasons form
- From support, view the form and revert the withdrawal. The withdrawal reasons should should be delete and the application choice has been updated to 'awaiting provider decision'. 

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
