### PR TITLE
Delete OneLoginAuth when deleting application

### DIFF
--- a/app/services/delete_application.rb
+++ b/app/services/delete_application.rb
@@ -69,6 +69,7 @@ class DeleteApplication
 
         reference = application_form.support_reference
         application_form.candidate.update!(email_address: "deleted-application-#{reference}@example.com")
+        application_form.candidate.one_login_auth&.delete
 
         application_form.own_and_associated_audits.destroy_all
         add_audit_event_for_deletion!

--- a/app/services/delete_application.rb
+++ b/app/services/delete_application.rb
@@ -70,6 +70,7 @@ class DeleteApplication
         reference = application_form.support_reference
         application_form.candidate.update!(email_address: "deleted-application-#{reference}@example.com")
         application_form.candidate.one_login_auth&.delete
+        application_form.candidate.sessions&.destroy_all
 
         application_form.own_and_associated_audits.destroy_all
         add_audit_event_for_deletion!

--- a/spec/services/delete_application_spec.rb
+++ b/spec/services/delete_application_spec.rb
@@ -62,6 +62,14 @@ RSpec.describe DeleteApplication do
       expect { one_login_auth.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
+    it 'destroys all sessions associated with user' do
+      session = create(:session, candidate: application_form.candidate)
+
+      service.call!
+
+      expect { session.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
     it 'replaces all audits with a single entry documenting the deletion' do
       service.call!
 

--- a/spec/services/delete_application_spec.rb
+++ b/spec/services/delete_application_spec.rb
@@ -55,6 +55,13 @@ RSpec.describe DeleteApplication do
       end
     end
 
+    it 'deletes one login auth if present' do
+      one_login_auth = create(:one_login_auth, candidate: application_form.candidate)
+      service.call!
+
+      expect { one_login_auth.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
     it 'replaces all audits with a single entry documenting the deletion' do
       service.call!
 


### PR DESCRIPTION
## Context
Trello: https://trello.com/c/FzFGRn9B

When we delete an Application, we change the email address, so we need to remove the one login auth association as well (if it exists).

## Changes proposed in this pull request

- Add a line in the service object to delete the `one_login_auth` record
- Add another line to delete sessions associated with the candidate.
- Add a specs

## Guidance to review

Am I missing anything important?

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
