### PR TITLE
Hide account recovery banner to users without one login auth

### DIFF
--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -110,7 +110,7 @@ class Candidate < ApplicationRecord
   end
 
   def recoverable?
-    return false if OneLogin.bypass? || FeatureFlag.inactive?(:one_login_candidate_sign_in)
+    return false if OneLogin.bypass? || FeatureFlag.inactive?(:one_login_candidate_sign_in) || one_login_auth.nil?
 
     account_recovery_status_not_started? &&
       !application_choices_submitted?

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -312,6 +312,13 @@ RSpec.describe Candidate do
       expect(candidate.recoverable?).to be_falsey
     end
 
+    it 'returns false if candidate has not got a one login auth' do
+      FeatureFlag.activate(:one_login_candidate_sign_in)
+      allow(OneLogin).to receive(:bypass?).and_return(false)
+
+      expect(candidate.recoverable?).to be_falsey
+    end
+
     context 'when candidate dismissed the banner' do
       let(:candidate) { create(:candidate, account_recovery_status: :dismissed) }
 
@@ -347,9 +354,15 @@ RSpec.describe Candidate do
     end
 
     context 'when candidate does not have submitted application choices' do
-      let(:candidate) { create(:candidate, account_recovery_status: :not_started) }
+      let(:candidate) do
+        create(
+          :candidate,
+          :with_live_session,
+          account_recovery_status: :not_started,
+        )
+      end
 
-      it 'returns false' do
+      it 'returns true' do
         FeatureFlag.activate(:one_login_candidate_sign_in)
         allow(OneLogin).to receive(:bypass?).and_return(false)
 


### PR DESCRIPTION
## Context

There is an edge case when one login will be switched on. The candidates that are already logged in, will still be logged in.

The issue comes when the account recovery banner will appear and when the one login feature flag is enabled, the user won't have a one login auth record in the DB. This record links the one login account to a candidate account.

If this one login auth record is not present, you cannot recover an account as the recovery account feature will look for a one login auth.

The 'fix' for this is to allow instruct the user to log out and login with one login, this will create a one login auth and then they can recover their account without issue.

This commit doesn't allow the candidate to recover their account unil they have a one login auth record in DB.

## Changes proposed in this pull request

Banner show/hide logic

## Guidance to review

This is a tricky one to test. It will be tested in the Bug party. I think at this point it's more realistic to just merge this.

Controller requests are also controlled by this recoverable method so we should block requests to those controller as well.



https://github.com/user-attachments/assets/81d073ef-00ea-42b0-b5f5-0ee9f6cd1354




## Link to Trello card



## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [ ] Attach the PR to the Trello card
