### PR TITLE
Add link to Trello card heading on PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,10 @@
 
 <!-- How could someone else check this work? Which parts do you want more feedback on? -->
 
+## Link to Trello card
+
+<!-- Paste the anonymised Trello link here. Avoid sharing the full card URL that reveals card details. -->
+
 ## Things to check
 
 - [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database


### PR DESCRIPTION
## Context

Trello/Github integration has been broken since last year, we don't know how long it will take for them to fix it.

## Changes proposed in this pull request

- Add a "Trello card" heading as a temporary measure to the PR template so that we don't forget to link PR's to Trello cards.

## Guidance to review

- Does the content look ok?
- Are there better work arounds?
