### PR TITLE
[548] Expire one login sessions after 7 days

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -23,11 +23,15 @@ private
   end
 
   def resume_session
-    Current.session ||= find_session_by_cookie
+    session = Current.session ||= find_session_by_cookie
+    session.touch if session.present?
+    session
   end
 
   def find_session_by_cookie
-    Session.find_by(id: cookies.signed[:session_id]) if cookies.signed[:session_id]
+    Session.find_by(
+      'id = ? AND updated_at > ?', cookies.signed[:session_id], 7.days.ago
+    )
   end
 
   def request_authentication

--- a/spec/system/candidate_interface/one_login_signup/candidate_is_logged_out_after_seven_days_spec.rb
+++ b/spec/system/candidate_interface/one_login_signup/candidate_is_logged_out_after_seven_days_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidate signs in' do
+  include OneLoginHelper
+
+  before do
+    FeatureFlag.activate(:one_login_candidate_sign_in)
+  end
+
+  scenario 'Candidate uses account before session expiry' do
+    given_i_am_logged_in_with_one_login
+    and_some_days_pass(6)
+    and_i_visit_my_applications_page
+    then_i_see_my_applications
+
+    given_some_days_pass(2)
+    and_i_visit_my_details_page
+    then_i_see_my_details
+
+    given_some_days_pass(7)
+    and_i_visit_my_applications_page
+    then_i_am_logged_out
+  end
+
+  scenario 'Candidate can login again after session expiry' do
+    given_i_am_logged_in_with_one_login
+    and_some_days_pass(7)
+    and_i_visit_my_applications_page
+    then_i_am_logged_out
+
+    when_i_login_again
+    and_i_visit_my_applications_page
+    then_i_see_my_applications
+  end
+
+private
+
+  def given_i_am_logged_in_with_one_login
+    @candidate = create(:candidate)
+    sign_in_with_one_login(@candidate.email_address)
+    visit candidate_interface_details_path
+  end
+
+  def given_some_days_pass(number_of_days)
+    advance_time_to number_of_days.days.from_now
+  end
+  alias_method :and_some_days_pass, :given_some_days_pass
+
+  def and_i_visit_my_details_page
+    click_on 'Your details'
+  end
+
+  def and_i_visit_my_applications_page
+    click_on 'Your applications'
+  end
+
+  def then_i_see_my_details
+    expect(page).to have_content 'Your details'
+    expect(page).to have_current_path candidate_interface_details_path
+  end
+
+  def then_i_see_my_applications
+    expect(page).to have_title('Your applications')
+    expect(page).to have_current_path candidate_interface_application_choices_path
+  end
+
+  def then_i_am_logged_out
+    expect(page).to have_title 'Create an account or sign in'
+    expect(page).to have_content 'You need a GOV.UK One Login to sign in to this service. You can create one if you do not already have one.'
+    expect(page).to have_current_path candidate_interface_create_account_or_sign_in_path
+  end
+
+  def when_i_login_again
+    click_on 'Continue'
+  end
+end


### PR DESCRIPTION
## Context

Trello: https://trello.com/c/rgrp8Gzo

With the magic link login, we used the devise.timeout_in method to expire sessions after 7 days of inactivity.

We want OneLogin sessions to expire by the same rule, after 7 days of inactivity.

## Changes proposed in this pull request

- Touch session (so `updated_at` is updated) every time we require authentication
- when we find the session, look for sessions that were updated less than 7 days ago
- Specs to ensure we are logged out after 7 days of inactivity

## Guidance to review

Good question. Once it is deployed on qa, we can test it out, but right now, I guess we have to trust the specs.

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
