### PR TITLE
Fix candidate forms using current_user

### DIFF
--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -11,7 +11,10 @@ module CandidateInterface
     before_action :track_email_click
     layout 'application'
     alias audit_user current_candidate
-    alias current_user current_candidate
+
+    def current_user
+      current_candidate
+    end
 
     def current_candidate
       super || Current.session&.candidate

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,6 +46,7 @@ require 'rspec/retry'
 require 'rspec/core/formatters/base_text_formatter'
 
 require_relative 'support/capybara'
+require 'support/test_helpers/one_login_helper'
 
 ENV['SERVICE_TYPE'] = 'test' # this is used for logging
 ENV['STATE_CHANGE_SLACK_URL'] = nil # ensure tests send no Slack notifications
@@ -62,6 +63,8 @@ RSpec.configure do |config|
       ex.run_with_retry retry: 3
     end
   end
+
+  config.include OneLoginHelper
 
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest

--- a/spec/support/test_helpers/one_login_helper.rb
+++ b/spec/support/test_helpers/one_login_helper.rb
@@ -23,4 +23,15 @@ module OneLoginHelper
       raise 'One login feature flag needs to be active'
     end
   end
+
+  def given_i_am_signed_in_with_one_login
+    if FeatureFlag.inactive?(:one_login_candidate_sign_in)
+      FeatureFlag.activate(:one_login_candidate_sign_in)
+    end
+
+    @current_candidate ||= create(:candidate)
+    user_exists_in_one_login(email_address: @current_candidate.email_address)
+    visit candidate_interface_create_account_or_sign_in_path
+    click_link_or_button 'Continue'
+  end
 end

--- a/spec/system/candidate_interface/entering_details/degrees/backlinks_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/backlinks_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Degrees' do
   include CandidateHelper
 
   scenario 'Candidate editing degree' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_completed_the_degree_section
     when_i_view_the_degree_section
     and_i_click_to_change_my_undergraduate_degree_type
@@ -65,13 +65,8 @@ RSpec.describe 'Degrees' do
     then_i_am_taken_back_to_the_degree_review_page
   end
 
-  def given_i_am_signed_in
-    @candidate = create(:candidate)
-    login_as(@candidate)
-  end
-
   def and_i_have_completed_the_degree_section
