### PR TITLE
[557] Update API docs

### DIFF
--- a/app/views/api_docs/vendor_api_docs/reference/_v1_6_changes.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/_v1_6_changes.html.erb
@@ -6,7 +6,7 @@
   The following field has been added to the <%= govuk_link_to 'reference', '#reference-object' %> object:
 
 <ul class="govuk-list govuk-list--bullet">
-  <li><code>confidential</code> (boolean, required)</li>
+  <li><code>confidential</code> (boolean) - This value must be selected by the referee when submitting the reference</li>
 </ul>
 
 <p class="govuk-heading-s">Add inactive to the ApplicationAttribute</p>

--- a/app/views/api_docs/vendor_api_docs/reference/draft.html.erb
+++ b/app/views/api_docs/vendor_api_docs/reference/draft.html.erb
@@ -78,7 +78,7 @@
   The following field has been added to the <%= govuk_link_to 'reference', '#reference-object' %> object:
 
 <ul class="govuk-list govuk-list--bullet">
-  <li><code>confidential</code> (boolean, required)</li>
+  <li><code>confidential</code> (boolean) - This value must be selected by the referee when submitting the reference</li>
 </ul>
 
 <p class="govuk-heading-s">Add inactive to the ApplicationAttribute</p>


### PR DESCRIPTION
## Context

We recently removed our not null constraint and default from the `confidential` column.

## Changes proposed in this pull request

- Update our API docs so that it is clear that this constraint is no longer enforced on the database.

## Guidance to review

- Do the docs need to be updated anywhere else? 
- Does anything else that I may have forgotten need to be updated as a result of this change?

## Link to Trello card

https://trello.com/c/E9CL806D