### PR TITLE
Add possible values to vendor api documentation for `confidential` and `inactive`

### DIFF
--- a/config/vendor_api/draft.yml
+++ b/config/vendor_api/draft.yml
@@ -22,6 +22,9 @@ components:
         inactive:
           type: boolean
           description: Indicates whether the application is inactive, based on time-sensitive criteria. If true, the application is considered inactive; otherwise, it remains active.
+          enum:
+          - true
+          - false
     Reference:
       type: object
       properties:
@@ -29,5 +32,9 @@ components:
           type: boolean
           description: The confidentiality status selected by the referee for the reference
           example: true
+          enum:
+          - true
+          - false
+          - null
       required:
         - confidential


### PR DESCRIPTION
## Context

Making it clear what possible values consumers of the API can receive.

## Changes proposed in this pull request

Add possible values to vendor api documentation: 

- For `confidential`
- For `inactive`

## Guidance to review

Does the wording make sense?

## Screenshot

<img width="1067" alt="image" src="https://github.com/user-attachments/assets/0b6596c7-4699-4b9a-945b-3b0fe1854e5e" />