-    @application_form = create(:application_form, candidate: @candidate)
+    @application_form = create(:application_form, candidate: @current_candidate)
     create(:application_qualification,
            level: 'degree',
            qualification_type: 'Bachelor of Arts',

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_adding_unknown_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_adding_unknown_degrees_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Adding an unknown degree', :js do
   include CandidateHelper
 
   scenario 'Candidate enters their degree' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     when_i_view_the_degree_section
 
     and_i_answer_that_i_have_a_university_degree
@@ -74,7 +74,7 @@ RSpec.describe 'Adding an unknown degree', :js do
   end
 
   def given_i_am_at_the_degree_subject_page
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     when_i_view_the_degree_section
 
     and_i_answer_that_i_have_a_university_degree
@@ -98,10 +98,6 @@ RSpec.describe 'Adding an unknown degree', :js do
 
   def then_the_custom_subject_remains_filled_in
     expect(@input.value).to eq('History of Art and History')
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def when_i_view_the_degree_section

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_delete_and_replace_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_delete_and_replace_degrees_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Deleting and replacing a degree' do
   include CandidateHelper
 
   scenario 'Candidate deletes and replaces their degree' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_completed_the_degree_section
     when_i_view_the_degree_section
     and_i_click_on_change_country
@@ -34,11 +34,6 @@ RSpec.describe 'Deleting and replacing a degree' do
     and_if_there_is_only_a_foundation_degree
     when_i_return_to_the_application_form
     then_the_degree_section_is_incomplete
-  end
-
-  def given_i_am_signed_in
-    @candidate = create(:candidate)
-    login_as(@candidate)
   end
 
   def when_i_view_the_degree_section
@@ -222,7 +217,7 @@ RSpec.describe 'Deleting and replacing a degree' do
   end
 
   def and_i_have_completed_the_degree_section
-    @application_form = create(:application_form, candidate: @candidate, university_degree: true)
+    @application_form = create(:application_form, candidate: @current_candidate, university_degree: true)
     create(:application_qualification, level: 'degree', application_form: @application_form)
     @application_form.update!(degrees_completed: true)
     @degree_id = @application_form.application_qualifications.first.id

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_editing_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_editing_degrees_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Editing a degree' do
   include CandidateHelper
 
   it 'Candidate edits their degree' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     and_i_have_completed_the_degree_section
     when_i_view_the_degree_section
     and_i_click_to_change_my_undergraduate_degree_type
@@ -70,13 +70,8 @@ RSpec.describe 'Editing a degree' do
     then_i_see_another_masters_degree_selected
   end
 
-  def given_i_am_signed_in
-    @candidate = create(:candidate)
-    login_as(@candidate)
-  end
-
   def and_i_have_completed_the_degree_section
-    @application_form = create(:application_form, candidate: @candidate)
+    @application_form = create(:application_form, candidate: @current_candidate)
     create(:application_qualification,
            level: 'degree',
            qualification_type: 'Bachelor of Arts',

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_editing_international_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_editing_international_degrees_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Editing a degree' do
   include CandidateHelper
 
   before do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     when_i_view_the_degree_section
     and_i_create_an_international_degree
   end
@@ -34,11 +34,6 @@ RSpec.describe 'Editing a degree' do
 
   def and_i_click_change_country
     click_on 'Change country'
-  end
-
-  def given_i_am_signed_in
-    @candidate = create(:candidate)
-    login_as(@candidate)
   end
 
   def when_i_view_the_degree_section

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degree_without_a_grade_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degree_without_a_grade_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Entering an international doctorate degree' do
   include CandidateHelper
 
   scenario 'Candidate enters their degree' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     when_i_view_the_degree_section
     and_i_answer_that_i_have_a_university_degree
     and_i_select_another_country
@@ -31,10 +31,6 @@ RSpec.describe 'Entering an international doctorate degree' do
   end
 
 private
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
-  end
 
   def when_i_view_the_degree_section
     visit candidate_interface_details_path

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degree_without_an_enic_reason_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degree_without_an_enic_reason_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Entering an international doctorate degree' do
   include CandidateHelper
 
   scenario 'Candidate enters their degree without an enic reason' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     when_i_view_the_degree_section
 
     and_i_answer_that_i_have_a_university_degree
@@ -20,10 +20,6 @@ RSpec.describe 'Entering an international doctorate degree' do
   end
 
 private
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
-  end
 
   def when_i_view_the_degree_section
     visit candidate_interface_details_path

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_international_degrees_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Entering an international degree' do
   include CandidateHelper
 
   scenario 'Candidate enters their degree' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     when_i_view_the_degree_section
 
     and_i_answer_that_i_have_a_university_degree
@@ -68,10 +68,6 @@ RSpec.describe 'Entering an international degree' do
     and_that_the_section_is_completed
     when_i_click_on_degree
     then_i_can_check_my_answers
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def when_i_view_the_degree_section

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_masters_degree_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_masters_degree_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Entering a Masters degree' do
   include CandidateHelper
 
   scenario 'Candidate enters their Masters degree' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     when_i_view_the_degree_section
 
     and_i_answer_that_i_have_a_university_degree
@@ -18,10 +18,6 @@ RSpec.describe 'Entering a Masters degree' do
     then_i_can_see_the_level_page
     when_i_choose_the_masters_level
     and_i_click_on_save_and_continue
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def when_i_view_the_degree_section

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_phd_degree_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_phd_degree_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Entering a PhD' do
   include CandidateHelper
 
   scenario 'Candidate enters their PhD' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     when_i_view_the_degree_section
 
     and_i_answer_that_i_have_a_university_degree
@@ -56,10 +56,6 @@ RSpec.describe 'Entering a PhD' do
 
     # Review
     then_i_can_check_my_phd
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def when_i_view_the_degree_section

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_university_degree_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_university_degree_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Entering a degree' do
   end
 
   scenario 'Candidate does not have a degree' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     when_i_view_the_degree_section
     then_i_can_see_the_university_degree_page
 
@@ -36,7 +36,7 @@ RSpec.describe 'Entering a degree' do
   end
 
   scenario 'Candidate does have a university degree' do
-    given_i_am_signed_in
+    given_i_am_signed_in_with_one_login
     when_i_view_the_degree_section
     then_i_can_see_the_university_degree_page
 
@@ -71,10 +71,6 @@ RSpec.describe 'Entering a degree' do
     TestSuiteTimeMachine.travel_permanently_to(
       CycleTimetableHelper.after_apply_deadline(2024),
     )
-  end
-
-  def given_i_am_signed_in
-    create_and_sign_in_candidate
   end
 
   def when_i_view_the_degree_section


### PR DESCRIPTION
## Context
Some forms like the degree form use current_user. In the candidate
context, this is the same as current_candidate.

As we switch to one login and DB backed sessions, current_user will be
nil. So to make this work and make it backwards compatible, in case we
need to revert back to using magic link for our candidates.

I've overridden the `current_user` method in the candidate interface
controller to always point to current_candidate. This way it should work
for DB backed sessions and cookies backed sessions.

Previously it would always return current_candidate but because of the DB backed session, this will return nil unless we fix it in this PR

I've also changed the degree system specs to use one login when signin
up. We would've probably spotted this if the spec was using one login to
sign up the candidate

I'm going to change all specs to use one login to sign up the candidate in this small PR https://github.com/DFE-Digital/apply-for-teacher-training/pull/10271
 
## Changes proposed in this pull request

Override current_user method in candidate interface controller to return current_candidate.

## Guidance to review

It's hard to replicate this because you need to pull this locally and switch off and on the one login feature flag.

You have to trust my video and maybe test it after it's merged as it's behind a feature flag


https://github.com/user-attachments/assets/b4515c88-dd47-4d28-afd1-c9b2b1740ffd



## Link to Trello card

https://trello.com/c/yU6Cho7o

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist, if included inform data insights team of the changes
- [ ] If this code adds a column that may include PII, the sanitise.sql script and 0025-protecting-personal-data-in-production-dump.md ADR have been updated.
- [ ] API release notes have been updated if necessary
- [ ] If it adds a significant user-facing change, is it documented in the [CHANGELOG](CHANGELOG.md)?
- [x] Attach the PR to the Trello card
