### PR TITLE
[558] Add email to candidates about login changes

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -513,6 +513,15 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def one_login_is_coming(application_form)
+    @application_form = application_form
+
+    email_for_candidate(
+      @application_form,
+      subject: I18n.t!('candidate_mailer.one_login_is_coming.subject'),
+    )
+  end
+
 private
 
   def email_for_candidate(application_form, args = {})

--- a/app/views/candidate_mailer/one_login_is_coming.text.erb
+++ b/app/views/candidate_mailer/one_login_is_coming.text.erb
@@ -1,0 +1,19 @@
+<% if @application_form.first_name.present? %>
+  Hello <%= @application_form.first_name %>,
+<% end %>
+
+# How you sign in to Apply for teacher training is changing
+
+During the week of 27 January, users will begin signing in using GOV.UK One Login. You'll be able to create a GOV.UK One Login if you do not already have one.
+
+You should use the same email address to create your GOV.UK One Login that you use to sign in to Apply for teacher training. This is so you keep the existing information in your account.
+
+If you use a different email address you’ll be able to transfer your account details after you sign in.
+
+# What is GOV.UK One Login?
+
+GOV.UK One Login allows you to sign in to some government services using the same email address and password.
+
+In the future you’ll be able to use your GOV.UK One Login to access all services on GOV.UK.
+
+<%= render 'unsubscribe_from_emails_like_this' %>

--- a/app/workers/send_candidate_one_login_is_coming_email_worker.rb
+++ b/app/workers/send_candidate_one_login_is_coming_email_worker.rb
@@ -1,0 +1,36 @@
+class SendCandidateOneLoginIsComingEmailWorker
+  include Sidekiq::Worker
+
+  def perform
+    return if should_not_perform?
+
+    BatchDelivery.new(relation:, batch_size: 200).each do |batch_time, application_forms|
+      SendOneLoginIsComingEmailBatchWorker.perform_at(batch_time, application_forms.pluck(:id))
+    end
+  end
+
+  def relation
+    ApplicationForm
+      .current_cycle
+      .joins(:candidate)
+      .merge(Candidate.for_marketing_or_nudge_emails)
+      .has_not_received_email('candidate_mailer', 'one_login_is_coming')
+      .distinct
+  end
+
+private
+
+  def should_not_perform?
+    FeatureFlag.active?(:one_login_candidate_sign_in) || OneLogin.bypass?
+  end
+end
+
+class SendOneLoginIsComingEmailBatchWorker
+  include Sidekiq::Worker
+
+  def perform(application_form_ids)
+    ApplicationForm.where(id: application_form_ids).find_each do |application_form|
+      CandidateMailer.one_login_is_coming(application_form).deliver_later
+    end
+  end
+end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -51,6 +51,7 @@ class Clock
   every(1.day, 'SendApplyToAnotherCourseWhenInactiveEmailToCandidatesWorker', at: '10:00') { SendApplyToAnotherCourseWhenInactiveEmailToCandidatesWorker.perform_async }
   every(1.day, 'SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesWorker', at: '10:00') { SendApplyToMultipleCoursesWhenInactiveEmailToCandidatesWorker.perform_async }
   every(1.day, 'DfE::Analytics::EntityTableCheckJob', at: '00:30') { DfE::Analytics::EntityTableCheckJob.perform_later }
+  every(1.day, 'SendCandidateOneLoginIsComingEmailWorker', at: '00:31') { SendCandidateOneLoginIsComingEmailWorker.perform_async }
 
   # End of cycle application choice status jobs
   # Changes unsubmitted application choices to 'application_not_sent'

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -95,3 +95,5 @@ en:
       subject: Get help with your personal statement
     apply_to_course_after_inactivity:
       subject: Increase your chances of receiving an offer for teacher training
+    one_login_is_coming:
+      subject: How you sign into Apply for teacher training is changing 

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -549,6 +549,11 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.apply_to_multiple_courses_after_30_working_days(application_form)
   end
 
+  def one_login_is_coming
+    application_form = FactoryBot.build(:application_form, first_name: 'Bob')
+    CandidateMailer.one_login_is_coming(application_form)
+  end
+
 private
 
   def candidate

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe 'Docs' do
   def and_it_contains_documentation_for_all_emails
     emails_outside_of_states = %w[
       provider_mailer-fallback_sign_in_email
+      candidate_mailer-one_login_is_coming
       candidate_mailer-eoc_first_deadline_reminder
       candidate_mailer-eoc_second_deadline_reminder
       candidate_mailer-application_deadline_has_passed

--- a/spec/workers/send_candidate_one_login_is_coming_email_worker_spec.rb
+++ b/spec/workers/send_candidate_one_login_is_coming_email_worker_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe SendCandidateOneLoginIsComingEmailWorker do
+  before { allow(OneLogin).to receive(:bypass?).and_return(false) }
+
+  describe '#perform' do
+    context 'feature flag is activated' do
+      before { FeatureFlag.activate('one_login_candidate_sign_in') }
+
+      it 'does not enqueue the batch worker' do
+        create(:application_form)
+
+        allow(SendOneLoginIsComingEmailBatchWorker).to receive(:perform_at)
+        described_class.new.perform
+        expect(SendOneLoginIsComingEmailBatchWorker).not_to have_received(:perform_at)
+      end
+    end
+
+    context 'feature flag is deactivated' do
+      before { FeatureFlag.deactivate('one_login_candidate_sign_in') }
+
+      it 'enqueues the batch worker with expected application forms' do
+        # Last year's application
+        create(:application_form, recruitment_cycle_year: RecruitmentCycle.previous_year)
+        # Unsubscribed candidate
+        create(:application_form, candidate: build(:candidate, unsubscribed_from_emails: true))
+        # Candidate with submission blocked
+        create(:application_form, candidate: build(:candidate, submission_blocked: true))
+        # Candidate with locked account
+        create(:application_form, candidate: build(:candidate, account_locked: true))
+        # Candidate has already been sent the email
+        create(:email, application_form: build(:application_form), mailer: 'candidate_mailer', mail_template: 'one_login_is_coming')
+
+        should_receive = create(:application_form)
+
+        allow(SendOneLoginIsComingEmailBatchWorker).to receive(:perform_at)
+        described_class.new.perform
+        expect(SendOneLoginIsComingEmailBatchWorker).to have_received(:perform_at).with(kind_of(Time), [should_receive.id])
+      end
+    end
+  end
+end

--- a/spec/workers/send_one_login_is_coming_email_batch_worker_spec.rb
+++ b/spec/workers/send_one_login_is_coming_email_batch_worker_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe SendOneLoginIsComingEmailBatchWorker do
+  describe '#perform' do
+    it 'enqueues candidate emails' do
+      application_forms = create_list(:application_form, 2)
+
+      expect { described_class.new.perform(application_forms.pluck(:id)) }
+        .to have_enqueued_mail(CandidateMailer, :one_login_is_coming).twice
+    end
+  end
+end


### PR DESCRIPTION
## Context

We wish to email candidates in the imminent week(s) that the way they login to our service is changing.

Recognising that lots of new candidates sign up each day, we will send this email daily to new sign ups until the feature flag is activated. 

Once the feature flag is activated and things are working normally, we will delete this email and worker from the code base as it's not to be reused. Even if we deactivate the feature flag, it won't really make much sense...

The first email that is sent will go to about 53k candidates. Subsequent messages sent daily will just be sent to candidates who have signed that day. 

The message will not be sent to anyone whose account is locked, submission blocked, or unsubscribed.

## Changes proposed in this pull request

Worker and email and associated tests. 

## Guidance to review

- Does the query look correct? 
- The email can be previewed locally or on the review app at `rails/mailers/candidate_mailer/one_login_is_coming`

## Link to Trello card

https://trello.com/c/ZAtlIyJO

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
